### PR TITLE
fix(ui): Don't capture 401 errors when fetching assistant

### DIFF
--- a/static/app/actionCreators/guides.tsx
+++ b/static/app/actionCreators/guides.tsx
@@ -11,8 +11,10 @@ export async function fetchGuides() {
   try {
     const data = await api.requestPromise('/assistant/');
     GuideStore.fetchSucceeded(data);
-  } catch (error) {
-    Sentry.captureException(error);
+  } catch (err) {
+    if (err.status !== 401 && err.status !== 403) {
+      Sentry.captureException(err);
+    }
   }
 }
 


### PR DESCRIPTION
We don't need to be alerted about authorization required or incorrect permissions.

JAVASCRIPT-25JX