### PR TITLE
sec: require contributor or label for getsentry dispatch

### DIFF
--- a/.github/workflows/getsentry-dispatch.yml
+++ b/.github/workflows/getsentry-dispatch.yml
@@ -8,14 +8,38 @@ on:
   #
   # See https://github.com/getsentry/sentry/pull/21600 for more details
   pull_request_target:
+    types: [labeled, opened, reopened, synchronize]
+
+# disable all other special privileges
+permissions:
+  # needed for `actions/checkout` to clone the code
+  contents: read
+  # needed to remove the pull-request label
+  pull-requests: write
 
 jobs:
   dispatch:
+    if: github.event.action != 'labeled' || github.event.label.name == 'trigger-getsentry-external'
     name: getsentry dispatch
     runs-on: ubuntu-20.04
     steps:
-      # Need to checkout just for `github/file-filters.yml`
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: permissions
+        run: |
+          python3 -uS .github/workflows/scripts/getsentry-dispatch-setup \
+              --repo-id ${{ github.event.repository.id }} \
+              --pr ${{ github.event.number }} \
+              --event ${{ github.event.action }} \
+              --username "$ARG_USERNAME" \
+              --label-names "$ARG_LABEL_NAMES"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # these can contain special characters
+          ARG_USERNAME: ${{ github.event.pull_request.user.login }}
+          ARG_LABEL_NAMES: ${{ toJSON(github.event.pull_request.labels.*.name) }}
 
       - name: Check for file changes
         uses: getsentry/paths-filter@v2

--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Check for file changes
         uses: getsentry/paths-filter@master

--- a/.github/workflows/scripts/getsentry-dispatch-setup
+++ b/.github/workflows/scripts/getsentry-dispatch-setup
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import urllib.request
+
+LABEL = "trigger-getsentry-external"
+
+
+def _has_write(repo_id: int, username: str, *, token: str) -> bool:
+    req = urllib.request.Request(
+        f"https://api.github.com/repositories/{repo_id}/collaborators/{username}/permission",
+        headers={"Authorization": f"token {token}"},
+    )
+    contents = json.load(urllib.request.urlopen(req, timeout=10))
+
+    return contents["permission"] in {"admin", "write"}
+
+
+def _remove_label(repo_id: int, pr: int, label: str, *, token: str) -> None:
+    req = urllib.request.Request(
+        f"https://api.github.com/repositories/{repo_id}/issues/{pr}/labels/{label}",
+        method="DELETE",
+        headers={"Authorization": f"token {token}"},
+    )
+    urllib.request.urlopen(req)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-id", type=int, required=True)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--username", required=True)
+    parser.add_argument("--label-names", type=json.loads, required=True)
+    args = parser.parse_args()
+
+    token = os.environ["GITHUB_TOKEN"]
+
+    write_permission = _has_write(args.repo_id, args.username, token=token)
+
+    if (
+        not write_permission
+        # `reopened` is included here due to close => push => reopen
+        and args.event in {"synchronize", "reopened"}
+        and LABEL in args.label_names
+    ):
+        print(f"invalidating label({LABEL}) due to code change...")
+        _remove_label(args.repo_id, args.pr, LABEL, token=token)
+        args.label_names.remove(LABEL)
+
+    if write_permission or LABEL in args.label_names:
+        print("permissions passed!")
+        print(f"- has write permission: {write_permission}")
+        print(f"- has [{LABEL}] label: {LABEL in args.label_names}")
+        return 0
+    else:
+        print(
+            f"please have a collaborator add the [{LABEL}] label once they "
+            f"have reviewed the code to trigger downstream tests."
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
(note: currently this workflow is disabled while I fixed this)

this adds a required label for external contributors to trigger the `getsentry` testsuite.

without this check an unprivileged PR could access secrets in `getsentry` through a code change as long as the user had contributed to the repository before.  now the PR must be labeled to trigger the external check.

sentry employees (users with write or admin permission on the repository) are exempt from this check

see inline comments for more details

___

validated in my testbed repo here: https://github.com/asottile-sentry/test-plz-ignore/pull/6
