### PR TITLE
fix(sudo modal): Stopped superuser prefill on sudo modal

### DIFF
--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -210,7 +210,7 @@ class AuthIndexEndpoint(Endpoint):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         validator = AuthVerifyValidator(data=request.data)
 
-        if not request.user.is_superuser:
+        if not request.user.is_superuser or not request.data.get("isSuperuserModal"):
             if not validator.is_valid():
                 return self.respond(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/api/endpoints/auth_index.py
+++ b/src/sentry/api/endpoints/auth_index.py
@@ -210,7 +210,7 @@ class AuthIndexEndpoint(Endpoint):
             return Response(status=status.HTTP_401_UNAUTHORIZED)
         validator = AuthVerifyValidator(data=request.data)
 
-        if not request.user.is_superuser or not request.data.get("isSuperuserModal"):
+        if not (request.user.is_superuser and request.data.get("isSuperuserModal")):
             if not validator.is_valid():
                 return self.respond(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -374,45 +374,6 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
             assert response.status_code == 401
             assert self.client.session.get("_next") is None
 
-    def test_superuser_sso_sudo_modal(self):
-        from sentry.auth.superuser import COOKIE_NAME, Superuser
-
-        with self.settings(SENTRY_SELF_HOSTED=False):
-            org_provider = AuthProvider.objects.create(
-                organization=self.organization, provider="dummy"
-            )
-
-            user = self.create_user("foo@example.com", is_superuser=True)
-
-            AuthIdentity.objects.create(user=user, auth_provider=org_provider)
-
-            user.update(password="")
-
-            with mock.patch.object(Superuser, "org_id", self.organization.id), override_settings(
-                SUPERUSER_ORG_ID=self.organization.id
-            ):
-                self.login_as(user, organization_id=self.organization.id)
-                response = self.client.put(self.path)
-
-                assert response.status_code == 200
-                assert COOKIE_NAME not in response.cookies
-
-    def test_superuser_no_sso_sudo_modal(self):
-        from sentry.auth.superuser import COOKIE_NAME, Superuser
-
-        with self.settings(SENTRY_SELF_HOSTED=False):
-            AuthProvider.objects.create(organization=self.organization, provider="dummy")
-
-            user = self.create_user("foo@example.com", is_superuser=True)
-
-            with mock.patch.object(Superuser, "org_id", self.organization.id), override_settings(
-                SUPERUSER_ORG_ID=self.organization.id
-            ):
-                self.login_as(user)
-                response = self.client.put(self.path)
-                assert response.status_code == 401
-                assert COOKIE_NAME not in response.cookies
-
 
 class AuthLogoutEndpointTest(APITestCase):
     path = "/api/0/auth/"


### PR DESCRIPTION
Bug seen here: https://sentry.slack.com/archives/C1B4LB39D/p1656534188888189

Cause of problem: When your session is expired, and you try to access superuser via the superuser modal, we want to save your input so you don't have to fill out the form again. Unfortunately, the sudo modal is getting prefilled since its going the verification of superuser flow which causes us to save the info. Once logging in again, we try to read the prefilled form which doesn't exist, causing the problem.

Solution: Make the sudo flow go through the normal verification path