### PR TITLE
feat(metrics): Option for percentage-wise org rollout [INGEST-1423]

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -368,6 +368,11 @@ register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
 # Example value: [{"project_id": 42}, {"project_id": 123}]
 register("relay.drop-transaction-metrics", default=[])
 
+# Sample rate for opting in orgs into transaction metrics extraction.
+# NOTE: If this value is > 0.0, the extraction feature will be enabled for the
+#       given fraction of orgs even if the corresponding feature flag is disabled.
+register("relay.transaction-metrics-org-sample-rate", default=0.0)
+
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=False)
 


### PR DESCRIPTION
Add an option to enable transaction metric extraction for a fraction of organizations.

Prerequisite for https://github.com/getsentry/sentry/pull/36313.