### PR TITLE
ref(smartsearch): improve keyboard navigation

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -73,7 +73,7 @@ const ACTION_OVERFLOW_STEPS = 75;
 const makeQueryState = (query: string) => ({
   query,
   // Anytime the query changes and it is not "" the dropdown should show
-  showDropdown: !!query,
+  showDropdown: true,
   parsedQuery: parseSearch(query),
 });
 

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -406,12 +406,6 @@ class SmartSearchBar extends Component<Props, State> {
     if (!this.searchInput.current) {
       return;
     }
-
-    if (this.state.showDropdown) {
-      this.setState({...this.state, showDropdown: false});
-      return;
-    }
-
     this.searchInput.current.blur();
   }
 
@@ -774,7 +768,7 @@ class SmartSearchBar extends Component<Props, State> {
     evt.preventDefault();
     const isSelectingDropdownItems = this.state.activeSearchItem > -1;
 
-    if (!isSelectingDropdownItems) {
+    if (!this.state.showDropdown) {
       this.blur();
       return;
     }

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -1005,6 +1005,8 @@ describe('SmartSearchBar', function () {
 
       mockCursorPosition(searchBarInst, 8);
 
+      searchBar.find('textarea').simulate('focus');
+
       searchBarInst.updateAutoCompleteItems();
 
       await tick();

--- a/tests/js/spec/views/issueList/searchBar.spec.jsx
+++ b/tests/js/spec/views/issueList/searchBar.spec.jsx
@@ -13,9 +13,6 @@ describe('IssueListSearchBar', function () {
     organization: {access: [], features: []},
   });
 
-  const clickInput = searchBar =>
-    searchBar.find('textarea[name="query"]').simulate('click');
-
   const mockCursorPosition = (wrapper, pos) => {
     const component = wrapper.find('SmartSearchBar').instance();
     delete component.cursorPosition;
@@ -51,15 +48,7 @@ describe('IssueListSearchBar', function () {
   });
 
   describe('updateAutoCompleteItems()', function () {
-    beforeAll(function () {
-      jest.useFakeTimers();
-    });
-
-    afterAll(function () {
-      jest.useRealTimers();
-    });
-
-    it('sets state with complete tag', function () {
+    it('sets state with complete tag', async () => {
       const loader = (key, value) => {
         expect(key).toEqual('url');
         expect(value).toEqual('fu');
@@ -74,13 +63,17 @@ describe('IssueListSearchBar', function () {
       };
       const searchBar = mountWithTheme(<IssueListSearchBar {...props} />, routerContext);
       mockCursorPosition(searchBar, 5);
-      clickInput(searchBar);
-      jest.advanceTimersByTime(301);
+
+      searchBar.find('textarea').simulate('click');
+      searchBar.find('textarea').simulate('focus');
+
+      await tick();
+
       expect(searchBar.find('SearchDropdown').prop('searchSubstring')).toEqual('"fu"');
       expect(searchBar.find('SearchDropdown').prop('items')).toEqual([]);
     });
 
-    it('sets state when value has colon', function () {
+    it('sets state when value has colon', async () => {
       const loader = (key, value) => {
         expect(key).toEqual('url');
         expect(value).toEqual('http://example.com');
@@ -97,17 +90,22 @@ describe('IssueListSearchBar', function () {
       };
 
       const searchBar = mountWithTheme(<IssueListSearchBar {...props} />, routerContext);
+
       mockCursorPosition(searchBar, 5);
-      clickInput(searchBar);
+
+      searchBar.find('textarea').simulate('click');
+      searchBar.find('textarea').simulate('focus');
+
+      await tick();
+
       expect(searchBar.state.searchTerm).toEqual();
       expect(searchBar.find('SearchDropdown').prop('searchSubstring')).toEqual(
         '"http://example.com"'
       );
       expect(searchBar.find('SearchDropdown').prop('items')).toEqual([]);
-      jest.advanceTimersByTime(301);
     });
 
-    it('does not request values when tag is `timesSeen`', function () {
+    it('does not request values when tag is `timesSeen`', async () => {
       // This should never get called
       const loader = jest.fn(x => x);
 
@@ -120,15 +118,18 @@ describe('IssueListSearchBar', function () {
         onSearch: jest.fn(),
       };
       const searchBar = mountWithTheme(<IssueListSearchBar {...props} />, routerContext);
-      clickInput(searchBar);
-      jest.advanceTimersByTime(301);
+
+      searchBar.find('textarea').simulate('click');
+      searchBar.find('textarea').simulate('focus');
+
+      await tick();
+
       expect(loader).not.toHaveBeenCalled();
     });
   });
 
   describe('Recent Searches', function () {
     it('saves search query as a recent search', async function () {
-      jest.useFakeTimers();
       const saveRecentSearch = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/recent-searches/',
         method: 'POST',
@@ -149,8 +150,11 @@ describe('IssueListSearchBar', function () {
       };
       const searchBar = mountWithTheme(<IssueListSearchBar {...props} />, routerContext);
       mockCursorPosition(searchBar, 5);
-      clickInput(searchBar);
-      jest.advanceTimersByTime(301);
+      searchBar.find('textarea').simulate('focus');
+      searchBar.find('textarea').simulate('click');
+
+      await tick();
+
       expect(searchBar.find('SearchDropdown').prop('searchSubstring')).toEqual('"fu"');
       expect(searchBar.find('SearchDropdown').prop('items')).toEqual([]);
 


### PR DESCRIPTION
I have been using the smart search more recently and noticed a couple of quirks when using only keyboard navigation to interface with the component. My use case is using the mouse to focus on the input, selecting a filter and value using keyboard navigation and then closing the dropdown and triggering a search. 

https://user-images.githubusercontent.com/9317857/175347638-0949ca12-c986-430c-86f4-2a2d9bc4edec.mp4

From ^, I find it confusing that first escape keydown only clears the current selection from the list, but keeps the dropdown open and the second escape calls blur on the input.

The [aria spec](https://w3c.github.io/aria-practices/#combobox) has the following recommendations:
```
When focus is in the combobox:
...
Escape: Dismisses the popup if it is visible. Optionally, if the popup is hidden before Escape is pressed, clears the combobox.
```
```
When focus is in a listbox popup:
...
Escape: Closes the popup and returns focus to the combobox. Optionally, if the combobox is editable, clears the contents of the combobox.
```

I think what I found counterintuitive was that pressing enter will fire a query **only if you are not currently selecting any items** in the dropdown which I didn't know of because it's not a common pattern. So what I ended up doing was pressing escape twice (at which point I lost focus on search so I could no longer press enter to apply my query and I had to click to focus again)

My change preserves the original functionality, but it also keeps the box more in line with the aria spec by adding the closing of dropdown mechanism and preserving focus, allowing users to hit enter to more explicitly apply the query.

New UX:

https://user-images.githubusercontent.com/9317857/175354241-0340cc9c-3b51-4ada-9062-684e867c54d3.mp4


Note: I havent bothered adding/updating tests yet, because I want to hear opinions first. There is also a bug where hitting enter will briefly display the dropdown which should not happen.

