### PR TITLE
fix(sms-auth): add stricter rate-limits to sms 2fa authenticator enrollment

### DIFF
--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -161,8 +161,8 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         """
         if ratelimiter.is_limited(
             f"auth:authenticator-enroll:{request.user.id}:{interface_id}",
-            limit=3,
-            window=300,  # 3 per 5 minutes
+            limit=10,
+            window=86400,  # 10 per day should be fine
         ):
             return HttpResponse(
                 "You have made too many authenticator enrollment attempts. Please try again later.",

--- a/src/sentry/auth/authenticators/sms.py
+++ b/src/sentry/auth/authenticators/sms.py
@@ -13,7 +13,7 @@ from .base import ActivationMessageResult, AuthenticatorInterface, OtpMixin
 logger = logging.getLogger("sentry.auth")
 
 
-class PotentialSMSFraud(Exception):
+class SMSRateLimitExceeded(Exception):
     def __init__(self, phone_number, user_id, remote_ip):
         super().__init__()
         self.phone_number = phone_number
@@ -109,7 +109,7 @@ class SmsInterface(OtpMixin, AuthenticatorInterface):
             limit=3,
             window=300,
         ):
-            raise PotentialSMSFraud(phone_number, user_id, request.META.get("REMOTE_ADDR", None))
+            raise SMSRateLimitExceeded(phone_number, user_id, request.META.get("REMOTE_ADDR", None))
 
         logger.info(
             "mfa.twilio-request",

--- a/src/sentry/auth/authenticators/sms.py
+++ b/src/sentry/auth/authenticators/sms.py
@@ -1,14 +1,24 @@
 import logging
+from hashlib import md5
 
 from django.utils.translation import ugettext_lazy as _
 
+from sentry.app import ratelimiter
 from sentry.utils.decorators import classproperty
 from sentry.utils.otp import TOTP
-from sentry.utils.sms import send_sms, sms_available
+from sentry.utils.sms import phone_number_as_e164, send_sms, sms_available
 
 from .base import ActivationMessageResult, AuthenticatorInterface, OtpMixin
 
 logger = logging.getLogger("sentry.auth")
+
+
+class PotentialSMSFraud(Exception):
+    def __init__(self, phone_number, user_id, remote_ip):
+        super().__init__()
+        self.phone_number = phone_number
+        self.user_id = user_id
+        self.remote_ip = remote_ip
 
 
 class SmsInterface(OtpMixin, AuthenticatorInterface):
@@ -82,7 +92,7 @@ class SmsInterface(OtpMixin, AuthenticatorInterface):
             text = _("%(code)s is your Sentry authentication code.")
 
         if request is not None:
-            text = "{}\n\n{}".format(text, _("Requested from %(ip)s"))
+            text = f"{text}\n"
             ctx["ip"] = request.META["REMOTE_ADDR"]
 
         if request and request.user.is_authenticated:
@@ -92,14 +102,23 @@ class SmsInterface(OtpMixin, AuthenticatorInterface):
         else:
             user_id = None
 
+        phone_number = phone_number_as_e164(self.phone_number)
+
+        if ratelimiter.is_limited(
+            f"sms:{md5(phone_number.encode('utf-8')).hexdigest()}",
+            limit=3,
+            window=300,
+        ):
+            raise PotentialSMSFraud(phone_number, user_id, request.META.get("REMOTE_ADDR", None))
+
         logger.info(
             "mfa.twilio-request",
             extra={
                 "ip": request.META["REMOTE_ADDR"] if request else None,
                 "user_id": user_id,
                 "authenticator_id": self.authenticator.id if self.authenticator else None,
-                "phone_number": self.phone_number,
+                "phone_number": phone_number,
             },
         )
 
-        return send_sms(text % ctx, to=self.phone_number)
+        return send_sms(text % ctx, to=phone_number)

--- a/src/sentry/utils/sms.py
+++ b/src/sentry/utils/sms.py
@@ -1,11 +1,53 @@
 import logging
 from urllib.parse import quote
 
+import phonenumbers
 import requests
 
 from sentry import options
 
 logger = logging.getLogger(__name__)
+
+
+class InvalidPhoneNumber(Exception):
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = None
+
+    def __str__(self):
+        if self.message:
+            return f"InvalidPhoneNumber: {self.message}"
+        else:
+            return "InvalidPhoneNumber"
+
+
+def validate_phone_number(phone_number: str) -> bool:
+    try:
+        p = phonenumbers.parse(phone_number, "US")
+    except phonenumbers.NumberParseException:
+        return False
+
+    return phonenumbers.is_valid_number(p) and phonenumbers.is_possible_number(p)
+
+
+def phone_number_as_e164(num: str) -> str:
+    """Validate and return the phone number in E.164 format.
+
+    If no country code is provided, defaults to assuming the US, "+1".
+
+    :param num: the number in string format can start with +43 (or other country codes)
+    :type num: str
+
+    :return: validated phone number in E.164 format
+    :rtype: str
+    """
+    if validate_phone_number(num):
+        p = phonenumbers.parse(num, "US")
+        return phonenumbers.format_number(p, phonenumbers.PhoneNumberFormat.E164)
+    else:
+        raise InvalidPhoneNumber
 
 
 def sms_available():
@@ -19,14 +61,17 @@ def send_sms(body, to, from_=None):
     if account[:2] != "AC":
         account = "AC" + account
     url = "https://api.twilio.com/2010-04-01/Accounts/%s/Messages.json" % quote(account)
+
+    phone_number = phone_number_as_e164(to)
+
     rv = requests.post(
         url,
         auth=(account, options.get("sms.twilio-token")),
-        data={"To": to, "From": options.get("sms.twilio-number"), "Body": body},
+        data={"To": phone_number, "From": options.get("sms.twilio-number"), "Body": body},
     )
     if not rv.ok:
         logging.exception(
-            "Failed to send text message to %s: (%s) %s", to, rv.status_code, rv.content
+            "Failed to send text message to %s: (%s) %s", phone_number, rv.status_code, rv.content
         )
         return False
     return True

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -191,8 +191,8 @@ class AuthLoginView(BaseView):
                 "auth:login:username:{}".format(
                     md5_text(login_form.clean_username(request.POST["username"])).hexdigest()
                 ),
-                limit=10,
-                window=60,  # 10 per minute should be enough for anyone
+                limit=5,
+                window=60,  # 5 per minute should be enough for anyone
             ):
                 login_form.errors["__all__"] = [
                     "You have made too many login attempts. Please try again later."

--- a/tests/sentry/auth/authenticators/test_sms.py
+++ b/tests/sentry/auth/authenticators/test_sms.py
@@ -1,8 +1,14 @@
+import datetime
+
+import pytest
 import responses
 from django.http import HttpRequest
+from freezegun import freeze_time
 
 from sentry.auth.authenticators import SmsInterface
+from sentry.auth.authenticators.sms import PotentialSMSFraud
 from sentry.testutils import TestCase
+from sentry.utils.sms import InvalidPhoneNumber, phone_number_as_e164
 
 
 class SmsInterfaceTest(TestCase):
@@ -39,17 +45,77 @@ class SmsInterfaceTest(TestCase):
                 "subresource_uris": {
                     "media": "/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Messages/SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Media.json"
                 },
-                "to": "+15551231234",
+                "to": "+12345678901",
                 "uri": "/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Messages/SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.json",
             },
         )
 
         interface = SmsInterface()
-        interface.phone_number = "5551231234"
+        interface.phone_number = "2345678901"
+
         with self.options({"sms.twilio-account": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}):
             rv = interface.activate(request)
 
         assert (
             rv.message
-            == "A confirmation code was sent to <strong>(***) ***-**34</strong>. It is valid for 45 seconds."
+            == "A confirmation code was sent to <strong>(***) ***-**01</strong>. It is valid for 45 seconds."
         )
+
+    @responses.activate
+    def test_ratelimit_exception(self):
+        request = HttpRequest()
+        request.user = self.user
+        request.META["REMOTE_ADDR"] = "127.0.0.1"
+
+        responses.add(
+            responses.POST,
+            "https://api.twilio.com/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Messages.json",
+            json={
+                "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "api_version": "2010-04-01",
+                "body": "Hi there!",
+                "date_created": "Thu, 30 Jul 2015 20:12:31 +0000",
+                "date_sent": "Thu, 30 Jul 2015 20:12:33 +0000",
+                "date_updated": "Thu, 30 Jul 2015 20:12:33 +0000",
+                "direction": "outbound-api",
+                "error_code": None,
+                "error_message": None,
+                "from": "+15551231234",
+                "messaging_service_sid": None,
+                "num_media": "0",
+                "num_segments": "1",
+                "price": None,
+                "price_unit": None,
+                "sid": "SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+                "status": "sent",
+                "subresource_uris": {
+                    "media": "/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Messages/SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Media.json"
+                },
+                "to": "+12345678901",
+                "uri": "/2010-04-01/Accounts/ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Messages/SMXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.json",
+            },
+        )
+
+        interface = SmsInterface()
+        interface.phone_number = "2345678901"
+
+        with freeze_time(datetime.datetime.now()):
+            with self.options({"sms.twilio-account": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}):
+                with pytest.raises(PotentialSMSFraud):
+                    for _ in range(4):
+                        rv = interface.activate(request)
+
+                interface.phone_number = "2345678900"
+                rv = interface.activate(request)
+                assert (
+                    rv.message
+                    == "A confirmation code was sent to <strong>(***) ***-**00</strong>. It is valid for 45 seconds."
+                )
+
+    def test_invalid_phone_number(self):
+        with pytest.raises(InvalidPhoneNumber):
+            phone_number_as_e164("+15555555555")
+
+    def test_valid_phone_number(self):
+        formatted_number = phone_number_as_e164("2345678900")
+        assert "+12345678900" == formatted_number

--- a/tests/sentry/auth/authenticators/test_sms.py
+++ b/tests/sentry/auth/authenticators/test_sms.py
@@ -6,7 +6,7 @@ from django.http import HttpRequest
 from freezegun import freeze_time
 
 from sentry.auth.authenticators import SmsInterface
-from sentry.auth.authenticators.sms import PotentialSMSFraud
+from sentry.auth.authenticators.sms import SMSRateLimitExceeded
 from sentry.testutils import TestCase
 from sentry.utils.sms import InvalidPhoneNumber, phone_number_as_e164
 
@@ -101,7 +101,7 @@ class SmsInterfaceTest(TestCase):
 
         with freeze_time(datetime.datetime.now()):
             with self.options({"sms.twilio-account": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"}):
-                with pytest.raises(PotentialSMSFraud):
+                with pytest.raises(SMSRateLimitExceeded):
                     for _ in range(4):
                         rv = interface.activate(request)
 


### PR DESCRIPTION
As good stewards, this introduces a rate-limit on the number of SMS text messages we will send for things like 2FA.

TLDR;
- Adjusted `mfa.twilio-request` log to normalize the phone number into [E.164 format](https://www.twilio.com/docs/glossary/what-e164).
- Detect invalid phone numbers and raise an error.
- Introduce a rate-limit on the number of messages we will send for 2FA per phone number: 3 messages per 5 minutes.
- Tighten rate-limit on login attempts from 10 per minute to 5 per minute.
- Maintain rate-limit of 10 attempts to set up an authenticator per day per user.
- Remove sending the calling IP address in the 2FA message.
- Additional logging when the SMS rate limit is exceeded.