### PR TITLE
fix(profiling): text highlighting in firefox

### DIFF
--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -60,9 +60,8 @@ class TextRenderer {
   ): void {
     this.maybeInvalidateCache();
 
-    this.context.font = `${this.theme.SIZES.BAR_FONT_SIZE * window.devicePixelRatio}px ${
-      this.theme.FONTS.FRAME_FONT
-    }`;
+    const fontSize = this.theme.SIZES.BAR_FONT_SIZE * window.devicePixelRatio;
+    this.context.font = `${fontSize}px ${this.theme.FONTS.FRAME_FONT}`;
 
     this.context.textBaseline = 'alphabetic';
 
@@ -158,18 +157,15 @@ class TextRenderer {
               continue;
             }
             const [startIndex, endIndex] = highlightedBounds;
-            const highlightTextSize = this.measureAndCacheText(
-              trimText.substring(startIndex, endIndex)
-            );
+
             const frontMatter = trimText.slice(0, startIndex);
-            const startHighlightX = this.measureAndCacheText(frontMatter).width;
-            this.context.fillRect(
-              startHighlightX + x,
-              y - highlightTextSize.fontBoundingBoxAscent,
-              highlightTextSize.width,
-              highlightTextSize.fontBoundingBoxAscent +
-                highlightTextSize.fontBoundingBoxDescent
-            );
+            const highlightOffsetX = this.measureAndCacheText(frontMatter).width;
+            const rectX = x + highlightOffsetX;
+            const rectY = frameInPhysicalSpace[1] + fontSize / 2;
+            const highlightWidth = this.measureAndCacheText(
+              trimText.substring(startIndex, endIndex)
+            ).width;
+            this.context.fillRect(rectX, rectY, highlightWidth, fontSize);
           }
         }
       }


### PR DESCRIPTION
Firefox does not support the `fontBoundingBoxAscent` and `fontBoundingBoxDescent` properties on `TextMetrics`. As a result highlighting is not working in FF.

Instead of depending on the `TextMetrics` we draw a rect based on the fontsize

![image](https://user-images.githubusercontent.com/7349258/175329992-131b6f4f-d9de-46f0-8cb6-fa956a3e8635.png)
