### PR TITLE
fix(profiling): add scroll margin

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStackTableRow.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackTableRow.tsx
@@ -183,6 +183,7 @@ const FrameCallersRow = styled('div')<{isSelected: boolean}>`
   display: flex;
   width: calc(100% + 400px);
   color: ${p => (p.isSelected ? p.theme.white : 'inherit')};
+  scroll-margin-top: 24px;
 
   &:focus {
     outline: none;


### PR DESCRIPTION
Adds a margin-scroll-top to adjust for the sticky header when scrolling.

Before:

https://user-images.githubusercontent.com/9317857/175318404-1ae73d10-fc52-4dbe-aeb0-f2eacec9b5fe.mp4

After

https://user-images.githubusercontent.com/9317857/175318435-0a4307a5-ab05-4578-97cf-1bf3b233efad.mp4


