### PR TITLE
[DO NOT MERGE] Experimenting with a script to hit the v3 endpoint [INGEST-1401]

### DIFF
--- a/bin/experiment.py
+++ b/bin/experiment.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+from sentry.runner import configure
+
+configure()
+
+import pprint
+import signal
+import time
+
+import ipdb
+import requests
+
+from sentry.models.projectkey import ProjectKey
+
+LIVE = True
+# the first 9 projects arent for testing the endpoint. this may be different in your local environment
+PROJ_START_OFFSET = 9
+NUM_PROJECTS = 100
+MAX_BATCH_LEN = 5  # max of projects in a single request
+
+BASE_URL = "http://localhost:8000/"
+PROJECT_CONFIG_URL = "api/0/relays/projectconfigs/"
+DEFAULT_HEADERS = {"version": "3", "fullConfig": "True", "noCache": "False"}
+
+
+def ctrlC_handler(_signal, _frame):
+    global LIVE
+    LIVE = False
+
+
+def get_project_keys():
+    public_keys = []
+    for i in range(PROJ_START_OFFSET, PROJ_START_OFFSET + NUM_PROJECTS):
+        key = ProjectKey.objects.get(id=i)
+        public_keys.append(key.public_key)
+    return public_keys
+
+
+signal.signal(signal.SIGINT, ctrlC_handler)
+
+
+def request_batch(batch):
+    # print(f"requesting batch of {len(batch)}...")
+
+    url = f"{BASE_URL}{PROJECT_CONFIG_URL}"
+    headers = DEFAULT_HEADERS.copy()
+    headers["publickeys"] = ":".join(batch)  # temporary protocol
+
+    return requests.post(url, headers=headers).json()
+
+
+def update_stats(response, stats):
+    """Updates the stats with the provided response from the server."""
+    for key in response.get("pending", []):
+        stats[key][-1] += 1
+
+    for key in response.get("configs", []):
+        stats[key][-1] += 1
+        stats[key].append(0)
+
+    return stats
+
+
+def prepare_next_batch(response, keys, key_idx, stats):
+    next_batch = [key for key in response.get("pending", [])]
+    remaining_seats = MAX_BATCH_LEN - len(next_batch)
+    if remaining_seats <= 0:
+        return next_batch, key_idx
+
+    next_keys, idx = get_next_keys(keys, key_idx, remaining_seats, stats)
+    next_batch.extend(next_keys)
+
+    # Try to get another batch of keys, in case we needed to reset the key
+    remaining_seats = MAX_BATCH_LEN - len(next_batch)
+    if remaining_seats > 0:
+        more_keys, idx = get_next_keys(keys, key_idx, remaining_seats, stats)
+        next_batch.extend(more_keys)
+
+    return next_batch, idx
+
+
+def get_next_keys(keys, key_idx, amount, stats):
+    if key_idx >= len(keys):
+        key_idx = 0
+
+    rv = []
+    remaining = min(len(keys), key_idx + amount)
+    if remaining <= 0:
+        return rv, key_idx
+
+    rv.extend(keys[key_idx:remaining])
+    return rv, key_idx + remaining
+
+
+"""
+dictionary mapping from a project's public key to a list.
+each list index represents the amount of requests that took to fetch the config
+of a project, where the total amount is the sum of all pendings plus the last
+config response. The last `0` doesnt have any meaning.
+
+for example:
+stats == {key1: [3, 2, 0]}
+means: there were 2 rounds (`len(stats) - 1`); the first round took 3 requests
+to resolve (two pendings + one config), and the second round 2 requests
+(one pending + one config).
+
+note:
+pending projects in the last response are prioritized over everything else. this
+means that in cases where the server returns pending for all projects, the
+following request will be the same, creating a chance for infinite loops.
+"""
+keys = get_project_keys()
+stats = {key: [0] for key in keys}
+batch = keys[:MAX_BATCH_LEN]
+key_idx = len(batch)
+
+print("\nSmashing the endpoint. Press ^C to stop.")
+
+while LIVE:
+    res = request_batch(batch)
+    stats = update_stats(res, stats)
+    batch, key_idx = prepare_next_batch(res, keys, key_idx, stats)
+    if len(batch) == 0:
+        print("Stopping, no more project configs to request")
+        LIVE = False
+    else:
+        time.sleep(0.25)
+        ipdb.set_trace(context=5)
+
+print()  # Empty line after potential ^C
+pprint.pprint(stats)

--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -336,9 +336,11 @@ def main(num_events=1, extra_events=False, load_trends=False, slow=False):
     dummy_user.set_password("dummy")
     dummy_user.save()
 
+    # team_name, project_names
     mocks = (
         ("Massive Dynamic", ("Ludic Science",)),
-        ("Captain Planet", ("Earth", "Fire", "Wind", "Water", "Heart")),
+        # ("Captain Planet", ("Earth", "Fire", "Wind", "Water", "Heart")),
+        ("Test Team", [f"proj_{i}" for i in range(1000)]),
     )
     project_map = {}
 

--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -8,7 +8,6 @@ from rest_framework.response import Response
 from sentry_sdk import Hub, set_tag, start_span, start_transaction
 
 from sentry import options
-from sentry.api.authentication import RelayAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.permissions import RelayPermission
 from sentry.models import Organization, OrganizationOption, Project, ProjectKey, ProjectKeyStatus
@@ -27,7 +26,6 @@ def _sample_apm():
 
 
 class RelayProjectConfigsEndpoint(Endpoint):
-    authentication_classes = (RelayAuthentication,)
     permission_classes = (RelayPermission,)
     enforce_rate_limit = False
 

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -15,7 +15,8 @@ from sentry.utils import auth
 
 class RelayPermission(permissions.BasePermission):
     def has_permission(self, request: Request, view):
-        return getattr(request, "relay", None) is not None
+        # return getattr(request, "relay", None) is not None
+        return True
 
 
 class SystemPermission(permissions.BasePermission):

--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -2,7 +2,7 @@ from sentry.relay.projectconfig_cache.base import ProjectConfigCache
 from sentry.utils import json, metrics, redis
 from sentry.utils.redis import validate_dynamic_cluster
 
-REDIS_CACHE_TIMEOUT = 3600  # 1 hr
+REDIS_CACHE_TIMEOUT = 10  # seconds
 
 
 class RedisProjectConfigCache(ProjectConfigCache):


### PR DESCRIPTION
This is an experiment to isolate the project config endpoint v3, DO NOT MERGE.

# Steps to run the experiment

1. Make sure your local development environment is working correctly.

2. Activate the venv if it isn't already, you will need it for all the following commands.
```shell
$ source .venv/bin/activate
```

3. Run the `bin/load-mocks` script. This will load a ton of mock project configs. By default it creates 1000 and takes a really long time to do it (>30'), having a smaller amount may be enough. Look at the diff to modify this value.
```shell
$ python bin/load-mocks
```

4. You may want to make sure the redis cache is empty before starting (each) experiment. If you want to do that, stop the running sentry instance, clear redis, and start sentry again after. To clear redis:
```
$ docker exec -it sentry_redis redis-cli
127.0.0.1:6379> FLUSHDB
OK
```

5. With sentry running, run the experiment script (you may need to install some python dependencies):
```shell
$ python bin/experiment.py
```

# The experiment's script

To configure the script, modify the constants at the top of it.

## Understanding the output

The script's output will look something similar to the following:
```txt
{'004e05ea563f49faaca3f711868bb636': [0],
 '0fe212a0b2524d368f5931ac8aa9fb46': [3],
 '45869fdaa2354fc9920d3af49cab5755': [3, 0],
 'b4b32a3665374c6c94a85b47c6ba468d': [0],
 'b51cf8143384445d80b77e4d6e1bb9ba': [1],
 'd77d14d05c764ac58438a303e99363cd': [2, 0],
 'd9f7bd2931bd4d4cb8f0178087f66fe3': [0],
 'df1076be297d4030ac14fc42afbf74db': [0],
 'e137f49fedda4b47a80de3de646f09fb': [0],
 'e44c9e227954430592b4ed198de4ed94': [0],
 'e501dbc5b2684e59a1d7b796ffe986a7': [3, 0],
 'e7d72ed95bf14c2bbe5c716f2cde0727': [3],
  // ...and more, depending how many projects you have set in the script.
}
```
Let's understand what each list means with examples:
- `[3, 0]`: two rounds of attempts. In the first round, the script got 2 pending responses and the config in the 3rd request. The second round didn't start yet.
- `[3]`: single round of attempts, and got 3 pending responses so far.
- `[0]`: single round without responses, i.e. a this project config hasn't been requested yet.