### PR TITLE
ref: upgrade actions/cache

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -66,7 +66,7 @@ runs:
         echo "::set-output name=pip-version::$(pip -V | awk -F ' ' '{print $2}')"
 
     - name: pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.pip-info.outputs.pip-cache-dir }}
         key: |

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -64,7 +64,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
@@ -146,13 +146,13 @@ jobs:
           echo "::set-output name=webpack-path::.webpack_cache"
 
       - name: yarn cache
-        uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
+        uses: actions/cache@v3
         with:
           path: ${{ steps.config.outputs.yarn-path }}
           key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
 
       - name: webpack cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.config.outputs.webpack-path }}
           key: ${{ runner.os }}-v2-webpack-cache-${{ hashFiles('webpack.config.ts') }}
@@ -235,7 +235,7 @@ jobs:
           chartcuterie: true
 
       - name: yarn cache
-        uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
+        uses: actions/cache@v3
         with:
           path: ${{ steps.setup.outputs.yarn-cache-dir }}
           key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -62,7 +62,7 @@ jobs:
           python-version: 3.8.12
 
       - name: Cache (yarn)
-        uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
+        uses: actions/cache@v3
         with:
           path: ${{ steps.info.outputs.yarn-cache-dir }}
           key: devenv-${{ runner.os }}-v1-yarn-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -53,7 +53,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
@@ -150,7 +150,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v1 # We are explicitly using v1 due to perf reasons
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}


### PR DESCRIPTION
newer versions of actions/cache add a socket timeout which may help with our timeout issues restoring the yarn cache

___

there's a comment about performance on these lines -- here's some (anecdotal) numbers:

- frontend test 1 before: 7s (here: https://github.com/getsentry/sentry/runs/7074301777?check_suite_focus=true )
- frontend test 1 after: 8s (here: https://github.com/getsentry/sentry/runs/7074768646?check_suite_focus=true)

clicking through some others I'm seeing ~3-4s for python deps and 7-8s for yarn cache which is the ~same as it was before

