### PR TITLE
ref: fix import warning for collections.abc deprecation

### DIFF
--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -1,6 +1,6 @@
 """ Classes needed to build a metrics query. Inspired by snuba_sdk.query. """
 import math
-from collections import Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Literal, Optional, Sequence, Set, Union


### PR DESCRIPTION
I should really finish the `pyugprade` autofixer for this so this doesn't regress :grimacing: 