### PR TITLE
fix: exception not showing in console focus area

### DIFF
--- a/static/app/views/replays/detail/console/consoleMessage.tsx
+++ b/static/app/views/replays/detail/console/consoleMessage.tsx
@@ -43,7 +43,9 @@ export function MessageFormatter({breadcrumb}: MessageFormatterProps) {
   if (!breadcrumb.data?.arguments) {
     // There is a possibility that we don't have arguments as we could be receiving an exception type breadcrumb.
     // In these cases we just need the message prop.
-    logMessage = renderString(breadcrumb.message || '') as string;
+
+    // There are cases in which our prop message is an array, we want to force it to become a string
+    logMessage = breadcrumb.message?.toString() || '';
     return <AnnotatedText meta={getMeta(breadcrumb, 'message')} value={logMessage} />;
   }
 

--- a/static/app/views/replays/detail/console/consoleMessage.tsx
+++ b/static/app/views/replays/detail/console/consoleMessage.tsx
@@ -40,6 +40,13 @@ function renderString(arg: string | number | boolean | Object) {
 export function MessageFormatter({breadcrumb}: MessageFormatterProps) {
   let logMessage = '';
 
+  if (!breadcrumb.data?.arguments) {
+    // There is a possibility that we don't have arguments as we could be receiving an exception type breadcrumb.
+    // In these cases we just need the message prop.
+    logMessage = renderString(breadcrumb.message || '') as string;
+    return <AnnotatedText meta={getMeta(breadcrumb, 'message')} value={logMessage} />;
+  }
+
   // Browser's console formatter only works on the first arg
   const [message, ...args] = breadcrumb.data?.arguments;
 

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -47,6 +47,7 @@ function FocusArea({}: Props) {
     case 'console':
       const consoleMessages = getBreadcrumbsByCategory(replay?.getRawCrumbs(), [
         'console',
+        'exception',
       ]);
       return (
         <Console


### PR DESCRIPTION
<!-- Describe your PR here. -->
By including 'exceptions' type breadcrumbs for the console category, erros now show in the "console" tab. Closes #36142 

![image](https://user-images.githubusercontent.com/39612839/176317928-21c9737a-d90a-4ad2-b6ac-0cd3d5d513a6.png)



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
