### PR TITLE
fix(tests) - use _indexer_record instead of indexer.record

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -128,7 +128,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
     def test_validate_include_meta_not_enabled_by_default(self):
         self.create_release(version="foo", project=self.project)
         for tag in ("release", "environment"):
-            indexer.record(self.project.organization_id, tag)
+            _indexer_record(self.project.organization_id, tag)
         response = self.get_success_response(
             self.project.organization.slug,
             project=self.project.id,


### PR DESCRIPTION
fix test that was added after I branched off and made a bunch of changes to this file for my feature

See https://github.com/getsentry/sentry/commit/6c83d7625e3f52969920c13de456c637e5fe9ff2#diff-dc7f016244b4356cc349cb294385c130f93722ad0af690046c61107fe0d15b07 for what those changes look like