### PR TITLE
fix(metrics): fix producer-topic configuration

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
@@ -132,12 +132,10 @@ class SimpleProduceStep(ProcessingStep[KafkaPayload]):  # type: ignore
         producer: Optional[AbstractProducer] = None,
     ) -> None:
         snuba_metrics = settings.KAFKA_TOPICS[output_topic]
-        snuba_metrics_producer = Producer(
+        self.__producer = Producer(
             kafka_config.get_kafka_producer_cluster_options(snuba_metrics["cluster"]),
         )
-        producer = snuba_metrics_producer
-        self.__producer = producer
-        self.__producer_topic = settings.KAFKA_SNUBA_METRICS
+        self.__producer_topic = output_topic
         self.__commit_function = commit_function
 
         self.__closed = False


### PR DESCRIPTION
We were writing to snuba-metrics (on the performance-metrics cluster) regardless of configuration values because of this logic mistake -- luckily it was on the new/separated cluster so no customer harm/data loss issue. But we want to use the actual output_topic provided in the `SimpleProduceStep` constructor