### PR TITLE
feat(mep): Write default value for `AlertRule.type`.

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -416,6 +416,16 @@ DEFAULT_ALERT_RULE_RESOLUTION = 1
 DEFAULT_CMP_ALERT_RULE_RESOLUTION = 2
 
 
+# Temporary mapping of `QueryDatasets` to `AlertRule.Type`. In the future, `Performance` will be
+# able to be run on `METRICS` as well.
+query_datasets_to_type = {
+    QueryDatasets.EVENTS: AlertRule.Type.Error,
+    QueryDatasets.TRANSACTIONS: AlertRule.Type.Performance,
+    QueryDatasets.SESSIONS: AlertRule.Type.CrashRate,
+    QueryDatasets.METRICS: AlertRule.Type.CrashRate,
+}
+
+
 def create_alert_rule(
     organization,
     projects,
@@ -491,6 +501,7 @@ def create_alert_rule(
         alert_rule = AlertRule.objects.create(
             organization=organization,
             snuba_query=snuba_query,
+            type=query_datasets_to_type[dataset].value,
             name=name,
             threshold_type=threshold_type.value,
             resolve_threshold=resolve_threshold,
@@ -641,6 +652,7 @@ def update_alert_rule(
 
         if dataset.value != alert_rule.snuba_query.dataset:
             updated_query_fields["dataset"] = dataset
+            updated_fields["type"] = query_datasets_to_type[dataset].value
     if event_types is not None:
         updated_query_fields["event_types"] = event_types
     if owner is not NOT_SET:

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -419,10 +419,10 @@ DEFAULT_CMP_ALERT_RULE_RESOLUTION = 2
 # Temporary mapping of `QueryDatasets` to `AlertRule.Type`. In the future, `Performance` will be
 # able to be run on `METRICS` as well.
 query_datasets_to_type = {
-    QueryDatasets.EVENTS: AlertRule.Type.Error,
-    QueryDatasets.TRANSACTIONS: AlertRule.Type.Performance,
-    QueryDatasets.SESSIONS: AlertRule.Type.CrashRate,
-    QueryDatasets.METRICS: AlertRule.Type.CrashRate,
+    QueryDatasets.EVENTS: AlertRule.Type.ERROR,
+    QueryDatasets.TRANSACTIONS: AlertRule.Type.PERFORMANCE,
+    QueryDatasets.SESSIONS: AlertRule.Type.CRASH_RATE,
+    QueryDatasets.METRICS: AlertRule.Type.CRASH_RATE,
 }
 
 

--- a/src/sentry/incidents/models.py
+++ b/src/sentry/incidents/models.py
@@ -348,9 +348,9 @@ class AlertRule(Model):
     __include_in_export__ = True
 
     class Type(Enum):
-        Error = 0
-        Performance = 1
-        CrashRate = 2
+        ERROR = 0
+        PERFORMANCE = 1
+        CRASH_RATE = 2
 
     objects = AlertRuleManager()
     objects_with_snapshots = BaseManager()

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -432,6 +432,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         )
         assert alert_rule.snuba_query.subscriptions.get().project == self.project
         assert alert_rule.name == name
+        assert alert_rule.type == AlertRule.Type.Error.value
         assert alert_rule.owner is None
         assert alert_rule.status == AlertRuleStatus.PENDING.value
         assert alert_rule.snuba_query.subscriptions.all().count() == 1
@@ -584,6 +585,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             1,
             dataset=QueryDatasets.SESSIONS,
         )
+        assert alert_rule.type == AlertRule.Type.CrashRate.value
         assert alert_rule.snuba_query.dataset == QueryDatasets.SESSIONS.value
 
         with self.feature("organizations:alert-crash-free-metrics"):
@@ -598,6 +600,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
                 1,
                 dataset=QueryDatasets.SESSIONS,
             )
+        assert alert_rule.type == AlertRule.Type.CrashRate.value
         assert alert_rule.snuba_query.dataset == QueryDatasets.METRICS.value
 
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -432,7 +432,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         )
         assert alert_rule.snuba_query.subscriptions.get().project == self.project
         assert alert_rule.name == name
-        assert alert_rule.type == AlertRule.Type.Error.value
+        assert alert_rule.type == AlertRule.Type.ERROR.value
         assert alert_rule.owner is None
         assert alert_rule.status == AlertRuleStatus.PENDING.value
         assert alert_rule.snuba_query.subscriptions.all().count() == 1
@@ -585,7 +585,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             1,
             dataset=QueryDatasets.SESSIONS,
         )
-        assert alert_rule.type == AlertRule.Type.CrashRate.value
+        assert alert_rule.type == AlertRule.Type.CRASH_RATE.value
         assert alert_rule.snuba_query.dataset == QueryDatasets.SESSIONS.value
 
         with self.feature("organizations:alert-crash-free-metrics"):
@@ -600,7 +600,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
                 1,
                 dataset=QueryDatasets.SESSIONS,
             )
-        assert alert_rule.type == AlertRule.Type.CrashRate.value
+        assert alert_rule.type == AlertRule.Type.CRASH_RATE.value
         assert alert_rule.snuba_query.dataset == QueryDatasets.METRICS.value
 
 


### PR DESCRIPTION
Start writing a temporary default value for `AlertRule.type`. This allows us to backfill this column
and make it not null. Api changes to how we use this will follow