### PR TITLE
feat(dynamic-sampling): Endpoint that returns project sdk info [TET-180]

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -1,0 +1,135 @@
+from datetime import timedelta
+from functools import cmp_to_key
+
+from django.utils import timezone
+from rest_framework.request import Request
+from rest_framework.response import Response
+from sentry_relay.processing import compare_version as compare_version_relay
+
+from sentry import features
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.snuba import discover
+from sentry.utils.dates import parse_stats_period
+
+
+class OrganizationDynamicSamplingSDKVersionsEndpoint(OrganizationEndpoint):
+    private = True
+
+    def get(self, request: Request, organization) -> Response:
+        """
+        Return a list of project SDK versions based on project filter that are used in the
+        organization, and are considered to be the latest according to semantic versioning. It
+        also returns information on whether these SDK versions are sending client side sample rates.
+        ``````````````````````````````````````````````````
+
+        :pparam string organization_slug: the slug of the organization.
+        :qparam array[string] project: A required list of project ids to filter
+        :qparam string statsPeriod: an optional stat period (can be one of
+                                    ``"24h"``, ``"14d"``, and ``""``).
+        :auth: required
+        """
+        if not features.has("organizations:server-side-sampling", organization, actor=request.user):
+            return Response(
+                {
+                    "detail": [
+                        "Dynamic sampling feature flag needs to be enabled before you can perform "
+                        "this action."
+                    ]
+                },
+                status=404,
+            )
+
+        requested_projects = self.get_requested_project_ids_unchecked(request)
+        if not requested_projects:
+            return Response([])
+
+        project_ids = [
+            p.id
+            for p in self.get_projects(
+                request=request, organization=organization, project_ids=requested_projects
+            )
+        ]
+
+        stats_period = min(
+            parse_stats_period(request.GET.get("statsPeriod", "24h")), timedelta(days=2)
+        )
+        end_time = timezone.now()
+        start_time = end_time - stats_period
+
+        avg_equation = 'count_if(trace.client_sample_rate, notEquals, "") / count()'
+
+        project_sdks_info = discover.query(
+            selected_columns=[
+                "sdk.name",
+                "sdk.version",
+                "project",
+                'count_if(trace.client_sample_rate, notEquals, "")',
+                "count()",
+            ],
+            query="event.type:transaction",
+            params={
+                "start": start_time,
+                "end": end_time,
+                "project_id": project_ids,
+                "organization_id": organization,
+            },
+            equations=[avg_equation],
+            orderby=[],
+            offset=0,
+            limit=100,
+            auto_fields=True,
+            auto_aggregations=True,
+            allow_metric_aggregates=True,
+            use_aggregate_conditions=True,
+            transform_alias_to_input_format=True,
+            referrer="dynamic-sampling.distribution.fetch-project-sdk-versions-info",
+        )["data"]
+
+        # Creates a dictionary that has the first level key as project id and values (second
+        # level key) as SDK versions, and finally that maps to the expected resulting project
+        # sdk version info if that SDKVersion was actually the latest observed, and that info
+        # contains project, latestSDKVersion, latestSDKName, and a boolean isSendingSampleRate
+        # which indicates if that SDK version is sending client side sample rate.
+        # Example:
+        # {
+        #     1: {
+        #         "1.0.0": {
+        #             "project": 1,
+        #             "latestSDKVersion": "1.0.0",
+        #             "latestSDKName": "Sentry",
+        #             "isSendingSampleRate": True
+        #         },
+        #         "1.0.1": {
+        #             "project": 1,
+        #             "latestSDKVersion": "1.0.1",
+        #             "latestSDKName": "Sentry",
+        #             "isSendingSampleRate": False
+        #         }
+        #     }
+        # }
+        project_to_sdk_version_to_info_dict = {}
+        for project_sdk_info in project_sdks_info:
+            assert project_sdk_info["sdk.version"] != "", "sdk.version cannot be empty"
+            project_to_sdk_version_to_info_dict.setdefault(project_sdk_info["project"], {})[
+                project_sdk_info["sdk.version"]
+            ] = {
+                "project": project_sdk_info["project"],
+                "latestSDKName": project_sdk_info["sdk.name"],
+                "lastestSDKVersion": project_sdk_info["sdk.version"],
+                "isSendingSampleRate": bool(project_sdk_info[f"equation|{avg_equation}"]),
+            }
+
+        # Essentially for each project, we fetch all the SDK versions from the previously
+        # computed dictionary, and then we find the latest SDK version according to
+        # semantic versioning and return the info for that particular project SDK version.
+        project_info_list = [
+            project_to_sdk_version_to_info_dict[project][
+                sorted(
+                    list(project_to_sdk_version_to_info_dict[project].keys()),
+                    key=cmp_to_key(compare_version_relay),
+                )[-1]
+            ]
+            for project in project_to_sdk_version_to_info_dict
+        ]
+
+        return Response(project_info_list)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -219,6 +219,9 @@ from .endpoints.organization_dashboard_widget_details import (
 )
 from .endpoints.organization_dashboards import OrganizationDashboardsEndpoint
 from .endpoints.organization_details import OrganizationDetailsEndpoint
+from .endpoints.organization_dynamic_sampling_sdk_versions import (
+    OrganizationDynamicSamplingSDKVersionsEndpoint,
+)
 from .endpoints.organization_environments import OrganizationEnvironmentsEndpoint
 from .endpoints.organization_event_details import OrganizationEventDetailsEndpoint
 from .endpoints.organization_eventid import EventIdLookupEndpoint
@@ -1530,6 +1533,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/transaction-anomaly-detection/$",
                     OrganizationTransactionAnomalyDetectionEndpoint.as_view(),
                     name="sentry-api-0-organization-transaction-anomaly-detection",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/dynamic-sampling/sdk-versions/$",
+                    OrganizationDynamicSamplingSDKVersionsEndpoint.as_view(),
+                    name="sentry-api-0-organization-dynamic-sampling-sdk-versions",
                 ),
                 # relay usage
                 url(

--- a/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
+++ b/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
@@ -1,0 +1,195 @@
+from datetime import timedelta
+from unittest import mock
+
+from django.urls import reverse
+from django.utils import timezone
+from freezegun import freeze_time
+
+from sentry.testutils import APITestCase
+from sentry.testutils.helpers import Feature
+
+
+def mocked_discover_query():
+    return {
+        "data": [
+            {
+                "project": "fire",
+                "sdk.name": "javascript",
+                "sdk.version": "7.1.6",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                "count()": 4,
+                'count_if(trace.client_sample_rate, notEquals, "")': 4,
+            },
+            {
+                "project": "water",
+                "sdk.name": "javascript",
+                "sdk.version": "7.1.4",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                "count()": 1,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+            },
+            {
+                "project": "water",
+                "sdk.name": "javascript",
+                "sdk.version": "7.1.6",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                "count()": 2,
+                'count_if(trace.client_sample_rate, notEquals, "")': 2,
+            },
+            {
+                "project": "wind",
+                "sdk.name": "javascript",
+                "sdk.version": "7.1.5",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                "count()": 2,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+            },
+            {
+                "project": "wind",
+                "sdk.name": "javascript",
+                "sdk.version": "7.1.3",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                "count()": 1,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+            },
+            {
+                "project": "fire",
+                "sdk.name": "javascript",
+                "sdk.version": "7.1.4",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                "count()": 6,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+            },
+            {
+                "project": "fire",
+                "sdk.name": "javascript",
+                "sdk.version": "7.1.5",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                "count()": 3,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+            },
+            {
+                "project": "fire",
+                "sdk.name": "javascript",
+                "sdk.version": "7.1.3",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                "count()": 8,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+            },
+        ]
+    }
+
+
+class OrganizationDynamicSamplingSDKVersionsTest(APITestCase):
+    @property
+    def endpoint(self):
+        return reverse(
+            "sentry-api-0-organization-dynamic-sampling-sdk-versions",
+            kwargs={
+                "organization_slug": self.organization.slug,
+            },
+        )
+
+    def test_permission(self):
+        user = self.create_user("foo@example.com")
+        self.login_as(user)
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.client.get(self.endpoint)
+            assert response.status_code == 403
+
+    def test_user_permissions_for_project_ids_filter(self):
+        user = self.create_user("foo@example.com")
+        self.login_as(user)
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.client.get(f"{self.endpoint}?project={self.project.id}")
+            assert response.status_code == 403
+
+    def test_feature_flag_disabled(self):
+        self.login_as(self.user)
+        response = self.client.get(self.endpoint)
+        assert response.status_code == 404
+
+    def test_no_project_ids_filter_requested(self):
+        self.login_as(self.user)
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.client.get(self.endpoint)
+            assert response.status_code == 200
+            assert response.data == []
+
+    @mock.patch("sentry.api.endpoints.organization_dynamic_sampling_sdk_versions.discover.query")
+    def test_successful_response(self, mock_query):
+        self.login_as(self.user)
+        mock_query.return_value = mocked_discover_query()
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.client.get(f"{self.endpoint}?project={self.project.id}")
+            assert response.json() == [
+                {
+                    "project": "fire",
+                    "latestSDKName": "javascript",
+                    "lastestSDKVersion": "7.1.6",
+                    "isSendingSampleRate": True,
+                },
+                {
+                    "project": "water",
+                    "latestSDKName": "javascript",
+                    "lastestSDKVersion": "7.1.6",
+                    "isSendingSampleRate": True,
+                },
+                {
+                    "project": "wind",
+                    "latestSDKName": "javascript",
+                    "lastestSDKVersion": "7.1.5",
+                    "isSendingSampleRate": False,
+                },
+            ]
+
+    @mock.patch("sentry.api.endpoints.organization_dynamic_sampling_sdk_versions.discover.query")
+    def test_response_when_no_transactions_are_available(self, mock_query):
+        self.login_as(self.user)
+        mock_query.return_value = {"data": []}
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.client.get(f"{self.endpoint}?project={self.project.id}")
+            assert response.json() == []
+
+    @freeze_time()
+    @mock.patch("sentry.api.endpoints.organization_dynamic_sampling_sdk_versions.discover.query")
+    def test_request_params_are_applied_to_discover_query(self, mock_query):
+        self.login_as(self.user)
+        mock_query.return_value = mocked_discover_query()
+
+        end_time = timezone.now()
+        start_time = end_time - timedelta(hours=6)
+
+        calls = [
+            mock.call(
+                selected_columns=[
+                    "sdk.name",
+                    "sdk.version",
+                    "project",
+                    'count_if(trace.client_sample_rate, notEquals, "")',
+                    "count()",
+                ],
+                query="event.type:transaction",
+                params={
+                    "start": start_time,
+                    "end": end_time,
+                    "project_id": [self.project.id],
+                    "organization_id": self.project.organization,
+                },
+                equations=['count_if(trace.client_sample_rate, notEquals, "") / count()'],
+                orderby=[],
+                offset=0,
+                limit=100,
+                auto_fields=True,
+                auto_aggregations=True,
+                allow_metric_aggregates=True,
+                use_aggregate_conditions=True,
+                transform_alias_to_input_format=True,
+                referrer="dynamic-sampling.distribution.fetch-project-sdk-versions-info",
+            ),
+        ]
+
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.client.get(f"{self.endpoint}?project={self.project.id}&statsPeriod=6h")
+            assert response.status_code == 200
+            assert mock_query.mock_calls == calls


### PR DESCRIPTION
Adds endpoint that returns SDK information about
projects within the last statsPeriod. The endpoint
returns the lastest observed release and whether
this release is sending client side sample rate or not

