### PR TITLE
ref: cache volta, node, yarn in github actions

### DIFF
--- a/.github/actions/setup-volta/action.yml
+++ b/.github/actions/setup-volta/action.yml
@@ -1,0 +1,32 @@
+name: 'volta setup'
+description: 'configures volta, node, yarn and caches'
+runs:
+  using: 'composite'
+  steps:
+    - name: setup-volta vars
+      id: vars
+      shell: bash
+      run: python3 -uS ${{ github.action_path }}/bin/setup-volta vars
+
+    - name: cache volta+node+yarn
+      id: cache
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.vars.outputs.volta-dir }}
+        key: ${{ steps.vars.outputs.cache-key }}
+
+    - name: install volta+node+yarn
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: python3 -uS ${{ github.action_path }}/bin/setup-volta install
+
+    - name: yarn cache dir
+      id: yarn
+      shell: bash
+      run: python3 -uS ${{ github.action_path }}/bin/setup-volta yarn-cache-dir
+
+    - name: cache yarn
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.yarn.outputs.cache-dir }}
+        key: ${{ steps.vars.outputs.cache-key }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/actions/setup-volta/bin/setup-volta
+++ b/.github/actions/setup-volta/bin/setup-volta
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import io
+import json
+import os.path
+import secrets
+import subprocess
+import sys
+import tarfile
+import urllib.request
+
+VOLTA = "1.0.8"
+VOLTA_DIR = os.path.expanduser("~/.volta")
+VOLTA_BIN = os.path.join(VOLTA_DIR, "bin")
+
+URL = {
+    "darwin": f"https://github.com/volta-cli/volta/releases/download/v{VOLTA}/volta-{VOLTA}-macos.tar.gz",
+    "linux": f"https://github.com/volta-cli/volta/releases/download/v{VOLTA}/volta-{VOLTA}-linux-openssl-1.1.tar.gz",
+}
+SHA256 = {
+    "darwin": "b07461399f934b43bb34dfb0541eaf398537ccddcd2955166567459de52159dd",
+    "linux": "981b61a35e0070b0a998361cdbc9040c99b7fb64b6fee0cc2de52243a1851412",
+}
+
+
+def _volta_bin(exe: str) -> str:
+    return os.path.join(VOLTA_BIN, exe)
+
+
+def _command_vars() -> int:
+    with open("package.json") as f:
+        package_json = json.load(f)
+
+    node = package_json["volta"]["node"]
+    yarn = package_json["volta"]["yarn"]
+
+    cache_key = f"{sys.platform}-volta-{VOLTA}-node-{node}-yarn-{yarn}"
+
+    print(f"::set-output name=cache-key::{cache_key}")
+    print(f"::set-output name=volta-dir::{VOLTA_DIR}")
+
+    print(f"adding {VOLTA_BIN} to path")
+    with open(os.environ["GITHUB_PATH"], "a+") as f:
+        f.write(f"{VOLTA_BIN}\n")
+
+    print(f"adding VOLTA_HOME={VOLTA_DIR} to env")
+    with open(os.environ["GITHUB_ENV"], "a+") as f:
+        f.write(f"VOLTA_HOME={VOLTA_DIR}\n")
+
+    return 0
+
+
+def _command_install() -> int:
+    print("downloading...")
+    req = urllib.request.urlopen(URL[sys.platform], timeout=30)
+    bio = io.BytesIO(req.read())
+    checksum = hashlib.sha256(bio.getvalue()).hexdigest()
+    if not secrets.compare_digest(checksum, SHA256[sys.platform]):
+        print(f"volta checksum mismatch {checksum} {SHA256[sys.platform]}")
+        return 1
+
+    print("extracting...")
+    with tarfile.open(fileobj=bio) as tarf:
+        tarf.extractall(VOLTA_DIR)
+
+    print("setting up volta...")
+    if subprocess.call((os.path.join(VOLTA_DIR, "volta"), "setup")):
+        return 1
+
+    print("setting up node...")
+    if subprocess.call((_volta_bin("node"), "--version")):
+        return 1
+
+    print("setting up yarn...")
+    if subprocess.call((_volta_bin("yarn"), "--version")):
+        return 1
+
+    return 0
+
+
+def _command_yarn_cache_dir() -> int:
+    out = subprocess.check_output((_volta_bin("yarn"), "cache", "dir"))
+    cache_dir = out.decode().strip()
+    print(f"::set-output name=cache-dir::{cache_dir}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("command", choices=("vars", "install", "yarn-cache-dir"))
+    args = parser.parse_args()
+
+    return {
+        "vars": _command_vars,
+        "install": _command_install,
+        "yarn-cache-dir": _command_yarn_cache_dir,
+    }[args.command]()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -57,17 +57,7 @@ jobs:
           # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
           fetch-depth: '2'
 
-      - uses: volta-cli/action@v1
-
-      # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
+      - uses: ./.github/actions/setup-volta
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -137,19 +127,11 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout sentry
 
-      - uses: volta-cli/action@v1
+      - uses: ./.github/actions/setup-volta
 
       - name: Step configurations
         id: config
-        run: |
-          echo "::set-output name=yarn-path::$(yarn cache dir)"
-          echo "::set-output name=webpack-path::.webpack_cache"
-
-      - name: yarn cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.config.outputs.yarn-path }}
-          key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
+        run: echo "::set-output name=webpack-path::.webpack_cache"
 
       - name: webpack cache
         uses: actions/cache@v3

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: volta-cli/action@v1
+      - uses: ./.github/actions/setup-volta
 
       - name: Setup sentry python env (python ${{ matrix.python-version }})
         uses: ./.github/actions/setup-sentry

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -49,9 +49,7 @@ jobs:
         run: |
           HOMEBREW_NO_AUTO_UPDATE=1 brew install -v libxmlsec1
 
-      - name: Install volta
-        run: |
-          curl https://get.volta.sh | bash
+      - name: .github/actions/setup-volta
 
       # This handles Python's cache
       - name: Setup Python & cache
@@ -61,18 +59,10 @@ jobs:
         with:
           python-version: 3.8.12
 
-      - name: Cache (yarn)
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.info.outputs.yarn-cache-dir }}
-          key: devenv-${{ runner.os }}-v1-yarn-${{ hashFiles('yarn.lock') }}
-
       # This tests starting up the dev services, loading mocks and pre-commit installation
       # This can take over 15 minutes
       - name: make bootstrap
         run: |
-          export VOLTA_HOME="$HOME/.volta"
-          export PATH="$HOME/.volta/bin:$PATH"
           python -m venv .venv
           source .venv/bin/activate
           make bootstrap

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -46,17 +46,7 @@ jobs:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-      - uses: volta-cli/action@v1
-
-      # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
+      - uses: ./.github/actions/setup-volta
 
       - name: Install dependencies
         id: dependencies
@@ -143,17 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: volta-cli/action@v1
-
-      # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v3
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-v2-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
+      - uses: ./.github/actions/setup-volta
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -41,9 +41,8 @@ jobs:
           repository: getsentry/sentry-api-schema
           path: sentry-api-schema
 
-      - name: Install/setup node
+      - uses: ./.github/actions/setup-volta
         if: steps.changes.outputs.api_docs == 'true'
-        uses: volta-cli/action@v1
 
       - name: Build OpenAPI Derefed JSON
         if: steps.changes.outputs.api_docs == 'true'

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -50,9 +50,8 @@ jobs:
           path: sentry-api-schema
           token: ${{ steps.getsentry.outputs.token }}
 
-      - name: Install/setup node
+      - uses: ./.github/actions/setup-volta
         if: steps.changes.outputs.api_docs == 'true'
-        uses: volta-cli/action@v1
 
       - name: Build OpenAPI Derefed JSON
         if: steps.changes.outputs.api_docs == 'true'

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ per-file-ignores =
     tests/*: S002
     # these scripts must have minimal dependencies so opt out of the usual sentry rules
     tools/*: S
+    .github/*: S
 
 [flake8:local-plugins]
 paths = .


### PR DESCRIPTION
this aims to solve the flakiness described in https://getsentry.atlassian.net/browse/DEVINFRA-55

I don't expect this to significantly speed up the node setup, mostly just to make it more reliable -- notably I expect github's caches to be more reliable than always downloading all the time from volta

on the perf perspective: 

anecdotal -- but hopefully enough to demonstrate that there isn't a performance regression:

[before (cache hit)](https://github.com/getsentry/sentry/runs/7133395320?check_suite_focus=true):
- volta-cli/action: 1s
- cache dir: 2s  (this installs node/yarn)
- actions/cache@v3: 8s
- install dependencies: 33s

(**setup time: 11s**)

[after (cache miss)](https://github.com/getsentry/sentry/runs/7135058976?check_suite_focus=true):
- setup-volta: 5s
- install dependencies: 55s

(**setup time: 5s, cache miss time ~25s**)

[after (cache hit)](https://github.com/getsentry/sentry/runs/7135059153?check_suite_focus=true):
- setup-volta: 11s
- install dependencies: 31s

(**setup time: 11s**)