### PR TITLE
fix(arm): prefix title for ActiveReleaseAlertNotification to differentiate from AlertRuleNotifications

### DIFF
--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -9,6 +9,7 @@ from django.utils.encoding import force_text
 from sentry import options
 from sentry.models import Project, ProjectOption, Team, User
 from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
+from sentry.notifications.notifications.rules import ActiveReleaseAlertNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -52,6 +53,10 @@ def get_subject_with_prefix(
     prefix = ""
     if isinstance(notification, ProjectNotification):
         prefix = f"{build_subject_prefix(notification.project).rstrip()} "
+
+    if isinstance(notification, ActiveReleaseAlertNotification):
+        prefix = f"**ARM** {prefix}"
+
     return f"{prefix}{notification.get_subject(context)}".encode()
 
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -108,6 +108,7 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
         to_committer = mail.outbox[0]
 
         assert to_committer
+        assert to_committer.subject == "**ARM** [Sentry] BAR-1 - Hello world"
 
 
 class MailAdapterGetSendableUsersTest(BaseMailAdapterTest):


### PR DESCRIPTION
Simple change. Prepend `**ARM**` to the email subject title so committers who receive these emails can differentiate from regular AlertRuleNotifications.