### PR TITLE
fix(alert): Metric alert preset log experiment & bug fixes

### DIFF
--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -224,10 +224,6 @@ const Body = styled(Layout.Body)`
   @media (min-width: ${p => p.theme.breakpoints.large}) {
     grid-template-columns: minmax(100px, auto) 400px;
   }
-
-  @media (min-width: ${p => p.theme.breakpoints.xlarge}) {
-    grid-template-columns: 1fr;
-  }
 `;
 
 export default Create;

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -909,7 +909,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
           const disabled = loading || !(isActiveSuperuser() || hasAccess);
 
           return (
-            <Main>
+            <Main fullWidth>
               <StyledForm
                 key={isSavedAlertRule(rule) ? rule.id : undefined}
                 onCancel={this.handleCancel}

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -563,7 +563,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
             }}
             flexibleControlStateSize
           >
-            {({onChange, onBlur, onKeyDown, initialData, model}) => (
+            {({onChange, onBlur, onKeyDown, initialData}) => (
               <SearchContainer>
                 <StyledSearchBar
                   searchSource="alert_builder"
@@ -583,7 +583,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                   organization={organization}
                   placeholder={this.searchPlaceholder}
                   onChange={onChange}
-                  query={model.getValue('query')}
+                  query={initialData.query}
                   onKeyDown={e => {
                     /**
                      * Do not allow enter key to submit the alerts form since it is unlikely

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -825,6 +825,11 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       />
     );
 
+    const showPresetSidebar = // organization.experiments.MetricAlertPresetExperiment &&
+      dataset === Dataset.TRANSACTIONS &&
+      project.firstTransactionEvent &&
+      !this.props.ruleId;
+
     return (
       <Access access={['alerts:write']}>
         {({hasAccess}) => {
@@ -832,22 +837,19 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
           return (
             <Fragment>
-              {organization.experiments.MetricAlertPresetExperiment &&
-                dataset === Dataset.TRANSACTIONS &&
-                project.firstTransactionEvent &&
-                !this.props.ruleId && (
-                  <Side>
-                    <PresetSidebar
-                      organization={organization}
-                      project={project}
-                      onSelect={(preset, context) => {
-                        this.setPreset(preset, context);
-                      }}
-                      selectedPresetId={selectedPresetId}
-                    />
-                  </Side>
-                )}
-              <Main>
+              {showPresetSidebar && (
+                <Side>
+                  <PresetSidebar
+                    organization={organization}
+                    project={project}
+                    onSelect={(preset, context) => {
+                      this.setPreset(preset, context);
+                    }}
+                    selectedPresetId={selectedPresetId}
+                  />
+                </Side>
+              )}
+              <Main fullWidth={!showPresetSidebar}>
                 <Form
                   model={this.form}
                   apiMethod={ruleId ? 'PUT' : 'POST'}

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -25,7 +25,7 @@ import IndicatorStore from 'sentry/stores/indicatorStore';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
-import {metric} from 'sentry/utils/analytics';
+import {logExperiment, metric} from 'sentry/utils/analytics';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import withProjects from 'sentry/utils/withProjects';
@@ -825,10 +825,19 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       />
     );
 
-    const showPresetSidebar = // organization.experiments.MetricAlertPresetExperiment &&
+    let showPresetSidebar: boolean =
       dataset === Dataset.TRANSACTIONS &&
       project.firstTransactionEvent &&
       !this.props.ruleId;
+    if (showPresetSidebar) {
+      logExperiment({
+        key: 'MetricAlertPresetExperiment',
+        organization,
+      });
+    }
+
+    showPresetSidebar =
+      showPresetSidebar && !!organization.experiments.MetricAlertPresetExperiment;
 
     return (
       <Access access={['alerts:write']}>


### PR DESCRIPTION
- Fixed layout so that when the preset sidebar doesn't show, we show the form full width.
- Fixed a bug where the `SmartSearchBar` automatically inserts white spaces after typing.
- Added `logExperiment` calls.