### PR TITLE
 feat: Add organizationUrl to OrganizationSummary (frontend)

### DIFF
--- a/fixtures/js-stubs/organization.js
+++ b/fixtures/js-stubs/organization.js
@@ -2,6 +2,7 @@ export function Organization(params = {}) {
   return {
     id: '3',
     slug: 'org-slug',
+    organizationUrl: 'https://org-slug.us.sentry.io',
     name: 'Organization Name',
     access: [
       'org:read',

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -15,6 +15,7 @@ export type OrganizationSummary = {
   id: string;
   isEarlyAdopter: boolean;
   name: string;
+  organizationUrl: string;
   require2FA: boolean;
   slug: string;
   status: {


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/36441.

Split from https://github.com/getsentry/sentry/pull/35169.

This adds typescript type for `organizationUrl` on `OrganizationSummary` for frontend. 