### PR TITLE
fix(metrics): fix datadog/metricsbackend tag

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -573,7 +573,7 @@ def metrics_streaming_consumer(**options):
     signal.signal(signal.SIGINT, handler)
     signal.signal(signal.SIGTERM, handler)
 
-    with global_tags(tags={"pipeline": ingest_config.internal_metrics_tag}, _all_threads=True):
+    with global_tags(_all_threads=True, pipeline=ingest_config.internal_metrics_tag):
         streamer.run()
 
 


### PR DESCRIPTION
The old code serialized this tag wrong: https://app.datadoghq.com/notebook/2735773/oliver-jun-22-2022-11-00

Pass with kwargs instead like other calls