### PR TITLE
fix(multi-region): Update org slug regex for new organizations

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -10,6 +10,7 @@ from sentry.api.base import Endpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.paginator import DateTimePaginator, OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.organization import BaseOrganizationSerializer
 from sentry.app import ratelimiter
 from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.query import in_iexact
@@ -24,9 +25,7 @@ from sentry.search.utils import tokenize_query
 from sentry.signals import terms_accepted
 
 
-class OrganizationSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=64, required=True)
-    slug = serializers.RegexField(r"^[a-z0-9_\-]+$", max_length=50, required=False)
+class OrganizationSerializer(BaseOrganizationSerializer):
     defaultTeam = serializers.BooleanField(required=False)
     agreeTerms = serializers.BooleanField(required=True)
 
@@ -34,6 +33,8 @@ class OrganizationSerializer(serializers.Serializer):
         super().__init__(*args, **kwargs)
         if not (settings.TERMS_URL and settings.PRIVACY_URL):
             del self.fields["agreeTerms"]
+        self.fields["slug"].required = False
+        self.fields["name"].required = True
 
     def validate_agreeTerms(self, value):
         if not value:

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -33,6 +33,7 @@ from sentry.constants import (
     REQUIRE_SCRUB_DATA_DEFAULT,
     REQUIRE_SCRUB_DEFAULTS_DEFAULT,
     REQUIRE_SCRUB_IP_ADDRESS_DEFAULT,
+    RESERVED_ORGANIZATION_SLUGS,
     SAFE_FIELDS_DEFAULT,
     SCRAPE_JAVASCRIPT_DEFAULT,
     SENSITIVE_FIELDS_DEFAULT,
@@ -57,6 +58,35 @@ _ORGANIZATION_SCOPE_PREFIX = "organizations:"
 
 if TYPE_CHECKING:
     from sentry.api.serializers import UserSerializerResponse, UserSerializerResponseSelf
+
+
+class BaseOrganizationSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=64)
+    slug = serializers.RegexField(r"^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$", max_length=50)
+
+    def validate_slug(self, value):
+        # Historically, the only check just made sure there was more than 1
+        # character for the slug, but since then, there are many slugs that
+        # fit within this new imposed limit. We're not fixing existing, but
+        # just preventing new bad values.
+        if len(value) < 3:
+            raise serializers.ValidationError(
+                f'This slug "{value}" is too short. Minimum of 3 characters.'
+            )
+        if value in RESERVED_ORGANIZATION_SLUGS:
+            raise serializers.ValidationError(f'This slug "{value}" is reserved and not allowed.')
+        qs = Organization.objects.filter(slug=value)
+        if "organization" in self.context:
+            qs = qs.exclude(id=self.context["organization"].id)
+        if qs.exists():
+            raise serializers.ValidationError(f'The slug "{value}" is already in use.')
+
+        contains_whitespace = any(c.isspace() for c in self.initial_data["slug"])
+        if contains_whitespace:
+            raise serializers.ValidationError(
+                f'The slug "{value}" should not contain any whitespace.'
+            )
+        return value
 
 
 class TrustedRelaySerializer(serializers.Serializer):  # type: ignore

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
     from sentry.api.serializers import UserSerializerResponse, UserSerializerResponseSelf
 
 
-class BaseOrganizationSerializer(serializers.Serializer):
+class BaseOrganizationSerializer(serializers.Serializer):  # type: ignore
     name = serializers.CharField(max_length=64)
     slug = serializers.RegexField(r"^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$", max_length=50)
 

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -64,7 +64,7 @@ class BaseOrganizationSerializer(serializers.Serializer):  # type: ignore
     name = serializers.CharField(max_length=64)
     slug = serializers.RegexField(r"^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$", max_length=50)
 
-    def validate_slug(self, value):
+    def validate_slug(self, value: str) -> str:
         # Historically, the only check just made sure there was more than 1
         # character for the slug, but since then, there are many slugs that
         # fit within this new imposed limit. We're not fixing existing, but

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -189,7 +189,8 @@ class Organization(Model):
         if not self.slug:
             lock = locks.get("slug:organization", duration=5, name="organization_slug")
             with TimedRetryPolicy(10)(lock.acquire):
-                slugify_instance(self, self.name, reserved=RESERVED_ORGANIZATION_SLUGS)
+                slugify_target = self.name.replace("_", "-").strip("-")
+                slugify_instance(self, slugify_target, reserved=RESERVED_ORGANIZATION_SLUGS)
             super().save(*args, **kwargs)
         else:
             super().save(*args, **kwargs)

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -95,7 +95,23 @@ class OrganizationsCreateTest(OrganizationIndexTest):
         assert org.name == "hello world"
         assert org.slug == "foobar"
 
-        self.get_error_response(status_code=409, **data)
+        self.get_error_response(status_code=400, **data)
+
+    def test_valid_slugs(self):
+        valid_slugs = ["santry", "downtown-canada", "1234", "SaNtRy"]
+        for slug in valid_slugs:
+            self.organization.refresh_from_db()
+            self.get_success_response(name=slug, slug=slug)
+
+    def test_invalid_slugs(self):
+        with self.options({"api.rate-limit.org-create": 9001}):
+            self.get_error_response(name="name", slug=" i have whitespace ", status_code=400)
+            self.get_error_response(name="name", slug="foo-bar ", status_code=400)
+            self.get_error_response(name="name", slug="bird-company!", status_code=400)
+            self.get_error_response(name="name", slug="downtown_canada", status_code=400)
+            self.get_error_response(name="name", slug="canada-", status_code=400)
+            self.get_error_response(name="name", slug="-canada", status_code=400)
+            self.get_error_response(name="name", slug="----", status_code=400)
 
     def test_without_slug(self):
         data = {"name": "hello world"}


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/35926.

The creation of new organizations didn't have their org slugs restricted.

I've consolidated the organization serializer such that we centralize the org slug regex in one spot. 