### PR TITLE
fix(replays): Remove duplicate replays from list

### DIFF
--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -62,9 +62,21 @@ function ReplayTable({replayList, idKey, showProjectColumn}: Props) {
     ? Object.fromEntries(data.map(item => [item.replayId, item]))
     : {};
 
+  const replays = useMemo(() => {
+    const replayIdMap = new Map();
+    const list: Replay[] = [];
+    for (const replay of replayList) {
+      if (replay && !replayIdMap.has(replay.replayId)) {
+        list.push(replay);
+        replayIdMap.set(replay.replayId, true);
+      }
+    }
+    return list;
+  }, [replayList]);
+
   return (
     <Fragment>
-      {replayList?.map(replay => (
+      {replays.map(replay => (
         <Fragment key={replay.id}>
           <UserBadge
             avatarSize={32}

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -14,6 +14,7 @@ export type Replay = {
   'user.ip_address': string;
   'user.name': string;
   'user.username': string;
+  replayId?: string;
 };
 
 export enum ReplayTabs {


### PR DESCRIPTION
### Changes
- Filters duplicate replays by replayId (they only differed in timestamp)
- Add replayId to Replay type

### Note
When I console logged the replays that had more fields then are defined in the Replay type. I added replayId to the type as optional to be safe because I'm not sure what the type should actually be.

Closes #36153 


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
