### PR TITLE
fix(active-release): fix release notification to render release link and commit data

### DIFF
--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -235,10 +235,12 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
                 "subject": c.message.split("\n", 1)[0] if c.message else "no subject",
                 "key": c.key,
             }
-            for c in sorted(_get_commits([release]), key=lambda x: x.order, reverse=True)
+            for c in sorted(_get_commits([release]), key=lambda x: str(x.order), reverse=True)
         ]
 
     def release_url(self, release: Release) -> str:
-        return absolute_uri(
-            f"/organizations/{release.organization.slug}/releases/{release.version}/?project={release.project_id}"
+        return str(
+            absolute_uri(
+                f"/organizations/{release.organization.slug}/releases/{release.version}/?project={release.project_id}"
+            )
         )

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -182,9 +182,7 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
         last_release: Optional[Release] = None,
     ) -> None:
         super().__init__(notification, target_type, target_identifier)
-
-        if not last_release:
-            self.last_release = latest_release(notification.event)
+        self.last_release = last_release if last_release else latest_release(notification.event)
 
     def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
         from sentry.integrations.slack.message_builder.issues import build_rule_url

--- a/src/sentry/rules/conditions/active_release.py
+++ b/src/sentry/rules/conditions/active_release.py
@@ -10,71 +10,76 @@ from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
 
 
+def latest_release(event: Event) -> Optional[Release]:
+    return Release.objects.filter(
+        organization_id=event.project.organization_id,
+        projects__id=event.project_id,
+        version=event.release,
+    ).first()
+
+
+def is_in_active_release(event: Event) -> bool:
+    if not event.group:
+        return False
+
+    now = timezone.now()
+    now_minus_1_hour = now - timedelta(hours=1.0)
+
+    if not event.group or not event.project:
+        return False
+
+    event_release = latest_release(event)
+
+    if not event_release:
+        return False
+
+    def release_deploy_time(release: Release, env_id: Optional[int]) -> Optional[DateTimeField]:
+        # check deploy -> release first
+        # then Release.date_released
+        # then EnvironmentRelease.first_seen
+        last_deploy: Deploy = (
+            Deploy.objects.filter(release_id=release.id).order_by("-date_finished").first()
+            or Deploy.objects.filter(id=release.last_deploy_id).first()
+        )
+        if last_deploy:
+            return last_deploy.date_finished
+        else:
+            if release.date_released:
+                return release.date_released
+            else:
+                if env_id:
+                    release_project_env = ReleaseProjectEnvironment.objects.filter(
+                        release_id=release.id, project=release.project_id, environment_id=env_id
+                    ).first()
+
+                    release_env = ReleaseEnvironment.objects.filter(
+                        release_id=release.id, environment_id=env_id
+                    ).first()
+
+                    if release_project_env and release_project_env.first_seen:
+                        return release_project_env.first_seen
+
+                    if release_env and release_env.first_seen:
+                        return release_env.first_seen
+
+        return None
+
+    evt_env = event.get_environment()
+    deploy_time = release_deploy_time(event_release, evt_env.id if evt_env else None)
+    if deploy_time:
+        return bool(now_minus_1_hour <= deploy_time <= now)
+
+    return False
+
+
 class ActiveReleaseEventCondition(EventCondition):
     id = "sentry.rules.conditions.active_release.ActiveReleaseEventCondition"
     label = "A new issue is created within an active release (1 hour of deployment)"
 
-    def is_in_active_release(self, event: Event) -> bool:
-        if not event.group:
-            return False
-
-        now = timezone.now()
-        now_minus_1_hour = now - timedelta(hours=1.0)
-
-        if not event.group or not event.project:
-            return False
-
-        event_release = Release.objects.filter(
-            organization_id=event.project.organization_id,
-            projects__id=event.project_id,
-            version=event.release,
-        ).first()
-
-        if not event_release:
-            return False
-
-        def release_deploy_time(release: Release, env_id: Optional[int]) -> Optional[DateTimeField]:
-            # check deploy -> release first
-            # then Release.date_released
-            # then EnvironmentRelease.first_seen
-            last_deploy: Deploy = (
-                Deploy.objects.filter(release_id=release.id).order_by("-date_finished").first()
-                or Deploy.objects.filter(id=release.last_deploy_id).first()
-            )
-            if last_deploy:
-                return last_deploy.date_finished
-            else:
-                if release.date_released:
-                    return release.date_released
-                else:
-                    if env_id:
-                        release_project_env = ReleaseProjectEnvironment.objects.filter(
-                            release_id=release.id, project=release.project_id, environment_id=env_id
-                        ).first()
-
-                        release_env = ReleaseEnvironment.objects.filter(
-                            release_id=release.id, environment_id=env_id
-                        ).first()
-
-                        if release_project_env and release_project_env.first_seen:
-                            return release_project_env.first_seen
-
-                        if release_env and release_env.first_seen:
-                            return release_env.first_seen
-
-            return None
-
-        evt_env = event.get_environment()
-        deploy_time = release_deploy_time(event_release, evt_env.id if evt_env else None)
-        if deploy_time:
-            return bool(now_minus_1_hour <= deploy_time <= now)
-
-        return False
-
     def passes(self, event: Event, state: EventState) -> bool:
         if self.rule and self.rule.environment_id is None:
-            return (state.is_new or state.is_regression) and self.is_in_active_release(event)
+            return (state.is_new or state.is_regression) and is_in_active_release(event)
         else:
-            return (
-                state.is_new_group_environment or state.is_regression
-            ) and self.is_in_active_release(event)
+            return (state.is_new_group_environment or state.is_regression) and is_in_active_release(
+                event
+            )

--- a/src/sentry/templates/sentry/emails/release_alert.html
+++ b/src/sentry/templates/sentry/emails/release_alert.html
@@ -74,7 +74,7 @@
             <tr>
               <td style="padding:0;width:32px;">{% email_avatar commit.author.name commit.author.email 32 %}</td>
               <td>
-                <h5 class="truncate">You made a commit in release {{ release.version }}</h5>
+                <h5 class="truncate">{{commit.author.name}} made a commit in release <a href="{{ last_release_link }}">{{ last_release.version }}</a>.</h5>
                 <div><small>{{ commit.subject }}</small></div>
               </td>
             </tr>

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -386,47 +386,31 @@ def release_alert(request):
             "group": group,
             "event": event,
             "timezone": pytz.timezone("Europe/Vienna"),
-            # http://testserver/organizations/example/issues/<issue-id>/?referrer=alert_email
-            #       &alert_type=email&alert_timestamp=<ts>&alert_rule_id=1
             "link": get_group_settings_link(group, None, get_rules([rule], org, project), 1337),
             "interfaces": interfaces,
             "tags": event.tags,
             "project": project,
-            "release": {
-                "version": "13.9.1",
+            "last_release": {
+                "version": "13.9.2",
             },
+            "last_release_link": f"http://testserver/organizations/{org.slug}/releases/13.9.2/?project={project.id}",
             "environment": "production",
             "commits": [
                 {
-                    "repository": {
-                        "status": "active",
-                        "name": "Example Repo",
-                        "url": "https://github.com/example/example",
-                        "dateCreated": "2018-02-28T23:39:22.402Z",
-                        "provider": {"id": "github", "name": "GitHub"},
-                        "id": "1",
-                    },
-                    "score": 2,
-                    "subject": "feat: Do something to raven/base.py",
-                    "message": "feat: Do something to raven/base.py\naptent vivamus vehicula tempus volutpat hac tortor",
-                    "id": "1b17483ffc4a10609e7921ee21a8567bfe0ed006",
-                    "shortId": "1b17483",
-                    "author": {
-                        "username": "dcramer@gmail.com",
-                        "isManaged": False,
-                        "lastActive": "2018-03-01T18:25:28.149Z",
-                        "id": "1",
-                        "isActive": True,
-                        "has2fa": False,
-                        "name": "dcramer@gmail.com",
-                        "avatarUrl": "https://secure.gravatar.com/avatar/51567a4f786cd8a2c41c513b592de9f9?s=32&d=mm",
-                        "dateJoined": "2018-02-27T22:04:32.847Z",
-                        "emails": [{"is_verified": False, "id": "1", "email": "dcramer@gmail.com"}],
-                        "avatar": {"avatarUuid": None, "avatarType": "letter_avatar"},
-                        "lastLogin": "2018-02-27T22:04:32.847Z",
-                        "email": "dcramer@gmail.com",
-                    },
-                }
+                    "subject": "fix bug really",
+                    "author": {"name": "committer1", "email": "test@example.com"},
+                    "key": "sha8910",
+                },
+                {
+                    "subject": "fix bug",
+                    "author": {"name": "committer2", "email": "test2@example.com"},
+                    "key": "sha567",
+                },
+                {
+                    "subject": "first commit",
+                    "author": {"name": "committer1", "email": "test@example.com"},
+                    "key": "sha1234",
+                },
             ],
         },
     ).render(request)

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1,5 +1,5 @@
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Mapping, Sequence
 from unittest import mock
 
@@ -17,6 +17,7 @@ from sentry.event_manager import EventManager, get_event_type
 from sentry.mail import build_subject_prefix, mail_adapter
 from sentry.models import (
     Activity,
+    Deploy,
     GroupRelease,
     Integration,
     NotificationSetting,
@@ -26,6 +27,7 @@ from sentry.models import (
     Project,
     ProjectOption,
     ProjectOwnership,
+    Release,
     Repository,
     Rule,
     User,
@@ -69,6 +71,43 @@ class BaseMailAdapterTest(TestCase):
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
             self.adapter.notify(Notification(event=event), target_type, target_identifier)
         assert sorted(email.to[0] for email in mail.outbox) == sorted(emails_sent_to)
+
+
+class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
+    @mock.patch("sentry.notifications.utils.participants.get_release_committers")
+    def test_simple(self, mock_get_release_committers):
+        mock_get_release_committers.return_value = [self.create_user(email="test@example.com")]
+        event = self.store_event(
+            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
+        )
+        newRelease = Release.objects.create(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            version="2",
+            date_added=timezone.now() - timedelta(days=1),
+            date_released=None,
+        )
+        Deploy.objects.create(
+            organization_id=self.organization.id,
+            environment_id=self.environment.id,
+            name="test_release_deployed",
+            notified=True,
+            release_id=newRelease.id,
+            date_started=timezone.now() - timedelta(minutes=37),
+            date_finished=timezone.now() - timedelta(minutes=20),
+        )
+        newRelease.add_project(self.project)
+
+        event.data["tags"] = (("sentry:release", newRelease.version),)
+
+        mail.outbox = []
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            self.adapter.notify(Notification(event=event), ActionTargetType.RELEASE_MEMBERS, None)
+
+        assert len(mail.outbox) == 1
+        to_committer = mail.outbox[0]
+
+        assert to_committer
 
 
 class MailAdapterGetSendableUsersTest(BaseMailAdapterTest):


### PR DESCRIPTION
Before:
<img width="719" alt="Screen Shot 2022-06-28 at 6 39 38 PM" src="https://user-images.githubusercontent.com/101606877/176332790-1cb5b8b3-763d-4f10-8c60-5b192e48a6b1.png">

After:
<img width="700" alt="Screen Shot 2022-06-28 at 6 38 56 PM" src="https://user-images.githubusercontent.com/101606877/176332773-b3510c45-36bc-4e42-90ab-2ca5c4ceffe1.png">


Release data wasn't properly being initialized in the Notication class. This should fix that. While we're here, also added proper commit data relevant to the release instead of the latest commits from a project.
