### PR TITLE
feat(auditlog): Update audit log endpoint for v2

### DIFF
--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -58,5 +58,5 @@ class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
 
         # TODO: Cleanup after frontend is moved to v2
         if "v2" in query:
-            response.data = {"rows": response.data, "options": audit_log.get_api_names}
+            response.data = {"rows": response.data, "options": audit_log.get_api_names()}
         return request

--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -1,3 +1,5 @@
+from urllib import response
+
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -46,10 +48,15 @@ class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
             else:
                 queryset = queryset.filter(event=query["event"])
 
-        return self.paginate(
+        request = self.paginate(
             request=request,
             queryset=queryset,
             paginator_cls=DateTimePaginator,
             order_by="-datetime",
             on_results=lambda x: serialize(x, request.user),
         )
+
+        # TODO: Cleanup after frontend is moved to v2
+        if "v2" in query:
+            response.data = {"rows": response.data, "options": audit_log.get_api_names}
+        return request

--- a/src/sentry/audit_log/manager.py
+++ b/src/sentry/audit_log/manager.py
@@ -38,12 +38,20 @@ To add a new audit log event:
 
 3. Record your AuditLogEvent.
 
+    User initiated example:
     self.create_audit_entry(
         request=request,
         organization_id=organization.id,
         target_object=member.id,
         data={"email": "email@gmail.com"},
-        event=audit_log.get_event_id(MEMBER_INVITE),
+        event=audit_log.get_event_id("MEMBER_INVITE"),
+    )
+
+    Sentry system initiated example -> only use if no user triggers the entry event:
+    create_system_audit_entry(
+        organization=organization,
+        target_object=organization.id,
+        event=audit_log.get_event_id("ORG_REMOVE"),
     )
 """
 


### PR DESCRIPTION
Updating the audit log api endpoint to handle requests for `/organizations/${organization.slug}/audit-logs/?v2`. This temporary endpoint will allow the `response.data` to be adjusted to include the audit log api names list only if the the requests specifies `v2`.

After the frontend updates have been merged/deployed for several days, the endpoint will be updated again to revert back to the `/organizations/${organization.slug}/audit-logs/` endpoint. 