### PR TITLE
feat(multi-region): Update org slug regex such that it's compatible with customer domains

### DIFF
--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -123,7 +123,7 @@ DEFERRED = object()
 
 class OrganizationSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=64)
-    slug = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50)
+    slug = serializers.RegexField(r"^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$", max_length=50)
     accountRateLimit = EmptyIntegerField(
         min_value=0, max_value=1000000, required=False, allow_null=True
     )

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -214,6 +214,10 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         self.get_error_response(self.organization.slug, slug=" i have whitespace ", status_code=400)
         self.get_error_response(self.organization.slug, slug="foo-bar ", status_code=400)
         self.get_error_response(self.organization.slug, slug="bird-company!", status_code=400)
+        self.get_error_response(self.organization.slug, slug="downtown_canada", status_code=400)
+        self.get_error_response(self.organization.slug, slug="canada-", status_code=400)
+        self.get_error_response(self.organization.slug, slug="-canada", status_code=400)
+        self.get_error_response(self.organization.slug, slug="----", status_code=400)
 
     def test_upload_avatar(self):
         data = {"avatarType": "upload", "avatar": b64encode(self.load_fixture("avatar.jpg"))}

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -210,7 +210,13 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         illegal_slug = list(RESERVED_ORGANIZATION_SLUGS)[0]
         self.get_error_response(self.organization.slug, slug=illegal_slug, status_code=400)
 
-    def test_invalid_slug(self):
+    def test_valid_slugs(self):
+        valid_slugs = ["santry", "downtown-canada", "1234", "SaNtRy"]
+        for slug in valid_slugs:
+            self.organization.refresh_from_db()
+            self.get_success_response(self.organization.slug, slug=slug)
+
+    def test_invalid_slugs(self):
         self.get_error_response(self.organization.slug, slug=" i have whitespace ", status_code=400)
         self.get_error_response(self.organization.slug, slug="foo-bar ", status_code=400)
         self.get_error_response(self.organization.slug, slug="bird-company!", status_code=400)


### PR DESCRIPTION
I'm updating the org slug regex with restrictions such that updated or new org slugs are compatible as a customer sub-domain.

These restrictions include:

- disallow underscores
- disallow hyphens at either the beginning or end of the org slug