### PR TITLE
fix(dashboards): extend handling no order by options to all datasets

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -722,7 +722,7 @@ function WidgetBuilder({
         });
         let orderOption: string;
         // If no orderby options are available because of DISABLED_SORTS
-        if (!!!orderOptions.length && state.dataSet === DataSet.RELEASES) {
+        if (!!!orderOptions.length) {
           newQuery.orderby = '';
         } else {
           orderOption = orderOptions[0].value;


### PR DESCRIPTION
Some errors and transactions widgets are triggering `cannot find properties of undefined`.
Updates non empty array check to include all datasets to prevent this.