### PR TITLE
fix(alerts): Show alert not found message on 404

### DIFF
--- a/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 import moment from 'moment';
 
-import Alert from 'sentry/components/alert';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Button from 'sentry/components/button';
@@ -87,6 +86,7 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
         'rule',
         `/projects/${orgId}/${projectId}/rules/${ruleId}/`,
         {query: {expand: 'lastTriggered'}},
+        {allowError: error => error.status === 404},
       ],
       ['memberList', `/organizations/${orgId}/users/`, {query: {projectSlug: projectId}}],
     ];
@@ -192,14 +192,18 @@ class AlertRuleDetails extends AsyncComponent<Props, State> {
     const {rule, memberList} = this.state;
 
     if (!rule) {
-      return <LoadingError message={t('There was an error loading the alert rule.')} />;
+      return (
+        <StyledLoadingError
+          message={t('The alert rule you were looking for was not found.')}
+        />
+      );
     }
 
     if (!project) {
       return (
-        <Alert type="warning">
-          {t('The project you were looking for was not found.')}
-        </Alert>
+        <StyledLoadingError
+          message={t('The project you were looking for was not found.')}
+        />
       );
     }
 
@@ -316,4 +320,8 @@ const RuleName = styled('div')`
   grid-template-columns: max-content 1fr;
   grid-column-gap: ${space(1)};
   align-items: center;
+`;
+
+const StyledLoadingError = styled(LoadingError)`
+  margin: ${space(2)};
 `;

--- a/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
+++ b/tests/js/spec/views/alerts/details/ruleDetails.spec.jsx
@@ -132,4 +132,18 @@ describe('AlertRuleDetails', () => {
     expect(await screen.findAllByText('Last Triggered')).toHaveLength(2);
     expect(screen.getByText('2 days ago')).toBeInTheDocument();
   });
+
+  it('renders not found on 404', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/rules/${rule.id}/`,
+      statusCode: 404,
+      body: {},
+      match: [MockApiClient.matchQuery({expand: 'lastTriggered'})],
+    });
+    createWrapper();
+
+    expect(
+      await screen.findByText('The alert rule you were looking for was not found.')
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Before, it was displaying the default sentry error component.

![image](https://user-images.githubusercontent.com/1400464/175425835-26e5f85e-8b64-47a8-89a2-773abe0a5b58.png)
