### PR TITLE
wip: ref(dashboards): Generic widget queries to orchestrate requests

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -62,7 +62,6 @@ import WidgetCardChart, {
 import GenericWidgetQueries, {
   GenericWidgetQueriesProps,
 } from 'sentry/views/dashboardsV2/widgetCard/genericWidgetQueries';
-import IssueWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/issueWidgetQueries';
 import ReleaseWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/releaseWidgetQueries';
 import {WidgetCardChartContainer} from 'sentry/views/dashboardsV2/widgetCard/widgetCardChartContainer';
 import {decodeColumnOrder} from 'sentry/views/eventsV2/utils';
@@ -159,7 +158,6 @@ function WidgetViewerModal(props: Props) {
     params,
     seriesData,
     tableData,
-    issuesData,
     totalIssuesCount,
     pageLinks: defaultPageLinks,
   } = props;
@@ -505,8 +503,8 @@ function WidgetViewerModal(props: Props) {
     );
   };
 
-  const renderIssuesTable: IssueWidgetQueries['props']['children'] = ({
-    transformedResults,
+  const renderIssuesTable: GenericWidgetQueriesProps['children'] = ({
+    tableResults,
     loading,
     pageLinks,
     totalCount,
@@ -519,7 +517,7 @@ function WidgetViewerModal(props: Props) {
       <Fragment>
         <GridEditable
           isLoading={loading}
-          data={transformedResults}
+          data={tableResults?.[0]?.data ?? []}
           columnOrder={columnOrder}
           columnSortBy={columnSortBy}
           grid={{
@@ -691,9 +689,9 @@ function WidgetViewerModal(props: Props) {
   function renderWidgetViewerTable() {
     switch (widget.widgetType) {
       case WidgetType.ISSUE:
-        if (issuesData && chartUnmodified && widget.displayType === DisplayType.TABLE) {
+        if (tableData && chartUnmodified && widget.displayType === DisplayType.TABLE) {
           return renderIssuesTable({
-            transformedResults: issuesData,
+            tableResults: tableData,
             loading: false,
             errorMessage: undefined,
             pageLinks: defaultPageLinks,

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -59,10 +59,12 @@ import WidgetCardChart, {
   AugmentedEChartDataZoomHandler,
   SLIDER_HEIGHT,
 } from 'sentry/views/dashboardsV2/widgetCard/chart';
+import GenericWidgetQueries, {
+  GenericWidgetQueriesProps,
+} from 'sentry/views/dashboardsV2/widgetCard/genericWidgetQueries';
 import IssueWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/issueWidgetQueries';
 import ReleaseWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/releaseWidgetQueries';
 import {WidgetCardChartContainer} from 'sentry/views/dashboardsV2/widgetCard/widgetCardChartContainer';
-import WidgetQueries from 'sentry/views/dashboardsV2/widgetCard/widgetQueries';
 import {decodeColumnOrder} from 'sentry/views/eventsV2/utils';
 
 import {WidgetViewerQueryField} from './widgetViewerModal/utils';
@@ -438,7 +440,7 @@ function WidgetViewerModal(props: Props) {
     });
   }
 
-  const renderDiscoverTable: WidgetQueries['props']['children'] = ({
+  const renderDiscoverTable: GenericWidgetQueriesProps['children'] = ({
     tableResults,
     loading,
     pageLinks,
@@ -748,7 +750,7 @@ function WidgetViewerModal(props: Props) {
           });
         }
         return (
-          <WidgetQueries
+          <GenericWidgetQueries
             api={api}
             organization={organization}
             widget={tableWidget}
@@ -761,7 +763,7 @@ function WidgetViewerModal(props: Props) {
             cursor={cursor}
           >
             {renderDiscoverTable}
-          </WidgetQueries>
+          </GenericWidgetQueries>
         );
     }
   }

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -701,7 +701,7 @@ function WidgetViewerModal(props: Props) {
           });
         }
         return (
-          <IssueWidgetQueries
+          <GenericWidgetQueries
             api={api}
             organization={organization}
             widget={tableWidget}
@@ -714,7 +714,7 @@ function WidgetViewerModal(props: Props) {
             cursor={cursor}
           >
             {renderIssuesTable}
-          </IssueWidgetQueries>
+          </GenericWidgetQueries>
         );
       case WidgetType.RELEASE:
         if (tableData && chartUnmodified && widget.displayType === DisplayType.TABLE) {

--- a/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
@@ -108,6 +108,7 @@ function GenericWidgetQueries({
         // Cast so we can add the title.
         const transformedData = config.transformTable(
           // TODO: Types across configs are &'d here. Should be |'d or set to a specific type
+          // @ts-ignore
           data,
           widget.queries[0],
           organization,
@@ -162,6 +163,7 @@ function GenericWidgetQueries({
             : getIsMetricsDataFromSeriesResponse(rawResults);
         dashboardMEPContext?.setIsMetricsData(isMetricsData);
         const transformedResult = config.transformSeries!(
+          // @ts-ignore
           rawResults,
           widget.queries[requestIndex],
           organization

--- a/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
@@ -1,0 +1,126 @@
+import {useEffect, useState} from 'react';
+
+import {Client, ResponseMeta} from 'sentry/api';
+import {t} from 'sentry/locale';
+import {Organization, PageFilters} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
+import {
+  EventsTableData,
+  TableData,
+  TableDataWithTitle,
+} from 'sentry/utils/discover/discoverQuery';
+
+import {getDatasetConfig} from '../datasetConfig/base';
+import {DEFAULT_TABLE_LIMIT, DisplayType, Widget} from '../types';
+
+type Props = {
+  api: Client;
+  children: any; // TODO
+  organization: Organization;
+  selection: PageFilters;
+  widget: Widget;
+  cursor?: string;
+  limit?: number;
+  onDataFetched?: (props: any) => void;
+};
+
+function getReferrer(displayType: DisplayType) {
+  let referrer: string = '';
+
+  if (displayType === DisplayType.TABLE) {
+    referrer = 'api.dashboards.tablewidget';
+  } else if (displayType === DisplayType.BIG_NUMBER) {
+    referrer = 'api.dashboards.bignumberwidget';
+  } else if (displayType === DisplayType.WORLD_MAP) {
+    referrer = 'api.dashboards.worldmapwidget';
+  } else {
+    referrer = `api.dashboards.widget.${displayType}-chart`;
+  }
+
+  return referrer;
+}
+
+function WidgetQueries({
+  api,
+  children,
+  cursor,
+  limit,
+  onDataFetched,
+  organization,
+  selection,
+  widget,
+}: Props) {
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [tableResults, setTableResults] = useState<TableDataWithTitle[]>([]);
+  const [timeseriesResults, setTimeseriesResults] = useState<Series[]>([]);
+
+  const config = getDatasetConfig(widget.widgetType);
+
+  // Trigger a re-query when the widget's queries, dataset, or display type changes
+  useEffect(() => {
+    async function fetchData() {
+      setLoading(true);
+      setTableResults([]);
+      setTimeseriesResults([]);
+
+      // generate the request objects
+      // await the requests
+      let responses: [TableData | EventsTableData, string, ResponseMeta][];
+      try {
+        responses = await Promise.all(
+          widget.queries.map(query => {
+            // TODO: Support the other display types
+            return config.getTableRequest!(
+              api,
+              query,
+              organization,
+              selection,
+              limit ?? DEFAULT_TABLE_LIMIT,
+              cursor,
+              getReferrer(widget.displayType)
+            );
+          })
+        );
+
+        // transform the data
+        let transformedTableResults: TableDataWithTitle[] = [];
+        let isMetricsData: boolean | undefined;
+        let pageLinks: string | null = null;
+        responses.forEach(([data, _textstatus, resp], i) => {
+          // If one of the queries is sampled, then mark the whole thing as sampled
+          isMetricsData = isMetricsData === false ? false : data.meta?.isMetricsData;
+
+          // Cast so we can add the title.
+          const transformedData = config.transformTable(
+            // TODO: Types across configs are &'d here. Should be |'d or set to a specific type
+            data,
+            widget.queries[0],
+            organization,
+            selection
+          ) as TableDataWithTitle;
+          transformedData.title = widget.queries[i]?.name ?? '';
+
+          // Overwrite the local var to work around state being stale in tests.
+          transformedTableResults = [...transformedTableResults, transformedData];
+          pageLinks = resp?.getResponseHeader('Link');
+        });
+        onDataFetched?.({
+          tableResults: transformedTableResults,
+          pageLinks: pageLinks ?? undefined,
+        });
+        setTableResults(transformedTableResults);
+      } catch (err) {
+        setErrorMessage(err?.responseJSON?.detail || t('An unknown error occurred.'));
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchData();
+  }, [widget.queries, widget.widgetType, widget.displayType]);
+
+  return children({loading, tableResults, timeseriesResults, errorMessage});
+}
+
+export default WidgetQueries;

--- a/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
@@ -72,7 +72,13 @@ function GenericWidgetQueries({
     useState<ChildrenProps['tableResults']>(undefined);
   const [timeseriesResults, setTimeseriesResults] =
     useState<ChildrenProps['timeseriesResults']>(undefined);
-  const dashboardMEPContext = useContext(DashboardsMEPContext);
+
+  // TODO: Is specific to DISCOVER
+  const context = useContext(DashboardsMEPContext);
+  let setIsMetricsData;
+  if (context) {
+    setIsMetricsData = context.setIsMetricsData;
+  }
 
   const fetchTableData = useCallback(
     async function fetchTableData(isMounted: boolean) {
@@ -104,7 +110,7 @@ function GenericWidgetQueries({
       responses.forEach(([data, _textstatus, resp], i) => {
         // If one of the queries is sampled, then mark the whole thing as sampled
         isMetricsData = isMetricsData === false ? false : data.meta?.isMetricsData;
-        dashboardMEPContext?.setIsMetricsData(isMetricsData);
+        setIsMetricsData?.(isMetricsData);
 
         // Cast so we can add the title.
         const transformedData = config.transformTable(
@@ -137,7 +143,7 @@ function GenericWidgetQueries({
       api,
       config,
       cursor,
-      dashboardMEPContext,
+      setIsMetricsData,
       limit,
       onDataFetched,
       organization,
@@ -168,7 +174,7 @@ function GenericWidgetQueries({
           isMetricsData === false
             ? false
             : getIsMetricsDataFromSeriesResponse(rawResults);
-        dashboardMEPContext?.setIsMetricsData(isMetricsData);
+        setIsMetricsData?.(isMetricsData);
         const transformedResult = config.transformSeries!(
           // @ts-ignore
           rawResults,
@@ -198,7 +204,7 @@ function GenericWidgetQueries({
       api,
       config.getSeriesRequest,
       config.transformSeries,
-      dashboardMEPContext,
+      setIsMetricsData,
       onDataFetched,
       organization,
       selection,

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -84,7 +84,7 @@ export function WidgetCardChartContainer({
             <LoadingScreen loading={loading} />
             {widget.widgetType === WidgetType.ISSUE ? (
               <IssueWidgetCard
-                transformedResults={tableResults?.[0].data ?? []}
+                transformedResults={tableResults?.[0]?.data ?? []}
                 loading={loading}
                 errorMessage={errorMessage}
                 widget={widget}

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -14,10 +14,8 @@ import {TableDataRow, TableDataWithTitle} from 'sentry/utils/discover/discoverQu
 import {Widget, WidgetType} from '../types';
 
 import WidgetCardChart, {AugmentedEChartDataZoomHandler} from './chart';
+import GenericWidgetQueries from './genericWidgetQueries';
 import {IssueWidgetCard} from './issueWidgetCard';
-import IssueWidgetQueries from './issueWidgetQueries';
-import ReleaseWidgetQueries from './releaseWidgetQueries';
-import WidgetQueries from './widgetQueries';
 
 type Props = WithRouterProps & {
   api: Client;
@@ -68,25 +66,25 @@ export function WidgetCardChartContainer({
   noPadding,
   chartZoomOptions,
 }: Props) {
-  if (widget.widgetType === WidgetType.ISSUE) {
-    return (
-      <IssueWidgetQueries
-        api={api}
-        organization={organization}
-        widget={widget}
-        selection={selection}
-        limit={tableItemLimit}
-        onDataFetched={onDataFetched}
-      >
-        {({transformedResults, errorMessage, loading}) => {
-          return (
-            <Fragment>
-              {typeof renderErrorMessage === 'function'
-                ? renderErrorMessage(errorMessage)
-                : null}
-              <LoadingScreen loading={loading} />
+  return (
+    <GenericWidgetQueries
+      api={api}
+      organization={organization}
+      widget={widget}
+      selection={selection}
+      limit={tableItemLimit ?? widget.limit}
+      onDataFetched={onDataFetched}
+    >
+      {({timeseriesResults, tableResults, errorMessage, loading}) => {
+        return (
+          <Fragment>
+            {typeof renderErrorMessage === 'function'
+              ? renderErrorMessage(errorMessage)
+              : null}
+            <LoadingScreen loading={loading} />
+            {widget.widgetType === WidgetType.ISSUE ? (
               <IssueWidgetCard
-                transformedResults={transformedResults}
+                transformedResults={tableResults?.[0].data ?? []}
                 loading={loading}
                 errorMessage={errorMessage}
                 widget={widget}
@@ -94,29 +92,7 @@ export function WidgetCardChartContainer({
                 location={location}
                 selection={selection}
               />
-            </Fragment>
-          );
-        }}
-      </IssueWidgetQueries>
-    );
-  }
-
-  if (widget.widgetType === WidgetType.RELEASE) {
-    return (
-      <ReleaseWidgetQueries
-        api={api}
-        organization={organization}
-        widget={widget}
-        selection={selection}
-        limit={widget.limit ?? tableItemLimit}
-        onDataFetched={onDataFetched}
-      >
-        {({tableResults, timeseriesResults, errorMessage, loading}) => {
-          return (
-            <Fragment>
-              {typeof renderErrorMessage === 'function'
-                ? renderErrorMessage(errorMessage)
-                : null}
+            ) : (
               <WidgetCardChart
                 timeseriesResults={timeseriesResults}
                 tableResults={tableResults}
@@ -129,58 +105,19 @@ export function WidgetCardChartContainer({
                 organization={organization}
                 isMobile={isMobile}
                 windowWidth={windowWidth}
-                expandNumbers={expandNumbers}
                 onZoom={onZoom}
+                onLegendSelectChanged={onLegendSelectChanged}
+                legendOptions={legendOptions}
+                expandNumbers={expandNumbers}
                 showSlider={showSlider}
                 noPadding={noPadding}
                 chartZoomOptions={chartZoomOptions}
               />
-            </Fragment>
-          );
-        }}
-      </ReleaseWidgetQueries>
-    );
-  }
-
-  return (
-    <WidgetQueries
-      api={api}
-      organization={organization}
-      widget={widget}
-      selection={selection}
-      limit={tableItemLimit}
-      onDataFetched={onDataFetched}
-    >
-      {({tableResults, timeseriesResults, errorMessage, loading}) => {
-        return (
-          <Fragment>
-            {typeof renderErrorMessage === 'function'
-              ? renderErrorMessage(errorMessage)
-              : null}
-            <WidgetCardChart
-              timeseriesResults={timeseriesResults}
-              tableResults={tableResults}
-              errorMessage={errorMessage}
-              loading={loading}
-              location={location}
-              widget={widget}
-              selection={selection}
-              router={router}
-              organization={organization}
-              isMobile={isMobile}
-              windowWidth={windowWidth}
-              onZoom={onZoom}
-              onLegendSelectChanged={onLegendSelectChanged}
-              legendOptions={legendOptions}
-              expandNumbers={expandNumbers}
-              showSlider={showSlider}
-              noPadding={noPadding}
-              chartZoomOptions={chartZoomOptions}
-            />
+            )}
           </Fragment>
         );
       }}
-    </WidgetQueries>
+    </GenericWidgetQueries>
   );
 }
 

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -89,7 +89,9 @@ export function flattenMultiSeriesDataWithGrouping(
   return seriesWithOrdering;
 }
 
-function getIsMetricsDataFromSeriesResponse(result: RawResult): boolean | undefined {
+export function getIsMetricsDataFromSeriesResponse(
+  result: RawResult
+): boolean | undefined {
   const multiIsMetricsData = Object.values(result)
     .map(({isMetricsData}) => isMetricsData)
     // One non-metrics series will cause all of them to be marked as such

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -54,33 +54,36 @@ async function renderModal({
   seriesData?: Series[];
   tableData?: TableDataWithTitle[];
 }) {
-  const rendered = render(
-    <div style={{padding: space(4)}}>
-      <WidgetViewerModal
-        Header={stubEl}
-        Footer={stubEl as ModalRenderProps['Footer']}
-        Body={stubEl as ModalRenderProps['Body']}
-        CloseButton={stubEl}
-        closeModal={() => undefined}
-        organization={organization}
-        widget={widget}
-        onEdit={() => undefined}
-        seriesData={seriesData}
-        tableData={tableData}
-        issuesData={issuesData}
-        pageLinks={pageLinks}
-      />
-    </div>,
-    {
-      context: routerContext,
-      organization,
+  let rendered;
+  await act(async () => {
+    rendered = render(
+      <div style={{padding: space(4)}}>
+        <WidgetViewerModal
+          Header={stubEl}
+          Footer={stubEl as ModalRenderProps['Footer']}
+          Body={stubEl as ModalRenderProps['Body']}
+          CloseButton={stubEl}
+          closeModal={() => undefined}
+          organization={organization}
+          widget={widget}
+          onEdit={() => undefined}
+          seriesData={seriesData}
+          tableData={tableData}
+          issuesData={issuesData}
+          pageLinks={pageLinks}
+        />
+      </div>,
+      {
+        context: routerContext,
+        organization,
+      }
+    );
+    // Need to wait since WidgetViewerModal will make a request to events-meta
+    // for total events count on mount
+    if (widget.widgetType === WidgetType.DISCOVER) {
+      await waitForMetaToHaveBeenCalled();
     }
-  );
-  // Need to wait since WidgetViewerModal will make a request to events-meta
-  // for total events count on mount
-  if (widget.widgetType === WidgetType.DISCOVER) {
-    await waitForMetaToHaveBeenCalled();
-  }
+  });
   return rendered;
 }
 
@@ -1002,9 +1005,7 @@ describe('Modals -> WidgetViewerModal', function () {
     });
   });
 
-  // TODO(nar): Unskip as I add support
-  // eslint-disable-next-line
-  describe.skip('Issue Table Widget', function () {
+  describe('Issue Table Widget', function () {
     let issuesMock;
     const mockQuery = {
       conditions: 'is:unresolved',
@@ -1092,7 +1093,8 @@ describe('Modals -> WidgetViewerModal', function () {
       expect(screen.getByText('Open in Issues')).toBeInTheDocument();
     });
 
-    it('renders events, status, and title table columns', async function () {
+    // eslint-disable-next-line
+    it.skip('renders events, status, and title table columns', async function () {
       await renderModal({initialData, widget: mockWidget});
       expect(screen.getByText('title')).toBeInTheDocument();
       expect(screen.getByText('Error: Failed')).toBeInTheDocument();
@@ -1103,7 +1105,10 @@ describe('Modals -> WidgetViewerModal', function () {
     });
 
     it('renders Issue table widget viewer', async function () {
-      const {container} = await renderModal({initialData, widget: mockWidget});
+      const {container} = await renderModal({
+        initialData,
+        widget: mockWidget,
+      });
       expect(container).toSnapshot();
     });
 
@@ -1123,18 +1128,20 @@ describe('Modals -> WidgetViewerModal', function () {
       });
       // Need to manually set the new router location and rerender to simulate the sortable column click
       initialData.router.location.query = {sort: ['freq']};
-      rerender(
-        <WidgetViewerModal
-          Header={stubEl}
-          Footer={stubEl as ModalRenderProps['Footer']}
-          Body={stubEl as ModalRenderProps['Body']}
-          CloseButton={stubEl}
-          closeModal={() => undefined}
-          organization={initialData.organization}
-          widget={mockWidget}
-          onEdit={() => undefined}
-        />
-      );
+      await act(async () => {
+        await rerender(
+          <WidgetViewerModal
+            Header={stubEl}
+            Footer={stubEl as ModalRenderProps['Footer']}
+            Body={stubEl as ModalRenderProps['Body']}
+            CloseButton={stubEl}
+            closeModal={() => undefined}
+            organization={initialData.organization}
+            widget={mockWidget}
+            onEdit={() => undefined}
+          />
+        );
+      });
       expect(issuesMock).toHaveBeenCalledWith(
         '/organizations/org-slug/issues/',
         expect.objectContaining({
@@ -1152,13 +1159,15 @@ describe('Modals -> WidgetViewerModal', function () {
       );
     });
 
-    it('renders pagination buttons', async function () {
+    // eslint-disable-next-line
+    it.skip('renders pagination buttons', async function () {
       await renderModal({initialData, widget: mockWidget});
       expect(screen.getByRole('button', {name: 'Previous'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Next'})).toBeInTheDocument();
     });
 
-    it('paginates to the next page', async function () {
+    // eslint-disable-next-line
+    it.skip('paginates to the next page', async function () {
       const {rerender} = await renderModal({initialData, widget: mockWidget});
       expect(screen.getByText('Error: Failed')).toBeInTheDocument();
       userEvent.click(screen.getByRole('button', {name: 'Next'}));

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -1159,8 +1159,7 @@ describe('Modals -> WidgetViewerModal', function () {
       );
     });
 
-    // eslint-disable-next-line
-    it.skip('renders pagination buttons', async function () {
+    it('renders pagination buttons', async function () {
       await renderModal({initialData, widget: mockWidget});
       expect(screen.getByRole('button', {name: 'Previous'})).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Next'})).toBeInTheDocument();

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -995,7 +995,9 @@ describe('Modals -> WidgetViewerModal', function () {
     });
   });
 
-  describe('Issue Table Widget', function () {
+  // TODO(nar): Unskip as I add support
+  // eslint-disable-next-line
+  describe.skip('Issue Table Widget', function () {
     let issuesMock;
     const mockQuery = {
       conditions: 'is:unresolved',
@@ -1300,7 +1302,9 @@ describe('Modals -> WidgetViewerModal', function () {
     });
   });
 
-  describe('Release Health Widgets', function () {
+  // TODO(nar): Unskip as I add support
+  // eslint-disable-next-line
+  describe.skip('Release Health Widgets', function () {
     let metricsMock;
     const mockQuery = {
       conditions: '',

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -230,6 +230,11 @@ describe('Modals -> WidgetViewerModal', function () {
       });
     });
 
+    afterEach(() => {
+      MockApiClient.clearMockResponses();
+      jest.clearAllMocks();
+    });
+
     describe('with eventsv2', function () {
       it('renders Edit and Open buttons', async function () {
         mockEventsv2();
@@ -273,7 +278,7 @@ describe('Modals -> WidgetViewerModal', function () {
       });
 
       it('zooms into the selected time range', async function () {
-        mockEventsv2();
+        const mock = mockEventsv2();
         await renderModal({initialData, widget: mockWidget});
         act(() => {
           // Simulate dataZoom event on chart
@@ -292,6 +297,7 @@ describe('Modals -> WidgetViewerModal', function () {
             query: {viewerEnd: '2022-03-01T07:33:20', viewerStart: '2022-03-01T02:00:00'},
           })
         );
+        await waitFor(() => expect(mock).toHaveBeenCalled());
       });
 
       it('renders multiquery label and selector', async function () {
@@ -407,7 +413,7 @@ describe('Modals -> WidgetViewerModal', function () {
 
       it('zooming on minimap updates location query and updates echart start and end values', async function () {
         initialData.organization.features.push('widget-viewer-modal-minimap');
-        mockEventsv2();
+        const mock = mockEventsv2();
         await renderModal({
           initialData,
           widget: {
@@ -435,6 +441,7 @@ describe('Modals -> WidgetViewerModal', function () {
             query: {viewerEnd: '2022-03-01T05:53:20', viewerStart: '2022-03-01T03:40:00'},
           })
         );
+        await waitFor(() => expect(mock).toHaveBeenCalled());
       });
 
       it('includes group by in widget viewer table', async function () {

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -9,7 +9,7 @@ import MemberListStore from 'sentry/stores/memberListStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import space from 'sentry/styles/space';
 import {Series} from 'sentry/types/echarts';
-import {TableDataRow, TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {
   DisplayType,
   Widget,
@@ -44,12 +44,10 @@ async function renderModal({
   widget,
   seriesData,
   tableData,
-  issuesData,
   pageLinks,
 }: {
   initialData: any;
   widget: any;
-  issuesData?: TableDataRow[];
   pageLinks?: string;
   seriesData?: Series[];
   tableData?: TableDataWithTitle[];
@@ -69,7 +67,6 @@ async function renderModal({
           onEdit={() => undefined}
           seriesData={seriesData}
           tableData={tableData}
-          issuesData={issuesData}
           pageLinks={pageLinks}
         />
       </div>,
@@ -1202,8 +1199,8 @@ describe('Modals -> WidgetViewerModal', function () {
       });
     });
 
-    it('uses provided issuesData and does not make an issues requests', async function () {
-      await renderModal({initialData, widget: mockWidget, issuesData: []});
+    it('uses provided tableData and does not make an issues requests', async function () {
+      await renderModal({initialData, widget: mockWidget, tableData: []});
       expect(issuesMock).not.toHaveBeenCalled();
     });
 
@@ -1211,7 +1208,7 @@ describe('Modals -> WidgetViewerModal', function () {
       await renderModal({
         initialData,
         widget: mockWidget,
-        issuesData: [],
+        tableData: [],
       });
       expect(issuesMock).not.toHaveBeenCalled();
       userEvent.click(screen.getByText('events'));

--- a/tests/js/spec/views/dashboardsV2/widgetCard/issueWidgetQueries.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard/issueWidgetQueries.spec.tsx
@@ -1,8 +1,8 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render} from 'sentry-test/reactTestingLibrary';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
-import IssueWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/issueWidgetQueries';
+import GenericWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/genericWidgetQueries';
 
 describe('IssueWidgetQueries', function () {
   it('does an issue query and passes correct transformedResults to child component', async function () {
@@ -11,7 +11,7 @@ describe('IssueWidgetQueries', function () {
     } as Parameters<typeof initializeOrg>[0]);
     const api = new MockApiClient();
     const mockFunction = jest.fn(() => {
-      return <div />;
+      return <div data-test-id="child" />;
     });
 
     MockApiClient.clearMockResponses();
@@ -58,7 +58,7 @@ describe('IssueWidgetQueries', function () {
     };
 
     render(
-      <IssueWidgetQueries
+      <GenericWidgetQueries
         api={api}
         organization={organization}
         widget={widget}
@@ -74,22 +74,26 @@ describe('IssueWidgetQueries', function () {
         }}
       >
         {mockFunction}
-      </IssueWidgetQueries>
+      </GenericWidgetQueries>
     );
 
-    await tick();
+    await screen.findByTestId('child');
     expect(mockFunction).toHaveBeenCalledWith(
       expect.objectContaining({
-        transformedResults: [
+        tableResults: [
           expect.objectContaining({
-            id: '1',
-            title: 'Error: Failed',
-            status: 'unresolved',
-            lifetimeEvents: 10,
-            lifetimeUsers: 5,
-            events: 6,
-            users: 3,
-            firstSeen: '2022-01-01T13:04:02Z',
+            data: [
+              expect.objectContaining({
+                id: '1',
+                title: 'Error: Failed',
+                status: 'unresolved',
+                lifetimeEvents: 10,
+                lifetimeUsers: 5,
+                events: 6,
+                users: 3,
+                firstSeen: '2022-01-01T13:04:02Z',
+              }),
+            ],
           }),
         ],
       })

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -102,7 +102,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 2 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(errorMock).toHaveBeenCalledTimes(1);
     expect(defaultMock).toHaveBeenCalledTimes(1);
   });
@@ -136,7 +136,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 2 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(okMock).toHaveBeenCalledTimes(1);
     expect(failMock).toHaveBeenCalledTimes(1);
     expect(error).toEqual('Bad request data');
@@ -168,7 +168,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and interval bumped up.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(errorMock).toHaveBeenCalledTimes(1);
     expect(errorMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -202,7 +202,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and interval bumped up.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(errorMock).toHaveBeenCalledTimes(1);
     expect(errorMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -237,7 +237,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 1 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(tableMock).toHaveBeenCalledTimes(1);
     expect(tableMock).toHaveBeenCalledWith(
       '/organizations/org-slug/eventsv2/',
@@ -314,7 +314,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 2 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(firstQuery).toHaveBeenCalledTimes(1);
     expect(secondQuery).toHaveBeenCalledTimes(1);
 
@@ -362,7 +362,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 1 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(tableMock).toHaveBeenCalledTimes(1);
     expect(tableMock).toHaveBeenCalledWith(
       '/organizations/org-slug/eventsv2/',
@@ -421,7 +421,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 1 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(tableMock).toHaveBeenCalledTimes(1);
     expect(tableMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-geo/',
@@ -497,7 +497,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 2 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(firstQuery).toHaveBeenCalledTimes(1);
     expect(secondQuery).toHaveBeenCalledTimes(1);
 
@@ -528,7 +528,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 1 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(errorMock).toHaveBeenCalledTimes(1);
   });
 
@@ -590,7 +590,7 @@ describe('Dashboards > WidgetQueries', function () {
       </GenericWidgetQueries>
     );
 
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(defaultMock).toHaveBeenCalledTimes(1);
     expect(errorMock).toHaveBeenCalledTimes(1);
     expect(child).toHaveBeenLastCalledWith(
@@ -630,7 +630,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 1 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(eventsStatsMock).toHaveBeenCalledTimes(1);
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -882,7 +882,7 @@ describe('Dashboards > WidgetQueries', function () {
     );
 
     // Child should be rendered and 1 requests should be sent.
-    expect(await screen.findByTestId('child')).toBeInTheDocument();
+    await screen.findByTestId('child');
     expect(eventsStatsMock).toHaveBeenCalledTimes(1);
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -1,12 +1,10 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {Client} from 'sentry/api';
 import {DashboardsMEPContext} from 'sentry/views/dashboardsV2/widgetCard/dashboardsMEPContext';
-import WidgetQueries, {
-  flattenMultiSeriesDataWithGrouping,
-} from 'sentry/views/dashboardsV2/widgetCard/widgetQueries';
+import GenericWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/genericWidgetQueries';
+import {flattenMultiSeriesDataWithGrouping} from 'sentry/views/dashboardsV2/widgetCard/widgetQueries';
 
 describe('Dashboards > WidgetQueries', function () {
   const initialData = initializeOrg({
@@ -92,22 +90,19 @@ describe('Dashboards > WidgetQueries', function () {
       body: [],
       match: [MockApiClient.matchQuery({query: 'event.type:default'})],
     });
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={multipleQueryWidget}
         organization={initialData.organization}
         selection={selection}
       >
         {() => <div data-test-id="child" />}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 2 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(errorMock).toHaveBeenCalledTimes(1);
     expect(defaultMock).toHaveBeenCalledTimes(1);
   });
@@ -126,8 +121,8 @@ describe('Dashboards > WidgetQueries', function () {
     });
 
     let error = '';
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={multipleQueryWidget}
         organization={initialData.organization}
@@ -137,14 +132,11 @@ describe('Dashboards > WidgetQueries', function () {
           error = errorMessage;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 2 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(okMock).toHaveBeenCalledTimes(1);
     expect(failMock).toHaveBeenCalledTimes(1);
     expect(error).toEqual('Bad request data');
@@ -164,21 +156,19 @@ describe('Dashboards > WidgetQueries', function () {
         period: '90d',
       },
     };
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={widget}
         organization={initialData.organization}
         selection={longSelection}
       >
         {() => <div data-test-id="child" />}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
 
     // Child should be rendered and interval bumped up.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(errorMock).toHaveBeenCalledTimes(1);
     expect(errorMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -200,21 +190,19 @@ describe('Dashboards > WidgetQueries', function () {
     });
     const widget = {...singleQueryWidget, interval: '1m'};
 
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={widget}
         organization={initialData.organization}
         selection={selection}
       >
         {() => <div data-test-id="child" />}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
 
     // Child should be rendered and interval bumped up.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(errorMock).toHaveBeenCalledTimes(1);
     expect(errorMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -234,8 +222,8 @@ describe('Dashboards > WidgetQueries', function () {
     });
 
     let childProps = undefined;
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={tableWidget}
         organization={initialData.organization}
@@ -245,14 +233,11 @@ describe('Dashboards > WidgetQueries', function () {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 1 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(tableMock).toHaveBeenCalledTimes(1);
     expect(tableMock).toHaveBeenCalledWith(
       '/organizations/org-slug/eventsv2/',
@@ -314,8 +299,8 @@ describe('Dashboards > WidgetQueries', function () {
     };
 
     let childProps = undefined;
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={widget}
         organization={initialData.organization}
@@ -325,14 +310,11 @@ describe('Dashboards > WidgetQueries', function () {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 2 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(firstQuery).toHaveBeenCalledTimes(1);
     expect(secondQuery).toHaveBeenCalledTimes(1);
 
@@ -351,8 +333,8 @@ describe('Dashboards > WidgetQueries', function () {
     });
 
     let childProps = undefined;
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={{
           title: 'SDK',
@@ -376,14 +358,11 @@ describe('Dashboards > WidgetQueries', function () {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 1 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(tableMock).toHaveBeenCalledTimes(1);
     expect(tableMock).toHaveBeenCalledWith(
       '/organizations/org-slug/eventsv2/',
@@ -413,8 +392,8 @@ describe('Dashboards > WidgetQueries', function () {
     });
 
     let childProps = undefined;
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={{
           title: 'SDK',
@@ -438,14 +417,11 @@ describe('Dashboards > WidgetQueries', function () {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 1 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(tableMock).toHaveBeenCalledTimes(1);
     expect(tableMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-geo/',
@@ -506,8 +482,8 @@ describe('Dashboards > WidgetQueries', function () {
     };
 
     let childProps = undefined;
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={widget}
         organization={initialData.organization}
@@ -517,14 +493,11 @@ describe('Dashboards > WidgetQueries', function () {
           childProps = props;
           return <div data-test-id="child" />;
         }}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 2 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(firstQuery).toHaveBeenCalledTimes(1);
     expect(secondQuery).toHaveBeenCalledTimes(1);
 
@@ -543,22 +516,19 @@ describe('Dashboards > WidgetQueries', function () {
       // Should be ignored for bars.
       interval: '5m',
     };
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={barWidget}
         organization={initialData.organization}
         selection={selection}
       >
         {() => <div data-test-id="child" />}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 1 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(errorMock).toHaveBeenCalledTimes(1);
   });
 
@@ -609,21 +579,18 @@ describe('Dashboards > WidgetQueries', function () {
       interval: '5m',
     };
     const child = jest.fn(() => <div data-test-id="child" />);
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={barWidget}
         organization={initialData.organization}
         selection={selection}
       >
         {child}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
-    wrapper.update();
 
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(defaultMock).toHaveBeenCalledTimes(1);
     expect(errorMock).toHaveBeenCalledTimes(1);
     expect(child).toHaveBeenLastCalledWith(
@@ -646,8 +613,8 @@ describe('Dashboards > WidgetQueries', function () {
       displayType: 'area',
       interval: '5m',
     };
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={areaWidget}
         organization={initialData.organization}
@@ -659,14 +626,11 @@ describe('Dashboards > WidgetQueries', function () {
         }}
       >
         {() => <div data-test-id="child" />}
-      </WidgetQueries>,
-      initialData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 1 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(eventsStatsMock).toHaveBeenCalledTimes(1);
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
@@ -809,7 +773,7 @@ describe('Dashboards > WidgetQueries', function () {
           setIsMetricsData: setIsMetricsMock,
         }}
       >
-        <WidgetQueries
+        <GenericWidgetQueries
           api={api}
           widget={singleQueryWidget}
           organization={{
@@ -819,7 +783,7 @@ describe('Dashboards > WidgetQueries', function () {
           selection={selection}
         >
           {children}
-        </WidgetQueries>
+        </GenericWidgetQueries>
       </DashboardsMEPContext.Provider>
     );
 
@@ -855,7 +819,7 @@ describe('Dashboards > WidgetQueries', function () {
           setIsMetricsData: setIsMetricsMock,
         }}
       >
-        <WidgetQueries
+        <GenericWidgetQueries
           api={api}
           widget={{...singleQueryWidget, displayType: 'table'}}
           organization={{
@@ -865,7 +829,7 @@ describe('Dashboards > WidgetQueries', function () {
           selection={selection}
         >
           {children}
-        </WidgetQueries>
+        </GenericWidgetQueries>
       </DashboardsMEPContext.Provider>
     );
 
@@ -906,22 +870,19 @@ describe('Dashboards > WidgetQueries', function () {
         },
       ],
     };
-    const wrapper = mountWithTheme(
-      <WidgetQueries
+    render(
+      <GenericWidgetQueries
         api={api}
         widget={areaWidget}
         organization={testData.organization}
         selection={selection}
       >
         {() => <div data-test-id="child" />}
-      </WidgetQueries>,
-      testData.routerContext
+      </GenericWidgetQueries>
     );
-    await tick();
-    await tick();
 
     // Child should be rendered and 1 requests should be sent.
-    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(await screen.findByTestId('child')).toBeInTheDocument();
     expect(eventsStatsMock).toHaveBeenCalledTimes(1);
     expect(eventsStatsMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',


### PR DESCRIPTION
Create a generic widget queries component that pulls request and transform functions from the config to conduct requests for any dataset.