### PR TITLE
Revert "ref(perf): Remove perf wrapper from transactions table"

### DIFF
--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -18,6 +18,7 @@ import {
   fieldAlignment,
   getAggregateAlias,
 } from 'sentry/utils/discover/fields';
+import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import CellAction, {Actions} from 'sentry/views/eventsV2/table/cellAction';
 import {TableColumn} from 'sentry/views/eventsV2/table/types';
 import {GridCell, GridCellNumber} from 'sentry/views/performance/styles';
@@ -205,17 +206,19 @@ class TransactionsTable extends PureComponent<Props> {
     const loader = <LoadingIndicator style={{margin: '70px auto'}} />;
 
     return (
-      <PanelTable
-        data-test-id="transactions-table"
-        isEmpty={!hasResults}
-        emptyMessage={t('No transactions found')}
-        headers={this.renderHeader()}
-        isLoading={isLoading}
-        disablePadding
-        loader={loader}
-      >
-        {this.renderResults()}
-      </PanelTable>
+      <VisuallyCompleteWithData id="TransactionsTable" hasData={hasResults}>
+        <PanelTable
+          data-test-id="transactions-table"
+          isEmpty={!hasResults}
+          emptyMessage={t('No transactions found')}
+          headers={this.renderHeader()}
+          isLoading={isLoading}
+          disablePadding
+          loader={loader}
+        >
+          {this.renderResults()}
+        </PanelTable>
+      </VisuallyCompleteWithData>
     );
   }
 }


### PR DESCRIPTION
### Summary

Putting the perf wrapper back around the transactions table since we found LCP was dropped due to another reason and this includes long task instrumentation for perf pages.