### PR TITLE
fix(issues): Reduce padding on user email does not exist alert

### DIFF
--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -227,7 +227,6 @@ const EmailAlert = styled(Alert)`
   margin: 10px -13px -13px;
   border-radius: 0;
   border-color: #ece0b0;
-  padding: 10px;
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: normal;
   box-shadow: none;


### PR DESCRIPTION
this hovercard shows up on issue details suspect committers click to assign thing

before
![Screen Shot 2022-06-30 at 3 29 14 PM](https://user-images.githubusercontent.com/1400464/176789378-4cb58314-a288-42a8-9aa1-b8a0e62f6c9c.png)



after
![Screen Shot 2022-06-30 at 3 27 32 PM](https://user-images.githubusercontent.com/1400464/176789311-8ae7ee59-d896-4c27-8b78-e17f97dc590d.png)
