### PR TITLE
Django 32 upgrade/main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ filterwarnings = [
     # This is just to prevent pytest from exiting if pytest-xdist isn't installed.
     "ignore:Unknown config option.*looponfailroots:pytest.PytestConfigWarning",
 
-    "ignore::django.utils.deprecation.RemovedInDjango30Warning",
+    "ignore::django.utils.deprecation.RemovedInDjango40Warning",
 
     # At writing, the Google Bigtable Emulator relies on deprecated behavior
     # internally, this can be removed once a version containing this fix is

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -10,7 +10,7 @@ croniter==0.3.37
 datadog==0.29.3
 django-crispy-forms==1.14.0
 django-pg-zero-downtime-migrations==0.11
-Django==2.2.28
+Django==3.2.13
 djangorestframework==3.12.4
 drf-spectacular==0.22.1
 email-reply-parser==0.5.12

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -4,10 +4,9 @@ import math
 from datetime import datetime
 from urllib.parse import quote, unquote
 
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import EmptyResultSet, ObjectDoesNotExist
 from django.db import connections
 from django.db.models.functions import Lower
-from django.db.models.sql.datastructures import EmptyResultSet
 from django.utils import timezone
 
 from sentry.utils.cursors import Cursor, CursorResult, build_cursor

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -521,7 +521,8 @@ class Release(Model):
         other specialized release.  This for instance lets us treat them
         separately for serialization purposes.
         """
-        return Model.__eq__(self, other) and self._for_project_id == other._for_project_id
+        other_project_id = getattr(other, "_for_project_id", None)
+        return Model.__eq__(self, other) and self._for_project_id == other_project_id
 
     def __hash__(self):
         # https://code.djangoproject.com/ticket/30333

--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -4,7 +4,7 @@ from django.db import models
 from sentry.new_migrations.monkey.executor import SentryMigrationExecutor
 from sentry.new_migrations.monkey.fields import deconstruct
 
-LAST_VERIFIED_DJANGO_VERSION = (2, 2)
+LAST_VERIFIED_DJANGO_VERSION = (3, 2)
 CHECK_MESSAGE = """Looks like you're trying to upgrade Django! Since we monkeypatch
 the Django migration library in several places, please verify that we have the latest
 code, and that the monkeypatching still works as expected. Currently the main things

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -92,10 +92,6 @@ def configure(ctx, py, yaml, skip_service_validation=False):
     # Make sure that our warnings are always displayed.
     warnings.filterwarnings("default", "", Warning, r"^sentry")
 
-    from django.utils.deprecation import RemovedInDjango30Warning
-
-    warnings.filterwarnings(action="ignore", category=RemovedInDjango30Warning)
-
     # Add in additional mimetypes that are useful for our static files
     # which aren't common in default system registries
     import mimetypes

--- a/src/sentry/runner/settings.py
+++ b/src/sentry/runner/settings.py
@@ -92,6 +92,10 @@ def configure(ctx, py, yaml, skip_service_validation=False):
     # Make sure that our warnings are always displayed.
     warnings.filterwarnings("default", "", Warning, r"^sentry")
 
+    from django.utils.deprecation import RemovedInDjango40Warning
+
+    warnings.filterwarnings(action="ignore", category=RemovedInDjango40Warning)
+
     # Add in additional mimetypes that are useful for our static files
     # which aren't common in default system registries
     import mimetypes

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -24,10 +24,6 @@ TEST_ROOT = os.path.normpath(
 def pytest_configure(config):
     import warnings
 
-    from django.utils.deprecation import RemovedInDjango30Warning
-
-    warnings.filterwarnings(action="ignore", category=RemovedInDjango30Warning)
-
     # This is just to filter out an obvious warning before the pytest session starts.
     warnings.filterwarnings(
         action="ignore",

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -24,6 +24,10 @@ TEST_ROOT = os.path.normpath(
 def pytest_configure(config):
     import warnings
 
+    from django.utils.deprecation import RemovedInDjango40Warning
+
+    warnings.filterwarnings(action="ignore", category=RemovedInDjango40Warning)
+
     # This is just to filter out an obvious warning before the pytest session starts.
     warnings.filterwarnings(
         action="ignore",


### PR DESCRIPTION
All backend python failing tests:

- [ ] sentry/api/endpoints/test_group_tags.py::GroupTagsTest::test_simple - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/api/endpoints/test_organization_dashboards.py::OrganizationDashboardsTest::test_get_sortby_mydashboards - AssertionError: b'{"detail":"Internal Error","errorId":null}'
- [ ] sentry/api/endpoints/test_organization_sdk_updates.py::OrganizationSdkUpdates::test_unknown_version - ValueError: too many values to unpack (expected 1)
- [ ] sentry/api/endpoints/test_sentry_app_details.py::UpdateSentryAppDetailsTest::test_update_published_app - AssertionError: assert {'allowedOrig...e7be804', ...} == {'allowedOrig...e7be804', ...}
- [ ] sentry/charts/test_chartcuterie.py::ChartcuterieTest::test_simple - AssertionError: assert 'http://tests...ia/abc123.png' == 'http://tests...ia/abc123.png'
- [ ] sentry/event_manager/test_event_manager.py::EventManagerTest::test_group_environment - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/event_manager/test_event_manager.py::EventManagerTest::test_group_release_no_env - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/event_manager/test_event_manager.py::EventManagerTest::test_group_release_with_env - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/event_manager/test_event_manager.py::EventManagerTest::test_marks_as_unresolved_with_new_release - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/event_manager/test_event_manager.py::EventManagerTest:: test_marks_as_unresolved_with_new_release_with_integration - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/event_manager/test_event_manager.py::ReleaseIssueTest::test_different_groups - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/event_manager/test_event_manager.py::ReleaseIssueTest::test_same_group - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/event_manager/test_event_manager.py::ReleaseIssueTest::test_same_group_different_environment - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/incidents/endpoints/test_organization_alert_rule_index.py:: OrganizationCombinedRuleIndexEndpointTest::test_expand_latest_incident - AssertionError: b'{"detail":"Internal Error","errorId":null}'
- [ ] sentry/mail/test_adapter.py::MailAdapterNotifyIssueOwnersTest::test_notify_with_dist_tag - AttributeError: 'NoneType' object has no attribute '_for_project_id'
- [ ] sentry/middleware/test_ratelimit_middleware.py::TestRatelimitHeader::test_omit_header - AttributeError: 'Response' object has no attribute '_headers'
- [ ] sentry/notifications/utils/test_participants.py::GetSentToReleaseMembersTest::test_default_committer - AttributeError: 'int' object has no attribute '_for_project_id'
- [ ] sentry/release_health/test_tasks.py::TestMetricReleaseMonitor::test_monitor_release_adoption - sentry.utils.snuba.SnubaError: ParsingException: org_metrics_counters is not a valid entity name
- [ ] sentry/release_health/release_monitor/test_metrics.py::MetricFetchProjectsWithRecentSessionsTest:: test_monitor_release_adoption - sentry.utils.snuba.SnubaError: ParsingException: org_metrics_counters is not a valid entity name
- [ ] sentry/utils/email/test_signer.py::CaseInsensitiveSignerTests::test_it_works - AssertionError: assert 'foo:oqwd6f2h...alfcgcxvfzrw4' == 'foo:wkpxg5dj...zktktfl9hdzw4'
- [ ] sentry/web/frontend/test_js_sdk_loader.py::JavaScriptSdkLoaderTest::test_equal_to_v7_returns_es5 - TypeError: get() missing 1 required positional argument: 'minified'
- [ ] sentry/web/frontend/test_js_sdk_loader.py::JavaScriptSdkLoaderTest::test_greater_than_v7_returns_es5 - TypeError: get() missing 1 required positional argument: 'minified'
- [ ] sentry/web/frontend/test_js_sdk_loader.py::JavaScriptSdkLoaderTest::test_headers - TypeError: get() missing 1 required positional argument: 'minified'
- [ ] sentry/web/frontend/test_js_sdk_loader.py::JavaScriptSdkLoaderTest::test_less_than_v7_returns_es6 - TypeError: get() missing 1 required positional argument: 'minified'
- [ ] sentry/web/frontend/test_js_sdk_loader.py::JavaScriptSdkLoaderTest::test_minified - TypeError: get() missing 1 required positional argument: 'minified'
- [ ] sentry/web/frontend/test_js_sdk_loader.py::JavaScriptSdkLoaderTest::test_no_replace - TypeError: get() missing 1 required positional argument: 'minified'
- [ ] sentry/web/frontend/test_js_sdk_loader.py::JavaScriptSdkLoaderTest::test_noop - TypeError: get() missing 1 required positional argument: 'minified'
- [ ] sentry/web/frontend/test_js_sdk_loader.py::JavaScriptSdkLoaderTest::test_noop_no_pub_key - TypeError: get() missing 1 required positional argument: 'minified'
- [ ] sentry/web/frontend/test_js_sdk_loader.py::JavaScriptSdkLoaderTest::test_renders_js_loader - TypeError: get() missing 1 required positional argument: 'minified'
- [ ] sentry/migrations/test_0223_semver_backfill_2.py::TestBackfill::test - AssertionError: no migrations detected!
- [ ] sentry/migrations/test_0286_backfill_alertrule_organization.py::TestBackfill::test - AssertionError: no migrations detected!
- [ ] sentry/migrations/test_0287_backfill_snubaquery_environment.py::TestBackfill::test - AssertionError: no migrations detected!
- [ ] sentry/migrations/test_0289_dashboardwidgetquery_convert_orderby_to_field.py:: TestConvertDashboardWidgetQueryOrderby::test - AssertionError: no migrations detected!
- [ ] sentry/migrations/test_0290_fix_project_has_releases.py::BackfillProjectHasReleaseTest::test - AssertionError: no migrations detected!