### PR TITLE
feat(auditlog): Add version 2 to audit log endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -46,10 +46,14 @@ class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
             else:
                 queryset = queryset.filter(event=query["event"])
 
-        return self.paginate(
+        response = self.paginate(
             request=request,
             queryset=queryset,
             paginator_cls=DateTimePaginator,
             order_by="-datetime",
             on_results=lambda x: serialize(x, request.user),
         )
+        # TODO: Cleanup after frontend is fully moved to version 2
+        if "version" in request.GET:
+            response.data = {"rows": response.data, "options": audit_log.get_api_names()}
+        return response

--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -54,6 +54,6 @@ class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
             on_results=lambda x: serialize(x, request.user),
         )
         # TODO: Cleanup after frontend is fully moved to version 2
-        if "version" in request.GET:
+        if "version" in request.GET and request.GET.get("version") == "2":
             response.data = {"rows": response.data, "options": audit_log.get_api_names()}
         return response

--- a/tests/sentry/api/endpoints/test_organization_auditlogs.py
+++ b/tests/sentry/api/endpoints/test_organization_auditlogs.py
@@ -154,3 +154,21 @@ class OrganizationAuditLogsTest(APITestCase):
                 )
             ]
         }
+
+    def test_version_two_response(self):
+        # Test that version two request will send "rows" with audit log entries
+        # and "options" with the audit log api names list.
+        now = timezone.now()
+
+        entry = AuditLogEntry.objects.create(
+            organization=self.organization,
+            event=audit_log.get_event_id("ORG_EDIT"),
+            actor=self.user,
+            datetime=now,
+        )
+        audit_log_api_names = set(audit_log.get_api_names())
+
+        response = self.get_success_response(self.organization.slug, qs_params={"version": "2"})
+        assert len(response.data) == 2
+        assert response.data["rows"][0]["id"] == str(entry.id)
+        assert set(response.data["options"]) == audit_log_api_names

--- a/tests/sentry/api/endpoints/test_organization_auditlogs.py
+++ b/tests/sentry/api/endpoints/test_organization_auditlogs.py
@@ -172,3 +172,7 @@ class OrganizationAuditLogsTest(APITestCase):
         assert len(response.data) == 2
         assert response.data["rows"][0]["id"] == str(entry.id)
         assert set(response.data["options"]) == audit_log_api_names
+
+        response_2 = self.get_success_response(self.organization.slug, qs_params={"version": "3"})
+        assert len(response_2.data) == 1
+        assert response_2.data[0]["id"] == str(entry.id)


### PR DESCRIPTION
Updating the audit log api endpoint to a version 2. This will be a temporary endpoint change and will allow the response.data to be adjusted to include the audit log api names list only if the the requests specifies the `version`. 

The refactored frontend will include `version: '2'` in the payload data that is set as the query. 

After the frontend updates have been merged/deployed for several days, the endpoint will be updated again to remove the `version` check and return the `rows` and `options` for all requests.