### PR TITLE
feat(replays): Add annotations to LCP highlights

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -16,6 +16,11 @@ import HighlightReplayPlugin from './highlightReplayPlugin';
 type Dimensions = {height: number; width: number};
 type RootElem = null | HTMLDivElement;
 
+type HighlightParams = {
+  nodeId: number;
+  annotation?: string;
+};
+
 // Important: Don't allow context Consumers to access `Replayer` directly.
 // It has state that, when changed, will not trigger a react render.
 // Instead only expose methods that wrap `Replayer` and manage state.
@@ -58,7 +63,7 @@ type ReplayPlayerContextProps = {
   /**
    * Highlight a node in the replay
    */
-  highlight: ({nodeId}: {nodeId: number}) => void;
+  highlight: (args: HighlightParams) => void;
 
   /**
    * Required to be called with a <div> Ref
@@ -202,13 +207,13 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
     setFFSpeed(0);
   };
 
-  const highlight = useCallback(({nodeId}: {nodeId: number}) => {
+  const highlight = useCallback(({nodeId, annotation}: HighlightParams) => {
     const replayer = replayerRef.current;
     if (!replayer) {
       return;
     }
 
-    highlightNode({replayer, nodeId});
+    highlightNode({replayer, nodeId, annotation});
   }, []);
 
   const clearAllHighlightsCallback = useCallback(() => {

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -79,7 +79,7 @@ function Breadcrumbs({}: Props) {
         // XXX: Kind of hacky, but mouseLeave does not fire if you move from a
         // crumb to a tooltip
         clearAllHighlights();
-        highlight({nodeId: item.data.nodeId});
+        highlight({nodeId: item.data.nodeId, annotation: item.data.label ?? ''});
       }
     },
     [setCurrentHoverTime, startTimestamp, highlight, clearAllHighlights]

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -79,7 +79,7 @@ function Breadcrumbs({}: Props) {
         // XXX: Kind of hacky, but mouseLeave does not fire if you move from a
         // crumb to a tooltip
         clearAllHighlights();
-        highlight({nodeId: item.data.nodeId, annotation: item.data.label ?? ''});
+        highlight({nodeId: item.data.nodeId, annotation: item.data.label});
       }
     },
     [setCurrentHoverTime, startTimestamp, highlight, clearAllHighlights]


### PR DESCRIPTION
When hovering over a breadcrumb with a `data.label` property (e.g. LCP), pass the label to the `highlight()` fn to draw an annotation to be included with the highlight

![image](https://user-images.githubusercontent.com/79684/176225164-717d97c5-2a7e-4c3d-b2ef-db08f98262af.png)
