### PR TITLE
feat(dev): Add additional hosts to mkcert, call `-install` after creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "build-production": "NODE_ENV=production yarn webpack --mode production",
     "build": "NODE_OPTIONS=--max-old-space-size=4096 yarn webpack",
     "validate-api-examples": "cd api-docs && yarn openapi-examples-validator ../tests/apidocs/openapi-derefed.json --no-additional-properties",
-    "mkcert-localhost": "mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost"
+    "mkcert-localhost": "mkcert -key-file config/localhost-key.pem -cert-file config/localhost.pem localhost 127.0.0.1 dev.getsentry.net && mkcert -install"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Adds `127.0.0.1` and `dev.getsentry.net` as additional hosts for our local dev certificate. Also calls `mkcert -install` after creating certs to install them to OS.
