### PR TITLE
ref(storybook): Fix type issues in Assets/Icons

### DIFF
--- a/docs-ui/stories/assets/icons/data.tsx
+++ b/docs-ui/stories/assets/icons/data.tsx
@@ -1,4 +1,22 @@
-type IconGroupName =
+import {IconProps} from './sample';
+
+type DefinedIconProps = Required<
+  Pick<IconProps, 'size' | 'direction' | 'isCircled' | 'isSolid' | 'type'>
+>;
+
+type IconPropDefinitions = {
+  [key in keyof DefinedIconProps]: {
+    type: 'boolean' | 'select';
+    default?: DefinedIconProps[key];
+    /**
+     * Whether to list all variants of this prop in the icon list
+     */
+    enumerate?: boolean;
+    options?: {label: string; value: DefinedIconProps[key]}[];
+  };
+};
+
+type IconGroup =
   | 'product'
   | 'action'
   | 'navigation'
@@ -7,30 +25,11 @@ type IconGroupName =
   | 'device'
   | 'logo';
 
-export type IconPropName = 'size' | 'direction' | 'isCircled' | 'isSolid' | 'type';
-
-type IconProps = {
-  [key in IconPropName]: {
-    type: 'boolean' | 'select';
-    default?: string;
-    /**
-     * Whether to list all variants of this prop in the icon list
-     */
-    enumerate?: boolean;
-    options?: [string, string][];
-  };
-};
-
-type IconGroup = {
-  id: IconGroupName;
-  label: string;
-};
-
 export type IconData = {
   /**
    * Groups that the icon belongs to
    */
-  groups: IconGroupName[];
+  groups: IconGroup[];
   id: string;
   /**
    * List of alternative keywords for better icon search, e.g. the
@@ -41,35 +40,37 @@ export type IconData = {
    * Any additional props besides 'size' and 'color'. This includes
    * props like 'isCircled' and 'direction'.
    */
-  additionalProps?: IconPropName[];
+  additionalProps?: (keyof DefinedIconProps)[];
   /**
    * Limit the set of options available for certain additional props.
    * For example, {direction: ['left', 'up']} would limit the available
    * options for the prop 'direction' to just 'left' and 'up'. Useful for
    * controlling prop enumeration in the icon list.
    */
-  limitOptions?: Partial<Record<IconPropName, string[][]>>;
+  limitOptions?: {
+    [key in keyof DefinedIconProps]?: {label: string; value: DefinedIconProps[key]}[];
+  };
 };
 
-export const iconProps: IconProps = {
+export const iconProps: IconPropDefinitions = {
   size: {
     type: 'select',
     options: [
-      ['xs', 'Extra small'],
-      ['sm', 'Small'],
-      ['md', 'Medium'],
-      ['lg', 'Large'],
-      ['xl', 'Extra large'],
+      {value: 'xs', label: 'Extra small'},
+      {value: 'sm', label: 'Small'},
+      {value: 'md', label: 'Medium'},
+      {value: 'lg', label: 'Large'},
+      {value: 'xl', label: 'Extra large'},
     ],
     default: 'sm',
   },
   type: {
     type: 'select',
     options: [
-      ['line', 'Line'],
-      ['circle', 'Circle'],
-      ['bar', 'Bar'],
-      ['area', 'Area'],
+      {value: 'line', label: 'Line'},
+      {value: 'circle', label: 'Circle'},
+      {value: 'bar', label: 'Bar'},
+      {value: 'area', label: 'Area'},
     ],
     default: 'line',
     enumerate: true,
@@ -77,10 +78,10 @@ export const iconProps: IconProps = {
   direction: {
     type: 'select',
     options: [
-      ['left', 'Left'],
-      ['right', 'Right'],
-      ['up', 'Up'],
-      ['down', 'Down'],
+      {value: 'left', label: 'Left'},
+      {value: 'right', label: 'Right'},
+      {value: 'up', label: 'Up'},
+      {value: 'down', label: 'Down'},
     ],
     default: 'left',
     enumerate: true,
@@ -89,35 +90,14 @@ export const iconProps: IconProps = {
   isSolid: {type: 'boolean', enumerate: true},
 };
 
-export const iconGroups: IconGroup[] = [
-  {
-    id: 'product',
-    label: 'Product',
-  },
-  {
-    id: 'logo',
-    label: 'Logos',
-  },
-  {
-    id: 'navigation',
-    label: 'Navigation',
-  },
-  {
-    id: 'status',
-    label: 'Status',
-  },
-  {
-    id: 'action',
-    label: 'Action',
-  },
-  {
-    id: 'chart',
-    label: 'Chart',
-  },
-  {
-    id: 'device',
-    label: 'Device',
-  },
+export const iconGroups: {id: IconGroup; label: string}[] = [
+  {id: 'product', label: 'Product'},
+  {id: 'logo', label: 'Logos'},
+  {id: 'navigation', label: 'Navigation'},
+  {id: 'status', label: 'Status'},
+  {id: 'action', label: 'Action'},
+  {id: 'chart', label: 'Chart'},
+  {id: 'device', label: 'Device'},
 ];
 
 export const icons: IconData[] = [

--- a/docs-ui/stories/assets/icons/info.tsx
+++ b/docs-ui/stories/assets/icons/info.tsx
@@ -6,8 +6,8 @@ import Code from 'docs-ui/components/code';
 import {AnimatePresence} from 'framer-motion';
 
 import Button, {ButtonLabel} from 'sentry/components/button';
-import SelectField from 'sentry/components/deprecatedforms/selectField';
 import BooleanField from 'sentry/components/forms/booleanField';
+import SelectField from 'sentry/components/forms/selectField';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import space from 'sentry/styles/space';
 import useOverlay from 'sentry/utils/useOverlay';
@@ -66,56 +66,55 @@ const IconInfo = ({icon}: {icon: ExtendedIconData}) => {
                     {...(isSolid ? {isSolid} : {})}
                   />
                 </SampleWrap>
-                <SelectorWrap>
-                  <SelectorLabel>Size</SelectorLabel>
+                <div>
                   <StyledSelectField
                     name="size"
-                    defaultValue={size}
-                    choices={iconProps.size.options}
-                    onChange={value => setSize(value as string)}
+                    label="Size"
+                    value={size}
+                    options={iconProps.size.options}
+                    onChange={value => setSize(value)}
                     clearable={false}
+                    flexibleControlStateSize
                   />
-                </SelectorWrap>
-                {icon.additionalProps?.includes('direction') && (
-                  <SelectorWrap>
-                    <SelectorLabel>Direction</SelectorLabel>
+                  {icon.additionalProps?.includes('direction') && (
                     <StyledSelectField
                       name="direction"
-                      defaultValue={direction}
-                      choices={iconProps.direction.options}
-                      onChange={value => setDirection(value as string)}
+                      label="Direction"
+                      value={direction}
+                      options={iconProps.direction.options}
+                      onChange={value => setDirection(value)}
                       clearable={false}
+                      flexibleControlStateSize
                     />
-                  </SelectorWrap>
-                )}
-                {icon.additionalProps?.includes('type') && (
-                  <SelectorWrap>
-                    <SelectorLabel>Type</SelectorLabel>
+                  )}
+                  {icon.additionalProps?.includes('type') && (
                     <StyledSelectField
                       name="type"
-                      defaultValue={type}
-                      choices={iconProps.type.options}
-                      onChange={value => setType(value as string)}
+                      label="Type"
+                      value={type}
+                      options={iconProps.type.options}
+                      onChange={value => setType(value)}
                       clearable={false}
+                      flexibleControlStateSize
                     />
-                  </SelectorWrap>
-                )}
-                {icon.additionalProps?.includes('isCircled') && (
-                  <StyledBooleanField
-                    name="isCircled"
-                    label="Circled"
-                    value={isCircled}
-                    onChange={value => setIsCircled(value)}
-                  />
-                )}
-                {icon.additionalProps?.includes('isSolid') && (
-                  <StyledBooleanField
-                    name="isSolid"
-                    label="Solid"
-                    value={isSolid}
-                    onChange={value => setIsSolid(value)}
-                  />
-                )}
+                  )}
+                  {icon.additionalProps?.includes('isCircled') && (
+                    <StyledBooleanField
+                      name="isCircled"
+                      label="Circled"
+                      value={isCircled}
+                      onChange={value => setIsCircled(value)}
+                    />
+                  )}
+                  {icon.additionalProps?.includes('isSolid') && (
+                    <StyledBooleanField
+                      name="isSolid"
+                      label="Solid"
+                      value={isSolid}
+                      onChange={value => setIsSolid(value)}
+                    />
+                  )}
+                </div>
                 <Code className="language-jsx">{codeSample}</Code>
               </StyledOverlay>
             </PositionWrapper>
@@ -171,29 +170,10 @@ const SampleWrap = styled('div')`
   margin: 0 auto ${space(3)};
 `;
 
-const SelectorWrap = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  &:not(:first-of-type) {
-    padding-top: ${space(2)};
-  }
-  &:not(:last-of-type) {
-    padding-bottom: ${space(2)};
-    border-bottom: solid 1px ${p => p.theme.innerBorder};
-  }
-`;
-
-const SelectorLabel = styled('p')`
-  margin-bottom: 0;
-`;
-
 const StyledSelectField = styled(SelectField)`
-  width: 50%;
-  padding-left: 10px;
+  padding: ${space(1)} 0;
 `;
 
 const StyledBooleanField = styled(BooleanField)`
-  padding-left: 0;
+  padding: ${space(1)} 0;
 `;

--- a/docs-ui/stories/assets/icons/searchPanel.tsx
+++ b/docs-ui/stories/assets/icons/searchPanel.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import Fuse from 'fuse.js';
 
-import TextField from 'sentry/components/deprecatedforms/textField';
+import Input from 'sentry/components/forms/controls/input';
 import space from 'sentry/styles/space';
 
 import {IconData, iconGroups, iconProps, icons} from './data';
@@ -104,11 +104,11 @@ function SearchPanel() {
 
   return (
     <Wrap>
-      <TextField
+      <Input
         name="query"
-        placeholder="Search icons by name or similar keywords"
         value={query}
-        onChange={value => setQuery(value as string)}
+        placeholder="Search icons by name or similar keywords"
+        onChange={e => setQuery(e.target.value)}
       />
 
       {results.map(group => (


### PR DESCRIPTION
Fix typescript errors in `docs-ui/stories/assets/icons` by doing 2 things:
 - Update prop types in `/data.tsx`
 - Use newer input components from `forms/` instead of the deprecated ones from `deprecatedforms/`

<img width="1129" alt="image" src="https://user-images.githubusercontent.com/44172267/177873998-6481bbb6-d01e-48f0-9854-226f7f30e93c.png">
