### PR TITLE
feat(dynamic-sampling): Index trace sample rate as a tag

### DIFF
--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -135,7 +135,7 @@ class MonitorContextType(ContextType):
 @contexttype
 class TraceContextType(ContextType):
     type = "trace"
-    indexed_fields = {}
+    indexed_fields = {"": "{id}", "sample_rate": "{sample_rate}"}
 
 
 class Contexts(Interface):


### PR DESCRIPTION
Adding trace `sample_rate` to the trace context to make it searchable
as part of the dynamic sampling onboarding flow

