### PR TITLE
fix(discover): Handle has conditions on trace fields

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1072,7 +1072,9 @@ class QueryBuilder:
         # Tags are never null, but promoted tags are columns and so can be null.
         # To handle both cases, use `ifNull` to convert to an empty string and
         # compare so we need to check for empty values.
-        if isinstance(lhs, Column) and lhs.subscriptable == "tags":
+        is_tag = isinstance(lhs, Column) and lhs.subscriptable == "tags"
+        is_context = isinstance(lhs, Column) and lhs.subscriptable == "contexts"
+        if is_tag:
             if operator not in ["IN", "NOT IN"] and not isinstance(value, str):
                 sentry_sdk.set_tag("query.lhs", lhs)
                 sentry_sdk.set_tag("query.rhs", value)
@@ -1082,7 +1084,7 @@ class QueryBuilder:
 
         # Handle checks for existence
         if search_filter.operator in ("=", "!=") and search_filter.value.value == "":
-            if search_filter.key.is_tag:
+            if is_tag or is_context:
                 return Condition(lhs, Op(search_filter.operator), value)
             else:
                 # If not a tag, we can just check that the column is null.

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -522,8 +522,8 @@ class Columns(Enum):
     SPAN_ID = Column(
         group_name="events.contexts[trace.span_id]",
         event_name="contexts[trace.span_id]",
-        transaction_name="contexts[trace.span_id]",
-        discover_name="contexts[trace.span_id]",
+        transaction_name="span_id",
+        discover_name="span_id",
         alias="trace.span",
     )
     PARENT_SPAN_ID = Column(


### PR DESCRIPTION
- This fixes a bug where has:trace.span and has:trace.parent_span_id
  wasn't working anymore cause the conditions we built were incorrect
