### PR TITLE
feat(profiling): add layout component

### DIFF
--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -7,7 +7,6 @@ import {
   useRef,
   useState,
 } from 'react';
-import styled from '@emotion/styled';
 import {mat3, vec2} from 'gl-matrix';
 
 import {FlamegraphOptionsMenu} from 'sentry/components/profiling/flamegraphOptionsMenu';
@@ -23,7 +22,6 @@ import {
 import {ThreadMenuSelector} from 'sentry/components/profiling/threadSelector';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {Flamegraph as FlamegraphModel} from 'sentry/utils/profiling/flamegraph';
-import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/useFlamegraphPreferences';
 import {useFlamegraphProfiles} from 'sentry/utils/profiling/flamegraph/useFlamegraphProfiles';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
@@ -35,6 +33,8 @@ import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
 import {useDevicePixelRatio} from 'sentry/utils/useDevicePixelRatio';
 import {useMemoWithPrevious} from 'sentry/utils/useMemoWithPrevious';
+
+import {ProfilingFlamechartLayout} from './profilingFlamechartLayout';
 
 function getTransactionConfigSpace(profiles: Profile[]): Rect {
   const startedAt = Math.min(...profiles.map(p => p.startedAt));
@@ -270,49 +270,38 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
         <FlamegraphOptionsMenu canvasPoolManager={canvasPoolManager} />
       </FlamegraphToolbar>
 
-      <FlamegraphZoomViewMinimapContainer height={flamegraphTheme.SIZES.MINIMAP_HEIGHT}>
-        <FlamegraphZoomViewMinimap
-          canvasPoolManager={canvasPoolManager}
-          flamegraph={flamegraph}
-          flamegraphMiniMapCanvas={flamegraphMiniMapCanvas}
-          flamegraphMiniMapCanvasRef={flamegraphMiniMapCanvasRef}
-          flamegraphMiniMapOverlayCanvasRef={flamegraphMiniMapOverlayCanvasRef}
-          flamegraphMiniMapView={flamegraphView}
-          setFlamegraphMiniMapCanvasRef={setFlamegraphMiniMapCanvasRef}
-          setFlamegraphMiniMapOverlayCanvasRef={setFlamegraphMiniMapOverlayCanvasRef}
-        />
-      </FlamegraphZoomViewMinimapContainer>
-      <FlamegraphZoomViewContainer>
-        <ProfileDragDropImport onImport={props.onImport}>
-          <FlamegraphZoomView
-            canvasBounds={canvasBounds.current}
+      <ProfilingFlamechartLayout
+        layoutType="minimap_top"
+        minimap={
+          <FlamegraphZoomViewMinimap
             canvasPoolManager={canvasPoolManager}
             flamegraph={flamegraph}
-            flamegraphCanvas={flamegraphCanvas}
-            flamegraphCanvasRef={flamegraphCanvasRef}
-            flamegraphOverlayCanvasRef={flamegraphOverlayCanvasRef}
-            flamegraphView={flamegraphView}
-            setFlamegraphCanvasRef={setFlamegraphCanvasRef}
-            setFlamegraphOverlayCanvasRef={setFlamegraphOverlayCanvasRef}
+            flamegraphMiniMapCanvas={flamegraphMiniMapCanvas}
+            flamegraphMiniMapCanvasRef={flamegraphMiniMapCanvasRef}
+            flamegraphMiniMapOverlayCanvasRef={flamegraphMiniMapOverlayCanvasRef}
+            flamegraphMiniMapView={flamegraphView}
+            setFlamegraphMiniMapCanvasRef={setFlamegraphMiniMapCanvasRef}
+            setFlamegraphMiniMapOverlayCanvasRef={setFlamegraphMiniMapOverlayCanvasRef}
           />
-        </ProfileDragDropImport>
-      </FlamegraphZoomViewContainer>
+        }
+        flamechart={
+          <ProfileDragDropImport onImport={props.onImport}>
+            <FlamegraphZoomView
+              canvasBounds={canvasBounds.current}
+              canvasPoolManager={canvasPoolManager}
+              flamegraph={flamegraph}
+              flamegraphCanvas={flamegraphCanvas}
+              flamegraphCanvasRef={flamegraphCanvasRef}
+              flamegraphOverlayCanvasRef={flamegraphOverlayCanvasRef}
+              flamegraphView={flamegraphView}
+              setFlamegraphCanvasRef={setFlamegraphCanvasRef}
+              setFlamegraphOverlayCanvasRef={setFlamegraphOverlayCanvasRef}
+            />
+          </ProfileDragDropImport>
+        }
+      />
     </Fragment>
   );
 }
-
-const FlamegraphZoomViewMinimapContainer = styled('div')<{
-  height: FlamegraphTheme['SIZES']['MINIMAP_HEIGHT'];
-}>`
-  position: relative;
-  height: ${p => p.height}px;
-  flex-shrink: 0;
-`;
-
-const FlamegraphZoomViewContainer = styled('div')`
-  position: relative;
-  display: flex;
-  flex: 1 1 100%;
-`;
 
 export {Flamegraph};

--- a/static/app/components/profiling/profilingFlamechartLayout.tsx
+++ b/static/app/components/profiling/profilingFlamechartLayout.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
@@ -14,16 +13,14 @@ export function ProfilingFlamechartLayout(props: ProfilingFlamechartLayoutProps)
   const flamegraphTheme = useFlamegraphTheme();
 
   return (
-    <Fragment>
-      <ProfilingFlamechartLayoutContainer>
-        <ProfilingFlamechartGrid layoutType={props.layoutType}>
-          <MinimapContainer height={flamegraphTheme.SIZES.MINIMAP_HEIGHT}>
-            {props.minimap}
-          </MinimapContainer>
-          <ZoomViewContainer>{props.flamechart}</ZoomViewContainer>
-        </ProfilingFlamechartGrid>
-      </ProfilingFlamechartLayoutContainer>
-    </Fragment>
+    <ProfilingFlamechartLayoutContainer>
+      <ProfilingFlamechartGrid layoutType={props.layoutType}>
+        <MinimapContainer height={flamegraphTheme.SIZES.MINIMAP_HEIGHT}>
+          {props.minimap}
+        </MinimapContainer>
+        <ZoomViewContainer>{props.flamechart}</ZoomViewContainer>
+      </ProfilingFlamechartGrid>
+    </ProfilingFlamechartLayoutContainer>
   );
 }
 

--- a/static/app/components/profiling/profilingFlamechartLayout.tsx
+++ b/static/app/components/profiling/profilingFlamechartLayout.tsx
@@ -1,0 +1,65 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
+
+interface ProfilingFlamechartLayoutProps {
+  flamechart: React.ReactNode;
+  layoutType: 'minimap_top';
+  minimap: React.ReactNode;
+}
+
+export function ProfilingFlamechartLayout(props: ProfilingFlamechartLayoutProps) {
+  const flamegraphTheme = useFlamegraphTheme();
+
+  return (
+    <Fragment>
+      <ProfilingFlamechartLayoutContainer>
+        <ProfilingFlamechartGrid layoutType={props.layoutType}>
+          <MinimapContainer height={flamegraphTheme.SIZES.MINIMAP_HEIGHT}>
+            {props.minimap}
+          </MinimapContainer>
+          <ZoomViewContainer>{props.flamechart}</ZoomViewContainer>
+        </ProfilingFlamechartGrid>
+      </ProfilingFlamechartLayoutContainer>
+    </Fragment>
+  );
+}
+
+const ProfilingFlamechartLayoutContainer = styled('div')`
+  display: flex;
+  flex: 1 1 100%;
+`;
+
+const ProfilingFlamechartGrid = styled('div')<{
+  layoutType?: ProfilingFlamechartLayoutProps['layoutType'];
+}>`
+  display: grid;
+  width: 100%;
+  grid-template-rows: ${({layoutType}) =>
+    layoutType === 'minimap_top' ? 'auto 1fr' : '1fr auto'};
+  grid-template-areas: ${({layoutType}) =>
+    layoutType === 'minimap_top'
+      ? `
+    'minimap'
+    'flamegraph'`
+      : `
+    'flamegraph'
+    'minimap'`};
+`;
+
+const MinimapContainer = styled('div')<{
+  height: FlamegraphTheme['SIZES']['MINIMAP_HEIGHT'];
+}>`
+  position: relative;
+  height: ${p => p.height}px;
+  grid-area: minimap;
+`;
+
+const ZoomViewContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 100%;
+  grid-area: flamegraph;
+`;


### PR DESCRIPTION
Introduces a new layout component that allows us to rearrange how we visualize the layout. It leverages grid areas which allows us to do minimum amount of rerendering and updates. Currently only ships with single view, I will add a way to have the frame stack table display bottom, left or right later, but I first need to decouple the renderer dependency from that component.

The buttons from the recording were there just to demonstrate the layout changes and were removed.
https://user-images.githubusercontent.com/9317857/177818232-9c55b940-4b4b-4305-a045-90906ed43b25.mp4
