### PR TITLE
feat(dev): Fix `webpack-dev-server` https deprecation

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -541,8 +541,8 @@ if (
 if (IS_UI_DEV_ONLY) {
   // Try and load certificates from mkcert if available. Use $ yarn mkcert-localhost
   const certPath = path.join(__dirname, 'config');
-  const https = !fs.existsSync(path.join(certPath, 'localhost.pem'))
-    ? true
+  const httpsOptions = !fs.existsSync(path.join(certPath, 'localhost.pem'))
+    ? {}
     : {
         key: fs.readFileSync(path.join(certPath, 'localhost-key.pem')),
         cert: fs.readFileSync(path.join(certPath, 'localhost.pem')),
@@ -551,7 +551,10 @@ if (IS_UI_DEV_ONLY) {
   appConfig.devServer = {
     ...appConfig.devServer,
     compress: true,
-    https,
+    server: {
+      type: 'https',
+      options: httpsOptions,
+    },
     static: {
       publicPath: '/_assets/',
     },


### PR DESCRIPTION
This fixes a `webpack-dev-server` deprecation of the `devServer.https` option. https://webpack.js.org/configuration/dev-server/#devserverhttps

It is replaced with [`server`](https://webpack.js.org/configuration/dev-server/#devserverserver)
