### PR TITLE
feat(dashboards): Updates metric badge to Sampled and adds tooltip to Open in Discover buttons for CM widgets

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -980,6 +980,13 @@ function WidgetViewerModal(props: Props) {
                 priority="primary"
                 type="button"
                 disabled={isCustomMeasurementWidget(widget)}
+                title={
+                  isCustomMeasurementWidget(widget)
+                    ? t(
+                        'Widget using custom performance metrics cannot be opened in Discover.'
+                      )
+                    : undefined
+                }
                 onClick={() => {
                   trackAdvancedAnalyticsEvent(
                     'dashboards_views.widget_viewer.open_source',

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -983,7 +983,7 @@ function WidgetViewerModal(props: Props) {
                 title={
                   isCustomMeasurementWidget(widget)
                     ? t(
-                        'Widget using custom performance metrics cannot be opened in Discover.'
+                        'Widgets using custom performance metrics cannot be opened in Discover.'
                       )
                     : undefined
                 }

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -231,7 +231,7 @@ function WidgetCardContextMenu({
           <Feature organization={organization} features={['dashboards-mep']}>
             {isMetricsData === false && (
               <SampledTag
-                tooltipText={t('This widget is only applicable to sampled event data.')}
+                tooltipText={t('This widget is only applicable to sampled events.')}
               >
                 {t('Sampled')}
               </SampledTag>

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -10,6 +10,7 @@ import DropdownMenuControlV2 from 'sentry/components/dropdownMenuControlV2';
 import {MenuItemProps} from 'sentry/components/dropdownMenuItemV2';
 import {isWidgetViewerPath} from 'sentry/components/modals/widgetViewerModal/utils';
 import Tag from 'sentry/components/tag';
+import Tooltip from 'sentry/components/tooltip';
 import {IconEllipsis, IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -144,7 +145,18 @@ function WidgetCardContextMenu({
       const discoverPath = getWidgetDiscoverUrl(widget, selection, organization);
       menuOptions.push({
         key: 'open-in-discover',
-        label: t('Open in Discover'),
+        label: usingCustomMeasurements ? (
+          <Tooltip
+            skipWrapper
+            title={t(
+              'Widget using custom performance metrics cannot be opened in Discover.'
+            )}
+          >
+            {t('Open in Discover')}
+          </Tooltip>
+        ) : (
+          t('Open in Discover')
+        ),
         to:
           !usingCustomMeasurements && widget.queries.length === 1
             ? discoverPath
@@ -218,11 +230,11 @@ function WidgetCardContextMenu({
         <ContextWrapper>
           <Feature organization={organization} features={['dashboards-mep']}>
             {isMetricsData === false && (
-              <StoredTag
-                tooltipText={t('This widget is only applicable to stored event data.')}
+              <SampledTag
+                tooltipText={t('This widget is only applicable to sampled event data.')}
               >
-                {t('Stored')}
-              </StoredTag>
+                {t('Sampled')}
+              </SampledTag>
             )}
           </Feature>
           <StyledDropdownMenuControlV2
@@ -285,6 +297,6 @@ const OpenWidgetViewerButton = styled(Button)`
   }
 `;
 
-const StoredTag = styled(Tag)`
+const SampledTag = styled(Tag)`
   margin-right: ${space(0.5)};
 `;

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -643,7 +643,7 @@ describe('Dashboards > WidgetCard', function () {
 
     await waitFor(() => {
       // Badge in the widget header
-      expect(screen.getByText('Stored')).toBeInTheDocument();
+      expect(screen.getByText('Sampled')).toBeInTheDocument();
     });
 
     await waitFor(() => {
@@ -809,7 +809,7 @@ describe('Dashboards > WidgetCard', function () {
 
       await waitFor(() => {
         // Badge in the widget header
-        expect(screen.getByText('Stored')).toBeInTheDocument();
+        expect(screen.getByText('Sampled')).toBeInTheDocument();
       });
 
       await waitFor(() => {


### PR DESCRIPTION
Updates metric badge to Sampled and adds tooltip to Open in Discover buttons for CM widgets
![image](https://user-images.githubusercontent.com/83961295/177397717-6dbf18eb-fda0-4fd3-bbf9-c8aa30a8e7ae.png)
![image](https://user-images.githubusercontent.com/83961295/177397750-7b2966d7-93cf-412f-bec9-0b95a1a34372.png)
![image](https://user-images.githubusercontent.com/83961295/177397778-1229e857-762b-4bd5-81c9-d9a12e918aca.png)
