### PR TITLE
fix(dev): Do not complain if a variable is unbound

### DIFF
--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is an interface to any of the methods of lib.sh
 # Call this script as "do.sh method_from_lib" to execute any function from that library
-set -eu
+set -e
 HERE="$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     pwd -P

--- a/scripts/do.sh
+++ b/scripts/do.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is an interface to any of the methods of lib.sh
 # Call this script as "do.sh method_from_lib" to execute any function from that library
-set -e
+set -eu
 HERE="$(
     cd "$(dirname "${BASH_SOURCE[0]}")"
     pwd -P

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -24,18 +24,10 @@ require() {
 }
 
 configure-sentry-cli() {
-    # XXX: For version 1.70.1 there's a bug hitting SENTRY_CLI_NO_EXIT_TRAP: unbound variable
-    # We can remove this after it's fixed
-    # https://github.com/getsentry/sentry-cli/pull/1059
-    export SENTRY_CLI_NO_EXIT_TRAP=${SENTRY_CLI_NO_EXIT_TRAP-0}
     if [ -z "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
         if ! require sentry-cli; then
             curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.0.4 bash
         fi
-        # This exported variable does not persist outside of the calling script, thus, not affecting other
-        # parts of the system
-        export SENTRY_DSN="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503"
-        eval "$(sentry-cli bash-hook)"
     fi
 }
 


### PR DESCRIPTION
Steps to reproduce on `master`:

```
$ direnv deny
$ make install-py-dev
You have a virtualenv, but it doesn't seem to be activated. Please run: source .venv/bin/activate
/Users/armenzg/code/sentry/scripts/lib.sh: line 63: $1: unbound variable
```

It's unclear where line 63 comes from.