### PR TITLE
feat: Add organizationUrl to OrganizationSummary

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -19,6 +19,7 @@ from sentry.api.serializers.models.role import (
     TeamRoleSerializer,
 )
 from sentry.api.serializers.models.team import TeamSerializerResponse
+from sentry.api.utils import generate_customer_url
 from sentry.app import quotas
 from sentry.auth.access import Access
 from sentry.constants import (
@@ -149,6 +150,7 @@ class OrganizationSerializerResponse(TypedDict):
     name: str
     dateCreated: datetime
     isEarlyAdopter: bool
+    organizationUrl: str
     require2FA: bool
     requireEmailVerification: bool
     avatar: Any  # TODO replace with Avatar
@@ -240,6 +242,7 @@ class OrganizationSerializer(Serializer):  # type: ignore
             "name": obj.name or obj.slug,
             "dateCreated": obj.date_added,
             "isEarlyAdopter": bool(obj.flags.early_adopter),
+            "organizationUrl": generate_customer_url(obj.slug),
             "require2FA": bool(obj.flags.require_2fa),
             "requireEmailVerification": bool(
                 features.has("organizations:required-email-verification", obj)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -19,7 +19,7 @@ from sentry.api.serializers.models.role import (
     TeamRoleSerializer,
 )
 from sentry.api.serializers.models.team import TeamSerializerResponse
-from sentry.api.utils import generate_customer_url
+from sentry.api.utils import generate_organization_url
 from sentry.app import quotas
 from sentry.auth.access import Access
 from sentry.constants import (
@@ -242,7 +242,7 @@ class OrganizationSerializer(Serializer):  # type: ignore
             "name": obj.name or obj.slug,
             "dateCreated": obj.date_added,
             "isEarlyAdopter": bool(obj.flags.early_adopter),
-            "organizationUrl": generate_customer_url(obj.slug),
+            "organizationUrl": generate_organization_url(obj.slug),
             "require2FA": bool(obj.flags.require_2fa),
             "requireEmailVerification": bool(
                 features.has("organizations:required-email-verification", obj)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -57,6 +57,8 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
     def test_simple(self):
         response = self.get_success_response(self.organization.slug)
 
+        assert response.data["slug"] == self.organization.slug
+        assert response.data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
         assert response.data["onboardingTasks"] == []
         assert response.data["id"] == str(self.organization.id)
         assert response.data["role"] == "owner"


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/36387. But branched from https://github.com/getsentry/sentry/pull/36431

This pull request injects `organizationUrl` into the organization summary.