### PR TITLE
perf(sdk): Switch asset measurement to capture more data

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -7,7 +7,10 @@ import {_browserPerformanceTimeOriginMode} from '@sentry/utils';
 
 import {DISABLE_RR_WEB, SENTRY_RELEASE_VERSION, SPA_DSN} from 'sentry/constants';
 import {Config} from 'sentry/types';
-import {LongTaskObserver} from 'sentry/utils/performanceForSentry';
+import {
+  initializeMeasureAssetsTimeout,
+  LongTaskObserver,
+} from 'sentry/utils/performanceForSentry';
 
 /**
  * We accept a routes argument here because importing `static/routes`
@@ -107,4 +110,5 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
   Sentry.setTag('rrweb.active', hasReplays ? 'yes' : 'no');
 
   LongTaskObserver.startPerformanceObserver();
+  initializeMeasureAssetsTimeout();
 }

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -13,7 +13,6 @@ import {PageFilters, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/performanceEventViewContext';
-import {MeasureAssetsOnTransaction} from 'sentry/utils/performanceForSentry';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
@@ -160,26 +159,24 @@ function PerformanceContent({selection, location, demoMode}: Props) {
               },
             }}
           >
-            <MeasureAssetsOnTransaction>
-              <PerformanceLanding
-                eventView={eventView}
-                setError={setError}
-                handleSearch={handleSearch}
-                handleTrendsClick={() =>
-                  handleTrendsClick({
-                    location,
-                    organization,
-                    projectPlatforms: getSelectedProjectPlatforms(location, projects),
-                  })
-                }
-                onboardingProject={onboardingProject}
-                organization={organization}
-                location={location}
-                projects={projects}
-                selection={selection}
-                withStaticFilters={withStaticFilters}
-              />
-            </MeasureAssetsOnTransaction>
+            <PerformanceLanding
+              eventView={eventView}
+              setError={setError}
+              handleSearch={handleSearch}
+              handleTrendsClick={() =>
+                handleTrendsClick({
+                  location,
+                  organization,
+                  projectPlatforms: getSelectedProjectPlatforms(location, projects),
+                })
+              }
+              onboardingProject={onboardingProject}
+              organization={organization}
+              location={location}
+              projects={projects}
+              selection={selection}
+              withStaticFilters={withStaticFilters}
+            />
           </PageFiltersContainer>
         </MEPSettingProvider>
       </PerformanceEventViewProvider>


### PR DESCRIPTION
### Summary
This makes a timeout callback for asset measurement some time after the sdk has initialized, assuming the transaction should exist at that time.

It's fine if not all transactions get captured, we just want to collect most of them. If the timeout is causing some edge case we can fix this to hook into the transactions existence properly (perhaps via router instrumentation).

