### PR TITLE
feat(mep): Remove `entity_key` and `time_col` from `BaseEntitySubscription`

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -314,9 +314,7 @@ def build_incident_query_builder(
     for i, column in enumerate(query_builder.columns):
         if column.alias == CRASH_RATE_ALERT_AGGREGATE_ALIAS:
             query_builder.columns[i] = replace(column, alias="count")
-    time_col = ENTITY_TIME_COLUMNS[
-        get_entity_key_from_query_builder(query_builder.get_snql_query())
-    ]
+    time_col = ENTITY_TIME_COLUMNS[get_entity_key_from_query_builder(query_builder)]
     query_builder.add_conditions(
         [
             Condition(Column(time_col), Op.GTE, start),

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -37,10 +37,10 @@ from sentry.models import Integration, PagerDutyService, Project, SentryApp
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.fields import resolve_field
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
-from sentry.snuba.dataset import EntityKey
 from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
     EntitySubscription,
+    get_entity_key_from_query_builder,
     get_entity_subscription_for_dataset,
 )
 from sentry.snuba.models import QueryDatasets
@@ -314,7 +314,9 @@ def build_incident_query_builder(
     for i, column in enumerate(query_builder.columns):
         if column.alias == CRASH_RATE_ALERT_AGGREGATE_ALIAS:
             query_builder.columns[i] = replace(column, alias="count")
-    time_col = ENTITY_TIME_COLUMNS[EntityKey(query_builder.get_snql_query().query.match.name)]
+    time_col = ENTITY_TIME_COLUMNS[
+        get_entity_key_from_query_builder(query_builder.get_snql_query())
+    ]
     query_builder.add_conditions(
         [
             Condition(Column(time_col), Op.GTE, start),
@@ -387,7 +389,7 @@ def get_incident_aggregates(
             "incidents.get_incident_aggregates.snql.query.error",
             tags={
                 "dataset": snuba_query.dataset,
-                "entity": query_builder.get_snql_query().query.match.name,
+                "entity": get_entity_key_from_query_builder(query_builder).value,
             },
         )
         raise

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -24,8 +24,11 @@ from sentry.incidents.logic import (
     update_alert_rule,
 )
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType, AlertRuleTrigger
-from sentry.snuba.dataset import Dataset
-from sentry.snuba.entity_subscription import get_entity_subscription_for_dataset
+from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.entity_subscription import (
+    ENTITY_TIME_COLUMNS,
+    get_entity_subscription_for_dataset,
+)
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
 from sentry.snuba.tasks import build_query_builder
 
@@ -259,7 +262,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         dataset = Dataset(data["dataset"].value)
         self._validate_time_window(dataset, data.get("time_window"))
 
-        time_col = entity_subscription.time_col
+        time_col = ENTITY_TIME_COLUMNS[EntityKey(query_builder.get_snql_query().query.match.name)]
         query_builder.add_conditions(
             [
                 Condition(Column(time_col), Op.GTE, start),

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -24,9 +24,10 @@ from sentry.incidents.logic import (
     update_alert_rule,
 )
 from sentry.incidents.models import AlertRule, AlertRuleThresholdType, AlertRuleTrigger
-from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
+    get_entity_key_from_query_builder,
     get_entity_subscription_for_dataset,
 )
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
@@ -262,7 +263,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         dataset = Dataset(data["dataset"].value)
         self._validate_time_window(dataset, data.get("time_window"))
 
-        time_col = ENTITY_TIME_COLUMNS[EntityKey(query_builder.get_snql_query().query.match.name)]
+        time_col = ENTITY_TIME_COLUMNS[get_entity_key_from_query_builder(query_builder)]
         query_builder.add_conditions(
             [
                 Condition(Column(time_col), Op.GTE, start),

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -30,8 +30,11 @@ from sentry.incidents.models import (
 )
 from sentry.incidents.tasks import handle_trigger_action
 from sentry.models import Project
-from sentry.snuba.dataset import EntityKey
-from sentry.snuba.entity_subscription import ENTITY_TIME_COLUMNS, BaseMetricsEntitySubscription
+from sentry.snuba.entity_subscription import (
+    ENTITY_TIME_COLUMNS,
+    BaseMetricsEntitySubscription,
+    get_entity_key_from_query_builder,
+)
 from sentry.snuba.models import QueryDatasets
 from sentry.snuba.tasks import build_query_builder, get_entity_subscription_for_dataset
 from sentry.utils import metrics, redis
@@ -192,9 +195,7 @@ class SubscriptionProcessor:
                     "end": end,
                 },
             )
-            time_col = ENTITY_TIME_COLUMNS[
-                EntityKey(query_builder.get_snql_query().query.match.name)
-            ]
+            time_col = ENTITY_TIME_COLUMNS[get_entity_key_from_query_builder(query_builder)]
             query_builder.add_conditions(
                 [
                     Condition(Column(time_col), Op.GTE, start),

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -30,7 +30,8 @@ from sentry.incidents.models import (
 )
 from sentry.incidents.tasks import handle_trigger_action
 from sentry.models import Project
-from sentry.snuba.entity_subscription import BaseMetricsEntitySubscription
+from sentry.snuba.dataset import EntityKey
+from sentry.snuba.entity_subscription import ENTITY_TIME_COLUMNS, BaseMetricsEntitySubscription
 from sentry.snuba.models import QueryDatasets
 from sentry.snuba.tasks import build_query_builder, get_entity_subscription_for_dataset
 from sentry.utils import metrics, redis
@@ -191,7 +192,9 @@ class SubscriptionProcessor:
                     "end": end,
                 },
             )
-            time_col = entity_subscription.time_col
+            time_col = ENTITY_TIME_COLUMNS[
+                EntityKey(query_builder.get_snql_query().query.match.name)
+            ]
             query_builder.add_conditions(
                 [
                     Condition(Column(time_col), Op.GTE, start),

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -551,5 +551,5 @@ def map_aggregate_to_entity_key(dataset: QueryDatasets, aggregate: str) -> Entit
     return entity_key
 
 
-def get_entity_key_from_query_builder(query_builder: QueryBuilder):
+def get_entity_key_from_query_builder(query_builder: QueryBuilder) -> EntityKey:
     return EntityKey(query_builder.get_snql_query().query.match.name)

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -549,3 +549,7 @@ def map_aggregate_to_entity_key(dataset: QueryDatasets, aggregate: str) -> Entit
             f"{dataset} dataset does not have an entity key mapped to it"
         )
     return entity_key
+
+
+def get_entity_key_from_query_builder(query_builder: QueryBuilder):
+    return EntityKey(query_builder.get_snql_query().query.match.name)

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -112,7 +112,6 @@ class _EntitySpecificParams(TypedDict, total=False):
 
 @dataclass
 class _EntitySubscription:
-    entity_key: EntityKey
     dataset: QueryDatasets
     time_col: str
 
@@ -128,7 +127,7 @@ class BaseEntitySubscription(ABC, _EntitySubscription):
     def __init__(
         self, aggregate: str, time_window: int, extra_fields: Optional[_EntitySpecificParams] = None
     ):
-        self.time_col = ENTITY_TIME_COLUMNS[self.entity_key]
+        pass
 
     @abstractmethod
     def get_entity_extra_params(self) -> Mapping[str, Any]:
@@ -204,17 +203,14 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
 
 class EventsEntitySubscription(BaseEventsAndTransactionEntitySubscription):
     dataset = QueryDatasets.EVENTS
-    entity_key = EntityKey.Events
 
 
 class TransactionsEntitySubscription(BaseEventsAndTransactionEntitySubscription):
     dataset = QueryDatasets.TRANSACTIONS
-    entity_key = EntityKey.Transactions
 
 
 class SessionsEntitySubscription(BaseEntitySubscription):
     dataset = QueryDatasets.SESSIONS
-    entity_key = EntityKey.Sessions
 
     def __init__(
         self, aggregate: str, time_window: int, extra_fields: Optional[_EntitySpecificParams] = None
@@ -289,7 +285,6 @@ class SessionsEntitySubscription(BaseEntitySubscription):
 
 class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
     dataset = QueryDatasets.METRICS
-    entity_key: EntityKey
     metric_key: SessionMRI
 
     def __init__(
@@ -466,7 +461,6 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
 
 
 class MetricsCountersEntitySubscription(BaseMetricsEntitySubscription):
-    entity_key: EntityKey = EntityKey.MetricsCounters
     metric_key: SessionMRI = SessionMRI.SESSION
 
     def get_snql_aggregations(self) -> List[str]:
@@ -486,7 +480,6 @@ class MetricsCountersEntitySubscription(BaseMetricsEntitySubscription):
 
 
 class MetricsSetsEntitySubscription(BaseMetricsEntitySubscription):
-    entity_key: EntityKey = EntityKey.MetricsSets
     metric_key: SessionMRI = SessionMRI.USER
 
     def get_snql_aggregations(self) -> List[str]:

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -113,7 +113,6 @@ class _EntitySpecificParams(TypedDict, total=False):
 @dataclass
 class _EntitySubscription:
     dataset: QueryDatasets
-    time_col: str
 
 
 class BaseEntitySubscription(ABC, _EntitySubscription):

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -194,7 +194,7 @@ def _create_in_snuba(subscription: QuerySubscription) -> str:
 
     response = _snuba_pool.urlopen(
         "POST",
-        f"/{snuba_query.dataset}/{entity_subscription.entity_key.value}/subscriptions",
+        f"/{snuba_query.dataset}/{snql_query.query.match.name}/subscriptions",
         body=json.dumps(body),
     )
     if response.status != 202:

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -11,7 +11,6 @@ from sentry.models import Any, Environment, Mapping, Optional
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.entity_subscription import (
     BaseEntitySubscription,
-    get_entity_key_from_query_builder,
     get_entity_subscription_for_dataset,
     map_aggregate_to_entity_key,
 )
@@ -195,7 +194,7 @@ def _create_in_snuba(subscription: QuerySubscription) -> str:
 
     response = _snuba_pool.urlopen(
         "POST",
-        f"/{snuba_query.dataset}/{get_entity_key_from_query_builder(snql_query).value}/subscriptions",
+        f"/{snuba_query.dataset}/{snql_query.query.match.name}/subscriptions",
         body=json.dumps(body),
     )
     if response.status != 202:

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -11,6 +11,7 @@ from sentry.models import Any, Environment, Mapping, Optional
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.entity_subscription import (
     BaseEntitySubscription,
+    get_entity_key_from_query_builder,
     get_entity_subscription_for_dataset,
     map_aggregate_to_entity_key,
 )
@@ -194,7 +195,7 @@ def _create_in_snuba(subscription: QuerySubscription) -> str:
 
     response = _snuba_pool.urlopen(
         "POST",
-        f"/{snuba_query.dataset}/{snql_query.query.match.name}/subscriptions",
+        f"/{snuba_query.dataset}/{get_entity_key_from_query_builder(snql_query).value}/subscriptions",
         body=json.dumps(body),
     )
     if response.status != 202:

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -9,9 +9,7 @@ from sentry.exceptions import (
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import resolve, resolve_tag_key
-from sentry.snuba.dataset import EntityKey
 from sentry.snuba.entity_subscription import (
-    ENTITY_TIME_COLUMNS,
     EventsEntitySubscription,
     MetricsCountersEntitySubscription,
     MetricsSetsEntitySubscription,
@@ -86,8 +84,6 @@ class EntitySubscriptionTestCase(TestCase):
         assert entity_subscription.get_entity_extra_params() == {
             "organization": self.organization.id
         }
-        assert entity_subscription.entity_key == EntityKey.Sessions
-        assert entity_subscription.time_col == ENTITY_TIME_COLUMNS[EntityKey.Sessions]
         assert entity_subscription.dataset == QueryDatasets.SESSIONS
         snql_query = entity_subscription.build_query_builder(
             "", [self.project.id], None
@@ -148,8 +144,6 @@ class EntitySubscriptionTestCase(TestCase):
             "organization": self.organization.id,
             "granularity": 10,
         }
-        assert entity_subscription.entity_key == EntityKey.MetricsSets
-        assert entity_subscription.time_col == ENTITY_TIME_COLUMNS[EntityKey.MetricsSets]
         assert entity_subscription.dataset == QueryDatasets.METRICS
         session_status = resolve_tag_key(org_id, "session.status")
         session_status_crashed = resolve(org_id, "crashed")
@@ -202,8 +196,6 @@ class EntitySubscriptionTestCase(TestCase):
             "organization": self.organization.id,
             "granularity": 10,
         }
-        assert entity_subscription.entity_key == EntityKey.MetricsCounters
-        assert entity_subscription.time_col == ENTITY_TIME_COLUMNS[EntityKey.MetricsCounters]
         assert entity_subscription.dataset == QueryDatasets.METRICS
         session_status = resolve_tag_key(org_id, "session.status")
         session_status_crashed = resolve(org_id, "crashed")
@@ -260,8 +252,6 @@ class EntitySubscriptionTestCase(TestCase):
         assert isinstance(entity_subscription, TransactionsEntitySubscription)
         assert entity_subscription.aggregate == aggregate
         assert entity_subscription.get_entity_extra_params() == {}
-        assert entity_subscription.entity_key == EntityKey.Transactions
-        assert entity_subscription.time_col == ENTITY_TIME_COLUMNS[EntityKey.Transactions]
         assert entity_subscription.dataset == QueryDatasets.TRANSACTIONS
         snql_query = entity_subscription.build_query_builder(
             "", [self.project.id], None
@@ -283,8 +273,6 @@ class EntitySubscriptionTestCase(TestCase):
         assert isinstance(entity_subscription, EventsEntitySubscription)
         assert entity_subscription.aggregate == aggregate
         assert entity_subscription.get_entity_extra_params() == {}
-        assert entity_subscription.entity_key == EntityKey.Events
-        assert entity_subscription.time_col == ENTITY_TIME_COLUMNS[EntityKey.Events]
         assert entity_subscription.dataset == QueryDatasets.EVENTS
 
         snql_query = entity_subscription.build_query_builder(


### PR DESCRIPTION
This removes `entity_key` and the derived `time_col` from the entity subscription classes. I'm doing
this so that we can have an entity subscription that will be able to produce a query for any of the
metric entities (count, sets, etc) without having to manually define it. This allows us to use
`QueryBuilder` to determine the entity instead of having to parse the aggregates ourselves.

We can then use `QueryBuilder` to fetch the entities in place of these previously hardcoded values.