### PR TITLE
fix(release-notifications): retrieve the release version from event instead of group

### DIFF
--- a/src/sentry/rules/conditions/active_release.py
+++ b/src/sentry/rules/conditions/active_release.py
@@ -31,12 +31,6 @@ class ActiveReleaseEventCondition(EventCondition):
         if not event.group or not event.project:
             return False
 
-        # last_release_version: Optional[str] = event.group.get_last_release()
-        # if not last_release_version:
-        #     return False
-        #
-        # last_release: Release = Release.get(project=event.project, version=last_release_version)
-
         # XXX(gilbert):
         # adapted from LatestReleaseFilter
         # need to add caching later on

--- a/src/sentry/rules/conditions/active_release.py
+++ b/src/sentry/rules/conditions/active_release.py
@@ -101,7 +101,7 @@ class ActiveReleaseEventCondition(EventCondition):
         return False
 
     def passes(self, event: Event, state: EventState) -> bool:
-        if self.rule and self.rule.environment_id is None:  # type: ignore
+        if self.rule and self.rule.environment_id is None:
             return (state.is_new or state.is_regression) and self.is_in_active_release(event)
         else:
             return (

--- a/tests/sentry/rules/conditions/test_active_release_event.py
+++ b/tests/sentry/rules/conditions/test_active_release_event.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timedelta
+
+from django.utils import timezone
+
 from sentry.eventstore import Filter
 from sentry.eventstore.snuba import SnubaEventStorage
-from sentry.models import Group, Rule
+from sentry.models import Group, Release, Rule
 from sentry.rules.conditions.active_release import ActiveReleaseEventCondition
 from sentry.testutils import RuleTestCase, SnubaTestCase
 
@@ -13,16 +17,62 @@ class ActiveReleaseEventConditionTest(SnubaTestCase, RuleTestCase):
         self.eventstore = SnubaEventStorage()
 
     def test_applies_correctly(self):
-        rule = self.get_rule(rule=Rule(environment_id=1))
+        rule = self.get_rule()
 
         self.assertDoesNotPass(rule, self.event, is_new=True)
 
+    def test_release_date_released(self):
+        event = self.get_event()
+        oldRelease = Release.objects.create(
+            organization_id=self.organization.id,
+            version="1",
+            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
+            date_released=datetime(2020, 9, 1, 3, 8, 24, 880386),
+        )
+        oldRelease.add_project(self.project)
+
+        newRelease = Release.objects.create(
+            organization_id=self.organization.id,
+            version="2",
+            date_added=timezone.now() - timedelta(minutes=30),
+            date_released=timezone.now() - timedelta(minutes=30),
+        )
+        newRelease.add_project(self.project)
+
+        event.data["tags"] = (("release", newRelease.version),)
+        rule = self.get_rule()
+        self.assertPasses(rule, event)
+
+    def test_deployed(self):
+        pass
+
+    def test_release_project_env(self):
+        pass
+
+    def test_release_env(self):
+        pass
+
     # XXX(gilbert): delete this later
     def test_event_group_last_release_version(self):
+        oldRelease = Release.objects.create(
+            organization_id=self.organization.id,
+            version="1",
+            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
+        )
+        oldRelease.add_project(self.project)
+
+        newRelease = Release.objects.create(
+            organization_id=self.organization.id,
+            version="2",
+            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
+        )
+        newRelease.add_project(self.project)
+
         evt = self.store_event(
             data={
                 "event_id": "a" * 32,
                 "message": "\u3053\u3093\u306b\u3061\u306f",
+                "tags": (("release", newRelease.version),),
             },
             project_id=self.project.id,
         )
@@ -30,6 +80,7 @@ class ActiveReleaseEventConditionTest(SnubaTestCase, RuleTestCase):
             data={
                 "event_id": "b" * 32,
                 "message": "\u3053\u3093\u306b\u3061\u306f",
+                "tags": (("release", newRelease.version),),
             },
             project_id=self.project.id,
         )
@@ -48,6 +99,9 @@ class ActiveReleaseEventConditionTest(SnubaTestCase, RuleTestCase):
             Group.objects.filter(id__in=(evt.group_id, evt2.group_id)).values_list("id", flat=True)
         ) == [evt.group_id]
 
-        rule = self.get_rule(rule=Rule(environment_id=1))
+        # assert GroupRelease.objects.all().count() == 1
+        rule = self.get_rule(rule=Rule(environment_id=self.environment.id))
 
-        self.assertDoesNotPass(rule, evt, is_new=True)
+        self.assertDoesNotPass(rule, evt)
+
+        # self.assertDoesNotPass(rule, evt, is_new=True)


### PR DESCRIPTION
Adapted logic to retrieve the latest release from the event instead of using the `Group.get_last_release` logic. 

I suspect this may be blocking our experiment from evaluating correctly.

Gonna add more test coverage when I have the time.