### PR TITLE
fix(api): allow OrganizationReleaseDetailsEndpoint to accept empty version 

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1411,7 +1411,7 @@ urlpatterns = [
                     name="sentry-api-0-organization-releases-stats",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]+)/$",
+                    r"^(?P<organization_slug>[^\/]+)/releases/(?P<version>[^/]*)/$",
                     OrganizationReleaseDetailsEndpoint.as_view(),
                     name="sentry-api-0-organization-release-details",
                 ),

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -719,6 +719,13 @@ class ReleaseSerializerTest(TestCase):
         )
         assert not serializer.is_valid()
 
+    def test_version_empty(self):
+        serializer = ReleaseWithVersionSerializer(
+            data={"version": ""},
+            context={"organization": self.organization},
+        )
+        assert not serializer.is_valid()
+
     def test_owner_must_have_org_access(self):
         serializer = ReleaseWithVersionSerializer(
             data={

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -676,6 +676,7 @@ class SetRefsTest(SetRefsTestCase):
     def test_invalid_version(self):
         release = Release.objects.create(organization=self.org)
         assert not release.is_valid_version(None)
+        assert not release.is_valid_version("")
 
     @staticmethod
     def test_invalid_chars_in_version():


### PR DESCRIPTION
Customer reported trying to archive a release with a empty `version` field. Looking at the DB, there are 152 rows of releases where this is the case - possibly due to an old code? 

To allow customers to archive these presumably faulty releases, this change is needed to accept PUT requests with empty `version` in the URL path.