### PR TITLE
feat(dashboard-filters): Update endpoint to save filters

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -152,6 +152,7 @@ class DashboardDetailsSerializer(Serializer):
             "createdBy": serialize(obj.created_by, serializer=UserSerializer()),
             "widgets": attrs["widgets"],
             "projects": [project.id for project in obj.projects.all()],
+            "filters": {},
         }
 
         if obj.filters is not None:
@@ -161,8 +162,6 @@ class DashboardDetailsSerializer(Serializer):
 
             for key in dashboard_filter_keys:
                 if obj.filters.get(key) is not None:
-                    if data.get("filters") is None:
-                        data["filters"] = {}
                     data["filters"][key] = obj.filters[key]
 
         return data

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -12,6 +12,7 @@ from sentry.models import (
     DashboardWidgetTypes,
 )
 from sentry.utils import json
+from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 
 @register(DashboardWidget)
@@ -163,5 +164,12 @@ class DashboardDetailsSerializer(Serializer):
             for key in dashboard_filter_keys:
                 if obj.filters.get(key) is not None:
                     data["filters"][key] = obj.filters[key]
+
+            start, end = obj.filters.get("start"), obj.filters.get("end")
+            if start and end:
+                start, end = parse_timestamp(start), parse_timestamp(end)
+                data["expired"], data["start"] = outside_retention_with_modified_start(
+                    start, end, obj.organization
+                )
 
         return data

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -143,11 +143,18 @@ class DashboardDetailsSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
+        page_filter_keys = ["environment", "range"]
         data = {
             "id": str(obj.id),
             "title": obj.title,
             "dateCreated": obj.date_added,
             "createdBy": serialize(obj.created_by, serializer=UserSerializer()),
             "widgets": attrs["widgets"],
+            "projects": [project.id for project in obj.projects.all()],
         }
+
+        for key in page_filter_keys:
+            if obj.filters is not None and obj.filters.get(key) is not None:
+                data[key] = obj.filters[key]
+
         return data

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -143,7 +143,7 @@ class DashboardDetailsSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
-        page_filter_keys = ["environment", "range"]
+        page_filter_keys = ["environment", "range", "start", "end"]
         dashboard_filter_keys = ["releases"]
         data = {
             "id": str(obj.id),

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -154,14 +154,15 @@ class DashboardDetailsSerializer(Serializer):
             "projects": [project.id for project in obj.projects.all()],
         }
 
-        for key in page_filter_keys:
-            if obj.filters is not None and obj.filters.get(key) is not None:
-                data[key] = obj.filters[key]
+        if obj.filters is not None:
+            for key in page_filter_keys:
+                if obj.filters.get(key) is not None:
+                    data[key] = obj.filters[key]
 
-        for key in dashboard_filter_keys:
-            if obj.filters is not None and obj.filters.get(key) is not None:
-                if data.get("filters") is None:
-                    data["filters"] = {}
-                data["filters"][key] = obj.filters[key]
+            for key in dashboard_filter_keys:
+                if obj.filters.get(key) is not None:
+                    if data.get("filters") is None:
+                        data["filters"] = {}
+                    data["filters"][key] = obj.filters[key]
 
         return data

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -144,6 +144,7 @@ class DashboardDetailsSerializer(Serializer):
 
     def serialize(self, obj, attrs, user, **kwargs):
         page_filter_keys = ["environment", "range"]
+        dashboard_filter_keys = ["releases"]
         data = {
             "id": str(obj.id),
             "title": obj.title,
@@ -151,10 +152,15 @@ class DashboardDetailsSerializer(Serializer):
             "createdBy": serialize(obj.created_by, serializer=UserSerializer()),
             "widgets": attrs["widgets"],
             "projects": [project.id for project in obj.projects.all()],
+            "filters": {},
         }
 
         for key in page_filter_keys:
             if obj.filters is not None and obj.filters.get(key) is not None:
                 data[key] = obj.filters[key]
+
+        for key in dashboard_filter_keys:
+            if obj.filters is not None and obj.filters.get(key) is not None:
+                data["filters"][key] = obj.filters[key]
 
         return data

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -144,7 +144,7 @@ class DashboardDetailsSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
-        page_filter_keys = ["environment", "range"]
+        page_filter_keys = ["environment", "period"]
         dashboard_filter_keys = ["releases"]
         data = {
             "id": str(obj.id),

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -152,7 +152,6 @@ class DashboardDetailsSerializer(Serializer):
             "createdBy": serialize(obj.created_by, serializer=UserSerializer()),
             "widgets": attrs["widgets"],
             "projects": [project.id for project in obj.projects.all()],
-            "filters": {},
         }
 
         for key in page_filter_keys:
@@ -161,6 +160,8 @@ class DashboardDetailsSerializer(Serializer):
 
         for key in dashboard_filter_keys:
             if obj.filters is not None and obj.filters.get(key) is not None:
+                if data.get("filters") is None:
+                    data["filters"] = {}
                 data["filters"][key] = obj.filters[key]
 
         return data

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -144,7 +144,7 @@ class DashboardDetailsSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
-        page_filter_keys = ["environment", "range", "start", "end"]
+        page_filter_keys = ["environment", "range"]
         dashboard_filter_keys = ["releases"]
         data = {
             "id": str(obj.id),
@@ -171,5 +171,6 @@ class DashboardDetailsSerializer(Serializer):
                 data["expired"], data["start"] = outside_retention_with_modified_start(
                     start, end, obj.organization
                 )
+                data["end"] = end
 
         return data

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -306,9 +306,9 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
     validate_id = validate_id
 
     def validate_projects(self, projects):
-        from sentry.api.validators import validate_projects
+        from sentry.api.validators import validate_project_ids
 
-        return validate_projects(projects, self.context["projects"])
+        return validate_project_ids(projects, {project.id for project in self.context["projects"]})
 
     def validate(self, data):
         start = data.get("start")

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -320,6 +320,15 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
 
         return projects
 
+    def validate(self, data):
+        start = data.get("start")
+        end = data.get("end")
+
+        if start and end and start >= end:
+            raise serializers.ValidationError("start must be before end")
+
+        return data
+
     def update_dashboard_filters(self, instance, validated_data):
         page_filter_keys = ["environment", "range", "start", "end"]
         dashboard_filter_keys = ["releases"]

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -298,7 +298,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
     widgets = DashboardWidgetSerializer(many=True, required=False)
     projects = ListField(child=serializers.IntegerField(), required=False, default=[])
     environment = ListField(child=serializers.CharField(), required=False, allow_null=True)
-    range = serializers.CharField(required=False, allow_null=True)
+    period = serializers.CharField(required=False, allow_null=True)
     start = serializers.DateTimeField(required=False, allow_null=True)
     end = serializers.DateTimeField(required=False, allow_null=True)
     filters = serializers.DictField(required=False)
@@ -320,7 +320,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
         return data
 
     def update_dashboard_filters(self, instance, validated_data):
-        page_filter_keys = ["environment", "range", "start", "end"]
+        page_filter_keys = ["environment", "period", "start", "end"]
         dashboard_filter_keys = ["releases"]
 
         if "projects" in validated_data:

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -303,7 +303,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
     range = serializers.CharField(required=False, allow_null=True)
     start = serializers.DateTimeField(required=False, allow_null=True)
     end = serializers.DateTimeField(required=False, allow_null=True)
-    filters = serializers.DictField(required=False)  # TODO: allow empty?
+    filters = serializers.DictField(required=False)
 
     validate_id = validate_id
 

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -301,6 +301,8 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
     projects = ListField(child=serializers.IntegerField(), required=False, default=[])
     environment = ListField(child=serializers.CharField(), required=False, allow_null=True)
     range = serializers.CharField(required=False, allow_null=True)
+    start = serializers.DateTimeField(required=False, allow_null=True)
+    end = serializers.DateTimeField(required=False, allow_null=True)
     filters = serializers.DictField(required=False)  # TODO: allow empty?
 
     validate_id = validate_id
@@ -325,7 +327,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
         Only call save() on this serializer from within a transaction or
         bad things will happen
         """
-        page_filter_keys = ["environment", "range"]
+        page_filter_keys = ["environment", "range", "start", "end"]
         dashboard_filter_keys = ["releases"]
         self.instance = Dashboard.objects.create(
             organization=self.context.get("organization"),

--- a/src/sentry/api/validators/__init__.py
+++ b/src/sentry/api/validators/__init__.py
@@ -6,6 +6,7 @@ from .external_actor import *  # noqa: F401,F403
 from .integrations import *  # noqa: F401,F403
 from .monitor import *  # noqa: F401,F403
 from .notifications import *  # noqa: F401,F403
+from .project import *  # noqa: F401,F403
 from .project_codeowners import *  # noqa: F401,F403
 from .sentry_apps.schema import *  # noqa: F401,F403
 from .servicehook import *  # noqa: F401,F403

--- a/src/sentry/api/validators/project.py
+++ b/src/sentry/api/validators/project.py
@@ -1,0 +1,17 @@
+from rest_framework.exceptions import PermissionDenied
+
+from sentry.constants import ALL_ACCESS_PROJECTS
+
+
+def validate_projects(raw_project_ids, associated_projects):
+    raw_project_ids = set(raw_project_ids)
+
+    # Don't need to check all projects or my projects
+    if raw_project_ids == ALL_ACCESS_PROJECTS or len(raw_project_ids) == 0:
+        return raw_project_ids
+
+    # Check that there aren't projects in the query the user doesn't have access to
+    if len(raw_project_ids - {project.id for project in associated_projects}) > 0:
+        raise PermissionDenied
+
+    return raw_project_ids

--- a/src/sentry/api/validators/project.py
+++ b/src/sentry/api/validators/project.py
@@ -3,7 +3,7 @@ from rest_framework.exceptions import PermissionDenied
 from sentry.constants import ALL_ACCESS_PROJECTS
 
 
-def validate_projects(raw_project_ids, associated_projects):
+def validate_project_ids(raw_project_ids, associated_projects):
     raw_project_ids = set(raw_project_ids)
 
     # Don't need to check all projects or my projects
@@ -11,7 +11,7 @@ def validate_projects(raw_project_ids, associated_projects):
         return raw_project_ids
 
     # Check that there aren't projects in the query the user doesn't have access to
-    if len(raw_project_ids - {project.id for project in associated_projects}) > 0:
+    if len(raw_project_ids - set(associated_projects)) > 0:
         raise PermissionDenied
 
     return raw_project_ids

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -3,7 +3,6 @@ from typing import Sequence
 
 from django.db.models import Count, Max
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
 
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers.rest_framework import ListField
@@ -172,17 +171,9 @@ class DiscoverSavedQuerySerializer(serializers.Serializer):
     }
 
     def validate_projects(self, projects):
-        projects = set(projects)
+        from sentry.api.validators import validate_project_ids
 
-        # Don't need to check all projects or my projects
-        if projects == ALL_ACCESS_PROJECTS or len(projects) == 0:
-            return projects
-
-        # Check that there aren't projects in the query the user doesn't have access to
-        if len(projects - set(self.context["params"]["project_id"])) > 0:
-            raise PermissionDenied
-
-        return projects
+        return validate_project_ids(projects, self.context["params"]["project_id"])
 
     def validate(self, data):
         query = {}

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -137,6 +137,21 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["widgets"][0]["queries"][0]["fieldAliases"][0] == "Count Alias"
         assert response.data["widgets"][1]["queries"][0]["fieldAliases"] == []
 
+    def test_filters_are_not_in_response_if_not_applicable(self):
+        filters = {"environment": ["alpha"]}
+        dashboard = Dashboard.objects.create(
+            title="Dashboard With Filters",
+            created_by=self.user,
+            organization=self.organization,
+            filters=filters,
+        )
+
+        response = self.do_request("get", self.url(dashboard.id))
+        assert response.data["projects"] == []
+        assert response.data["environment"] == filters["environment"]
+        assert "range" not in response.data
+        assert "filters" not in response.data
+
     def test_dashboard_filters_are_returned_in_response(self):
         filters = {"environment": ["alpha"], "range": "24hr", "releases": ["test-release"]}
         dashboard = Dashboard.objects.create(

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -137,7 +137,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["widgets"][0]["queries"][0]["fieldAliases"][0] == "Count Alias"
         assert response.data["widgets"][1]["queries"][0]["fieldAliases"] == []
 
-    def test_filters_are_not_in_response_if_not_applicable(self):
+    def test_filters_is_empty_dict_in_response_if_not_applicable(self):
         filters = {"environment": ["alpha"]}
         dashboard = Dashboard.objects.create(
             title="Dashboard With Filters",
@@ -149,8 +149,8 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         response = self.do_request("get", self.url(dashboard.id))
         assert response.data["projects"] == []
         assert response.data["environment"] == filters["environment"]
+        assert response.data["filters"] == {}
         assert "range" not in response.data
-        assert "filters" not in response.data
 
     def test_dashboard_filters_are_returned_in_response(self):
         filters = {"environment": ["alpha"], "range": "24hr", "releases": ["test-release"]}

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -135,7 +135,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["widgets"][1]["queries"][0]["fieldAliases"] == []
 
     def test_dashboard_filters_are_returned_in_response(self):
-        filters = {"environment": ["alpha"], "range": "24hr"}
+        filters = {"environment": ["alpha"], "range": "24hr", "releases": ["test-release"]}
         dashboard = Dashboard.objects.create(
             title="Dashboard With Filters",
             created_by=self.user,
@@ -148,6 +148,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["projects"] == list(dashboard.projects.values_list("id", flat=True))
         assert response.data["environment"] == filters["environment"]
         assert response.data["range"] == filters["range"]
+        assert response.data["filters"]["releases"] == filters["releases"]
 
 
 class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCase):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -150,10 +150,10 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["projects"] == []
         assert response.data["environment"] == filters["environment"]
         assert response.data["filters"] == {}
-        assert "range" not in response.data
+        assert "period" not in response.data
 
     def test_dashboard_filters_are_returned_in_response(self):
-        filters = {"environment": ["alpha"], "range": "24hr", "releases": ["test-release"]}
+        filters = {"environment": ["alpha"], "period": "24hr", "releases": ["test-release"]}
         dashboard = Dashboard.objects.create(
             title="Dashboard With Filters",
             created_by=self.user,
@@ -165,7 +165,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         response = self.do_request("get", self.url(dashboard.id))
         assert response.data["projects"] == list(dashboard.projects.values_list("id", flat=True))
         assert response.data["environment"] == filters["environment"]
-        assert response.data["range"] == filters["range"]
+        assert response.data["period"] == filters["period"]
         assert response.data["filters"]["releases"] == filters["releases"]
 
     def test_start_and_end_filters_are_returned_in_response(self):
@@ -1357,7 +1357,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             "title": "First dashboard",
             "projects": [project1.id, project2.id],
             "environment": ["alpha"],
-            "range": "7d",
+            "period": "7d",
             "filters": {"releases": ["v1"]},
         }
 
@@ -1365,7 +1365,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.status_code == 200, response.data
         assert response.data["projects"] == [project1.id, project2.id]
         assert response.data["environment"] == ["alpha"]
-        assert response.data["range"] == "7d"
+        assert response.data["period"] == "7d"
         assert response.data["filters"]["releases"] == ["v1"]
 
     def test_update_dashboard_with_invalid_project_filter(self):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -1317,6 +1317,25 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         response = self.do_request("put", self.url(self.dashboard.id), data=data)
         assert response.status_code == 200, response.data
 
+    def test_update_dashboard_with_filters(self):
+        project1 = self.create_project(name="foo", organization=self.organization)
+        project2 = self.create_project(name="bar", organization=self.organization)
+        data = {
+            "title": "First dashboard",
+            "widgets": [],
+            "projects": [project1.id, project2.id],
+            "environment": ["alpha"],
+            "range": "7d",
+            "filters": {"releases": ["v1"]},
+        }
+
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+        assert response.data["projects"] == [project1.id, project2.id]
+        assert response.data["environment"] == ["alpha"]
+        assert response.data["range"] == "7d"
+        assert response.data["filters"]["releases"] == ["v1"]
+
 
 class OrganizationDashboardVisitTest(OrganizationDashboardDetailsTestCase):
     def url(self, dashboard_id):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -1322,7 +1322,6 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         project2 = self.create_project(name="bar", organization=self.organization)
         data = {
             "title": "First dashboard",
-            "widgets": [],
             "projects": [project1.id, project2.id],
             "environment": ["alpha"],
             "range": "7d",
@@ -1335,6 +1334,19 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.data["environment"] == ["alpha"]
         assert response.data["range"] == "7d"
         assert response.data["filters"]["releases"] == ["v1"]
+
+    def test_update_dashboard_with_invalid_project(self):
+        other_project = self.create_project(name="other", organization=self.create_organization())
+        data = {
+            "title": "First dashboard",
+            "projects": [other_project.id],
+            "environment": ["alpha"],
+            "range": "7d",
+            "filters": {"releases": ["v1"]},
+        }
+
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 403, response.data
 
 
 class OrganizationDashboardVisitTest(OrganizationDashboardDetailsTestCase):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -181,8 +181,8 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         dashboard.projects.set([Project.objects.create(organization=self.organization)])
 
         response = self.do_request("get", self.url(dashboard.id))
-        assert response.data["start"] == start
-        assert response.data["end"] == end
+        assert iso_format(response.data["start"]) == start
+        assert iso_format(response.data["end"]) == end
 
     def test_response_truncates_with_retention(self):
         start = iso_format(datetime.now() - timedelta(days=3))

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -1335,14 +1335,11 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.data["range"] == "7d"
         assert response.data["filters"]["releases"] == ["v1"]
 
-    def test_update_dashboard_with_invalid_project(self):
+    def test_update_dashboard_with_invalid_project_filter(self):
         other_project = self.create_project(name="other", organization=self.create_organization())
         data = {
             "title": "First dashboard",
             "projects": [other_project.id],
-            "environment": ["alpha"],
-            "range": "7d",
-            "filters": {"releases": ["v1"]},
         }
 
         response = self.do_request("put", self.url(self.dashboard.id), data=data)

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -134,6 +134,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["widgets"][0]["queries"][0]["fieldAliases"][0] == "Count Alias"
         assert response.data["widgets"][1]["queries"][0]["fieldAliases"] == []
 
+    # TODO: Support start & end as well
     def test_dashboard_filters_are_returned_in_response(self):
         filters = {"environment": ["alpha"], "range": "24hr", "releases": ["test-release"]}
         dashboard = Dashboard.objects.create(

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -498,7 +498,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.data["range"] == "7d"
         assert response.data["filters"]["releases"] == ["v1"]
 
-    def test_post_with_start_and_end_values(self):
+    def test_post_with_start_and_end_filter(self):
         start = iso_format(datetime.now() - timedelta(seconds=10))
         end = iso_format(datetime.now())
         response = self.do_request(
@@ -510,7 +510,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.data["start"].strftime("%Y-%m-%dT%H:%M:%S") == start
         assert response.data["end"].strftime("%Y-%m-%dT%H:%M:%S") == end
 
-    def test_post_dashboard_with_projects_that_user_is_not_a_part_of(self):
+    def test_post_dashboard_with_invalid_project_filter(self):
         other_org = self.create_organization()
         other_project = self.create_project(name="other", organization=other_org)
         response = self.do_request(

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from django.urls import reverse
 
 from sentry.models import (
@@ -8,7 +10,7 @@ from sentry.models import (
     DashboardWidgetTypes,
 )
 from sentry.testutils import OrganizationDashboardWidgetTestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 
 class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
@@ -475,7 +477,6 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         response = self.do_request("post", self.url, data=data)
         assert response.status_code == 400, response.data
 
-    # TODO: Test for start & end values
     def test_post_dashboard_with_filters(self):
         project1 = self.create_project(name="foo", organization=self.organization)
         project2 = self.create_project(name="bar", organization=self.organization)
@@ -496,6 +497,18 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.data["environment"] == ["alpha"]
         assert response.data["range"] == "7d"
         assert response.data["filters"]["releases"] == ["v1"]
+
+    def test_post_with_start_and_end_values(self):
+        start = iso_format(datetime.now() - timedelta(seconds=10))
+        end = iso_format(datetime.now())
+        response = self.do_request(
+            "post",
+            self.url,
+            data={"title": "Dashboard from Post", "start": start, "end": end},
+        )
+        assert response.status_code == 201
+        assert response.data["start"].strftime("%Y-%m-%dT%H:%M:%S") == start
+        assert response.data["end"].strftime("%Y-%m-%dT%H:%M:%S") == end
 
     def test_post_dashboard_with_projects_that_user_is_not_a_part_of(self):
         other_org = self.create_organization()

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -475,6 +475,41 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         response = self.do_request("post", self.url, data=data)
         assert response.status_code == 400, response.data
 
+    # TODO: Test for start & end values
+    def test_post_dashboard_with_filters(self):
+        project1 = self.create_project(name="foo", organization=self.organization)
+        project2 = self.create_project(name="bar", organization=self.organization)
+
+        response = self.do_request(
+            "post",
+            self.url,
+            data={
+                "title": "Dashboard from Post",
+                "projects": [project1.id, project2.id],
+                "environment": ["alpha"],
+                "range": "7d",
+                "filters": {"releases": ["v1"]},
+            },
+        )
+        assert response.status_code == 201
+        assert response.data["projects"] == [project1.id, project2.id]
+        assert response.data["environment"] == ["alpha"]
+        assert response.data["range"] == "7d"
+        assert response.data["filters"]["releases"] == ["v1"]
+
+    def test_post_dashboard_with_projects_that_user_is_not_a_part_of(self):
+        other_org = self.create_organization()
+        other_project = self.create_project(name="other", organization=other_org)
+        response = self.do_request(
+            "post",
+            self.url,
+            data={
+                "title": "Dashboard from Post",
+                "projects": [other_project.id],
+            },
+        )
+        assert response.status_code == 403
+
     def test_add_widget_with_limit(self):
         data = {
             "title": "Dashboard from Post",

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -523,6 +523,16 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         )
         assert response.status_code == 403
 
+    def test_post_dashboard_with_invalid_start_end_filter(self):
+        start = iso_format(datetime.now())
+        end = iso_format(datetime.now() - timedelta(seconds=10))
+        response = self.do_request(
+            "post",
+            self.url,
+            data={"title": "Dashboard from Post", "start": start, "end": end},
+        )
+        assert response.status_code == 400
+
     def test_add_widget_with_limit(self):
         data = {
             "title": "Dashboard from Post",

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -488,14 +488,14 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 "title": "Dashboard from Post",
                 "projects": [project1.id, project2.id],
                 "environment": ["alpha"],
-                "range": "7d",
+                "period": "7d",
                 "filters": {"releases": ["v1"]},
             },
         )
         assert response.status_code == 201
         assert response.data["projects"] == [project1.id, project2.id]
         assert response.data["environment"] == ["alpha"]
-        assert response.data["range"] == "7d"
+        assert response.data["period"] == "7d"
         assert response.data["filters"]["releases"] == ["v1"]
 
     def test_post_with_start_and_end_filter(self):


### PR DESCRIPTION
This updates the dashboards endpoint to expose `projects`, `environment`, `range`, `start`, `end`, and `releases` as filters. This is the format we expect to enforce:
```
{
  ... pre-existing dashboard request data,
  projects?: integer[],
  environment?: string[],
  range?: string,
  start?: string,
  end?: string
  filters?: {
     releases?: string[]
  }
}
```

The following validation should apply:
* Should enforce that projects in the request are projects that the user has access to (i.e. in their org)
* If start and end are included, then start must be before end

If a field is not applicable, don't show it. The exception is projects which will always return at least `[]`