### PR TITLE
ref(gitlab): Update installation modal

### DIFF
--- a/src/sentry/templates/sentry/integrations/gitlab-config.html
+++ b/src/sentry/templates/sentry/integrations/gitlab-config.html
@@ -60,7 +60,7 @@
         {% endfor %}
       </ul>
     </li>
-    <li>{% trans "Select 'Confidential' and 'Expire access tokens'." %}</li>
+    <li>{% trans "Ensure 'Confidential' is checked." %}</li>
     <li>{% trans "Click Save Application." %}</li>
     <li>{% trans "In the resulting page, you'll see the Application ID and Secret. You'll need those for the next phase of setup." %}</li>
   </ol>


### PR DESCRIPTION
The GitLab application token page no longer has an "expire access tokens" checkbox, and the "confidential" one is checked by default, so this PR updates the installation modal language to be more accurate to the current state of things. 