### PR TITLE
fix(replays): Fix stack order of elements in the timeline

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -51,6 +51,13 @@ function ReplayTimeline({}: Props) {
               <MinorGridlines duration={duration} width={width} />
               <MajorGridlines duration={duration} width={width} />
               <TimelineScubber />
+              <UnderTimestamp paddingTop="52px">
+                <ReplayTimelineSpans
+                  duration={duration}
+                  spans={networkSpans}
+                  startTimestamp={startTimestamp}
+                />
+              </UnderTimestamp>
               <TimelinePosition
                 color={theme.purple300}
                 currentTime={currentTime}
@@ -63,17 +70,12 @@ function ReplayTimeline({}: Props) {
                   duration={duration}
                 />
               ) : null}
-              <UnderTimestamp>
+              <UnderTimestamp paddingTop="24px">
                 <ReplayTimelineEvents
                   crumbs={userCrumbs}
                   duration={duration}
                   startTimestamp={startTimestamp}
                   width={width}
-                />
-                <ReplayTimelineSpans
-                  duration={duration}
-                  spans={networkSpans}
-                  startTimestamp={startTimestamp}
                 />
               </UnderTimestamp>
             </Stacked>
@@ -84,9 +86,9 @@ function ReplayTimeline({}: Props) {
   );
 }
 
-const UnderTimestamp = styled('div')`
+const UnderTimestamp = styled('div')<{paddingTop: string}>`
   /* Weird size to put equal space above/below a <small> node that MajorGridlines emits */
-  padding-top: 16px;
+  padding-top: ${p => p.paddingTop};
 `;
 
 export default ReplayTimeline;

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -45,7 +45,6 @@ function ReplayTimelineEvents({
 
 const EventColumns = styled(Timeline.Columns)`
   height: ${space(4)};
-  margin-top: ${space(1)};
 `;
 
 const EventColumn = styled(Timeline.Col)<{column: number}>`


### PR DESCRIPTION
Fixed the stacking order so that network spans render behind the currentTime and hoverTime markers. 

The Event circles are still rendered on top of everything.

Before:
![image](https://user-images.githubusercontent.com/187460/176492243-ed6d6539-08b5-40f1-876f-bb010f76dc1c.png)


After:
<img width="170" alt="Screen Shot 2022-06-29 at 9 49 24 AM" src="https://user-images.githubusercontent.com/187460/176492230-55434d15-e836-4f77-8270-557847ddc9e7.png">

