### PR TITLE
chore: Update sentry-relay version to get new categories

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,7 @@ rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-arroyo==0.2.0
-sentry-relay==0.8.12
+sentry-relay==0.8.13
 sentry-sdk==1.6.0
 snuba-sdk==1.0.0
 simplejson==3.17.6

--- a/tests/sentry/event_manager/interfaces/snapshots/test_frame/test_context_with_nan/neginf.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_frame/test_context_with_nan/neginf.pysnap
@@ -8,4 +8,4 @@ to_json:
   abs_path: x
   filename: x
   vars:
-    x: 0
+    x: -0.0


### PR DESCRIPTION
Updating sentry-relay will give us access to the new TransactionProcessed data category that we need in getsentry to track usage of dynamic sampling.
