### PR TITLE
fix(dynamic-sampling): Change query time boundaries for cache

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -53,7 +53,13 @@ class OrganizationDynamicSamplingSDKVersionsEndpoint(OrganizationEndpoint):
         stats_period = min(
             parse_stats_period(request.GET.get("statsPeriod", "24h")), timedelta(days=2)
         )
+
         end_time = timezone.now()
+        # Quantize time boundary down so that during a 5-minute interval, the query time boundaries
+        # remain the same to leverage the snuba cache
+        end_time = end_time.replace(
+            minute=(end_time.minute - end_time.minute % 5), second=0, microsecond=0
+        )
         start_time = end_time - stats_period
 
         avg_equation = 'count_if(trace.client_sample_rate, notEquals, "") / count()'

--- a/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
+++ b/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
@@ -1,3 +1,4 @@
+import datetime
 from datetime import timedelta
 from unittest import mock
 
@@ -151,13 +152,13 @@ class OrganizationDynamicSamplingSDKVersionsTest(APITestCase):
             response = self.client.get(f"{self.endpoint}?project={self.project.id}")
             assert response.json() == []
 
-    @freeze_time()
+    @freeze_time("2022-07-07 03:21:34")
     @mock.patch("sentry.api.endpoints.organization_dynamic_sampling_sdk_versions.discover.query")
     def test_request_params_are_applied_to_discover_query(self, mock_query):
         self.login_as(self.user)
         mock_query.return_value = mocked_discover_query()
 
-        end_time = timezone.now()
+        end_time = datetime.datetime(2022, 7, 7, 3, 20, 0, tzinfo=timezone.utc)
         start_time = end_time - timedelta(hours=6)
 
         calls = [


### PR DESCRIPTION
Quantizes query time boundaries so that if
it has the same time boundaries within a 5 minute
interval to leverage the snuba cache