### PR TITLE
fix(search): Handle new array search query in search builder

### DIFF
--- a/static/app/utils/stream.tsx
+++ b/static/app/utils/stream.tsx
@@ -47,7 +47,11 @@ export function objToQuery(queryObj: QueryObj): string {
   const {__text, ...tags} = queryObj;
 
   const parts = Object.entries(tags).map(([tagKey, value]) => {
-    if (value.indexOf(' ') > -1) {
+    if (
+      value.indexOf(' ') > -1 &&
+      value.indexOf('[') === -1 &&
+      value.indexOf(']') === -1
+    ) {
       value = `"${value}"`;
     }
 

--- a/static/app/views/issueList/sidebar.tsx
+++ b/static/app/views/issueList/sidebar.tsx
@@ -53,8 +53,8 @@ class IssueListSidebar extends Component<Props, State> {
       .map(p => p.text)
       .join(' ');
     const parsedFilers = parsedResult?.filter(
-      p => p.type === Token.Filter
-    ) as TokenResult<Token.Filter>[];
+      (p): p is TokenResult<Token.Filter> => p.type === Token.Filter
+    );
     const queryObj = Object.fromEntries(
       parsedFilers.map((p: TokenResult<Token.Filter>) => [p.key.text, p.value.text])
     );

--- a/static/app/views/issueList/sidebar.tsx
+++ b/static/app/views/issueList/sidebar.tsx
@@ -46,6 +46,16 @@ class IssueListSidebar extends Component<Props, State> {
 
   state: State = this.parseQueryToState(this.props.query);
 
+  componentWillReceiveProps(nextProps: Props) {
+    // If query was updated by another source (e.g. SearchBar),
+    // clobber state of sidebar with new query.
+    const query = objToQuery(this.state.queryObj);
+
+    if (!isEqual(nextProps.query, query)) {
+      this.setState(this.parseQueryToState(nextProps.query));
+    }
+  }
+
   parseQueryToState(query: string): State {
     const parsedResult: ParseResult = parseSearch(query) ?? [];
     const textFilter = parsedResult
@@ -63,16 +73,6 @@ class IssueListSidebar extends Component<Props, State> {
       queryObj,
       textFilter,
     };
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    // If query was updated by another source (e.g. SearchBar),
-    // clobber state of sidebar with new query.
-    const query = objToQuery(this.state.queryObj);
-
-    if (!isEqual(nextProps.query, query)) {
-      this.setState(this.parseQueryToState(nextProps.query));
-    }
   }
 
   onSelectTag = (tag: Tag, value: string | null) => {


### PR DESCRIPTION
This updates the issue details sidebar query builder to parse the query with the new parser. The issue was with how arrays were handled in the old parser, quotation marks aren't necessary.

jira: [WOR-1887](https://getsentry.atlassian.net/browse/WOR-1887)