### PR TITLE
fix(flamegraph): preserve x when inverting matrix

### DIFF
--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -342,7 +342,7 @@ export class Rect {
    * This causes the bottom of the rect to be the top of the rect and vice versa.
    */
   invertYTransform(): mat3 {
-    return mat3.fromValues(1, 0, 0, 0, -1, 0, 1, this.y * 2 + this.height, 1);
+    return mat3.fromValues(1, 0, 0, 0, -1, 0, 0, this.y * 2 + this.height, 1);
   }
 
   withHeight(height: number): Rect {

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -342,7 +342,7 @@ export class Rect {
    * This causes the bottom of the rect to be the top of the rect and vice versa.
    */
   invertYTransform(): mat3 {
-    return mat3.fromValues(1, 0, 0, 0, -1, 0, this.x, this.y * 2 + this.height, 1);
+    return mat3.fromValues(1, 0, 0, 0, -1, 0, 1, this.y * 2 + this.height, 1);
   }
 
   withHeight(height: number): Rect {


### PR DESCRIPTION
When the chart is inverted and user is no longer at 0, we want to make sure we preserve the x when inverting the axis