### PR TITLE
feat(sampling): Add onboarding guides [TET-164]

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -23,6 +23,8 @@ GUIDES = {
     "new_page_filters": 24,
     "new_page_filters_pin": 25,
     "releases_widget": 26,
+    "activate_sampling_rule": 27,
+    "create_conditional_rule": 28,
 }
 
 # demo mode has different guides

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -226,6 +226,36 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
         },
       ],
     },
+    {
+      guide: 'activate_sampling_rule',
+      requiredTargets: ['sampling_rule_toggle'],
+      dateThreshold: new Date('2022-07-05'),
+      steps: [
+        {
+          title: t('Activate first rule'),
+          target: 'sampling_rule_toggle',
+          description: t('Rules will propagate within a few minutes.'),
+          nextText: t('Activate Rule'),
+          dismissText: t('Later'),
+          hasNextGuide: true,
+        },
+      ],
+    },
+    {
+      guide: 'create_conditional_rule',
+      requiredTargets: ['add_conditional_rule'],
+      dateThreshold: new Date('2022-07-05'),
+      steps: [
+        {
+          title: t('Create a new rule based on specific conditions'),
+          target: 'add_conditional_rule',
+          description: t(
+            'Target the transactions you want more details on (where your quota actually goes).'
+          ),
+          dismissText: t('Enough already'),
+        },
+      ],
+    },
   ];
 }
 

--- a/static/app/views/settings/project/server-side-sampling/rule.tsx
+++ b/static/app/views/settings/project/server-side-sampling/rule.tsx
@@ -118,7 +118,7 @@ export function Rule({
             // TODO(sampling): activate the rule
           }}
           // TODO(sampling): disable if sdks are not yet updated
-          disabled={!isUniform}
+          disabled={true || !isUniform}
         >
           <ActiveToggle
             inline={false}

--- a/static/app/views/settings/project/server-side-sampling/rule.tsx
+++ b/static/app/views/settings/project/server-side-sampling/rule.tsx
@@ -4,6 +4,7 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import MenuItemActionLink from 'sentry/components/actions/menuItemActionLink';
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
 import DropdownLink from 'sentry/components/dropdownLink';
 import NewBooleanField from 'sentry/components/forms/booleanField';
@@ -111,13 +112,22 @@ export function Rule({
         <SampleRate>{`${rule.sampleRate * 100}\u0025`}</SampleRate>
       </RateColumn>
       <ActiveColumn>
-        <ActiveToggle
-          inline={false}
-          hideControlState
-          aria-label={rule.active ? t('Deactivate Rule') : t('Activate Rule')}
-          onClick={onActivate}
-          name="active"
-        />
+        <GuideAnchor
+          target="sampling_rule_toggle"
+          onFinish={() => {
+            // TODO(sampling): activate the rule
+          }}
+          // TODO(sampling): disable if sdks are not yet updated
+          disabled={!isUniform}
+        >
+          <ActiveToggle
+            inline={false}
+            hideControlState
+            aria-label={rule.active ? t('Deactivate Rule') : t('Activate Rule')}
+            onClick={onActivate}
+            name="active"
+          />
+        </GuideAnchor>
       </ActiveColumn>
       <Column>
         <EllipisDropDownButton

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -5,6 +5,7 @@ import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
+import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {Panel, PanelFooter, PanelHeader} from 'sentry/components/panels';
@@ -283,19 +284,25 @@ export function ServerSideSampling({project}: Props) {
                   <Button href={SERVER_SIDE_SAMPLING_DOC_LINK} external>
                     {t('Read Docs')}
                   </Button>
-                  <AddRuleButton
-                    disabled={!hasAccess}
-                    title={
-                      !hasAccess
-                        ? t("You don't have permission to add a rule")
-                        : undefined
-                    }
-                    priority="primary"
-                    onClick={handleAddRule}
-                    icon={<IconAdd isCircled />}
+                  <GuideAnchor
+                    target="add_conditional_rule"
+                    // TODO(sampling): disable unless the base rule is active
+                    disabled={!hasAccess || rules.length !== 1}
                   >
-                    {t('Add Rule')}
-                  </AddRuleButton>
+                    <AddRuleButton
+                      disabled={!hasAccess}
+                      title={
+                        !hasAccess
+                          ? t("You don't have permission to add a rule")
+                          : undefined
+                      }
+                      priority="primary"
+                      onClick={handleAddRule}
+                      icon={<IconAdd isCircled />}
+                    >
+                      {t('Add Rule')}
+                    </AddRuleButton>
+                  </GuideAnchor>
                 </ButtonBar>
               </RulesPanelFooter>
             </Fragment>

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -287,7 +287,7 @@ export function ServerSideSampling({project}: Props) {
                   <GuideAnchor
                     target="add_conditional_rule"
                     // TODO(sampling): disable unless the base rule is active
-                    disabled={!hasAccess || rules.length !== 1}
+                    disabled={true || !hasAccess || rules.length !== 1}
                   >
                     <AddRuleButton
                       disabled={!hasAccess}


### PR DESCRIPTION
This PR adds the onbaording guides to the sampling page.

<img width="926" alt="image" src="https://user-images.githubusercontent.com/9060071/177537134-1c87d2b9-9fcb-49a4-83cb-7cca8385b1f0.png">

For now, they are always hidden. We'll need to add the activate condition in the follow-up PR once the backend work is finished.