### PR TITLE
ref: upgrade unidiff to avoid escape sequence warnings

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -65,7 +65,7 @@ symbolic==8.7.1
 toronado==0.1.0
 typing-extensions==3.10.0.2
 ua-parser==0.10.0
-unidiff==0.7.1
+unidiff==0.7.4
 urllib3[brotli]==1.26.9
 brotli==1.0.9
 # See if we can remove LDFLAGS from lib.sh


### PR DESCRIPTION
0.7.2 / 0.7.3 was broken:
- unidiff issue: https://github.com/matiasb/python-unidiff/issues/93
- unidiff fix: https://github.com/matiasb/python-unidiff/pull/95
- sentry rollback to older unidiff: https://github.com/getsentry/sentry/pull/34691 (patch contains test to validate safety of upgrade)