### PR TITLE
feat(search): Filter descriptions and keywords alongside the field key

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -51,6 +51,7 @@ import {ItemType, SearchGroup, SearchItem, Shortcut, ShortcutType} from './types
 import {
   addSpace,
   createSearchGroups,
+  filterKeysFromQuery,
   generateOperatorEntryMap,
   getSearchGroupWithItemMarkedActive,
   getTagItemsFromKeys,
@@ -923,17 +924,17 @@ class SmartSearchBar extends Component<Props, State> {
   /**
    * Returns array of possible key values that substring match `query`
    */
-  getTagKeys(query: string): [SearchItem[], ItemType] {
+  getTagKeys(searchTerm: string): [SearchItem[], ItemType] {
     const {prepareQuery, supportedTagType} = this.props;
 
     const supportedTags = this.props.supportedTags ?? {};
 
-    let tagKeys = Object.keys(supportedTags);
+    let tagKeys = Object.keys(supportedTags).sort((a, b) => a.localeCompare(b));
 
-    if (query) {
-      const preparedQuery =
-        typeof prepareQuery === 'function' ? prepareQuery(query) : query;
-      tagKeys = tagKeys.filter(key => key.indexOf(preparedQuery) > -1);
+    if (searchTerm) {
+      const preparedSearchTerm = prepareQuery ? prepareQuery(searchTerm) : searchTerm;
+
+      tagKeys = filterKeysFromQuery(tagKeys, preparedSearchTerm);
     }
 
     // If the environment feature is active and excludeEnvironment = true

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -371,66 +371,64 @@ export const getTagItemsFromKeys = (
     [key: string]: Tag;
   }
 ) => {
-  return [...tagKeys]
-    .sort((a, b) => a.localeCompare(b))
-    .reduce((groups, key) => {
-      const keyWithColon = `${key}:`;
-      const sections = key.split('.');
+  return [...tagKeys].reduce((groups, key) => {
+    const keyWithColon = `${key}:`;
+    const sections = key.split('.');
 
-      const definition =
-        supportedTags[key]?.kind === FieldKind.FUNCTION
-          ? getFieldDefinition(key.split('(')[0])
-          : getFieldDefinition(key);
-      const kind = supportedTags[key]?.kind ?? definition?.kind ?? FieldKind.FIELD;
+    const definition =
+      supportedTags[key]?.kind === FieldKind.FUNCTION
+        ? getFieldDefinition(key.split('(')[0])
+        : getFieldDefinition(key);
+    const kind = supportedTags[key]?.kind ?? definition?.kind ?? FieldKind.FIELD;
 
-      const item: SearchItem = {
-        value: keyWithColon,
-        title: getItemTitle(key, kind),
-        documentation: definition?.desc ?? '-',
-        kind,
-        deprecated: definition?.deprecated,
-      };
+    const item: SearchItem = {
+      value: keyWithColon,
+      title: getItemTitle(key, kind),
+      documentation: definition?.desc ?? '-',
+      kind,
+      deprecated: definition?.deprecated,
+    };
 
-      const lastGroup = groups.at(-1);
+    const lastGroup = groups.at(-1);
 
-      const [title] = sections;
+    const [title] = sections;
 
-      if (kind !== FieldKind.FUNCTION && lastGroup) {
-        if (lastGroup.children && lastGroup.title === title) {
-          lastGroup.children.push(item);
-          return groups;
-        }
+    if (kind !== FieldKind.FUNCTION && lastGroup) {
+      if (lastGroup.children && lastGroup.title === title) {
+        lastGroup.children.push(item);
+        return groups;
+      }
 
-        if (lastGroup.title && lastGroup.title.split('.')[0] === title) {
-          if (lastGroup.title === title) {
-            return [
-              ...groups.slice(0, -1),
-              {
-                title,
-                value: lastGroup.value,
-                documentation: lastGroup.documentation,
-                kind: lastGroup.kind,
-                children: [item],
-              },
-            ];
-          }
-
-          // Add a blank parent if the last group's full key is not the same as the title
+      if (lastGroup.title && lastGroup.title.split('.')[0] === title) {
+        if (lastGroup.title === title) {
           return [
             ...groups.slice(0, -1),
             {
               title,
-              value: null,
-              documentation: '-',
+              value: lastGroup.value,
+              documentation: lastGroup.documentation,
               kind: lastGroup.kind,
-              children: [lastGroup, item],
+              children: [item],
             },
           ];
         }
-      }
 
-      return [...groups, item];
-    }, [] as SearchItem[]);
+        // Add a blank parent if the last group's full key is not the same as the title
+        return [
+          ...groups.slice(0, -1),
+          {
+            title,
+            value: null,
+            documentation: '-',
+            kind: lastGroup.kind,
+            children: [lastGroup, item],
+          },
+        ];
+      }
+    }
+
+    return [...groups, item];
+  }, [] as SearchItem[]);
 };
 
 /**
@@ -472,3 +470,43 @@ export const getSearchGroupWithItemMarkedActive = (
     }),
   }));
 };
+
+/**
+ * Filter tag keys based on the query and the key, description, and associated keywords of each tag.
+ */
+export const filterKeysFromQuery = (tagKeys: string[], searchTerm: string): string[] =>
+  tagKeys
+    .flatMap(key => {
+      const keyWithoutFunctionPart = key.replaceAll(/\(.*\)/g, '');
+      const definition = getFieldDefinition(keyWithoutFunctionPart);
+      const lowerCasedSearchTerm = searchTerm.toLocaleLowerCase();
+
+      const combinedKeywords = [
+        ...(definition?.desc ? [definition.desc] : []),
+        ...(definition?.keywords ?? []),
+      ]
+        .join(' ')
+        .toLocaleLowerCase();
+
+      const matchedInKey = keyWithoutFunctionPart.includes(lowerCasedSearchTerm);
+      const matchedInKeywords = combinedKeywords.includes(lowerCasedSearchTerm);
+
+      if (!matchedInKey && !matchedInKeywords) {
+        return [];
+      }
+
+      return [{matchedInKey, matchedInKeywords, key}];
+    })
+    .sort((a, b) => {
+      // Sort by matched in key first, then by matched in keywords
+      if (a.matchedInKey && !b.matchedInKey) {
+        return -1;
+      }
+
+      if (b.matchedInKey && !a.matchedInKey) {
+        return 1;
+      }
+
+      return a.key < b.key ? -1 : 1;
+    })
+    .map(({key}) => key);

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -164,6 +164,7 @@ export interface FieldDefinition {
   valueType: FieldValueType | null;
   deprecated?: boolean;
   desc?: string;
+  keywords?: string[];
 }
 
 export const AGGREGATION_FIELDS: Record<string, FieldDefinition> = {
@@ -553,6 +554,7 @@ export const FIELDS: Record<FieldKey & AggregationKey & MobileVital, FieldDefini
     desc: t('The properties of an issue (i.e. Resolved, unresolved)'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+    keywords: ['ignored', 'assigned', 'for_review', 'unassigned', 'linked', 'unlinked'],
   },
   [FieldKey.ISSUE]: {
     desc: t('The issue identification code'),
@@ -711,6 +713,7 @@ export const FIELDS: Record<FieldKey & AggregationKey & MobileVital, FieldDefini
     desc: t('Total number of events'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.NUMBER,
+    keywords: ['count'],
   },
   [FieldKey.TIMESTAMP]: {
     desc: t('The time an event finishes'),

--- a/tests/js/spec/components/events/searchBar.spec.jsx
+++ b/tests/js/spec/components/events/searchBar.spec.jsx
@@ -194,7 +194,6 @@ describe('Events > SearchBar', function () {
     const wrapper = mountWithTheme(<SearchBar {...props} maxQueryLength={5} />, options);
     await tick();
     wrapper.update();
-    wrapper.setState;
 
     setQuery(wrapper, 'g');
     await tick();
@@ -202,16 +201,16 @@ describe('Events > SearchBar', function () {
 
     expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('g');
     expect(wrapper.find('SearchDropdown SearchItemTitleWrapper')).toEqual({});
+
     expect(
       wrapper.find('SearchListItem[data-test-id="search-autocomplete-item"]')
-    ).toHaveLength(1);
+    ).toHaveLength(2);
   });
 
   it('returns zero dropdown suggestions if out of characters', async function () {
     const wrapper = mountWithTheme(<SearchBar {...props} maxQueryLength={2} />, options);
     await tick();
     wrapper.update();
-    wrapper.setState;
 
     setQuery(wrapper, 'g');
     await tick();

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -5,7 +5,7 @@ import {SmartSearchBar} from 'sentry/components/smartSearchBar';
 import {ShortcutType} from 'sentry/components/smartSearchBar/types';
 import {shortcuts} from 'sentry/components/smartSearchBar/utils';
 import TagStore from 'sentry/stores/tagStore';
-import * as Fields from 'sentry/utils/fields';
+import {FieldKey} from 'sentry/utils/fields';
 
 describe('SmartSearchBar', function () {
   let location, options, organization, supportedTags;
@@ -986,49 +986,24 @@ describe('SmartSearchBar', function () {
   });
 
   describe('getTagKeys()', function () {
-    const supportedTagsMock = {
-      has: {
-        key: 'has',
-      },
-      aa: {
-        key: 'aa',
-      },
-      bb: {
-        key: 'bb',
-      },
-    };
-
-    let spy;
-    beforeAll(() => {
-      spy = jest.spyOn(Fields, 'getFieldDefinition').mockImplementation(key => {
-        const map = {
-          has: {
-            desc: 'Has lol',
-          },
-          aa: {
-            desc: 'this has the word in it',
-          },
-          bb: {
-            desc: 'this does not have the word in it',
-          },
-        };
-
-        return map[key];
-      });
-    });
-
-    afterAll(() => {
-      spy?.mockRestore();
-    });
-
     it('filters both keys and descriptions', async function () {
       jest.useRealTimers();
 
       const props = {
-        query: 'has',
+        query: 'event',
         organization,
         location,
-        supportedTags: supportedTagsMock,
+        supportedTags: {
+          [FieldKey.DEVICE_CHARGING]: {
+            key: FieldKey.DEVICE_CHARGING,
+          },
+          [FieldKey.EVENT_TYPE]: {
+            key: FieldKey.EVENT_TYPE,
+          },
+          [FieldKey.DEVICE_ARCH]: {
+            key: FieldKey.DEVICE_ARCH,
+          },
+        },
       };
       const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
       const searchBar = smartSearchBar.instance();
@@ -1039,18 +1014,28 @@ describe('SmartSearchBar', function () {
       await tick();
 
       expect(searchBar.state.flatSearchItems).toHaveLength(2);
-      expect(searchBar.state.flatSearchItems[0].title).toBe('has');
-      expect(searchBar.state.flatSearchItems[1].title).toBe('aa');
+      expect(searchBar.state.flatSearchItems[0].title).toBe(FieldKey.EVENT_TYPE);
+      expect(searchBar.state.flatSearchItems[1].title).toBe(FieldKey.DEVICE_CHARGING);
     });
 
     it('filters only keys', async function () {
       jest.useRealTimers();
 
       const props = {
-        query: 'aa',
+        query: 'device',
         organization,
         location,
-        supportedTags: supportedTagsMock,
+        supportedTags: {
+          [FieldKey.DEVICE_CHARGING]: {
+            key: FieldKey.DEVICE_CHARGING,
+          },
+          [FieldKey.EVENT_TYPE]: {
+            key: FieldKey.EVENT_TYPE,
+          },
+          [FieldKey.DEVICE_ARCH]: {
+            key: FieldKey.DEVICE_ARCH,
+          },
+        },
       };
       const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
       const searchBar = smartSearchBar.instance();
@@ -1060,18 +1045,29 @@ describe('SmartSearchBar', function () {
 
       await tick();
 
-      expect(searchBar.state.flatSearchItems).toHaveLength(1);
-      expect(searchBar.state.flatSearchItems[0].title).toBe('aa');
+      expect(searchBar.state.flatSearchItems).toHaveLength(2);
+      expect(searchBar.state.flatSearchItems[0].title).toBe(FieldKey.DEVICE_ARCH);
+      expect(searchBar.state.flatSearchItems[1].title).toBe(FieldKey.DEVICE_CHARGING);
     });
 
     it('filters only descriptions', async function () {
       jest.useRealTimers();
 
       const props = {
-        query: 'word',
+        query: 'time',
         organization,
         location,
-        supportedTags: supportedTagsMock,
+        supportedTags: {
+          [FieldKey.DEVICE_CHARGING]: {
+            key: FieldKey.DEVICE_CHARGING,
+          },
+          [FieldKey.EVENT_TYPE]: {
+            key: FieldKey.EVENT_TYPE,
+          },
+          [FieldKey.DEVICE_ARCH]: {
+            key: FieldKey.DEVICE_ARCH,
+          },
+        },
       };
       const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
       const searchBar = smartSearchBar.instance();
@@ -1081,9 +1077,8 @@ describe('SmartSearchBar', function () {
 
       await tick();
 
-      expect(searchBar.state.flatSearchItems).toHaveLength(2);
-      expect(searchBar.state.flatSearchItems[0].title).toBe('aa');
-      expect(searchBar.state.flatSearchItems[1].title).toBe('bb');
+      expect(searchBar.state.flatSearchItems).toHaveLength(1);
+      expect(searchBar.state.flatSearchItems[0].title).toBe(FieldKey.DEVICE_CHARGING);
     });
   });
 

--- a/tests/js/spec/components/smartSearchBar/utils.spec.tsx
+++ b/tests/js/spec/components/smartSearchBar/utils.spec.tsx
@@ -6,7 +6,7 @@ import {
   getTagItemsFromKeys,
   removeSpace,
 } from 'sentry/components/smartSearchBar/utils';
-import * as Fields from 'sentry/utils/fields';
+import {FieldKey, FieldKind, getFieldDefinition} from 'sentry/utils/fields';
 
 describe('addSpace()', function () {
   it('should add a space when there is no trailing space', function () {
@@ -66,17 +66,17 @@ describe('getTagItemsFromKeys()', function () {
   it('gets items from tags', () => {
     const supportedTags = {
       browser: {
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
         key: 'browser',
         name: 'Browser',
       },
       device: {
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
         key: 'device',
         name: 'Device',
       },
       someTag: {
-        kind: Fields.FieldKind.TAG,
+        kind: FieldKind.TAG,
         key: 'someTag',
         name: 'someTag',
       },
@@ -89,19 +89,19 @@ describe('getTagItemsFromKeys()', function () {
       {
         title: 'browser',
         value: 'browser:',
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
         documentation: '-',
       },
       {
         title: 'device',
         value: 'device:',
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
         documentation: '-',
       },
       {
         title: 'someTag',
         value: 'someTag:',
-        kind: Fields.FieldKind.TAG,
+        kind: FieldKind.TAG,
         documentation: '-',
       },
     ]);
@@ -112,17 +112,17 @@ describe('getTagItemsFromKeys()', function () {
       'tag1.arch': {
         key: 'tag1.arch',
         name: 'Tag1 Arch',
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
       },
       'tag1.family': {
         key: 'tag1.family',
         name: 'Tag1 Family',
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
       },
       test: {
         key: 'test',
         name: 'Test',
-        kind: Fields.FieldKind.TAG,
+        kind: FieldKind.TAG,
       },
     };
     const tagKeys = Object.keys(supportedTags);
@@ -133,19 +133,19 @@ describe('getTagItemsFromKeys()', function () {
       {
         title: 'tag1',
         value: null,
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
         documentation: '-',
         children: [
           {
             title: 'tag1.arch',
             value: 'tag1.arch:',
-            kind: Fields.FieldKind.FIELD,
+            kind: FieldKind.FIELD,
             documentation: '-',
           },
           {
             title: 'tag1.family',
             value: 'tag1.family:',
-            kind: Fields.FieldKind.FIELD,
+            kind: FieldKind.FIELD,
             documentation: '-',
           },
         ],
@@ -153,7 +153,7 @@ describe('getTagItemsFromKeys()', function () {
       {
         title: 'test',
         value: 'test:',
-        kind: Fields.FieldKind.TAG,
+        kind: FieldKind.TAG,
         documentation: '-',
       },
     ]);
@@ -162,17 +162,17 @@ describe('getTagItemsFromKeys()', function () {
   it('groups tags with single word parent', () => {
     const supportedTags = {
       tag1: {
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
         key: 'tag1',
         name: 'Tag1',
       },
       'tag1.family': {
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
         key: 'tag1.family',
         name: 'Tag1 Family',
       },
       test: {
-        kind: Fields.FieldKind.TAG,
+        kind: FieldKind.TAG,
         key: 'test',
         name: 'Test',
       },
@@ -185,13 +185,13 @@ describe('getTagItemsFromKeys()', function () {
       {
         title: 'tag1',
         value: 'tag1:',
-        kind: Fields.FieldKind.FIELD,
+        kind: FieldKind.FIELD,
         documentation: '-',
         children: [
           {
             title: 'tag1.family',
             value: 'tag1.family:',
-            kind: Fields.FieldKind.FIELD,
+            kind: FieldKind.FIELD,
             documentation: '-',
           },
         ],
@@ -199,7 +199,7 @@ describe('getTagItemsFromKeys()', function () {
       {
         title: 'test',
         value: 'test:',
-        kind: Fields.FieldKind.TAG,
+        kind: FieldKind.TAG,
         documentation: '-',
       },
     ]);
@@ -224,56 +224,53 @@ describe('getTagItemsFromKeys()', function () {
       {
         title: 'device.family',
         value: 'device.family:',
-        kind: Fields.getFieldDefinition('device.family')?.kind,
-        documentation: Fields.getFieldDefinition('device.family')?.desc,
+        kind: getFieldDefinition('device.family')?.kind,
+        documentation: getFieldDefinition('device.family')?.desc,
       },
       {
         title: 'has',
         value: 'has:',
-        kind: Fields.getFieldDefinition('has')?.kind,
-        documentation: Fields.getFieldDefinition('has')?.desc,
+        kind: getFieldDefinition('has')?.kind,
+        documentation: getFieldDefinition('has')?.desc,
       },
     ]);
   });
 });
 
 describe('filterKeysFromQuery', () => {
-  let spy: jest.SpyInstance | undefined;
-  beforeAll(() => {
-    spy = jest.spyOn(Fields, 'getFieldDefinition').mockImplementation((key: string) => {
-      const map = {
-        has: {
-          desc: 'Has lol',
-        },
-        aa: {
-          desc: 'this has the word in it',
-        },
-        bb: {
-          desc: 'this does not have the word in it',
-          keywords: ['cc'],
-        },
-      };
-
-      return map[key];
-    });
-  });
-
-  afterAll(() => {
-    spy?.mockRestore();
-  });
-
   it('filters', () => {
-    expect(filterKeysFromQuery(['has', 'aa', 'bb'], 'has')).toMatchObject(['has', 'aa']);
+    expect(
+      filterKeysFromQuery(
+        [FieldKey.DEVICE_ARCH, FieldKey.DEVICE_CHARGING, FieldKey.EVENT_TYPE],
+        'event'
+      )
+    ).toMatchObject([FieldKey.EVENT_TYPE, FieldKey.DEVICE_CHARGING]);
   });
 
   it('filters via description only', () => {
-    expect(filterKeysFromQuery(['has', 'aa', 'bb'], 'word')).toMatchObject(['aa', 'bb']);
+    expect(
+      filterKeysFromQuery(
+        [FieldKey.DEVICE_ARCH, FieldKey.DEVICE_CHARGING, FieldKey.EVENT_TYPE],
+        'time'
+      )
+    ).toMatchObject([FieldKey.DEVICE_CHARGING]);
   });
 
   it('filters via key only', () => {
-    expect(filterKeysFromQuery(['has', 'aa', 'bb'], 'aa')).toMatchObject(['aa']);
+    expect(
+      filterKeysFromQuery(
+        [FieldKey.DEVICE_ARCH, FieldKey.DEVICE_CHARGING, FieldKey.EVENT_TYPE],
+        'device'
+      )
+    ).toMatchObject([FieldKey.DEVICE_ARCH, FieldKey.DEVICE_CHARGING]);
   });
+
   it('filters via keywords', () => {
-    expect(filterKeysFromQuery(['has', 'aa', 'bb'], 'cc')).toMatchObject(['bb']);
+    expect(
+      filterKeysFromQuery(
+        [FieldKey.IS, FieldKey.DEVICE_CHARGING, FieldKey.EVENT_TYPE],
+        'unresolved'
+      )
+    ).toMatchObject([FieldKey.IS]);
   });
 });

--- a/tests/js/spec/components/smartSearchBar/utils.spec.tsx
+++ b/tests/js/spec/components/smartSearchBar/utils.spec.tsx
@@ -215,7 +215,7 @@ describe('getTagItemsFromKeys()', function () {
         name: 'Device Family',
       },
     };
-    const tagKeys = Object.keys(supportedTags);
+    const tagKeys = Object.keys(supportedTags).sort((a, b) => a.localeCompare(b));
 
     const items = getTagItemsFromKeys(tagKeys, supportedTags);
 


### PR DESCRIPTION
- Filters the description alongside the key when searching in the smart searchbar.
- Sorts the matches inside the key to show up before matches in the description/keywords.
- Highlights the matching term in the description if there is one.

Only added some sample keywords for `is` and `timesSeen`. Following up with more alternative keywords/synonyms for the search fields is easy by just adding to the field definitions object.

Old:
<img width="1065" alt="Screen Shot 2022-07-29 at 3 04 35 PM" src="https://user-images.githubusercontent.com/30991498/181850014-1eef7cab-eb4d-475d-b51b-eff2b9dfa6b7.png">

New:
<img width="1071" alt="Screen Shot 2022-07-29 at 3 04 03 PM" src="https://user-images.githubusercontent.com/30991498/181849988-e826323e-3256-4528-8ebe-7d8933f69e6d.png">

This feature addition should greatly increase search field discovery