### PR TITLE
feat(locks): Add locks count metric tagged with name

### DIFF
--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -244,7 +244,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
             om.save()
 
         if result["teams"]:
-            lock = locks.get(f"org:member:{om.id}", duration=5)
+            lock = locks.get(f"org:member:{om.id}", duration=5, name="org_member")
             with TimedRetryPolicy(10)(lock.acquire):
                 save_team_assignments(om, result["teams"])
 

--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -82,7 +82,7 @@ class OrganizationInviteRequestIndexEndpoint(OrganizationEndpoint):
             )
 
             if result["teams"]:
-                lock = locks.get(f"org:member:{om.id}", duration=5)
+                lock = locks.get(f"org:member:{om.id}", duration=5, name="org_member_invite")
                 with TimedRetryPolicy(10)(lock.acquire):
                     save_team_assignments(om, result["teams"])
 

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -731,7 +731,11 @@ class AuthHelper(Pipeline):
         auth_provider = self.provider_model
         user_id = identity["id"]
 
-        lock = locks.get(f"sso:auth:{auth_provider.id}:{md5_text(user_id).hexdigest()}", duration=5)
+        lock = locks.get(
+            f"sso:auth:{auth_provider.id}:{md5_text(user_id).hexdigest()}",
+            duration=5,
+            name="sso_auth",
+        )
         with TimedRetryPolicy(5)(lock.acquire):
             try:
                 auth_identity = AuthIdentity.objects.select_related("user").get(

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -96,7 +96,9 @@ class RedisBackend(Backend):
 
     def _get_timeline_lock(self, key: str, duration: int) -> Lock:
         lock_key = f"{self.namespace}:t:{key}"
-        return self.locks.get(lock_key, duration=duration, routing_key=lock_key)
+        return self.locks.get(
+            lock_key, duration=duration, routing_key=lock_key, name="digest_timeline_lock"
+        )
 
     def add(
         self,

--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -25,7 +25,11 @@ class BitbucketRepositoryProvider(IntegrationRepositoryProvider):
 
     def get_webhook_secret(self, organization):
         # TODO(LB): Revisit whether Integrations V3 should be using OrganizationOption for storage
-        lock = locks.get(f"bitbucket:webhook-secret:{organization.id}", duration=60)
+        lock = locks.get(
+            f"bitbucket:webhook-secret:{organization.id}",
+            duration=60,
+            name="bitbucket_webhook_secret",
+        )
         with lock.acquire():
             secret = OrganizationOption.objects.get_value(
                 organization=organization, key="bitbucket:webhook_secret"

--- a/src/sentry/models/deploy.py
+++ b/src/sentry/models/deploy.py
@@ -42,7 +42,7 @@ class Deploy(Model):
         from sentry.models import Activity, Environment, ReleaseCommit, ReleaseHeadCommit
 
         lock_key = cls.get_lock_key(deploy_id)
-        lock = locks.get(lock_key, duration=30)
+        lock = locks.get(lock_key, duration=30, name="deploy_notify")
         with TimedRetryPolicy(10)(lock.acquire):
             deploy = cls.objects.filter(id=deploy_id).select_related("release").get()
             if deploy.notified:

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -69,7 +69,9 @@ def _get_size_and_checksum(fileobj, logger=nooplogger):
 @contextmanager
 def _locked_blob(checksum, logger=nooplogger):
     logger.debug("_locked_blob.start", extra={"checksum": checksum})
-    lock = locks.get(f"fileblob:upload:{checksum}", duration=UPLOAD_RETRY_TIME)
+    lock = locks.get(
+        f"fileblob:upload:{checksum}", duration=UPLOAD_RETRY_TIME, name="fileblob_upload_model"
+    )
     with TimedRetryPolicy(UPLOAD_RETRY_TIME, metric_instance="lock.fileblob.upload")(lock.acquire):
         logger.debug("_locked_blob.acquired", extra={"checksum": checksum})
         # test for presence
@@ -273,7 +275,11 @@ class FileBlob(Model):
     def delete(self, *args, **kwargs):
         if self.path:
             self.deletefile(commit=False)
-        lock = locks.get(f"fileblob:upload:{self.checksum}", duration=UPLOAD_RETRY_TIME)
+        lock = locks.get(
+            f"fileblob:upload:{self.checksum}",
+            duration=UPLOAD_RETRY_TIME,
+            name="fileblob_upload_delete",
+        )
         with TimedRetryPolicy(UPLOAD_RETRY_TIME, metric_instance="lock.fileblob.delete")(
             lock.acquire
         ):

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -187,7 +187,7 @@ class Organization(Model):
 
     def save(self, *args, **kwargs):
         if not self.slug:
-            lock = locks.get("slug:organization", duration=5)
+            lock = locks.get("slug:organization", duration=5, name="organization_slug")
             with TimedRetryPolicy(10)(lock.acquire):
                 slugify_instance(self, self.name, reserved=RESERVED_ORGANIZATION_SLUGS)
             super().save(*args, **kwargs)

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -166,7 +166,7 @@ class Project(Model, PendingDeletionMixin):
 
     def save(self, *args, **kwargs):
         if not self.slug:
-            lock = locks.get("slug:project", duration=5)
+            lock = locks.get("slug:project", duration=5, name="project_slug")
             with TimedRetryPolicy(10)(lock.acquire):
                 slugify_instance(
                     self,
@@ -379,7 +379,7 @@ class Project(Model, PendingDeletionMixin):
         Rule.objects.filter(owner_id=team.actor_id, project=self).update(owner=None)
 
     def get_security_token(self):
-        lock = locks.get(self.get_lock_key(), duration=5)
+        lock = locks.get(self.get_lock_key(), duration=5, name="project_security_token")
         with TimedRetryPolicy(10)(lock.acquire):
             security_token = self.get_option("sentry:token", None)
             if security_token is None:

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -844,7 +844,7 @@ class Release(Model):
             if not RepositoryProvider.should_ignore_commit(c.get("message", ""))
         ]
         lock_key = type(self).get_lock_key(self.organization_id, self.id)
-        lock = locks.get(lock_key, duration=10)
+        lock = locks.get(lock_key, duration=10, name="release_set_commits")
         if lock.locked():
             # Signal failure to the consumer rapidly. This aims to prevent the number
             # of timeouts and prevent web worker exhaustion when customers create

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -166,7 +166,7 @@ class Team(Model):
 
     def save(self, *args, **kwargs):
         if not self.slug:
-            lock = locks.get("slug:team", duration=5)
+            lock = locks.get("slug:team", duration=5, name="team_slug")
             with TimedRetryPolicy(10)(lock.acquire):
                 slugify_instance(self, self.name, organization=self.organization)
         super().save(*args, **kwargs)

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -90,7 +90,7 @@ def upgrade(ctx, verbosity, traceback, noinput, lock, no_repair, with_nodestore)
         from sentry.app import locks
         from sentry.utils.locking import UnableToAcquireLock
 
-        lock = locks.get("upgrade", duration=0)
+        lock = locks.get("upgrade", duration=0, name="command_upgrade")
         try:
             with lock.acquire():
                 _upgrade(not noinput, traceback, verbosity, not no_repair, with_nodestore)

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -113,7 +113,7 @@ def send_beacon():
             # XXX(dcramer): we're missing a unique constraint on upstream_id
             # so we're using a lock to work around that. In the future we'd like
             # to have a data migration to clean up the duplicates and add the constraint
-            lock = locks.get("broadcasts:{}".format(notice["id"]), duration=60)
+            lock = locks.get("broadcasts:{}".format(notice["id"]), duration=60, name="broadcasts")
             with lock.acquire():
                 affected = Broadcast.objects.filter(upstream_id=notice["id"]).update(**defaults)
                 if not affected:

--- a/src/sentry/tasks/files.py
+++ b/src/sentry/tasks/files.py
@@ -18,7 +18,7 @@ def delete_file(path, checksum, **kwargs):
     from sentry.models.file import FileBlob, get_storage
     from sentry.utils.retries import TimedRetryPolicy
 
-    lock = locks.get(f"fileblob:upload:{checksum}", duration=60 * 10)
+    lock = locks.get(f"fileblob:upload:{checksum}", duration=60 * 10, name="fileblob_upload")
     with TimedRetryPolicy(60)(lock.acquire):
         if not FileBlob.objects.filter(checksum=checksum).exists():
             get_storage().delete(path)

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -114,7 +114,9 @@ def _process_suspect_commits(
 def process_suspect_commits(
     event_id, event_platform, event_frames, group_id, project_id, sdk_name=None, **kwargs
 ):
-    lock = locks.get(f"process-suspect-commits:{group_id}", duration=10)
+    lock = locks.get(
+        f"process-suspect-commits:{group_id}", duration=10, name="process_suspect_commits"
+    )
     try:
         with lock.acquire():
             _process_suspect_commits(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -154,7 +154,7 @@ def handle_group_owners(project, group, owners):
     from sentry.models.team import Team
     from sentry.models.user import User
 
-    lock = locks.get(f"groupowner-bulk:{group.id}", duration=10)
+    lock = locks.get(f"groupowner-bulk:{group.id}", duration=10, name="groupowner_bulk")
     try:
         with metrics.timer("post_process.handle_group_owners"), sentry_sdk.start_span(
             op="post_process.handle_group_owners"
@@ -366,6 +366,7 @@ def post_process_group(
                 lock = locks.get(
                     f"w-o:{event.group_id}-d-l",
                     duration=10,
+                    name="post_process_w_o",
                 )
                 with lock.acquire():
                     has_commit_key = f"w-o:{event.project.organization_id}-h-c"

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -23,7 +23,7 @@ def process_pending(partition=None):
     else:
         lock_key = "buffer:process_pending:%d" % partition
 
-    lock = locks.get(lock_key, duration=60)
+    lock = locks.get(lock_key, duration=60, name="process_pending")
 
     try:
         with lock.acquire():

--- a/src/sentry/tasks/reprocessing.py
+++ b/src/sentry/tasks/reprocessing.py
@@ -18,7 +18,7 @@ def reprocess_events(project_id, **kwargs):
 
     lock_key = "events:reprocess_events:%s" % project_id
     have_more = False
-    lock = app.locks.get(lock_key, duration=60)
+    lock = app.locks.get(lock_key, duration=60, name="reprocess_events")
 
     try:
         with lock.acquire():

--- a/src/sentry/tasks/scheduler.py
+++ b/src/sentry/tasks/scheduler.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("sentry.scheduler")
 def enqueue_scheduled_jobs(**kwargs):
     from sentry.celery import app
 
-    with locks.get("scheduler.process", duration=60).acquire():
+    with locks.get("scheduler.process", duration=60, name="scheduler_process").acquire():
         job_list = list(ScheduledJob.objects.filter(date_scheduled__lte=timezone.now())[:101])
 
         if len(job_list) > 100:

--- a/src/sentry/utils/locking/manager.py
+++ b/src/sentry/utils/locking/manager.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from sentry.utils import metrics
 from sentry.utils.locking.lock import Lock
 
 
@@ -7,8 +8,11 @@ class LockManager:
     def __init__(self, backend):
         self.backend = backend
 
-    def get(self, key: str, duration: int, routing_key: Optional[str] = None) -> Lock:
+    def get(
+        self, key: str, duration: int, routing_key: Optional[str] = None, name: Optional[str] = None
+    ) -> Lock:
         """
         Retrieve a ``Lock`` instance.
         """
+        metrics.incr("lockmanager.get", tags={"lock_name": name} if name else None)
         return Lock(self.backend, key, duration, routing_key)

--- a/src/sentry_plugins/bitbucket/repository_provider.py
+++ b/src/sentry_plugins/bitbucket/repository_provider.py
@@ -45,7 +45,11 @@ class BitbucketRepositoryProvider(BitbucketMixin, RepositoryProvider):
         return config
 
     def get_webhook_secret(self, organization):
-        lock = locks.get(f"bitbucket:webhook-secret:{organization.id}", duration=60)
+        lock = locks.get(
+            f"bitbucket:webhook-secret:{organization.id}",
+            duration=60,
+            name="bitbucket_webhook_secret",
+        )
         with lock.acquire():
             secret = OrganizationOption.objects.get_value(
                 organization=organization, key="bitbucket:webhook_secret"

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -289,7 +289,9 @@ class GitHubRepositoryProvider(GitHubMixin, RepositoryProvider):
         return config
 
     def get_webhook_secret(self, organization):
-        lock = locks.get(f"github:webhook-secret:{organization.id}", duration=60)
+        lock = locks.get(
+            f"github:webhook-secret:{organization.id}", duration=60, name="github_webhook_secret"
+        )
         with lock.acquire():
             # TODO(dcramer): get_or_create would be a useful native solution
             secret = OrganizationOption.objects.get_value(

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -846,7 +846,7 @@ class UpdateReleaseDetailsTest(APITestCase):
 
         # Simulate a concurrent request by using an existing release
         # that has its commit lock taken out.
-        lock = locks.get(Release.get_lock_key(org.id, release.id), duration=10)
+        lock = locks.get(Release.get_lock_key(org.id, release.id), duration=10, name="release")
         lock.acquire()
 
         url = reverse(

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1455,7 +1455,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         # Simulate a concurrent request by using an existing release
         # that has its commit lock taken out.
         release = self.create_release(project, self.user, version="1.2.1")
-        lock = locks.get(Release.get_lock_key(org.id, release.id), duration=10)
+        lock = locks.get(Release.get_lock_key(org.id, release.id), duration=10, name="release")
         lock.acquire()
 
         url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -86,7 +86,7 @@ class FetchCommitsTest(TestCase):
         refs = [{"repository": repo.name, "commit": "b" * 40}]
         new_release = Release.objects.create(organization_id=org.id, version="12345678")
 
-        lock = locks.get(Release.get_lock_key(org.id, new_release.id), duration=10)
+        lock = locks.get(Release.get_lock_key(org.id, new_release.id), duration=10, name="release")
         lock.acquire()
 
         with self.tasks():


### PR DESCRIPTION
The new `lockmanager.get` counter metrics should provide us with a better understanding of how and by which component locks are used. At the moment all locks are being handled by one (redis) backend and this metric will provide needed data in case we decide to put some of the locks on their own backend.
