### PR TITLE
fix(menuListItem): Fix sizing issue related to scrollbar display

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -235,6 +235,7 @@ export const InnerWrap = styled('div', {
 const ContentWrap = styled('div')<{isFocused: boolean; showDivider: boolean}>`
   position: relative;
   width: 100%;
+  min-width: 0;
   display: flex;
   gap: ${space(1)};
   justify-content: space-between;
@@ -271,6 +272,7 @@ const LeadingItems = styled('div')<{isDisabled: boolean; spanFullHeight: boolean
 const LabelWrap = styled('div')`
   padding-right: ${space(1)};
   width: 100%;
+  min-width: 0;
 `;
 
 const Label = styled('p')`


### PR DESCRIPTION
Fix a flexbox sizing issue in `MenuListItem` that occurs when the browser renders an always-on scrollbar (this can be enabled in OS settings). Instead of appearing on top of scrollable content, these scrollbars take up space within the scrollable container. This behavior can sometimes lead to sizing/alignment issues.

To fix this, we just need to make the flex items in `MenuListItem` more resistant to size changes.

**Before:**
<img width="360" alt="Screen Shot 2022-06-29 at 2 53 57 PM" src="https://user-images.githubusercontent.com/44172267/176552060-08dd1dcb-ea7e-4613-92eb-c671ae114c81.png">

**After:**
<img width="360" alt="Screen Shot 2022-06-29 at 2 53 38 PM" src="https://user-images.githubusercontent.com/44172267/176552064-f28d612c-809a-4bbd-9362-6a350056cd64.png">