### PR TITLE
feat(replays): Rewrite navtabs so click targets are bigger

### DIFF
--- a/static/app/components/replays/navTabs.tsx
+++ b/static/app/components/replays/navTabs.tsx
@@ -1,12 +1,14 @@
 import styled from '@emotion/styled';
 
+import space from 'sentry/styles/space';
+
 type Props = {
   underlined: boolean;
 };
 const NavTabs = styled('ul')<Props>`
-  margin: 0 0 20px;
+  margin: 0 0 ${space(3)};
   padding-left: 0;
-  font-size: 14px;
+  font-size: ${p => p.theme.fontSizeMedium};
   border-bottom: ${p => (p.underlined ? '1px solid #e2dee6' : 'none')};
 
   & > li {
@@ -18,7 +20,7 @@ const NavTabs = styled('ul')<Props>`
 
   & > li a {
     position: relative;
-    border-radius: 4px 4px 0 0;
+    border-radius: ${space(0.5)} ${space(0.5)} 0 0;
 
     display: flex;
     align-items: center;
@@ -50,7 +52,7 @@ const NavTabs = styled('ul')<Props>`
   }
 
   & > li.active a > span {
-    border-bottom: 4px solid ${p => p.theme.purple300};
+    border-bottom: ${space(0.5)} solid ${p => p.theme.purple300};
   }
 `;
 

--- a/static/app/components/replays/navTabs.tsx
+++ b/static/app/components/replays/navTabs.tsx
@@ -6,10 +6,10 @@ type Props = {
   underlined: boolean;
 };
 const NavTabs = styled('ul')<Props>`
+  border-bottom: ${p => (p.underlined ? '1px solid #e2dee6' : 'none')};
+  font-size: ${p => p.theme.fontSizeMedium};
   margin: 0 0 ${space(3)};
   padding-left: 0;
-  font-size: ${p => p.theme.fontSizeMedium};
-  border-bottom: ${p => (p.underlined ? '1px solid #e2dee6' : 'none')};
 
   & > li {
     float: left;
@@ -32,9 +32,11 @@ const NavTabs = styled('ul')<Props>`
     min-width: 30px;
     text-align: center;
   }
+
   & > li:first-child a {
     padding-left: 0;
   }
+
   & > li:last-child a {
     padding-right: 0;
   }
@@ -48,7 +50,7 @@ const NavTabs = styled('ul')<Props>`
     border: 0;
     background: none;
     color: #161319;
-    font-weight: 400;
+    font-weight: normal;
   }
 
   & > li.active a > span {

--- a/static/app/components/replays/navTabs.tsx
+++ b/static/app/components/replays/navTabs.tsx
@@ -1,0 +1,57 @@
+import styled from '@emotion/styled';
+
+type Props = {
+  underlined: boolean;
+};
+const NavTabs = styled('ul')<Props>`
+  margin: 0 0 20px;
+  padding-left: 0;
+  font-size: 14px;
+  border-bottom: ${p => (p.underlined ? '1px solid #e2dee6' : 'none')};
+
+  & > li {
+    float: left;
+    margin-bottom: -1px;
+    position: relative;
+    display: block;
+  }
+
+  & > li a {
+    position: relative;
+    border-radius: 4px 4px 0 0;
+
+    display: flex;
+    align-items: center;
+    padding: 0 10px 0;
+    margin: 0;
+    border: 0;
+    background: none;
+    color: #7c6a8e;
+    min-width: 30px;
+    text-align: center;
+  }
+  & > li:first-child a {
+    padding-left: 0;
+  }
+  & > li:last-child a {
+    padding-right: 0;
+  }
+
+  & > li a > span {
+    padding-bottom: 10px;
+  }
+
+  & > li.active a {
+    cursor: pointer;
+    border: 0;
+    background: none;
+    color: #161319;
+    font-weight: 400;
+  }
+
+  & > li.active a > span {
+    border-bottom: 4px solid ${p => p.theme.purple300};
+  }
+`;
+
+export default NavTabs;

--- a/static/app/views/replays/detail/focusTabs.tsx
+++ b/static/app/views/replays/detail/focusTabs.tsx
@@ -1,7 +1,7 @@
 import {MouseEvent} from 'react';
 import styled from '@emotion/styled';
 
-import NavTabs from 'sentry/components/navTabs';
+import NavTabs from 'sentry/components/replays/navTabs';
 import useActiveReplayTab, {
   ReplayTabs,
 } from 'sentry/utils/replays/hooks/useActiveReplayTab';
@@ -22,7 +22,7 @@ function FocusTabs({}: Props) {
               e.preventDefault();
             }}
           >
-            {label}
+            <span>{label}</span>
           </a>
         </Tab>
       ))}


### PR DESCRIPTION
**Before** the the NavTabs had smaller click targets, and the gap between each tab meant that our section resizer was always getting :hover triggered and the background color changed.

small click target:
<img width="341" alt="Screen Shot 2022-07-06 at 6 11 12 PM" src="https://user-images.githubusercontent.com/187460/177596167-cd3889e6-8035-42f5-bf5e-918aa704360a.png">

**Now** the click targets are bigger, and if you're mousing over the tabs then you won't trigger :hover on anything in the background:
<img width="295" alt="Screen Shot 2022-07-06 at 6 10 49 PM" src="https://user-images.githubusercontent.com/187460/177596266-eeedbdf4-96ad-41bd-9608-9ab5b4e5356d.png">

