### PR TITLE
fix(profiling): guard from negative deltas

### DIFF
--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -485,7 +485,7 @@ export function collapseSamples(profile: ChromeTrace.CpuProfile): {
     // While we are not at the end and next sample is the same as current
     while (j < profile.samples.length && profile.samples[j + 1] === nodeId) {
       // Update the delta and advance j
-      delta += profile.timeDeltas[j + 1];
+      delta = Math.max(delta + profile.timeDeltas[j + 1], delta);
       j++;
     }
 
@@ -504,7 +504,7 @@ export function collapseSamples(profile: ChromeTrace.CpuProfile): {
       // If we have not skipped samples, then we just push the sample and the delta to the list
       samples.push(nodeId);
       sampleTimes.push(elapsed);
-      elapsed += profile.timeDeltas[i + 1];
+      elapsed = Math.max(elapsed + profile.timeDeltas[i + 1], elapsed);
     }
   }
   return {samples, sampleTimes};

--- a/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
@@ -382,4 +382,30 @@ describe('collapseSamples', () => {
     expect(result.samples).toEqual(test.expectedSamples);
     expect(result.sampleTimes).toEqual(test.expectedTimeDeltas);
   });
+
+  it('guards from negative samples', () => {
+    const result = collapseSamples({
+      startTime: 0,
+      endTime: 100,
+      samples: [1, 2, 3],
+      timeDeltas: [1, -1, 1],
+      nodes: [],
+    });
+
+    expect(result.samples).toEqual([1, 2, 3]);
+    expect(result.sampleTimes).toEqual([1, 1, 2]);
+  });
+
+  it('guards from negative samples when they are being collapsed', () => {
+    const result = collapseSamples({
+      startTime: 0,
+      endTime: 100,
+      samples: [1, 1, 1],
+      timeDeltas: [1, -1, 2],
+      nodes: [],
+    });
+
+    expect(result.samples).toEqual([1, 1]);
+    expect(result.sampleTimes).toEqual([1, 3]);
+  });
 });


### PR DESCRIPTION
For some reason, it seems that timeDeltas can sometimes be negative. This change adds a guard from going back in time when collapsing sample. 