### PR TITLE
fix(ui): Convert project alert settings to RTL, add id to range slider label

### DIFF
--- a/static/app/components/forms/controls/rangeSlider/index.tsx
+++ b/static/app/components/forms/controls/rangeSlider/index.tsx
@@ -1,4 +1,5 @@
 import {forwardRef as reactFowardRef, useEffect, useState} from 'react';
+import {useId} from '@react-aria/utils';
 
 import Input from 'sentry/components/forms/controls/input';
 import {t} from 'sentry/locale';
@@ -90,12 +91,14 @@ function RangeSlider({
   showLabel = true,
   ...props
 }: SliderProps) {
+  const elementId = useId();
   const [sliderValue, setSliderValue] = useState(
     allowedValues ? allowedValues.indexOf(Number(value || 0)) : value
   );
 
   useEffect(() => {
     updateSliderValue();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
   function updateSliderValue() {
@@ -171,13 +174,14 @@ function RangeSlider({
   return (
     <div className={className} ref={forwardRef}>
       {!showCustomInput && showLabel && (
-        <SliderLabel htmlFor={name}>
+        <SliderLabel htmlFor={elementId}>
           {formatLabel?.(actualValue) ?? displayValue}
         </SliderLabel>
       )}
       <SliderAndInputWrapper showCustomInput={showCustomInput}>
         <Slider
           type="range"
+          id={elementId}
           name={name}
           min={min}
           max={max}

--- a/tests/js/spec/views/settings/projectAlerts/settings.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/settings.spec.jsx
@@ -5,7 +5,14 @@ import Settings from 'sentry/views/settings/projectAlerts/settings';
 
 describe('ProjectAlertSettings', () => {
   const organization = TestStubs.Organization();
-  const project = TestStubs.Project();
+  // 12 minutes
+  const digestsMinDelay = 12 * 60;
+  // 55 minutes
+  const digestsMaxDelay = 55 * 60;
+  const project = TestStubs.Project({
+    digestsMinDelay,
+    digestsMaxDelay,
+  });
 
   beforeEach(() => {
     Client.addMockResponse({
@@ -32,7 +39,8 @@ describe('ProjectAlertSettings', () => {
     );
 
     expect(screen.getByPlaceholderText('e.g. $shortID - $title')).toBeInTheDocument();
-    expect(screen.getAllByRole('slider')).toHaveLength(2);
+    expect(screen.getByRole('slider', {name: '12 minutes'})).toBeInTheDocument();
+    expect(screen.getByRole('slider', {name: '55 minutes'})).toBeInTheDocument();
     expect(
       screen.getByText(
         "Oops! Looks like there aren't any available integrations installed."

--- a/tests/js/spec/views/settings/projectAlerts/settings.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/settings.spec.jsx
@@ -1,17 +1,13 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
-import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Client} from 'sentry/api';
 import Settings from 'sentry/views/settings/projectAlerts/settings';
 
-describe('ProjectAlertSettings', function () {
-  let organization;
-  let project;
-  let routerContext;
+describe('ProjectAlertSettings', () => {
+  const organization = TestStubs.Organization();
+  const project = TestStubs.Project();
 
-  beforeEach(function () {
-    ({organization, project, routerContext} = initializeOrg());
-
+  beforeEach(() => {
     Client.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/`,
       method: 'GET',
@@ -25,20 +21,22 @@ describe('ProjectAlertSettings', function () {
     });
   });
 
-  it('renders', function () {
-    const wrapper = mountWithTheme(
+  it('renders', () => {
+    render(
       <Settings
         canEditRule
         params={{orgId: organization.slug, projectId: project.slug}}
         organization={organization}
         routes={[]}
-      />,
-      routerContext
+      />
     );
 
-    expect(wrapper.find('Input[name="subjectTemplate"]')).toHaveLength(1);
-    expect(wrapper.find('RangeSlider[name="digestsMinDelay"]')).toHaveLength(1);
-    expect(wrapper.find('RangeSlider[name="digestsMaxDelay"]')).toHaveLength(1);
-    expect(wrapper.find('PluginList')).toHaveLength(1);
+    expect(screen.getByPlaceholderText('e.g. $shortID - $title')).toBeInTheDocument();
+    expect(screen.getAllByRole('slider')).toHaveLength(2);
+    expect(
+      screen.getByText(
+        "Oops! Looks like there aren't any available integrations installed."
+      )
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Converts project alert settings to RTL, uses react aria for the range selector htmlFor label. htmlFor expects a matching id attribute to find the label.