### PR TITLE
feat(multi-region): Add customer domain support to endpoint classes

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -472,18 +472,18 @@ class ReleaseAnalyticsMixin:
         )
 
 
-def create_customer_endpoint_class(endpoint_class):
+def create_region_endpoint_class(endpoint_class):
     """
-    Create a new class that extends endpoint_class with the same name, but prefixed with Customer.
+    Create a new class that extends endpoint_class with the same name, but prefixed with Region.
     For example, if the endpoint_class's name is "OrganizationEventsEndpoint", then the extended class will be
-    "CustomerOrganizationEventsEndpoint".
+    "RegionOrganizationEventsEndpoint".
 
     In addition, we decorate the extended class with the extend_schema_view decorator such that the operation_id for
-    any and all methods that are decorated with the extend_schema decorator are suffixed with "(customer silo)".
+    any and all methods that are decorated with the extend_schema decorator are suffixed with "(region aware)".
     For example, if a method's operation_id value is "Query Discover Events in Table Format", then the operation_id of
-    the extended class's method will be "Query Discover Events in Table Format (customer silo)".
+    the extended class's method will be "Query Discover Events in Table Format (region aware)".
     """
-    customer_endpoint_class = type(f"Customer{endpoint_class.__name__}", (endpoint_class,), {})
+    region_endpoint_class = type(f"Region{endpoint_class.__name__}", (endpoint_class,), {})
     schema = {}
     for method_name in get_view_method_names(endpoint_class):
         method = isolate_view_method(endpoint_class, method_name)
@@ -498,8 +498,8 @@ def create_customer_endpoint_class(endpoint_class):
         )
         schema[method_name] = extend_schema(
             operation_id=f"{extended_schema.get_operation_id()} (region aware)",
-            # Exclude this endpoint that is specific for customer silo from the schema.
+            # Exclude this endpoint that is specific for a region silo from the schema.
             # In the future, we may include them once we can publicly allow users to consume these APIs.
             exclude=True,
         )
-    return extend_schema_view(**schema)(customer_endpoint_class)
+    return extend_schema_view(**schema)(region_endpoint_class)

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -11,6 +11,8 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.utils.http import urlquote
 from django.views.decorators.csrf import csrf_exempt
+from drf_spectacular.drainage import get_view_method_names, isolate_view_method
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from pytz import utc
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ParseError
@@ -468,3 +470,36 @@ class ReleaseAnalyticsMixin:
             project_ids=project_ids,
             user_agent=request.META.get("HTTP_USER_AGENT", ""),
         )
+
+
+def create_customer_endpoint_class(endpoint_class):
+    """
+    Create a new class that extends endpoint_class with the same name, but prefixed with Customer.
+    For example, if the endpoint_class's name is "OrganizationEventsEndpoint", then the extended class will be
+    "CustomerOrganizationEventsEndpoint".
+
+    In addition, we decorate the extended class with the extend_schema_view decorator such that the operation_id for
+    any and all methods that are decorated with the extend_schema decorator are suffixed with "(customer silo)".
+    For example, if a method's operation_id value is "Query Discover Events in Table Format", then the operation_id of
+    the extended class's method will be "Query Discover Events in Table Format (customer silo)".
+    """
+    customer_endpoint_class = type(f"Customer{endpoint_class.__name__}", (endpoint_class,), {})
+    schema = {}
+    for method_name in get_view_method_names(endpoint_class):
+        method = isolate_view_method(endpoint_class, method_name)
+        if not (method and hasattr(method, "kwargs") and "schema" in method.kwargs):
+            continue
+        extended_schema = method.kwargs["schema"]()
+        # NOTE: this is a hack to be able to retrieve the operation_id values
+        extended_schema.view = type(
+            "View",
+            (),
+            {"request": None, "kwargs": {}, "determine_version": lambda self: (None, None)},
+        )
+        schema[method_name] = extend_schema(
+            operation_id=f"{extended_schema.get_operation_id()} (region aware)",
+            # Exclude this endpoint that is specific for customer silo from the schema.
+            # In the future, we may include them once we can publicly allow users to consume these APIs.
+            exclude=True,
+        )
+    return extend_schema_view(**schema)(customer_endpoint_class)

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -174,6 +174,13 @@ def parse_subdomain(subdomain):
     return org_slug, region
 
 
+def resolve_org_slug_region(request: Request, organization_slug: Optional[str] = None):
+    region = None
+    if organization_slug is None and request.subdomain is not None:
+        organization_slug, region = parse_subdomain(request.subdomain)
+    return organization_slug, region
+
+
 class OrganizationEndpoint(Endpoint):
     permission_classes = (OrganizationPermission,)
 
@@ -359,8 +366,9 @@ class OrganizationEndpoint(Endpoint):
         return params
 
     def convert_args(self, request: Request, organization_slug=None, *args, **kwargs):
-        if organization_slug is None and request.subdomain is not None:
-            organization_slug, region = parse_subdomain(request.subdomain)
+        organization_slug, region = resolve_org_slug_region(
+            request=request, organization_slug=organization_slug
+        )
 
         if not organization_slug:
             raise ResourceDoesNotExist

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.request import Request
 
+from sentry import options
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
@@ -155,6 +156,22 @@ class OrganizationAlertRulePermission(OrganizationPermission):
         "PUT": ["org:write", "org:admin", "alert_rule:write"],
         "DELETE": ["org:write", "org:admin", "alert_rule:write"],
     }
+
+
+def parse_subdomain(subdomain):
+    if subdomain is None:
+        return None, None
+    org_base_hostname = options.get("system.organization-base-hostname")
+    if not org_base_hostname or "{slug}" not in org_base_hostname:
+        return None, None
+    org_slug = subdomain
+    region = None
+    if "{region}" in org_base_hostname:
+        if "." in subdomain:
+            org_slug, _, region = subdomain.rpartition(".")
+        else:
+            return None, None
+    return org_slug, region
 
 
 class OrganizationEndpoint(Endpoint):
@@ -341,7 +358,13 @@ class OrganizationEndpoint(Endpoint):
 
         return params
 
-    def convert_args(self, request: Request, organization_slug, *args, **kwargs):
+    def convert_args(self, request: Request, organization_slug=None, *args, **kwargs):
+        if organization_slug is None and request.subdomain is not None:
+            organization_slug, region = parse_subdomain(request.subdomain)
+
+        if not organization_slug:
+            raise ResourceDoesNotExist
+
         try:
             organization = Organization.objects.get_from_cache(slug=organization_slug)
         except Organization.DoesNotExist:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.api.bases.organization import resolve_org_slug_region
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import GenericOffsetPaginator
@@ -61,6 +62,9 @@ CONCURRENT_RATE_LIMIT = 50
 
 
 def rate_limit_events(request: Request, organization_slug=None, *args, **kwargs) -> RateLimitConfig:
+    organization_slug, _ = resolve_org_slug_region(
+        request=request, organization_slug=organization_slug
+    )
     try:
         organization = Organization.objects.get_from_cache(slug=organization_slug)
     except Organization.DoesNotExist:

--- a/src/sentry/api/region_organization_urls.py
+++ b/src/sentry/api/region_organization_urls.py
@@ -1,0 +1,14 @@
+from django.conf.urls import url
+
+from sentry.api.base import create_region_endpoint_class
+
+from .endpoints.organization_events import OrganizationEventsEndpoint
+
+urlpatterns = [  # Organizations
+    # Organizations
+    url(
+        r"^events/$",
+        create_region_endpoint_class(OrganizationEventsEndpoint).as_view(),
+        name="sentry-api-0-region-organization-events",
+    )
+]

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import include, url
 
+from sentry.api.base import create_customer_endpoint_class
 from sentry.api.endpoints.integration_features import IntegrationFeaturesEndpoint
 from sentry.api.endpoints.organization_codeowners_associations import (
     OrganizationCodeOwnersAssociationsEndpoint,
@@ -835,6 +836,11 @@ urlpatterns = [
         ),
     ),
     # Organizations
+    url(
+        r"^events/$",
+        create_customer_endpoint_class(OrganizationEventsEndpoint).as_view(),
+        name="sentry-api-0-subdomain-organization-events",
+    ),
     url(
         r"^organizations/",
         include(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1,6 +1,5 @@
 from django.conf.urls import include, url
 
-from sentry.api.base import create_region_endpoint_class
 from sentry.api.endpoints.integration_features import IntegrationFeaturesEndpoint
 from sentry.api.endpoints.organization_codeowners_associations import (
     OrganizationCodeOwnersAssociationsEndpoint,
@@ -835,12 +834,9 @@ urlpatterns = [
             ]
         ),
     ),
+    # Organizations - region aware
+    url(r"", include("sentry.api.region_organization_urls")),
     # Organizations
-    url(
-        r"^events/$",
-        create_region_endpoint_class(OrganizationEventsEndpoint).as_view(),
-        name="sentry-api-0-region-organization-events",
-    ),
     url(
         r"^organizations/",
         include(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import include, url
 
-from sentry.api.base import create_customer_endpoint_class
+from sentry.api.base import create_region_endpoint_class
 from sentry.api.endpoints.integration_features import IntegrationFeaturesEndpoint
 from sentry.api.endpoints.organization_codeowners_associations import (
     OrganizationCodeOwnersAssociationsEndpoint,
@@ -838,8 +838,8 @@ urlpatterns = [
     # Organizations
     url(
         r"^events/$",
-        create_customer_endpoint_class(OrganizationEventsEndpoint).as_view(),
-        name="sentry-api-0-subdomain-organization-events",
+        create_region_endpoint_class(OrganizationEventsEndpoint).as_view(),
+        name="sentry-api-0-region-organization-events",
     ),
     url(
         r"^organizations/",

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -11092,7 +11092,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
 
 
 class CustomerOrganizationEventsEndpointTest(OrganizationEventsEndpointTest):
-    viewname = "sentry-api-0-subdomain-organization-events"
+    viewname = "sentry-api-0-region-organization-events"
 
     def client_get(self, *args, **kwargs):
         if "HTTP_HOST" not in kwargs:

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -12,6 +12,7 @@ from snuba_sdk.column import Column
 from snuba_sdk.conditions import InvalidConditionError
 from snuba_sdk.function import Function
 
+from sentry.api.utils import generate_organization_hostname
 from sentry.discover.models import TeamKeyTransaction
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.models import ApiKey, ProjectTeam, ProjectTransactionThreshold, ReleaseStages
@@ -5979,17 +5980,22 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         self.transaction_data = load_data("transaction", timestamp=before_now(minutes=1))
         self.features = {}
 
+    def client_get(self, *args, **kwargs):
+        return self.client.get(*args, **kwargs)
+
+    def reverse_url(self):
+        return reverse(
+            self.viewname,
+            kwargs={"organization_slug": self.organization.slug},
+        )
+
     def do_request(self, query, features=None):
         if features is None:
             features = {"organizations:discover-basic": True}
         features.update(self.features)
         self.login_as(user=self.user)
-        url = reverse(
-            self.viewname,
-            kwargs={"organization_slug": self.organization.slug},
-        )
         with self.feature(features):
-            return self.client.get(url, query, format="json")
+            return self.client_get(self.reverse_url(), query, format="json")
 
     def test_no_projects(self):
         response = self.do_request({})
@@ -6009,11 +6015,8 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         api_key = ApiKey.objects.create(organization=self.organization, scope_list=["org:read"])
         query = {"field": ["project.name", "environment"], "project": [project.id]}
 
-        url = reverse(
-            self.viewname,
-            kwargs={"organization_slug": self.organization.slug},
-        )
-        response = self.client.get(
+        url = self.reverse_url()
+        response = self.client_get(
             url,
             query,
             format="json",
@@ -9892,13 +9895,10 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
 
         features = {"organizations:discover-basic": True}
         features.update(self.features)
-        url = reverse(
-            self.viewname,
-            kwargs={"organization_slug": self.organization.slug},
-        )
+        url = self.reverse_url()
 
         with self.feature(features):
-            self.client.get(
+            self.client_get(
                 url,
                 query,
                 format="json",
@@ -11089,6 +11089,36 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
                 self.do_request(query)
             response = self.do_request(query)
             assert response.status_code == 200, response.content
+
+
+class CustomerOrganizationEventsEndpointTest(OrganizationEventsEndpointTest):
+    viewname = "sentry-api-0-subdomain-organization-events"
+
+    def client_get(self, *args, **kwargs):
+        if "HTTP_HOST" not in kwargs:
+            kwargs["HTTP_HOST"] = generate_organization_hostname(self.organization.slug)
+        return self.client.get(
+            *args,
+            **kwargs,
+        )
+
+    def reverse_url(self):
+        return reverse(self.viewname)
+
+    def test_invalid_org_slug(self):
+        self.organization.slug = "not-found"
+        response = self.do_request({})
+
+        assert response.status_code == 404, response.content
+
+    def test_non_customer_base_host(self):
+        self.login_as(user=self.user)
+        with self.feature({"organizations:discover-basic": True}):
+            query = {}
+            response = self.client_get(
+                self.reverse_url(), query, format="json", HTTP_HOST="testserver"
+            )
+            assert response.status_code == 404, response.content
 
 
 class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPerformanceTestCase):


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/36387; but branched from https://github.com/getsentry/sentry/pull/36442.

Split from https://github.com/getsentry/sentry/pull/35169

------

This adds utilities for adding customer domain support to a class endpoint. The Discover events endpoint is used as the first class endpoint to add customer domain support to.

Customer domain support for other endpoints will follow later on. 