### PR TITLE
feat(alert): Use combined rules hit count headers

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -359,9 +359,11 @@ type Props = {
   alertOption?: keyof typeof AlertWizardAlertNames;
   hideIcon?: boolean;
   iconProps?: SVGIconProps;
-  /// Callback when the button is clicked.
-  /// This is different from `onClick` which always overrides the default
-  /// behavior when the button was clicked.
+  /**
+   * Callback when the button is clicked.
+   * This is different from `onClick` which always overrides the default
+   * behavior when the button was clicked.
+   */
   onEnter?: () => void;
   projectSlug?: string;
   referrer?: string;

--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -359,6 +359,10 @@ type Props = {
   alertOption?: keyof typeof AlertWizardAlertNames;
   hideIcon?: boolean;
   iconProps?: SVGIconProps;
+  /// Callback when the button is clicked.
+  /// This is different from `onClick` which always overrides the default
+  /// behavior when the button was clicked.
+  onEnter?: () => void;
   projectSlug?: string;
   referrer?: string;
   showPermissionGuide?: boolean;
@@ -375,6 +379,7 @@ const CreateAlertButton = withRouter(
     hideIcon,
     showPermissionGuide,
     alertOption,
+    onEnter,
     ...buttonProps
   }: Props) => {
     const api = useApi();
@@ -400,6 +405,7 @@ const CreateAlertButton = withRouter(
 
     function handleClickWithoutProject(event: React.MouseEvent) {
       event.preventDefault();
+      onEnter?.();
 
       navigateTo(createAlertUrl(':projectId'), router);
     }
@@ -438,7 +444,7 @@ const CreateAlertButton = withRouter(
             maxWidth: '270px',
           },
         }}
-        onClick={projectSlug ? undefined : handleClickWithoutProject}
+        onClick={projectSlug ? onEnter : handleClickWithoutProject}
         {...buttonProps}
       >
         {buttonProps.children ?? t('Create Alert')}

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -5,7 +5,6 @@ import type {Guide} from 'sentry/components/assistant/types';
 import type DateRange from 'sentry/components/organizations/timeRangeSelector/dateRange';
 import type SelectorItems from 'sentry/components/organizations/timeRangeSelector/selectorItems';
 import type SidebarItem from 'sentry/components/sidebar/sidebarItem';
-import {CombinedMetricIssueAlerts} from 'sentry/views/alerts/types';
 import type {NavigationItem, NavigationSection} from 'sentry/views/settings/types';
 
 import type {ExperimentKey} from './experiments';
@@ -97,7 +96,6 @@ type CodeOwnersCTAProps = {
 
 type AlertsHeaderProps = {
   organization: Organization;
-  ruleList: CombinedMetricIssueAlerts[] | null;
 };
 /**
  * Component wrapping hooks

--- a/static/app/views/alerts/list/rules/index.tsx
+++ b/static/app/views/alerts/list/rules/index.tsx
@@ -63,13 +63,15 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     ];
   }
 
-  onRequestSuccess({resp}) {
-    const issueRuleCount = resp.getResponseHeader('X-Sentry-Issue-Rule-Hits');
-    const alertRuleCount = resp.getResponseHeader('X-Sentry-Alert-Rule-Hits');
-    this.setState({
-      issueRuleCount: parseInt(issueRuleCount, 10),
-      alertRuleCount: parseInt(alertRuleCount, 10),
-    });
+  onRequestSuccess({stateKey, resp}) {
+    if (stateKey === 'ruleList') {
+      const issueRuleCount = resp.getResponseHeader('X-Sentry-Issue-Rule-Hits');
+      const alertRuleCount = resp.getResponseHeader('X-Sentry-Alert-Rule-Hits');
+      this.setState({
+        issueRuleCount: parseInt(issueRuleCount, 10),
+        alertRuleCount: parseInt(alertRuleCount, 10),
+      });
+    }
   }
 
   get projectsFromIncidents() {

--- a/static/app/views/alerts/list/rules/index.tsx
+++ b/static/app/views/alerts/list/rules/index.tsx
@@ -181,7 +181,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     return (
       <Layout.Body>
         <Layout.Main fullWidth>
-          {issueRuleCount !== undefined && issueRuleCount > 0 && alertRuleCount === 0 && (
+          {issueRuleCount !== undefined && issueRuleCount > 0 && alertRuleCount === 0 && !query.name && (
             <HookHeader organization={organization} />
           )}
           <FilterBar

--- a/static/app/views/alerts/list/rules/index.tsx
+++ b/static/app/views/alerts/list/rules/index.tsx
@@ -32,6 +32,8 @@ type Props = RouteComponentProps<{orgId: string}, {}> & {
 };
 
 type State = {
+  alertRuleCount?: number;
+  issueRuleCount?: number;
   ruleList?: CombinedMetricIssueAlerts[];
   teamFilterSearch?: string;
 };
@@ -59,6 +61,15 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
         },
       ],
     ];
+  }
+
+  onRequestSuccess({resp}) {
+    const issueRuleCount = resp.getResponseHeader('X-Sentry-Issue-Rule-Hits');
+    const alertRuleCount = resp.getResponseHeader('X-Sentry-Alert-Rule-Hits');
+    this.setState({
+      issueRuleCount: parseInt(issueRuleCount, 10),
+      alertRuleCount: parseInt(alertRuleCount, 10),
+    });
   }
 
   get projectsFromIncidents() {
@@ -141,7 +152,13 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
       organization,
       router,
     } = this.props;
-    const {loading, ruleList = [], ruleListPageLinks} = this.state;
+    const {
+      loading,
+      ruleList = [],
+      ruleListPageLinks,
+      issueRuleCount,
+      alertRuleCount,
+    } = this.state;
     const {query} = location;
     const hasEditAccess = organization.access.includes('alerts:write');
 
@@ -162,7 +179,9 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     return (
       <Layout.Body>
         <Layout.Main fullWidth>
-          <HookHeader organization={organization} ruleList={ruleList} />
+          {issueRuleCount !== undefined && issueRuleCount > 0 && alertRuleCount === 0 && (
+            <HookHeader organization={organization} />
+          )}
           <FilterBar
             location={location}
             onChangeFilter={this.handleChangeFilter}

--- a/static/app/views/alerts/list/rules/index.tsx
+++ b/static/app/views/alerts/list/rules/index.tsx
@@ -181,9 +181,10 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     return (
       <Layout.Body>
         <Layout.Main fullWidth>
-          {issueRuleCount !== undefined && issueRuleCount > 0 && alertRuleCount === 0 && !query.name && (
-            <HookHeader organization={organization} />
-          )}
+          {issueRuleCount !== undefined &&
+            issueRuleCount > 0 &&
+            alertRuleCount === 0 &&
+            !query.name && <HookHeader organization={organization} />}
           <FilterBar
             location={location}
             onChangeFilter={this.handleChangeFilter}
@@ -294,12 +295,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
 
     return (
       <SentryDocumentTitle title={t('Alerts')} orgSlug={orgId}>
-        <PageFiltersContainer
-          organization={organization}
-          showDateSelector={false}
-          showEnvironmentSelector={false}
-          hideGlobalHeader
-        >
+        <PageFiltersContainer>
           <AlertHeader
             organization={organization}
             router={router}


### PR DESCRIPTION
- Use the response headers added in #35929 to decide if we're going to show a banner or not.
- Adds `onEnter` callback to `CreateAlertButton`. 