### PR TITLE
fix(dashboard): Prevent really long releases query string

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
@@ -85,7 +85,7 @@ function getReleasesQuery(releases: Release[]): {
   if (releases.length < 10) {
     return {releaseQueryString: releaseCondition, releasesUsed: releasesArray};
   }
-  if (releases.length > 10 && releaseCondition.length > 2000) {
+  if (releases.length > 10 && releaseCondition.length > 1500) {
     return getReleasesQuery(releases.slice(0, -10));
   }
   return {releaseQueryString: releaseCondition, releasesUsed: releasesArray};

--- a/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
@@ -85,7 +85,7 @@ function getReleasesQuery(releases: Release[]): {
   if (releases.length < 10) {
     return {releaseQueryString: releaseCondition, releasesUsed: releasesArray};
   }
-  if (releases.length > 10 && releaseCondition.length > 1000) {
+  if (releases.length > 10 && releaseCondition.length > 2000) {
     return getReleasesQuery(releases.slice(0, -10));
   }
   return {releaseQueryString: releaseCondition, releasesUsed: releasesArray};

--- a/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
@@ -69,6 +69,28 @@ export function derivedMetricsToField(field: string): string {
   return METRICS_EXPRESSION_TO_FIELD[field] ?? field;
 }
 
+function getReleasesQuery(releases: Release[]): {
+  releaseQueryString: string;
+  releasesUsed: string[];
+} {
+  let releaseCondition = '';
+  const releasesArray: string[] = [];
+  releaseCondition += 'release:[' + releases[0].version;
+  releasesArray.push(releases[0].version);
+  for (let i = 1; i < releases.length; i++) {
+    releaseCondition += ',' + releases[i].version;
+    releasesArray.push(releases[i].version);
+  }
+  releaseCondition += ']';
+  if (releases.length < 10) {
+    return {releaseQueryString: releaseCondition, releasesUsed: releasesArray};
+  }
+  if (releases.length > 10 && releaseCondition.length > 1000) {
+    return getReleasesQuery(releases.slice(0, -10));
+  }
+  return {releaseQueryString: releaseCondition, releasesUsed: releasesArray};
+}
+
 /**
  * Given a list of requested fields, this function returns
  * 'aggregates' which is a list of aggregate functions that
@@ -325,13 +347,9 @@ class ReleaseWidgetQueries extends Component<Props, State> {
         releasesArray.push(releases[0].version);
       }
       if (releases && releases.length > 1) {
-        releaseCondition += 'release:[' + releases[0].version;
-        releasesArray.push(releases[0].version);
-        for (let i = 1; i < releases.length; i++) {
-          releaseCondition += ',' + releases[i].version;
-          releasesArray.push(releases[i].version);
-        }
-        releaseCondition += ']';
+        const {releaseQueryString, releasesUsed} = getReleasesQuery(releases);
+        releaseCondition += releaseQueryString;
+        releasesArray.push(...releasesUsed);
 
         if (!!!isDescending) {
           releasesArray.reverse();


### PR DESCRIPTION
We want to have as many release versions in the filter string
as possible. But we also want to have the release query string
not be super long that it gets truncated, so reducing the
number of release versions if the query string is too long.

Prevents this:

![Screen Shot 2022-06-28 at 12 27 27 PM](https://user-images.githubusercontent.com/63818634/176231787-0ab79d51-f302-4d25-a960-b370663435b1.png)

