### PR TITLE
feat(profiling): create a virtual root for the flamegraph

### DIFF
--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -214,7 +214,7 @@ export class Flamegraph {
       }
 
       stackTop.end = offset + value;
-      stackTop.depth = stack.length - 1;
+      stackTop.depth = stack.length;
 
       // Dont draw 0 width frames
       if (stackTop.end - stackTop.start === 0) {
@@ -236,7 +236,9 @@ export class Flamegraph {
         childTime += child.totalWeight;
       });
 
-      closeFrame(node, start + node.totalWeight);
+      if (!node.frame.isRoot()) {
+        closeFrame(node, start + node.totalWeight);
+      }
     }
     visit(profile.appendOrderTree, 0);
     return frames;

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -83,7 +83,7 @@ class FlamegraphRenderer {
 
     this.colors = new Array(VERTICES * COLOR_COMPONENTS);
     this.frames = [...this.flamegraph.frames];
-    this.roots = this.flamegraph.frames.filter(f => !f.parent);
+    this.roots = [...this.flamegraph.root.children];
 
     // Generate colors for the flamegraph
     const {colorBuffer, colorMap} = this.theme.COLORS.STACK_TO_COLOR(

--- a/static/app/utils/profiling/renderers/flamegraphRenderer2D.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer2D.tsx
@@ -65,7 +65,7 @@ export class FlamegraphRenderer2d {
       throw new Error('No canvas to draw on');
     }
 
-    const queue: FlamegraphFrame[] = [...this.flamegraph.roots];
+    const queue: FlamegraphFrame[] = [...this.flamegraph.root.children];
     const context = this.canvas.getContext('2d');
 
     if (!context) {

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -77,7 +77,7 @@ class TextRenderer {
     // This allows us to do a couple optimizations that improve our best case performance.
     // 1. We can skip drawing the entire tree if the root frame is not visible
     // 2. We can skip drawing and
-    const frames: FlamegraphFrame[] = [...this.flamegraph.roots];
+    const frames: FlamegraphFrame[] = [...this.flamegraph.root.children];
     while (frames.length) {
       const frame = frames.pop()!;
 


### PR DESCRIPTION
Instead of marking nodes as roots and pushing them to a separate array, create a virtual root node and read it's children. This allows us to treat the entire tree as a single node and will make calculating weights easier later.