### PR TITLE
feat(active-release): add commit data to slack release notifications

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -411,7 +411,7 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
 
         return "\n".join(
             [
-                f'[{x.get("author").__getattribute__("email") if x.get("author") else "no email"}] - {x.get("subject", "no subject")} ({x.get("key", "no key")})'
+                f'[{getattr(x.get("author"), "email") if x.get("author") else "no email"}] - {x.get("subject", "no subject")} ({x.get("key", "no key")})'
                 for x in (commit_data or ())
             ]
         )

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -409,7 +409,7 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
         return "\n".join(
             [
                 f'[{x.get("author").email if x.get("author") else "no email"}] - {x.get("subject", "no subject")} ({x.get("key", "no key")})'
-                for x in commit_data
+                for x in (commit_data or ())
             ]
         )
 

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 from django.core.cache import cache
 from sentry_relay import parse_release
@@ -405,10 +405,13 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
         self.release_commits = release_commits
 
     @staticmethod
-    def commit_data_text(commit_data: Sequence[CommitData]) -> str:
+    def commit_data_text(commit_data: Optional[Sequence[CommitData]]) -> str:
+        if not commit_data:
+            return ""
+
         return "\n".join(
             [
-                f'[{x.get("author").email if x.get("author") else "no email"}] - {x.get("subject", "no subject")} ({x.get("key", "no key")})'
+                f'[{x.get("author").__getattribute__("email") if x.get("author") else "no email"}] - {x.get("subject", "no subject")} ({x.get("key", "no key")})'
                 for x in (commit_data or ())
             ]
         )

--- a/src/sentry/integrations/slack/message_builder/notifications/issues.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/issues.py
@@ -57,4 +57,6 @@ class ActiveReleaseIssueNotificationMessageBuilder(SlackNotificationsMessageBuil
             notification=self.notification,
             recipient=self.recipient,
             last_release=self.context.get("last_release", None),
+            last_release_link=self.context.get("last_release_link", None),
+            release_commits=self.context.get("commits", None),
         ).build()

--- a/src/sentry/integrations/slack/message_builder/notifications/issues.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/issues.py
@@ -57,6 +57,6 @@ class ActiveReleaseIssueNotificationMessageBuilder(SlackNotificationsMessageBuil
             notification=self.notification,
             recipient=self.recipient,
             last_release=self.context.get("last_release", None),
-            last_release_link=self.context.get("last_release_link", None),
+            last_release_link=self.context.get("last_release_slack_link", None),
             release_commits=self.context.get("commits", None),
         ).build()

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence, TypedDict
+from urllib.parse import quote
 
 import pytz
 
@@ -218,6 +219,7 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
             "enhanced_privacy": enhanced_privacy,
             "last_release": self.last_release,
             "last_release_link": self.release_url(self.last_release),
+            "last_release_slack_link": self.slack_release_url(self.last_release),
             "commits": self.get_release_commits(self.last_release)[:15],
             "environment": environment,
             "slack_link": get_integration_link(self.organization, "slack"),
@@ -254,11 +256,11 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
         ]
 
     @staticmethod
-    def release_url(self, release: Release) -> str:
+    def release_url(release: Release) -> str:
         params = {"project": release.project_id, "referrer": "alert_email_release"}
         url = "/organizations/{org}/releases/{version}/{params}".format(
             org=release.organization.slug,
-            version=release.version,
+            version={quote(release.version)},
             params="?" + urlencode(params),
         )
 

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -231,7 +231,8 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
 
         return context
 
-    def get_release_commits(self, release: Release) -> Sequence[CommitData]:
+    @staticmethod
+    def get_release_commits(release: Release) -> Sequence[CommitData]:
         if not release:
             return []
 
@@ -252,6 +253,7 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
             for rc in release_commits
         ]
 
+    @staticmethod
     def release_url(self, release: Release) -> str:
         params = {"project": release.project_id, "referrer": "alert_email_release"}
         url = "/organizations/{org}/releases/{version}/{params}".format(

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -218,7 +218,7 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
             "enhanced_privacy": enhanced_privacy,
             "last_release": self.last_release,
             "last_release_link": self.release_url(self.last_release),
-            "commits": self.get_release_commits(self.last_release),
+            "commits": self.get_release_commits(self.last_release)[:15],
             "environment": environment,
             "slack_link": get_integration_link(self.organization, "slack"),
             "has_alert_integration": has_alert_integration(self.project),

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -260,7 +260,18 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
         params = {"project": release.project_id, "referrer": "alert_email_release"}
         url = "/organizations/{org}/releases/{version}/{params}".format(
             org=release.organization.slug,
-            version={quote(release.version)},
+            version=release.version,
+            params="?" + urlencode(params),
+        )
+
+        return str(absolute_uri(url))
+
+    @staticmethod
+    def slack_release_url(release: Release) -> str:
+        params = {"project": release.project_id, "referrer": "alert_slack_release"}
+        url = "/organizations/{org}/releases/{version}/{params}".format(
+            org=release.organization.slug,
+            version=quote(release.version),
             params="?" + urlencode(params),
         )
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -154,7 +154,7 @@ class BuildGroupAttachmentTest(TestCase):
         attachments = SlackReleaseIssuesMessageBuilder(
             group, last_release=release, last_release_link=release_link
         ).build()
-        group_link = f"http://testserver/organizations/{group.organization.slug}/issues/{group.id}/?referrer=slack"
+        group_link = f"http://testserver/organizations/{group.organization.slug}/issues/{group.id}/?referrer=slack_release"
 
         assert attachments["title"] == f"Release <{release_link}|{release.version}> has a new issue"
         assert attachments["text"] == f"<{group_link}|*{group.title}*> \nFirst line of Text"
@@ -177,7 +177,7 @@ class BuildGroupAttachmentTest(TestCase):
             release_commits=release_commits,
         ).build()
 
-        group_link = f"http://testserver/organizations/{group.organization.slug}/issues/{group.id}/?referrer=slack"
+        group_link = f"http://testserver/organizations/{group.organization.slug}/issues/{group.id}/?referrer=slack_release"
         assert attachments["title"] == f"Release <{release_link}|{release.version}> has a new issue"
 
         assert (

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -16,6 +16,7 @@ from sentry.integrations.slack.message_builder.issues import (
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.models import Group, Team, User
+from sentry.notifications.notifications.rules import ActiveReleaseAlertNotification
 from sentry.testutils import TestCase
 from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
@@ -149,13 +150,40 @@ class BuildGroupAttachmentTest(TestCase):
         )
         release = self.create_release(version="1.0.0", project=self.project)
 
-        attachments = SlackReleaseIssuesMessageBuilder(group, last_release=release).build()
-        release_link = absolute_uri(
-            f"/organizations/{group.organization.slug}/releases/{release.version}/?project={group.project_id}"
-        )
-        group_link = f"http://testserver/organizations/{group.organization.slug}/issues/{group.id}/?referrer=slack_release"
+        release_link = ActiveReleaseAlertNotification.release_url(release)
+        attachments = SlackReleaseIssuesMessageBuilder(
+            group, last_release=release, last_release_link=release_link
+        ).build()
+        group_link = f"http://testserver/organizations/{group.organization.slug}/issues/{group.id}/?referrer=slack"
+
         assert attachments["title"] == f"Release <{release_link}|{release.version}> has a new issue"
         assert attachments["text"] == f"<{group_link}|*{group.title}*> \nFirst line of Text"
+        assert "title_link" not in attachments
+
+    def test_build_group_release_with_commits_attachment(self):
+        group = self.create_group(project=self.project)
+        release = self.create_release(version="1.0.0", project=self.project)
+
+        release_link = ActiveReleaseAlertNotification.release_url(release)
+        release_commits = [
+            {"author": None, "key": "sha789", "subject": "third commit"},
+            {"author": self.user, "key": "sha456", "subject": "second commit"},
+            {"author": self.user, "key": "sha123", "subject": "first commit"},
+        ]
+        attachments = SlackReleaseIssuesMessageBuilder(
+            group,
+            last_release=release,
+            last_release_link=release_link,
+            release_commits=release_commits,
+        ).build()
+
+        group_link = f"http://testserver/organizations/{group.organization.slug}/issues/{group.id}/?referrer=slack"
+        assert attachments["title"] == f"Release <{release_link}|{release.version}> has a new issue"
+
+        assert (
+            attachments["text"]
+            == f"<{group_link}|*{group.title}*> \n{SlackReleaseIssuesMessageBuilder.commit_data_text(release_commits)}\n"
+        )
         assert "title_link" not in attachments
 
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -150,7 +150,7 @@ class BuildGroupAttachmentTest(TestCase):
         )
         release = self.create_release(version="1.0.0", project=self.project)
 
-        release_link = ActiveReleaseAlertNotification.release_url(release)
+        release_link = ActiveReleaseAlertNotification.slack_release_url(release)
         attachments = SlackReleaseIssuesMessageBuilder(
             group, last_release=release, last_release_link=release_link
         ).build()
@@ -164,7 +164,7 @@ class BuildGroupAttachmentTest(TestCase):
         group = self.create_group(project=self.project)
         release = self.create_release(version="1.0.0", project=self.project)
 
-        release_link = ActiveReleaseAlertNotification.release_url(release)
+        release_link = ActiveReleaseAlertNotification.slack_release_url(release)
         release_commits = [
             {"author": None, "key": "sha789", "subject": "third commit"},
             {"author": self.user, "key": "sha456", "subject": "second commit"},


### PR DESCRIPTION
Don't have a preview of the slack notification, but this formats the slack notification for a release notification to include commit data as part of a release. 

We have something like this in the email version of this notification - this PR adds the same thing for slack notifications.
