### PR TITLE
fix(overlayArrow): Use unique mask IDs

### DIFF
--- a/static/app/components/overlayArrow.tsx
+++ b/static/app/components/overlayArrow.tsx
@@ -1,7 +1,8 @@
-import {forwardRef} from 'react';
+import {forwardRef, useMemo} from 'react';
 import {PopperProps} from 'react-popper';
 import styled from '@emotion/styled';
 
+import domId from 'sentry/utils/domId';
 import {ColorOrAlias} from 'sentry/utils/theme';
 
 type Props = React.HTMLAttributes<HTMLDivElement> & {
@@ -41,6 +42,9 @@ const BaseOverlayArrow: React.ForwardRefRenderFunction<HTMLDivElement, Props> = 
     `C ${w * 0.55} ${s / 2} ${w * 0.75} ${h - s / 2} ${w} ${h - s / 2}`,
   ].join('');
 
+  const strokeMaskId = useMemo(() => domId('stroke-mask'), []);
+  const fillMaskId = useMemo(() => domId('fill-mask'), []);
+
   return (
     <Wrap ref={ref} placement={placement} size={size} {...props}>
       <SVG
@@ -52,17 +56,21 @@ const BaseOverlayArrow: React.ForwardRefRenderFunction<HTMLDivElement, Props> = 
         border={border}
       >
         <defs>
-          <mask id="stroke-mask">
+          <mask id={strokeMaskId}>
             <rect x="0" y={-strokeWidth} width="100%" height="100%" fill="white" />
           </mask>
-          <mask id="fill-mask">
+          <mask id={fillMaskId}>
             <rect x="0" y="0" width="100%" height="100%" fill="white" />
             <path d={arrowPath} vectorEffect="non-scaling-stroke" stroke="black" />
           </mask>
         </defs>
 
-        <path d={`${arrowPath} V ${h} H 0 Z`} mask="url(#fill-mask)" className="fill" />
-        <path d={arrowPath} mask="url(#stroke-mask)" className="stroke" />
+        <path
+          d={`${arrowPath} V ${h} H 0 Z`}
+          mask={`url(#${fillMaskId})`}
+          className="fill"
+        />
+        <path d={arrowPath} mask={`url(#${strokeMaskId})`} className="stroke" />
       </SVG>
     </Wrap>
   );


### PR DESCRIPTION
Use unique IDs for mask elements in `OverlayArrow`. IDs inside `svg` elements are global to the document, not specific to the containing `svg` element.

**Before:** the first overlay has a correctly rendered arrow, but the second's looks broken
<img width="389" alt="Screen Shot 2022-06-30 at 2 03 48 PM" src="https://user-images.githubusercontent.com/44172267/176778219-0a480f78-c478-40fe-b73f-3e71510f5931.png">

**After:** both overlays have correctly rendered arrows
<img width="389" alt="Screen Shot 2022-06-30 at 2 03 15 PM" src="https://user-images.githubusercontent.com/44172267/176778232-255387fe-ece0-45f9-8c09-155ca105b14d.png">

