### PR TITLE
feat(dyn-sampling): Filter out non active rules from config [TET-200]

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -178,7 +178,10 @@ def _get_project_config(project, full_config=True, project_keys=None):
     if allow_dynamic_sampling:
         dynamic_sampling = project.get_option("sentry:dynamic_sampling")
         if dynamic_sampling is not None:
-            cfg["config"]["dynamicSampling"] = dynamic_sampling
+            # filter out rules that do not have active set to True
+            cfg["config"]["dynamicSampling"] = {
+                "rules": [r for r in dynamic_sampling["rules"] if r.get("active")]
+            }
 
     if not full_config:
         # This is all we need for external Relay processors

--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -264,12 +264,13 @@ def default_activity(default_group, default_project, default_user):
 @pytest.fixture()
 def dyn_sampling_data():
     # return a function that returns fresh config so we don't accidentally get tests interfering with each other
-    def inner():
+    def inner(active=True):
         return {
             "rules": [
                 {
                     "sampleRate": 0.7,
                     "type": "trace",
+                    "active": active,
                     "condition": {
                         "op": "and",
                         "inner": [


### PR DESCRIPTION
Filters out non active DS rules from being sent to
relay


