### PR TITLE
fix(dynamic-sampling): Relax permissions on dyn sampling endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_dynamic_sampling.py
+++ b/src/sentry/api/endpoints/project_dynamic_sampling.py
@@ -32,9 +32,7 @@ def percentile_fn(data, percentile):
 
 
 class DynamicSamplingPermission(ProjectPermission):
-    # ToDo(ahmed): Revisit the permission level for Dynamic Sampling once the requirements are
-    #  better defined
-    scope_map = {"GET": ["project:write", "project:admin"]}
+    scope_map = {"GET": ["project:write"]}
 
 
 class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):


### PR DESCRIPTION
Relaxes permissions on the `GET` for project
dynamic sampling endpoint by removing the
`project:admin` permission

