### PR TITLE
fix(dynamic-sampling): Add query optimization for fetching random root transactions [TET-184]

### DIFF
--- a/src/sentry/api/endpoints/project_dynamic_sampling.py
+++ b/src/sentry/api/endpoints/project_dynamic_sampling.py
@@ -207,7 +207,7 @@ class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
         requested_sample_size = min(int(request.GET.get("sampleSize", 100)), 1000)
         distributed_trace = request.GET.get("distributedTrace", "1") == "1"
         stats_period = min(
-            parse_stats_period(request.GET.get("statsPeriod", "7d")), timedelta(days=7)
+            parse_stats_period(request.GET.get("statsPeriod", "1h")), timedelta(hours=24)
         )
 
         end_time = timezone.now()

--- a/src/sentry/api/endpoints/project_dynamic_sampling.py
+++ b/src/sentry/api/endpoints/project_dynamic_sampling.py
@@ -4,12 +4,17 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
+from snuba_sdk import Column
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.request import Request as SnubaRequest
 
 from sentry import features
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
 from sentry.models import Project
+from sentry.search.events.builder import QueryBuilder
 from sentry.snuba import discover
 from sentry.utils.dates import parse_stats_period
+from sentry.utils.snuba import Dataset, raw_snql_query
 
 
 def percentile_fn(data, percentile):
@@ -43,6 +48,124 @@ class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
             "p95": percentile_fn(data, 0.95),
             "p99": percentile_fn(data, 0.99),
         }
+
+    @staticmethod
+    def __get_root_transactions_count(project, query, sample_size, start_time, end_time):
+        # Run query that gets total count of transactions with these conditions for the specified
+        # time period
+        return discover.query(
+            selected_columns=[
+                "count()",
+            ],
+            query=f"{query} event.type:transaction !has:trace.parent_span_id",
+            params={
+                "start": start_time,
+                "end": end_time,
+                "project_id": [project.id],
+                "organization_id": project.organization,
+            },
+            orderby=[],
+            offset=0,
+            limit=sample_size,
+            equations=[],
+            auto_fields=True,
+            auto_aggregations=True,
+            allow_metric_aggregates=True,
+            use_aggregate_conditions=True,
+            transform_alias_to_input_format=True,
+            functions_acl=None,
+            referrer="dynamic-sampling.distribution.fetch-parent-transactions-count",
+        )["data"][0]["count()"]
+
+    def __generate_root_transactions_sampling_factor(
+        self, project, query, sample_size, start_time, end_time
+    ):
+        """
+        Generate a sampling factor representative of the total transactions count, that is
+        divisible by 10 (for simplicity). Essentially the logic here does the following:
+        If we have total count of n = 50000 then, we want the `normalized_transactions_count` to be
+        10000 as long as the n value doesn't exceed the 75% threshold between 10000 and 100000 else,
+        we default to 100000. The reason we do this is because falling back to 10000 will
+        yield more results as more numbers will be divisible by 10000 than 100000 for example.
+        We add a 75% threshold that is an arbitrary threshold just to limit the number of returned
+        results when dealing with values of n like 90,000 (In this case, we probably want the
+        `normalized_transactions_coun`t to be 100,000 rather than 10,000)
+        """
+        root_transactions_count = self.__get_root_transactions_count(
+            project=project,
+            query=query,
+            sample_size=sample_size,
+            start_time=start_time,
+            end_time=end_time,
+        )
+
+        if sample_size % 10 == 0:
+            normalized_sample_count = sample_size
+        else:
+            sample_digit_count = len(str(sample_size))
+            normalized_sample_count = 10**sample_digit_count
+
+        digit_count = len(str(root_transactions_count))
+        normalized_transactions_count = (
+            10 ** (digit_count - 1)
+            if (root_transactions_count <= 0.75 * 10**digit_count)
+            else 10**digit_count
+        )
+        return normalized_transactions_count / (10 * normalized_sample_count)
+
+    def __fetch_randomly_sampled_root_transactions(
+        self, project, query, sample_size, start_time, end_time
+    ):
+        """
+        Fetches a random sample of root transactions of size `sample_size` in the last period
+        defined by `stats_period`. The random sample is fetched by generating a random number by
+        for every row, and then doing a modulo operation on it, and if that number is divisible
+        by the sampling factor then its kept, otherwise is discarded. This is an alternative to
+        sampling the query before applying the conditions. The goal here is to fetch the
+        transaction ids, their sample rates and their trace ids.
+        """
+        sampling_factor = self.__generate_root_transactions_sampling_factor(
+            project=project,
+            query=query,
+            sample_size=sample_size,
+            start_time=start_time,
+            end_time=end_time,
+        )
+        builder = QueryBuilder(
+            Dataset.Discover,
+            params={
+                "start": start_time,
+                "end": end_time,
+                "project_id": [project.id],
+                "organization_id": project.organization,
+            },
+            query=f"{query} event.type:transaction !has:trace.parent_span_id",
+            selected_columns=[
+                "id",
+                "trace",
+                "trace.client_sample_rate",
+                "random_number() as rand_num",
+                f"modulo(rand_num, {sampling_factor}) as modulo_num",
+            ],
+            equations=[],
+            orderby=None,
+            auto_fields=True,
+            auto_aggregations=True,
+            use_aggregate_conditions=True,
+            functions_acl=["random_number", "modulo"],
+            limit=sample_size,
+            offset=0,
+            equation_config={"auto_add": False},
+        )
+        builder.add_conditions([Condition(lhs=Column("modulo_num"), op=Op.EQ, rhs=0)])
+        snuba_query = builder.get_snql_query().query
+        groupby = snuba_query.groupby + [Column("modulo_num")]
+        snuba_query = snuba_query.set_groupby(groupby)
+
+        return raw_snql_query(
+            SnubaRequest(dataset=Dataset.Discover.value, app_id="default", query=snuba_query),
+            referrer="dynamic-sampling.distribution.fetch-parent-transactions",
+        )["data"]
 
     def get(self, request: Request, project) -> Response:
         """
@@ -84,43 +207,16 @@ class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
         end_time = timezone.now()
         start_time = end_time - stats_period
 
-        # Fetches a random sample of root transactions of size `sample_size` in the last period
-        # defined by `stats_period`. The random sample is fetched by ordering by the
-        # `random_number` which is generated by a `random_number` function which generates a random
-        # number for every row. The goal here is to fetch the transaction ids, their sample rates
-        # and their trace ids.
-        root_transactions = discover.query(
-            selected_columns=[
-                "id",
-                "trace",
-                "trace.client_sample_rate",
-                "random_number() AS random_number",
-            ],
-            query=f"{query} event.type:transaction !has:trace.parent_span_id",
-            params={
-                "start": start_time,
-                "end": end_time,
-                "project_id": [project.id],
-                "organization_id": project.organization,
-            },
-            orderby=["-random_number"],
-            offset=0,
-            limit=requested_sample_size,
-            equations=[],
-            auto_fields=True,
-            auto_aggregations=True,
-            allow_metric_aggregates=True,
-            use_aggregate_conditions=True,
-            transform_alias_to_input_format=True,
-            functions_acl=["random_number"],
-            referrer="dynamic-sampling.distribution.fetch-parent-transactions",
-        )["data"]
+        root_transactions = self.__fetch_randomly_sampled_root_transactions(
+            project=project,
+            query=query,
+            sample_size=requested_sample_size,
+            start_time=start_time,
+            end_time=end_time,
+        )
 
         sample_size = len(root_transactions)
-        sample_rates = sorted(
-            transaction.get("trace.client_sample_rate") for transaction in root_transactions
-        )
-        if len(sample_rates) == 0:
+        if sample_size == 0:
             return Response(
                 {
                     "project_breakdown": None,
@@ -130,6 +226,9 @@ class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
                 }
             )
 
+        sample_rates = sorted(
+            transaction.get("trace.client_sample_rate") for transaction in root_transactions
+        )
         non_null_sample_rates = sorted(
             float(sample_rate) for sample_rate in sample_rates if sample_rate not in {"", None}
         )

--- a/src/sentry/api/endpoints/project_dynamic_sampling.py
+++ b/src/sentry/api/endpoints/project_dynamic_sampling.py
@@ -230,7 +230,6 @@ class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
                     "sample_rate_distributions": None,
                 }
             )
-
         sample_size = len(root_transactions)
         sample_rates = sorted(
             transaction.get("trace.client_sample_rate") for transaction in root_transactions
@@ -249,7 +248,7 @@ class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
             )
 
             project_breakdown = discover.query(
-                selected_columns=["project", "count()"],
+                selected_columns=["project_id", "project", "count()"],
                 query=f"event.type:transaction trace:[{','.join(trace_id_list)}]",
                 params={
                     "start": start_time,

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -382,6 +382,17 @@ class DiscoverDatasetConfig(DatasetConfig):
                     private=True,
                 ),
                 SnQLFunction(
+                    "modulo",
+                    required_args=[SnQLStringArg("column"), NumberRange("factor", None, None)],
+                    snql_aggregate=lambda args, alias: Function(
+                        "modulo",
+                        [Column(args["column"]), args["factor"]],
+                        alias,
+                    ),
+                    default_result_type="integer",
+                    private=True,
+                ),
+                SnQLFunction(
                     "avg_range",
                     required_args=[
                         NumericColumn("column"),

--- a/tests/sentry/api/endpoints/test_project_dynamic_sampling.py
+++ b/tests/sentry/api/endpoints/test_project_dynamic_sampling.py
@@ -176,11 +176,11 @@ def mocked_discover_query(referrer):
     elif referrer == "dynamic-sampling.distribution.fetch-project-breakdown":
         return {
             "data": [
-                {"project": "earth", "count()": 34},
-                {"project": "heart", "count()": 3},
-                {"project": "water", "count()": 3},
-                {"project": "wind", "count()": 3},
-                {"project": "fire", "count()": 21},
+                {"project_id": 27, "project": "earth", "count()": 34},
+                {"project_id": 28, "project": "heart", "count()": 3},
+                {"project_id": 24, "project": "water", "count()": 3},
+                {"project_id": 23, "project": "wind", "count()": 3},
+                {"project_id": 25, "project": "fire", "count()": 21},
             ]
         }
     raise Exception("Something went wrong!")
@@ -224,11 +224,11 @@ class ProjectDynamicSamplingTest(APITestCase):
             response = self.client.get(self.endpoint)
             assert response.json() == {
                 "project_breakdown": [
-                    {"project": "earth", "count()": 34},
-                    {"project": "heart", "count()": 3},
-                    {"project": "water", "count()": 3},
-                    {"project": "wind", "count()": 3},
-                    {"project": "fire", "count()": 21},
+                    {"project_id": 27, "project": "earth", "count()": 34},
+                    {"project_id": 28, "project": "heart", "count()": 3},
+                    {"project_id": 24, "project": "water", "count()": 3},
+                    {"project_id": 23, "project": "wind", "count()": 3},
+                    {"project_id": 25, "project": "fire", "count()": 21},
                 ],
                 "sample_size": 21,
                 "null_sample_rate_percentage": 71.42857142857143,
@@ -279,7 +279,7 @@ class ProjectDynamicSamplingTest(APITestCase):
             mocked_discover_query("dynamic-sampling.distribution.fetch-parent-transactions-count"),
             {
                 "data": [
-                    {"project": "fire", "count()": 2},
+                    {"project_id": 25, "project": "fire", "count()": 2},
                 ]
             },
         ]
@@ -306,7 +306,7 @@ class ProjectDynamicSamplingTest(APITestCase):
             response = self.client.get(f"{self.endpoint}?sampleSize=2")
             assert response.json() == {
                 "project_breakdown": [
-                    {"project": "fire", "count()": 2},
+                    {"project_id": 25, "project": "fire", "count()": 2},
                 ],
                 "sample_size": 2,
                 "null_sample_rate_percentage": 100.0,
@@ -342,17 +342,17 @@ class ProjectDynamicSamplingTest(APITestCase):
             mocked_discover_query("dynamic-sampling.distribution.fetch-parent-transactions-count"),
             {
                 "data": [
-                    {"project": "earth", "count()": 34},
-                    {"project": "heart", "count()": 3},
-                    {"project": "water", "count()": 3},
-                    {"project": "wind", "count()": 3},
-                    {"project": "fire", "count()": 21},
-                    {"project": "air", "count()": 21},
-                    {"project": "fire-air", "count()": 21},
-                    {"project": "fire-water", "count()": 21},
-                    {"project": "fire-earth", "count()": 21},
-                    {"project": "fire-fire", "count()": 21},
-                    {"project": "fire-heart", "count()": 21},
+                    {"project_id": 27, "project": "earth", "count()": 34},
+                    {"project_id": 28, "project": "heart", "count()": 3},
+                    {"project_id": 24, "project": "water", "count()": 3},
+                    {"project_id": 23, "project": "wind", "count()": 3},
+                    {"project_id": 25, "project": "fire", "count()": 21},
+                    {"project_id": 21, "project": "air", "count()": 21},
+                    {"project_id": 20, "project": "fire-air", "count()": 21},
+                    {"project_id": 22, "project": "fire-water", "count()": 21},
+                    {"project_id": 30, "project": "fire-earth", "count()": 21},
+                    {"project_id": 31, "project": "fire-fire", "count()": 21},
+                    {"project_id": 32, "project": "fire-heart", "count()": 21},
                 ]
             },
         ]
@@ -374,7 +374,7 @@ class ProjectDynamicSamplingTest(APITestCase):
             {"data": [{"count()": 1000}]},
             {
                 "data": [
-                    {"project": "fire", "count()": 2},
+                    {"project_id": 25, "project": "fire", "count()": 2},
                 ]
             },
         ]
@@ -430,7 +430,7 @@ class ProjectDynamicSamplingTest(APITestCase):
                 referrer="dynamic-sampling.distribution.fetch-parent-transactions-count",
             ),
             mock.call(
-                selected_columns=["project", "count()"],
+                selected_columns=["project_id", "project", "count()"],
                 query=f"event.type:transaction trace:[{','.join(trace_id_list)}]",
                 params={
                     "start": start_time,


### PR DESCRIPTION
This PR is a continuation of #36113
It introduces a sampling optimization to the query that fetches random transactions in the last 24hours by
- Running a count query to get the total number of transactions
- Calculating a sampling factor from the total count, and then applying the modulo operation on that sampling factor, and discarding any values that are not divisible by that factor
- Adds `project_id` to response of project breakdown