### PR TITLE
fix(replays): Timeline cursor position rendering is misaligned with currentTime

### DIFF
--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
 import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
@@ -21,7 +20,7 @@ function Scrubber({className}: Props) {
   return (
     <Wrapper className={className}>
       <Meter>
-        {currentHoverTime ? <MouseTrackingValue percent={hoverPlace} /> : null}
+        {currentHoverTime && <MouseTrackingValue percent={hoverPlace} />}
         <PlaybackTimeValue percent={percentComplete} />
       </Meter>
       <RangeWrapper>
@@ -52,6 +51,21 @@ const Range = styled(RangeSlider)`
     cursor: pointer;
     opacity: 0;
     height: 100%;
+
+    &::-webkit-slider-thumb {
+      height: 0px;
+      width: 0px;
+    }
+
+    &::-moz-range-thumb {
+      height: 0px;
+      width: 0px;
+    }
+
+    &::-ms-thumb {
+      height: 0px;
+      width: 0px;
+    }
   }
 `;
 


### PR DESCRIPTION
The bug was related to the size of the input[type=range] nub as it was affecting how js picked the value. Setting the nub for the Scrubber component to 0px on all browsers, fixed the problem. Closes #35909 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
