### PR TITLE
fix(settings) Fix docs link on DSN list.

### DIFF
--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -189,7 +189,9 @@ class ProjectKeys extends AsyncView<Props, State> {
           information on integrating Sentry with your application take a look at our
           [link:documentation].`,
             {
-              link: <ExternalLink href="https://docs.sentry.io/" />,
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platform-redirect/?next=/configuration/options/" />
+              ),
               code: <code />,
             }
           )}


### PR DESCRIPTION
Point to a useful page vs. 'the docs'.