### PR TITLE
feat(multi-region): Add customer domain support to frontend

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -8,6 +8,7 @@ export class Request {}
 
 export const initApiClientErrorHandling = RealApi.initApiClientErrorHandling;
 export const hasProjectBeenRenamed = RealApi.hasProjectBeenRenamed;
+export const resolveUrl = RealApi.resolveUrl;
 
 const respond = (isAsync: boolean, fn?: Function, ...args: any[]): void => {
   if (!fn) {

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -245,6 +245,8 @@ type HandleRequestErrorOptions = {
   requestOptions: Readonly<RequestOptions>;
 };
 
+const DEFAULT_BASE_URL = '/api/0';
+
 /**
  * The API client is used to make HTTP requests to Sentry's backend.
  *
@@ -255,7 +257,7 @@ export class Client {
   activeRequests: Record<string, Request>;
 
   constructor(options: ClientOptions = {}) {
-    this.baseUrl = options.baseUrl ?? '/api/0';
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
     this.activeRequests = {};
   }
 

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -614,7 +614,7 @@ function canUseOrganizationUrl(organizationUrl: string | undefined) {
 export function resolveUrl(
   routeType: APIRouteType,
   organization: OrganizationSummary,
-  routeParams: {[key: string]: string | undefined} = {}
+  routeParams: {[key: string]: string | number | undefined} = {}
 ) {
   const [legacyRoute, customerDomainRoute] = routeRenderMap[routeType];
   const {organizationUrl} = organization;

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -597,7 +597,7 @@ type CustomerDomainRoute = string;
 type RouteTuple = [LegacyRoute, CustomerDomainRoute];
 
 const routeRenderMap: Record<APIRouteType, RouteTuple> = {
-  'organization-events': ['/organizations/:slug/events/', '/events/'],
+  'organization-events': ['/organizations/:org_slug/events/', '/events/'],
 };
 
 function canUseOrganizationUrl(organizationUrl: string | undefined) {
@@ -625,7 +625,7 @@ export function resolveUrl(
   const route = shouldUseLegacyRoute ? legacyRoute : customerDomainRoute;
 
   const renderedRoute = replaceRouterParams(route, {
-    slug: organization.slug,
+    org_slug: organization.slug,
     ...routeParams,
   });
 

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -608,7 +608,8 @@ export function resolveUrl(
   const [legacyRoute, customerDomainRoute] = routeRenderMap[routeType];
   const {organizationUrl} = organization;
 
-  const shouldUseLegacyRoute = !organizationUrl;
+  const shouldUseLegacyRoute =
+    !organizationUrl || !organization.features.includes('customer-domains');
   const route = shouldUseLegacyRoute ? legacyRoute : customerDomainRoute;
 
   const renderedRoute = replaceRouterParams(route, {

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -600,17 +600,6 @@ const routeRenderMap: Record<APIRouteType, RouteTuple> = {
   'organization-events': ['/organizations/:org_slug/events/', '/events/'],
 };
 
-function canUseOrganizationUrl(organizationUrl: string | undefined) {
-  if (!organizationUrl) {
-    return false;
-  }
-  const currentURL = new URL('/', window.location.origin);
-  const organizationUrlParsed = new URL('/', organizationUrl);
-  return (
-    currentURL.hostname.toLowerCase() === organizationUrlParsed.hostname.toLowerCase()
-  );
-}
-
 export function resolveUrl(
   routeType: APIRouteType,
   organization: OrganizationSummary,
@@ -619,9 +608,7 @@ export function resolveUrl(
   const [legacyRoute, customerDomainRoute] = routeRenderMap[routeType];
   const {organizationUrl} = organization;
 
-  const useOrganizationUrl = canUseOrganizationUrl(organizationUrl);
-  const shouldUseLegacyRoute = !organizationUrl || !useOrganizationUrl;
-
+  const shouldUseLegacyRoute = !organizationUrl;
   const route = shouldUseLegacyRoute ? legacyRoute : customerDomainRoute;
 
   const renderedRoute = replaceRouterParams(route, {
@@ -631,7 +618,7 @@ export function resolveUrl(
 
   const result = shouldUseLegacyRoute
     ? renderedRoute
-    : `${generateOrganizationBaseUrl(organizationUrl)}/${renderedRoute}`;
+    : `${generateOrganizationBaseUrl(organizationUrl)}${renderedRoute}`;
 
   const currentTransaction = Sentry.getCurrentHub().getScope()?.getTransaction();
   if (currentTransaction && currentTransaction.tags.hasOrganizationUrl !== String(true)) {

--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {EventQuery} from 'sentry/actionCreators/events';
-import {Client} from 'sentry/api';
+import {Client, resolveUrl} from 'sentry/api';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
@@ -95,7 +95,7 @@ class Table extends PureComponent<TableProps, TableState> {
       'discover-frontend-use-events-endpoint'
     );
     const url = shouldUseEvents
-      ? `/organizations/${organization.slug}/events/`
+      ? resolveUrl('organization-events', organization)
       : `/organizations/${organization.slug}/eventsv2/`;
     const tableFetchID = Symbol('tableFetchID');
 


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/36443

This adds `resolveUrl()` and other utility functions to be able to dynamically make use of `organizationsURL` from an organization's props to make API calls.

This hooks into the Discover events API call.