### PR TITLE
feat(profiling): Add a route to map a transaction ID to a profile ID

### DIFF
--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -31,6 +31,19 @@ class ProjectProfilingBaseEndpoint(ProjectEndpoint):  # type: ignore
         return params
 
 
+class ProjectProfilingTransactionIDProfileIDEndpoint(ProjectProfilingBaseEndpoint):
+    def get(self, request: Request, project: Project, transaction_id: str) -> StreamingHttpResponse:
+        if not features.has("organizations:profiling", project.organization, actor=request.user):
+            return Response(status=404)
+        kwargs: Dict[str, Any] = {
+            "method": "GET",
+            "path": f"/organizations/{project.organization.id}/projects/{project.id}/transactions/{transaction_id}",
+        }
+        if "Accept-Encoding" in request.headers:
+            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
+        return proxy_profiling_service(**kwargs)
+
+
 class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
     def get(self, request: Request, project: Project, profile_id: str) -> StreamingHttpResponse:
         if not features.has("organizations:profiling", project.organization, actor=request.user):

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -385,6 +385,7 @@ from .endpoints.project_processingissues import (
 from .endpoints.project_profiling_profile import (
     ProjectProfilingFunctionsEndpoint,
     ProjectProfilingProfileEndpoint,
+    ProjectProfilingTransactionIDProfileIDEndpoint,
 )
 from .endpoints.project_release_commits import ProjectReleaseCommitsEndpoint
 from .endpoints.project_release_details import ProjectReleaseDetailsEndpoint
@@ -2210,6 +2211,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/profiling/profiles/(?P<profile_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
                     ProjectProfilingProfileEndpoint.as_view(),
                     name="sentry-api-0-project-profiling-profile",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/profiling/transactions/(?P<transaction_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
+                    ProjectProfilingTransactionIDProfileIDEndpoint.as_view(),
+                    name="sentry-api-0-project-profiling-transactions",
                 ),
             ]
         ),


### PR DESCRIPTION
This is meant to provide a profile ID matching a transaction ID.
```
HTTP/1.1 200 OK
Cache-Control: public, max-age=3600, immutable
Content-Length: 49
Content-Type: application/json
Date: Thu, 23 Jun 2022 22:44:41 GMT
Vary: Accept-Encoding

{
    "profile_id": "91633534d5f6455a8138f29843058229"
}
```