### PR TITLE
fix(replays): extra 0 rendering near the scrubber on hover

### DIFF
--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -20,7 +20,7 @@ function Scrubber({className}: Props) {
   return (
     <Wrapper className={className}>
       <Meter>
-        {currentHoverTime && <MouseTrackingValue percent={hoverPlace} />}
+        {currentHoverTime ? <MouseTrackingValue percent={hoverPlace} /> : null}
         <PlaybackTimeValue percent={percentComplete} />
       </Meter>
       <RangeWrapper>


### PR DESCRIPTION
<!-- Describe your PR here. -->
Change the render condition for the component `MouseTrackingValue` to ternary to avoid this problem. Closes #36222 
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
