### PR TITLE
feat(discover): allows a function to be passed as rate limit and updates events endpoint to use rate limit

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -955,6 +955,8 @@ SENTRY_FEATURES = {
     "organizations:discover-frontend-use-events-endpoint": True,
     # Enables events endpoint usage on performance frontend
     "organizations:performance-frontend-use-events-endpoint": True,
+    # Enables events endpoint rate limit
+    "organizations:discover-events-rate-limit": False,
     # Enable duplicating alert rules.
     "organizations:duplicate-alert-rule": False,
     # Enable attaching arbitrary files to events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -77,6 +77,7 @@ default_manager.add(
 default_manager.add(
     "organizations:performance-frontend-use-events-endpoint", OrganizationFeature, True
 )
+default_manager.add("organizations:discover-events-rate-limit", OrganizationFeature, True)
 default_manager.add("organizations:duplicate-alert-rule", OrganizationFeature, True)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)
 default_manager.add("organizations:filters-and-sampling", OrganizationFeature, True)

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -55,7 +55,9 @@ class RatelimitMiddleware:
                 if not view_class:
                     return
 
-                rate_limit_config = get_rate_limit_config(view_class)
+                rate_limit_config = get_rate_limit_config(
+                    view_class, request, view_args, view_kwargs
+                )
                 rate_limit_group = (
                     rate_limit_config.group if rate_limit_config else RateLimitConfig().group
                 )

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -56,7 +56,7 @@ class RatelimitMiddleware:
                     return
 
                 rate_limit_config = get_rate_limit_config(
-                    view_class, request, view_args, view_kwargs
+                    view_class, view_args, {**view_kwargs, "request": request}
                 )
                 rate_limit_group = (
                     rate_limit_config.group if rate_limit_config else RateLimitConfig().group

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -114,7 +114,10 @@ def get_organization_id_from_token(token_id: str) -> int | None:
 
 
 def get_rate_limit_config(
-    endpoint: Type[object], request: Optional[Request] = None, view_args=None, view_kwargs=None
+    endpoint: Type[object],
+    request: Optional[Request] = None,
+    view_args: Any = None,
+    view_kwargs: Any = None,
 ) -> RateLimitConfig | None:
     """Read the rate limit config from the view function to be used for the rate limit check.
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Type
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Type
 
 from django.conf import settings
 from rest_framework.request import Request
@@ -113,13 +113,17 @@ def get_organization_id_from_token(token_id: str) -> int | None:
     return installation.organization_id if installation else None
 
 
-def get_rate_limit_config(endpoint: Type[object]) -> RateLimitConfig | None:
+def get_rate_limit_config(
+    endpoint: Type[object], request: Optional[Request], view_args, view_kwargs
+) -> RateLimitConfig | None:
     """Read the rate limit config from the view function to be used for the rate limit check.
 
     If there is no rate limit defined on the endpoint, use the rate limit defined for the group
     or the default across the board
     """
     rate_limit_config = getattr(endpoint, "rate_limits", DEFAULT_RATE_LIMIT_CONFIG)
+    if callable(rate_limit_config):
+        rate_limit_config = rate_limit_config(request, *view_args, **view_kwargs)
     return RateLimitConfig.from_rate_limit_override_dict(rate_limit_config)
 
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -114,7 +114,7 @@ def get_organization_id_from_token(token_id: str) -> int | None:
 
 
 def get_rate_limit_config(
-    endpoint: Type[object], request: Optional[Request], view_args, view_kwargs
+    endpoint: Type[object], request: Optional[Request] = None, view_args=None, view_kwargs=None
 ) -> RateLimitConfig | None:
     """Read the rate limit config from the view function to be used for the rate limit check.
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Optional, Type
+from typing import TYPE_CHECKING, Any, Callable, Mapping, Type
 
 from django.conf import settings
 from rest_framework.request import Request
@@ -115,7 +115,6 @@ def get_organization_id_from_token(token_id: str) -> int | None:
 
 def get_rate_limit_config(
     endpoint: Type[object],
-    request: Optional[Request] = None,
     view_args: Any = None,
     view_kwargs: Any = None,
 ) -> RateLimitConfig | None:
@@ -126,7 +125,7 @@ def get_rate_limit_config(
     """
     rate_limit_config = getattr(endpoint, "rate_limits", DEFAULT_RATE_LIMIT_CONFIG)
     if callable(rate_limit_config):
-        rate_limit_config = rate_limit_config(request, *view_args, **view_kwargs)
+        rate_limit_config = rate_limit_config(*view_args, **view_kwargs)
     return RateLimitConfig.from_rate_limit_override_dict(rate_limit_config)
 
 

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -306,7 +306,7 @@ class CallableRateLimitConfigEndpoint(Endpoint):
     permission_classes = (AllowAny,)
     enforce_rate_limit = True
 
-    def rate_limits(_):
+    def rate_limits(request):
         return {
             "GET": {
                 RateLimitCategory.IP: RateLimit(20, 1),

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -302,10 +302,32 @@ class ConcurrentRateLimitedEndpoint(Endpoint):
         return Response({"ok": True})
 
 
+class CallableRateLimitConfigEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+    enforce_rate_limit = True
+
+    def rate_limits(_):
+        return {
+            "GET": {
+                RateLimitCategory.IP: RateLimit(20, 1),
+                RateLimitCategory.USER: RateLimit(20, 1),
+                RateLimitCategory.ORGANIZATION: RateLimit(20, 1),
+            },
+        }
+
+    def get(self, request):
+        return Response({"ok": True})
+
+
 urlpatterns = [
     url(r"^/ratelimit$", RateLimitHeaderTestEndpoint.as_view(), name="ratelimit-header-endpoint"),
     url(r"^/race-condition$", RaceConditionEndpoint.as_view(), name="race-condition-endpoint"),
     url(r"^/concurrent$", ConcurrentRateLimitedEndpoint.as_view(), name="concurrent-endpoint"),
+    url(
+        r"^/callable-config$",
+        CallableRateLimitConfigEndpoint.as_view(),
+        name="callable-config-endpoint",
+    ),
 ]
 
 
@@ -422,3 +444,15 @@ class TestConcurrentRateLimiter(APITestCase):
                 int(response["X-Sentry-Rate-Limit-ConcurrentRemaining"])
                 == CONCURRENT_RATE_LIMIT - 1
             )
+
+
+@override_settings(
+    ROOT_URLCONF="tests.sentry.middleware.test_ratelimit_middleware", SENTRY_SELF_HOSTED=False
+)
+class TestCallableRateLimitConfig(APITestCase):
+    endpoint = "callable-config-endpoint"
+
+    def test_request_finishes(self):
+        response = self.get_success_response()
+        assert int(response["X-Sentry-Rate-Limit-Remaining"]) == 19
+        assert int(response["X-Sentry-Rate-Limit-Limit"]) == 20


### PR DESCRIPTION
Updates `ratelimit` configs to be called if it's a callable.

Using this to conditionally apply a rate limit depending on the feature flags of an org.
We only want to rate limit the `events` endpoint if the org is flagged (in case we need to quickly roll back). 