### PR TITLE
ref: increase self-hosted e2e test timeout

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -65,7 +65,7 @@ steps:
           docker-compose logs;
           exit $test_return;
         fi
-    timeout: 660s
+    timeout: 900s
   - name: 'gcr.io/cloud-builders/docker'
     id: docker-push
     waitFor:


### PR DESCRIPTION
I've notice this somewhat frequently times out on feature branches
