### PR TITLE
feat(multi-region): Attach SubdomainMiddleware

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -281,6 +281,7 @@ MIDDLEWARE = (
     "sentry.middleware.stats.RequestTimingMiddleware",
     "sentry.middleware.access_log.access_log_middleware",
     "sentry.middleware.stats.ResponseCodeMiddleware",
+    "sentry.middleware.subdomain.SubdomainMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",


### PR DESCRIPTION
Another attempt of https://github.com/getsentry/sentry/pull/35760.

Needs https://github.com/getsentry/getsentry/pull/7760 so that a test in `getsentry` doesn't patch `sentry.options.get` to fail for all options. 