### PR TITLE
fix(dashboards): Fix flakey debounce test

### DIFF
--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -98,6 +98,8 @@ describe('VisualizationStep', function () {
 
     await screen.findByText('Table');
 
+    await waitFor(() => expect(eventsv2Mock).toHaveBeenCalledTimes(1));
+
     userEvent.type(screen.getByPlaceholderText('Alias'), 'First Alias{enter}');
     act(() => {
       jest.advanceTimersByTime(DEFAULT_DEBOUNCE_DURATION + 1);


### PR DESCRIPTION
Attempting to fix flakey test by waiting for the first `eventsv2` request to complete before typing to trigger the second request.