### PR TITLE
ref(locks): Make the post_process locks backend configurable

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2673,3 +2673,9 @@ MAX_REDIS_SNOWFLAKE_RETRY_COUNTER = 5
 
 SNOWFLAKE_VERSION_ID = 1
 SNOWFLAKE_REGION_ID = 0
+
+
+SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS = {
+    "path": "sentry.utils.locking.backends.redis.RedisLockBackend",
+    "options": {"cluster": "default"},
+}

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1,9 +1,9 @@
 import logging
 
 import sentry_sdk
+from django.conf import settings
 
 from sentry import analytics, features
-from sentry.app import locks
 from sentry.exceptions import PluginError
 from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
@@ -13,10 +13,15 @@ from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.event_frames import get_sdk_name
 from sentry.utils.locking import UnableToAcquireLock
+from sentry.utils.locking.manager import LockManager
 from sentry.utils.safe import safe_execute
 from sentry.utils.sdk import bind_organization_context, set_current_event_project
+from sentry.utils.services import build_instance_from_options
 
 logger = logging.getLogger("sentry")
+
+
+locks = LockManager(build_instance_from_options(settings.SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS))
 
 
 def _get_service_hooks(project_id):

--- a/src/sentry/utils/locking/backends/redis.py
+++ b/src/sentry/utils/locking/backends/redis.py
@@ -12,7 +12,11 @@ class RedisLockBackend(LockBackend):
         if uuid is None:
             uuid = uuid4().hex
 
-        self.cluster = cluster
+        if isinstance(cluster, str):
+            self.cluster = redis.clusters.get(cluster)
+        else:
+            self.cluster = cluster
+
         self.prefix = prefix
         self.uuid = uuid
 

--- a/tests/sentry/utils/locking/backends/test_redis.py
+++ b/tests/sentry/utils/locking/backends/test_redis.py
@@ -58,3 +58,6 @@ class RedisLockBackendTestCase(TestCase):
         self.backend.acquire(key, duration)
         assert self.backend.locked(key)
         self.backend.release(key)
+
+    def test_cluster_as_str(self):
+        assert RedisLockBackend(cluster="default").cluster == self.cluster


### PR DESCRIPTION
This PR, as a preparation for the migration of `post_process` locks to their own Redis cluster, separates the `post_process` locks from the rest of the app by using its own instance of `LockManager` with a configurable backend. The default configuration uses the same backend as `sentry.app.locks` so functionally nothing changes.