### PR TITLE
fix(issues): Show missing suggested assignees

### DIFF
--- a/static/app/components/group/suggestedOwners/suggestedOwners.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.tsx
@@ -147,10 +147,10 @@ class SuggestedOwners extends AsyncComponent<Props, State> {
    */
   getOwnerList() {
     const committers = this.props.committers ?? [];
-    const owners = committers.map(commiter => ({
-      actor: {...commiter.author, type: 'user' as Actor['type']},
+    const owners: OwnerList = committers.map(commiter => ({
+      actor: {...commiter.author, type: 'user'},
       commits: commiter.commits,
-    })) as OwnerList;
+    }));
 
     this.state.event_owners.owners.forEach(owner => {
       const normalizedOwner = {
@@ -158,9 +158,10 @@ class SuggestedOwners extends AsyncComponent<Props, State> {
         rules: findMatchedRules(this.state.event_owners.rules || [], owner),
       };
 
-      const existingIdx = owners.findIndex(o =>
-        committers.length === 0 ? o.actor === owner : o.actor.email === owner.email
-      );
+      const existingIdx =
+        committers.length > 0 && owner.email && owner.type === 'user'
+          ? owners.findIndex(o => o.actor.email === owner.email)
+          : -1;
       if (existingIdx > -1) {
         owners[existingIdx] = {...normalizedOwner, ...owners[existingIdx]};
         return;

--- a/tests/js/spec/components/group/suggestedOwners.spec.jsx
+++ b/tests/js/spec/components/group/suggestedOwners.spec.jsx
@@ -22,6 +22,8 @@ describe('SuggestedOwners', function () {
   const endpoint = `/projects/${organization.slug}/${project.slug}/events/${event.id}`;
 
   beforeEach(function () {
+    CommitterStore.init();
+    TeamStore.init();
     MemberListStore.loadInitialData([user, TestStubs.CommitAuthor()]);
     Client.addMockResponse({
       url: `/projects/${organization.slug}/${project.slug}/codeowners/`,

--- a/tests/js/spec/components/group/suggestedOwners.spec.jsx
+++ b/tests/js/spec/components/group/suggestedOwners.spec.jsx
@@ -1,5 +1,4 @@
 import {
-  act,
   render,
   screen,
   userEvent,
@@ -11,6 +10,7 @@ import {Client} from 'sentry/api';
 import SuggestedOwners from 'sentry/components/group/suggestedOwners/suggestedOwners';
 import CommitterStore from 'sentry/stores/committerStore';
 import MemberListStore from 'sentry/stores/memberListStore';
+import TeamStore from 'sentry/stores/teamStore';
 
 describe('SuggestedOwners', function () {
   const user = TestStubs.User();
@@ -41,7 +41,8 @@ describe('SuggestedOwners', function () {
 
   afterEach(function () {
     Client.clearMockResponses();
-    act(() => CommitterStore.reset());
+    TeamStore.teardown();
+    CommitterStore.teardown();
   });
 
   it('Renders suggested owners', async function () {
@@ -132,5 +133,37 @@ describe('SuggestedOwners', function () {
 
     expect(await screen.findByText('sentry/tagstore/*')).toBeInTheDocument();
     expect(screen.getByText('Matching Ownership Rules')).toBeInTheDocument();
+  });
+
+  it('displays two teams when there are committers', async function () {
+    const team1 = TestStubs.Team({slug: 'team-1', id: '1'});
+    const team2 = TestStubs.Team({slug: 'team-2', id: '2'});
+    TeamStore.loadInitialData([team1, team2], false, null);
+
+    Client.addMockResponse({
+      url: `${endpoint}/committers/`,
+      body: {
+        committers: [{author: TestStubs.CommitAuthor(), commits: [TestStubs.Commit()]}],
+      },
+    });
+
+    Client.addMockResponse({
+      url: `${endpoint}/owners/`,
+      body: {
+        owners: [
+          {type: 'team', id: team1.id, name: team1.slug},
+          {type: 'team', id: team2.id, name: team2.slug},
+        ],
+        rules: [[['path', 'sentry/tagstore/*'], [['team', team1.slug]]]],
+      },
+    });
+
+    render(<SuggestedOwners project={project} group={group} event={event} />, {
+      organization,
+    });
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId('suggested-assignee')).toHaveLength(3)
+    );
   });
 });


### PR DESCRIPTION
when there was committers, `actor.email === owner.email` was causing teams to be overwritten since they don't have an email
