### PR TITLE
ref: use new find_element(s) apis

### DIFF
--- a/fixtures/page_objects/base.py
+++ b/fixtures/page_objects/base.py
@@ -1,3 +1,6 @@
+from selenium.webdriver.common.by import By
+
+
 class BasePage:
     """Base class for PageObjects"""
 
@@ -36,7 +39,7 @@ class ButtonElement(BaseElement):
 class ButtonWithIconElement(ButtonElement):
     @property
     def icon_href(self):
-        return self.element.find_element_by_tag_name("use").get_attribute("href")
+        return self.element.find_element(by=By.TAG_NAME, value="use").get_attribute("href")
 
 
 class TextBoxElement(BaseElement):

--- a/fixtures/page_objects/issue_details.py
+++ b/fixtures/page_objects/issue_details.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 from .base import BasePage
 from .global_selection import GlobalSelectionPage
 
@@ -25,7 +27,9 @@ class IssueDetailsPage(BasePage):
         self.browser.wait_until('[data-test-id="group-tag-value"]')
 
     def get_environment(self):
-        return self.browser.find_element_by_css_selector('[data-test-id="env-label"').text.lower()
+        return self.browser.find_element(
+            by=By.CSS_SELECTOR, value='[data-test-id="env-label"'
+        ).text.lower()
 
     def go_back_to_issues(self):
         self.global_selection.go_back_to_issues()
@@ -34,8 +38,8 @@ class IssueDetailsPage(BasePage):
         return self.client.get(f"/api/0/issues/{groupid}/")
 
     def go_to_subtab(self, name):
-        tabs = self.browser.find_element_by_css_selector(".group-detail .nav-tabs")
-        tabs.find_element_by_partial_link_text(name).click()
+        tabs = self.browser.find_element(by=By.CSS_SELECTOR, value=".group-detail .nav-tabs")
+        tabs.find_element(by=By.PARTIAL_LINK_TEXT, value=name).click()
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def open_issue_errors(self):
@@ -43,7 +47,7 @@ class IssueDetailsPage(BasePage):
         self.browser.wait_until(".entries > .errors ul")
 
     def open_curl(self):
-        self.browser.find_element_by_xpath("//a//code[contains(text(), 'curl')]").click()
+        self.browser.find_element(by=By.XPATH, value="//a//code[contains(text(), 'curl')]").click()
 
     def resolve_issue(self):
         self.browser.click('[aria-label="Resolve"]')
@@ -64,21 +68,25 @@ class IssueDetailsPage(BasePage):
         self.browser.wait_until('[data-test-id="unbookmark"]')
 
     def assign_to(self, user):
-        assignee = self.browser.find_element_by_css_selector(".assigned-to")
+        assignee = self.browser.find_element(by=By.CSS_SELECTOR, value=".assigned-to")
 
         # Open the assignee picker
-        assignee.find_element_by_css_selector('[role="button"]').click()
-        assignee.find_element_by_tag_name("input").send_keys(user)
+        assignee.find_element(by=By.CSS_SELECTOR, value='[role="button"]').click()
+        assignee.find_element(by=By.TAG_NAME, value="input").send_keys(user)
 
         # Click the member/team
-        options = assignee.find_elements_by_css_selector('[data-test-id="assignee-option"]')
+        options = assignee.find_elements(
+            by=By.CSS_SELECTOR, value='[data-test-id="assignee-option"]'
+        )
         assert len(options) > 0, "No assignees could be found."
         options[0].click()
 
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
     def find_comment_form(self):
-        return self.browser.find_element_by_css_selector('[data-test-id="note-input-form"]')
+        return self.browser.find_element(
+            by=By.CSS_SELECTOR, value='[data-test-id="note-input-form"]'
+        )
 
     def has_comment(self, text):
         element = self.browser.element('[data-test-id="activity-note-body"]')

--- a/fixtures/page_objects/organization_integration_settings.py
+++ b/fixtures/page_objects/organization_integration_settings.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 from .base import BasePage, ButtonElement, ModalElement
 
 
@@ -7,9 +9,9 @@ class ExampleIntegrationSetupWindowElement(ModalElement):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.name = self.element.find_element_by_name("name")
-        continue_button_element = self.element.find_element_by_css_selector(
-            self.submit_button_selector
+        self.name = self.element.find_element(by=By.NAME, value="name")
+        continue_button_element = self.element.find_element(
+            by=By.CSS_SELECTOR, value=self.submit_button_selector
         )
         self.continue_button = ButtonElement(continue_button_element)
 
@@ -29,7 +31,7 @@ class OrganizationAbstractDetailViewPage(BasePage):
         self.browser.click('[data-test-id="confirm-button"]')
 
     def switch_to_configuration_view(self):
-        self.browser.find_element_by_link_text(self.configurations_text).click()
+        self.browser.find_element(by=By.LINK_TEXT, value=self.configurations_text).click()
 
 
 class OrganizationIntegrationDetailViewPage(OrganizationAbstractDetailViewPage):

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -1,6 +1,5 @@
 # TODO(dcramer): this heavily inspired by pytest-selenium, and it's possible
 # we could simply inherit from the plugin at this point
-
 import logging
 import os
 import sys
@@ -17,6 +16,7 @@ from selenium.common.exceptions import (
     WebDriverException,
 )
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -129,10 +129,10 @@ class Browser:
 
         if xpath is not None:
             self.wait_until(xpath=xpath)
-            return self.driver.find_element_by_xpath(xpath)
+            return self.driver.find_element(by=By.XPATH, value=xpath)
         else:
             self.wait_until(selector)
-            return self.driver.find_element_by_css_selector(selector)
+            return self.driver.find_element(by=By.CSS_SELECTOR, value=selector)
 
     def elements(self, selector=None, xpath=None):
         """
@@ -141,17 +141,17 @@ class Browser:
 
         if xpath is not None:
             self.wait_until(xpath=xpath)
-            return self.driver.find_elements_by_xpath(xpath)
+            return self.driver.find_elements(by=By.XPATH, value=xpath)
         else:
             self.wait_until(selector)
-            return self.driver.find_elements_by_css_selector(selector)
+            return self.driver.find_elements(by=By.CSS_SELECTOR, value=selector)
 
     def element_exists(self, selector):
         """
         Check if an element exists on the page. This method will *not* wait for the element.
         """
         try:
-            self.driver.find_element_by_css_selector(selector)
+            self.driver.find_element(by=By.CSS_SELECTOR, value=selector)
         except NoSuchElementException:
             return False
         return True
@@ -186,7 +186,7 @@ class Browser:
         return self
 
     def find_element_by_name(self, name):
-        return self.driver.find_element_by_name(name)
+        return self.driver.find_element(by=By.NAME, value=name)
 
     def move_to(self, selector=None):
         """
@@ -205,8 +205,6 @@ class Browser:
         Waits until ``selector`` is visible and enabled to be clicked, or until ``timeout``
         is hit, whichever happens first.
         """
-        from selenium.webdriver.common.by import By
-
         if selector:
             condition = expected_conditions.element_to_be_clickable((By.CSS_SELECTOR, selector))
         else:
@@ -221,8 +219,6 @@ class Browser:
         Waits until ``selector`` is found in the browser, or until ``timeout``
         is hit, whichever happens first.
         """
-        from selenium.webdriver.common.by import By
-
         if selector:
             condition = expected_conditions.presence_of_element_located((By.CSS_SELECTOR, selector))
         elif xpath:
@@ -244,8 +240,6 @@ class Browser:
         Waits until ``selector`` is NOT found in the browser, or until
         ``timeout`` is hit, whichever happens first.
         """
-        from selenium.webdriver.common.by import By
-
         if selector:
             condition = expected_conditions.presence_of_element_located((By.CSS_SELECTOR, selector))
         elif title:
@@ -328,7 +322,7 @@ class Browser:
             with self.full_viewport():
                 screenshot_path = f"{snapshot_dir}/{filename}.png"
                 # This will make sure we resize viewport height to fit contents
-                self.driver.find_element_by_tag_name("body").screenshot(screenshot_path)
+                self.driver.find_element(by=By.TAG_NAME, value="body").screenshot(screenshot_path)
 
                 if os.environ.get("SENTRY_SCREENSHOT"):
                     import click
@@ -340,7 +334,9 @@ class Browser:
                 )
                 if has_tooltips:
                     screenshot_path = f"{snapshot_dir}-tooltips/{filename}.png"
-                    self.driver.find_element_by_tag_name("body").screenshot(screenshot_path)
+                    self.driver.find_element(by=By.TAG_NAME, value="body").screenshot(
+                        screenshot_path
+                    )
                     self.driver.execute_script(
                         "window.__closeAllTooltips && window.__closeAllTooltips()"
                     )
@@ -348,7 +344,7 @@ class Browser:
         if not desktop_only:
             with self.mobile_viewport():
                 screenshot_path = f"{snapshot_dir}-mobile/{filename}.png"
-                self.driver.find_element_by_tag_name("body").screenshot(screenshot_path)
+                self.driver.find_element(by=By.TAG_NAME, value="body").screenshot(screenshot_path)
 
                 if os.environ.get("SENTRY_SCREENSHOT"):
                     import click

--- a/tests/acceptance/test_auth.py
+++ b/tests/acceptance/test_auth.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 from sentry.testutils import AcceptanceTestCase
 
 
@@ -7,9 +9,11 @@ class AuthTest(AcceptanceTestCase):
         self.browser.driver.execute_script(
             "document.addEventListener('invalid', function(e) { e.preventDefault(); }, true);"
         )
-        self.browser.find_element_by_id("id_username").send_keys(username)
-        self.browser.find_element_by_id("id_password").send_keys(password)
-        self.browser.find_element_by_xpath("//button[contains(text(), 'Continue')]").click()
+        self.browser.find_element(by=By.ID, value="id_username").send_keys(username)
+        self.browser.find_element(by=By.ID, value="id_password").send_keys(password)
+        self.browser.find_element(
+            by=By.XPATH, value="//button[contains(text(), 'Continue')]"
+        ).click()
 
     def test_renders(self):
         self.browser.get("/auth/login/")

--- a/tests/acceptance/test_create_team.py
+++ b/tests/acceptance/test_create_team.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 from sentry.models import Team
 from sentry.testutils import AcceptanceTestCase
 
@@ -27,5 +29,5 @@ class CreateTeamTest(AcceptanceTestCase):
         self.browser.wait_until_not("[role='dialog']")
 
         # New team should be in dom
-        assert self.browser.find_element_by_xpath("//span[contains(text(), 'new-team')]")
+        assert self.browser.find_element(by=By.XPATH, value="//span[contains(text(), 'new-team')]")
         assert Team.objects.filter(slug="new-team", organization=self.org).exists()

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlencode
 
+from selenium.webdriver.common.by import By
+
 from sentry.testutils import AcceptanceTestCase
 from sentry.testutils.factories import get_fixture_path
 
@@ -61,7 +63,7 @@ class EmailTestCase(AcceptanceTestCase):
             # Text output is asserted against static fixture files
             self.browser.get(build_url(url, "txt"))
             self.browser.wait_until("#preview")
-            elem = self.browser.find_element_by_css_selector("#preview pre")
+            elem = self.browser.find_element(by=By.CSS_SELECTOR, value="#preview pre")
             text_src = elem.get_attribute("innerHTML")
 
             fixture_src = read_txt_email_fixture(name)

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from django.utils import timezone
+from selenium.webdriver.common.by import By
 
 from fixtures.page_objects.issue_details import IssueDetailsPage
 from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox
@@ -74,7 +75,7 @@ class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
         self.page.visit_issue_activity(self.org.slug, event.group.id)
 
         form = self.page.find_comment_form()
-        form.find_element_by_tag_name("textarea").send_keys("this looks bad")
+        form.find_element(by=By.TAG_NAME, value="textarea").send_keys("this looks bad")
         form.submit()
 
         assert self.page.has_comment("this looks bad")

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 from sentry.testutils import AcceptanceTestCase
 
 
@@ -85,7 +87,7 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
 
         self.browser.wait_until(".ref-success")
 
-        link = self.browser.find_element_by_link_text("Tesla App")
+        link = self.browser.find_element(by=By.LINK_TEXT, value="Tesla App")
         link.click()
 
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
@@ -102,8 +104,8 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
         self.browser.click('[data-test-id="token-delete"]')
         self.browser.wait_until(".ref-success")
 
-        assert self.browser.find_element_by_xpath(
-            "//div[contains(text(), 'No tokens created yet.')]"
+        assert self.browser.find_element(
+            by=By.XPATH, value="//div[contains(text(), 'No tokens created yet.')]"
         )
 
     def test_add_tokens_internal_app(self):

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 
 import pytest
 import pytz
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
 from sentry.discover.models import DiscoverSavedQuery
@@ -603,9 +604,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             card = self.browser.element(card_selector)
 
             # Open the context menu
-            card.find_element_by_css_selector('[data-test-id="menu-trigger"]').click()
+            card.find_element(by=By.CSS_SELECTOR, value='[data-test-id="menu-trigger"]').click()
             # Delete the query
-            card.find_element_by_css_selector('[data-test-id="delete"]').click()
+            card.find_element(by=By.CSS_SELECTOR, value='[data-test-id="delete"]').click()
 
             # Wait for card to clear
             self.browser.wait_until_not(card_selector)
@@ -630,8 +631,8 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             card = self.browser.element(card_selector)
 
             # Open the context menu, and duplicate
-            card.find_element_by_css_selector('[data-test-id="menu-trigger"]').click()
-            card.find_element_by_css_selector('[data-test-id="duplicate"]').click()
+            card.find_element(by=By.CSS_SELECTOR, value='[data-test-id="menu-trigger"]').click()
+            card.find_element(by=By.CSS_SELECTOR, value='[data-test-id="duplicate"]').click()
 
             duplicate_name = f"{query.name} copy"
 

--- a/tests/acceptance/test_organization_integration_configuration_tabs.py
+++ b/tests/acceptance/test_organization_integration_configuration_tabs.py
@@ -1,3 +1,5 @@
+from selenium.webdriver.common.by import By
+
 from sentry.models import Integration
 from sentry.testutils import AcceptanceTestCase
 
@@ -77,7 +79,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
             self.browser.wait_until("[role='dialog']")
 
             # Add Mapping Modal
-            externalName = self.browser.find_element_by_name("externalName")
+            externalName = self.browser.find_element(by=By.NAME, value="externalName")
             externalName.send_keys("@user2")
             self.browser.click("#userId:first-child div")
             self.browser.click('[id="react-select-2-option-1"]')
@@ -112,7 +114,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
             self.browser.wait_until("[role='dialog']")
 
             # Add Mapping Modal
-            externalName = self.browser.find_element_by_name("externalName")
+            externalName = self.browser.find_element(by=By.NAME, value="externalName")
             externalName.send_keys("@getsentry/ecosystem")
             self.browser.click("#teamId:first-child div")
             self.browser.click('[id="react-select-2-option-0"]')
@@ -149,7 +151,7 @@ class OrganizationIntegrationConfigurationTabs(AcceptanceTestCase):
             self.browser.click(".nav-tabs li:nth-child(1) a")
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
-            name = self.browser.find_element_by_name("name")
+            name = self.browser.find_element(by=By.NAME, value="name")
             name.clear()
             name.send_keys("New Name")
 

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -1,4 +1,5 @@
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.utils.retries import TimedRetryPolicy
@@ -47,7 +48,7 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
             selector = '[data-test-id="autocomplete-list"] [data-test-id="badge-display-name"]'
             self.browser.wait_until(selector)
 
-            return self.browser.find_elements_by_css_selector(selector)
+            return self.browser.find_elements(by=By.CSS_SELECTOR, value=selector)
 
         transition_urls = [
             OrganizationSwitchTest.url_creator(page, self.organization.slug)

--- a/tests/acceptance/test_project_settings_sampling.py
+++ b/tests/acceptance/test_project_settings_sampling.py
@@ -1,4 +1,5 @@
 from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
 from sentry.api.endpoints.project_details import DynamicSamplingSerializer
@@ -185,7 +186,11 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
 
             # There are no transaction rules
             assert (
-                len(self.browser.find_elements_by_css_selector('[data-test-id="sampling-rule"]'))
+                len(
+                    self.browser.find_elements(
+                        by=By.CSS_SELECTOR, value='[data-test-id="sampling-rule"]'
+                    )
+                )
                 == 0
             )
 
@@ -203,7 +208,12 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
             assert self.browser.element_exists('[data-test-id="sampling-rule"]')
 
             assert (
-                len(self.browser.find_elements_by_css_selector('[data-test-id="empty-state"]')) == 0
+                len(
+                    self.browser.find_elements(
+                        by=By.CSS_SELECTOR, value='[data-test-id="empty-state"]'
+                    )
+                )
+                == 0
             )
 
     def test_add_individual_transaction_rule_with_all_possible_conditions(self):


### PR DESCRIPTION
selenium 4.x deprecates the old way of calling these apis

automated using this script:

```python
from __future__ import annotations


import re
import subprocess
import sys

REG = re.compile(r'(\.find_elements?)_by_([^(]+)\(')


def _replace(match: re.Match[str]) -> str:
    return f'{match[1]}(by=By.{match[2].upper()}, value='


def main() -> int:
    for fname in sys.argv[1:]:
        with open(fname) as f:
            contents = f.read()

        contents = REG.sub(_replace, contents)
        with open(fname, 'w') as f:
            f.write(contents)

    subprocess.call((
        sys.executable, '-m', 'reorder_python_imports',
        '--add-import', 'from selenium.webdriver.common.by import By',
        *sys.argv[1:]
    ))

    subprocess.call((
        sys.executable, '-m', 'pre_commit', 'run', '--files', *sys.argv[1:],
    ))

if __name__ == '__main__':
    raise SystemExit(main())
```