### PR TITLE
ref: replace some map() calls with f-strings

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -28,7 +28,6 @@ from sentry.search.utils import (
     parse_numeric_value,
     parse_percentage,
 )
-from sentry.utils.compat import map
 from sentry.utils.snuba import (
     Dataset,
     is_duration_measurement,
@@ -377,7 +376,7 @@ class SearchFilter(NamedTuple):
     value: SearchValue
 
     def __str__(self):
-        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
+        return f"{self.key.name}{self.operator}{self.value.raw_value}"
 
     @property
     def is_negation(self) -> bool:
@@ -404,7 +403,7 @@ class AggregateFilter(NamedTuple):
     value: SearchValue
 
     def __str__(self):
-        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
+        return f"{self.key.name}{self.operator}{self.value.raw_value}"
 
 
 class AggregateKey(NamedTuple):

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -1,6 +1,5 @@
 import itertools
 import logging
-import operator
 import random
 import uuid
 from collections import defaultdict, namedtuple
@@ -667,7 +666,7 @@ class RedisTSDB(BaseTSDB):
 
     def make_frequency_table_keys(self, model, rollup, timestamp, key, environment_id):
         prefix = self.make_key(model, rollup, timestamp, key, environment_id)
-        return map(operator.methodcaller("format", prefix), ("{}:i", "{}:e"))
+        return [f"{prefix}:i", f"{prefix}:e"]
 
     def record_frequency_multi(self, requests, timestamp=None, environment_id=None):
         self.validate_arguments([model for model, request in requests], [environment_id])


### PR DESCRIPTION
I'm slowly trying to delete the utils.compat module