### PR TITLE
ref(auditlog): Update auditlog to functional component

### DIFF
--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -98,43 +98,40 @@ function OrganizationAuditLog({organization}: Props) {
     }));
   };
 
-  const fetchAuditLogData = useCallback(
-    async (cursor = state.currentCursor, event = state.eventType) => {
-      try {
-        const payload = {cursor, event};
-        if (!payload.cursor) {
-          delete payload.cursor;
-        }
-        if (!payload.event) {
-          delete payload.event;
-        }
-        const [data, _, response] = await api.requestPromise(
-          `/organizations/${organization.slug}/audit-logs/`,
-          {
-            method: 'GET',
-            includeAllArgs: true,
-            query: payload,
-          }
-        );
-        setState(prevState => ({
-          ...prevState,
-          entryList: data,
-          isLoading: false,
-          entryListPageLinks: response?.getResponseHeader('Link') ?? null,
-        }));
-      } catch (err) {
-        if (err.status !== 401 && err.status !== 403) {
-          Sentry.captureException(err);
-        }
-        setState(prevState => ({
-          ...prevState,
-          isLoading: false,
-        }));
-        addErrorMessage('Unable to load usage loads.');
+  const fetchAuditLogData = useCallback(async () => {
+    try {
+      const payload = {cursor: state.currentCursor, event: state.eventType};
+      if (!payload.cursor) {
+        delete payload.cursor;
       }
-    },
-    [api, organization.slug, state.currentCursor, state.eventType]
-  );
+      if (!payload.event) {
+        delete payload.event;
+      }
+      const [data, _, response] = await api.requestPromise(
+        `/organizations/${organization.slug}/audit-logs/`,
+        {
+          method: 'GET',
+          includeAllArgs: true,
+          query: payload,
+        }
+      );
+      setState(prevState => ({
+        ...prevState,
+        entryList: data,
+        isLoading: false,
+        entryListPageLinks: response?.getResponseHeader('Link') ?? null,
+      }));
+    } catch (err) {
+      if (err.status !== 401 && err.status !== 403) {
+        Sentry.captureException(err);
+      }
+      setState(prevState => ({
+        ...prevState,
+        isLoading: false,
+      }));
+      addErrorMessage('Unable to load audit logs.');
+    }
+  }, [api, organization.slug, state.currentCursor, state.eventType]);
 
   useEffect(() => {
     fetchAuditLogData();

--- a/tests/js/spec/views/settings/auditLogView.spec.jsx
+++ b/tests/js/spec/views/settings/auditLogView.spec.jsx
@@ -1,10 +1,17 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Client} from 'sentry/api';
 import OrganizationAuditLog from 'sentry/views/settings/organizationAuditLog';
 
-describe('OrganizationAuditLog', function () {
-  const org = TestStubs.Organization();
+describe('OrganizationAuditLog', () => {
+  const {routerContext, org} = initializeOrg({
+    projects: [],
+    router: {
+      location: {query: {}},
+      params: {orgId: 'org-slug'},
+    },
+  });
   const ENDPOINT = `/organizations/${org.slug}/audit-logs/`;
 
   beforeEach(function () {
@@ -15,27 +22,40 @@ describe('OrganizationAuditLog', function () {
     });
   });
 
-  it('renders', async function () {
-    const wrapper = mountWithTheme(
-      <OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />
-    );
-    wrapper.setState({loading: false});
-    wrapper.update();
-    await tick();
+  it('renders', async () => {
+    render(<OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />, {
+      context: routerContext,
+    });
 
-    wrapper.update();
-    expect(wrapper).toSnapshot();
+    expect(await screen.findByRole('heading')).toHaveTextContent('Audit Log');
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByText('Member')).toBeInTheDocument();
+    expect(screen.getByText('Action')).toBeInTheDocument();
+    expect(screen.getByText('IP')).toBeInTheDocument();
+    expect(screen.getByText('Time')).toBeInTheDocument();
+    expect(screen.queryByText('No audit entries available')).not.toBeInTheDocument();
   });
 
-  it('displays whether an action was done by a superuser', function () {
-    const wrapper = mountWithTheme(
-      <OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />
-    );
-    expect(wrapper.find('div[data-test-id="actor-name"]').at(0).text()).toEqual(
-      expect.stringContaining('(Sentry Staff)')
-    );
-    expect(wrapper.find('div[data-test-id="actor-name"]').at(1).text()).toEqual(
-      expect.not.stringContaining('(Sentry Staff)')
-    );
+  it('renders empty', async () => {
+    Client.clearMockResponses();
+    Client.addMockResponse({
+      url: ENDPOINT,
+      body: [],
+    });
+
+    render(<OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />, {
+      context: routerContext,
+    });
+
+    expect(await screen.findByText('No audit entries available')).toBeInTheDocument();
+  });
+
+  it('displays whether an action was done by a superuser', async () => {
+    render(<OrganizationAuditLog location={{query: ''}} params={{orgId: org.slug}} />, {
+      context: routerContext,
+    });
+
+    expect(await screen.findByText('Foo Bar (Sentry Staff)')).toBeInTheDocument();
+    expect(screen.getByText('Foo Bar')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/settings/auditLogView.spec.jsx
+++ b/tests/js/spec/views/settings/auditLogView.spec.jsx
@@ -34,6 +34,7 @@ describe('OrganizationAuditLog', () => {
     expect(screen.getByText('IP')).toBeInTheDocument();
     expect(screen.getByText('Time')).toBeInTheDocument();
     expect(screen.queryByText('No audit entries available')).not.toBeInTheDocument();
+    expect(screen.getByText('edited project ludic-science')).toBeInTheDocument();
   });
 
   it('renders empty', async () => {

--- a/tests/js/spec/views/settings/organizationAuditLog.spec.jsx
+++ b/tests/js/spec/views/settings/organizationAuditLog.spec.jsx
@@ -17,7 +17,7 @@ describe('OrganizationAuditLog', () => {
     ConfigStore.loadInitialData({user});
   });
 
-  it('renders', () => {
+  it('renders', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/audit-logs/`,
       method: 'GET',
@@ -65,7 +65,7 @@ describe('OrganizationAuditLog', () => {
       }
     );
 
-    expect(screen.getByText('project.remove')).toBeInTheDocument();
+    expect(await screen.findByText('project.remove')).toBeInTheDocument();
     expect(screen.getByText('org.create')).toBeInTheDocument();
     expect(screen.getAllByText('127.0.0.1')).toHaveLength(2);
     expect(screen.getByText('17:29 PDT')).toBeInTheDocument();


### PR DESCRIPTION
Updating `OrganizationAuditLog` to a functional component prior to updating the usage log API endpoint. The `AsyncView` component currently used will not support the changes to the endpoint (endpoint will be updated to have both an entries list and an audit log api names list so that the event filter will automatically update for new audit log events). 

Also replaces the deprecated `SelectField` filter with `SelectControl`.