### PR TITLE
fix(tests): Flakey group id filters test

### DIFF
--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -612,7 +612,7 @@ class ParseBooleanSearchQueryTest(TestCase):
                 params={"organization_id": self.organization.id, "project_id": [self.project.id]},
             )
             assert test[1] == result.conditions, test[0]
-            assert test[2] == result.group_ids, test[0]
+            assert sorted(test[2]) == sorted(result.group_ids), test[0]
 
     def test_invalid_conditional_filters(self):
         with pytest.raises(


### PR DESCRIPTION
The list of group ids returned by `get_filter` seems non deterministic in order.
This ensures that the same group ids are returned but allows for any order.

Fixes SENTRY-TESTS-2XS