### PR TITLE
fix(perf) Transaction summary graphs respect global date

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -385,6 +385,7 @@ function SidebarChartsContainer({
       organization={organization}
       interval={getInterval(datetimeSelection)}
       showLoading={false}
+      period={requestCommonProps.statsPeriod}
       includePrevious={false}
       yAxis={['apdex()', 'failure_rate()', 'epm()']}
       partial


### PR DESCRIPTION
Before (with 24 hour selected)
<img width="982" alt="image" src="https://user-images.githubusercontent.com/44422760/175977180-8e84207d-686b-4bf9-bd13-a5f326268a66.png">

After
<img width="862" alt="image" src="https://user-images.githubusercontent.com/44422760/175977537-ed2d18bb-a5a5-47fb-90ca-ce5c4c2466f5.png">

