### PR TITLE
feat(replays): Improved Breadcrumb Signifiers and Functionality 

### DIFF
--- a/static/app/components/replays/playerRelativeTime.tsx
+++ b/static/app/components/replays/playerRelativeTime.tsx
@@ -30,7 +30,7 @@ const PlayerRelativeTime = ({relativeTime, timestamp}: Props) => {
 };
 
 const Value = styled('p')`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   font-variant-numeric: tabular-nums;
 `;

--- a/static/app/components/replays/playerRelativeTime.tsx
+++ b/static/app/components/replays/playerRelativeTime.tsx
@@ -30,8 +30,8 @@ const PlayerRelativeTime = ({relativeTime, timestamp}: Props) => {
 };
 
 const Value = styled('p')`
-  color: ${p => p.theme.subText};
-  font-size: 0.9em;
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeSmall};
   font-variant-numeric: tabular-nums;
 `;
 

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -122,7 +122,7 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
   &::after {
     content: '';
     position: absolute;
-    left: 19px;
+    left: 19.5px;
     width: 1px;
     background: ${p => p.theme.gray200};
     height: 100%;

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -79,6 +79,7 @@ const CrumbDetails = styled('div')`
 const TitleContainer = styled('div')`
   display: flex;
   justify-content: space-between;
+  gap: ${space(1)};
 `;
 
 const Title = styled('span')`
@@ -126,17 +127,17 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
     width: 1px;
     background: ${p => p.theme.gray200};
     height: 100%;
-    z-index: 1;
   }
 
+  /* Draw a vertical line behind the breadcrumb icon. The line connects each row together, but is truncated for the first and last items */
   &:first-of-type::after {
+    top: 8px;
     bottom: 0;
-    height: 50%;
   }
 
   &:last-of-type::after {
     top: 0;
-    height: 50%;
+    height: 8px;
   }
 `;
 
@@ -154,7 +155,7 @@ const IconWrapper = styled('div')<Required<Pick<SVGIconProps, 'color'>>>`
   background: ${p => p.theme[p.color] ?? p.color};
   box-shadow: ${p => p.theme.dropShadowLightest};
   position: relative;
-  z-index: 2;
+  z-index: ${p => p.theme.zIndex.initial};
 `;
 
 const MemoizedBreadcrumbItem = memo(BreadcrumbItem);

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -120,6 +120,7 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
   ${p => p.isHovered && `background-color: ${p.theme.surface100};`}
   border-radius: 4px;
 
+  /* Draw a vertical line behind the breadcrumb icon. The line connects each row together, but is truncated for the first and last items */
   &::after {
     content: '';
     position: absolute;
@@ -129,7 +130,6 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
     height: 100%;
   }
 
-  /* Draw a vertical line behind the breadcrumb icon. The line connects each row together, but is truncated for the first and last items */
   &:first-of-type::after {
     top: 8px;
     bottom: 0;

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -78,6 +78,8 @@ const CrumbDetails = styled('div')`
 const Title = styled('span')`
   ${p => p.theme.overflowEllipsis};
   text-transform: capitalize;
+  font-weight: 600;
+  color: ${p => p.theme.gray400};
 `;
 
 const Description = styled('span')`
@@ -93,7 +95,7 @@ type CrumbItemProps = {
 
 const CrumbItem = styled(PanelItem)<CrumbItemProps>`
   display: grid;
-  grid-template-columns: max-content max-content auto max-content;
+  grid-template-columns: max-content auto max-content;
   align-items: center;
   gap: ${space(1)};
   width: 100%;
@@ -103,22 +105,33 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
   padding: 0;
   padding-right: ${space(1)};
   text-align: left;
-
   border: none;
-  border-bottom: 1px solid ${p => p.theme.innerBorder};
-  ${p => p.isHovered && `background: ${p.theme.surface400};`}
+  position: relative;
+  ${p => (p.isSelected || p.isHovered) && `background-color: ${p.theme.purple100};`}
+  margin: 0 ${space(0.5)};
+  border-radius: 4px;
 
-  /* overrides PanelItem css */
-  &:last-child {
-    border-bottom: 1px solid ${p => p.theme.innerBorder};
+  &::after {
+    content: '';
+    position: absolute;
+    left: 18px;
+    width: 1px;
+    background: ${p => p.theme.gray200};
+    height: 100%;
+    z-index: 1;
   }
 
-  /* Selected state */
-  ::before {
-    content: '';
-    width: 4px;
-    height: 100%;
-    ${p => p.isSelected && `background-color: ${p.theme.purple300};`}
+  &:first-of-type {
+    margin-top: ${space(0.5)};
+    &::after {
+      bottom: 0;
+      height: 50%;
+    }
+  }
+
+  &:last-of-type::after {
+    top: 0;
+    height: 50%;
   }
 `;
 
@@ -136,6 +149,8 @@ const IconWrapper = styled('div')<Required<Pick<SVGIconProps, 'color'>>>`
   background: ${p => p.theme[p.color] ?? p.color};
   box-shadow: ${p => p.theme.dropShadowLightest};
   position: relative;
+  margin-left: ${space(1)};
+  z-index: 2;
 `;
 
 const MemoizedBreadcrumbItem = memo(BreadcrumbItem);

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -118,7 +118,7 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
   position: relative;
   ${p => p.isSelected && `background-color: ${p.theme.purple100};`}
   ${p => p.isHovered && `background-color: ${p.theme.surface100};`}
-  border-radius: 4px;
+  border-radius: ${p => p.theme.borderRadius};
 
   /* Draw a vertical line behind the breadcrumb icon. The line connects each row together, but is truncated for the first and last items */
   &::after {
@@ -131,13 +131,13 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
   }
 
   &:first-of-type::after {
-    top: 8px;
+    top: ${space(1)};
     bottom: 0;
   }
 
   &:last-of-type::after {
     top: 0;
-    height: 8px;
+    height: ${space(1)};
   }
 `;
 

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -102,13 +102,12 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
 
   font-size: ${p => p.theme.fontSizeMedium};
   background: transparent;
-  padding: 0;
-  padding-right: ${space(1)};
+  padding: 0 ${space(1)};
   text-align: left;
   border: none;
   position: relative;
   ${p => (p.isSelected || p.isHovered) && `background-color: ${p.theme.purple100};`}
-  margin: 0 ${space(0.5)};
+  /* margin: 0 ${space(0.5)}; */
   border-radius: 4px;
 
   &::after {
@@ -121,12 +120,9 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
     z-index: 1;
   }
 
-  &:first-of-type {
-    margin-top: ${space(0.5)};
-    &::after {
-      bottom: 0;
-      height: 50%;
-    }
+  &:first-of-type::after {
+    bottom: 0;
+    height: 50%;
   }
 
   &:last-of-type::after {
@@ -149,7 +145,6 @@ const IconWrapper = styled('div')<Required<Pick<SVGIconProps, 'color'>>>`
   background: ${p => p.theme[p.color] ?? p.color};
   box-shadow: ${p => p.theme.dropShadowLightest};
   position: relative;
-  margin-left: ${space(1)};
   z-index: 2;
 `;
 

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -59,10 +59,13 @@ function BreadcrumbItem({
         <BreadcrumbIcon type={crumb.type} />
       </IconWrapper>
       <CrumbDetails>
-        <Title>{title}</Title>
+        <TitleContainer>
+          <Title>{title}</Title>
+          <PlayerRelativeTime relativeTime={startTimestamp} timestamp={crumb.timestamp} />
+        </TitleContainer>
+
         <Description title={description}>{description}</Description>
       </CrumbDetails>
-      <PlayerRelativeTime relativeTime={startTimestamp} timestamp={crumb.timestamp} />
     </CrumbItem>
   );
 }
@@ -71,8 +74,11 @@ const CrumbDetails = styled('div')`
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  line-height: 1.2;
-  padding: ${space(1)} 0;
+`;
+
+const TitleContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
 `;
 
 const Title = styled('span')`
@@ -80,12 +86,15 @@ const Title = styled('span')`
   text-transform: capitalize;
   font-weight: 600;
   color: ${p => p.theme.gray400};
+  line-height: ${p => p.theme.text.lineHeightBody};
 `;
 
 const Description = styled('span')`
   ${p => p.theme.overflowEllipsis};
   font-size: 0.7rem;
   font-variant-numeric: tabular-nums;
+  line-height: ${p => p.theme.text.lineHeightBody};
+  color: ${p => p.theme.subText};
 `;
 
 type CrumbItemProps = {
@@ -95,25 +104,25 @@ type CrumbItemProps = {
 
 const CrumbItem = styled(PanelItem)<CrumbItemProps>`
   display: grid;
-  grid-template-columns: max-content auto max-content;
-  align-items: center;
+  grid-template-columns: max-content auto;
+  align-items: flex-start;
   gap: ${space(1)};
   width: 100%;
 
   font-size: ${p => p.theme.fontSizeMedium};
   background: transparent;
-  padding: 0 ${space(1)};
+  padding: ${space(1)};
   text-align: left;
   border: none;
   position: relative;
-  ${p => (p.isSelected || p.isHovered) && `background-color: ${p.theme.purple100};`}
-  /* margin: 0 ${space(0.5)}; */
+  ${p => p.isSelected && `background-color: ${p.theme.purple100};`}
+  ${p => p.isHovered && `background-color: ${p.theme.surface100};`}
   border-radius: 4px;
 
   &::after {
     content: '';
     position: absolute;
-    left: 18px;
+    left: 19px;
     width: 1px;
     background: ${p => p.theme.gray200};
     height: 100%;
@@ -138,8 +147,8 @@ const IconWrapper = styled('div')<Required<Pick<SVGIconProps, 'color'>>>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   color: ${p => p.theme.white};
   background: ${p => p.theme[p.color] ?? p.color};

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -147,6 +147,7 @@ const PanelHeader = styled(BasePanelHeader)`
 `;
 
 const PanelBody = styled(BasePanelBody)`
+  padding: ${space(0.5)};
   overflow-y: auto;
   max-height: calc(100% - ${TAB_HEADER_HEIGHT}px);
 `;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -23,7 +23,7 @@ function CrumbPlaceholder({number}: {number: number}) {
   return (
     <Fragment>
       {[...Array(number)].map((_, i) => (
-        <PlaceholderMargin key={i} height="40px" />
+        <PlaceholderMargin key={i} height="53px" />
       ))}
     </Fragment>
   );
@@ -153,8 +153,9 @@ const PanelBody = styled(BasePanelBody)`
 `;
 
 const PlaceholderMargin = styled(Placeholder)`
-  margin: ${space(1)} ${space(1.5)};
+  margin: ${space(1)} 0;
   width: auto;
+  border-radius: 4px;
 `;
 
 export default Breadcrumbs;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -155,7 +155,7 @@ const PanelBody = styled(BasePanelBody)`
 const PlaceholderMargin = styled(Placeholder)`
   margin: ${space(1)} 0;
   width: auto;
-  border-radius: 4px;
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 export default Breadcrumbs;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -138,11 +138,12 @@ const Panel = styled(BasePanel)`
 
 const PanelHeader = styled(BasePanelHeader)`
   background-color: ${p => p.theme.background};
-  border-bottom: none;
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.gray500};
   text-transform: capitalize;
-  padding: ${space(1.5)} ${space(2)} ${space(0.5)};
+  padding: ${space(1)} ${space(1.5)} ${space(1)};
+  font-weight: 600;
 `;
 
 const PanelBody = styled(BasePanelBody)`


### PR DESCRIPTION
<!-- Describe your PR here. -->
Added new styles to the breadcrumb component which highlights in a better way when the user is on its event. Closes #36112 

![image](https://user-images.githubusercontent.com/39612839/177661859-c605f003-4893-4055-a968-496f27b560a3.png)

![image](https://user-images.githubusercontent.com/39612839/177661890-85263f15-0278-4fc8-acc7-9d845cde1881.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
