### PR TITLE
fix(dashboards): flaky acceptance test click intercepted

### DIFF
--- a/fixtures/page_objects/dashboard_detail.py
+++ b/fixtures/page_objects/dashboard_detail.py
@@ -41,8 +41,8 @@ class DashboardDetailPage(BasePage):
 
     def click_dashboard_add_widget_button(self):
         button = self.browser.element('[data-test-id="widget-add"]')
-        self.browser.wait_until_clickable('[data-test-id="widget-add"]')
-        button.click()
+        # HACK: Use JavaScript to execute click to avoid click intercepted issues
+        self.browser.driver.execute_script("arguments[0].click()", button)
         self.wait_until_loaded()
 
     def click_dashboard_header_add_widget_button(self):

--- a/fixtures/page_objects/dashboard_detail.py
+++ b/fixtures/page_objects/dashboard_detail.py
@@ -34,26 +34,26 @@ class DashboardDetailPage(BasePage):
         self.wait_until_loaded()
 
     def enter_edit_state(self):
-        self.browser.wait_until_clickable('[data-test-id="dashboard-edit"]')
         button = self.browser.element('[data-test-id="dashboard-edit"]')
+        self.browser.wait_until_clickable('[data-test-id="dashboard-edit"]')
         button.click()
         self.wait_until_loaded()
 
     def click_dashboard_add_widget_button(self):
-        self.browser.wait_until_clickable('[data-test-id="widget-add"]')
         button = self.browser.element('[data-test-id="widget-add"]')
+        self.browser.wait_until_clickable('[data-test-id="widget-add"]')
         button.click()
         self.wait_until_loaded()
 
     def click_dashboard_header_add_widget_button(self):
-        self.browser.wait_until_clickable('[data-test-id="add-widget-library"]')
         button = self.browser.element('[data-test-id="add-widget-library"]')
+        self.browser.wait_until_clickable('[data-test-id="add-widget-library"]')
         button.click()
         self.wait_until_loaded()
 
     def click_cancel_button(self):
-        self.browser.wait_until_clickable('[data-test-id="dashboard-cancel"]')
         button = self.browser.element('[data-test-id="dashboard-cancel"]')
+        self.browser.wait_until_clickable('[data-test-id="dashboard-cancel"]')
         button.click()
         self.wait_until_loaded()
 
@@ -66,7 +66,7 @@ class DashboardDetailPage(BasePage):
         self.wait_until_loaded()
 
     def save_dashboard(self):
-        self.browser.wait_until_clickable('[data-test-id="dashboard-commit"]')
         button = self.browser.element('[data-test-id="dashboard-commit"]')
+        self.browser.wait_until_clickable('[data-test-id="dashboard-commit"]')
         button.click()
         self.wait_until_loaded()


### PR DESCRIPTION
The test at `tests/acceptance/test_organization_dashboards.py::OrganizationDashboardLayoutAcceptanceTest::test_resize_new_and_existing_widgets` is being flaky because its click would be intercepted by another component. This PR moves the check for the elements' clickability to just before calling `.click()`

I also changed the offending click to a javascript-based one so it should bypass the selenium visibility check.

More details can be found on the SENTRY-TESTS-38K issue