### PR TITLE
ref(performance): Use CompactSelect for Trends dropdowns

### DIFF
--- a/static/app/views/performance/trends/content.tsx
+++ b/static/app/views/performance/trends/content.tsx
@@ -6,9 +6,9 @@ import {Location} from 'history';
 import Alert from 'sentry/components/alert';
 import Breadcrumbs from 'sentry/components/breadcrumbs';
 import DatePageFilter from 'sentry/components/datePageFilter';
-import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
+import CompactSelect from 'sentry/components/forms/compactSelect';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -250,40 +250,24 @@ class TrendsContent extends Component<Props, State> {
                   onSearch={this.handleSearch}
                   maxQueryLength={MAX_QUERY_LENGTH}
                 />
-                <div data-test-id="trends-dropdown">
-                  <DropdownControl
-                    buttonProps={{prefix: t('Percentile')}}
-                    label={currentTrendFunction.label}
-                  >
-                    {TRENDS_FUNCTIONS.map(({label, field}) => (
-                      <DropdownItem
-                        key={field}
-                        onSelect={this.handleTrendFunctionChange}
-                        eventKey={field}
-                        data-test-id={field}
-                        isActive={field === currentTrendFunction.field}
-                      >
-                        {label}
-                      </DropdownItem>
-                    ))}
-                  </DropdownControl>
-                </div>
-                <DropdownControl
-                  buttonProps={{prefix: t('Parameter')}}
-                  label={currentTrendParameter.label}
-                >
-                  {TRENDS_PARAMETERS.map(({label}) => (
-                    <DropdownItem
-                      key={label}
-                      onSelect={this.handleParameterChange}
-                      eventKey={label}
-                      data-test-id={label}
-                      isActive={label === currentTrendParameter.label}
-                    >
-                      {label}
-                    </DropdownItem>
-                  ))}
-                </DropdownControl>
+                <CompactSelect
+                  triggerProps={{prefix: t('Percentile')}}
+                  value={currentTrendFunction.field}
+                  options={TRENDS_FUNCTIONS.map(({label, field}) => ({
+                    value: field,
+                    label,
+                  }))}
+                  onChange={opt => this.handleTrendFunctionChange(opt.value)}
+                />
+                <CompactSelect
+                  triggerProps={{prefix: t('Parameter')}}
+                  value={currentTrendParameter.label}
+                  options={TRENDS_PARAMETERS.map(({label}) => ({
+                    value: label,
+                    label,
+                  }))}
+                  onChange={opt => this.handleParameterChange(opt.value)}
+                />
               </FilterActions>
               <ListContainer>
                 <ChangedTransactions

--- a/tests/js/spec/views/performance/trends/index.spec.tsx
+++ b/tests/js/spec/views/performance/trends/index.spec.tsx
@@ -45,45 +45,39 @@ jest.mock('moment', () => {
 });
 
 async function getTrendDropdown() {
-  const dropdown = (await screen.findAllByTestId('dropdown-control'))[0];
+  const dropdown = await screen.findByRole('button', {name: /Percentile.+/});
   expect(dropdown).toBeInTheDocument();
   return dropdown;
 }
 
 async function getParameterDropdown() {
-  const dropdown = (await screen.findAllByTestId('dropdown-control'))[1];
+  const dropdown = await screen.findByRole('button', {name: /Parameter.+/});
   expect(dropdown).toBeInTheDocument();
   return dropdown;
 }
 
-async function selectMenuItemFromDropdown(dropdownEl, testid) {
+async function selectMenuItemFromDropdown(value) {
   (browserHistory.push as any).mockReset();
   expect(browserHistory.push).not.toHaveBeenCalled();
-  const option = await within(await within(dropdownEl).findByTestId(testid)).findByTestId(
-    'menu-item'
-  );
+  const option = await screen.findByTestId(value);
   expect(option).toBeInTheDocument();
   clickEl(option);
 
   await waitFor(() => expect(browserHistory.push).toHaveBeenCalled());
 }
 
-async function selectTrendFunction(field) {
+async function selectTrendFunction(value) {
   const dropdown = await getTrendDropdown();
   clickEl(dropdown);
 
-  await selectMenuItemFromDropdown(dropdown, field);
+  await selectMenuItemFromDropdown(value);
 }
 
-async function getDropdownButtons() {
-  return await screen.findAllByTestId('dropdown-control-button');
-}
-
-async function selectTrendParameter(label) {
+async function selectTrendParameter(value) {
   const dropdown = await getParameterDropdown();
   clickEl(dropdown);
 
-  await selectMenuItemFromDropdown(dropdown, label);
+  await selectMenuItemFromDropdown(value);
 }
 
 async function waitForMockCall(mock: any) {
@@ -295,7 +289,8 @@ describe('Performance > Trends', function () {
       }
     );
 
-    expect(await screen.findByTestId('trends-dropdown')).toBeInTheDocument();
+    expect(await getTrendDropdown()).toBeInTheDocument();
+    expect(await getParameterDropdown()).toBeInTheDocument();
     expect(screen.getAllByTestId('changed-transactions')).toHaveLength(2);
   });
 
@@ -491,8 +486,8 @@ describe('Performance > Trends', function () {
       }
     );
 
-    const dropdownButton = await getDropdownButtons();
-    expect(dropdownButton[1]).toHaveTextContent('LCP');
+    const trendDropdownButton = await getTrendDropdown();
+    expect(trendDropdownButton).toHaveTextContent('Percentilep50');
   });
 
   it('sets duration as a default trend parameter for backend project if query does not specify trend parameter', async function () {
@@ -507,8 +502,8 @@ describe('Performance > Trends', function () {
       }
     );
 
-    const dropdownButton = await getDropdownButtons();
-    expect(dropdownButton[1]).toHaveTextContent('Duration');
+    const parameterDropdownButton = await getParameterDropdown();
+    expect(parameterDropdownButton).toHaveTextContent('ParameterDuration');
   });
 
   it('sets trend parameter from query and ignores default trend parameter', async function () {
@@ -523,8 +518,8 @@ describe('Performance > Trends', function () {
       }
     );
 
-    const dropdownButton = await getDropdownButtons();
-    expect(dropdownButton[1]).toHaveTextContent('FCP');
+    const parameterDropdownButton = await getParameterDropdown();
+    expect(parameterDropdownButton).toHaveTextContent('ParameterFCP');
   });
 
   it('choosing a parameter changes location', async function () {


### PR DESCRIPTION
**Before:**
<img width="374" alt="Screen Shot 2022-06-24 at 1 24 37 PM" src="https://user-images.githubusercontent.com/44172267/175662116-51d60441-84a5-45ca-9466-2eec3c41f18d.png">
<img width="374" alt="Screen Shot 2022-06-24 at 1 24 47 PM" src="https://user-images.githubusercontent.com/44172267/175662147-56d5373b-962b-4821-9845-000b5508fa66.png">


**After:**
<img width="374" alt="Screen Shot 2022-06-24 at 1 25 13 PM" src="https://user-images.githubusercontent.com/44172267/175662201-5fdb2b8e-0a28-4fc7-8e1d-ba6e59887127.png">
<img width="374" alt="Screen Shot 2022-06-24 at 1 25 24 PM" src="https://user-images.githubusercontent.com/44172267/175662222-35b1115b-4e78-40cf-97d3-c5b4eccd0f8d.png">

