### PR TITLE
feat: Update replaceRouterParams to support number parameters

### DIFF
--- a/static/app/utils/replaceRouterParams.tsx
+++ b/static/app/utils/replaceRouterParams.tsx
@@ -5,7 +5,7 @@
  */
 export default function replaceRouterParams(
   route: string,
-  params: {[key: string]: string | undefined}
+  params: {[key: string]: string | number | undefined}
 ): string {
   // parse route params from route
   const matches = route.match(/:\w+/g);
@@ -21,7 +21,7 @@ export default function replaceRouterParams(
       return;
     }
 
-    route = route.replace(param, params[paramName] as string);
+    route = route.replace(param, String(params[paramName]));
   });
 
   return route;

--- a/tests/js/spec/utils/replaceRouterParams.spec.tsx
+++ b/tests/js/spec/utils/replaceRouterParams.spec.tsx
@@ -3,15 +3,20 @@ import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 const params = {
   orgId: 'org-slug',
   projectId: 'project-slug',
+  project: 1234,
 };
 
 describe('replaceRouterParams', function () {
-  it('replaces `:orgId` in a path', function () {
+  it('replaces parameters in a path', function () {
     expect(replaceRouterParams('/path/to/:orgId/test', params)).toBe(
       '/path/to/org-slug/test'
     );
     expect(replaceRouterParams('/path/to/:orgId/test/:projectId', params)).toBe(
       '/path/to/org-slug/test/project-slug'
+    );
+
+    expect(replaceRouterParams('/path/to/:orgId/test/:project/:projectId', params)).toBe(
+      '/path/to/org-slug/test/1234/project-slug'
     );
   });
 


### PR DESCRIPTION
Cherry picked from https://github.com/getsentry/sentry/pull/36444.

This updates `replaceRouterParams()` to support numbered parameters. 