### PR TITLE
ref: remove backend generation of junitxml since it is not being consumed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ fetch-release-registry:
 
 run-acceptance:
 	@echo "--> Running acceptance tests"
-	pytest tests/acceptance --cov . --cov-report="xml:.artifacts/acceptance.coverage.xml" --junit-xml=".artifacts/acceptance.junit.xml"
+	pytest tests/acceptance --cov . --cov-report="xml:.artifacts/acceptance.coverage.xml"
 	@echo ""
 
 test-cli:
@@ -127,7 +127,7 @@ test-python-ci:
 		--ignore tests/sentry/snuba \
 		--ignore tests/sentry/search/events \
 		--ignore tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
-		--cov . --cov-report="xml:.artifacts/python.coverage.xml" --junit-xml=".artifacts/python.junit.xml" || exit 1
+		--cov . --cov-report="xml:.artifacts/python.coverage.xml"
 	@echo ""
 
 test-snuba:
@@ -136,12 +136,12 @@ test-snuba:
 		tests/sentry/eventstream/kafka \
 		tests/sentry/snuba \
 		tests/sentry/search/events \
-		-vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml" --junit-xml=".artifacts/snuba.junit.xml"
+		-vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml"
 	@echo ""
 
 test-tools:
 	@echo "--> Running tools tests"
-	pytest -c /dev/null --confcutdir tests/tools tests/tools -vv --cov=tools --cov=tests/tools --cov-report="xml:.artifacts/tools.coverage.xml" --junit-xml=".artifacts/tools.junit.xml"
+	pytest -c /dev/null --confcutdir tests/tools tests/tools -vv --cov=tools --cov=tests/tools --cov-report="xml:.artifacts/tools.coverage.xml"
 	@echo ""
 
 backend-typing:
@@ -151,12 +151,12 @@ backend-typing:
 
 test-symbolicator:
 	@echo "--> Running symbolicator tests"
-	pytest tests/symbolicator -vv --cov . --cov-report="xml:.artifacts/symbolicator.coverage.xml" --junit-xml=".artifacts/symbolicator.junit.xml"
+	pytest tests/symbolicator -vv --cov . --cov-report="xml:.artifacts/symbolicator.coverage.xml"
 	@echo ""
 
 test-chartcuterie:
 	@echo "--> Running chartcuterie tests"
-	pytest tests/chartcuterie -vv --cov . --cov-report="xml:.artifacts/chartcuterie.coverage.xml" --junit-xml=".artifacts/chartcuterie.junit.xml"
+	pytest tests/chartcuterie -vv --cov . --cov-report="xml:.artifacts/chartcuterie.coverage.xml"
 	@echo ""
 
 test-acceptance: node-version-check
@@ -166,7 +166,7 @@ test-acceptance: node-version-check
 
 test-plugins:
 	@echo "--> Running plugin tests"
-	pytest tests/sentry_plugins -vv --cov . --cov-report="xml:.artifacts/plugins.coverage.xml" --junit-xml=".artifacts/plugins.junit.xml" || exit 1
+	pytest tests/sentry_plugins -vv --cov . --cov-report="xml:.artifacts/plugins.coverage.xml"
 	@echo ""
 
 test-relay-integration:
@@ -174,7 +174,7 @@ test-relay-integration:
 	pytest \
 		tests/relay_integration \
 		tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py \
-		-vv --cov . --cov-report="xml:.artifacts/relay.coverage.xml" --junit-xml=".artifacts/relay.junit.xml"
+		-vv --cov . --cov-report="xml:.artifacts/relay.coverage.xml"
 	@echo ""
 
 test-api-docs: build-api-docs


### PR DESCRIPTION
I also removed some stray `|| exit 1`s from the output -- make will already error on any nonzero exit code