### PR TITLE
feat(workflow): Remove alert-filters backend checks

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -17,7 +17,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         condition_list = []
         filter_list = []
 
-        project_has_filters = features.has("projects:alert-filters", project)
         can_create_tickets = features.has(
             "organizations:integrations-ticket-rules", project.organization
         )
@@ -28,8 +27,8 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
             node = rule_cls(project)
-            # skip over conditions if they are not in the migrated set for a project with alert-filters
-            if project_has_filters and node.id in MIGRATED_CONDITIONS:
+            # skip over conditions that are no longer supported
+            if node.id in MIGRATED_CONDITIONS:
                 continue
 
             if not can_create_tickets and node.id in TICKET_ACTIONS:

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1139,8 +1139,6 @@ SENTRY_FEATURES = {
     "organizations:team-insights": True,
     # Enable setting team-level roles and receiving permissions from them
     "organizations:team-roles": False,
-    # Adds additional filters and a new section to issue alert rules.
-    "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.
     "projects:custom-inbound-filters": False,
     # Enable data forwarding functionality for projects.

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -236,7 +236,8 @@ _SENTRY_RULES = (
     "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
     "sentry.rules.filters.assigned_to.AssignedToFilter",
     "sentry.rules.filters.latest_release.LatestReleaseFilter",
-    # The following filters are duplicates of their respective conditions and are conditionally shown if the user has issue alert-filters
+    # The following filters are duplicates of their respective conditions
+    # The older versions were deprecated and migrated to these newer filters
     "sentry.rules.filters.event_attribute.EventAttributeFilter",
     "sentry.rules.filters.tagged_event.TaggedEventFilter",
     "sentry.rules.filters.level.LevelFilter",

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -58,7 +58,6 @@ default_manager.add("organizations:create")
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:active-release-notification-opt-in", OrganizationFeature, True)
-default_manager.add("organizations:alert-filters", OrganizationFeature)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, True)
 default_manager.add("organizations:alert-release-notification-workflow", OrganizationFeature, True)
 default_manager.add("organizations:alert-wizard-v3", OrganizationFeature, True)
@@ -188,7 +187,6 @@ default_manager.add("organizations:sso-saml2", OrganizationFeature)
 default_manager.add("organizations:team-insights", OrganizationFeature)
 
 # Project scoped features
-default_manager.add("projects:alert-filters", ProjectFeature)
 default_manager.add("projects:custom-inbound-filters", ProjectFeature)
 default_manager.add("projects:data-forwarding", ProjectFeature)
 default_manager.add("projects:discard-groups", ProjectFeature)


### PR DESCRIPTION
We used the alert-filters to migrate projects to new filters and deprecate old ones. The flag should always be applied now
