### PR TITLE
test(ui): Increase wait for element timeout in flakey test

### DIFF
--- a/tests/js/spec/views/settings/project/sampling/modal.spec.tsx
+++ b/tests/js/spec/views/settings/project/sampling/modal.spec.tsx
@@ -138,8 +138,9 @@ describe('Sampling - Modal', function () {
 
     // Close Modal
     userEvent.click(screen.getByLabelText('Close Modal'));
-    await waitForElementToBeRemoved(() =>
-      screen.queryByText('Add Distributed Trace Rule')
+    await waitForElementToBeRemoved(
+      () => screen.queryByText('Add Distributed Trace Rule'),
+      {timeout: 2500}
     );
 
     expect(saveMock).toHaveBeenLastCalledWith(


### PR DESCRIPTION
There's a few failures, the default timeout is 1000ms, just bumping it up to see if that fixes it.

https://sentry.io/organizations/sentry/performance/summary/events/?breakdown=none&project=4857230&query=+transaction.status:internal_error&showTransactions=p100&sort=-transaction.duration&statsPeriod=7d&transaction=Sampling+-+Modal+%3E+saves+distributed+traces+rule