### PR TITLE
chore: Re-export hasProjectBeenRenamed for api.tsx in tests

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -7,6 +7,7 @@ const RealApi: typeof ApiNamespace = jest.requireActual('sentry/api');
 export class Request {}
 
 export const initApiClientErrorHandling = RealApi.initApiClientErrorHandling;
+export const hasProjectBeenRenamed = RealApi.hasProjectBeenRenamed;
 
 const respond = (isAsync: boolean, fn?: Function, ...args: any[]): void => {
   if (!fn) {


### PR DESCRIPTION
This was cherry-picked from https://github.com/getsentry/sentry/pull/35169

I had a hard time understanding why the `hasProjectBeenRenamed` export was `undefined` when importing it from the `sentry/api` module in the frontend tests.

So I'm re-exporting it here for completeness. 