### PR TITLE
fix(dashboards): Fix sortby on RH widgets and project slugs on search

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -53,7 +53,15 @@ export function ReleaseSearchBar({
       return Promise.resolve(SESSION_STATUSES);
     }
     const projectIdStrings = projectIds?.map(String);
-    return fetchTagValues(api, orgSlug, tag.key, searchQuery, projectIdStrings).then(
+    return fetchTagValues(
+      api,
+      orgSlug,
+      tag.key,
+      searchQuery,
+      projectIdStrings,
+      undefined,
+      true
+    ).then(
       tagValues => (tagValues as TagValue[]).map(({value}) => value),
       () => {
         throw new Error('Unable to fetch tag values');

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
@@ -107,7 +107,7 @@ export function SortByStep({
     if (['count_healthy', 'count_errored'].includes(option.value.meta.name)) {
       return false;
     }
-    if (option.value.kind === FieldValueKind.TAG) {
+    if (option.value.kind === FieldValueKind.FIELD) {
       // Only allow sorting by release tag
       return (
         columnSet.has(option.value.meta.name) && option.value.meta.name === 'release'

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2571,6 +2571,40 @@ describe('WidgetBuilder', function () {
         expect(screen.getByRole('textbox', {name: 'Sort by'})).toBeDisabled();
       });
 
+      it('does not allow sort on tags except release', async function () {
+        renderTestComponent({
+          orgFeatures: releaseHealthFeatureFlags,
+        });
+
+        expect(
+          await screen.findByText('Releases (sessions, crash rates)')
+        ).toBeInTheDocument();
+
+        userEvent.click(screen.getByLabelText(/releases/i));
+
+        expect(screen.getByText('High to low')).toBeEnabled();
+        expect(screen.getByText('crash_free_rate(session)')).toBeInTheDocument();
+
+        userEvent.click(screen.getByLabelText('Add a Column'));
+        await selectEvent.select(screen.getByText('(Required)'), 'release');
+
+        userEvent.click(screen.getByLabelText('Add a Column'));
+        await selectEvent.select(screen.getByText('(Required)'), 'environment');
+
+        expect(await screen.findByText('Sort by a column')).toBeInTheDocument();
+
+        // Selector "sortDirection"
+        expect(screen.getByText('High to low')).toBeInTheDocument();
+
+        // Selector "sortBy"
+        userEvent.click(screen.getAllByText('crash_free_rate(session)')[1]);
+
+        // release exists in sort by selector
+        expect(screen.getAllByText('release')).toHaveLength(3);
+        // environment does not exist in sort by selector
+        expect(screen.getAllByText('environment')).toHaveLength(2);
+      });
+
       it('makes the appropriate sessions call', async function () {
         renderTestComponent({
           orgFeatures: releaseHealthFeatureFlags,


### PR DESCRIPTION
There was a bug where tags like environment, project and session.status
were options on the sortby but the metrics endpoint doesn't
support alpha numeric sort so we just filter them out.
Also fixing autocomplete on project to return slugs instead of
project ids by passing the `includeTransactions` flag to
fetch tag values.