### PR TITLE
fix(gha): Fix labeling permissions for outsiders

### DIFF
--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -2,14 +2,17 @@
 name: meta(labels)
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   label-pullrequest:
+    permissions:
+      contents: read
+      pull-requests: write
     name: labels pull requests (frontend / backend)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Check for file changes
         uses: getsentry/paths-filter@master


### PR DESCRIPTION
Note that this is a dangerous PR.

In general, the addition of the `permissions` section should reduce the risk considerably (it means that this workflow can close the PR, or add labels, or comments, or do other things to it, but it can't write to the repository, e.g. by merging).

The current behavior is "fail safe" by "doing nothing" for PRs from forks created by users who aren't a member of the destination repository. -- e.g. https://github.com/getsentry/sentry/runs/7068260468?check_suite_focus=true

The new behavior means that the workflow will _run_.

By switching from `pull_request` to `pull_request_target`, actions/checkout will switch to checking out the base of the PR not the HEAD. This is for security reasons.

Afaict, https://github.com/getsentry/paths-filter claims it will figure out the right answer based on the PR and not the checkout, which means it shouldn't matter which thing is checked out. I don't actually know if that assertion is correct (I haven't read the code). If it isn't, then additional care would be required to change the workflow to checkout the `head_ref`.

The version bump from `v2` to `v3` is meaningless fwiw, they upgraded their version of `node` and that forced a major version bump per semver.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
