### PR TITLE
fix(profiling): profileDetails browserhistory

### DIFF
--- a/static/app/views/profiling/profileDetails.tsx
+++ b/static/app/views/profiling/profileDetails.tsx
@@ -134,7 +134,7 @@ function ProfileDetails() {
 
   const handleSearch = useCallback(
     searchString => {
-      browserHistory.push({
+      browserHistory.replace({
         ...location,
         query: {
           ...location.query,


### PR DESCRIPTION
## Summary
When searching on the `profileDetails` page we're using `history.push` to update the query-string. This effectively pollutes our browser history with every keystroke. Pressing the browser back button does not return to the previous page, it just returns to the last keystroke.

### Before
https://user-images.githubusercontent.com/7349258/175946381-7befdb1d-1fc8-47ee-8b77-bbd6ed2aa43b.mov

### After
https://user-images.githubusercontent.com/7349258/175946511-c227d9a3-fd1f-4a69-96f2-127ca09a0cc2.mov


