### PR TITLE
feat(profiling): flamegraph pinch to zoom

### DIFF
--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -573,7 +573,8 @@ function FlamegraphZoomView({
       // rendered on the flamegraph are removed from the flamegraphView
       setConfigSpaceCursor(null);
 
-      if (evt.metaKey) {
+      // pinch to zoom is recognized as `ctrlKey + wheelEvent`
+      if (evt.metaKey || evt.ctrlKey) {
         zoom(evt);
         setLastInteraction('zoom');
       } else {

--- a/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
@@ -398,7 +398,7 @@ function FlamegraphZoomViewMinimap({
       // rendered on the flamegraph are removed from the view
       setConfigSpaceCursor(null);
 
-      if (evt.metaKey) {
+      if (evt.metaKey || evt.ctrlKey) {
         onMinimapZoom(evt);
         setLastInteraction('zoom');
       } else {


### PR DESCRIPTION
This change adds pinch to zoom support for mice that support multi-touch gestures. 

It technically should fix zoom behaviour for windows devices, since `metaKey` maps to the "windows" key and is not the standard key for these types of key combos. Generally speaking, on windows `ctrl` is analogous for `cmd`... _most of the time_.

Note: this does not add GestureEvent support as that is a Safari only spec. It also does not address touch events.



https://user-images.githubusercontent.com/7349258/175077521-a3fed1ee-2edf-40b1-a793-e0dd2f325727.mov





for future reference:
https://developer.mozilla.org/en-US/docs/Web/API/WheelEvent
![image](https://user-images.githubusercontent.com/7349258/175096106-cf54f999-ceec-4075-906e-e32826bb8cb8.png)
