### PR TITLE
ref(sdk): Bump sentry-sdk to 1.6

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -56,7 +56,7 @@ rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-arroyo==0.2.0
 sentry-relay==0.8.12
-sentry-sdk>=1.4.3,<1.6.0
+sentry-sdk==1.6.0
 snuba-sdk==1.0.0
 simplejson==3.17.6
 statsd==3.3


### PR DESCRIPTION
### Summary
We've released the 1.6 version of sentry-python a few days ago, this updates our Sentry version to a pinned 1.6 (not sure why we went unpinned last time). Put this up quickly since I need it in to make another PR easier to merge, we'll see if tests pass.
