### PR TITLE
fix(dashboards): Fixes widgetQuery not updating isMetricData correctly

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -133,15 +133,14 @@ function WidgetQueries({
     [isMetricsData, setIsMetricsData]
   );
 
-  const afterFetchTableData = useCallback(
-    (rawResults: TableResult) => {
-      // If one of the queries is sampled, then mark the whole thing as sampled
-      const currentResultIsMetricsData =
-        isMetricsData === false ? false : rawResults.meta?.isMetricsData;
-      setIsMetricsData?.(currentResultIsMetricsData);
-    },
-    [isMetricsData, setIsMetricsData]
-  );
+  const isMetricsDataResults: boolean[] = [];
+  const afterFetchTableData = (rawResults: TableResult) => {
+    if (rawResults.meta?.isMetricsData !== undefined) {
+      isMetricsDataResults.push(rawResults.meta.isMetricsData);
+    }
+    // If one of the queries is sampled, then mark the whole thing as sampled
+    setIsMetricsData?.(!isMetricsDataResults.includes(false));
+  };
 
   return (
     <GenericWidgetQueries<SeriesResult, TableResult>

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -497,7 +497,7 @@ describe('Dashboards > WidgetCard', function () {
     );
   });
 
-  it.only('has sticky table headers', async function () {
+  it('has sticky table headers', async function () {
     const tableWidget: Widget = {
       title: 'Table Widget',
       interval: '5m',

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -497,7 +497,7 @@ describe('Dashboards > WidgetCard', function () {
     );
   });
 
-  it('has sticky table headers', async function () {
+  it.only('has sticky table headers', async function () {
     const tableWidget: Widget = {
       title: 'Table Widget',
       interval: '5m',
@@ -532,7 +532,8 @@ describe('Dashboards > WidgetCard', function () {
         tableItemLimit={20}
       />
     );
-    await tick();
+    await waitFor(() => expect(eventsv2Mock).toHaveBeenCalled());
+
     expect(SimpleTableChart).toHaveBeenCalledWith(
       expect.objectContaining({stickyHeaders: true}),
       expect.anything()


### PR DESCRIPTION
Due to the way `currentResultIsMetricsData` is defined:
```const currentResultIsMetricsData =
        isMetricsData === false ? false : rawResults.meta?.isMetricsData;
```

If `isMetricsData` (which comes from the `DashboardsMEPContext`) has been set to `false` by an previous query, `currentResultIsMetricsData` will always be `false` even if the most recent widgetQuery result `isMetricsData = true`.

Refactored this code to store all `isMetricsData` results from each widgetQuery request in a boolean array and evaluate on that instead. This allows us to avoid being mislead by `isMetricsData` from previous unrelated runs