### PR TITLE
ref(stats): Support dynamic category usage chart

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -38,7 +38,12 @@ const COLOR_ATTACHMENTS = Color(commonTheme.dataCategory.attachments)
 const COLOR_DROPPED = commonTheme.red300;
 const COLOR_FILTERED = commonTheme.pink100;
 
-export type CategoryOption = {yAxisMinInterval: number} & SelectValue<DataCategory>;
+export type CategoryOption = {
+  /**
+   * Scale of y-axis with no usage data.
+   */
+  yAxisMinInterval: number;
+} & SelectValue<DataCategory>;
 
 export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
   {

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -18,7 +18,6 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {DataCategory, IntervalPeriod, SelectValue} from 'sentry/types';
 import {parsePeriodToHours, statsPeriodToDays} from 'sentry/utils/dates';
-import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import commonTheme, {Theme} from 'sentry/utils/theme';
 
@@ -39,21 +38,26 @@ const COLOR_ATTACHMENTS = Color(commonTheme.dataCategory.attachments)
 const COLOR_DROPPED = commonTheme.red300;
 const COLOR_FILTERED = commonTheme.pink100;
 
-export const CHART_OPTIONS_DATACATEGORY: SelectValue<DataCategory>[] = [
+export type CategoryOption = {yAxisMinInterval: number} & SelectValue<DataCategory>;
+
+export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
   {
     label: DATA_CATEGORY_NAMES[DataCategory.ERRORS],
     value: DataCategory.ERRORS,
     disabled: false,
+    yAxisMinInterval: 100,
   },
   {
     label: DATA_CATEGORY_NAMES[DataCategory.TRANSACTIONS],
     value: DataCategory.TRANSACTIONS,
     disabled: false,
+    yAxisMinInterval: 100,
   },
   {
     label: DATA_CATEGORY_NAMES[DataCategory.ATTACHMENTS],
     value: DataCategory.ATTACHMENTS,
     disabled: false,
+    yAxisMinInterval: 0.5 * GIGABYTE,
   },
 ];
 
@@ -83,6 +87,10 @@ export enum SeriesTypes {
 }
 
 type DefaultProps = {
+  /**
+   * Config for category dropdown options
+   */
+  categoryOptions: CategoryOption[];
   /**
    * Modify the usageStats using the transformation method selected.
    * 1. This must be a pure function!
@@ -150,6 +158,7 @@ export type ChartStats = {
 
 export class UsageChart extends Component<Props, State> {
   static defaultProps: DefaultProps = {
+    categoryOptions: CHART_OPTIONS_DATACATEGORY,
     usageDateShowUtc: true,
     usageDateInterval: '1d',
     handleDataTransformation: (stats, transform) => {
@@ -229,7 +238,7 @@ export class UsageChart extends Component<Props, State> {
     yAxisFormatter: (val: number) => string;
     yAxisMinInterval: number;
   } {
-    const {usageDateStart, usageDateEnd} = this.props;
+    const {categoryOptions, usageDateStart, usageDateEnd} = this.props;
     const {
       usageDateInterval,
       usageStats,
@@ -239,9 +248,7 @@ export class UsageChart extends Component<Props, State> {
     } = this.props;
     const {xAxisDates} = this.state;
 
-    const selectDataCategory = CHART_OPTIONS_DATACATEGORY.find(
-      o => o.value === dataCategory
-    );
+    const selectDataCategory = categoryOptions.find(o => o.value === dataCategory);
     if (!selectDataCategory) {
       throw new Error('Selected item is not supported');
     }
@@ -276,20 +283,7 @@ export class UsageChart extends Component<Props, State> {
       dataPeriod / barPeriod
     );
 
-    const {label, value} = selectDataCategory;
-
-    if (value === DataCategory.ERRORS || value === DataCategory.TRANSACTIONS) {
-      return {
-        chartLabel: label,
-        chartData,
-        xAxisData: xAxisDates,
-        xAxisTickInterval,
-        xAxisLabelInterval,
-        yAxisMinInterval: 100,
-        yAxisFormatter: formatAbbreviatedNumber,
-        tooltipValueFormatter: getTooltipFormatter(dataCategory),
-      };
-    }
+    const {label, yAxisMinInterval} = selectDataCategory;
 
     return {
       chartLabel: label,
@@ -297,9 +291,9 @@ export class UsageChart extends Component<Props, State> {
       xAxisData: xAxisDates,
       xAxisTickInterval,
       xAxisLabelInterval,
-      yAxisMinInterval: 0.5 * GIGABYTE,
+      yAxisMinInterval,
       yAxisFormatter: (val: number) =>
-        formatUsageWithUnits(val, DataCategory.ATTACHMENTS, {
+        formatUsageWithUnits(val, dataCategory, {
           isAbbreviated: true,
           useUnitScaling: true,
         }),

--- a/static/app/views/organizationStats/usageChart/utils.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.tsx
@@ -76,12 +76,8 @@ export function getXAxisDates(
 }
 
 export function getTooltipFormatter(dataCategory: DataCategory) {
-  if (dataCategory === DataCategory.ATTACHMENTS) {
-    return (val: number = 0) =>
-      formatUsageWithUnits(val, DataCategory.ATTACHMENTS, {useUnitScaling: true});
-  }
-
-  return (val: number = 0) => val.toLocaleString();
+  return (val: number = 0) =>
+    formatUsageWithUnits(val, dataCategory, {useUnitScaling: true});
 }
 
 const MAX_NUMBER_OF_LABELS = 10;


### PR DESCRIPTION
To display usage for upcoming data categories, this replaces a default to attachments chart metadata, and allows for a custom data category option config.