### PR TITLE
feat(sampling): Add active rule without updated sdk alert [TET-164]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -121,6 +121,9 @@ export function ServerSideSampling({project}: Props) {
     })
     .filter(defined);
 
+  // TODO(sampling): test this after the backend work is finished
+  const atLeastOneRuleActive = rules.some(rule => rule.active);
+
   useEffect(() => {
     if (!isEqual(previousRules, currentRules)) {
       setRules(currentRules ?? []);
@@ -263,17 +266,21 @@ export function ServerSideSampling({project}: Props) {
         {!!recommendedSdkUpgrades.length && !!rules.length && (
           <Alert
             data-test-id="recommended-sdk-upgrades-alert"
-            type="info"
+            type={atLeastOneRuleActive ? 'error' : 'info'}
             showIcon
             trailingItems={
               <Button onClick={handleOpenRecommendedSteps} priority="link" borderless>
-                {t('Learn More')}
+                {atLeastOneRuleActive ? t('Resolve Now') : t('Learn More')}
               </Button>
             }
           >
-            {t(
-              'To keep a consistent amount of transactions across your applications multiple services, we recommend you update the SDK versions for the following projects:'
-            )}
+            {atLeastOneRuleActive
+              ? t(
+                  'Server-side sampling rules are in effect without the following SDK’s being updated to their latest version.'
+                )
+              : t(
+                  'To keep a consistent amount of transactions across your applications multiple services, we recommend you update the SDK versions for the following projects:'
+                )}
             <Projects>
               {recommendedSdkUpgrades.map(recommendedSdkUpgrade => (
                 <ProjectBadge

--- a/static/app/views/settings/project/server-side-sampling/utils/useSdkVersions.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/useSdkVersions.tsx
@@ -30,7 +30,7 @@ function useSdkVersions({orgSlug, projSlug, projectIds = []}: Props) {
           {
             method: 'GET',
             query: {
-              projects: projectIds,
+              project: projectIds,
             },
           }
         );


### PR DESCRIPTION
Adding the alert if there are active rules detected without updated SDKs.

![image](https://user-images.githubusercontent.com/9060071/177562489-dd3e1bef-130e-4392-b282-2e0436793683.png)
