### PR TITLE
fix(tests): Mail actions test unstable order

### DIFF
--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -197,7 +197,7 @@ class NotifyEmailTest(RuleTestCase):
             )
 
         assert len(mail.outbox) == 3
-        sent_out_to = [x for out in mail.outbox for x in out.to]
-        assert sent_out_to == [self.user.email, gil_workflow.email, dan_workflow.email]
+        sent_out_to = {x for out in mail.outbox for x in out.to}
+        assert sent_out_to == {self.user.email, gil_workflow.email, dan_workflow.email}
         for x in [out.subject for out in mail.outbox]:
             assert "uh oh" in x

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -197,7 +197,7 @@ class NotifyEmailTest(RuleTestCase):
             )
 
         assert len(mail.outbox) == 3
-        sent_out_to = {x for out in mail.outbox for x in out.to}
-        assert sent_out_to == {self.user.email, gil_workflow.email, dan_workflow.email}
+        sent_out_to = sorted(x for out in mail.outbox for x in out.to)
+        assert sent_out_to == sorted([self.user.email, gil_workflow.email, dan_workflow.email])
         for x in [out.subject for out in mail.outbox]:
             assert "uh oh" in x


### PR DESCRIPTION
The order in the mail outbox is unstable, ensure the assertion doesn't assume
the order.