### PR TITLE
feat(ci): 20% rollout of new diff library for visual snapshots

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -283,7 +283,7 @@ jobs:
       - name: Determine snapshot version
         run: |
           random=$(( ( RANDOM % 10 )  + 1 ));
-          echo "::set-output name=ref::$([[ $random -ge 5 ]] && echo "pixelmatch" || echo "odiff")"
+          echo "::set-output name=ref::$([[ $random -ge 2 ]] && echo "pixelmatch" || echo "odiff")"
 
       - name: Diff snapshots
         id: visual-snapshots-diff-pixelmatch

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -281,6 +281,7 @@ jobs:
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
 
       - name: Determine snapshot version
+        id: snapshot_ref
         run: |
           random=$(( ( RANDOM % 10 )  + 1 ));
           echo "::set-output name=ref::$([[ $random -ge 2 ]] && echo "pixelmatch" || echo "odiff")"

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -290,7 +290,7 @@ jobs:
         uses: getsentry/action-visual-snapshot@main
         # Run this step only if there are acceptance related code changes
         # Forks are handled in visual-diff.yml
-        if: env.snapshot_ref == 'main' && needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
+        if: steps.snapshot_ref.outputs.ref == 'pixelmatch' && needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -280,12 +280,28 @@ jobs:
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
 
+      - name: Determine snapshot version
+        run: |
+          random=$(( ( RANDOM % 10 )  + 1 ));
+          echo "snapshot_ref=$([[ $random -ge 5 ]] && echo "main" || echo "905b7e3a7fdd913189b9a35dcef51b6b927f9598")" >> $GITHUB_ENV;
+
       - name: Diff snapshots
-        id: visual-snapshots-diff
+        id: visual-snapshots-diff-pixelmatch
         uses: getsentry/action-visual-snapshot@main
         # Run this step only if there are acceptance related code changes
         # Forks are handled in visual-diff.yml
-        if: needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
+        if: env.snapshot_ref == 'main' && needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
+        with:
+          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
+          gcs-bucket: 'sentry-visual-snapshots'
+          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
+
+      - name: Diff snapshots
+        id: visual-snapshots-diff-odiff
+        uses: getsentry/action-visual-snapshot@905b7e3a7fdd913189b9a35dcef51b6b927f9598
+        # Run this step only if there are acceptance related code changes
+        # Forks are handled in visual-diff.yml
+        if: env.snapshot_ref == '905b7e3a7fdd913189b9a35dcef51b6b927f9598' && needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -283,7 +283,7 @@ jobs:
       - name: Determine snapshot version
         run: |
           random=$(( ( RANDOM % 10 )  + 1 ));
-          echo "snapshot_ref=$([[ $random -ge 5 ]] && echo "main" || echo "905b7e3a7fdd913189b9a35dcef51b6b927f9598")" >> $GITHUB_ENV;
+          echo "::set-output name=ref::$([[ $random -ge 5 ]] && echo "pixelmatch" || echo "odiff")"
 
       - name: Diff snapshots
         id: visual-snapshots-diff-pixelmatch

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -301,7 +301,7 @@ jobs:
         uses: getsentry/action-visual-snapshot@905b7e3a7fdd913189b9a35dcef51b6b927f9598
         # Run this step only if there are acceptance related code changes
         # Forks are handled in visual-diff.yml
-        if: env.snapshot_ref == '905b7e3a7fdd913189b9a35dcef51b6b927f9598' && needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
+        if: steps.snapshot_ref.outputs.ref == 'odiff' && needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'


### PR DESCRIPTION
Split CI runs between the new odiff and old pixelmatch run. Currently setup to run at 50/50 split, I may lower that. Allows us to gracefully introduce the new diffing and monitor for any errors.

Sadly, expressions do not work in `using` field so I had to duplicate the run and change the `if` condition