### PR TITLE
ref(projectconfig): Move invalidation tasks to the bulk queue

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -186,7 +186,7 @@ def compute_projectkey_config(key):
 
 @instrumented_task(
     name="sentry.tasks.relay.invalidate_project_config",
-    queue="relay_config",
+    queue="relay_config_bulk",
     acks_late=True,
     soft_time_limit=25 * 60,  # 25mins
     time_limit=25 * 60 + 5,


### PR DESCRIPTION
We'd like to keep the normal queue fast for build tasks since relays
need those asap.  This queue is already set up with it's own workers.