### PR TITLE
feat(segment): Adjust throttling for data-forwarding to Segment

### DIFF
--- a/src/sentry/plugins/bases/data_forwarding.py
+++ b/src/sentry/plugins/bases/data_forwarding.py
@@ -21,7 +21,9 @@ class DataForwardingPlugin(Plugin):
         return True
 
     def get_rate_limit(self):
-        # number of requests, number of seconds (window)
+        """
+        Returns a tuple of (Number of Requests, Window in Seconds)
+        """
         return (50, 1)
 
     def forward_event(self, event: Event, payload: MutableMapping[str, Any]) -> bool:

--- a/src/sentry_plugins/segment/plugin.py
+++ b/src/sentry_plugins/segment/plugin.py
@@ -42,8 +42,7 @@ class SegmentPlugin(CorePluginMixin, DataForwardingPlugin):
         ]
 
     def get_rate_limit(self):
-        # number of requests, number of seconds (window)
-        return (50, 1)
+        return (200, 1)
 
     def get_event_props(self, event):
         props = {


### PR DESCRIPTION


<!-- Describe your PR here. -->

This PR adjusts the rate limit we impose on ourselves in sending requests to Segment. 


<!--

  Sentry employees and contractors can delete or ignore the following.

-->