### PR TITLE
fix(copy): tidied up the copy of release quick start

### DIFF
--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -198,20 +198,23 @@ const ReleasesPromo = ({organization, project}: Props) => {
   return renderComponent(
     <Panel>
       <Container>
-        <p>
-          {t(
-            'Configuring releases associates new issues with the right version of your code and ensures the right team members are notified of these issues.'
-          )}
-        </p>
         <StyledPageHeader>
-          <h3>{t('Configure Releases with the CLI')}</h3>
+          <h3>{t('Set up Releases')}</h3>
 
-          <Button priority="primary" size="small" href={releasesSetupUrl} external>
+          <Button priority="default" size="small" href={releasesSetupUrl} external>
             {t('Full Documentation')}
           </Button>
         </StyledPageHeader>
+
         <p>
-          Add the following commands to your CI config when you deploy your application.
+          {t(
+            'Find which release caused an issue, apply source maps, and get notified about your deploys.'
+          )}
+        </p>
+        <p>
+          {t(
+            'Add the following commands to your CI config when you deploy your application.'
+          )}
         </p>
 
         <CodeBlock>

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -135,9 +135,7 @@ describe('ReleasesList', () => {
       }
     );
 
-    expect(
-      await screen.findByText('Configure Releases with the CLI')
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Set up Releases')).toBeInTheDocument();
     expect(screen.queryByTestId('release-panel')).not.toBeInTheDocument();
 
     // has releases set up and no releases


### PR DESCRIPTION
Made a few copy fixes to move it closer towards [the new design](https://www.figma.com/file/mq2Iy03p3x9R8jIGJIlidk/Release-Quick-Start?node-id=0%3A1).


## Before
![CleanShot 2022-07-07 at 16 42 22](https://user-images.githubusercontent.com/1900676/177889149-915a557f-1c48-4ea9-bd2b-32daf5e225cd.png)

## After
![CleanShot 2022-07-07 at 16 40 50](https://user-images.githubusercontent.com/1900676/177889158-6b204221-4b27-47fb-b555-93d12fda33d9.png)

