### PR TITLE
feat(2fa): support for upcoming 2fa backend change

### DIFF
--- a/fixtures/js-stubs/authenticators.js
+++ b/fixtures/js-stubs/authenticators.js
@@ -12,6 +12,7 @@ export function Authenticators() {
       configureButton: 'Info',
       name: 'Authenticator App',
       allowMultiEnrollment: false,
+      disallowNewEnrollment: false,
       authId: '15',
       canValidateOtp: true,
       isBackupInterface: false,
@@ -27,6 +28,7 @@ export function Authenticators() {
       configureButton: 'Info',
       id: 'sms',
       isBackupInterface: false,
+      disallowNewEnrollment: false,
       description:
         "This authenticator sends you text messages for verification.  It's useful as a backup method or when you do not have a phone that supports an authenticator application.",
       ...params,
@@ -43,6 +45,7 @@ export function Authenticators() {
       configureButton: 'Configure',
       name: 'U2F (Universal 2nd Factor)',
       allowMultiEnrollment: true,
+      disallowNewEnrollment: false,
       authId: '23',
       canValidateOtp: false,
       isBackupInterface: false,

--- a/static/app/types/auth.tsx
+++ b/static/app/types/auth.tsx
@@ -33,6 +33,10 @@ export type Authenticator = {
   description: string;
   devices: AuthenticatorDevice[];
   /**
+   * New enrollments of this 2FA interface are not allowed
+   */
+  disallowNewEnrollment: boolean;
+  /**
    * String used to display on button for user as CTA to enroll
    */
   enrollButton: string;

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -136,9 +136,13 @@ class AccountSecurity extends AsyncView<Props> {
                   description,
                   isBackupInterface,
                   isEnrolled,
+                  disallowNewEnrollment,
                   configureButton,
                   name,
                 } = auth;
+                if (disallowNewEnrollment && !isEnrolled) {
+                  return null;
+                }
                 return (
                   <AuthenticatorPanelItem key={id}>
                     <AuthenticatorHeader>

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -324,6 +324,26 @@ describe('AccountSecurity', function () {
     expect(wrapper.find('AuthenticatorName')).toHaveLength(2);
   });
 
+  it('renders primary interface if new enrollments are disallowed, but we are enrolled', function () {
+    Client.addMockResponse({
+      url: ENDPOINT,
+      body: [
+        TestStubs.Authenticators().Sms({isEnrolled: true, disallowNewEnrollment: true}),
+      ],
+    });
+
+    const wrapper = mountWithTheme(
+      <AccountSecurityWrapper>
+        <AccountSecurity />
+      </AccountSecurityWrapper>,
+      TestStubs.routerContext()
+    );
+
+    // Should still render the authenticator since we are already enrolled
+    expect(wrapper.find('AuthenticatorName')).toHaveLength(1);
+    expect(wrapper.find('AuthenticatorName').prop('children')).toBe('Text Message');
+  });
+
   it('renders a backup interface that is enrolled', function () {
     Client.addMockResponse({
       url: ENDPOINT,

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -303,6 +303,27 @@ describe('AccountSecurity', function () {
     expect(wrapper.find('TwoFactorRequired')).toHaveLength(1);
   });
 
+  it('does not render primary interface that disallows new enrollments', function () {
+    Client.addMockResponse({
+      url: ENDPOINT,
+      body: [
+        TestStubs.Authenticators().Totp({disallowNewEnrollment: false}),
+        TestStubs.Authenticators().U2f({disallowNewEnrollment: null}),
+        TestStubs.Authenticators().Sms({disallowNewEnrollment: true}),
+      ],
+    });
+
+    const wrapper = mountWithTheme(
+      <AccountSecurityWrapper>
+        <AccountSecurity />
+      </AccountSecurityWrapper>,
+      TestStubs.routerContext()
+    );
+
+    // There should only be two authenticators rendered
+    expect(wrapper.find('AuthenticatorName')).toHaveLength(2);
+  });
+
   it('renders a backup interface that is enrolled', function () {
     Client.addMockResponse({
       url: ENDPOINT,


### PR DESCRIPTION
(Backend PR: https://github.com/getsentry/sentry/pull/36344)

Introduce an option to disallow new enrollments for a particular 2FA interface. For example, if we want to start phasing out SMS, we can set the `sms.disallow-new-enrollment` option to `True`.

With this set to `True`:
- users already enrolled in SMS 2FA will still be able to authenticate using SMS 2FA
  - they will only be able to view or delete the SMS 2FA enrollment details
- users who were **not** already enrolled in SMS 2FA will not see the option to enroll in it

**Already enrolled in SMS 2FA**
<img width="717" alt="image" src="https://user-images.githubusercontent.com/20070360/177429508-7e17e7bb-f6d7-4d24-b7dd-7cf94512c88e.png">

**Not already enrolled in SMS 2FA**
<img width="795" alt="image" src="https://user-images.githubusercontent.com/20070360/177429582-52a3bd56-15bb-444a-a16b-fd6a480c4f21.png">
