### PR TITLE
fix(selectOption): Autoscroll to focused/selected option

### DIFF
--- a/static/app/components/forms/selectOption.tsx
+++ b/static/app/components/forms/selectOption.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 import {components as selectComponents} from 'react-select';
+import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import MenuListItem from 'sentry/components/menuListItem';
@@ -22,6 +23,7 @@ function SelectOption(props: Props) {
     isFocused,
     isDisabled,
     innerProps,
+    innerRef,
   } = props;
   const {showDividers} = selectProps;
   const {
@@ -40,35 +42,45 @@ function SelectOption(props: Props) {
   const itemPriority = priority ?? (isSelected && !isMultiple ? 'primary' : 'default');
 
   return (
-    <Tooltip skipWrapper title={tooltip} {...tooltipOptions}>
-      <MenuListItem
-        {...itemProps}
-        {...innerProps}
-        as="div"
-        className="option"
-        value={value}
-        label={label}
-        isDisabled={isDisabled}
-        isFocused={isFocused}
-        showDivider={showDividers}
-        priority={itemPriority}
-        innerWrapProps={{'data-test-id': value}}
-        labelProps={{as: typeof label === 'string' ? 'p' : 'div'}}
-        leadingItems={
-          <Fragment>
-            <CheckWrap isMultiple={isMultiple} isSelected={isSelected}>
-              {isSelected && (
-                <IconCheckmark
-                  size={isMultiple ? 'xs' : 'sm'}
-                  color={isMultiple ? 'white' : undefined}
-                />
-              )}
-            </CheckWrap>
-            {data.leadingItems}
-          </Fragment>
-        }
-      />
-    </Tooltip>
+    <ClassNames>
+      {({cx}) => (
+        <Tooltip skipWrapper title={tooltip} {...tooltipOptions}>
+          <MenuListItem
+            {...itemProps}
+            {...innerProps}
+            ref={innerRef}
+            className={cx({
+              option: true,
+              'option--is-disabled': isDisabled,
+              'option--is-focused': isFocused,
+              'option--is-selected': isSelected,
+            })}
+            as="div"
+            value={value}
+            label={label}
+            isDisabled={isDisabled}
+            isFocused={isFocused}
+            showDivider={showDividers}
+            priority={itemPriority}
+            innerWrapProps={{'data-test-id': value}}
+            labelProps={{as: typeof label === 'string' ? 'p' : 'div'}}
+            leadingItems={
+              <Fragment>
+                <CheckWrap isMultiple={isMultiple} isSelected={isSelected}>
+                  {isSelected && (
+                    <IconCheckmark
+                      size={isMultiple ? 'xs' : 'sm'}
+                      color={isMultiple ? 'white' : undefined}
+                    />
+                  )}
+                </CheckWrap>
+                {data.leadingItems}
+              </Fragment>
+            }
+          />
+        </Tooltip>
+      )}
+    </ClassNames>
   );
 }
 


### PR DESCRIPTION
When using the keyboard to navigate dropdown selectors using the arrow up and down keys, `react-select` used to automatically scroll the menu so that the focused item is always in view:
https://user-images.githubusercontent.com/44172267/176023276-2d10fde3-1bb4-4e00-929f-03a3c3ede0d1.mp4

This broke after https://github.com/getsentry/sentry/pull/35758:
https://user-images.githubusercontent.com/44172267/176023478-96a540c7-edd9-4702-9e45-df5bab2afe03.mp4

`react-select` uses a system of class names and ref objects to implement this autoscroll behavior. To fix it, we just need to re-add those things to `MenuListItem` in `SelectOption.tsx`.