### PR TITLE
fix(api): Remove nonexistent metric alert owners when transferring projects

### DIFF
--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -67,11 +67,12 @@ class ProjectTransferEndpoint(ProjectEndpoint):
         old_org = Organization.objects.get(id=project.organization.id)
         alerts = AlertRule.objects.filter(organization=old_org)
         for alert in alerts:
-            alert_owner = OrganizationMember.objects.filter(
+            member = OrganizationMember.objects.filter(
                 organization=owner.organization, id=alert.owner_id
             ).first()
 
-            if alert_owner is None:
+            # Remove the alert owner if the owner is not in the new organization
+            if member is None:
                 alert.update(owner=None)
 
         transaction_id = uuid4().hex

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -41,6 +41,34 @@ class ProjectTransferTest(APITestCase):
                 # assertion does not pass
                 assert mail.outbox
 
+    def test_transfer_project_with_alert_owners(self):
+        project = self.create_project()
+        new_user = self.create_user("b@example.com")
+        self.create_organization(name="New Org", owner=new_user)
+        alert_owner = self.create_user(email="c@example.com")
+        _ = self.create_alert_rule(
+            name="alert_rule_0",
+            user=self.user,
+            organization=self.project.organization,
+            owner=alert_owner.actor.get_actor_tuple(),
+        )
+
+        self.login_as(user=self.user)
+
+        url = reverse(
+            "sentry-api-0-project-transfer",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+
+        with self.settings(SENTRY_PROJECT=0):
+            with self.tasks():
+                response = self.client.post(url, {"email": new_user.email})
+
+                assert response.status_code == 204
+                # stdout seems to print log messages that mail should be sent but this
+                # assertion does not pass
+                assert mail.outbox
+
     def test_transfer_project_to_invalid_user(self):
         project = self.create_project()
         # new user is not an owner of anything


### PR DESCRIPTION
Remove nonexistent owners for metric alerts when transferring a projects

Transferring projects with alert owners can result in orphaned alerts if the owners are not a part of the new project. We should remove the alert owners before proceeding with the transfer. 

Fixes WOR-1855
