### PR TITLE
feat(profiling): split hovered and selected states

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -22,14 +22,14 @@ interface FrameStackProps {
 
 const FrameStack = memo(function FrameStack(props: FrameStackProps) {
   const theme = useFlamegraphTheme();
-  const {root} = useFlamegraphProfilesValue();
+  const {selectedRoot} = useFlamegraphProfilesValue();
 
   const [tab, setTab] = useState<'bottom up' | 'call order'>('call order');
   const [treeType, setTreeType] = useState<'all' | 'application' | 'system'>('all');
   const [recursion, setRecursion] = useState<'collapsed' | null>(null);
 
   const roots: FlamegraphFrame[] | null = useMemo(() => {
-    if (!root) {
+    if (!selectedRoot) {
       return null;
     }
 
@@ -41,14 +41,16 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
         : () => false;
 
     const maybeFilteredRoots =
-      treeType !== 'all' ? filterFlamegraphTree([root], skipFunction) : [root];
+      treeType !== 'all'
+        ? filterFlamegraphTree([selectedRoot], skipFunction)
+        : [selectedRoot];
 
     if (tab === 'call order') {
       return maybeFilteredRoots;
     }
 
     return invertCallTree(maybeFilteredRoots);
-  }, [root, tab, treeType]);
+  }, [selectedRoot, tab, treeType]);
 
   const handleRecursionChange = useCallback(
     (evt: React.ChangeEvent<HTMLInputElement>) => {
@@ -82,7 +84,7 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
     minHeight: 30,
   });
 
-  return root ? (
+  return selectedRoot ? (
     <FrameDrawer
       style={{
         height,
@@ -157,7 +159,7 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
         {...props}
         recursion={recursion}
         roots={roots ?? []}
-        referenceNode={root}
+        referenceNode={selectedRoot}
         canvasPoolManager={props.canvasPoolManager}
       />
     </FrameDrawer>

--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -22,14 +22,14 @@ interface FrameStackProps {
 
 const FrameStack = memo(function FrameStack(props: FrameStackProps) {
   const theme = useFlamegraphTheme();
-  const {selectedNode} = useFlamegraphProfilesValue();
+  const {root} = useFlamegraphProfilesValue();
 
   const [tab, setTab] = useState<'bottom up' | 'call order'>('call order');
   const [treeType, setTreeType] = useState<'all' | 'application' | 'system'>('all');
   const [recursion, setRecursion] = useState<'collapsed' | null>(null);
 
   const roots: FlamegraphFrame[] | null = useMemo(() => {
-    if (!selectedNode) {
+    if (!root) {
       return null;
     }
 
@@ -41,16 +41,14 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
         : () => false;
 
     const maybeFilteredRoots =
-      treeType !== 'all'
-        ? filterFlamegraphTree([selectedNode], skipFunction)
-        : [selectedNode];
+      treeType !== 'all' ? filterFlamegraphTree([root], skipFunction) : [root];
 
     if (tab === 'call order') {
       return maybeFilteredRoots;
     }
 
     return invertCallTree(maybeFilteredRoots);
-  }, [selectedNode, tab, treeType]);
+  }, [root, tab, treeType]);
 
   const handleRecursionChange = useCallback(
     (evt: React.ChangeEvent<HTMLInputElement>) => {
@@ -84,7 +82,7 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
     minHeight: 30,
   });
 
-  return selectedNode ? (
+  return root ? (
     <FrameDrawer
       style={{
         height,
@@ -159,7 +157,7 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
         {...props}
         recursion={recursion}
         roots={roots ?? []}
-        referenceNode={selectedNode}
+        referenceNode={root}
         canvasPoolManager={props.canvasPoolManager}
       />
     </FrameDrawer>

--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -156,6 +156,7 @@ function FlamegraphSearch({
   const onZoomIntoFrame = useCallback(
     (frame: FlamegraphFrame) => {
       canvasPoolManager.dispatch('zoomIntoFrame', [frame, 'min']);
+      canvasPoolManager.dispatch('highlightFrame', [frame, 'selected']);
     },
     [canvasPoolManager]
   );

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -476,15 +476,15 @@ function FlamegraphZoomView({
       if (lastInteraction === 'click') {
         if (
           hoveredNode &&
-          flamegraphState.profiles.root &&
-          hoveredNode === flamegraphState.profiles.root
+          flamegraphState.profiles.selectedRoot &&
+          hoveredNode === flamegraphState.profiles.selectedRoot
         ) {
           // If double click is fired on a node, then zoom into it
           canvasPoolManager.dispatch('zoomIntoFrame', [hoveredNode, 'exact']);
         }
 
         canvasPoolManager.dispatch('highlightFrame', [hoveredNode, 'selected']);
-        dispatchFlamegraphState({type: 'set root node', payload: hoveredNode});
+        dispatchFlamegraphState({type: 'set selected root', payload: hoveredNode});
       }
 
       setLastInteraction(null);
@@ -492,7 +492,7 @@ function FlamegraphZoomView({
     },
     [
       configSpaceCursor,
-      flamegraphState.profiles.root,
+      flamegraphState.profiles.selectedRoot,
       dispatchFlamegraphState,
       hoveredNode,
       canvasPoolManager,

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -310,13 +310,8 @@ function FlamegraphZoomView({
     flamegraphTheme,
     textRenderer,
     gridRenderer,
-<<<<<<< HEAD
-    sampleTickRenderer,
-    flamegraphState.profiles.selectedNode,
-    hoveredNode,
-=======
->>>>>>> e01f5136b2 (feat(profiling): split highlighted node draw from selected node)
     selectedFrameRenderer,
+    sampleTickRenderer,
     canvasPoolManager,
     flamegraphSearch,
   ]);

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -26,6 +26,8 @@ import {SelectedFrameRenderer} from 'sentry/utils/profiling/renderers/selectedFr
 import {TextRenderer} from 'sentry/utils/profiling/renderers/textRenderer';
 import usePrevious from 'sentry/utils/usePrevious';
 
+import {FlamegraphFrame} from '../../utils/profiling/flamegraphFrame';
+
 import {BoundTooltip} from './boundTooltip';
 import {FlamegraphOptionsContextMenu} from './flamegraphOptionsContextMenu';
 
@@ -247,13 +249,7 @@ function FlamegraphZoomView({
   ]);
 
   useEffect(() => {
-    if (
-      !flamegraphCanvas ||
-      !flamegraphView ||
-      !textRenderer ||
-      !gridRenderer ||
-      !selectedFrameRenderer
-    ) {
+    if (!flamegraphCanvas || !flamegraphView || !textRenderer || !gridRenderer) {
       return undefined;
     }
 
@@ -264,41 +260,6 @@ function FlamegraphZoomView({
         textRenderer.canvas.width,
         textRenderer.canvas.height
       );
-    };
-
-    const drawSelectedFrameBorder = () => {
-      if (flamegraphState.profiles.selectedNode) {
-        selectedFrameRenderer.draw(
-          new Rect(
-            flamegraphState.profiles.selectedNode.start,
-            flamegraphState.profiles.selectedNode.depth,
-            flamegraphState.profiles.selectedNode.end -
-              flamegraphState.profiles.selectedNode.start,
-            1
-          ),
-          {
-            BORDER_COLOR: flamegraphTheme.COLORS.SELECTED_FRAME_BORDER_COLOR,
-            BORDER_WIDTH: flamegraphTheme.SIZES.FRAME_BORDER_WIDTH,
-          },
-          flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
-        );
-      }
-
-      if (hoveredNode && flamegraphState.profiles.selectedNode !== hoveredNode) {
-        selectedFrameRenderer.draw(
-          new Rect(
-            hoveredNode.start,
-            hoveredNode.depth,
-            hoveredNode.end - hoveredNode.start,
-            1
-          ),
-          {
-            BORDER_COLOR: flamegraphTheme.COLORS.HOVERED_FRAME_BORDER_COLOR,
-            BORDER_WIDTH: flamegraphTheme.SIZES.HOVERED_FRAME_BORDER_WIDTH,
-          },
-          flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
-        );
-      }
     };
 
     const drawText = () => {
@@ -329,7 +290,6 @@ function FlamegraphZoomView({
     };
 
     scheduler.registerBeforeFrameCallback(clearOverlayCanvas);
-    scheduler.registerBeforeFrameCallback(drawSelectedFrameBorder);
     scheduler.registerAfterFrameCallback(drawText);
     scheduler.registerAfterFrameCallback(drawGrid);
     scheduler.registerAfterFrameCallback(drawInternalSampleTicks);
@@ -338,7 +298,6 @@ function FlamegraphZoomView({
 
     return () => {
       scheduler.unregisterBeforeFrameCallback(clearOverlayCanvas);
-      scheduler.unregisterBeforeFrameCallback(drawSelectedFrameBorder);
       scheduler.unregisterAfterFrameCallback(drawText);
       scheduler.unregisterAfterFrameCallback(drawGrid);
       scheduler.unregisterAfterFrameCallback(drawInternalSampleTicks);
@@ -351,11 +310,105 @@ function FlamegraphZoomView({
     flamegraphTheme,
     textRenderer,
     gridRenderer,
+<<<<<<< HEAD
     sampleTickRenderer,
     flamegraphState.profiles.selectedNode,
     hoveredNode,
+=======
+>>>>>>> e01f5136b2 (feat(profiling): split highlighted node draw from selected node)
     selectedFrameRenderer,
+    canvasPoolManager,
     flamegraphSearch,
+  ]);
+
+  useEffect(() => {
+    if (!flamegraphCanvas || !flamegraphView || !selectedFrameRenderer) {
+      return undefined;
+    }
+
+    const state: {selectedNode: FlamegraphFrame | null} = {
+      selectedNode: null,
+    };
+
+    const onNodeHighlight = (
+      node: FlamegraphFrame | null,
+      mode: 'hover' | 'selected'
+    ) => {
+      if (mode === 'selected') {
+        state.selectedNode = node;
+      }
+      scheduler.draw();
+    };
+
+    const drawSelectedFrameBorder = () => {
+      if (state.selectedNode) {
+        selectedFrameRenderer.draw(
+          new Rect(
+            state.selectedNode.start,
+            state.selectedNode.depth,
+            state.selectedNode.end - state.selectedNode.start,
+            1
+          ),
+          {
+            BORDER_COLOR: flamegraphTheme.COLORS.SELECTED_FRAME_BORDER_COLOR,
+            BORDER_WIDTH: flamegraphTheme.SIZES.FRAME_BORDER_WIDTH,
+          },
+          flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
+        );
+      }
+    };
+
+    scheduler.on('highlightFrame', onNodeHighlight);
+    scheduler.registerAfterFrameCallback(drawSelectedFrameBorder);
+
+    return () => {
+      scheduler.off('highlightFrame', onNodeHighlight);
+      scheduler.unregisterAfterFrameCallback(drawSelectedFrameBorder);
+    };
+  }, [
+    flamegraphView,
+    flamegraphCanvas,
+    scheduler,
+    selectedFrameRenderer,
+    flamegraphTheme,
+  ]);
+
+  useEffect(() => {
+    if (!flamegraphCanvas || !flamegraphView || !selectedFrameRenderer) {
+      return undefined;
+    }
+
+    const drawHoveredFrameBorder = () => {
+      if (hoveredNode) {
+        selectedFrameRenderer.draw(
+          new Rect(
+            hoveredNode.start,
+            hoveredNode.depth,
+            hoveredNode.end - hoveredNode.start,
+            1
+          ),
+          {
+            BORDER_COLOR: flamegraphTheme.COLORS.HOVERED_FRAME_BORDER_COLOR,
+            BORDER_WIDTH: flamegraphTheme.SIZES.HOVERED_FRAME_BORDER_WIDTH,
+          },
+          flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
+        );
+      }
+    };
+
+    scheduler.registerAfterFrameCallback(drawHoveredFrameBorder);
+    scheduler.draw();
+
+    return () => {
+      scheduler.unregisterAfterFrameCallback(drawHoveredFrameBorder);
+    };
+  }, [
+    flamegraphView,
+    flamegraphCanvas,
+    scheduler,
+    hoveredNode,
+    selectedFrameRenderer,
+    flamegraphTheme,
   ]);
 
   useEffect(() => {
@@ -423,13 +476,15 @@ function FlamegraphZoomView({
       if (lastInteraction === 'click') {
         if (
           hoveredNode &&
-          flamegraphState.profiles.selectedNode &&
-          hoveredNode === flamegraphState.profiles.selectedNode
+          flamegraphState.profiles.root &&
+          hoveredNode === flamegraphState.profiles.root
         ) {
+          // If double click is fired on a node, then zoom into it
           canvasPoolManager.dispatch('zoomIntoFrame', [hoveredNode, 'exact']);
         }
-        canvasPoolManager.dispatch('setSelectedNode', [hoveredNode]);
-        dispatchFlamegraphState({type: 'set selected node', payload: hoveredNode});
+
+        canvasPoolManager.dispatch('highlightFrame', [hoveredNode, 'selected']);
+        dispatchFlamegraphState({type: 'set root node', payload: hoveredNode});
       }
 
       setLastInteraction(null);
@@ -437,7 +492,7 @@ function FlamegraphZoomView({
     },
     [
       configSpaceCursor,
-      flamegraphState.profiles.selectedNode,
+      flamegraphState.profiles.root,
       dispatchFlamegraphState,
       hoveredNode,
       canvasPoolManager,

--- a/static/app/utils/profiling/canvasScheduler.tsx
+++ b/static/app/utils/profiling/canvasScheduler.tsx
@@ -7,9 +7,9 @@ type DrawFn = () => void;
 type ArgumentTypes<F> = F extends (...args: infer A) => any ? A : never;
 
 export interface FlamegraphEvents {
+  highlightFrame: (frame: FlamegraphFrame | null, mode: 'hover' | 'selected') => void;
   resetZoom: () => void;
   setConfigView: (configView: Rect) => void;
-  setSelectedNode: (frame: FlamegraphFrame | null) => void;
   transformConfigView: (transform: mat3) => void;
   zoomIntoFrame: (frame: FlamegraphFrame, strategy: 'min' | 'exact') => void;
 }
@@ -25,7 +25,7 @@ export class CanvasScheduler {
 
   events: EventStore = {
     resetZoom: new Set<FlamegraphEvents['resetZoom']>(),
-    setSelectedNode: new Set<FlamegraphEvents['setSelectedNode']>(),
+    highlightFrame: new Set<FlamegraphEvents['highlightFrame']>(),
     setConfigView: new Set<FlamegraphEvents['setConfigView']>(),
     transformConfigView: new Set<FlamegraphEvents['transformConfigView']>(),
     zoomIntoFrame: new Set<FlamegraphEvents['zoomIntoFrame']>(),

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
@@ -5,24 +5,15 @@ type SetProfilesActiveIndex = {
   type: 'set thread id';
 };
 
-type SetSelectedNode = {
+type SetRootNode = {
   payload: FlamegraphFrame | null;
-  type: 'set selected node';
+  type: 'set root node';
 };
 
-type SetHighlightedNode = {
-  payload: FlamegraphFrame | null;
-  type: 'set highlighted node';
-};
-
-type FlamegraphProfilesAction =
-  | SetProfilesActiveIndex
-  | SetSelectedNode
-  | SetHighlightedNode;
+type FlamegraphProfilesAction = SetProfilesActiveIndex | SetRootNode;
 
 type FlamegraphProfilesState = {
-  highlightedNode: FlamegraphFrame | null;
-  selectedNode: FlamegraphFrame | null;
+  root: FlamegraphFrame | null;
   threadId: number | null;
 };
 
@@ -31,17 +22,14 @@ export function flamegraphProfilesReducer(
   action: FlamegraphProfilesAction
 ): FlamegraphProfilesState {
   switch (action.type) {
-    case 'set selected node': {
-      return {...state, selectedNode: action.payload};
-    }
-    case 'set highlighted node': {
-      return {...state, highlightedNode: action.payload};
+    case 'set root node': {
+      return {...state, root: action.payload};
     }
     case 'set thread id': {
       // When the profile index changes, we want to drop the selected and hovered nodes
       return {
         ...state,
-        selectedNode: null,
+        root: null,
         threadId: action.payload,
       };
     }

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
@@ -7,13 +7,13 @@ type SetProfilesActiveIndex = {
 
 type SetRootNode = {
   payload: FlamegraphFrame | null;
-  type: 'set root node';
+  type: 'set selected root';
 };
 
 type FlamegraphProfilesAction = SetProfilesActiveIndex | SetRootNode;
 
 type FlamegraphProfilesState = {
-  root: FlamegraphFrame | null;
+  selectedRoot: FlamegraphFrame | null;
   threadId: number | null;
 };
 
@@ -22,14 +22,14 @@ export function flamegraphProfilesReducer(
   action: FlamegraphProfilesAction
 ): FlamegraphProfilesState {
   switch (action.type) {
-    case 'set root node': {
-      return {...state, root: action.payload};
+    case 'set selected root': {
+      return {...state, selectedRoot: action.payload};
     }
     case 'set thread id': {
       // When the profile index changes, we want to drop the selected and hovered nodes
       return {
         ...state,
-        root: null,
+        selectedRoot: null,
         threadId: action.payload,
       };
     }

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
@@ -10,9 +10,18 @@ type SetSelectedNode = {
   type: 'set selected node';
 };
 
-type FlamegraphProfilesAction = SetProfilesActiveIndex | SetSelectedNode;
+type SetHighlightedNode = {
+  payload: FlamegraphFrame | null;
+  type: 'set highlighted node';
+};
+
+type FlamegraphProfilesAction =
+  | SetProfilesActiveIndex
+  | SetSelectedNode
+  | SetHighlightedNode;
 
 type FlamegraphProfilesState = {
+  highlightedNode: FlamegraphFrame | null;
   selectedNode: FlamegraphFrame | null;
   threadId: number | null;
 };
@@ -24,6 +33,9 @@ export function flamegraphProfilesReducer(
   switch (action.type) {
     case 'set selected node': {
       return {...state, selectedNode: action.payload};
+    }
+    case 'set highlighted node': {
+      return {...state, highlightedNode: action.payload};
     }
     case 'set thread id': {
       // When the profile index changes, we want to drop the selected and hovered nodes

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -164,7 +164,7 @@ interface FlamegraphStateProviderProps {
 const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
   profiles: {
     threadId: null,
-    selectedNode: null,
+    root: null,
   },
   position: {
     view: Rect.Empty(),
@@ -188,8 +188,7 @@ export function FlamegraphStateProvider(
   const [profileGroup] = useProfileGroup();
   const reducer = useUndoableReducer(combinedReducers, {
     profiles: {
-      selectedNode: null,
-      highlightedNode: null,
+      root: null,
       threadId:
         props.initialState?.profiles?.threadId ??
         DEFAULT_FLAMEGRAPH_STATE.profiles.threadId,

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -164,7 +164,7 @@ interface FlamegraphStateProviderProps {
 const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
   profiles: {
     threadId: null,
-    root: null,
+    selectedRoot: null,
   },
   position: {
     view: Rect.Empty(),
@@ -188,7 +188,7 @@ export function FlamegraphStateProvider(
   const [profileGroup] = useProfileGroup();
   const reducer = useUndoableReducer(combinedReducers, {
     profiles: {
-      root: null,
+      selectedRoot: null,
       threadId:
         props.initialState?.profiles?.threadId ??
         DEFAULT_FLAMEGRAPH_STATE.profiles.threadId,

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -189,6 +189,7 @@ export function FlamegraphStateProvider(
   const reducer = useUndoableReducer(combinedReducers, {
     profiles: {
       selectedNode: null,
+      highlightedNode: null,
       threadId:
         props.initialState?.profiles?.threadId ??
         DEFAULT_FLAMEGRAPH_STATE.profiles.threadId,

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -663,7 +663,7 @@ export function computeConfigViewWithStategy(
       return view;
     }
 
-    let offset = view;
+    let offset = view.clone();
     if (frame.left < view.left) {
       // If frame is to the left of the view, translate it left
       // to frame.x so that start of the frame is in the view

--- a/tests/js/spec/utils/profiling/canvasScheduler.spec.tsx
+++ b/tests/js/spec/utils/profiling/canvasScheduler.spec.tsx
@@ -3,7 +3,7 @@ import {CanvasScheduler, FlamegraphEvents} from 'sentry/utils/profiling/canvasSc
 const handlers: (keyof FlamegraphEvents)[] = [
   'resetZoom',
   'setConfigView',
-  'setSelectedNode',
+  'highlightFrame',
   'transformConfigView',
   'zoomIntoFrame',
 ];


### PR DESCRIPTION
It has always bothered me that a highlighted node was implicitly also a selected node. This PR adds the ability to arbitrarily highlight any node on the chart without having to set is as selected. By decoupling the two, we can implement cycling through search results without changing the selected node that the user has clicked and only change its visual state. 

Something I noticed was that we were depending on hoveredNode in our useEffect, which meant that we were creating most draw calls each time a user moved the cursor. I split those apart so that they can be treated atomically and redraw independently.