### PR TITLE
fix(perf): Fix periods of sidebars charts on summary

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -356,7 +356,7 @@ function SidebarChartsContainer({
     api,
     start,
     end,
-    statsPeriod,
+    period: statsPeriod,
     project,
     environment,
     query,


### PR DESCRIPTION
### Summary
The sidebar charts were constantly returning as 2-weeks (default) instead of being responsive to the current period selection
