### PR TITLE
fix(ci): Collector jobs should handle when the workflow is cancelled

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -275,8 +275,9 @@ jobs:
     timeout-minutes: 20
     steps:
       # If any jobs we depend on fail, we will fail since this checks triggers Visual Snapshots which is a required check
+      # NOTE: A timeout is considered a failure
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -435,8 +435,9 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      # If any jobs we depend on fail, we will fail since this checks triggers Visual Snapshots which is a required check
+      # If any jobs we depend on fail, we will fail since this is a required check
+      # NOTE: A timeout is considered a failure
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -179,8 +179,9 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     steps:
-      # If any jobs we depend on fail, we will fail since this checks triggers Visual Snapshots which is a required check
+      # If any jobs we depend on fail, we will fail since this is a required check
+      # NOTE: A timeout is considered a failure
       - name: Check for failures
-        if: contains(needs.*.result, 'failure')
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1


### PR DESCRIPTION
If a job is cancelled, it will be marked as such but will not count towards turning the collector job red.

An [example](https://github.com/getsentry/sentry/actions/runs/2536212946/attempts/1) of the issue.
<img width="856" alt="image" src="https://user-images.githubusercontent.com/44410/175385630-ab255ad0-c099-4b56-a0aa-042d3242d301.png">

This fixes it. Tested in here:
https://github.com/getsentry/github-actions-testing/pull/9#discussion_r905383136