### PR TITLE
fix(code mappings): Allow searching for repo outside of 100 results

### DIFF
--- a/static/app/components/repositoryProjectPathConfigForm.tsx
+++ b/static/app/components/repositoryProjectPathConfigForm.tsx
@@ -12,7 +12,10 @@ import {
   Repository,
   RepositoryProjectPathConfig,
 } from 'sentry/types';
-import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
+import {
+  sentryNameToOption,
+  trackIntegrationAnalytics,
+} from 'sentry/utils/integrationUtil';
 
 type Props = {
   integration: Integration;
@@ -38,7 +41,8 @@ export default class RepositoryProjectPathConfigForm extends Component<Props> {
   }
 
   get formFields(): Field[] {
-    const {projects, repos} = this.props;
+    const {projects, repos, organization} = this.props;
+    const orgSlug = organization.slug;
     const repoChoices = repos.map(({name, id}) => ({value: id, label: name}));
     return [
       {
@@ -50,11 +54,13 @@ export default class RepositoryProjectPathConfigForm extends Component<Props> {
       },
       {
         name: 'repositoryId',
-        type: 'select',
+        type: 'select_async',
         required: true,
         label: t('Repo'),
         placeholder: t('Choose repo'),
-        options: repoChoices,
+        url: `/organizations/${orgSlug}/repos/`,
+        defaultOptions: repoChoices,
+        onResults: results => results.map(sentryNameToOption),
       },
       {
         name: 'defaultBranch',

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -147,7 +147,7 @@ describe('IntegrationCodeMappings', function () {
     const modal = await mountGlobalModal();
 
     selectByValue(modal, projects[1].id, {control: true, name: 'projectId'});
-    selectByValue(modal, repos[1].id, {name: 'repositoryId'});
+    selectByValue(modal, repos[1].id, {control: true, name: 'repositoryId'});
 
     modal
       .find('input[name="stackRoot"]')


### PR DESCRIPTION
Use the `select_async` form option instead of `select` so that if you have more than 100 repos in the dropdown, you can still type the name of it and have it show up in the "configure code path mapping" modal. 

Fixes: https://github.com/getsentry/sentry/issues/35906