### PR TITLE
feat(sampling): Wire up the save/edit uniform rule flow [TET-164]

### DIFF
--- a/static/app/types/sampling.tsx
+++ b/static/app/types/sampling.tsx
@@ -212,3 +212,10 @@ export type RecommendedSdkUpgrade = {
   latestSDKVersion: SamplingSdkVersion['latestSDKVersion'];
   project: Project;
 };
+
+export type UniformModalsSubmit = (
+  sampleRate: number,
+  rule?: SamplingRule,
+  onSuccess?: () => void,
+  onError?: () => void
+) => void;

--- a/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
@@ -1,6 +1,6 @@
 import 'prism-sentry/index.css';
 
-import {Fragment} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -18,24 +18,29 @@ import {
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
-import {RecommendedSdkUpgrade} from 'sentry/types/sampling';
+import {
+  RecommendedSdkUpgrade,
+  SamplingRule,
+  UniformModalsSubmit,
+} from 'sentry/types/sampling';
 import {formatPercentage} from 'sentry/utils/formatters';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-import {SERVER_SIDE_SAMPLING_DOC_LINK} from '../utils';
+import {isValidSampleRate, SERVER_SIDE_SAMPLING_DOC_LINK} from '../utils';
+import {projectStatsToSampleRates} from '../utils/projectStatsToSampleRates';
+import useProjectStats from '../utils/useProjectStats';
 
 import {FooterActions, Stepper} from './uniformRateModal';
 
 export type RecommendedStepsModalProps = ModalRenderProps & {
-  /**
-   * Decimal value of the client sample rate
-   */
-  clientSampleRate: number;
-  onSubmit: () => void;
   organization: Organization;
   recommendedSdkUpgrades: RecommendedSdkUpgrade[];
+  clientSampleRate?: number;
   onGoBack?: () => void;
+  onSubmit?: UniformModalsSubmit;
   project?: Project;
+  serverSampleRate?: number;
+  uniformRule?: SamplingRule;
 };
 
 export function RecommendedStepsModal({
@@ -48,7 +53,50 @@ export function RecommendedStepsModal({
   onGoBack,
   onSubmit,
   clientSampleRate,
+  serverSampleRate,
+  uniformRule,
+  project,
 }: RecommendedStepsModalProps) {
+  const [saving, setSaving] = useState(false);
+  const {projectStats} = useProjectStats({
+    orgSlug: organization.slug,
+    projectId: project?.id,
+    interval: '1h',
+    statsPeriod: '48h',
+    disable: !!clientSampleRate,
+  });
+  const {maxSafeSampleRate} = projectStatsToSampleRates(projectStats);
+  const suggestedClientSampleRate = clientSampleRate
+    ? clientSampleRate / 100
+    : maxSafeSampleRate;
+
+  const isValid =
+    isValidSampleRate(clientSampleRate) && isValidSampleRate(serverSampleRate);
+
+  function handleDone() {
+    if (!onSubmit) {
+      closeModal();
+    }
+
+    if (!isValid) {
+      return;
+    }
+
+    setSaving(true);
+
+    onSubmit?.(
+      serverSampleRate!,
+      uniformRule,
+      () => {
+        setSaving(false);
+        closeModal();
+      },
+      () => {
+        setSaving(false);
+      }
+    );
+  }
+
   return (
     <Fragment>
       <Header closeButton>
@@ -72,10 +120,13 @@ export function RecommendedStepsModal({
               </TextBlock>
               <UpgradeSDKfromProjects>
                 {recommendedSdkUpgrades.map(
-                  ({project, latestSDKName, latestSDKVersion}) => {
+                  ({project: upgradableProject, latestSDKName, latestSDKVersion}) => {
                     return (
-                      <div key={project.id}>
-                        <SdkProjectBadge project={project} organization={organization} />
+                      <div key={upgradableProject.id}>
+                        <SdkProjectBadge
+                          project={upgradableProject}
+                          organization={organization}
+                        />
                         <SdkOutdatedVersion>
                           {tct('This project is on [current-version]', {
                             ['current-version']: (
@@ -112,10 +163,13 @@ export function RecommendedStepsModal({
                     {'  traceSampleRate'}
                   </span>
                   <span className="token operator">:</span>{' '}
-                  <span className="token string">{clientSampleRate}</span>
+                  <span className="token string">{suggestedClientSampleRate || ''}</span>
                   <span className="token punctuation">,</span>{' '}
                   <span className="token comment">
-                    // {formatPercentage(clientSampleRate)}
+                    //{' '}
+                    {suggestedClientSampleRate
+                      ? formatPercentage(suggestedClientSampleRate)
+                      : ''}
                   </span>
                   <br />
                   <span className="token punctuation">{'}'}</span>
@@ -140,7 +194,18 @@ export function RecommendedStepsModal({
               </Fragment>
             )}
             {!onGoBack && <Button onClick={closeModal}>{t('Cancel')}</Button>}
-            <Button priority="primary" onClick={onSubmit}>
+            <Button
+              priority="primary"
+              onClick={handleDone}
+              disabled={onSubmit ? saving || !isValid : false} // do not disable the button if there's on onSubmit handler (modal was opened from the sdk alert)
+              title={
+                onSubmit
+                  ? !isValid
+                    ? t('Sample rate is not valid')
+                    : undefined
+                  : undefined
+              }
+            >
               {t('Done')}
             </Button>
           </ButtonBar>

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -11,13 +11,13 @@ import {IconRefresh} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Project, SeriesApi} from 'sentry/types';
-import {SamplingRule} from 'sentry/types/sampling';
+import {SamplingRule, UniformModalsSubmit} from 'sentry/types/sampling';
 import {defined} from 'sentry/utils';
 import {formatPercentage} from 'sentry/utils/formatters';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 import {SamplingSDKAlert} from '../samplingSDKAlert';
-import {SERVER_SIDE_SAMPLING_DOC_LINK} from '../utils';
+import {isValidSampleRate, SERVER_SIDE_SAMPLING_DOC_LINK} from '../utils';
 import {projectStatsToPredictedSeries} from '../utils/projectStatsToPredictedSeries';
 import {projectStatsToSampleRates} from '../utils/projectStatsToSampleRates';
 import {projectStatsToSeries} from '../utils/projectStatsToSeries';
@@ -36,11 +36,11 @@ enum Step {
   RECOMMENDED_STEPS = 'recommended_steps',
 }
 
-type Props = Omit<RecommendedStepsModalProps, 'onSubmit' | 'clientSampleRate'> & {
+type Props = Omit<RecommendedStepsModalProps, 'onSubmit'> & {
+  onSubmit: UniformModalsSubmit;
   rules: SamplingRule[];
   project?: Project;
   projectStats?: SeriesApi;
-  uniformRule?: SamplingRule;
 };
 
 function UniformRateModal({
@@ -54,6 +54,7 @@ function UniformRateModal({
   project,
   uniformRule,
   rules,
+  onSubmit,
   ...props
 }: Props) {
   const {projectStats: projectStats30d, loading: loading30d} = useProjectStats({
@@ -87,6 +88,11 @@ function UniformRateModal({
   const [client, setClient] = useState(recommendedClientSampling);
   const [server, setServer] = useState(recommendedServerSampling);
 
+  const [saving, setSaving] = useState(false);
+
+  const shouldHaveStep2 =
+    client !== currentClientSampling || recommendedSdkUpgrades.length > 0;
+
   useEffect(() => {
     setClient(recommendedClientSampling);
     setServer(recommendedServerSampling);
@@ -95,7 +101,36 @@ function UniformRateModal({
   const isEdited =
     client !== recommendedClientSampling || server !== recommendedServerSampling;
 
-  if (activeStep === Step.RECOMMENDED_STEPS && defined(client)) {
+  const isValid = isValidSampleRate(client) && isValidSampleRate(server);
+
+  function handlePrimaryButtonClick() {
+    // this can either be "Next" or "Done"
+
+    if (!isValid) {
+      return;
+    }
+
+    if (shouldHaveStep2) {
+      setActiveStep(Step.RECOMMENDED_STEPS);
+      return;
+    }
+
+    setSaving(true);
+
+    onSubmit(
+      server!,
+      uniformRule,
+      () => {
+        setSaving(false);
+        closeModal();
+      },
+      () => {
+        setSaving(false);
+      }
+    );
+  }
+
+  if (activeStep === Step.RECOMMENDED_STEPS) {
     return (
       <RecommendedStepsModal
         {...props}
@@ -106,8 +141,10 @@ function UniformRateModal({
         organization={organization}
         recommendedSdkUpgrades={recommendedSdkUpgrades}
         onGoBack={() => setActiveStep(Step.SET_UNIFORM_SAMPLE_RATE)}
-        onSubmit={() => {}}
-        clientSampleRate={Math.max(Math.min(Number(client) / 100, 1), 0)}
+        onSubmit={onSubmit}
+        clientSampleRate={client}
+        serverSampleRate={server}
+        uniformRule={uniformRule}
       />
     );
   }
@@ -251,13 +288,21 @@ function UniformRateModal({
           </Button>
 
           <ButtonBar gap={1}>
-            <Stepper>{t('Step 1 of 2')}</Stepper>
+            {shouldHaveStep2 && <Stepper>{t('Step 1 of 2')}</Stepper>}
             <Button onClick={closeModal}>{t('Cancel')}</Button>
             <Button
               priority="primary"
-              onClick={() => setActiveStep(Step.RECOMMENDED_STEPS)}
+              onClick={handlePrimaryButtonClick}
+              disabled={saving || !isValid || selectedStrategy === Strategy.CURRENT}
+              title={
+                selectedStrategy === Strategy.CURRENT
+                  ? t('Current sampling values selected')
+                  : !isValid
+                  ? t('Sample rate is not valid')
+                  : undefined
+              }
             >
-              {t('Next')}
+              {shouldHaveStep2 ? t('Next') : t('Done')}
             </Button>
           </ButtonBar>
         </FooterActions>

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -90,7 +90,7 @@ function UniformRateModal({
 
   const [saving, setSaving] = useState(false);
 
-  const shouldHaveStep2 =
+  const shouldHaveNextStep =
     client !== currentClientSampling || recommendedSdkUpgrades.length > 0;
 
   useEffect(() => {
@@ -110,7 +110,7 @@ function UniformRateModal({
       return;
     }
 
-    if (shouldHaveStep2) {
+    if (shouldHaveNextStep) {
       setActiveStep(Step.RECOMMENDED_STEPS);
       return;
     }
@@ -288,7 +288,7 @@ function UniformRateModal({
           </Button>
 
           <ButtonBar gap={1}>
-            {shouldHaveStep2 && <Stepper>{t('Step 1 of 2')}</Stepper>}
+            {shouldHaveNextStep && <Stepper>{t('Step 1 of 2')}</Stepper>}
             <Button onClick={closeModal}>{t('Cancel')}</Button>
             <Button
               priority="primary"
@@ -302,7 +302,7 @@ function UniformRateModal({
                   : undefined
               }
             >
-              {shouldHaveStep2 ? t('Next') : t('Done')}
+              {shouldHaveNextStep ? t('Next') : t('Done')}
             </Button>
           </ButtonBar>
         </FooterActions>

--- a/static/app/views/settings/project/server-side-sampling/samplingSDKAlert.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingSDKAlert.tsx
@@ -31,15 +31,13 @@ export function SamplingSDKAlert({
     return null;
   }
 
-  function handleOpenRecommendedSteps(uniformRule: SamplingRule) {
+  function handleOpenRecommendedSteps() {
     openModal(modalProps => (
       <RecommendedStepsModal
         {...modalProps}
         organization={organization}
         project={project}
         recommendedSdkUpgrades={recommendedSdkUpgrades}
-        clientSampleRate={uniformRule.sampleRate}
-        onSubmit={() => {}}
       />
     ));
   }
@@ -55,11 +53,7 @@ export function SamplingSDKAlert({
       showIcon
       trailingItems={
         showLinkToTheModal && uniformRule ? (
-          <Button
-            onClick={() => handleOpenRecommendedSteps(uniformRule)}
-            priority="link"
-            borderless
-          >
+          <Button onClick={handleOpenRecommendedSteps} priority="link" borderless>
             {atLeastOneRuleActive ? t('Resolve Now') : t('Learn More')}
           </Button>
         ) : undefined

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -15,7 +15,12 @@ import {t} from 'sentry/locale';
 import ProjectStore from 'sentry/stores/projectsStore';
 import space from 'sentry/styles/space';
 import {Project} from 'sentry/types';
-import {SamplingRule, SamplingRuleOperator} from 'sentry/types/sampling';
+import {
+  SamplingConditionOperator,
+  SamplingRule,
+  SamplingRuleOperator,
+  SamplingRuleType,
+} from 'sentry/types/sampling';
 import {defined} from 'sentry/utils';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 import useApi from 'sentry/utils/useApi';
@@ -171,6 +176,7 @@ export function ServerSideSampling({project}: Props) {
           projectStats={projectStats}
           recommendedSdkUpgrades={recommendedSdkUpgrades}
           rules={rules}
+          onSubmit={saveUniformRule}
         />
       ),
       {
@@ -234,6 +240,7 @@ export function ServerSideSampling({project}: Props) {
             uniformRule={rule}
             rules={rules}
             recommendedSdkUpgrades={recommendedSdkUpgrades}
+            onSubmit={saveUniformRule}
           />
         ),
         {
@@ -269,6 +276,50 @@ export function ServerSideSampling({project}: Props) {
       const message = t('Unable to delete sampling rule');
       handleXhrErrorResponse(message)(error);
       addErrorMessage(message);
+    }
+  }
+
+  async function saveUniformRule(
+    sampleRate: number,
+    rule?: SamplingRule,
+    onSuccess?: () => void,
+    onError?: () => void
+  ) {
+    const newRule: SamplingRule = {
+      // All new/updated rules must have id equal to 0
+      id: 0,
+      active: rule ? rule.active : false,
+      type: SamplingRuleType.TRACE,
+      condition: {
+        op: SamplingConditionOperator.AND,
+        inner: [],
+      },
+      sampleRate: sampleRate / 100,
+    };
+
+    const newRules = rule
+      ? rules.map(existingRule => (existingRule.id === rule.id ? newRule : existingRule))
+      : [...rules, newRule];
+
+    try {
+      const response = await api.requestPromise(
+        `/projects/${organization.slug}/${project.slug}/`,
+        {method: 'PUT', data: {dynamicSampling: {rules: newRules}}}
+      );
+      ProjectStore.onUpdateSuccess(response);
+      addSuccessMessage(
+        rule
+          ? t('Successfully edited sampling rule')
+          : t('Successfully added sampling rule')
+      );
+      onSuccess?.();
+    } catch (error) {
+      addErrorMessage(
+        typeof error === 'string'
+          ? error
+          : error.message || t('Failed to save sampling rule')
+      );
+      onError?.();
     }
   }
 

--- a/static/app/views/settings/project/server-side-sampling/utils/index.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/index.tsx
@@ -1,5 +1,6 @@
 import {t} from 'sentry/locale';
 import {SamplingInnerName, SamplingRule, SamplingRuleType} from 'sentry/types/sampling';
+import {defined} from 'sentry/utils';
 
 // TODO: Update this link as soon as we have one for sampling
 export const SERVER_SIDE_SAMPLING_DOC_LINK =
@@ -30,4 +31,12 @@ export function isUniformRule(rule?: SamplingRule) {
   }
 
   return rule.type === SamplingRuleType.TRACE && rule.condition.inner.length === 0;
+}
+
+export function isValidSampleRate(sampleRate: number | undefined) {
+  if (!defined(sampleRate)) {
+    return false;
+  }
+
+  return !isNaN(sampleRate) && sampleRate <= 100 && sampleRate >= 0;
 }

--- a/static/app/views/settings/project/server-side-sampling/utils/useProjectStats.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/useProjectStats.tsx
@@ -7,7 +7,7 @@ import useApi from 'sentry/utils/useApi';
 
 import {projectStatsToSeries} from './projectStatsToSeries';
 
-function useProjectStats({orgSlug, projectId, interval, statsPeriod}) {
+function useProjectStats({orgSlug, projectId, interval, statsPeriod, disable = false}) {
   const api = useApi();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
@@ -37,8 +37,10 @@ function useProjectStats({orgSlug, projectId, interval, statsPeriod}) {
         setLoading(false);
       }
     }
-    fetchStats();
-  }, [api, projectId, orgSlug, interval, statsPeriod]);
+    if (!disable) {
+      fetchStats();
+    }
+  }, [api, projectId, orgSlug, interval, statsPeriod, disable]);
 
   return {
     loading,

--- a/tests/js/spec/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
@@ -40,7 +40,7 @@ describe('Server-side Sampling - Recommended Steps Modal', function () {
           },
         ]}
         onSubmit={jest.fn()}
-        clientSampleRate={uniformRule.sampleRate}
+        clientSampleRate={50}
       />
     ));
 


### PR DESCRIPTION
This PR connects all the modals together and wires them up with the API.
We can now save and update the uniform rules.
Based on your choices you can get either the step 1 modal, step2 or both.

Will add test coverage in a follow-up.