### PR TITLE
fix(redis): Disconnect from the redis cluster after buffer service validation

### DIFF
--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -63,6 +63,8 @@ class RedisBuffer(Buffer):
             # wait 10 seconds at most
             with self.cluster.all(timeout=10) as client:
                 client.ping()
+            # disconnect after successfull service validation
+            self.cluster.disconnect_pools()
         except Exception as e:
             raise InvalidConfiguration(str(e))
 


### PR DESCRIPTION
Most parts of the application do not use buffer service so there's no need to keep the connections around after validation. A new connection(s) will be open when needed.