### PR TITLE
feat(ingest): Pass has_attachments from ingest consumer

### DIFF
--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -300,6 +300,7 @@ def _load_event(
                     start_time=start_time,
                     event_id=event_id,
                     project=project,
+                    has_attachments=bool(attachments),
                 )
 
         # remember for an 1 hour that we saved this event (deduplication protection)

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -66,6 +66,7 @@ def test_deduplication_works(default_project, task_runner, preprocess_event):
         "event_id": event_id,
         "project": default_project,
         "start_time": start_time,
+        "has_attachments": False,
     }
 
 


### PR DESCRIPTION
Start passing the `has_attachments` argument from ingest consumer which is then passed through the pipeline. See https://github.com/getsentry/sentry/pull/36119

This is the final step for the events with attachments to be routed to a separate `save_event` queue.