### PR TITLE
fix(notifications): fix bug where we considered users with only Slack enabled

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -94,7 +94,7 @@ class MailAdapter:
         notifications for the provided project.
         """
         recipients_by_provider = NotificationSetting.objects.get_notification_recipients(project)
-        return recipients_by_provider.get(ExternalProviders.EMAIL)
+        return recipients_by_provider.get(ExternalProviders.EMAIL, [])
 
     def get_sendable_user_ids(self, project):
         users = self.get_sendable_user_objects(project)

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -17,6 +17,7 @@ from sentry.notifications.notifications.user_report import UserReportNotificatio
 from sentry.notifications.types import ActionTargetType
 from sentry.plugins.base.structs import Notification
 from sentry.tasks.digests import deliver_digest
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -93,7 +94,7 @@ class MailAdapter:
         notifications for the provided project.
         """
         recipients_by_provider = NotificationSetting.objects.get_notification_recipients(project)
-        return {user for users in recipients_by_provider.values() for user in users}
+        return recipients_by_provider.get(ExternalProviders.EMAIL)
 
     def get_sendable_user_ids(self, project):
         users = self.get_sendable_user_objects(project)

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -119,6 +119,14 @@ class MailAdapterGetSendableUsersTest(BaseMailAdapterTest):
             user=user4,
         )
 
+        # add a specific setting for a different provider
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.SLACK,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.ALWAYS,
+            user=user4,
+        )
+
         assert user4 not in self.adapter.get_sendable_user_objects(project)
 
         NotificationSetting.objects.remove_settings(


### PR DESCRIPTION
This fixes a bug where we didn't consider the provider when getting a list of users to email