### PR TITLE
feat(replays): aside tabs for sidebar layout

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -206,7 +206,7 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
   const [fastForwardSpeed, setFFSpeed] = useState(0);
   const [buffer, setBufferTime] = useState({target: -1, previous: -1});
   const playTimer = useRef<number | undefined>(undefined);
-  const unMountedRef = useRef<boolean>(false);
+  const unMountedRef = useRef(false);
 
   const isFinished = replayerRef.current?.getCurrentTime() === finishedAtMS;
 

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -71,14 +71,14 @@ const ReplayControllerWrapper = styled(PanelBody)`
 
 const PanelNoMargin = styled(Panel)<{isFullscreen: boolean}>`
   margin-bottom: 0;
-
+  height: 100%;
   ${p =>
     p.isFullscreen
-      ? `height: 100%;
+      ? `
       display: grid;
       grid-template-rows: auto 1fr auto;
       `
-      : ''}
+      : ''};
 `;
 
 const PanelHeader = styled(_PanelHeader)<{noBorder?: boolean}>`

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -78,7 +78,7 @@ const PanelNoMargin = styled(Panel)<{isFullscreen: boolean}>`
       display: grid;
       grid-template-rows: auto 1fr auto;
       `
-      : ''};
+      : ''}
 `;
 
 const PanelHeader = styled(_PanelHeader)<{noBorder?: boolean}>`

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -17,6 +17,8 @@ import {useCurrentItemScroller} from 'sentry/utils/replays/hooks/useCurrentItemS
 
 import BreadcrumbItem from './breadcrumbItem';
 
+const TAB_HEADER_HEIGHT = 28;
+
 function CrumbPlaceholder({number}: {number: number}) {
   return (
     <Fragment>
@@ -145,7 +147,7 @@ const PanelHeader = styled(BasePanelHeader)`
 
 const PanelBody = styled(BasePanelBody)`
   overflow-y: auto;
-  max-height: calc(100% - 34px);
+  max-height: calc(100% - ${TAB_HEADER_HEIGHT}px);
 `;
 
 const PlaceholderMargin = styled(Placeholder)`

--- a/static/app/views/replays/detail/layout/asideTabs_v2.tsx
+++ b/static/app/views/replays/detail/layout/asideTabs_v2.tsx
@@ -10,26 +10,41 @@ import ReplayReader from 'sentry/utils/replays/replayReader';
 import TagPanel from '../tagPanel';
 
 import ResizePanel from './resizePanel';
-import {VideoContainer} from '.';
+import {BreadCrumbsContainer, VideoContainer} from '.';
+
+type Props = {
+  showCrumbs?: boolean;
+  showVideo?: boolean;
+};
 
 const TABS = {
-  video: t('Video Player'),
+  video: t('Replay'),
   tags: t('Tags'),
 };
 
-type Props = {};
-
-function renderTabContent(key: string, loadedReplay: ReplayReader) {
-  if (key === 'tags') {
-    return <TagPanel replay={loadedReplay} />;
-  }
-
-  return <VideoContainer />;
-}
-
-function AsideTabsV2({}: Props) {
+function AsideTabsV2({showCrumbs = true, showVideo = true}: Props) {
   const {replay} = useReplayContext();
   const [active, setActive] = useState<string>('video');
+
+  const renderTabContent = (key: string, loadedReplay: ReplayReader) => {
+    if (key === 'tags') {
+      return <TagPanel replay={loadedReplay} />;
+    }
+
+    return (
+      <React.Fragment>
+        {showVideo ? (
+          <ResizePanel direction="s" style={{height: '325px'}}>
+            <Container>
+              <VideoContainer />
+            </Container>
+          </ResizePanel>
+        ) : null}
+
+        {showCrumbs ? <BreadCrumbsContainer /> : null}
+      </React.Fragment>
+    );
+  };
 
   return (
     <React.Fragment>
@@ -42,20 +57,15 @@ function AsideTabsV2({}: Props) {
           );
         })}
       </NavTabs>
-      <ResizePanel direction="s" style={{height: '325px'}}>
-        <Container>
-          {replay ? renderTabContent(active, replay) : <Placeholder height="100%" />}
-        </Container>
-      </ResizePanel>
+      {replay ? renderTabContent(active, replay) : <Placeholder height="100%" />}
     </React.Fragment>
   );
 }
 
-// TODO(replays): WIP 👇
 const Container = styled('div')`
   height: 100%;
-  min-height: 200px;
-  max-height: calc(100vh - 70%);
+  /* TODO(replays): calc max height so the user can't resize infinitely but always showing both elements */
+  max-height: 50vh;
 `;
 
 export default AsideTabsV2;

--- a/static/app/views/replays/detail/layout/asideTabs_v2.tsx
+++ b/static/app/views/replays/detail/layout/asideTabs_v2.tsx
@@ -1,0 +1,56 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import NavTabs from 'sentry/components/navTabs';
+import Placeholder from 'sentry/components/placeholder';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {t} from 'sentry/locale';
+import ReplayReader from 'sentry/utils/replays/replayReader';
+
+import TagPanel from '../tagPanel';
+
+import {VideoContainer} from '.';
+
+const TABS = {
+  video: t('Video Player'),
+  tags: t('Tags'),
+};
+
+type Props = {};
+
+function renderTabContent(key: string, loadedReplay: ReplayReader) {
+  if (key === 'tags') {
+    return <TagPanel replay={loadedReplay} />;
+  }
+
+  return <VideoContainer />;
+}
+
+function AsideTabsV2({}: Props) {
+  const {replay} = useReplayContext();
+  const [active, setActive] = useState<string>('video');
+
+  return (
+    <Container>
+      <NavTabs underlined>
+        {Object.entries(TABS).map(([tab, label]) => {
+          return (
+            <li key={tab} className={active === tab ? 'active' : ''}>
+              <a onClick={() => setActive(tab)}>{label}</a>
+            </li>
+          );
+        })}
+      </NavTabs>
+      {replay ? renderTabContent(active, replay) : <Placeholder height="100%" />}
+    </Container>
+  );
+}
+
+// FYI: height: 0; will helps us to reset the height
+// min-height: 300 will helps us to start at some height, making our breadcrumbs to not overlap
+const Container = styled('div')`
+  height: 0;
+  min-height: 300px;
+`;
+
+export default AsideTabsV2;

--- a/static/app/views/replays/detail/layout/asideTabs_v2.tsx
+++ b/static/app/views/replays/detail/layout/asideTabs_v2.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import React, {useState} from 'react';
 import styled from '@emotion/styled';
 
 import NavTabs from 'sentry/components/navTabs';
@@ -9,6 +9,7 @@ import ReplayReader from 'sentry/utils/replays/replayReader';
 
 import TagPanel from '../tagPanel';
 
+import ResizePanel from './resizePanel';
 import {VideoContainer} from '.';
 
 const TABS = {
@@ -31,7 +32,7 @@ function AsideTabsV2({}: Props) {
   const [active, setActive] = useState<string>('video');
 
   return (
-    <Container>
+    <React.Fragment>
       <NavTabs underlined>
         {Object.entries(TABS).map(([tab, label]) => {
           return (
@@ -41,16 +42,20 @@ function AsideTabsV2({}: Props) {
           );
         })}
       </NavTabs>
-      {replay ? renderTabContent(active, replay) : <Placeholder height="100%" />}
-    </Container>
+      <ResizePanel direction="s" style={{height: '325px'}}>
+        <Container>
+          {replay ? renderTabContent(active, replay) : <Placeholder height="100%" />}
+        </Container>
+      </ResizePanel>
+    </React.Fragment>
   );
 }
 
-// FYI: height: 0; will helps us to reset the height
-// min-height: 300 will helps us to start at some height, making our breadcrumbs to not overlap
+// TODO(replays): WIP 👇
 const Container = styled('div')`
-  height: 0;
-  min-height: 300px;
+  height: 100%;
+  min-height: 200px;
+  max-height: calc(100vh - 70%);
 `;
 
 export default AsideTabsV2;

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -9,6 +9,7 @@ import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import FocusArea from 'sentry/views/replays/detail/focusArea';
 import FocusTabs from 'sentry/views/replays/detail/focusTabs';
 
+import AsideTabsV2 from './asideTabs_v2';
 import Container from './container';
 import ResizePanel from './resizePanel';
 
@@ -50,14 +51,25 @@ type Props = {
   showVideo?: boolean;
 };
 
+export function VideoContainer() {
+  const {ref: fullscreenRef, isFullscreen, toggle: toggleFullscreen} = useFullscreen();
+  return (
+    <VideoSection>
+      <ErrorBoundary mini>
+        <div ref={fullscreenRef}>
+          <ReplayView toggleFullscreen={toggleFullscreen} isFullscreen={isFullscreen} />
+        </div>
+      </ErrorBoundary>
+    </VideoSection>
+  );
+}
+
 function ReplayLayout({
   layout = 'topbar',
   showCrumbs = true,
   showTimeline = true,
   showVideo = true,
 }: Props) {
-  const {ref: fullscreenRef, isFullscreen, toggle: toggleFullscreen} = useFullscreen();
-
   const timeline = showTimeline ? (
     <TimelineSection>
       <ErrorBoundary mini>
@@ -66,13 +78,7 @@ function ReplayLayout({
     </TimelineSection>
   ) : null;
 
-  const video = showVideo ? (
-    <VideoSection ref={fullscreenRef}>
-      <ErrorBoundary mini>
-        <ReplayView toggleFullscreen={toggleFullscreen} isFullscreen={isFullscreen} />
-      </ErrorBoundary>
-    </VideoSection>
-  ) : null;
+  const video = showVideo ? <VideoContainer /> : null;
 
   const crumbs = showCrumbs ? (
     <BreadcrumbSection>
@@ -99,7 +105,11 @@ function ReplayLayout({
           {content}
           <ResizePanel direction="w" minWidth={SIDEBAR_MIN_WIDTH}>
             <SidebarSection>
-              {video ? <ResizePanel direction="s">{video}</ResizePanel> : null}
+              {showVideo ? (
+                <ResizePanel direction="s">
+                  <AsideTabsV2 />
+                </ResizePanel>
+              ) : null}
               {crumbs}
             </SidebarSection>
           </ResizePanel>

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -53,14 +53,23 @@ type Props = {
 
 export function VideoContainer() {
   const {ref: fullscreenRef, isFullscreen, toggle: toggleFullscreen} = useFullscreen();
+
   return (
-    <VideoSection>
+    <VideoSection ref={fullscreenRef}>
       <ErrorBoundary mini>
-        <div ref={fullscreenRef}>
-          <ReplayView toggleFullscreen={toggleFullscreen} isFullscreen={isFullscreen} />
-        </div>
+        <ReplayView toggleFullscreen={toggleFullscreen} isFullscreen={isFullscreen} />
       </ErrorBoundary>
     </VideoSection>
+  );
+}
+
+export function BreadCrumbsContainer() {
+  return (
+    <BreadcrumbSection>
+      <ErrorBoundary mini>
+        <Breadcrumbs />
+      </ErrorBoundary>
+    </BreadcrumbSection>
   );
 }
 
@@ -80,13 +89,7 @@ function ReplayLayout({
 
   const video = showVideo ? <VideoContainer /> : null;
 
-  const crumbs = showCrumbs ? (
-    <BreadcrumbSection>
-      <ErrorBoundary mini>
-        <Breadcrumbs />
-      </ErrorBoundary>
-    </BreadcrumbSection>
-  ) : null;
+  const crumbs = showCrumbs ? <BreadCrumbsContainer /> : null;
 
   const content = (
     <ContentSection>
@@ -105,8 +108,7 @@ function ReplayLayout({
           {content}
           <ResizePanel direction="w" minWidth={SIDEBAR_MIN_WIDTH}>
             <SidebarSection>
-              {showVideo ? <AsideTabsV2 /> : null}
-              {crumbs}
+              <AsideTabsV2 showCrumbs={showCrumbs} showVideo={showVideo} />
             </SidebarSection>
           </ResizePanel>
         </PageRow>
@@ -157,6 +159,7 @@ const ContentSection = styled(PageColumn)`
 `;
 
 const VideoSection = styled(PageColumn)`
+  height: 100%;
   flex-grow: 2;
 `;
 

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -1,9 +1,6 @@
-import styled from '@emotion/styled';
-
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline';
 import ReplayView from 'sentry/components/replays/replayView';
-import space from 'sentry/styles/space';
 import useFullscreen from 'sentry/utils/replays/hooks/useFullscreen';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import FocusArea from 'sentry/views/replays/detail/focusArea';
@@ -11,6 +8,17 @@ import FocusTabs from 'sentry/views/replays/detail/focusTabs';
 
 import AsideTabsV2 from './asideTabs_v2';
 import Container from './container';
+import {
+  BreadcrumbSection,
+  ContentSection,
+  PageRow,
+  SIDEBAR_MIN_WIDTH,
+  SidebarSection,
+  TimelineSection,
+  TOPBAR_MIN_HEIGHT,
+  TopbarSection,
+  VideoSection,
+} from './pageSections';
 import ResizePanel from './resizePanel';
 
 type Layout =
@@ -41,9 +49,6 @@ type Layout =
    */
   | 'topbar';
 
-const SIDEBAR_MIN_WIDTH = 325;
-const TOPBAR_MIN_HEIGHT = 325;
-
 type Props = {
   layout?: Layout;
   showCrumbs?: boolean;
@@ -51,34 +56,14 @@ type Props = {
   showVideo?: boolean;
 };
 
-export function VideoContainer() {
-  const {ref: fullscreenRef, isFullscreen, toggle: toggleFullscreen} = useFullscreen();
-
-  return (
-    <VideoSection ref={fullscreenRef}>
-      <ErrorBoundary mini>
-        <ReplayView toggleFullscreen={toggleFullscreen} isFullscreen={isFullscreen} />
-      </ErrorBoundary>
-    </VideoSection>
-  );
-}
-
-export function BreadCrumbsContainer() {
-  return (
-    <BreadcrumbSection>
-      <ErrorBoundary mini>
-        <Breadcrumbs />
-      </ErrorBoundary>
-    </BreadcrumbSection>
-  );
-}
-
 function ReplayLayout({
   layout = 'topbar',
   showCrumbs = true,
   showTimeline = true,
   showVideo = true,
 }: Props) {
+  const {ref: fullscreenRef, isFullscreen, toggle: toggleFullscreen} = useFullscreen();
+
   const timeline = showTimeline ? (
     <TimelineSection>
       <ErrorBoundary mini>
@@ -87,9 +72,21 @@ function ReplayLayout({
     </TimelineSection>
   ) : null;
 
-  const video = showVideo ? <VideoContainer /> : null;
+  const video = showVideo ? (
+    <VideoSection ref={fullscreenRef}>
+      <ErrorBoundary mini>
+        <ReplayView toggleFullscreen={toggleFullscreen} isFullscreen={isFullscreen} />
+      </ErrorBoundary>
+    </VideoSection>
+  ) : null;
 
-  const crumbs = showCrumbs ? <BreadCrumbsContainer /> : null;
+  const crumbs = showCrumbs ? (
+    <BreadcrumbSection>
+      <ErrorBoundary mini>
+        <Breadcrumbs />
+      </ErrorBoundary>
+    </BreadcrumbSection>
+  ) : null;
 
   const content = (
     <ContentSection>
@@ -134,49 +131,5 @@ function ReplayLayout({
     </Container>
   );
 }
-
-const PageColumn = styled('section')`
-  display: flex;
-  flex-grow: 1;
-  flex-wrap: nowrap;
-  flex-direction: column;
-`;
-
-const PageRow = styled(PageColumn)`
-  flex-direction: row;
-`;
-
-const TimelineSection = styled(PageColumn)`
-  flex-grow: 0;
-`;
-
-const ContentSection = styled(PageColumn)`
-  flex-grow: 3; /* Higher growth than SidebarSection or TopVideoSection */
-
-  height: 100%;
-  min-height: 300px;
-  width: 100%;
-`;
-
-const VideoSection = styled(PageColumn)`
-  height: 100%;
-  flex-grow: 2;
-`;
-
-const BreadcrumbSection = styled(PageColumn)``;
-
-const SidebarSection = styled(PageColumn)`
-  min-width: ${SIDEBAR_MIN_WIDTH}px;
-`;
-
-const TopbarSection = styled(PageRow)`
-  height: ${TOPBAR_MIN_HEIGHT}px;
-  min-height: ${TOPBAR_MIN_HEIGHT}px;
-
-  ${BreadcrumbSection} {
-    max-width: ${SIDEBAR_MIN_WIDTH}px;
-    margin-left: ${space(2)};
-  }
-`;
 
 export default ReplayLayout;

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -105,11 +105,7 @@ function ReplayLayout({
           {content}
           <ResizePanel direction="w" minWidth={SIDEBAR_MIN_WIDTH}>
             <SidebarSection>
-              {showVideo ? (
-                <ResizePanel direction="s">
-                  <AsideTabsV2 />
-                </ResizePanel>
-              ) : null}
+              {showVideo ? <AsideTabsV2 /> : null}
               {crumbs}
             </SidebarSection>
           </ResizePanel>

--- a/static/app/views/replays/detail/layout/pageSections.tsx
+++ b/static/app/views/replays/detail/layout/pageSections.tsx
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+
+import space from 'sentry/styles/space';
+
+export const SIDEBAR_MIN_WIDTH = 325;
+export const TOPBAR_MIN_HEIGHT = 325;
+
+const PageColumn = styled('section')`
+  display: flex;
+  flex-grow: 1;
+  flex-wrap: nowrap;
+  flex-direction: column;
+`;
+
+export const PageRow = styled(PageColumn)`
+  flex-direction: row;
+`;
+
+export const TimelineSection = styled(PageColumn)`
+  flex-grow: 0;
+`;
+
+export const ContentSection = styled(PageColumn)`
+  flex-grow: 3; /* Higher growth than SidebarSection or TopVideoSection */
+
+  height: 100%;
+  min-height: 300px;
+  width: 100%;
+`;
+
+export const VideoSection = styled(PageColumn)`
+  height: 100%;
+  flex-grow: 2;
+`;
+
+export const BreadcrumbSection = styled(PageColumn)``;
+
+export const SidebarSection = styled(PageColumn)`
+  min-width: ${SIDEBAR_MIN_WIDTH}px;
+`;
+
+export const TopbarSection = styled(PageRow)`
+  height: ${TOPBAR_MIN_HEIGHT}px;
+  min-height: ${TOPBAR_MIN_HEIGHT}px;
+
+  ${BreadcrumbSection} {
+    max-width: ${SIDEBAR_MIN_WIDTH}px;
+    margin-left: ${space(2)};
+  }
+`;

--- a/static/app/views/replays/detail/layout/resizePanel.tsx
+++ b/static/app/views/replays/detail/layout/resizePanel.tsx
@@ -1,3 +1,4 @@
+import {CSSProperties} from 'react';
 import BaseResizePanel from 'react-resize-panel';
 import styled from '@emotion/styled';
 
@@ -6,6 +7,7 @@ type Props = {
   minHeight?: number;
   minWidth?: number;
   modifierClass?: string;
+  style?: CSSProperties;
 };
 
 export const CLASSNAMES = {

--- a/static/app/views/replays/detail/tagPanel.tsx
+++ b/static/app/views/replays/detail/tagPanel.tsx
@@ -16,6 +16,8 @@ type Props = {
   replay: ReplayReader;
 };
 
+const TAB_HEADER_HEIGHT = 28;
+
 function TagPanel({replay}: Props) {
   return (
     <Panel>
@@ -45,7 +47,7 @@ const PanelHeader = styled(BasePanelHeader)`
 const PanelBody = styled(BasePanelBody)`
   padding: ${space(1.5)};
   overflow-y: auto;
-  max-height: calc(100% - 34px);
+  max-height: calc(100% - ${TAB_HEADER_HEIGHT}px);
   ${SectionHeading} {
     display: none;
   }


### PR DESCRIPTION
<!-- Describe your PR here. -->
- Added Tabs for the sidebar layout in order to switch between the video player and tags. Closes #36273 

Loom video: 

https://user-images.githubusercontent.com/39612839/176917522-6f6e8619-17eb-4e5b-b577-e3167cb9fe73.mp4

NOTE: 
There's a bug with the resize height as you can see in the video, which I'm still working on the fix - prob just fixing the height will fix the problem which might also get #36271
<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
