### PR TITLE
chore(ci): drop pixelmatch

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -263,23 +263,6 @@ jobs:
         run: |
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
 
-      - name: Determine snapshot version
-        id: snapshot_ref
-        run: |
-          random=$(( ( RANDOM % 10 )  + 1 ));
-          echo "::set-output name=ref::$([[ $random -ge 9 ]] && echo "pixelmatch" || echo "odiff")"
-
-      - name: Diff snapshots
-        id: visual-snapshots-diff-pixelmatch
-        uses: getsentry/action-visual-snapshot@main
-        # Run this step only if there are acceptance related code changes
-        # Forks are handled in visual-diff.yml
-        if: steps.snapshot_ref.outputs.ref == 'pixelmatch' && needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'
-        with:
-          api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
-          gcs-bucket: 'sentry-visual-snapshots'
-          gcp-service-account-key: ${{ secrets.SNAPSHOT_GOOGLE_SERVICE_ACCOUNT_KEY }}
-
       - name: Diff snapshots
         id: visual-snapshots-diff-odiff
         uses: getsentry/action-visual-snapshot@905b7e3a7fdd913189b9a35dcef51b6b927f9598


### PR DESCRIPTION
Drops pixelmatch diffs - we still need to merge the actual PR to main branch on the visual snapshot repo so we still target a specific sha (I will update that to target a sha on master once the PR is merged)