### PR TITLE
Document new project param for release deploys endpoint

### DIFF
--- a/api-docs/paths/releases/deploys.json
+++ b/api-docs/paths/releases/deploys.json
@@ -103,6 +103,10 @@
                 "type": "string",
                 "description": "The optional name of the deploy."
               },
+              "projects": {
+                "type": "array",
+                "description": "The optional list of projects to deploy."
+              },
               "dateStarted": {
                 "type": "string",
                 "format": "date-time",


### PR DESCRIPTION
Document the API changes from #35916 to add a 'projects' query param for release deploys.