### PR TITLE
ref(profiling): memo FrameStack component to minimize rerenders

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState} from 'react';
+import {memo, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
@@ -20,7 +20,7 @@ interface FrameStackProps {
   flamegraphRenderer: FlamegraphRenderer;
 }
 
-function FrameStack(props: FrameStackProps) {
+const FrameStack = memo(function FrameStack(props: FrameStackProps) {
   const theme = useFlamegraphTheme();
   const {selectedNode} = useFlamegraphProfilesValue();
 
@@ -164,7 +164,7 @@ function FrameStack(props: FrameStackProps) {
       />
     </FrameDrawer>
   ) : null;
-}
+});
 
 const FrameDrawerLabel = styled('label')`
   display: flex;


### PR DESCRIPTION
## Summary
`FrameStack` is rendering its whole component tree unnecessarily on `FlameGraphZoomView` mouse movements; this can cause a janky UX. 

Aside; I identified this while exploring our "scope to view" functionality and also identified the following:
- There are alot of frame drops/jank when using scope to view, this fix should help a bit but i'm still working through it.
- Currently we cannot scope to view on another frame if we've already scoped to another view on another frame. 
- The right click context menu sometimes stays mounted despite clicking "scope to view"


## Before

https://user-images.githubusercontent.com/7349258/175975277-696a0842-7c0c-452f-bd7f-09e72db04026.mov

## After
https://user-images.githubusercontent.com/7349258/175975325-b1e9ffba-139c-4c52-bef6-ca3212af5d6b.mov


