### PR TITLE
ref(logFileViewer): Replace ansicolor lib with ansi-to-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/webpack-dev-server": "^4.7.2",
     "@types/webpack-env": "^1.17.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.1",
-    "ansicolor": "^1.1.100",
+    "ansi-to-react": "^6.1.6",
     "babel-loader": "^8.2.5",
     "babel-plugin-add-react-displayname": "^0.0.5",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/static/app/components/events/attachmentViewers/logFileViewer.tsx
+++ b/static/app/components/events/attachmentViewers/logFileViewer.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import ansicolor from 'ansicolor';
+import Ansi from 'ansi-to-react';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
 import PreviewPanelItem from 'sentry/components/events/attachmentViewers/previewPanelItem';
@@ -8,73 +8,67 @@ import {
   ViewerProps,
 } from 'sentry/components/events/attachmentViewers/utils';
 import space from 'sentry/styles/space';
-import theme from 'sentry/utils/theme';
 
 type Props = ViewerProps & AsyncComponent['props'];
 
 type State = AsyncComponent['state'];
 
-const COLORS = {
-  black: theme.black,
-  white: theme.white,
-  redDim: theme.red200,
-  red: theme.red300,
-  greenDim: theme.green200,
-  green: theme.green300,
-  yellowDim: theme.pink200,
-  yellow: theme.pink300,
-  blueDim: theme.blue200,
-  blue: theme.blue300,
-  magentaDim: theme.pink200,
-  magenta: theme.pink300,
-  cyanDim: theme.blue200,
-  cyan: theme.blue300,
-};
-
-export default class LogFileViewer extends AsyncComponent<Props, State> {
+class LogFileViewer extends AsyncComponent<Props, State> {
   getEndpoints(): [string, string][] {
     return [['attachmentText', getAttachmentUrl(this.props)]];
   }
 
   renderBody() {
     const {attachmentText} = this.state;
-    if (!attachmentText) {
-      return null;
-    }
 
-    const spans = ansicolor
-      .parse(attachmentText)
-      .spans.map(({color, bgColor, text}, idx) => {
-        const style = {} as React.CSSProperties;
-        if (color) {
-          if (color.name) {
-            style.color =
-              COLORS[color.name + (color.dim ? 'Dim' : '')] || COLORS[color.name] || '';
-          }
-          if (color.bright) {
-            style.fontWeight = 500;
-          }
-        }
-        if (bgColor && bgColor.name) {
-          style.background =
-            COLORS[bgColor.name + (bgColor.dim ? 'Dim' : '')] ||
-            COLORS[bgColor.name] ||
-            '';
-        }
-        return (
-          <span style={style} key={idx}>
-            {text}
-          </span>
-        );
-      });
-
-    return (
+    return !attachmentText ? null : (
       <PreviewPanelItem>
-        <CodeWrapper>{spans}</CodeWrapper>
+        <CodeWrapper>
+          <SentryStyleAnsi useClasses>{attachmentText}</SentryStyleAnsi>
+        </CodeWrapper>
       </PreviewPanelItem>
     );
   }
 }
+
+export default LogFileViewer;
+
+/**
+ * Maps ANSI color names -> theme.tsx color names
+ */
+const COLOR_MAP = {
+  red: 'red',
+  green: 'green',
+  blue: 'blue',
+  yellow: 'yellow',
+  magenta: 'pink',
+  cyan: 'purple',
+};
+
+const SentryStyleAnsi = styled(Ansi)`
+  ${p =>
+    Object.entries(COLOR_MAP).map(
+      ([ansiColor, themeColor]) => `
+      .ansi-${ansiColor}-bg {
+        background-color: ${p.theme[`${themeColor}400`]};
+      }
+      .ansi-${ansiColor}-fg {
+        color: ${p.theme[`${themeColor}400`]};
+      }
+      .ansi-bright-${ansiColor}-fg {
+        color: ${p.theme[`${themeColor}200`]};
+      }`
+    )}
+
+  .ansi-black-fg,
+  .ansi-bright-black-fg {
+    color: ${p => p.theme.black};
+  }
+  .ansi-white-fg,
+  .ansi-bright-white-fg {
+    color: ${p => p.theme.white};
+  }
+`;
 
 const CodeWrapper = styled('pre')`
   padding: ${space(1)} ${space(2)};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5251,6 +5251,11 @@ algoliasearch@^4.13.1:
     "@algolia/requester-node-http" "4.13.1"
     "@algolia/transporter" "4.13.1"
 
+anser@^1.4.1:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.10.tgz#befa3eddf282684bd03b63dcda3927aef8c2e35b"
+  integrity sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==
+
 ansi-align@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
@@ -5326,10 +5331,13 @@ ansi-to-html@^0.6.11:
   dependencies:
     entities "^1.1.2"
 
-ansicolor@^1.1.100:
-  version "1.1.100"
-  resolved "https://registry.yarnpkg.com/ansicolor/-/ansicolor-1.1.100.tgz#811f1afbf726edca3aafb942a14df8351996304a"
-  integrity sha512-Jl0pxRfa9WaQVUX57AB8/V2my6FJxrOR1Pp2qqFbig20QB4HzUoQ48THTKAgHlUCJeQm/s2WoOPcoIDhyCL/kw==
+ansi-to-react@^6.1.6:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/ansi-to-react/-/ansi-to-react-6.1.6.tgz#d6fe15ecd4351df626a08121b1646adfe6c02ccb"
+  integrity sha512-+HWn72GKydtupxX9TORBedqOMsJRiKTqaLUKW8txSBZw9iBpzPKLI8KOu4WzwD4R7hSv1zEspobY6LwlWvwZ6Q==
+  dependencies:
+    anser "^1.4.1"
+    escape-carriage "^1.3.0"
 
 ansis@^1.3.6:
   version "1.3.6"
@@ -7698,6 +7706,11 @@ escalade@^3.0.2, escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+
+escape-carriage@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/escape-carriage/-/escape-carriage-1.3.0.tgz#71006b2d4da8cb6828686addafcb094239c742f3"
+  integrity sha512-ATWi5MD8QlAGQOeMgI8zTp671BG8aKvAC0M7yenlxU4CRLGO/sKthxVUyjiOFKjHdIo+6dZZUNFgHFeVEaKfGQ==
 
 escape-html@~1.0.3:
   version "1.0.3"


### PR DESCRIPTION
The ansicolor library had an unfortunate sideffect that it was mutating the `String.prototype` and adding a number of 'color' methods that would wrap the strings in ansi color escape sequence's https://github.com/xpl/ansicolor/blob/5ce0946ad33ce08db760d741e7c00fac5f86ed0a/ansicolor.js#L341-L355

This patching of the prototype isn't actually supposed to happen unless you import the library and access the `nice` property, but the mjs module generated re-exports `Colors.nice`, which.. Accesses the property.

The result of this is that all strings now had a bunch of `red`, `blue`, `bgGreen`, etc getter attributes. The kicker though, is that it added a `default` attribute, which quacks quite similarly to the CommonJs ESM compat `module.exports.default`. I noticed this happening in GH-35330 after quite a bit of debugging. This is because of a change made in the platformicons library here https://github.com/getsentry/platformicons/commit/d0f1a37e057bcc003dfbc1f873a047175f4092cb#diff-516ad21a41c3152e0451ce030935a9e88e2c0bf7f38c45d8f156ed9bb47a8260R166 for interop.

See also https://github.com/xpl/ansicolor/issues/19

Here's what the log viewer looks like
![image](https://user-images.githubusercontent.com/1421724/176154371-04b9d8ff-5328-42f1-8cbd-ad5fe6416a77.png)

(The old one)
![image](https://user-images.githubusercontent.com/1421724/176154515-187d0692-f383-49db-b961-02801e5f300f.png)

---
### Here's some fun debugging

![image](https://user-images.githubusercontent.com/1421724/176152996-fcc7e331-c2b4-4dc5-9c12-cd744bbb3534.png)

_Let's look at the `__proto__`...._

![telegram-cloud-photo-size-1-5033113157769472590-x](https://user-images.githubusercontent.com/1421724/176153340-5f717594-ecc8-49b7-bec3-d97e2b09a29b.jpg)

What is all of that doing in here 😱 

Sure enough there is a `default`

![telegram-cloud-photo-size-1-5033113157769472591-m](https://user-images.githubusercontent.com/1421724/176153399-c0a05973-4dea-4811-a381-25c28301e8d0.jpg)

