### PR TITLE
fix(profiling): properly detect typescript profiles

### DIFF
--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -261,7 +261,7 @@ function createFrameInfoFromEvent(event: ChromeTrace.Event) {
   };
 }
 
-export function parseChromeTraceArrayFormat(
+export function parseTypescriptChromeTraceArrayFormat(
   input: ChromeTrace.ArrayFormat,
   traceID: string,
   options?: ImportOptions

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -2,16 +2,16 @@ import * as Sentry from '@sentry/react';
 import {Transaction} from '@sentry/types';
 
 import {
-  isChromeTraceArrayFormat,
   isChromeTraceFormat,
   isChromeTraceObjectFormat,
   isEventedProfile,
   isJSProfile,
   isSampledProfile,
   isSchema,
+  isTypescriptChromeTraceArrayFormat,
 } from '../guards/profile';
 
-import {parseChromeTraceArrayFormat} from './chromeTraceProfile';
+import {parseTypescriptChromeTraceArrayFormat} from './chromeTraceProfile';
 import {EventedProfile} from './eventedProfile';
 import {JSSelfProfile} from './jsSelfProfile';
 import {Profile} from './profile';
@@ -100,8 +100,8 @@ function importChromeTrace(
     throw new Error('Chrometrace object format is not yet supported');
   }
 
-  if (isChromeTraceArrayFormat(input)) {
-    return parseChromeTraceArrayFormat(input, traceID, options);
+  if (isTypescriptChromeTraceArrayFormat(input)) {
+    return parseTypescriptChromeTraceArrayFormat(input, traceID, options);
   }
 
   throw new Error('Failed to parse trace input format');

--- a/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
@@ -34,7 +34,7 @@ describe('splitEventsByProcessAndTraceId', () => {
 });
 
 describe('parseTypescriptChromeTraceArrayFormat', () => {
-  it('returns chrometrace profile', () => {
+  it('returns typescript profile', () => {
     expect(
       parseTypescriptChromeTraceArrayFormat(
         [

--- a/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/chromeTraceProfile.spec.tsx
@@ -1,7 +1,7 @@
 import {
   ChromeTraceProfile,
   collapseSamples,
-  parseChromeTraceArrayFormat,
+  parseTypescriptChromeTraceArrayFormat,
   splitEventsByProcessAndTraceId,
 } from 'sentry/utils/profiling/profile/chromeTraceProfile';
 
@@ -33,10 +33,10 @@ describe('splitEventsByProcessAndTraceId', () => {
   });
 });
 
-describe('parseChromeTraceArrayFormat', () => {
+describe('parseTypescriptChromeTraceArrayFormat', () => {
   it('returns chrometrace profile', () => {
     expect(
-      parseChromeTraceArrayFormat(
+      parseTypescriptChromeTraceArrayFormat(
         [
           {
             ph: 'M',
@@ -64,7 +64,7 @@ describe('parseChromeTraceArrayFormat', () => {
 
   it('marks process name', () => {
     expect(
-      parseChromeTraceArrayFormat(
+      parseTypescriptChromeTraceArrayFormat(
         [
           {
             ph: 'M',
@@ -92,7 +92,7 @@ describe('parseChromeTraceArrayFormat', () => {
 
   it('marks thread name', () => {
     expect(
-      parseChromeTraceArrayFormat(
+      parseTypescriptChromeTraceArrayFormat(
         [
           {
             ph: 'M',
@@ -119,7 +119,7 @@ describe('parseChromeTraceArrayFormat', () => {
   });
 
   it('imports a simple trace', () => {
-    const trace = parseChromeTraceArrayFormat(
+    const trace = parseTypescriptChromeTraceArrayFormat(
       [
         {
           ph: 'B',
@@ -150,7 +150,7 @@ describe('parseChromeTraceArrayFormat', () => {
   });
 
   it('closes unclosed events', () => {
-    const trace = parseChromeTraceArrayFormat(
+    const trace = parseTypescriptChromeTraceArrayFormat(
       [
         {
           ph: 'B',
@@ -192,7 +192,7 @@ describe('parseChromeTraceArrayFormat', () => {
   });
 
   it('handles out of order E events', () => {
-    const trace = parseChromeTraceArrayFormat(
+    const trace = parseTypescriptChromeTraceArrayFormat(
       [
         {
           ph: 'B',
@@ -248,7 +248,7 @@ describe('parseChromeTraceArrayFormat', () => {
   });
 
   it('handles out of order B events', () => {
-    const trace = parseChromeTraceArrayFormat(
+    const trace = parseTypescriptChromeTraceArrayFormat(
       [
         {
           ph: 'B',
@@ -304,7 +304,7 @@ describe('parseChromeTraceArrayFormat', () => {
   });
 
   it('handles X trace with tdur', () => {
-    const trace = parseChromeTraceArrayFormat(
+    const trace = parseTypescriptChromeTraceArrayFormat(
       [
         {
           ph: 'X',
@@ -324,7 +324,7 @@ describe('parseChromeTraceArrayFormat', () => {
   });
 
   it('handles X trace with dur', () => {
-    const trace = parseChromeTraceArrayFormat(
+    const trace = parseTypescriptChromeTraceArrayFormat(
       [
         {
           ph: 'X',

--- a/tests/js/spec/utils/profiling/profile/importProfile.spec.tsx
+++ b/tests/js/spec/utils/profiling/profile/importProfile.spec.tsx
@@ -1,3 +1,4 @@
+import {ChromeTraceProfile} from 'sentry/utils/profiling/profile/chromeTraceProfile';
 import {EventedProfile} from 'sentry/utils/profiling/profile/eventedProfile';
 import {
   importDroppedProfile,
@@ -67,6 +68,32 @@ describe('importProfile', () => {
     );
 
     expect(imported.profiles[0]).toBeInstanceOf(SampledProfile);
+  });
+
+  it('imports typescript profile', () => {
+    const typescriptProfile: ChromeTrace.ArrayFormat = [
+      {
+        ph: 'B',
+        ts: 1000,
+        cat: 'program',
+        pid: 0,
+        tid: 0,
+        name: 'createProgram',
+        args: {configFilePath: '/Users/jonasbadalic/Work/sentry/tsconfig.json'},
+      },
+      {
+        ph: 'E',
+        ts: 2000,
+        cat: 'program',
+        pid: 0,
+        tid: 0,
+        name: 'createProgram',
+        args: {configFilePath: '/Users/jonasbadalic/Work/sentry/tsconfig.json'},
+      },
+    ];
+
+    const imported = importProfile(typescriptProfile, '');
+    expect(imported.profiles[0]).toBeInstanceOf(ChromeTraceProfile);
   });
   it('imports JS self profile from schema', () => {
     const jsSelfProfile: JSSelfProfiling.Trace = {
@@ -192,7 +219,7 @@ describe('importDroppedProfile', () => {
     await expect(importDroppedProfile(file)).rejects.toBeInstanceOf(Error);
   });
 
-  it('imports schema file', async () => {
+  it('imports dropped schema file', async () => {
     const schema: Profiling.Schema = {
       activeProfileIndex: 0,
       durationNS: 0,
@@ -223,7 +250,35 @@ describe('importDroppedProfile', () => {
     expect(imported.profiles[0]).toBeInstanceOf(SampledProfile);
   });
 
-  it('imports JS self profile', async () => {
+  it('imports dropped typescript profile', async () => {
+    const typescriptProfile: ChromeTrace.ArrayFormat = [
+      {
+        ph: 'B',
+        ts: 1000,
+        cat: 'program',
+        pid: 0,
+        tid: 0,
+        name: 'createProgram',
+        args: {configFilePath: '/Users/jonasbadalic/Work/sentry/tsconfig.json'},
+      },
+      {
+        ph: 'E',
+        ts: 2000,
+        cat: 'program',
+        pid: 0,
+        tid: 0,
+        name: 'createProgram',
+        args: {configFilePath: '/Users/jonasbadalic/Work/sentry/tsconfig.json'},
+      },
+    ];
+
+    const file = new File([JSON.stringify(typescriptProfile)], 'test.tsx');
+    const imported = await importDroppedProfile(file);
+
+    expect(imported.profiles[0]).toBeInstanceOf(ChromeTraceProfile);
+  });
+
+  it('imports dropped JS self profile', async () => {
     const jsSelfProfile: JSSelfProfiling.Trace = {
       resources: ['app.js', 'vendor.js'],
       frames: [{name: 'ReactDOM.render', line: 1, column: 1, resourceId: 0}],


### PR DESCRIPTION
Fixes the wrongly updated chrometrace type guard. Added tests for importProfile and importDroppedProfile so we hopefully prevent this from happening again.