### PR TITLE
ref(perf): Do not ignore react-hooks/exhaustive-deps errors in performance

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -123,77 +123,72 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
       },
       transform: transformDiscoverToList,
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [props.chartSetting, mepSetting.memoizationKey]
   );
 
-  const chartQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
-    () => {
-      return {
-        enabled: widgetData => {
-          return !!widgetData?.list?.data?.length;
-        },
-        fields: field,
-        component: provided => {
-          const eventView = props.eventView.clone();
-          if (!provided.widgetData.list.data[selectedListIndex]?.transaction) {
+  const chartQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(() => {
+    return {
+      enabled: widgetData => {
+        return !!widgetData?.list?.data?.length;
+      },
+      fields: field,
+      component: provided => {
+        const eventView = props.eventView.clone();
+        if (!provided.widgetData.list.data[selectedListIndex]?.transaction) {
+          return null;
+        }
+        eventView.additionalConditions.setFilterValues('transaction', [
+          provided.widgetData.list.data[selectedListIndex].transaction as string,
+        ]);
+        if (props.chartSetting === PerformanceWidgetSetting.MOST_RELATED_ISSUES) {
+          if (!provided.widgetData.list.data[selectedListIndex]?.issue) {
             return null;
           }
-          eventView.additionalConditions.setFilterValues('transaction', [
-            provided.widgetData.list.data[selectedListIndex].transaction as string,
+          eventView.fields = [
+            {field: 'issue'},
+            {field: 'issue.id'},
+            {field: 'transaction'},
+            {field},
+          ];
+          eventView.additionalConditions.setFilterValues('issue', [
+            provided.widgetData.list.data[selectedListIndex].issue as string,
           ]);
-          if (props.chartSetting === PerformanceWidgetSetting.MOST_RELATED_ISSUES) {
-            if (!provided.widgetData.list.data[selectedListIndex]?.issue) {
-              return null;
-            }
-            eventView.fields = [
-              {field: 'issue'},
-              {field: 'issue.id'},
-              {field: 'transaction'},
-              {field},
-            ];
-            eventView.additionalConditions.setFilterValues('issue', [
-              provided.widgetData.list.data[selectedListIndex].issue as string,
-            ]);
-            eventView.additionalConditions.setFilterValues('event.type', ['error']);
-            eventView.additionalConditions.setFilterValues('!tags[transaction]', ['']);
-            eventView.additionalConditions.removeFilter('transaction.op'); // Remove transaction op incase it's applied from the performance view.
-            eventView.additionalConditions.removeFilter('!transaction.op'); // Remove transaction op incase it's applied from the performance view.
-            const mutableSearch = new MutableSearch(eventView.query);
-            mutableSearch.removeFilter('transaction.duration');
-            eventView.query = mutableSearch.formatString();
-          } else {
-            eventView.fields = [{field: 'transaction'}, {field}];
-          }
-          return (
-            <EventsRequest
-              {...pick(provided, eventsRequestQueryProps)}
-              limit={1}
-              includePrevious
-              includeTransformedData
-              partial
-              currentSeriesNames={[field]}
-              query={eventView.getQueryWithAdditionalConditions()}
-              interval={getInterval(
-                {
-                  start: provided.start,
-                  end: provided.end,
-                  period: provided.period,
-                },
-                'medium'
-              )}
-              hideError
-              onError={pageError.setPageError}
-              queryExtras={getMEPParamsIfApplicable(mepSetting, props.chartSetting)}
-            />
-          );
-        },
-        transform: transformEventsRequestToArea,
-      };
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [props.chartSetting, selectedListIndex, mepSetting.memoizationKey]
-  );
+          eventView.additionalConditions.setFilterValues('event.type', ['error']);
+          eventView.additionalConditions.setFilterValues('!tags[transaction]', ['']);
+          eventView.additionalConditions.removeFilter('transaction.op'); // Remove transaction op incase it's applied from the performance view.
+          eventView.additionalConditions.removeFilter('!transaction.op'); // Remove transaction op incase it's applied from the performance view.
+          const mutableSearch = new MutableSearch(eventView.query);
+          mutableSearch.removeFilter('transaction.duration');
+          eventView.query = mutableSearch.formatString();
+        } else {
+          eventView.fields = [{field: 'transaction'}, {field}];
+        }
+        return (
+          <EventsRequest
+            {...pick(provided, eventsRequestQueryProps)}
+            limit={1}
+            includePrevious
+            includeTransformedData
+            partial
+            currentSeriesNames={[field]}
+            query={eventView.getQueryWithAdditionalConditions()}
+            interval={getInterval(
+              {
+                start: provided.start,
+                end: provided.end,
+                period: provided.period,
+              },
+              'medium'
+            )}
+            hideError
+            onError={pageError.setPageError}
+            queryExtras={getMEPParamsIfApplicable(mepSetting, props.chartSetting)}
+          />
+        );
+      },
+      transform: transformEventsRequestToArea,
+    };
+  }, [props.chartSetting, selectedListIndex, mepSetting.memoizationKey]);
 
   const Queries = {
     list: listQuery,

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -85,7 +85,6 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
       ),
       transform: transformTrendsDiscover,
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [props.chartSetting, trendChangeType]
   );
 

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -137,7 +137,6 @@ export function VitalWidget(props: PerformanceWidgetProps) {
         },
         transform: transformDiscoverToList,
       }),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
       [props.eventView, fieldsList, props.organization.slug, mepSetting.memoizationKey]
     ),
     chart: useMemo<QueryDefinition<DataType, WidgetDataResult>>(
@@ -178,7 +177,6 @@ export function VitalWidget(props: PerformanceWidgetProps) {
         },
         transform: transformEventsRequestToVitals,
       }),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
       [props.chartSetting, selectedListIndex, mepSetting.memoizationKey]
     ),
   };

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.tsx
@@ -55,14 +55,10 @@ function TransactionOverview(props: Props) {
 
   const {location, selection, organization, projects} = props;
 
-  useEffect(
-    () => {
-      loadOrganizationTags(api, organization.slug, selection);
-      addRoutePerformanceContext(selection);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selection]
-  );
+  useEffect(() => {
+    loadOrganizationTags(api, organization.slug, selection);
+    addRoutePerformanceContext(selection);
+  }, [selection]);
 
   return (
     <MEPSettingProvider>

--- a/static/app/views/performance/transactionSummary/transactionTags/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/content.tsx
@@ -123,7 +123,6 @@ const InnerContent = (
     if (initialTag) {
       changeTagSelected(initialTag);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialTag]);
 
   const handleSearch = (query: string) => {


### PR DESCRIPTION
After the `react-hooks/exhaustive-deps` rule was enabled, we saw a bunch of errors in the code. Ignoring this rule is tempting but can have subtle hard-to-debug bugs like old variable references being used from within `useEffect` (read more on that [here](https://betterprogramming.pub/stop-lying-to-react-about-missing-dependencies-10612e9aeeda)). Instead of disabling the rule and accepting our defeat, let's keep the rule active so that we can eventually get to fixing those bugs. Thoughts?
