### PR TITLE
fix(tests): Disable SDK in tests entirely [INGEST-1352]

### DIFF
--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -131,9 +131,6 @@ def pytest_configure(config):
         settings.SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"
         settings.SENTRY_EVENTSTREAM = "sentry.eventstream.snuba.SnubaEventStream"
 
-    if os.environ.get("DISABLE_TEST_SDK", False):
-        settings.SENTRY_SDK_CONFIG = {}
-
     if not hasattr(settings, "SENTRY_OPTIONS"):
         settings.SENTRY_OPTIONS = {}
 
@@ -203,6 +200,7 @@ def pytest_configure(config):
     from sentry.runner.initializer import initialize_app
 
     initialize_app({"settings": settings, "options": None})
+    Hub.main.bind_client(None)
     register_extensions()
 
     from sentry.utils.redis import clusters


### PR DESCRIPTION
Since other people are just working around the SDK spewing error logs
all the time, let's just disable the SDK in tests.

This also fixes a test failure of
`tests/relay_integration/test_sdk.py::test_simple` that cannot be
reproduced in CI.

I think the reason it cannot be reproduced in CI is because test_simple
relies on the test teardown of another test, where the client is
deinitialized. this works locally, at least if the datascrubbing tests
run first:

`pytest  tests/relay_integration/test_sdk.py tests/sentry/test_datascrubbing.py`

this doesn't:

`pytest  tests/relay_integration/test_sdk.py`
