### PR TITLE
fix(replays): Constrain mouse tracking to the parent rect

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -11,8 +10,8 @@ import {
 import ReplayTimelineEvents from 'sentry/components/replays/breadcrumbs/replayTimelineEvents';
 import ReplayTimelineSpans from 'sentry/components/replays/breadcrumbs/replayTimelineSpans';
 import Stacked from 'sentry/components/replays/breadcrumbs/stacked';
-import HorizontalMouseTracking from 'sentry/components/replays/player/horizontalMouseTracking';
 import {TimelineScubber} from 'sentry/components/replays/player/scrubber';
+import ScrubberMouseTracking from 'sentry/components/replays/player/scrubberMouseTracking';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {Resizeable} from 'sentry/components/replays/resizeable';
 import TimelinePosition from 'sentry/components/replays/timelinePosition';
@@ -44,7 +43,7 @@ function ReplayTimeline({}: Props) {
 
   return (
     <Panel>
-      <HorizontalMouseTracking>
+      <ScrubberMouseTracking>
         <Resizeable>
           {({width}) => (
             <Stacked>
@@ -79,7 +78,7 @@ function ReplayTimeline({}: Props) {
             </Stacked>
           )}
         </Resizeable>
-      </HorizontalMouseTracking>
+      </ScrubberMouseTracking>
     </Panel>
   );
 }

--- a/static/app/components/replays/player/scrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/scrubberMouseTracking.tsx
@@ -1,0 +1,39 @@
+import {useCallback} from 'react';
+
+import MouseTracking, {
+  Props as MouseTrackingProps,
+} from 'sentry/components/replays/mouseTracking';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+
+type OnMouseMoveParams = Parameters<MouseTrackingProps['onMouseMove']>;
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function ScrubberMouseTracking({children}: Props) {
+  const {duration = 0, setCurrentHoverTime} = useReplayContext();
+
+  const handleMouseMove = useCallback(
+    (params: OnMouseMoveParams[0]) => {
+      if (!params || duration === undefined) {
+        setCurrentHoverTime(undefined);
+        return;
+      }
+      const {left, width} = params;
+
+      if (left >= 0) {
+        const percent = left / width;
+        const time = percent * duration;
+        setCurrentHoverTime(time);
+      } else {
+        setCurrentHoverTime(undefined);
+      }
+    },
+    [duration, setCurrentHoverTime]
+  );
+
+  return <MouseTracking onMouseMove={handleMouseMove}>{children}</MouseTracking>;
+}
+
+export default ScrubberMouseTracking;

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -1,10 +1,10 @@
-import React, {useEffect, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
 import {Panel, PanelBody, PanelHeader as _PanelHeader} from 'sentry/components/panels';
-import HorizontalMouseTracking from 'sentry/components/replays/player/horizontalMouseTracking';
 import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
+import ScrubberMouseTracking from 'sentry/components/replays/player/scrubberMouseTracking';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
@@ -55,9 +55,9 @@ function ReplayView({isFullscreen, toggleFullscreen}: Props) {
       <PanelHeader ref={playerRef} disablePadding noBorder>
         <ReplayPlayer height={isFullscreen ? Infinity : playerHeight} />
       </PanelHeader>
-      <HorizontalMouseTracking>
+      <ScrubberMouseTracking>
         <PlayerScrubber />
-      </HorizontalMouseTracking>
+      </ScrubberMouseTracking>
       <ReplayControllerWrapper>
         <ReplayController toggleFullscreen={toggleFullscreen} />
       </ReplayControllerWrapper>


### PR DESCRIPTION
Previously it was possible to click+drag the scrubber and pull it all the way outside it's container. Both the Scrubber under the replay and Timeline had the same problem.

It looked like this:
<img width="492" alt="Screen Shot 2022-06-29 at 10 37 39 AM" src="https://user-images.githubusercontent.com/187460/176501002-e67763d5-a5f8-4971-abf7-4a59ccc4f11d.png">


Now there is a constraint on the reported left & top values. 

Also I've refactored a bit to make the mouse tracking code more generic, and to extend it so that it tracks top/height as well. So it could be more reusable for someone else.
