### PR TITLE
feat(replays): Use data field for description in custom crumbs

### DIFF
--- a/static/app/components/replays/breadcrumbs/utils.tsx
+++ b/static/app/components/replays/breadcrumbs/utils.tsx
@@ -9,6 +9,8 @@ export function getDescription(crumb: Crumb) {
       return `${crumb.data?.from ? `${crumb.data?.from} => ` : ''}${
         crumb.data?.to ?? ''
       }`;
+    case BreadcrumbType.DEFAULT:
+      return JSON.stringify(crumb.data);
     default:
       return crumb.message || '';
   }


### PR DESCRIPTION
### Changes
- Prints data field as JSON for the description for 'default' type crumbs

![Screen Shot 2022-06-28 at 3 07 56 PM](https://user-images.githubusercontent.com/3721977/176270932-c694514e-81db-451d-bd99-9511329b21f5.png)


Closes #36034 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
