### PR TITLE
fix(active-release): Add custom slack referrer

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -274,17 +274,16 @@ def get_title_link(
     link_to_event: bool,
     issue_details: bool,
     notification: BaseNotification | None,
-    referrer: str | None = "slack",
 ) -> str:
     if event and link_to_event:
-        url = group.get_absolute_url(params={"referrer": referrer}, event_id=event.event_id)
+        url = group.get_absolute_url(params={"referrer": "slack"}, event_id=event.event_id)
 
     elif issue_details and notification:
-        notification_referrer = notification.get_referrer(ExternalProviders.SLACK)
-        url = group.get_absolute_url(params={"referrer": notification_referrer})
+        referrer = notification.get_referrer(ExternalProviders.SLACK)
+        url = group.get_absolute_url(params={"referrer": referrer})
 
     else:
-        url = group.get_absolute_url(params={"referrer": referrer})
+        url = group.get_absolute_url(params={"referrer": "slack"})
 
     # Explicitly typing to satisfy mypy.
     url_str: str = url
@@ -425,14 +424,10 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
 
         issue_title = build_attachment_title(obj)
         title_url = get_title_link(
-            self.group,
-            self.event,
-            self.link_to_event,
-            self.issue_details,
-            self.notification,
-            # TODO(workflow): Remove slack_release referrer experiement with flag "organizations:alert-release-notification-workflow"
-            "slack_release",
+            self.group, self.event, self.link_to_event, self.issue_details, self.notification
         )
+        # TODO(workflow): Remove referrer experiement with flag "organizations:alert-release-notification-workflow"
+        title_url = title_url.replace("referrer=slack", "referrer=slack_release")
         release = (
             parse_release(self.last_release.version)["description"]
             if self.last_release

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -423,11 +423,11 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
             payload_actions = []
 
         issue_title = build_attachment_title(obj)
-        title_url = get_title_link(
-            self.group, self.event, self.link_to_event, self.issue_details, self.notification
-        )
+        event_id = self.event.event_id if self.event else None
         # TODO(workflow): Remove referrer experiement with flag "organizations:alert-release-notification-workflow"
-        title_url = title_url.replace("referrer=slack", "referrer=slack_release")
+        title_url = self.group.get_absolute_url(
+            params={"referrer": "slack_release"}, event_id=event_id
+        )
         release = (
             parse_release(self.last_release.version)["description"]
             if self.last_release

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -274,16 +274,17 @@ def get_title_link(
     link_to_event: bool,
     issue_details: bool,
     notification: BaseNotification | None,
+    referrer: str | None = "slack",
 ) -> str:
     if event and link_to_event:
-        url = group.get_absolute_url(params={"referrer": "slack"}, event_id=event.event_id)
+        url = group.get_absolute_url(params={"referrer": referrer}, event_id=event.event_id)
 
     elif issue_details and notification:
-        referrer = notification.get_referrer(ExternalProviders.SLACK)
-        url = group.get_absolute_url(params={"referrer": referrer})
+        notification_referrer = notification.get_referrer(ExternalProviders.SLACK)
+        url = group.get_absolute_url(params={"referrer": notification_referrer})
 
     else:
-        url = group.get_absolute_url(params={"referrer": "slack"})
+        url = group.get_absolute_url(params={"referrer": referrer})
 
     # Explicitly typing to satisfy mypy.
     url_str: str = url
@@ -424,10 +425,14 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
 
         issue_title = build_attachment_title(obj)
         title_url = get_title_link(
-            self.group, self.event, self.link_to_event, self.issue_details, self.notification
+            self.group,
+            self.event,
+            self.link_to_event,
+            self.issue_details,
+            self.notification,
+            # TODO(workflow): Remove slack_release referrer experiement with flag "organizations:alert-release-notification-workflow"
+            "slack_release",
         )
-        # TODO(workflow): Remove referrer experiement with flag "organizations:alert-release-notification-workflow"
-        title_url = title_url.replace("referrer=slack", "referrer=slack_release")
         release = (
             parse_release(self.last_release.version)["description"]
             if self.last_release

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -426,6 +426,8 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
         title_url = get_title_link(
             self.group, self.event, self.link_to_event, self.issue_details, self.notification
         )
+        # TODO(workflow): Remove referrer experiement with flag "organizations:alert-release-notification-workflow"
+        title_url = title_url.replace("referrer=slack", "referrer=slack_release")
         release = (
             parse_release(self.last_release.version)["description"]
             if self.last_release

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -147,7 +147,7 @@ class BuildGroupAttachmentTest(TestCase):
         release_link = absolute_uri(
             f"/organizations/{group.organization.slug}/releases/{release.version}/?project={group.project_id}"
         )
-        group_link = f"http://testserver/organizations/{group.organization.slug}/issues/{group.id}/?referrer=slack"
+        group_link = f"http://testserver/organizations/{group.organization.slug}/issues/{group.id}/?referrer=slack_release"
         assert attachments["title"] == f"Release <{release_link}|{release.version}> has a new issue"
         assert attachments["text"] == f"<{group_link}|*{group.title}*> \n"
         assert "title_link" not in attachments


### PR DESCRIPTION
Adds a custom slack referrer to the active release slack notification so we can track them seperate from the other slack clicks