### PR TITLE
fix(ui): Remove integration annotations from issue details header

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -247,12 +247,6 @@ class GroupHeader extends Component<Props, State> {
                           </Link>
                         </EventAnnotationWithSpace>
                       )}
-                      {group.annotations.map((annotation, i) => (
-                        <EventAnnotationWithSpace
-                          key={i}
-                          dangerouslySetInnerHTML={{__html: annotation}}
-                        />
-                      ))}
                     </Fragment>
                   }
                 />


### PR DESCRIPTION
This removes the integration annotations only from the issue details header. They are shown in the sidebar thus don't need to be in the crowded issue details header.

Ref:
![Screen Shot 2022-06-28 at 11 17 55 AM](https://user-images.githubusercontent.com/15015880/176295625-d938e343-a4ca-49ed-80c5-6c0840ad3848.png)

jira: [WOR-1947](https://getsentry.atlassian.net/browse/WOR-1947)
