### PR TITLE
ref(sampling): Add add, edit, delete, sort handlers

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/conditions.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/conditions.tsx
@@ -1,0 +1,137 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import Button from 'sentry/components/button';
+import FieldRequiredBadge from 'sentry/components/forms/field/fieldRequiredBadge';
+import TextareaField from 'sentry/components/forms/textareaField';
+import {IconDelete} from 'sentry/icons/iconDelete';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {SamplingInnerName} from 'sentry/types/sampling';
+
+import {getInnerNameLabel} from '../../utils';
+
+import {TagValueAutocomplete, TagValueAutocompleteProps} from './tagValueAutocomplete';
+import {getMatchFieldPlaceholder, getTagKey} from './utils';
+
+export type Condition = {
+  category: SamplingInnerName | string; // string is used for custom tags
+  match?: string;
+};
+
+interface Props extends Pick<TagValueAutocompleteProps, 'orgSlug' | 'projectId'> {
+  conditions: Condition[];
+  onChange: <T extends keyof Condition>(
+    index: number,
+    field: T,
+    value: Condition[T]
+  ) => void;
+  onDelete: (index: number) => void;
+}
+
+export function Conditions({conditions, orgSlug, projectId, onDelete, onChange}: Props) {
+  return (
+    <Fragment>
+      {conditions.map((condition, index) => {
+        const {category, match} = condition;
+
+        const isAutoCompleteField =
+          category === SamplingInnerName.TRACE_ENVIRONMENT ||
+          category === SamplingInnerName.TRACE_RELEASE ||
+          category === SamplingInnerName.TRACE_TRANSACTION;
+
+        return (
+          <ConditionWrapper key={index}>
+            <LeftCell>
+              <span>
+                {getInnerNameLabel(category)}
+                <FieldRequiredBadge />
+              </span>
+            </LeftCell>
+            <CenterCell>
+              {isAutoCompleteField ? (
+                <TagValueAutocomplete
+                  category={category}
+                  tagKey={getTagKey(condition)}
+                  orgSlug={orgSlug}
+                  projectId={projectId}
+                  value={match}
+                  onChange={value => onChange(index, 'match', value)}
+                />
+              ) : (
+                <StyledTextareaField
+                  name="match"
+                  value={match}
+                  onChange={value => onChange(index, 'match', value)}
+                  placeholder={getMatchFieldPlaceholder(category)}
+                  inline={false}
+                  rows={1}
+                  autosize
+                  hideControlState
+                  flexibleControlStateSize
+                  required
+                  stacked
+                />
+              )}
+            </CenterCell>
+            <RightCell>
+              <Button
+                onClick={() => onDelete(index)}
+                icon={<IconDelete />}
+                aria-label={t('Delete Condition')}
+              />
+            </RightCell>
+          </ConditionWrapper>
+        );
+      })}
+    </Fragment>
+  );
+}
+
+const ConditionWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: flex-start;
+  padding: ${space(1)} ${space(2)};
+  :not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.gray100};
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-template-columns: minmax(0, 0.6fr) minmax(0, 1fr) max-content;
+  }
+`;
+
+const Cell = styled('div')`
+  min-height: 40px;
+  display: inline-flex;
+  align-items: center;
+`;
+
+const LeftCell = styled(Cell)`
+  padding-right: ${space(1)};
+  line-height: 16px;
+`;
+
+const CenterCell = styled(Cell)`
+  padding-top: ${space(1)};
+  grid-column: 1/-1;
+  grid-row: 2/2;
+  ${p => !p.children && 'display: none'};
+
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    grid-column: auto;
+    grid-row: auto;
+    padding-top: 0;
+  }
+`;
+
+const RightCell = styled(Cell)`
+  justify-content: flex-end;
+  padding-left: ${space(1)};
+`;
+
+const StyledTextareaField = styled(TextareaField)`
+  padding-bottom: 0;
+  width: 100%;
+`;

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.tsx
@@ -1,0 +1,406 @@
+import {Fragment, KeyboardEvent, useEffect, useState} from 'react';
+import {createFilter} from 'react-select';
+import styled from '@emotion/styled';
+import isEqual from 'lodash/isEqual';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {ModalRenderProps} from 'sentry/actionCreators/modal';
+import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
+import CompactSelect from 'sentry/components/forms/compactSelect';
+import FieldRequiredBadge from 'sentry/components/forms/field/fieldRequiredBadge';
+import NumberField from 'sentry/components/forms/numberField';
+import Option from 'sentry/components/forms/selectOption';
+import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
+import {IconAdd} from 'sentry/icons';
+import {IconSearch} from 'sentry/icons/iconSearch';
+import {t} from 'sentry/locale';
+import ProjectStore from 'sentry/stores/projectsStore';
+import space from 'sentry/styles/space';
+import {Organization, Project, SelectValue} from 'sentry/types';
+import {
+  SamplingConditionOperator,
+  SamplingInnerName,
+  SamplingRule,
+  SamplingRules,
+  SamplingRuleType,
+} from 'sentry/types/sampling';
+import {defined} from 'sentry/utils';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import useApi from 'sentry/utils/useApi';
+import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
+import TextBlock from 'sentry/views/settings/components/text/textBlock';
+
+import {Condition, Conditions} from './conditions';
+import {
+  distributedTracesConditions,
+  generateConditionCategoriesOptions,
+  getErrorMessage,
+  getNewCondition,
+} from './utils';
+
+const conditionAlreadyAddedTooltip = t('This condition has already been added');
+
+type State = {
+  conditions: Condition[];
+  errors: {
+    sampleRate?: string;
+  };
+  sampleRate: number | null;
+};
+
+type Props = ModalRenderProps & {
+  organization: Organization;
+  project: Project;
+  rules: SamplingRules;
+  rule?: SamplingRule;
+};
+
+export function SpecificConditionsModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  project,
+  rule,
+  rules,
+  organization,
+}: Props) {
+  const api = useApi();
+
+  const [data, setData] = useState<State>(getInitialState());
+  const [isSaving, setIsSaving] = useState(false);
+
+  const conditionCategories = generateConditionCategoriesOptions(
+    distributedTracesConditions
+  );
+
+  useEffect(() => {
+    setData(d => {
+      if (!!d.errors.sampleRate) {
+        return {...d, errors: {...d.errors, sampleRate: undefined}};
+      }
+
+      return d;
+    });
+  }, [data.sampleRate]);
+
+  function getInitialState(): State {
+    if (rule) {
+      const {condition: conditions, sampleRate} = rule;
+
+      const {inner} = conditions;
+
+      return {
+        conditions: inner.map(innerItem => {
+          const {name, value} = innerItem;
+
+          if (Array.isArray(value)) {
+            return {
+              category: name,
+              match: value.join('\n'),
+            };
+          }
+          return {category: name};
+        }),
+        sampleRate: sampleRate * 100,
+        errors: {},
+      };
+    }
+
+    return {
+      conditions: [],
+      sampleRate: null,
+      errors: {},
+    };
+  }
+
+  const {errors, conditions, sampleRate} = data;
+
+  function convertRequestErrorResponse(error: ReturnType<typeof getErrorMessage>) {
+    if (typeof error === 'string') {
+      addErrorMessage(error);
+      return;
+    }
+
+    switch (error.type) {
+      case 'sampleRate':
+        setData({...data, errors: {...errors, sampleRate: error.message}});
+        break;
+      default:
+        addErrorMessage(error.message);
+    }
+  }
+
+  async function handleSubmit() {
+    if (!defined(sampleRate)) {
+      return;
+    }
+
+    const newRule: SamplingRule = {
+      // All new/updated rules must have id equal to 0
+      id: 0,
+      active: rule ? rule.active : false,
+      type: SamplingRuleType.TRACE,
+      condition: {
+        op: SamplingConditionOperator.AND,
+        inner: !conditions.length ? [] : conditions.map(getNewCondition),
+      },
+      sampleRate: sampleRate / 100,
+    };
+
+    const newRules = rule
+      ? rules.map(r => (isEqual(r, rule) ? newRule : r))
+      : [...rules, newRule];
+
+    const currentRuleIndex = newRules.findIndex(newR => newR === newRule);
+
+    setIsSaving(true);
+
+    try {
+      const newProjectDetails = await api.requestPromise(
+        `/projects/${organization.slug}/${project.slug}/`,
+        {method: 'PUT', data: {dynamicSampling: {rules: newRules}}}
+      );
+      ProjectStore.onUpdateSuccess(newProjectDetails);
+      addSuccessMessage(
+        rule
+          ? t('Successfully edited sampling rule')
+          : t('Successfully added sampling rule')
+      );
+      closeModal();
+    } catch (error) {
+      convertRequestErrorResponse(getErrorMessage(error, currentRuleIndex));
+    }
+
+    setIsSaving(false);
+
+    const analyticsConditions = conditions.map(condition => condition.category);
+    const analyticsConditionsStringified = analyticsConditions.sort().join(', ');
+
+    trackAdvancedAnalyticsEvent('sampling.settings.rule.save', {
+      organization,
+      project_id: project.id,
+      sampling_rate: sampleRate,
+      conditions: analyticsConditions,
+      conditions_stringified: analyticsConditionsStringified,
+    });
+
+    if (defined(rule)) {
+      trackAdvancedAnalyticsEvent('sampling.settings.rule.update', {
+        organization,
+        project_id: project.id,
+        sampling_rate: sampleRate,
+        conditions: analyticsConditions,
+        conditions_stringified: analyticsConditionsStringified,
+        old_conditions: rule.condition.inner.map(({name}) => name),
+        old_conditions_stringified: rule.condition.inner
+          .map(({name}) => name)
+          .sort()
+          .join(', '),
+        old_sampling_rate: rule.sampleRate * 100,
+      });
+      return;
+    }
+
+    trackAdvancedAnalyticsEvent('sampling.settings.rule.create', {
+      organization,
+      project_id: project.id,
+      sampling_rate: sampleRate,
+      conditions: analyticsConditions,
+      conditions_stringified: analyticsConditionsStringified,
+    });
+  }
+
+  function handleAddCondition(selectedOptions: SelectValue<SamplingInnerName>[]) {
+    const previousCategories = conditions.map(({category}) => category);
+    const addedCategories = selectedOptions
+      .filter(({value}) => !previousCategories.includes(value))
+      .map(({value}) => value);
+
+    trackAdvancedAnalyticsEvent('sampling.settings.condition.add', {
+      organization,
+      project_id: project.id,
+      conditions: addedCategories,
+    });
+
+    setData({
+      ...data,
+      conditions: [
+        ...conditions,
+        ...addedCategories.map(addedCategory => ({category: addedCategory, match: ''})),
+      ],
+    });
+  }
+
+  function handleDeleteCondition(index: number) {
+    const newConditions = [...conditions];
+    newConditions.splice(index, 1);
+    setData({...data, conditions: newConditions});
+  }
+
+  function handleChangeCondition<T extends keyof Condition>(
+    index: number,
+    field: T,
+    value: Condition[T]
+  ) {
+    const newConditions = [...conditions];
+    newConditions[index][field] = value;
+
+    // If custom tag key changes, reset the value
+    if (field === 'category') {
+      newConditions[index].match = '';
+
+      trackAdvancedAnalyticsEvent('sampling.settings.condition.add', {
+        organization,
+        project_id: project.id,
+        conditions: [value as SamplingInnerName],
+      });
+    }
+
+    setData({...data, conditions: newConditions});
+  }
+
+  const predefinedConditionsOptions = conditionCategories.map(([value, label]) => {
+    const optionDisabled = conditions.some(condition => condition.category === value);
+    return {
+      value,
+      label,
+      disabled: optionDisabled,
+      tooltip: optionDisabled ? conditionAlreadyAddedTooltip : undefined,
+    };
+  });
+
+  const submitDisabled =
+    !defined(sampleRate) ||
+    !conditions.length ||
+    conditions.some(condition => !condition.match);
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h4>{rule ? t('Edit Rule') : t('Add Rule')}</h4>
+      </Header>
+      <Body>
+        <Fields>
+          <Description>
+            {t(
+              'Using a Trace ID, select all Transactions distributed across multiple projects/services which match your conditions.'
+            )}
+          </Description>
+          <StyledPanel>
+            <StyledPanelHeader hasButtons>
+              <div>
+                {t('Conditions')}
+                <FieldRequiredBadge />
+              </div>
+              <StyledCompactSelect
+                placement="bottom right"
+                triggerProps={{
+                  size: 'small',
+                  'aria-label': t('Add Condition'),
+                }}
+                triggerLabel={
+                  <TriggerLabel>
+                    <IconAdd isCircled />
+                    {t('Add Condition')}
+                  </TriggerLabel>
+                }
+                placeholder={t('Filter conditions')}
+                isOptionDisabled={opt => opt.disabled}
+                options={predefinedConditionsOptions}
+                value={conditions.map(({category}) => category)}
+                onChange={handleAddCondition}
+                isSearchable
+                multiple
+                filterOption={(candidate, input) => createFilter(null)(candidate, input)}
+                components={{
+                  Option: containerProps => <Option {...containerProps} />,
+                }}
+              />
+            </StyledPanelHeader>
+            <PanelBody>
+              {!conditions.length ? (
+                <EmptyMessage
+                  icon={<IconSearch size="xl" />}
+                  title={t('No conditions added')}
+                  description={t('Click on the button above to add (+) a condition')}
+                />
+              ) : (
+                <Conditions
+                  conditions={conditions}
+                  onDelete={handleDeleteCondition}
+                  onChange={handleChangeCondition}
+                  orgSlug={organization.slug}
+                  projectId={project.id}
+                />
+              )}
+            </PanelBody>
+          </StyledPanel>
+          <NumberField
+            label={`${t('Sample Rate')} \u0025`}
+            name="sampleRate"
+            onChange={value => {
+              setData({...data, sampleRate: !!value ? Number(value) : null});
+            }}
+            onKeyDown={(_value: string, e: KeyboardEvent) => {
+              if (e.key === 'Enter') {
+                handleSubmit();
+              }
+            }}
+            placeholder={'\u0025'}
+            value={sampleRate}
+            inline={false}
+            hideControlState={!errors.sampleRate}
+            error={errors.sampleRate}
+            showHelpInTooltip
+            stacked
+            required
+          />
+        </Fields>
+      </Body>
+      <Footer>
+        <ButtonBar gap={1}>
+          <Button onClick={closeModal}>{t('Cancel')}</Button>
+          <Button
+            priority="primary"
+            onClick={handleSubmit}
+            title={submitDisabled ? t('Required fields must be filled out') : undefined}
+            disabled={isSaving || submitDisabled}
+          >
+            {t('Save Rule')}
+          </Button>
+        </ButtonBar>
+      </Footer>
+    </Fragment>
+  );
+}
+
+const Fields = styled('div')`
+  display: grid;
+  gap: ${space(2)};
+`;
+
+const StyledCompactSelect = styled(CompactSelect)`
+  font-weight: 400;
+  text-transform: none;
+`;
+
+const StyledPanelHeader = styled(PanelHeader)`
+  padding-right: ${space(2)};
+`;
+
+const StyledPanel = styled(Panel)`
+  margin-bottom: 0;
+`;
+
+const TriggerLabel = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  align-items: center;
+  gap: ${space(1)};
+`;
+
+const Description = styled(TextBlock)`
+  margin: 0;
+`;

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.tsx
@@ -1,7 +1,6 @@
 import {Fragment, KeyboardEvent, useEffect, useState} from 'react';
 import {createFilter} from 'react-select';
 import styled from '@emotion/styled';
-import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -150,10 +149,8 @@ export function SpecificConditionsModal({
     };
 
     const newRules = rule
-      ? rules.map(r => (isEqual(r, rule) ? newRule : r))
+      ? rules.map(existingRule => (existingRule.id === rule.id ? newRule : existingRule))
       : [...rules, newRule];
-
-    const currentRuleIndex = newRules.findIndex(newR => newR === newRule);
 
     setIsSaving(true);
 
@@ -170,6 +167,7 @@ export function SpecificConditionsModal({
       );
       closeModal();
     } catch (error) {
+      const currentRuleIndex = newRules.findIndex(newR => newR === newRule);
       convertRequestErrorResponse(getErrorMessage(error, currentRuleIndex));
     }
 

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.tsx
@@ -1,0 +1,135 @@
+import {useCallback, useEffect, useState} from 'react';
+import {components, MultiValueProps} from 'react-select';
+import styled from '@emotion/styled';
+
+import {fetchTagValues} from 'sentry/actionCreators/tags';
+import SelectField from 'sentry/components/forms/selectField';
+import {t} from 'sentry/locale';
+import {Organization, Project} from 'sentry/types';
+import {SamplingInnerName} from 'sentry/types/sampling';
+import useApi from 'sentry/utils/useApi';
+
+import {TruncatedLabel} from './truncatedLabel';
+import {formatCreateTagLabel, getMatchFieldPlaceholder} from './utils';
+
+type Tag = {
+  value: string;
+};
+
+export interface TagValueAutocompleteProps {
+  category:
+    | SamplingInnerName.TRACE_ENVIRONMENT
+    | SamplingInnerName.TRACE_RELEASE
+    | SamplingInnerName.TRACE_TRANSACTION
+    | string;
+  onChange: (value: string) => void;
+  orgSlug: Organization['slug'];
+  projectId: Project['id'];
+  tagKey?: string;
+  value?: string;
+}
+
+function TagValueAutocomplete({
+  orgSlug,
+  projectId,
+  category,
+  onChange,
+  value,
+  tagKey,
+}: TagValueAutocompleteProps) {
+  const api = useApi();
+  const [tagValues, setTagValues] = useState<Tag[]>([]);
+
+  function getAriaLabel() {
+    switch (category) {
+      case SamplingInnerName.TRACE_RELEASE:
+        return t('Search or add a release');
+      case SamplingInnerName.TRACE_ENVIRONMENT:
+        return t('Search or add an environment');
+      case SamplingInnerName.TRACE_TRANSACTION:
+        return t('Search or add a transaction');
+      default:
+        return undefined;
+    }
+  }
+
+  const tagValueLoader = useCallback(async () => {
+    if (!tagKey) {
+      return;
+    }
+
+    try {
+      const response = await fetchTagValues(
+        api,
+        orgSlug,
+        tagKey,
+        null,
+        [projectId],
+        null,
+        true
+      );
+      setTagValues(response);
+    } catch {
+      // Do nothing. No results will be suggested
+    }
+  }, [tagKey, api, orgSlug, projectId]);
+
+  useEffect(() => {
+    tagValueLoader();
+  }, [tagValueLoader]);
+
+  // react-select doesn't seem to work very well when its value contains
+  // a created item that isn't listed in the options
+  const createdOptions: Tag[] = !value
+    ? []
+    : value
+        .split('\n')
+        .filter(v => !tagValues.some(tagValue => tagValue.value === v))
+        .map(v => ({value: v}));
+
+  return (
+    <StyledSelectField
+      name="match"
+      aria-label={getAriaLabel()}
+      options={[...createdOptions, ...tagValues].map(tagValue => ({
+        value: tagValue.value,
+        label: <TruncatedLabel value={tagValue.value} />,
+      }))}
+      value={value?.split('\n')}
+      onChange={newValue => {
+        onChange(newValue?.join('\n'));
+      }}
+      components={{
+        MultiValue: (multiValueProps: MultiValueProps<{}>) => (
+          <components.MultiValue
+            {...multiValueProps}
+            innerProps={{...multiValueProps.innerProps, 'data-test-id': 'multivalue'}}
+          />
+        ),
+      }}
+      formatCreateLabel={formatCreateTagLabel}
+      isValidNewOption={newOption => {
+        // Tag values cannot be empty and must have a maximum length of 200 characters
+        // https://github.com/getsentry/relay/blob/d8223d8d03ed4764063855eb3480f22684163d92/relay-general/src/store/normalize.rs#L230-L236
+        // In addition to that, it cannot contain a line-feed (newline) character
+        // https://github.com/getsentry/relay/blob/d8223d8d03ed4764063855eb3480f22684163d92/relay-general/src/protocol/tags.rs#L8
+        return !/\\n/.test(newOption) && newOption.length <= 200;
+      }}
+      placeholder={getMatchFieldPlaceholder(category)}
+      inline={false}
+      multiple
+      hideControlState
+      flexibleControlStateSize
+      required
+      stacked
+      creatable
+      allowClear
+    />
+  );
+}
+
+const StyledSelectField = styled(SelectField)`
+  width: 100%;
+`;
+
+export {TagValueAutocomplete};

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/truncatedLabel.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/truncatedLabel.tsx
@@ -1,0 +1,15 @@
+import Truncate from 'sentry/components/truncate';
+import theme from 'sentry/utils/theme';
+import useMedia from 'sentry/utils/useMedia';
+
+type Props = {
+  value: string;
+};
+
+export function TruncatedLabel({value}: Props) {
+  const isSmallDevice = useMedia(`(max-width: ${theme.breakpoints.small})`);
+
+  return (
+    <Truncate value={value} maxLength={isSmallDevice ? 30 : 40} expandable={false} />
+  );
+}

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/utils.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/utils.tsx
@@ -1,0 +1,160 @@
+import {t, tct} from 'sentry/locale';
+import {
+  SamplingConditionLogicalInner,
+  SamplingInnerName,
+  SamplingInnerOperator,
+  SamplingRule,
+} from 'sentry/types/sampling';
+
+import {getInnerNameLabel} from '../../utils';
+
+import {Conditions} from './conditions';
+import {TruncatedLabel} from './truncatedLabel';
+
+type Condition = React.ComponentProps<typeof Conditions>['conditions'][0];
+
+export function getMatchFieldPlaceholder(category: SamplingInnerName | string) {
+  switch (category) {
+    case SamplingInnerName.TRACE_USER_ID:
+      return t('ex. 4711 (Multiline)');
+    case SamplingInnerName.TRACE_USER_SEGMENT:
+      return t('ex. paid, common (Multiline)');
+    case SamplingInnerName.TRACE_ENVIRONMENT:
+      return t('ex. prod, dev');
+    case SamplingInnerName.TRACE_RELEASE:
+      return t('ex. 1*, [I3].[0-9].*');
+    case SamplingInnerName.TRACE_TRANSACTION:
+      return t('ex. page-load');
+    default:
+      return undefined;
+  }
+}
+
+export function getNewCondition(condition: Condition): SamplingConditionLogicalInner {
+  const newValue = (condition.match ?? '')
+    .split('\n')
+    .filter(match => !!match.trim())
+    .map(match => match.trim());
+
+  if (
+    condition.category === SamplingInnerName.TRACE_RELEASE ||
+    condition.category === SamplingInnerName.TRACE_TRANSACTION
+  ) {
+    return {
+      op: SamplingInnerOperator.GLOB_MATCH,
+      name: condition.category,
+      value: newValue,
+    };
+  }
+
+  if (condition.category === SamplingInnerName.TRACE_USER_ID) {
+    return {
+      op: SamplingInnerOperator.EQUAL,
+      name: condition.category,
+      value: newValue,
+      options: {
+        ignoreCase: false,
+      },
+    };
+  }
+
+  return {
+    op: SamplingInnerOperator.EQUAL,
+    // TODO(sampling): remove the cast
+    name: condition.category as
+      | SamplingInnerName.TRACE_ENVIRONMENT
+      | SamplingInnerName.TRACE_USER_ID
+      | SamplingInnerName.TRACE_USER_SEGMENT,
+    value: newValue,
+    options: {
+      ignoreCase: true,
+    },
+  };
+}
+
+const unexpectedErrorMessage = t('An internal error occurred while saving sampling rule');
+
+type ResponseJSONDetailed = {
+  detail: string[];
+};
+
+type ResponseJSON = {
+  dynamicSampling?: {
+    rules: Array<Partial<SamplingRule>>;
+  };
+};
+
+export function getErrorMessage(
+  error: {
+    responseJSON?: ResponseJSON | ResponseJSONDetailed;
+  },
+  currentRuleIndex: number
+) {
+  const detailedErrorResponse = (error.responseJSON as undefined | ResponseJSONDetailed)
+    ?.detail;
+
+  if (detailedErrorResponse) {
+    // This is a temp solution until we enable error rules again, therefore it does not need translation
+    return detailedErrorResponse[0];
+  }
+
+  const errorResponse = error.responseJSON as undefined | ResponseJSON;
+
+  if (!errorResponse) {
+    return unexpectedErrorMessage;
+  }
+
+  const responseErrors = errorResponse.dynamicSampling?.rules[currentRuleIndex] ?? {};
+
+  const [type, _value] = Object.entries(responseErrors)[0];
+
+  if (type === 'sampleRate') {
+    return {
+      type: 'sampleRate',
+      message: t('Ensure this value is a floating number between 0 and 100'),
+    };
+  }
+
+  return unexpectedErrorMessage;
+}
+
+export function getTagKey(condition: Condition) {
+  switch (condition.category) {
+    case SamplingInnerName.TRACE_RELEASE:
+      return 'release';
+    case SamplingInnerName.TRACE_ENVIRONMENT:
+      return 'environment';
+    case SamplingInnerName.TRACE_TRANSACTION:
+      return 'transaction';
+    default:
+      return undefined;
+  }
+}
+
+export const distributedTracesConditions = [
+  SamplingInnerName.TRACE_RELEASE,
+  SamplingInnerName.TRACE_ENVIRONMENT,
+  SamplingInnerName.TRACE_USER_ID,
+  SamplingInnerName.TRACE_USER_SEGMENT,
+  SamplingInnerName.TRACE_TRANSACTION,
+];
+
+export function generateConditionCategoriesOptions(
+  conditionCategories: SamplingInnerName[]
+): [SamplingInnerName, string][] {
+  const sortedConditionCategories = conditionCategories
+    // sort dropdown options alphabetically based on display labels
+    .sort((a, b) => getInnerNameLabel(a).localeCompare(getInnerNameLabel(b)));
+
+  // massage into format that select component understands
+  return sortedConditionCategories.map(innerName => [
+    innerName,
+    getInnerNameLabel(innerName),
+  ]);
+}
+
+export function formatCreateTagLabel(label: string) {
+  return tct('Add "[newLabel]"', {
+    newLabel: <TruncatedLabel value={label} />,
+  });
+}

--- a/static/app/views/settings/project/server-side-sampling/rule.tsx
+++ b/static/app/views/settings/project/server-side-sampling/rule.tsx
@@ -12,9 +12,9 @@ import {IconDownload, IconEllipsis} from 'sentry/icons';
 import {IconGrabbable} from 'sentry/icons/iconGrabbable';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {LegacyBrowser, SamplingRule, SamplingRuleOperator} from 'sentry/types/sampling';
+import {SamplingRule, SamplingRuleOperator} from 'sentry/types/sampling';
 
-import {getInnerNameLabel, LEGACY_BROWSER_LIST} from './utils';
+import {getInnerNameLabel} from './utils';
 
 type Props = {
   dragging: boolean;
@@ -103,21 +103,16 @@ export function Rule({
                   <div>
                     {[...condition.value].map((conditionValue, conditionValueIndex) => (
                       <Fragment key={conditionValue}>
-                        <ConditionValue>
-                          {LEGACY_BROWSER_LIST[conditionValue]?.title ?? conditionValue}
-                        </ConditionValue>
+                        <ConditionValue>{conditionValue}</ConditionValue>
                         {conditionValueIndex !==
-                          (condition.value as LegacyBrowser[]).length - 1 && (
+                          (condition.value as string[]).length - 1 && (
                           <ConditionSeparator>{'\u002C'}</ConditionSeparator>
                         )}
                       </Fragment>
                     ))}
                   </div>
                 ) : (
-                  <ConditionValue>
-                    {LEGACY_BROWSER_LIST[String(condition.value)]?.title ??
-                      String(condition.value)}
-                  </ConditionValue>
+                  <ConditionValue>{String(condition.value)}</ConditionValue>
                 )}
               </Fragment>
             ))}

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -1,7 +1,9 @@
-import {Fragment, useState} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import isEqual from 'lodash/isEqual';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
@@ -9,17 +11,22 @@ import {Panel, PanelFooter, PanelHeader} from 'sentry/components/panels';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconAdd} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import ProjectStore from 'sentry/stores/projectsStore';
 import space from 'sentry/styles/space';
 import {Project} from 'sentry/types';
 import {SamplingRule, SamplingRuleOperator, SamplingRules} from 'sentry/types/sampling';
+import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
+import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
+import usePrevious from 'sentry/utils/usePrevious';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionAlert from 'sentry/views/settings/organization/permissionAlert';
 
-import {DraggableList} from '../sampling/rules/draggableList';
+import {DraggableList, UpdateItemsProps} from '../sampling/rules/draggableList';
 
 import {ActivateModal} from './modals/activateModal';
+import {SpecificConditionsModal} from './modals/specificConditionsModal';
 import {UniformRateModal} from './modals/uniformRateModal';
 import {Promo} from './promo';
 import {
@@ -39,10 +46,18 @@ type Props = {
 
 export function ServerSideSampling({project}: Props) {
   const organization = useOrganization();
-  const hasAccess = organization.access.includes('project:write');
-  const dynamicSamplingRules = project.dynamicSampling?.rules ?? [];
+  const api = useApi();
 
-  const [rules, _setRules] = useState<SamplingRules>(dynamicSamplingRules);
+  const hasAccess = organization.access.includes('project:write');
+  const currentRules = project.dynamicSampling?.rules;
+  const previousRules = usePrevious(currentRules);
+  const [rules, setRules] = useState<SamplingRules>(currentRules ?? []);
+
+  useEffect(() => {
+    if (!isEqual(previousRules, currentRules)) {
+      setRules(currentRules ?? []);
+    }
+  }, [currentRules, previousRules]);
 
   function handleActivateToggle(rule: SamplingRule) {
     openModal(modalProps => <ActivateModal {...modalProps} rule={rule} />);
@@ -52,6 +67,79 @@ export function ServerSideSampling({project}: Props) {
     openModal(modalProps => (
       <UniformRateModal {...modalProps} organization={organization} project={project} />
     ));
+  }
+
+  async function handleSortRules({overIndex, reorderedItems: ruleIds}: UpdateItemsProps) {
+    if (!rules[overIndex].condition.inner.length) {
+      addErrorMessage(
+        t('Rules with conditions cannot be below rules without conditions')
+      );
+      return;
+    }
+
+    const sortedRules = ruleIds
+      .map(ruleId => rules.find(rule => String(rule.id) === ruleId))
+      .filter(rule => !!rule) as SamplingRule[];
+
+    setRules(sortedRules);
+
+    try {
+      const newProjectDetails = await api.requestPromise(
+        `/projects/${organization.slug}/${project.slug}/`,
+        {
+          method: 'PUT',
+          data: {dynamicSampling: {rules: sortedRules}},
+        }
+      );
+      ProjectStore.onUpdateSuccess(newProjectDetails);
+      addSuccessMessage(t('Successfully sorted sampling rules'));
+    } catch (error) {
+      setRules(previousRules ?? []);
+      const message = t('Unable to sort sampling rules');
+      handleXhrErrorResponse(message)(error);
+      addErrorMessage(message);
+    }
+  }
+
+  function handleAddRule() {
+    openModal(modalProps => (
+      <SpecificConditionsModal
+        {...modalProps}
+        organization={organization}
+        project={project}
+        rules={rules}
+      />
+    ));
+  }
+
+  function handleEditRule(rule: SamplingRule) {
+    openModal(modalProps => (
+      <SpecificConditionsModal
+        {...modalProps}
+        organization={organization}
+        project={project}
+        rule={rule}
+        rules={rules}
+      />
+    ));
+  }
+
+  async function handleDeleteRule(rule: SamplingRule) {
+    try {
+      const newProjectDetails = await api.requestPromise(
+        `/projects/${organization.slug}/${project.slug}/`,
+        {
+          method: 'PUT',
+          data: {dynamicSampling: {rules: rules.filter(({id}) => id !== rule.id)}},
+        }
+      );
+      ProjectStore.onUpdateSuccess(newProjectDetails);
+      addSuccessMessage(t('Successfully deleted sampling rule'));
+    } catch (error) {
+      const message = t('Unable to delete sampling rule');
+      handleXhrErrorResponse(message)(error);
+      addErrorMessage(message);
+    }
   }
 
   // Rules without a condition (Else case) always have to be 'pinned' to the bottom of the list
@@ -96,7 +184,7 @@ export function ServerSideSampling({project}: Props) {
               <DraggableList
                 disabled={!hasAccess}
                 items={items}
-                onUpdateItems={() => {}}
+                onUpdateItems={handleSortRules}
                 wrapperStyle={({isDragging, isSorting, index}) => {
                   if (isDragging) {
                     return {
@@ -149,8 +237,8 @@ export function ServerSideSampling({project}: Props) {
                           ...currentRule,
                           bottomPinned: itemsRule.bottomPinned,
                         }}
-                        onEditRule={() => {}}
-                        onDeleteRule={() => {}}
+                        onEditRule={() => handleEditRule(currentRule)}
+                        onDeleteRule={() => handleDeleteRule(currentRule)}
                         onActivate={() => handleActivateToggle(currentRule)}
                         noPermission={!hasAccess}
                         listeners={listeners}
@@ -175,7 +263,7 @@ export function ServerSideSampling({project}: Props) {
                         : undefined
                     }
                     priority="primary"
-                    onClick={() => {}}
+                    onClick={handleAddRule}
                     icon={<IconAdd isCircled />}
                   >
                     {t('Add Rule')}

--- a/static/app/views/settings/project/server-side-sampling/utils.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils.tsx
@@ -1,94 +1,23 @@
 import {t} from 'sentry/locale';
-import {LegacyBrowser, SamplingInnerName} from 'sentry/types/sampling';
+import {SamplingInnerName} from 'sentry/types/sampling';
 
 // TODO: Update this link as soon as we have one for sampling
 export const SERVER_SIDE_SAMPLING_DOC_LINK =
   'https://docs.sentry.io/product/data-management-settings/filtering/';
 
-const CUSTOM_TAG_PREFIX = 'event.tags.';
-
-export function stripCustomTagPrefix(name: string): string {
-  if (name.startsWith(CUSTOM_TAG_PREFIX)) {
-    return name.replace(CUSTOM_TAG_PREFIX, '');
-  }
-
-  return name;
-}
-
-export const LEGACY_BROWSER_LIST = {
-  [LegacyBrowser.IE_PRE_9]: {
-    icon: 'internet-explorer',
-    title: t('Internet Explorer version 8 and lower'),
-  },
-  [LegacyBrowser.IE9]: {
-    icon: 'internet-explorer',
-    title: t('Internet Explorer version 9'),
-  },
-  [LegacyBrowser.IE10]: {
-    icon: 'internet-explorer',
-    title: t('Internet Explorer version 10'),
-  },
-  [LegacyBrowser.IE11]: {
-    icon: 'internet-explorer',
-    title: t('Internet Explorer version 11'),
-  },
-  [LegacyBrowser.SAFARI_PRE_6]: {
-    icon: 'safari',
-    title: t('Safari version 5 and lower'),
-  },
-  [LegacyBrowser.OPERA_PRE_15]: {
-    icon: 'opera',
-    title: t('Opera version 14 and lower'),
-  },
-  [LegacyBrowser.OPERA_MINI_PRE_8]: {
-    icon: 'opera',
-    title: t('Opera Mini version 8 and lower'),
-  },
-  [LegacyBrowser.ANDROID_PRE_4]: {
-    icon: 'android',
-    title: t('Android version 3 and lower'),
-  },
-};
-
 export function getInnerNameLabel(name: SamplingInnerName | string) {
   switch (name) {
     case SamplingInnerName.TRACE_ENVIRONMENT:
-    case SamplingInnerName.EVENT_ENVIRONMENT:
       return t('Environment');
     case SamplingInnerName.TRACE_RELEASE:
-    case SamplingInnerName.EVENT_RELEASE:
       return t('Release');
-    case SamplingInnerName.EVENT_USER_ID:
     case SamplingInnerName.TRACE_USER_ID:
       return t('User Id');
-    case SamplingInnerName.EVENT_USER_SEGMENT:
     case SamplingInnerName.TRACE_USER_SEGMENT:
       return t('User Segment');
-    case SamplingInnerName.EVENT_LOCALHOST:
-      return t('Localhost');
-    case SamplingInnerName.EVENT_WEB_CRAWLERS:
-      return t('Web Crawlers');
-    case SamplingInnerName.EVENT_LEGACY_BROWSER:
-      return t('Legacy Browser');
-    case SamplingInnerName.EVENT_TRANSACTION:
     case SamplingInnerName.TRACE_TRANSACTION:
       return t('Transaction');
-    case SamplingInnerName.EVENT_CSP:
-      return t('Content Security Policy');
-    case SamplingInnerName.EVENT_IP_ADDRESSES:
-      return t('IP Address');
-    case SamplingInnerName.EVENT_OS_NAME:
-      return t('OS Name');
-    case SamplingInnerName.EVENT_OS_VERSION:
-      return t('OS Version');
-    case SamplingInnerName.EVENT_DEVICE_FAMILY:
-      return t('Device Family');
-    case SamplingInnerName.EVENT_DEVICE_NAME:
-      return t('Device Name');
-    case SamplingInnerName.EVENT_CUSTOM_TAG:
-      return t('Add Custom Tag');
-
     default:
-      return `${stripCustomTagPrefix(name)} - ${t('Custom')}`;
+      return '';
   }
 }

--- a/tests/js/spec/views/settings/project/server-side-sampling/activateModal.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/activateModal.spec.tsx
@@ -28,6 +28,7 @@ describe('Server-side Sampling - Activate Modal', function () {
             {
               sampleRate: 0.2,
               type: 'trace',
+              active: false,
               condition: {
                 op: 'and',
                 inner: [
@@ -38,10 +39,10 @@ describe('Server-side Sampling - Activate Modal', function () {
                   },
                 ],
               },
-              id: 40,
+              id: 1,
             },
           ],
-          next_id: 41,
+          next_id: 2,
         },
       }),
     ],

--- a/tests/js/spec/views/settings/project/server-side-sampling/index.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/index.spec.tsx
@@ -7,12 +7,16 @@ import {RouteContext} from 'sentry/views/routeContext';
 import ServerSideSampling from 'sentry/views/settings/project/server-side-sampling';
 import {SERVER_SIDE_SAMPLING_DOC_LINK} from 'sentry/views/settings/project/server-side-sampling/utils';
 
-function getMockData(project?: Project) {
+export function getMockData({
+  project,
+  access,
+}: {access?: string[]; project?: Project} = {}) {
   return initializeOrg({
     ...initializeOrg(),
     organization: {
       ...initializeOrg().organization,
       features: ['server-side-sampling'],
+      access: access ?? initializeOrg().organization.access,
     },
     projects: [project],
   });
@@ -69,13 +73,14 @@ describe('Server-side Sampling', function () {
   });
 
   it('renders rules panel', function () {
-    const {router, organization, project} = getMockData(
-      TestStubs.Project({
+    const {router, organization, project} = getMockData({
+      project: TestStubs.Project({
         dynamicSampling: {
           rules: [
             {
               sampleRate: 0.2,
               type: 'trace',
+              active: false,
               condition: {
                 op: 'and',
                 inner: [
@@ -86,13 +91,13 @@ describe('Server-side Sampling', function () {
                   },
                 ],
               },
-              id: 40,
+              id: 1,
             },
           ],
-          next_id: 41,
+          next_id: 2,
         },
-      })
-    );
+      }),
+    });
 
     const {container} = render(
       <RouteContext.Provider

--- a/tests/js/spec/views/settings/project/server-side-sampling/specificConditionsModal.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/specificConditionsModal.spec.tsx
@@ -1,0 +1,338 @@
+import {InjectedRouter} from 'react-router';
+
+import {
+  render,
+  screen,
+  userEvent,
+  waitForElementToBeRemoved,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
+
+import * as indicators from 'sentry/actionCreators/indicator';
+import GlobalModal from 'sentry/components/globalModal';
+import {Organization, Project} from 'sentry/types';
+import {SamplingInnerName} from 'sentry/types/sampling';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+import {RouteContext} from 'sentry/views/routeContext';
+import ServerSideSampling from 'sentry/views/settings/project/server-side-sampling';
+import {distributedTracesConditions} from 'sentry/views/settings/project/server-side-sampling/modals/specificConditionsModal/utils';
+import {getInnerNameLabel} from 'sentry/views/settings/project/server-side-sampling/utils';
+
+import {getMockData} from './index.spec';
+
+function TestComponent({
+  router,
+  project,
+  organization,
+}: {
+  organization: Organization;
+  project: Project;
+  router: InjectedRouter;
+}) {
+  return (
+    <RouteContext.Provider
+      value={{
+        router,
+        location: router.location,
+        params: {
+          orgId: organization.slug,
+          projectId: project.slug,
+        },
+        routes: [],
+      }}
+    >
+      <GlobalModal />
+      <OrganizationContext.Provider value={organization}>
+        <ServerSideSampling project={project} />
+      </OrganizationContext.Provider>
+    </RouteContext.Provider>
+  );
+}
+
+describe('Server-side Sampling - Specific Conditions Modal', function () {
+  const uniformRule = {
+    sampleRate: 1,
+    type: 'trace',
+    active: false,
+    condition: {
+      op: 'and',
+      inner: [],
+    },
+    id: 1,
+  };
+
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/tags/',
+      body: TestStubs.Tags,
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/release/values/',
+      method: 'GET',
+      body: [{value: '1.2.3'}],
+    });
+  });
+
+  afterEach(function () {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('add new rule', async function () {
+    const {organization, project, router} = getMockData({
+      project: TestStubs.Project({
+        dynamicSampling: {
+          rules: [uniformRule],
+        },
+      }),
+    });
+
+    const newRule = {
+      condition: {
+        inner: [{name: 'trace.release', op: 'glob', value: ['1.2.3']}],
+        op: 'and',
+      },
+      id: 0,
+      sampleRate: 0.2,
+      type: 'trace',
+      active: false,
+    };
+
+    const saveMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      method: 'PUT',
+      body: TestStubs.Project({
+        dynamicSampling: {
+          rules: [uniformRule, newRule],
+        },
+      }),
+    });
+
+    jest.spyOn(indicators, 'addSuccessMessage');
+
+    render(
+      <TestComponent organization={organization} project={project} router={router} />
+    );
+
+    // Rules Panel Content
+    userEvent.click(screen.getByLabelText('Add Rule'));
+
+    const dialog = await screen.findByRole('dialog');
+
+    // Dialog Header
+    expect(screen.getByRole('heading', {name: 'Add Rule'})).toBeInTheDocument();
+
+    // Dialog Content
+    expect(
+      screen.getByText(
+        'Using a Trace ID, select all Transactions distributed across multiple projects/services which match your conditions.'
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('No conditions added')).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Click on the button above to add (+) a condition')
+    ).toBeInTheDocument();
+
+    expect(screen.getByPlaceholderText('\u0025')).toHaveTextContent('');
+
+    // Dialog Footer
+    expect(screen.getByRole('button', {name: 'Cancel'})).toBeEnabled();
+    expect(screen.getByRole('button', {name: 'Save Rule'})).toBeDisabled();
+
+    userEvent.hover(screen.getByText('Save Rule'));
+
+    expect(
+      await screen.findByText('Required fields must be filled out')
+    ).toBeInTheDocument();
+
+    // Click on 'Add condition'
+    userEvent.click(screen.getByText('Add Condition'));
+
+    // Autocomplete
+    expect(screen.getByText(/filter conditions/i)).toBeInTheDocument();
+
+    // Distributed Traces Options
+    distributedTracesConditions.forEach(condition => {
+      expect(within(dialog).getByText(getInnerNameLabel(condition))).toBeInTheDocument();
+    });
+
+    // Click on the condition option
+    userEvent.click(
+      within(dialog).getByText(getInnerNameLabel(SamplingInnerName.TRACE_RELEASE))
+    );
+
+    // Release field is empty
+    expect(screen.queryByTestId('multivalue')).not.toBeInTheDocument();
+
+    // Type into release field
+    userEvent.paste(screen.getByLabelText('Search or add a release'), '1.2.3');
+
+    // Autocomplete suggests options
+    expect(screen.getByTestId('1.2.3')).toHaveTextContent('1.2.3');
+
+    // Click on the suggested option
+    userEvent.click(screen.getByTestId('1.2.3'));
+
+    // Button is still disabled
+    expect(screen.getByLabelText('Save Rule')).toBeDisabled();
+
+    // Fill sample rate field
+    userEvent.paste(screen.getByPlaceholderText('\u0025'), '20');
+
+    // Save button is now enabled
+    expect(screen.getByLabelText('Save Rule')).toBeEnabled();
+
+    // Click on save button
+    userEvent.click(screen.getByLabelText('Save Rule'));
+
+    // Dialog should close
+    await waitForElementToBeRemoved(() => screen.queryByText('Save Rule'), {
+      timeout: 2500,
+    });
+
+    expect(saveMock).toHaveBeenCalledTimes(1);
+
+    expect(saveMock).toHaveBeenLastCalledWith(
+      '/projects/org-slug/project-slug/',
+      expect.objectContaining({
+        data: {
+          dynamicSampling: {
+            rules: [uniformRule, newRule],
+          },
+        },
+      })
+    );
+
+    expect(indicators.addSuccessMessage).toHaveBeenCalledWith(
+      'Successfully added sampling rule'
+    );
+  });
+
+  it('edits the rule', async function () {
+    const {organization, project, router} = getMockData({
+      project: TestStubs.Project({
+        dynamicSampling: {
+          rules: [
+            uniformRule,
+            {
+              sampleRate: 0.2,
+              active: false,
+              type: 'trace',
+              condition: {
+                op: 'and',
+                inner: [
+                  {
+                    op: 'glob',
+                    name: 'trace.release',
+                    value: ['1.2.2'],
+                  },
+                ],
+              },
+              id: 2,
+            },
+          ],
+        },
+      }),
+    });
+
+    const newRule = {
+      condition: {
+        inner: [{name: 'trace.release', op: 'glob', value: ['1.2.3']}],
+        op: 'and',
+      },
+      id: 0,
+      sampleRate: 0.6,
+      type: 'trace',
+      active: false,
+    };
+
+    const saveMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      method: 'PUT',
+      body: TestStubs.Project({
+        dynamicSampling: {
+          rules: [uniformRule, newRule],
+        },
+      }),
+    });
+
+    jest.spyOn(indicators, 'addSuccessMessage');
+
+    render(
+      <TestComponent organization={organization} project={project} router={router} />
+    );
+
+    expect(screen.getByText('1.2.2')).toBeInTheDocument();
+    expect(screen.getByText('20%')).toBeInTheDocument();
+
+    const samplingRule = screen.getAllByTestId('sampling-rule')[1];
+
+    // Rules Panel Content
+    userEvent.click(within(samplingRule).getByLabelText('Actions'));
+
+    userEvent.click(within(samplingRule).getByText('Edit'));
+
+    await screen.findByRole('dialog');
+
+    // Empty conditions message is not displayed
+    expect(screen.queryByText('No conditions added')).not.toBeInTheDocument();
+
+    // Type into realease field
+    userEvent.clear(screen.getByLabelText('Search or add a release'));
+    userEvent.paste(screen.getByLabelText('Search or add a release'), '1.2.3');
+
+    // Click on the suggested option
+    userEvent.click(await screen.findByText(textWithMarkupMatcher('Add "1.2.3"')));
+
+    // Update sample rate field
+    userEvent.clear(screen.getByPlaceholderText('\u0025'));
+    userEvent.paste(screen.getByPlaceholderText('\u0025'), '60');
+
+    // Click on save button
+    userEvent.click(screen.getByLabelText('Save Rule'));
+
+    // Modal will close
+    await waitForElementToBeRemoved(() => screen.queryByText('Edit Rule'));
+
+    expect(saveMock).toHaveBeenCalledTimes(1);
+
+    expect(saveMock).toHaveBeenLastCalledWith(
+      '/projects/org-slug/project-slug/',
+      expect.objectContaining({
+        data: {
+          dynamicSampling: {
+            rules: [uniformRule, newRule],
+          },
+        },
+      })
+    );
+
+    expect(indicators.addSuccessMessage).toHaveBeenCalledWith(
+      'Successfully edited sampling rule'
+    );
+  });
+
+  it('does not let you add without permissions', async function () {
+    const {organization, project, router} = getMockData({
+      project: TestStubs.Project({
+        dynamicSampling: {
+          rules: [uniformRule],
+        },
+      }),
+      access: [],
+    });
+
+    render(
+      <TestComponent organization={organization} project={project} router={router} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Add Rule'})).toBeDisabled();
+    userEvent.hover(screen.getByText('Add Rule'));
+    expect(
+      await screen.findByText("You don't have permission to add a rule")
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
**What this PR does:**

- Moves the modal logic of adding rules from the sampling UI to the new server-side sampling UI, removing everything related to _events_ and leaving everything else related to _trace_ . The new folder is called `specificConditionsModal`
- Add back, but with a clearer code the `handleEdit`, `handleAdd`, `handleDelete` and `handleSort` 
- Add new tests excluding Individual transactions (Sampling.Event.*) logic 

**Preview**

https://user-images.githubusercontent.com/29228205/177177387-d1651593-504a-4d24-9991-13018864b00e.mov

