### PR TITLE
ref(discover): Use CompactSelect for landing page sort dropdown

### DIFF
--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -9,7 +9,7 @@ import Alert from 'sentry/components/alert';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import Button from 'sentry/components/button';
-import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import CompactSelect from 'sentry/components/forms/compactSelect';
 import {Title} from 'sentry/components/layouts/thirds';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SearchBar from 'sentry/components/searchBar';
@@ -216,18 +216,13 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
             toggle={this.togglePrebuilt}
           />
         </PrebuiltSwitch>
-        <DropdownControl buttonProps={{prefix: t('Sort By')}} label={activeSort.label}>
-          {SORT_OPTIONS.map(({label, value}) => (
-            <DropdownItem
-              key={value}
-              onSelect={this.handleSortChange}
-              eventKey={value}
-              isActive={value === activeSort.value}
-            >
-              {label}
-            </DropdownItem>
-          ))}
-        </DropdownControl>
+        <CompactSelect
+          triggerProps={{prefix: t('Sort By')}}
+          value={activeSort.value}
+          options={SORT_OPTIONS}
+          onChange={opt => this.handleSortChange(opt.value)}
+          placement="bottom right"
+        />
       </StyledActions>
     );
   }

--- a/tests/js/spec/views/eventsV2/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/index.spec.jsx
@@ -1,5 +1,6 @@
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {act} from 'sentry-test/reactTestingLibrary';
+import {triggerPress} from 'sentry-test/utils';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {DiscoverLanding} from 'sentry/views/eventsV2/landing';
@@ -96,14 +97,22 @@ describe('EventsV2 > Landing', function () {
     expect(content.text()).toContain("You don't have access to this feature");
   });
 
-  it('has the right sorts', function () {
+  it('has the right sorts', async function () {
     const org = TestStubs.Organization({features});
 
     const wrapper = mountWithTheme(
       <DiscoverLanding organization={org} location={{query: {}}} router={{}} />
     );
 
-    const dropdownItems = wrapper.find('DropdownItem span');
+    // Open sort menu
+    await act(async () => {
+      triggerPress(wrapper.find('CompactSelect Button'));
+
+      await tick();
+      wrapper.update();
+    });
+
+    const dropdownItems = wrapper.find('MenuItemWrap');
     expect(dropdownItems).toHaveLength(8);
 
     const expectedSorts = [


### PR DESCRIPTION
**Before:**
<img width="198" alt="image" src="https://user-images.githubusercontent.com/44172267/176507691-7b5f71d7-5ab9-47ec-b333-bd0551026f6e.png">

**After:**
<img width="219" alt="image" src="https://user-images.githubusercontent.com/44172267/176507773-2817b283-16fe-4414-804f-fabd6a7ca68a.png">
