### PR TITLE
feat(profiling): render initial search state

### DIFF
--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import Fuse from 'fuse.js';
@@ -132,6 +132,7 @@ function FlamegraphSearch({
   canvasPoolManager,
 }: FlamegraphSearchProps): React.ReactElement | null {
   const [search, dispatchSearch] = useFlamegraphSearch();
+  const [didInitialSearch, setDidInitialSearch] = useState(!search.query);
 
   const allFrames = useMemo(() => {
     if (Array.isArray(flamegraphs)) {
@@ -187,6 +188,14 @@ function FlamegraphSearch({
     },
     [dispatchSearch, allFrames, searchIndex]
   );
+
+  useEffect(() => {
+    if (didInitialSearch || allFrames.length === 0) {
+      return;
+    }
+    handleChange(search.query);
+    setDidInitialSearch(true);
+  }, [didInitialSearch, handleChange, allFrames, search.query]);
 
   const onNextSearchClick = useCallback(() => {
     const frames = memoizedSortFrameResults(search.results);


### PR DESCRIPTION
Search state is stored in the url querystring but we don't handle it on our initial render. This PR will now highlight rects/text when refreshing or visiting a url w/ search state.

Before:
https://user-images.githubusercontent.com/7349258/175369207-6252ae4f-f717-41eb-8941-5af1128a1fa4.mov


After:
https://user-images.githubusercontent.com/7349258/175369272-771c6d25-85d7-4222-9228-b37b171299dc.mov
