### PR TITLE
feat(ui): Add DataCategory for processed transactions

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -214,6 +214,7 @@ export const DATA_CATEGORY_NAMES = {
   [DataCategory.ERRORS]: t('Errors'),
   [DataCategory.TRANSACTIONS]: t('Transactions'),
   [DataCategory.ATTACHMENTS]: t('Attachments'),
+  [DataCategory.TRANSACTIONS_PROCESSED]: t('Processed Transactions'),
 };
 
 // Special Search characters

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -72,6 +72,7 @@ export enum DataCategory {
   ERRORS = 'errors',
   TRANSACTIONS = 'transactions',
   ATTACHMENTS = 'attachments',
+  TRANSACTIONS_PROCESSED = 'transactions_processed',
 }
 
 export type EventType = 'error' | 'transaction' | 'attachment';


### PR DESCRIPTION
Adds a data category constant for displaying processed transactions usage. Are these the names we want to go with?

Ref [getsentry/relay/1306](https://github.com/getsentry/relay/commit/4b0f1f015297b0a638bfb97f85cd587180634e9d)




