### PR TITLE
feat(active-release): add opt-in for release committers

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -929,6 +929,8 @@ CRISPY_TEMPLATE_PACK = "bootstrap3"
 SENTRY_FEATURES = {
     # Enables user registration.
     "auth:register": True,
+    # Workflow 2.0 Experimental ReleaseMembers who opt-in to get notified as a release committer
+    "organizations:active-release-notification-opt-in": False,
     # Enable advanced search features, like negation and wildcard matching.
     "organizations:advanced-search": True,
     # Use metrics as the dataset for crash free metric alerts

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -57,6 +57,7 @@ default_manager.add("auth:register")
 default_manager.add("organizations:create")
 
 # Organization scoped features that are in development or in customer trials.
+default_manager.add("organizations:active-release-notification-opt-in", OrganizationFeature, True)
 default_manager.add("organizations:alert-filters", OrganizationFeature)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, True)
 default_manager.add("organizations:alert-release-notification-workflow", OrganizationFeature, True)

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -269,8 +269,17 @@ def get_release_committers(project: Project, event: Event) -> Sequence[User]:
 
     # commit_author_id : Author
     author_users: Mapping[str, Author] = get_users_for_commits(commits)
-    return list(
+    release_committers = list(
         User.objects.filter(id__in={au["id"] for au in author_users.values() if au.get("id")})
+    )
+
+    return list(
+        filter(
+            lambda u: features.has(
+                "organizations:active-release-notification-opt-in", project.organization, actor=u
+            ),
+            release_committers,
+        )
     )
 
 


### PR DESCRIPTION
This PR adds a feature filter for active release notifications to allow internal Sentry employees to opt-in to be notified of new issues related to releases.

The intention of this feature flag is to allow our team to slowly control who will get these new notifications. Currently, there's no proper notification settings to suppress ActiveReleaseNotifications.