### PR TITLE
fix(replays): Buffer overlay stuck when clicking already current time

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -400,7 +400,9 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
   const currentPlayerTime = useCurrentTime(getCurrentTime);
 
   const [isBuffering, currentTime] =
-    buffer.target !== -1 && buffer.previous === currentPlayerTime
+    buffer.target !== -1 &&
+    buffer.previous === currentPlayerTime &&
+    buffer.target !== buffer.previous
       ? [true, buffer.target]
       : [false, currentPlayerTime];
 


### PR DESCRIPTION
### Changes

- Adds a check for if the previous buffer time is the same as the target

### Notes

Sometimes when you click a breadcrumb or scrubber to a specific time and don't move your mouse or leave the breadcrumb element the buffering overlay stays up. It looks like this will probably require a bigger refactor to correct. 

Closes #35910 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
