### PR TITLE
chore(deletion) Pause organization deletions part 2

### DIFF
--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -84,12 +84,18 @@ def run_deletion(deletion_id, first_pass=True):
         deletion.delete()
         return
 
+    if deletion.model_name == "Organization":
+        # TODO(mark) Organization deletions are temporarily disabled.
+        # We had a bad data used to schedule deletions for organizations in bulk.
+        return
+
     task = deletions.get(
         model=deletion.get_model(),
         query={"id": deletion.object_id},
         transaction_id=deletion.guid,
         actor_id=deletion.actor_id,
     )
+
     if not task.should_proceed(instance):
         logger.info(
             "object.delete.aborted",

--- a/tests/sentry/deletions/test_organization.py
+++ b/tests/sentry/deletions/test_organization.py
@@ -1,5 +1,7 @@
 from uuid import uuid4
 
+import pytest
+
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 from sentry.incidents.models import AlertRule, AlertRuleStatus
 from sentry.models import (
@@ -29,6 +31,7 @@ from sentry.testutils import TransactionTestCase
 
 
 class DeleteOrganizationTest(TransactionTestCase):
+    @pytest.mark.xfail(reason="org deletions are temporarily paused")
     def test_simple(self):
         org = self.create_organization(name="test")
         org2 = self.create_organization(name="test2")
@@ -110,6 +113,7 @@ class DeleteOrganizationTest(TransactionTestCase):
             id__in=[widget_1_data.id, widget_2_data_1.id, widget_2_data_2.id]
         ).exists()
 
+    @pytest.mark.xfail(reason="org deletions are temporarily paused")
     def test_no_delete_visible(self):
         org = self.create_organization(name="test")
         release = Release.objects.create(version="a" * 32, organization_id=org.id)
@@ -125,6 +129,7 @@ class DeleteOrganizationTest(TransactionTestCase):
         assert Release.objects.filter(id=release.id).exists()
         assert not ScheduledDeletion.objects.filter(id=deletion.id).exists()
 
+    @pytest.mark.xfail(reason="org deletions are temporarily paused")
     def test_large_child_relation_deletion(self):
         org = self.create_organization(name="test")
         self.create_team(organization=org, name="test1")
@@ -153,6 +158,7 @@ class DeleteOrganizationTest(TransactionTestCase):
         assert not Commit.objects.filter(organization_id=org.id).exists()
         assert not CommitAuthor.objects.filter(organization_id=org.id).exists()
 
+    @pytest.mark.xfail(reason="org deletions are temporarily paused")
     def test_group_first_release(self):
         org = self.create_organization(name="test")
         project = self.create_project(organization=org)
@@ -172,6 +178,7 @@ class DeleteOrganizationTest(TransactionTestCase):
         assert not Group.objects.filter(id=group.id).exists()
         assert not Organization.objects.filter(id=org.id).exists()
 
+    @pytest.mark.xfail(reason="org deletions are temporarily paused")
     def test_orphan_commits(self):
         # We have had a few orgs get into a state where they have commits
         # but no repositories. Ensure that we can proceed.
@@ -199,6 +206,7 @@ class DeleteOrganizationTest(TransactionTestCase):
         assert not Commit.objects.filter(id=commit.id).exists()
         assert not CommitAuthor.objects.filter(id=author.id).exists()
 
+    @pytest.mark.xfail(reason="org deletions are temporarily paused")
     def test_alert_rule(self):
         org = self.create_organization(name="test", owner=self.user)
         self.create_team(organization=org, name="test1")
@@ -228,6 +236,7 @@ class DeleteOrganizationTest(TransactionTestCase):
         assert not AlertRule.objects.filter(id=alert_rule.id).exists()
         assert not SnubaQuery.objects.filter(id=snuba_query.id).exists()
 
+    @pytest.mark.xfail(reason="org deletions are temporarily paused")
     def test_discover_query_cleanup(self):
         org = self.create_organization(name="test", owner=self.user)
         self.create_team(organization=org, name="test1")
@@ -253,6 +262,7 @@ class DeleteOrganizationTest(TransactionTestCase):
         assert not DiscoverSavedQuery.objects.filter(id=query.id).exists()
         assert not DiscoverSavedQueryProject.objects.filter(id=query_project.id).exists()
 
+    @pytest.mark.xfail(reason="org deletions are temporarily paused")
     def test_delete_org_simple(self):
         name_filter = {"name": "test_delete_org_simple"}
         org = self.create_organization(**name_filter)
@@ -269,6 +279,7 @@ class DeleteOrganizationTest(TransactionTestCase):
 
         assert Organization.objects.filter(**name_filter).count() == 0
 
+    @pytest.mark.xfail(reason="org deletions are temporarily paused")
     def test_delete_org_after_project_transfer(self):
         from_org = self.create_organization(name="from_org")
         from_user = self.create_user()


### PR DESCRIPTION
Revert "Revert "chore(deletion) Pause organization deletions (#36377)""

This reverts commit ad6a411e66fc190f98968f23d1724590571788e3. which
failed getsentry master because of a dependent test.