### PR TITLE
ref(deps): update arroyo 0.2.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -54,7 +54,7 @@ requests==2.25.1
 rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
-sentry-arroyo==0.0.16
+sentry-arroyo==0.2.0
 sentry-relay==0.8.12
 sentry-sdk>=1.4.3,<1.6.0
 snuba-sdk==1.0.0

--- a/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
@@ -50,8 +50,10 @@ class BatchConsumerStrategyFactory(ProcessingStrategyFactory):  # type: ignore
         self.__commit_max_batch_size = commit_max_batch_size
         self.__config = config
 
-    def create(
-        self, commit: Callable[[Mapping[Partition, Position]], None]
+    def create_with_partitions(
+        self,
+        commit: Callable[[Mapping[Partition, Position]], None],
+        partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
         transform_step = TransformStep(
             next_step=SimpleProduceStep(

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -55,8 +55,10 @@ class MetricsConsumerStrategyFactory(ProcessingStrategyFactory):  # type: ignore
         self.__commit_max_batch_size = commit_max_batch_size
         self.__commit_max_batch_time = commit_max_batch_time
 
-    def create(
-        self, commit: Callable[[Mapping[Partition, Position]], None]
+    def create_with_partitions(
+        self,
+        commit: Callable[[Mapping[Partition, Position]], None],
+        partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
         parallel_strategy = ParallelTransformStep(
             partial(process_messages, self.__config.use_case_id),


### PR DESCRIPTION
As of arroyo [`0.2.0`](https://github.com/getsentry/arroyo/releases/tag/0.2.0) factories can use `create_with_partitions` instead of `create` (which is now going to be deprecated). Information about _why_ this was added can be found in the relevant arroyo PR https://github.com/getsentry/arroyo/pull/75
