### PR TITLE
test(ui): Convert passwordForm to RTL

### DIFF
--- a/tests/js/spec/views/passwordForm.spec.jsx
+++ b/tests/js/spec/views/passwordForm.spec.jsx
@@ -1,14 +1,16 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import PasswordForm from 'sentry/views/settings/account/passwordForm';
 
 const ENDPOINT = '/users/me/password/';
 
 describe('PasswordForm', function () {
-  let wrapper;
   let putMock;
-  const routerContext = TestStubs.routerContext([
+  // The "help" message is currently inside the label element
+  const currentPasswordLabel = 'Current PasswordYour current password';
+  const newPasswordLabel = 'New Password';
+  const verifyNewPasswordLabel = 'Verify New PasswordVerify your new password';
+  const context = TestStubs.routerContext([
     {
       router: {
         ...TestStubs.router(),
@@ -20,55 +22,48 @@ describe('PasswordForm', function () {
   ]);
 
   beforeEach(function () {
-    Client.clearMockResponses();
-    putMock = Client.addMockResponse({
+    MockApiClient.clearMockResponses();
+    putMock = MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'PUT',
     });
-    wrapper = mountWithTheme(<PasswordForm />, routerContext);
   });
 
   it('has 3 text inputs', function () {
-    expect(wrapper.find('input[type="password"]')).toHaveLength(3);
+    render(<PasswordForm />, {context});
+    expect(screen.getByLabelText(currentPasswordLabel)).toBeInTheDocument();
+    expect(screen.getByLabelText(newPasswordLabel)).toBeInTheDocument();
+    expect(screen.getByLabelText(verifyNewPasswordLabel)).toBeInTheDocument();
   });
 
   it('does not submit when any password field is empty', function () {
-    wrapper.find('input[name="password"]').simulate('change', {target: {value: 'test'}});
-    wrapper.find('form').simulate('submit');
+    render(<PasswordForm />, {context});
+    userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
+    userEvent.click(screen.getByRole('button', {name: 'Change password'}));
     expect(putMock).not.toHaveBeenCalled();
 
-    wrapper.find('input[name="password"]').simulate('change', {target: {value: ''}});
-    wrapper
-      .find('input[name="passwordNew"]')
-      .simulate('change', {target: {value: 'test'}});
-    wrapper
-      .find('input[name="passwordVerify"]')
-      .simulate('change', {target: {value: 'test'}});
-    wrapper.find('form').simulate('submit');
+    userEvent.clear(screen.getByLabelText(currentPasswordLabel));
+    userEvent.type(screen.getByLabelText(newPasswordLabel), 'test');
+    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'test');
+    userEvent.click(screen.getByRole('button', {name: 'Change password'}));
     expect(putMock).not.toHaveBeenCalled();
   });
 
   it('does not submit when new passwords do not match', function () {
-    wrapper.find('input[name="password"]').simulate('change', {target: {value: 'test'}});
-    wrapper
-      .find('input[name="passwordNew"]')
-      .simulate('change', {target: {value: 'test'}});
-    wrapper
-      .find('input[name="passwordVerify"]')
-      .simulate('change', {target: {value: 'nottest'}});
-    wrapper.find('form').simulate('submit');
+    render(<PasswordForm />, {context});
+    userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
+    userEvent.type(screen.getByLabelText(newPasswordLabel), 'test');
+    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest');
+    userEvent.click(screen.getByRole('button', {name: 'Change password'}));
     expect(putMock).not.toHaveBeenCalled();
   });
 
   it('calls API when all fields are validated and clears form on success', async function () {
-    wrapper.find('input[name="password"]').simulate('change', {target: {value: 'test'}});
-    wrapper
-      .find('input[name="passwordNew"]')
-      .simulate('change', {target: {value: 'nottest'}});
-    wrapper
-      .find('input[name="passwordVerify"]')
-      .simulate('change', {target: {value: 'nottest'}});
-    wrapper.find('form').simulate('submit');
+    render(<PasswordForm />, {context});
+    userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
+    userEvent.type(screen.getByLabelText(newPasswordLabel), 'nottest');
+    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest');
+    userEvent.click(screen.getByRole('button', {name: 'Change password'}));
     expect(putMock).toHaveBeenCalledWith(
       ENDPOINT,
       expect.objectContaining({
@@ -81,31 +76,23 @@ describe('PasswordForm', function () {
       })
     );
 
-    await tick();
-    wrapper.update();
-    expect(wrapper.find('input[name="password"]').prop('value')).toBe('');
+    await waitFor(() =>
+      expect(screen.getByLabelText(currentPasswordLabel)).toHaveValue('')
+    );
   });
 
   it('validates mismatched passwords and remvoes validation on match', function () {
-    wrapper.find('input[name="password"]').simulate('change', {target: {value: 'test'}});
-    wrapper
-      .find('input[name="passwordNew"]')
-      .simulate('change', {target: {value: 'nottest'}});
-    wrapper
-      .find('input[name="passwordVerify"]')
-      .simulate('change', {target: {value: 'nottest-mismatch'}});
+    render(<PasswordForm />, {context});
+    userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
+    userEvent.type(screen.getByLabelText(newPasswordLabel), 'nottest');
+    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest-mismatch');
+    userEvent.click(screen.getByRole('button', {name: 'Change password'}));
 
-    const error = wrapper.find('Field[id="passwordVerify"] FieldErrorReason');
+    expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
 
-    expect(error.exists()).toBe(true);
-    expect(error.text()).toBe('Passwords do not match');
+    userEvent.clear(screen.getByLabelText(verifyNewPasswordLabel));
+    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest');
 
-    wrapper
-      .find('input[name="passwordVerify"]')
-      .simulate('change', {target: {value: 'nottest'}});
-
-    expect(wrapper.find('Field[id="passwordVerify"] FieldErrorReason').exists()).toBe(
-      false
-    );
+    expect(screen.queryByText('Passwords do not match')).not.toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/passwordForm.spec.jsx
+++ b/tests/js/spec/views/passwordForm.spec.jsx
@@ -10,16 +10,6 @@ describe('PasswordForm', function () {
   const currentPasswordLabel = 'Current PasswordYour current password';
   const newPasswordLabel = 'New Password';
   const verifyNewPasswordLabel = 'Verify New PasswordVerify your new password';
-  const context = TestStubs.routerContext([
-    {
-      router: {
-        ...TestStubs.router(),
-        params: {
-          authId: 15,
-        },
-      },
-    },
-  ]);
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
@@ -30,14 +20,14 @@ describe('PasswordForm', function () {
   });
 
   it('has 3 text inputs', function () {
-    render(<PasswordForm />, {context});
+    render(<PasswordForm />);
     expect(screen.getByLabelText(currentPasswordLabel)).toBeInTheDocument();
     expect(screen.getByLabelText(newPasswordLabel)).toBeInTheDocument();
     expect(screen.getByLabelText(verifyNewPasswordLabel)).toBeInTheDocument();
   });
 
   it('does not submit when any password field is empty', function () {
-    render(<PasswordForm />, {context});
+    render(<PasswordForm />);
     userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
     userEvent.click(screen.getByRole('button', {name: 'Change password'}));
     expect(putMock).not.toHaveBeenCalled();
@@ -50,7 +40,7 @@ describe('PasswordForm', function () {
   });
 
   it('does not submit when new passwords do not match', function () {
-    render(<PasswordForm />, {context});
+    render(<PasswordForm />);
     userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
     userEvent.type(screen.getByLabelText(newPasswordLabel), 'test');
     userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest');
@@ -59,7 +49,7 @@ describe('PasswordForm', function () {
   });
 
   it('calls API when all fields are validated and clears form on success', async function () {
-    render(<PasswordForm />, {context});
+    render(<PasswordForm />);
     userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
     userEvent.type(screen.getByLabelText(newPasswordLabel), 'nottest');
     userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest');
@@ -82,7 +72,7 @@ describe('PasswordForm', function () {
   });
 
   it('validates mismatched passwords and remvoes validation on match', function () {
-    render(<PasswordForm />, {context});
+    render(<PasswordForm />);
     userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
     userEvent.type(screen.getByLabelText(newPasswordLabel), 'nottest');
     userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest-mismatch');


### PR DESCRIPTION
Cannot use getByRole on password fields for some reason, the labels are also not great in this deprecated form.