### PR TITLE
feat(customer-domains): Add sentryUrl and organizationUrl to config on the frontend

### DIFF
--- a/fixtures/js-stubs/config.js
+++ b/fixtures/js-stubs/config.js
@@ -43,6 +43,8 @@ export function Config(params = {}) {
     apmSampling: 1,
     dsn_requests: '',
     demoMode: false,
+    sentryUrl: 'https://sentry.io',
+    organizationUrl: 'https://foobar.us.sentry.io',
     ...params,
   };
 }

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -132,12 +132,14 @@ export interface Config {
   messages: {level: keyof Theme['alert']; message: string}[];
   needsUpgrade: boolean;
 
+  organizationUrl: string | undefined;
   privacyUrl: string | null;
   sentryConfig: {
     dsn: string;
     release: string;
     whitelistUrls: string[];
   };
+  sentryUrl: string;
   singleOrganization: boolean;
   supportEmail: string;
   termsUrl: string | null;

--- a/tests/js/spec/stores/configStore.spec.tsx
+++ b/tests/js/spec/stores/configStore.spec.tsx
@@ -1,0 +1,8 @@
+import ConfigStore from 'sentry/stores/configStore';
+
+describe('ConfigStore', () => {
+  it('should have apiUrl and organizationUrl', () => {
+    expect(ConfigStore.get('sentryUrl')).toEqual('https://sentry.io');
+    expect(ConfigStore.get('organizationUrl')).toEqual('https://foobar.us.sentry.io');
+  });
+});


### PR DESCRIPTION
Split from https://github.com/getsentry/sentry/pull/35169

This pull request contains the frontend changes. The backend changes resides in https://github.com/getsentry/sentry/pull/36387

-----

- Add `sentryUrl` and `organizationUrl` to the `Config` Typescript type. And add their mock values for frontend tests.