### PR TITLE
fix(alert): Fix issue alert create layout

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -909,7 +909,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
           const disabled = loading || !(isActiveSuperuser() || hasAccess);
 
           return (
-            <Layout.Main>
+            <Main>
               <StyledForm
                 key={isSavedAlertRule(rule) ? rule.id : undefined}
                 onCancel={this.handleCancel}
@@ -1198,7 +1198,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                   )}
                 </List>
               </StyledForm>
-            </Layout.Main>
+            </Main>
           );
         }}
       </Access>
@@ -1346,4 +1346,8 @@ const StyledSelectField = styled(SelectField)<{hasAlertWizardV3?: boolean}>`
 
     margin-bottom: ${space(1)};
   `}
+`;
+
+const Main = styled(Layout.Main)`
+  padding: ${space(2)} ${space(4)};
 `;


### PR DESCRIPTION
Due to the requirement of having a separation line on the metric alert creation page, the padding on the parent was removed in #36043 and added to the metric alert `RuleForm` component. This component is not used for issue alerts so we need to add this padding for issue alerts as well.