### PR TITLE
ref(performance): Use CompactSelect for percentile dropdown in TransactionEvents

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -5,9 +5,9 @@ import omit from 'lodash/omit';
 
 import Button from 'sentry/components/button';
 import DatePageFilter from 'sentry/components/datePageFilter';
-import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
+import CompactSelect from 'sentry/components/forms/compactSelect';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
@@ -152,24 +152,15 @@ function Search(props: Props) {
         fields={eventView.fields}
         onSearch={handleSearch}
       />
-      <DropdownControl
-        buttonProps={{prefix: t('Percentile')}}
-        label={eventsFilterOptions[eventsDisplayFilterName].label}
-      >
-        {Object.entries(eventsFilterOptions).map(([name, filter]) => {
-          return (
-            <DropdownItem
-              key={name}
-              onSelect={onChangeEventsDisplayFilter}
-              eventKey={name}
-              data-test-id={name}
-              isActive={eventsDisplayFilterName === name}
-            >
-              {filter.label}
-            </DropdownItem>
-          );
-        })}
-      </DropdownControl>
+      <CompactSelect
+        triggerProps={{prefix: t('Percentile')}}
+        value={eventsDisplayFilterName}
+        onChange={opt => onChangeEventsDisplayFilter(opt.value)}
+        options={Object.entries(eventsFilterOptions).map(([name, filter]) => ({
+          value: name,
+          label: filter.label,
+        }))}
+      />
       <Button
         to={eventView.getResultsViewUrlTarget(organization.slug)}
         onClick={handleDiscoverButtonClick}

--- a/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -183,7 +183,7 @@ describe('Performance Transaction Events Content', function () {
     wrapper.update();
 
     expect(wrapper.find('EventsTable')).toHaveLength(1);
-    expect(wrapper.find('DropdownControl')).toHaveLength(1);
+    expect(wrapper.find('CompactSelect')).toHaveLength(1);
     expect(wrapper.find('StyledSearchBar')).toHaveLength(1);
     expect(wrapper.find('Filter')).toHaveLength(1);
 
@@ -221,7 +221,7 @@ describe('Performance Transaction Events Content', function () {
     wrapper.update();
 
     expect(wrapper.find('EventsTable')).toHaveLength(1);
-    expect(wrapper.find('DropdownControl')).toHaveLength(1);
+    expect(wrapper.find('CompactSelect')).toHaveLength(1);
     expect(wrapper.find('StyledSearchBar')).toHaveLength(1);
     expect(wrapper.find('Filter')).toHaveLength(1);
 


### PR DESCRIPTION
**Before:**
<img width="172" alt="Screen Shot 2022-06-28 at 11 18 58 AM" src="https://user-images.githubusercontent.com/44172267/176254521-71ef2ee2-07b6-410c-b41e-963f774c15dd.png">

**After:**
<img width="169" alt="Screen Shot 2022-06-28 at 11 18 44 AM" src="https://user-images.githubusercontent.com/44172267/176254516-1ea4af5b-118e-499c-805b-c6b581dffebc.png">

