### PR TITLE
feat(RH-widgets): Allow querying the metrics endpoint with RH widgets

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -110,7 +110,10 @@ class OrganizationMetricsDataEndpoint(OrganizationEndpoint):
     default_per_page = 50
 
     def get(self, request: Request, organization) -> Response:
-        if not features.has("organizations:metrics", organization, actor=request.user):
+        if not (
+            features.has("organizations:metrics", organization, actor=request.user)
+            or features.has("organizations:dashboards-releases", organization, actor=request.user)
+        ):
             return Response(status=404)
 
         projects = self.get_projects(request, organization)


### PR DESCRIPTION
The Release Health widget needs access to this endpoint to
adding the release health dashboard widget feature flag
(`organization:dashboards-releases`) to the allow list.
