### PR TITLE
fix(active-release): attach last_release to notification context to be used downstream

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications/issues.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/issues.py
@@ -56,5 +56,5 @@ class ActiveReleaseIssueNotificationMessageBuilder(SlackNotificationsMessageBuil
             issue_details=True,
             notification=self.notification,
             recipient=self.recipient,
-            last_release=getattr(self.notification, "last_release", None),
+            last_release=self.context.get("last_release", None),
         ).build()

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -188,3 +188,8 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
                 title_str += f" (+{len(self.rules) - 1} other)"
 
         return title_str
+
+    def get_context(self) -> MutableMapping[str, Any]:
+        ctx = super().get_context()
+        ctx["last_release"] = self.last_release
+        return ctx


### PR DESCRIPTION
This fixes the issues observed below since we weren't actually passing the `last_release` attr in the notification downstream for the NotificationBuilder. We're using the context here to pass extra data along.

![Screen Shot 2022-06-27 at 3 16 05 PM](https://user-images.githubusercontent.com/101606877/176085050-44220cf8-9997-4e36-9aac-0ad2e0f91568.png)
