### PR TITLE
feat(release-notifications): Add a new event to track when active release notifications are sent

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -1,3 +1,4 @@
+from .active_release_notification_sent import *  # noqa: F401,F403
 from .advanced_search_feature_gated import *  # noqa: F401,F403
 from .alert_created import *  # noqa: F401,F403
 from .alert_edited import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/active_release_notification_sent.py
+++ b/src/sentry/analytics/events/active_release_notification_sent.py
@@ -1,0 +1,17 @@
+from sentry import analytics
+
+
+class ActiveReleaseNotificationSent(analytics.Event):
+    type = "active_release_notification.sent"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("group_id"),
+        analytics.Attribute("provider"),
+        analytics.Attribute("release_version"),
+        analytics.Attribute("recipient_email"),
+        analytics.Attribute("recipient_username"),
+    )
+
+
+analytics.register(ActiveReleaseNotificationSent)

--- a/src/sentry/analytics/events/active_release_notification_sent.py
+++ b/src/sentry/analytics/events/active_release_notification_sent.py
@@ -6,6 +6,7 @@ class ActiveReleaseNotificationSent(analytics.Event):
 
     attributes = (
         analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
         analytics.Attribute("group_id"),
         analytics.Attribute("provider"),
         analytics.Attribute("release_version"),

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -9,7 +9,6 @@ from sentry.plugins.bases import IssueTrackingPlugin, IssueTrackingPlugin2
 from sentry.plugins.bases.notify import NotificationPlugin
 from sentry.receivers.rules import DEFAULT_RULE_DATA, DEFAULT_RULE_LABEL
 from sentry.signals import (
-    active_release_notification_sent,
     advanced_search,
     advanced_search_feature_gated,
     alert_rule_created,
@@ -228,28 +227,6 @@ def record_issue_unresolved(project, user, group, transition_type, **kwargs):
         organization_id=project.organization_id,
         group_id=group.id,
         transition_type=transition_type,
-    )
-
-
-@active_release_notification_sent.connect(weak=False)
-def record_active_release_notification_sent(
-    project,
-    group,
-    provider,
-    release_version,
-    recipient_email,
-    recipient_username,
-    **kwargs,
-):
-    analytics.record(
-        "active_release_notification.sent",
-        organization_id=project.organization_id,
-        project_id=project.id,
-        group_id=group.id,
-        provider=provider,
-        release_version=release_version,
-        email=recipient_email,
-        username=recipient_username,
     )
 
 

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -9,6 +9,7 @@ from sentry.plugins.bases import IssueTrackingPlugin, IssueTrackingPlugin2
 from sentry.plugins.bases.notify import NotificationPlugin
 from sentry.receivers.rules import DEFAULT_RULE_DATA, DEFAULT_RULE_LABEL
 from sentry.signals import (
+    active_release_notification_sent,
     advanced_search,
     advanced_search_feature_gated,
     alert_rule_created,
@@ -227,6 +228,28 @@ def record_issue_unresolved(project, user, group, transition_type, **kwargs):
         organization_id=project.organization_id,
         group_id=group.id,
         transition_type=transition_type,
+    )
+
+
+@active_release_notification_sent.connect(weak=False)
+def record_active_release_notification_sent(
+    project,
+    group,
+    provider,
+    release_version,
+    recipient_email,
+    recipient_username,
+    **kwargs,
+):
+    analytics.record(
+        "active_release_notification.sent",
+        organization_id=project.organization_id,
+        project_id=project.id,
+        group_id=group.id,
+        provider=provider,
+        release_version=release_version,
+        email=recipient_email,
+        username=recipient_username,
     )
 
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -114,18 +114,6 @@ issue_ignored = BetterSignal(providing_args=["project", "user", "group_list", "a
 issue_unignored = BetterSignal(providing_args=["project", "user", "group", "transition_type"])
 issue_mark_reviewed = BetterSignal(providing_args=["project", "user", "group"])
 
-active_release_notification_sent = BetterSignal(
-    providing_args=[
-        "project",
-        "group",
-        "provider",
-        "release_version",
-        "recipient_email",
-        "recipient_username",
-        "notification_type",
-    ]
-)
-
 # comments
 comment_created = BetterSignal(providing_args=["project", "user", "group", "activity_data"])
 comment_updated = BetterSignal(providing_args=["project", "user", "group", "activity_data"])

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -102,8 +102,10 @@ repo_linked = BetterSignal(providing_args=["repo", "user"])
 release_created = BetterSignal(providing_args=["release"])
 deploy_created = BetterSignal(providing_args=["deploy"])
 ownership_rule_created = BetterSignal(providing_args=["project"])
-issue_assigned = BetterSignal(providing_args=["project", "group", "user"])
 
+# issues
+issue_assigned = BetterSignal(providing_args=["project", "group", "user"])
+issue_deleted = BetterSignal(providing_args=["group", "user", "delete_type"])
 issue_resolved = BetterSignal(
     providing_args=["organization_id", "project", "group", "user", "resolution_type"]
 )
@@ -111,6 +113,20 @@ issue_unresolved = BetterSignal(providing_args=["project", "user", "group", "tra
 issue_ignored = BetterSignal(providing_args=["project", "user", "group_list", "activity_data"])
 issue_unignored = BetterSignal(providing_args=["project", "user", "group", "transition_type"])
 issue_mark_reviewed = BetterSignal(providing_args=["project", "user", "group"])
+
+active_release_notification_sent = BetterSignal(
+    providing_args=[
+        "project",
+        "group",
+        "provider",
+        "release_version",
+        "recipient_email",
+        "recipient_username",
+        "notification_type",
+    ]
+)
+
+# comments
 comment_created = BetterSignal(providing_args=["project", "user", "group", "activity_data"])
 comment_updated = BetterSignal(providing_args=["project", "user", "group", "activity_data"])
 comment_deleted = BetterSignal(providing_args=["project", "user", "group", "activity_data"])
@@ -124,7 +140,6 @@ team_created = BetterSignal(providing_args=["organization", "user", "team"])
 integration_added = BetterSignal(providing_args=["integration", "organization", "user"])
 integration_issue_created = BetterSignal(providing_args=["integration", "organization", "user"])
 integration_issue_linked = BetterSignal(providing_args=["integration", "organization", "user"])
-issue_deleted = BetterSignal(providing_args=["group", "user", "delete_type"])
 
 monitor_failed = BetterSignal(providing_args=["monitor"])
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -74,8 +74,9 @@ class BaseMailAdapterTest(TestCase):
 
 
 class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
+    @mock.patch("sentry.signals.active_release_notification_sent.send_robust")
     @mock.patch("sentry.notifications.utils.participants.get_release_committers")
-    def test_simple(self, mock_get_release_committers):
+    def test_simple(self, mock_get_release_committers, send_robust):
         mock_get_release_committers.return_value = [self.create_user(email="test@example.com")]
         event = self.store_event(
             data={"message": "Hello world", "level": "error"}, project_id=self.project.id
@@ -109,6 +110,7 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
 
         assert to_committer
         assert to_committer.subject == "**ARM** [Sentry] BAR-1 - Hello world"
+        assert send_robust.called
 
 
 class MailAdapterGetSendableUsersTest(BaseMailAdapterTest):

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -74,10 +74,12 @@ class BaseMailAdapterTest(TestCase):
 
 
 class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
-    @mock.patch("sentry.signals.active_release_notification_sent.send_robust")
+    @mock.patch("sentry.analytics.record")
     @mock.patch("sentry.notifications.utils.participants.get_release_committers")
-    def test_simple(self, mock_get_release_committers, send_robust):
-        mock_get_release_committers.return_value = [self.create_user(email="test@example.com")]
+    def test_simple(self, mock_get_release_committers, record):
+        mock_get_release_committers.return_value = [
+            self.create_user(email="test@example.com", username="foo")
+        ]
         event = self.store_event(
             data={"message": "Hello world", "level": "error"}, project_id=self.project.id
         )
@@ -110,7 +112,22 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
 
         assert to_committer
         assert to_committer.subject == "**ARM** [Sentry] BAR-1 - Hello world"
-        assert send_robust.called
+
+        notification_record = [
+            r for r in record.call_args_list if r[0][0] == "active_release_notification.sent"
+        ]
+        assert notification_record == [
+            mock.call(
+                "active_release_notification.sent",
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                group_id=event.group.id,
+                provider="email",
+                release_version="2",
+                recipient_email="test@example.com",
+                recipient_username="foo",
+            )
+        ]
 
 
 class MailAdapterGetSendableUsersTest(BaseMailAdapterTest):


### PR DESCRIPTION
Add a new event, `active_release_notification.sent`, for analytics around release notifications.

Documenting the new event [here](https://github.com/getsentry/etl/pull/782)