### PR TITLE
ref(searchbar): Remove max searchbar items due to new default state and set max height

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -4,10 +4,7 @@ import SearchBar, {SearchBarProps} from 'sentry/components/events/searchBar';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
 import {Organization, PageFilters, SavedSearchType} from 'sentry/types';
 import {WidgetQuery} from 'sentry/views/dashboardsV2/types';
-import {
-  MAX_MENU_HEIGHT,
-  MAX_SEARCH_ITEMS,
-} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
+import {MAX_MENU_HEIGHT} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 
 interface Props {
   onBlur: SearchBarProps['onBlur'];
@@ -37,7 +34,6 @@ export function EventsSearchBar({
       onBlur={onBlur}
       useFormWrapper={false}
       maxQueryLength={MAX_QUERY_LENGTH}
-      maxSearchItems={MAX_SEARCH_ITEMS}
       maxMenuHeight={MAX_MENU_HEIGHT}
       savedSearchType={SavedSearchType.EVENT}
     />

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
@@ -9,10 +9,7 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import useApi from 'sentry/utils/useApi';
 import withIssueTags from 'sentry/utils/withIssueTags';
 import {WidgetQuery} from 'sentry/views/dashboardsV2/types';
-import {
-  MAX_MENU_HEIGHT,
-  MAX_SEARCH_ITEMS,
-} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
+import {MAX_MENU_HEIGHT} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 
 interface Props {
@@ -59,7 +56,6 @@ function IssuesSearchBarContainer({
           placeholder={t('Search for issues, status, assigned, and more')}
           tagValueLoader={tagValueLoader}
           onSidebarToggle={() => undefined}
-          maxSearchItems={MAX_SEARCH_ITEMS}
           savedSearchType={SavedSearchType.ISSUE}
           dropdownClassName={css`
             max-height: ${MAX_MENU_HEIGHT}px;

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -10,10 +10,7 @@ import {t} from 'sentry/locale';
 import {Organization, PageFilters, SavedSearchType, Tag, TagValue} from 'sentry/types';
 import useApi from 'sentry/utils/useApi';
 import {WidgetQuery} from 'sentry/views/dashboardsV2/types';
-import {
-  MAX_MENU_HEIGHT,
-  MAX_SEARCH_ITEMS,
-} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
+import {MAX_MENU_HEIGHT} from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 
 import {SESSION_STATUSES, SESSIONS_FILTER_TAGS} from '../../releaseWidget/fields';
 
@@ -92,7 +89,6 @@ export function ReleaseSearchBar({
           onSearch={onSearch}
           onBlur={onBlur}
           maxQueryLength={MAX_QUERY_LENGTH}
-          maxSearchItems={MAX_SEARCH_ITEMS}
           searchSource="widget_builder"
           query={widgetQuery.conditions}
           savedSearchType={SavedSearchType.SESSION}

--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -313,9 +313,6 @@ export function getMetricFields(queries: WidgetQuery[]) {
   }, [] as string[]);
 }
 
-// Used to limit the number of results of the "filter your results" fields dropdown
-export const MAX_SEARCH_ITEMS = 5;
-
 // Used to set the max height of the smartSearchBar menu
 export const MAX_MENU_HEIGHT = 250;
 

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -133,7 +133,6 @@ class IssueListSearchBar extends Component<Props, State> {
       <SmartSearchBar
         searchSource="main_search"
         hasRecentSearches
-        maxSearchItems={5}
         savedSearchType={SavedSearchType.ISSUE}
         onGetTagValues={this.getTagValues}
         defaultSearchItems={this.state.defaultSearchItems}
@@ -143,6 +142,7 @@ class IssueListSearchBar extends Component<Props, State> {
           makeSaveSearchAction({sort}),
           makeSearchBuilderAction({onSidebarToggle}),
         ]}
+        maxMenuHeight={500}
         {...props}
       />
     );

--- a/static/app/views/projectDetail/projectFilters.tsx
+++ b/static/app/views/projectDetail/projectFilters.tsx
@@ -36,7 +36,6 @@ function ProjectFilters({query, relativeDateOptions, tagValueLoader, onSearch}: 
           searchSource="project_filters"
           query={query}
           placeholder={t('Search by release version, build, package, or stage')}
-          maxSearchItems={5}
           hasRecentSearches={false}
           supportedTags={{
             ...SEMVER_TAGS,
@@ -45,6 +44,7 @@ function ProjectFilters({query, relativeDateOptions, tagValueLoader, onSearch}: 
               name: 'release',
             },
           }}
+          maxMenuHeight={500}
           onSearch={onSearch}
           onGetTagValues={getTagValues}
         />

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -544,7 +544,6 @@ class ReleasesList extends AsyncView<Props, State> {
                   searchSource="releases"
                   query={this.getQuery()}
                   placeholder={t('Search by version, build, package, or stage')}
-                  maxSearchItems={5}
                   hasRecentSearches={false}
                   supportedTags={{
                     ...SEMVER_TAGS,
@@ -553,6 +552,7 @@ class ReleasesList extends AsyncView<Props, State> {
                       name: 'release',
                     },
                   }}
+                  maxMenuHeight={500}
                   supportedTagType={ItemType.PROPERTY}
                   onSearch={this.handleSearch}
                   onGetTagValues={this.getTagValues}


### PR DESCRIPTION
(Split from #35859 for pr size)

Because the new default state for the smart searchBar's dropdown now shows all possible keys, instead of setting the max search items we set a max height and make it scrollable instead.

## Issues List:

Before:
<img width="1140" alt="Screen Shot 2022-06-29 at 11 43 00 AM" src="https://user-images.githubusercontent.com/30991498/176512160-02e25c67-0803-42c8-91ee-dd67a00fdd15.png">


After:
<img width="1108" alt="Screen Shot 2022-06-29 at 11 43 20 AM" src="https://user-images.githubusercontent.com/30991498/176512213-1716b472-4564-48b3-90c7-303d347d930f.png">



## Widget Builder:

Before:
<img width="1040" alt="Screen Shot 2022-06-29 at 11 42 31 AM" src="https://user-images.githubusercontent.com/30991498/176512084-e82b202a-4c8f-40d1-ac8e-47be1af3c7bc.png">


After:
<img width="1021" alt="Screen Shot 2022-06-29 at 11 41 47 AM" src="https://user-images.githubusercontent.com/30991498/176512035-dc79d9e9-3b63-4d18-9099-79b7b73703bd.png">

