### PR TITLE
poc(sdk): Add experimental dsn for upcoming perf work

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -309,6 +309,9 @@ register("processing.can-use-scrubbers", default=True)
 # Note: A value that is neither 0 nor 1 is regarded as 0
 register("store.use-relay-dsn-sample-rate", default=1)
 
+# A rate to apply to any events denoted as experimental to be sent to an experimental dsn.
+register("store.use-experimental-dsn-sample-rate", default=0.0)
+
 # Mock out integrations and services for tests
 register("mocks.jira", default=False)
 


### PR DESCRIPTION
### Summary
This adds an experimental dsn/transport to the MultiplexingTransport to intentionally send specific flagged events solely to a separate dsn, which will help us avoid troubles with ingesting random errors into our main Sentry project.

Will be followed up with the perf-issue experimental sdk changes to be added to `getsentry` along with adding the experimental dsn key (`experimental_dsn`) there.

Refs: https://github.com/getsentry/sentry-python/commit/caa41400423fc47bfac1d373b15304cfb0a7d8b5
