### PR TITLE
fix(active-release): retrieve the release_version from the event 

### DIFF
--- a/src/sentry/rules/conditions/active_release.py
+++ b/src/sentry/rules/conditions/active_release.py
@@ -37,7 +37,10 @@ class ActiveReleaseEventCondition(EventCondition):
             # check deploy -> release first
             # then Release.date_released
             # then EnvironmentRelease.first_seen
-            last_deploy: Deploy = Deploy.objects.filter(id=release.last_deploy_id).first()
+            last_deploy: Deploy = (
+                Deploy.objects.filter(release_id=release.id).order_by("-date_finished").first()
+                or Deploy.objects.filter(id=release.last_deploy_id).first()
+            )
             if last_deploy:
                 return last_deploy.date_finished
             else:

--- a/src/sentry/rules/conditions/active_release.py
+++ b/src/sentry/rules/conditions/active_release.py
@@ -11,20 +11,17 @@ from sentry.rules.conditions.base import EventCondition
 
 
 def _get_release(event: Event) -> Optional[Release]:
-    if event:
-        release_version = (
-            event.release
-            or event.get_tag("release")
-            or event.data.get("sentry:release")
-            or event.data.get("release")
-        )
-        return Release.objects.filter(
-            organization_id=event.project.organization_id,
-            project_id=event.project_id,
-            version=release_version,
-        ).first()
-
-    return None
+    release_version = (
+        event.release
+        or event.get_tag("release")
+        or event.data.get("sentry:release")
+        or event.data.get("release")
+    )
+    return Release.objects.filter(
+        organization_id=event.project.organization_id,
+        projects__id=event.project_id,
+        version=release_version,
+    ).first()
 
 
 class ActiveReleaseEventCondition(EventCondition):

--- a/tests/sentry/rules/conditions/test_active_release_event.py
+++ b/tests/sentry/rules/conditions/test_active_release_event.py
@@ -25,6 +25,7 @@ class ActiveReleaseEventConditionTest(SnubaTestCase, RuleTestCase):
         event = self.get_event()
         oldRelease = Release.objects.create(
             organization_id=self.organization.id,
+            project_id=self.project.id,
             version="1",
             date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
             date_released=datetime(2020, 9, 1, 3, 8, 24, 880386),
@@ -33,6 +34,7 @@ class ActiveReleaseEventConditionTest(SnubaTestCase, RuleTestCase):
 
         newRelease = Release.objects.create(
             organization_id=self.organization.id,
+            project_id=self.project.id,
             version="2",
             date_added=timezone.now() - timedelta(minutes=30),
             date_released=timezone.now() - timedelta(minutes=30),

--- a/tests/sentry/rules/conditions/test_active_release_event.py
+++ b/tests/sentry/rules/conditions/test_active_release_event.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 
 from sentry.eventstore import Filter
 from sentry.eventstore.snuba import SnubaEventStorage
-from sentry.models import Group, Release, Rule
+from sentry.models import Deploy, Group, Release, Rule
 from sentry.rules.conditions.active_release import ActiveReleaseEventCondition
 from sentry.testutils import RuleTestCase, SnubaTestCase
 
@@ -25,28 +25,46 @@ class ActiveReleaseEventConditionTest(SnubaTestCase, RuleTestCase):
         event = self.get_event()
         oldRelease = Release.objects.create(
             organization_id=self.organization.id,
-            project_id=self.project.id,
             version="1",
-            date_added=datetime(2020, 9, 1, 3, 8, 24, 880386),
-            date_released=datetime(2020, 9, 1, 3, 8, 24, 880386),
+            date_added=timezone.now() - timedelta(hours=2),
+            date_released=timezone.now() - timedelta(hours=2),
         )
-        oldRelease.add_project(self.project)
-
         newRelease = Release.objects.create(
             organization_id=self.organization.id,
-            project_id=self.project.id,
             version="2",
             date_added=timezone.now() - timedelta(minutes=30),
             date_released=timezone.now() - timedelta(minutes=30),
         )
+        oldRelease.add_project(self.project)
         newRelease.add_project(self.project)
 
-        event.data["tags"] = (("release", newRelease.version),)
+        event.data["tags"] = (("sentry:release", newRelease.version),)
         rule = self.get_rule()
         self.assertPasses(rule, event)
 
-    def test_deployed(self):
-        pass
+    def test_release_deployed(self):
+        event = self.get_event()
+        newRelease = Release.objects.create(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            version="2",
+            date_added=timezone.now() - timedelta(days=1),
+            date_released=None,
+        )
+        Deploy.objects.create(
+            organization_id=self.organization.id,
+            environment_id=self.environment.id,
+            name="test_release_deployed",
+            notified=True,
+            release_id=newRelease.id,
+            date_started=timezone.now() - timedelta(minutes=37),
+            date_finished=timezone.now() - timedelta(minutes=20),
+        )
+        newRelease.add_project(self.project)
+
+        event.data["tags"] = (("sentry:release", newRelease.version),)
+        rule = self.get_rule()
+        self.assertPasses(rule, event)
 
     def test_release_project_env(self):
         pass
@@ -74,7 +92,7 @@ class ActiveReleaseEventConditionTest(SnubaTestCase, RuleTestCase):
             data={
                 "event_id": "a" * 32,
                 "message": "\u3053\u3093\u306b\u3061\u306f",
-                "tags": (("release", newRelease.version),),
+                "tags": (("sentry:release", newRelease.version),),
             },
             project_id=self.project.id,
         )
@@ -82,7 +100,7 @@ class ActiveReleaseEventConditionTest(SnubaTestCase, RuleTestCase):
             data={
                 "event_id": "b" * 32,
                 "message": "\u3053\u3093\u306b\u3061\u306f",
-                "tags": (("release", newRelease.version),),
+                "tags": (("sentry:release", newRelease.version),),
             },
             project_id=self.project.id,
         )


### PR DESCRIPTION
Before, we were retrieving the latest release from the project. What we should have been doing was retrieving the release version from the event and querying the release from there.

This change fixes that defect.