### PR TITLE
fix(metrics): include use_case_id in output

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -213,6 +213,7 @@ def process_messages(
             new_payload_value["metric_id"] = mapping[org_id][metric_name]
             new_payload_value["retention_days"] = 90
             new_payload_value["mapping_meta"] = output_message_meta
+            new_payload_value["use_case_id"] = use_case_id.value
 
             del new_payload_value["name"]
 

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -254,6 +254,7 @@ def __translated_payload(
     )
     payload["retention_days"] = 90
     payload["tags"] = new_tags
+    payload["use_case_id"] = "release-health"
 
     del payload["name"]
     return payload


### PR DESCRIPTION
The processing on `snuba-generic-metrics` requires this field (it was optional before) so it caused a bunch of errors when we tried to deploy without setting it:

https://sentry.io/organizations/sentry/issues/3385232058/?project=300688&query=is%3Aunresolved