### PR TITLE
ref(sampling): Fix infinite loop in the useSdkVersions hook

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment, useEffect, useMemo, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
@@ -77,12 +77,18 @@ export function ServerSideSampling({project}: Props) {
     projSlug: project.slug,
   });
 
+  const projectIds = useMemo(
+    () =>
+      samplingDistribution?.project_breakdown?.map(
+        projectBreakdown => projectBreakdown.project_id
+      ),
+    [samplingDistribution?.project_breakdown]
+  );
+
   const {samplingSdkVersions} = useSdkVersions({
     orgSlug: organization.slug,
     projSlug: project.slug,
-    projectIds: samplingDistribution?.project_breakdown?.map(
-      projectBreakdown => projectBreakdown.project_id
-    ),
+    projectIds,
   });
 
   const notSendingSampleRateSdkUpgrades =

--- a/static/app/views/settings/project/server-side-sampling/utils/useSdkVersions.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/useSdkVersions.tsx
@@ -19,11 +19,11 @@ function useSdkVersions({orgSlug, projSlug, projectIds = []}: Props) {
   >(undefined);
 
   useEffect(() => {
-    async function fetchSamplingSdkVersions() {
-      if (!projectIds.length) {
-        return;
-      }
+    if (!projectIds.length) {
+      return;
+    }
 
+    async function fetchSamplingSdkVersions() {
       try {
         const response = await api.requestPromise(
           `/organizations/${orgSlug}/dynamic-sampling/sdk-versions/`,


### PR DESCRIPTION
```
   projectIds: samplingDistribution?.project_breakdown?.map(
      projectBreakdown => projectBreakdown.project_id
    ),
```

the `projectIds` array was being created in all re-renders causing the constant to have a new reference and consequently triggering the fetch over and over again (infinite loop). This PR solves the issue 