### PR TITLE
fix(email) Update org deletion email for system audits

### DIFF
--- a/src/sentry/templates/sentry/emails/org_delete_confirm.html
+++ b/src/sentry/templates/sentry/emails/org_delete_confirm.html
@@ -5,7 +5,7 @@
 {% block main %}
     <h3>Organization Queued for Deletion</h3>
     <p>The <strong>{{ organization.name }}</strong> organization has been scheduled for deletion by:</p>
-    <p><pre>User: {{ audit_log_entry.actor.get_display_name }}
+    <p><pre>User: {{ audit_log_entry.get_actor_name }}
 IP: {{ audit_log_entry.ip_address }}
 Date: {{ audit_log_entry.datetime }}</pre></p>
     <p>This irreversible deletion will take place at <strong>{{ eta }}</strong> and will permanently remove all associated data including events, projects, and team members.</p>

--- a/src/sentry/templates/sentry/emails/org_delete_confirm.txt
+++ b/src/sentry/templates/sentry/emails/org_delete_confirm.txt
@@ -1,6 +1,6 @@
 The {{ organization.name }} organization has been scheduled for deletion by:
 
-User: {{ audit_log_entry.actor.get_display_name }}
+User: {{ audit_log_entry.get_actor_name }}
 IP: {{ audit_log_entry.ip_address }}
 Date: {{ audit_log_entry.datetime }}
 


### PR DESCRIPTION
We need to purge some spam accounts and want to use the existing pending deletion flow that organizations have. The delete script will need to create audits as a 'system' actor as we don't have a specific user we're operating as.

The organization deletion email was expecting a User based audit actor prior to these changes.

Refs getsentry/getsentry#7673