### PR TITLE
feat(multi-region): Add `sentryUrl` and `organizationUrl` to config

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -117,18 +117,18 @@ def is_member_disabled_from_limit(request, organization):
 
 def generate_organization_hostname(org_slug: str) -> str:
     url_prefix_hostname = urlparse(options.get("system.url-prefix")).netloc
-    customer_base_hostname_template = options.get("system.organization-base-hostname")
-    if not customer_base_hostname_template:
+    org_base_hostname_template = options.get("system.organization-base-hostname")
+    if not org_base_hostname_template:
         return url_prefix_hostname
-    if "{slug}" not in customer_base_hostname_template:
+    if "{slug}" not in org_base_hostname_template:
         return url_prefix_hostname
-    customer_hostname = customer_base_hostname_template.replace("{slug}", org_slug)
-    if "{region}" in customer_base_hostname_template:
+    org_hostname = org_base_hostname_template.replace("{slug}", org_slug)
+    if "{region}" in org_base_hostname_template:
         region = options.get("system.region") or None
         if region is None:
             return url_prefix_hostname
-        customer_hostname = customer_hostname.replace("{region}", region)
-    return customer_hostname
+        org_hostname = org_hostname.replace("{region}", region)
+    return org_hostname
 
 
 def generate_organization_url(org_slug: str) -> str:

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -131,8 +131,8 @@ def generate_customer_hostname(org_slug: str) -> str:
     return customer_hostname
 
 
-def generate_customer_url(org_slug: str) -> str:
-    customer_url_template = options.get("system.customer-url-template")
-    if not customer_url_template:
+def generate_organization_url(org_slug: str) -> str:
+    org_url_template = options.get("system.customer-url-template")
+    if not org_url_template:
         return options.get("system.url-prefix")
-    return customer_url_template.replace("{hostname}", generate_customer_hostname(org_slug))
+    return org_url_template.replace("{hostname}", generate_customer_hostname(org_slug))

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -132,7 +132,7 @@ def generate_organization_hostname(org_slug: str) -> str:
 
 
 def generate_organization_url(org_slug: str) -> str:
-    org_url_template = options.get("system.customer-url-template")
+    org_url_template = options.get("system.organization-url-template")
     if not org_url_template:
         return options.get("system.url-prefix")
     return org_url_template.replace("{hostname}", generate_organization_hostname(org_slug))

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -129,3 +129,10 @@ def generate_customer_hostname(org_slug: str) -> str:
             return url_prefix_hostname
         customer_hostname = customer_hostname.replace("{region}", region)
     return customer_hostname
+
+
+def generate_customer_url(org_slug: str) -> str:
+    customer_url_template = options.get("system.customer-url-template")
+    if not customer_url_template:
+        return options.get("system.url-prefix")
+    return customer_url_template.replace("{hostname}", generate_customer_hostname(org_slug))

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -115,7 +115,7 @@ def is_member_disabled_from_limit(request, organization):
         return member.flags["member-limit:restricted"]
 
 
-def generate_customer_hostname(org_slug: str) -> str:
+def generate_organization_hostname(org_slug: str) -> str:
     url_prefix_hostname = urlparse(options.get("system.url-prefix")).netloc
     customer_base_hostname_template = options.get("system.organization-base-hostname")
     if not customer_base_hostname_template:
@@ -135,4 +135,4 @@ def generate_organization_url(org_slug: str) -> str:
     org_url_template = options.get("system.customer-url-template")
     if not org_url_template:
         return options.get("system.url-prefix")
-    return org_url_template.replace("{hostname}", generate_customer_hostname(org_slug))
+    return org_url_template.replace("{hostname}", generate_organization_hostname(org_slug))

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -120,14 +120,13 @@ def generate_organization_hostname(org_slug: str) -> str:
     org_base_hostname_template = options.get("system.organization-base-hostname")
     if not org_base_hostname_template:
         return url_prefix_hostname
-    if "{slug}" not in org_base_hostname_template:
+    if "{slug}" not in org_base_hostname_template or "{region}" not in org_base_hostname_template:
         return url_prefix_hostname
     org_hostname = org_base_hostname_template.replace("{slug}", org_slug)
-    if "{region}" in org_base_hostname_template:
-        region = options.get("system.region") or None
-        if region is None:
-            return url_prefix_hostname
-        org_hostname = org_hostname.replace("{region}", region)
+    region = options.get("system.region") or None
+    if region is None:
+        return url_prefix_hostname
+    org_hostname = org_hostname.replace("{region}", region)
     return org_hostname
 
 

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -1,8 +1,10 @@
 import logging
 from datetime import timedelta
+from urllib.parse import urlparse
 
 from django.utils import timezone
 
+from sentry import options
 from sentry.auth.access import get_cached_organization_member
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import OrganizationMember
@@ -111,3 +113,19 @@ def is_member_disabled_from_limit(request, organization):
         return False
     else:
         return member.flags["member-limit:restricted"]
+
+
+def generate_customer_hostname(org_slug: str) -> str:
+    url_prefix_hostname = urlparse(options.get("system.url-prefix")).netloc
+    customer_base_hostname_template = options.get("system.organization-base-hostname")
+    if not customer_base_hostname_template:
+        return url_prefix_hostname
+    if "{slug}" not in customer_base_hostname_template:
+        return url_prefix_hostname
+    customer_hostname = customer_base_hostname_template.replace("{slug}", org_slug)
+    if "{region}" in customer_base_hostname_template:
+        region = options.get("system.region") or None
+        if region is None:
+            return url_prefix_hostname
+        customer_hostname = customer_hostname.replace("{region}", region)
+    return customer_hostname

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -31,7 +31,7 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE,
 )
 register(
-    "system.customer-url-template", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE
+    "system.organization-url-template", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE
 )
 register("system.region", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE)
 register("system.root-api-key", flags=FLAG_PRIORITIZE_DISK)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -30,6 +30,9 @@ register(
     "system.organization-base-hostname",
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE,
 )
+register(
+    "system.customer-url-template", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE
+)
 register("system.root-api-key", flags=FLAG_PRIORITIZE_DISK)
 register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -33,6 +33,7 @@ register(
 register(
     "system.customer-url-template", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE
 )
+register("system.region", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE)
 register("system.root-api-key", flags=FLAG_PRIORITIZE_DISK)
 register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)
 # This is used for the chunk upload endpoint

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -139,6 +139,7 @@ def pytest_configure(config):
             "system.url-prefix": "http://testserver",
             "system.base-hostname": "testserver",
             "system.organization-base-hostname": "{slug}.{region}.testserver",
+            "system.customer-url-template": "http://{hostname}",
             "system.secret-key": "a" * 52,
             "slack.client-id": "slack-client-id",
             "slack.client-secret": "slack-client-secret",

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -139,7 +139,7 @@ def pytest_configure(config):
             "system.url-prefix": "http://testserver",
             "system.base-hostname": "testserver",
             "system.organization-base-hostname": "{slug}.{region}.testserver",
-            "system.customer-url-template": "http://{hostname}",
+            "system.organization-url-template": "http://{hostname}",
             "system.region": "us",
             "system.secret-key": "a" * 52,
             "slack.client-id": "slack-client-id",

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -140,6 +140,7 @@ def pytest_configure(config):
             "system.base-hostname": "testserver",
             "system.organization-base-hostname": "{slug}.{region}.testserver",
             "system.customer-url-template": "http://{hostname}",
+            "system.region": "us",
             "system.secret-key": "a" * 52,
             "slack.client-id": "slack-client-id",
             "slack.client-secret": "slack-client-secret",

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -9,7 +9,7 @@ import sentry
 from sentry import features, options
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
-from sentry.api.utils import generate_customer_url
+from sentry.api.utils import generate_organization_url
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import ProjectKey
 from sentry.utils import auth
@@ -182,7 +182,9 @@ def get_client_config(request=None):
         "enableAnalytics": settings.ENABLE_ANALYTICS,
         "validateSUForm": getattr(settings, "VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON", False),
         "sentryUrl": options.get("system.url-prefix"),
-        "organizationUrl": generate_customer_url(last_organization) if last_organization else None,
+        "organizationUrl": generate_organization_url(last_organization)
+        if last_organization
+        else None,
     }
     if user and user.is_authenticated:
         context.update(

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -9,6 +9,7 @@ import sentry
 from sentry import features, options
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
+from sentry.api.utils import generate_customer_url
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import ProjectKey
 from sentry.utils import auth
@@ -138,6 +139,8 @@ def get_client_config(request=None):
 
     public_dsn = _get_public_dsn()
 
+    last_organization = session["activeorg"] if session and "activeorg" in session else None
+
     context = {
         "singleOrganization": settings.SENTRY_SINGLE_ORGANIZATION,
         "supportEmail": get_support_mail(),
@@ -160,7 +163,7 @@ def get_client_config(request=None):
         # Note `lastOrganization` should not be expected to update throughout frontend app lifecycle
         # It should only be used on a fresh browser nav to a path where an
         # organization is not in context
-        "lastOrganization": session["activeorg"] if session and "activeorg" in session else None,
+        "lastOrganization": last_organization,
         "languageCode": language_code,
         "userIdentity": user_identity,
         "csrfCookieName": settings.CSRF_COOKIE_NAME,
@@ -178,6 +181,8 @@ def get_client_config(request=None):
         "demoMode": settings.DEMO_MODE,
         "enableAnalytics": settings.ENABLE_ANALYTICS,
         "validateSUForm": getattr(settings, "VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON", False),
+        "sentryUrl": options.get("system.url-prefix"),
+        "organizationUrl": generate_customer_url(last_organization) if last_organization else None,
     }
     if user and user.is_authenticated:
         context.update(

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -105,3 +105,36 @@ class ClientConfigViewTest(TestCase):
         assert data["user"]
         assert data["user"]["email"] == user.email
         assert data["user"]["isSuperuser"]
+
+    def test_url_prefix_unauthenticated(self):
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+        assert not data["isAuthenticated"]
+        assert data["user"] is None
+        assert data["lastOrganization"] is None
+        assert data["sentryUrl"] == "http://testserver"
+        assert data["organizationUrl"] is None
+
+    def test_url_prefix_authenticated(self):
+        self.login_as(self.user)
+
+        # Induce last active organization
+        resp = self.client.get(
+            reverse("sentry-api-0-organization-projects", args=[self.organization.slug])
+        )
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+
+        assert data["isAuthenticated"] is True
+        assert data["lastOrganization"] == self.organization.slug
+        assert data["sentryUrl"] == "http://testserver"
+        assert data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -106,7 +106,7 @@ class ClientConfigViewTest(TestCase):
         assert data["user"]["email"] == user.email
         assert data["user"]["isSuperuser"]
 
-    def test_url_prefix_unauthenticated(self):
+    def test_organization_url_unauthenticated(self):
         resp = self.client.get(self.path)
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"
@@ -118,7 +118,7 @@ class ClientConfigViewTest(TestCase):
         assert data["sentryUrl"] == "http://testserver"
         assert data["organizationUrl"] is None
 
-    def test_url_prefix_authenticated(self):
+    def test_organization_url_authenticated(self):
         self.login_as(self.user)
 
         # Induce last active organization

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -138,3 +138,105 @@ class ClientConfigViewTest(TestCase):
         assert data["lastOrganization"] == self.organization.slug
         assert data["sentryUrl"] == "http://testserver"
         assert data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
+
+    def test_organization_url_region(self):
+        self.login_as(self.user)
+
+        # Induce last active organization
+        resp = self.client.get(
+            reverse("sentry-api-0-organization-projects", args=[self.organization.slug])
+        )
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        with self.options({"system.region": "eu"}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+
+            data = json.loads(resp.content)
+
+            assert data["isAuthenticated"] is True
+            assert data["lastOrganization"] == self.organization.slug
+            assert data["sentryUrl"] == "http://testserver"
+            assert data["organizationUrl"] == f"http://{self.organization.slug}.eu.testserver"
+
+    def test_organization_url_organization_base_hostname(self):
+        self.login_as(self.user)
+
+        # Induce last active organization
+        resp = self.client.get(
+            reverse("sentry-api-0-organization-projects", args=[self.organization.slug])
+        )
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        with self.options({"system.organization-base-hostname": "invalid"}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+
+            data = json.loads(resp.content)
+
+            assert data["isAuthenticated"] is True
+            assert data["lastOrganization"] == self.organization.slug
+            assert data["sentryUrl"] == "http://testserver"
+            assert data["organizationUrl"] == "http://testserver"
+
+        with self.options({"system.organization-base-hostname": "{region}.{slug}.testserver"}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+
+            data = json.loads(resp.content)
+
+            assert data["isAuthenticated"] is True
+            assert data["lastOrganization"] == self.organization.slug
+            assert data["sentryUrl"] == "http://testserver"
+            assert data["organizationUrl"] == f"http://us.{self.organization.slug}.testserver"
+
+    def test_organization_url_organization_url_template(self):
+        self.login_as(self.user)
+
+        # Induce last active organization
+        resp = self.client.get(
+            reverse("sentry-api-0-organization-projects", args=[self.organization.slug])
+        )
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        with self.options({"system.organization-url-template": "invalid"}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+
+            data = json.loads(resp.content)
+
+            assert data["isAuthenticated"] is True
+            assert data["lastOrganization"] == self.organization.slug
+            assert data["sentryUrl"] == "http://testserver"
+            assert data["organizationUrl"] == "invalid"
+
+        with self.options({"system.organization-url-template": None}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+
+            data = json.loads(resp.content)
+
+            assert data["isAuthenticated"] is True
+            assert data["lastOrganization"] == self.organization.slug
+            assert data["sentryUrl"] == "http://testserver"
+            assert data["organizationUrl"] == "http://testserver"
+
+        with self.options({"system.organization-url-template": "ftp://{hostname}"}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+
+            data = json.loads(resp.content)
+
+            assert data["isAuthenticated"] is True
+            assert data["lastOrganization"] == self.organization.slug
+            assert data["sentryUrl"] == "http://testserver"
+            assert data["organizationUrl"] == f"ftp://{self.organization.slug}.us.testserver"


### PR DESCRIPTION
Split from https://github.com/getsentry/sentry/pull/35169

The frontend portion resides in https://github.com/getsentry/sentry/pull/36431

-----

- Introduce `system.region` option which indicates the region we use when constructing the organization URLs. This will also be used to indicate the silo a Sentry instance will be serving from.
- Introduce `system.organization-url-template` option that will be used as a template for constructing the organization URLs.
- Add `generate_organization_hostname()` utility function for generating the organization URL hostname.
- Add `generate_organization_url()` utility function that will be used for generating the organization URLs.
- Add `sentryUrl` and `organizationUrl` to the config initial data. This is populated to the initial django template served to the user (via `window.__initialData`), and when the bootstrap URL is used for fetching the latest client config.