### PR TITLE
feat(ui): Avoid overscroll on stacktrace preview hovercard

### DIFF
--- a/static/app/components/stacktracePreview.tsx
+++ b/static/app/components/stacktracePreview.tsx
@@ -257,6 +257,7 @@ const StyledHovercard = styled(Hovercard)<{state: 'loading' | 'empty' | 'done'}>
     padding: 0;
     max-height: 300px;
     overflow-y: auto;
+    overscroll-behavior: contain;
     border-bottom-left-radius: ${p => p.theme.borderRadius};
     border-bottom-right-radius: ${p => p.theme.borderRadius};
   }


### PR DESCRIPTION
Makes it so scrolling isinde it does not scroll the parent window