### PR TITLE
fix(sampling): Include transaction values in sampling modal

### DIFF
--- a/static/app/views/settings/project/sampling/modal/tagValueAutocomplete.tsx
+++ b/static/app/views/settings/project/sampling/modal/tagValueAutocomplete.tsx
@@ -80,7 +80,15 @@ function TagValueAutocomplete({
     }
 
     try {
-      const response = await fetchTagValues(api, orgSlug, tagKey, null, [projectId]);
+      const response = await fetchTagValues(
+        api,
+        orgSlug,
+        tagKey,
+        null,
+        [projectId],
+        null,
+        true
+      );
       setTagValues(response);
     } catch {
       // Do nothing. No results will be suggested


### PR DESCRIPTION
This PR makes sure that we fetch transactions tag values for the value autocomplete in the sampling modal.