### PR TITLE
wip: Remove unittest.TestCase from all django tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,4 @@ filterwarnings = [
 # This is for people who install pytest-xdist locally,
 # and use the -f/--looponfail feature.
 looponfailroots = ["src", "tests"]
+python_classes = "Test* *Test"

--- a/src/sentry/testutils/helpers/django.py
+++ b/src/sentry/testutils/helpers/django.py
@@ -1,0 +1,43 @@
+from functools import wraps
+
+import pytest
+from django.test import utils
+
+
+class TestContextDecorator:
+    """
+    Same as django's TestContextDecorator, but works on non-django classes
+    """
+
+    def __enter__(self):
+        return self.enable()
+
+    def __exit__(self, exc, ty, tb):
+        self.disable()
+
+    def roll_name(self):
+        return f"apply_decorator_{self.__class__.__name__}"
+
+    def __call__(slf, f):
+        if isinstance(f, type):
+
+            @pytest.fixture(autouse=True)
+            def _applied_decorator(self):
+                with slf:
+                    yield
+
+            setattr(f, slf.roll_name(), _applied_decorator)
+            return f
+        else:
+            assert callable(f)
+
+            @wraps(f)
+            def inner(*args, **kwargs):
+                with slf:
+                    return f(*args, **kwargs)
+
+            return inner
+
+
+class override_settings(TestContextDecorator, utils.override_settings):
+    pass

--- a/src/sentry/testutils/unittest_compat.py
+++ b/src/sentry/testutils/unittest_compat.py
@@ -1,0 +1,88 @@
+import collections
+from unittest.case import _count_diff_all_purpose, _count_diff_hashable
+
+import pytest
+
+
+class UnittestCompatMixin:
+    def assertEqual(self, first, second):
+        assert first == second
+
+    def assertDictEqual(self, first, second):
+        assert first == second
+
+    def assertNotEqual(self, first, second):
+        assert first != second
+
+    def assertNotIn(self, member, container):
+        assert member not in container
+
+    def assertIs(self, expr1, expr2):
+        assert expr1 is expr2
+
+    def assertIsNot(self, expr1, expr2):
+        assert expr1 is not expr2
+
+    def assertIsNone(self, obj):
+        assert obj is None
+
+    def assertIsNotNone(self, obj):
+        assert obj is not None
+
+    def assertIsInstance(self, obj, cls):
+        assert isinstance(obj, cls)
+
+    def assertTrue(self, expr):
+        assert expr
+
+    def assertFalse(self, expr):
+        assert not expr
+
+    def assertCountEqual(self, first, second):
+        """Asserts that two iterables have the same elements, the same number of
+        times, without regard to order.
+
+            self.assertEqual(Counter(list(first)),
+                             Counter(list(second)))
+
+         Example:
+            - [0, 1, 1] and [1, 0, 1] compare equal.
+            - [0, 0, 1] and [0, 1] compare unequal.
+
+        """
+        first_seq, second_seq = list(first), list(second)
+        try:
+            first = collections.Counter(first_seq)
+            second = collections.Counter(second_seq)
+        except TypeError:
+            # Handle case with unhashable elements
+            differences = _count_diff_all_purpose(first_seq, second_seq)
+        else:
+            if first == second:
+                return
+            differences = _count_diff_hashable(first_seq, second_seq)
+
+        if differences:
+            standardMsg = "Element counts were not equal:\n"
+            lines = ["First has %d, Second has %d:  %r" % diff for diff in differences]
+            diffMsg = "\n".join(lines)
+            raise AssertionError(standardMsg + diffMsg)
+
+    assertRaises = pytest.raises
+
+
+from pytest_django import asserts as django_asserts
+
+
+def _patch_assert_from_django(func_name):
+    inner = getattr(django_asserts, func_name)
+
+    def wrapper(self, *args, **kwargs):
+        return inner(*args, **kwargs)
+
+    setattr(UnittestCompatMixin, func_name, wrapper)
+
+
+for func_name in dir(django_asserts):
+    if func_name.startswith("assert"):
+        _patch_assert_from_django(func_name)

--- a/src/sentry/utils/pytest/__init__.py
+++ b/src/sentry/utils/pytest/__init__.py
@@ -6,4 +6,5 @@ pytest_plugins = [
     "sentry.utils.pytest.kafka",
     "sentry.utils.pytest.relay",
     "sentry.utils.pytest.stale_database_reads",
+    "sentry.utils.pytest.testcase_misuse",
 ]

--- a/src/sentry/utils/pytest/testcase_misuse.py
+++ b/src/sentry/utils/pytest/testcase_misuse.py
@@ -1,0 +1,85 @@
+import inspect
+
+import pytest
+
+# Ensure that testcases that ask for DB setup actually make use of the
+# DB. If they don't, they're wasting CI time.
+#
+# Only works for class-based tests
+
+
+@pytest.fixture(autouse=True, scope="class")
+def _require_db_usage(request):
+    from rest_framework.test import APITestCase
+
+    if (
+        request.cls is None
+        or "django_db" not in {mark.name for mark in request.node.iter_markers()}
+        or issubclass(request.cls, APITestCase)
+    ):
+        yield
+        return
+
+    class State:
+        used_db = {}
+        base = request.cls
+
+    state = State()
+
+    yield state
+
+    did_not_use = set()
+    did_use = set()
+    for name, used in state.used_db.items():
+        if used:
+            did_use.add(name)
+        else:
+            did_not_use.add(name)
+
+    if did_not_use and not did_use:
+        pytest.fail(
+            f"none of the test functions in {state.base} used the DB! Use `unittest.TestCase` "
+            f"instead of `sentry.testutils.TestCase` for those kinds of tests"
+        )
+    elif did_not_use and did_use:
+        pytest.fail(
+            f"Some of the test functions in {state.base} used the DB and some did not! "
+            f"test functions using the db: {did_use}\n"
+            f"Use `unittest.TestCase` instead of `sentry.testutils.TestCase` for the tests not using the db."
+        )
+
+
+@pytest.fixture(autouse=True, scope="function")
+def _check_function_for_db(request, monkeypatch, _require_db_usage):
+    if _require_db_usage is None:
+        return
+
+    from django.db.backends.base.base import BaseDatabaseWrapper
+
+    real_ensure_connection = BaseDatabaseWrapper.ensure_connection
+
+    state = _require_db_usage
+
+    def ensure_connection(*args, **kwargs):
+        for info in inspect.stack():
+            frame = info.frame
+            try:
+                first_arg_name = frame.f_code.co_varnames[0]
+                first_arg = frame.f_locals[first_arg_name]
+            except LookupError:
+                continue
+
+            # make an exact check here for two reasons.  One is that this is
+            # good enough as we do not expect subclasses, secondly however because
+            # it turns out doing an isinstance check on untrusted input can cause
+            # bad things to happen because it's hookable.  In particular this
+            # blows through max recursion limits here if it encounters certain
+            # types of broken lazy proxy objects.
+            if type(first_arg) is state.base and info.function in state.used_db:
+                state.used_db[info.function] = True
+                break
+
+        return real_ensure_connection(*args, **kwargs)
+
+    monkeypatch.setattr(BaseDatabaseWrapper, "ensure_connection", ensure_connection)
+    state.used_db[request.function.__name__] = False

--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -1,4 +1,4 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from fixtures.page_objects.organization_integration_settings import (
     OrganizationAbstractDetailViewPage,

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -5,7 +5,7 @@ import pytest
 from django.db.models import F
 from django.test import RequestFactory
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from freezegun import freeze_time
 from rest_framework.exceptions import PermissionDenied
 

--- a/tests/sentry/api/endpoints/test_assistant.py
+++ b/tests/sentry/api/endpoints/test_assistant.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.assistant import manager
 from sentry.models import AssistantActivity

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -1,9 +1,9 @@
 import pytest
 from django.conf import settings
-from django.test.utils import override_settings
 
 from sentry import newsletter
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.django import override_settings
 
 
 class AuthConfigEndpointTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -1,12 +1,11 @@
 from base64 import b64encode
 from unittest import mock
 
-from django.test import override_settings
-
 from sentry.models import Authenticator, AuthProvider
 from sentry.models.authidentity import AuthIdentity
 from sentry.testutils import APITestCase
 from sentry.testutils.cases import AuthProviderTestCase
+from sentry.testutils.helpers.django import override_settings
 
 
 class AuthDetailsEndpointTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -2,7 +2,6 @@ from base64 import b64encode
 from datetime import timedelta
 from unittest import mock
 
-from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -26,6 +25,7 @@ from sentry.models import (
 )
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.types.activity import ActivityType
 
 

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, Integration
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_group_user_reports.py
+++ b/tests/sentry/api/endpoints/test_group_user_reports.py
@@ -1,4 +1,4 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Environment, UserReport
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/sentry/api/endpoints/test_organization_environments.py
+++ b/tests/sentry/api/endpoints/test_organization_environments.py
@@ -1,4 +1,4 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.serializers import serialize
 from sentry.models import Environment

--- a/tests/sentry/api/endpoints/test_organization_invite_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_details.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry import audit_log
 from sentry.models import (

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -1,7 +1,7 @@
 import responses
 from django.core import mail
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import (
     InviteStatus,

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import responses
 from django.core import mail
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import AuthProvider, InviteStatus, OrganizationMember, OrganizationOption
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -1,4 +1,4 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from rest_framework import status
 
 from sentry.models import (

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.endpoints.organization_pinned_searches import PINNED_SEARCH_NAME
 from sentry.models.savedsearch import SavedSearch, SortOptions

--- a/tests/sentry/api/endpoints/test_organization_recent_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_recent_searches.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from freezegun import freeze_time
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/endpoints/test_organization_relay_usage.py
+++ b/tests/sentry/api/endpoints/test_organization_relay_usage.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 import pytz
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import RelayUsage
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import pytz
 from django.urls import reverse
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.endpoints.organization_releases import (
     ReleaseHeadCommitSerializer,

--- a/tests/sentry/api/endpoints/test_organization_search_details.py
+++ b/tests/sentry/api/endpoints/test_organization_search_details.py
@@ -1,4 +1,4 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import SavedSearch
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_searches.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.serializers import serialize
 from sentry.models.savedsearch import SavedSearch, SortOptions

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import OrganizationMember, OrganizationMemberTeam, Team
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
+++ b/tests/sentry/api/endpoints/test_project_app_store_connect_credentials.py
@@ -2,13 +2,13 @@ from unittest import mock
 
 import django.urls
 import pytest
-from django.test import override_settings
 
 import sentry.tasks.app_store_connect
 from sentry.api.endpoints.project_app_store_connect_credentials import (
     AppStoreUpdateCredentialsSerializer,
 )
 from sentry.lang.native.appconnect import AppStoreConnectConfig
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 
 

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import pytz
 from django.urls import reverse
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.api.endpoints.project_releases import ReleaseWithVersionSerializer

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -5,12 +5,12 @@ from typing import Any, Mapping, Sequence
 from unittest.mock import patch
 
 import responses
-from django.test import override_settings
 from rest_framework import status
 
 from sentry.models import Environment, Rule, RuleActivity, RuleActivityType, RuleStatus
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import install_slack
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 
 

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -2,12 +2,12 @@ import re
 import uuid
 from contextlib import contextmanager
 
-from django.test import override_settings
 from django.urls import reverse
 from sentry_relay.auth import generate_key_pair
 
 from sentry.models.relay import Relay
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json, safe
 
 

--- a/tests/sentry/api/helpers/test_processing_issues.py
+++ b/tests/sentry/api/helpers/test_processing_issues.py
@@ -1,4 +1,4 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.helpers.processing_issues import get_processing_issues
 from sentry.models import (

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from django.db.models import F
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry import features
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/test_handlers.py
+++ b/tests/sentry/api/test_handlers.py
@@ -1,11 +1,11 @@
 import math
 
 from django.conf.urls import url
-from django.test import override_settings
 from rest_framework.permissions import AllowAny
 
 from sentry.api.base import Endpoint
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils.snuba import RateLimitExceeded
 
 

--- a/tests/sentry/auth/providers/test_oauth2.py
+++ b/tests/sentry/auth/providers/test_oauth2.py
@@ -1,7 +1,7 @@
 from typing import Any, Mapping
 
 import pytest
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.providers.oauth2 import OAuth2Provider

--- a/tests/sentry/db/postgres/schema/safe_migrations/integration/test_migrations.py
+++ b/tests/sentry/db/postgres/schema/safe_migrations/integration/test_migrations.py
@@ -1,10 +1,10 @@
 import pytest
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
-from django.test import override_settings
 from django_zero_downtime_migrations.backends.postgres.schema import UnsafeOperationException
 
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 
 
 class BaseSafeMigrationTest(TestCase):

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from functools import reduce
 
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.digests import Record
 from sentry.digests.notifications import (

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -8,10 +8,10 @@ from unittest.mock import patch
 
 import pytest
 from confluent_kafka.admin import AdminClient
-from django.test import override_settings
 
 from sentry.eventstream.kafka import KafkaEventStream
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json, kafka_config
 from sentry.utils.batching_kafka_consumer import wait_for_topics
 

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from requests.exceptions import SSLError
 
 import sentry.identity

--- a/tests/sentry/incidents/action_handlers/__init__.py
+++ b/tests/sentry/incidents/action_handlers/__init__.py
@@ -4,7 +4,7 @@ from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models import Incident, IncidentStatus, IncidentStatusMethod
 
 
-class FireTest(abc.ABC):
+class FireTestBase(abc.ABC):
     @abc.abstractmethod
     def run_test(self, incident: Incident, method: str):
         pass

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -4,7 +4,7 @@ import responses
 from django.core import mail
 from django.urls import reverse
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from freezegun import freeze_time
 
 from sentry.incidents.action_handlers import (
@@ -25,11 +25,11 @@ from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 
-from . import FireTest
+from . import FireTestBase
 
 
 @freeze_time()
-class EmailActionHandlerTest(FireTest, TestCase):
+class EmailActionHandlerTest(FireTestBase, TestCase):
     @responses.activate
     def run_test(self, incident, method):
         action = self.create_alert_rule_trigger_action(

--- a/tests/sentry/incidents/action_handlers/test_msteams.py
+++ b/tests/sentry/incidents/action_handlers/test_msteams.py
@@ -9,11 +9,11 @@ from sentry.models import Integration
 from sentry.testutils import TestCase
 from sentry.utils import json
 
-from . import FireTest
+from . import FireTestBase
 
 
 @freeze_time()
-class MsTeamsActionHandlerTest(FireTest, TestCase):
+class MsTeamsActionHandlerTest(FireTestBase, TestCase):
     @responses.activate
     def run_test(self, incident, method):
         from sentry.integrations.msteams.card_builder import build_incident_attachment

--- a/tests/sentry/incidents/action_handlers/test_pagerduty.py
+++ b/tests/sentry/incidents/action_handlers/test_pagerduty.py
@@ -8,11 +8,11 @@ from sentry.models import Integration, PagerDutyService
 from sentry.testutils import TestCase
 from sentry.utils import json
 
-from . import FireTest
+from . import FireTestBase
 
 
 @freeze_time()
-class PagerDutyActionHandlerTest(FireTest, TestCase):
+class PagerDutyActionHandlerTest(FireTestBase, TestCase):
     def setUp(self):
         self.integration_key = "pfc73e8cb4s44d519f3d63d45b5q77g9"
         service = [

--- a/tests/sentry/incidents/action_handlers/test_sentry_app.py
+++ b/tests/sentry/incidents/action_handlers/test_sentry_app.py
@@ -6,11 +6,11 @@ from sentry.incidents.models import AlertRuleTriggerAction, IncidentStatus
 from sentry.testutils import TestCase
 from sentry.utils import json
 
-from . import FireTest
+from . import FireTestBase
 
 
 @freeze_time()
-class SentryAppActionHandlerTest(FireTest, TestCase):
+class SentryAppActionHandlerTest(FireTestBase, TestCase):
     def setUp(self):
         self.sentry_app = self.create_sentry_app(
             name="foo",
@@ -61,7 +61,7 @@ class SentryAppActionHandlerTest(FireTest, TestCase):
 
 
 @freeze_time()
-class SentryAppAlertRuleUIComponentActionHandlerTest(FireTest, TestCase):
+class SentryAppAlertRuleUIComponentActionHandlerTest(FireTestBase, TestCase):
     def setUp(self):
         self.sentry_app = self.create_sentry_app(
             name="foo",

--- a/tests/sentry/incidents/action_handlers/test_slack.py
+++ b/tests/sentry/incidents/action_handlers/test_slack.py
@@ -9,11 +9,11 @@ from sentry.models import Integration
 from sentry.testutils import TestCase
 from sentry.utils import json
 
-from . import FireTest
+from . import FireTestBase
 
 
 @freeze_time()
-class SlackActionHandlerTest(FireTest, TestCase):
+class SlackActionHandlerTest(FireTestBase, TestCase):
     @responses.activate
     def run_test(self, incident, method, chart_url=None):
         from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder
@@ -76,7 +76,7 @@ class SlackActionHandlerTest(FireTest, TestCase):
 
 
 @freeze_time()
-class SlackWorkspaceActionHandlerTest(FireTest, TestCase):
+class SlackWorkspaceActionHandlerTest(FireTestBase, TestCase):
     @responses.activate
     def run_test(self, incident, method):
         from sentry.integrations.slack.message_builder.incidents import SlackIncidentsMessageBuilder

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 import responses
 from django.conf import settings
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import DetailedAlertRuleSerializer

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 import pytz
 import requests
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from freezegun import freeze_time
 
 from sentry import audit_log

--- a/tests/sentry/incidents/endpoints/test_organization_incident_activity_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_activity_index.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import create_incident_activity

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
@@ -1,4 +1,4 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.incidents.models import IncidentActivity, IncidentActivityType
 from sentry.testutils import APITestCase

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_index.py
@@ -1,4 +1,4 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.serializers import serialize
 from sentry.incidents.models import IncidentActivity, IncidentActivityType, IncidentSubscription

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -2,14 +2,14 @@ from datetime import datetime
 from unittest import mock
 
 import pytz
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.serializers import serialize
 from sentry.incidents.models import Incident, IncidentActivity, IncidentStatus
 from sentry.testutils import APITestCase
 
 
-class BaseIncidentDetailsTest:
+class IncidentDetailsTestBase:
     endpoint = "sentry-api-0-organization-incident-details"
 
     def setUp(self):
@@ -41,7 +41,7 @@ class BaseIncidentDetailsTest:
         assert resp.status_code == 404
 
 
-class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
+class OrganizationIncidentDetailsTest(IncidentDetailsTestBase, APITestCase):
     @mock.patch("django.utils.timezone.now")
     def test_simple(self, mock_now):
         mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
@@ -64,7 +64,7 @@ class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
         assert [item["id"] for item in resp.data["seenBy"]] == [item["id"] for item in seen_by]
 
 
-class OrganizationIncidentUpdateStatusTest(BaseIncidentDetailsTest, APITestCase):
+class OrganizationIncidentUpdateStatusTest(IncidentDetailsTestBase, APITestCase):
     method = "put"
 
     def get_success_response(self, *args, **params):

--- a/tests/sentry/incidents/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_index.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import update_incident_status

--- a/tests/sentry/incidents/endpoints/test_organization_incident_seen.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_seen.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.incidents.models import IncidentSeen
 from sentry.testutils import APITestCase

--- a/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
@@ -1,11 +1,11 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.incidents.logic import subscribe_to_incident
 from sentry.incidents.models import IncidentSubscription
 from sentry.testutils import APITestCase
 
 
-class BaseOrganizationSubscriptionEndpointTest:
+class OrganizationSubscriptionEndpointTestBase:
     endpoint = "sentry-api-0-organization-incident-subscription-index"
 
     @fixture
@@ -35,7 +35,7 @@ class BaseOrganizationSubscriptionEndpointTest:
 
 
 class OrganizationIncidentSubscribeEndpointTest(
-    BaseOrganizationSubscriptionEndpointTest, APITestCase
+    OrganizationSubscriptionEndpointTestBase, APITestCase
 ):
     method = "post"
 
@@ -53,7 +53,7 @@ class OrganizationIncidentSubscribeEndpointTest(
 
 
 class OrganizationIncidentUnsubscribeEndpointTest(
-    BaseOrganizationSubscriptionEndpointTest, APITestCase
+    OrganizationSubscriptionEndpointTestBase, APITestCase
 ):
     method = "delete"
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -3,8 +3,7 @@ from unittest.mock import patch
 import pytz
 import requests
 import responses
-from django.test.utils import override_settings
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from freezegun import freeze_time
 
 from sentry import audit_log
@@ -18,6 +17,7 @@ from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.models import QueryDatasets
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 from tests.sentry.api.serializers.test_alert_rule import BaseAlertRuleSerializerTest
 

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -2,8 +2,7 @@ from unittest.mock import patch
 
 import pytest
 import responses
-from django.test import override_settings
-from exam import fixture
+from django.utils.functional import cached_property
 from rest_framework import serializers
 from rest_framework.exceptions import ErrorDetail
 
@@ -26,11 +25,12 @@ from sentry.incidents.serializers import (
 from sentry.models import ACTOR_TYPES, Environment, Integration
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 
 
 class TestAlertRuleSerializer(TestCase):
-    @fixture
+    @cached_property
     def valid_params(self):
         return {
             "name": "hello",
@@ -63,18 +63,18 @@ class TestAlertRuleSerializer(TestCase):
             "event_types": [SnubaQueryEventType.EventType.DEFAULT.name.lower()],
         }
 
-    @fixture
+    @cached_property
     def valid_transaction_params(self):
         params = self.valid_params.copy()
         params["dataset"] = QueryDatasets.TRANSACTIONS.value
         params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
         return params
 
-    @fixture
+    @cached_property
     def access(self):
         return from_user(self.user, self.organization)
 
-    @fixture
+    @cached_property
     def context(self):
         return {"organization": self.organization, "access": self.access, "user": self.user}
 
@@ -648,15 +648,15 @@ class TestAlertRuleSerializer(TestCase):
 
 
 class TestAlertRuleTriggerSerializer(TestCase):
-    @fixture
+    @cached_property
     def other_project(self):
         return self.create_project()
 
-    @fixture
+    @cached_property
     def alert_rule(self):
         return self.create_alert_rule(projects=[self.project, self.other_project])
 
-    @fixture
+    @cached_property
     def valid_params(self):
         return {
             "label": "something",
@@ -667,11 +667,11 @@ class TestAlertRuleTriggerSerializer(TestCase):
             "actions": [{"type": "email", "targetType": "team", "targetIdentifier": self.team.id}],
         }
 
-    @fixture
+    @cached_property
     def access(self):
         return from_user(self.user, self.organization)
 
-    @fixture
+    @cached_property
     def context(self):
         return {
             "organization": self.organization,
@@ -697,19 +697,19 @@ class TestAlertRuleTriggerSerializer(TestCase):
 
 
 class TestAlertRuleTriggerActionSerializer(TestCase):
-    @fixture
+    @cached_property
     def other_project(self):
         return self.create_project()
 
-    @fixture
+    @cached_property
     def alert_rule(self):
         return self.create_alert_rule(projects=[self.project, self.other_project])
 
-    @fixture
+    @cached_property
     def trigger(self):
         return create_alert_rule_trigger(self.alert_rule, "hello", 100)
 
-    @fixture
+    @cached_property
     def valid_params(self):
         return {
             "type": AlertRuleTriggerAction.get_registered_type(
@@ -719,11 +719,11 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
             "target_identifier": "test@test.com",
         }
 
-    @fixture
+    @cached_property
     def access(self):
         return from_user(self.user, self.organization)
 
-    @fixture
+    @cached_property
     def context(self):
         return {
             "organization": self.organization,
@@ -733,7 +733,7 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
             "trigger": self.trigger,
         }
 
-    @fixture
+    @cached_property
     def sentry_app(self):
         return self.create_sentry_app(
             organization=self.organization,
@@ -747,7 +747,7 @@ class TestAlertRuleTriggerActionSerializer(TestCase):
             },
         )
 
-    @fixture
+    @cached_property
     def sentry_app_installation(self):
         return self.create_sentry_app_installation(
             slug=self.sentry_app.slug, organization=self.organization, user=self.user

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -6,7 +6,8 @@ import responses
 from django.conf import settings
 from django.core import mail
 from django.utils import timezone
-from exam import fixture, patcher
+from django.utils.functional import cached_property as fixture
+from exam import patcher
 from freezegun import freeze_time
 
 from sentry.constants import ObjectStatus

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -6,7 +6,8 @@ from uuid import uuid4
 
 import pytz
 from django.utils import timezone
-from exam import fixture, patcher
+from django.utils.functional import cached_property as fixture
+from exam import patcher
 from freezegun import freeze_time
 
 from sentry.incidents.logic import (

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -4,7 +4,8 @@ from unittest.mock import Mock, call, patch
 import pytz
 from django.urls import reverse
 from django.utils import timezone
-from exam import fixture, patcher
+from django.utils.functional import cached_property as fixture
+from exam import patcher
 from freezegun import freeze_time
 
 from sentry.incidents.logic import (

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -8,11 +8,11 @@ import msgpack
 import pytest
 from confluent_kafka import KafkaError
 from django.conf import settings
-from django.test import override_settings
 
 from sentry import eventstore
 from sentry.event_manager import EventManager
 from sentry.ingest.ingest_consumer import ConsumerType, get_ingest_consumer
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 
 logger = logging.getLogger(__name__)

--- a/tests/sentry/integrations/aws_lambda/test_utils.py
+++ b/tests/sentry/integrations/aws_lambda/test_utils.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.cache import cache
-from django.test import override_settings
 
 from sentry.integrations.aws_lambda.utils import (
     OPTION_ACCOUNT_NUMBER,
@@ -19,6 +18,7 @@ from sentry.integrations.aws_lambda.utils import (
 )
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.testutils.helpers.faux import Mock
 
 

--- a/tests/sentry/integrations/bitbucket/test_repository.py
+++ b/tests/sentry/integrations/bitbucket/test_repository.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 import responses
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from fixtures.bitbucket import COMMIT_DIFF_PATCH, COMPARE_COMMITS_EXAMPLE, REPO
 from sentry.integrations.bitbucket.repository import BitbucketRepositoryProvider

--- a/tests/sentry/integrations/bitbucket_server/test_repository.py
+++ b/tests/sentry/integrations/bitbucket_server/test_repository.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 import responses
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from fixtures.bitbucket_server import (
     COMMIT_CHANGELIST_EXAMPLE,

--- a/tests/sentry/integrations/custom_scm/test_repository.py
+++ b/tests/sentry/integrations/custom_scm/test_repository.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.integrations.custom_scm.repository import CustomSCMRepositoryProvider
 from sentry.models import Integration, Repository

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import responses
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.models import ExternalIssue, Integration

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from fixtures.github import COMPARE_COMMITS_EXAMPLE, GET_COMMIT_EXAMPLE, GET_LAST_COMMITS_EXAMPLE
 from sentry.integrations.github.repository import GitHubRepositoryProvider

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import responses
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
 from sentry.models import ExternalIssue, Integration

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -1,6 +1,6 @@
 import pytest
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from fixtures.gitlab import COMMIT_DIFF_RESPONSE, COMMIT_LIST_RESPONSE, COMPARE_RESPONSE
 from sentry.integrations.gitlab.repository import GitlabRepositoryProvider

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -4,9 +4,8 @@ from unittest.mock import patch
 
 import pytest
 import responses
-from django.test.utils import override_settings
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from fixtures.integrations import StubService
 from fixtures.integrations.jira import StubJiraApiClient
@@ -21,6 +20,7 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils import APITestCase, IntegrationTestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 from sentry.utils.signing import sign

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -2,7 +2,7 @@ from urllib.parse import parse_qs, urlparse
 
 import responses
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from fixtures.integrations.mock_service import StubService
 from sentry.models import Integration

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -1,12 +1,12 @@
 from unittest.mock import patch
 
 import responses
-from django.test.utils import override_settings
 
 from fixtures.integrations.mock_service import StubService
 from sentry.integrations.mixins import IssueSyncMixin
 from sentry.models import Integration
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.django import override_settings
 
 TOKEN = "JWT anexampletoken"
 

--- a/tests/sentry/integrations/jira_server/test_integration.py
+++ b/tests/sentry/integrations/jira_server/test_integration.py
@@ -1,10 +1,10 @@
 import responses
-from django.test.utils import override_settings
 from requests.exceptions import ReadTimeout
 
 from sentry.integrations.jira_server import JiraServerIntegrationProvider
 from sentry.models import Identity, IdentityProvider, Integration, OrganizationIntegration
 from sentry.testutils import IntegrationTestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json, jwt
 
 from . import EXAMPLE_PRIVATE_KEY

--- a/tests/sentry/integrations/jira_server/test_search.py
+++ b/tests/sentry/integrations/jira_server/test_search.py
@@ -2,7 +2,7 @@ from urllib.parse import parse_qs, urlparse
 
 import responses
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs
 from uuid import uuid4
 
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.incidents.models import AlertRule, AlertRuleTriggerAction
 from sentry.integrations.slack.utils import SLACK_RATE_LIMITED_MESSAGE, RedisRuleStatus

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -3,7 +3,7 @@ from time import time
 import pytest
 import responses
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from fixtures.vsts import (
     GET_PROJECTS_RESPONSE,

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -3,7 +3,7 @@ from time import time
 
 import responses
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from fixtures.vsts import COMMIT_DETAILS_EXAMPLE, COMPARE_COMMITS_EXAMPLE, FILE_CHANGES_EXAMPLE
 from sentry.integrations.vsts.repository import VstsRepositoryProvider

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core import mail
 from django.db.models import F
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.userreport import UserReportWithGroupSerializer

--- a/tests/sentry/middleware/test_access_log_middleware.py
+++ b/tests/sentry/middleware/test_access_log_middleware.py
@@ -2,7 +2,6 @@ import logging
 
 import pytest
 from django.conf.urls import url
-from django.test import override_settings
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
@@ -11,6 +10,7 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.models import ApiToken
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 

--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -1,7 +1,7 @@
 import base64
 
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.middleware.auth import AuthenticationMiddleware
 from sentry.models import ApiKey, ApiToken, UserIP

--- a/tests/sentry/middleware/test_health.py
+++ b/tests/sentry/middleware/test_health.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.middleware.health import HealthCheck
 from sentry.status_checks import Problem

--- a/tests/sentry/middleware/test_proxy.py
+++ b/tests/sentry/middleware/test_proxy.py
@@ -1,5 +1,5 @@
 from django.http import HttpRequest
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.middleware.proxy import SetRemoteAddrFromForwardedFor
 from sentry.testutils import TestCase

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -4,9 +4,9 @@ from unittest.mock import patch
 
 from django.conf.urls import url
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory, override_settings
+from django.test import RequestFactory
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from freezegun import freeze_time
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -22,6 +22,7 @@ from sentry.middleware.ratelimit import (
 from sentry.models import ApiKey, ApiToken, SentryAppInstallation, User
 from sentry.ratelimits.config import RateLimitConfig, get_default_rate_limits_for_group
 from sentry.testutils import APITestCase, TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
@@ -30,11 +31,11 @@ class RatelimitMiddlewareTest(TestCase):
     middleware = RatelimitMiddleware(None)
     factory = fixture(RequestFactory)
 
-    class TestEndpoint(Endpoint):
+    class DummyEndpoint(Endpoint):
         def get(self):
             return Response({"ok": True})
 
-    _test_endpoint = TestEndpoint.as_view()
+    _test_endpoint = DummyEndpoint.as_view()
 
     def populate_sentry_app_request(self, request):
         sentry_app = self.create_sentry_app(
@@ -211,7 +212,7 @@ class RatelimitMiddlewareTest(TestCase):
 
 
 @override_settings(SENTRY_SELF_HOSTED=False)
-class TestGetRateLimitValue(TestCase):
+class TestGetRateLimitValue:
     def test_default_rate_limit_values(self):
         """Ensure that the default rate limits are called for endpoints without overrides"""
 

--- a/tests/sentry/middleware/test_stats.py
+++ b/tests/sentry/middleware/test_stats.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from django.test import RequestFactory, override_settings
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 

--- a/tests/sentry/middleware/test_useractive.py
+++ b/tests/sentry/middleware/test_useractive.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from django.test import RequestFactory
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.middleware.user import UserActiveMiddleware
 from sentry.testutils import TestCase

--- a/tests/sentry/net/test_socket.py
+++ b/tests/sentry/net/test_socket.py
@@ -1,10 +1,9 @@
 from unittest.mock import patch
 
-from django.test import override_settings
-
 from sentry.net.socket import ensure_fqdn, is_ipaddress_allowed, is_safe_hostname
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import override_blacklist
+from sentry.testutils.helpers.django import override_settings
 
 
 class SocketTest(TestCase):

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 from django.conf import settings
 from django.core.cache.backends.locmem import LocMemCache
-from exam import around, fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Option
 from sentry.options.manager import (
@@ -32,7 +32,7 @@ class OptionsManagerTest(TestCase):
     def manager(self):
         return OptionsManager(store=self.store)
 
-    @around
+    @pytest.fixture(autouse=True)
     def register(self):
         default_options = settings.SENTRY_DEFAULT_OPTIONS.copy()
         settings.SENTRY_DEFAULT_OPTIONS = {}

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -4,7 +4,7 @@ from uuid import uuid1
 import pytest
 from django.conf import settings
 from django.core.cache.backends.locmem import LocMemCache
-from exam import before, fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Option
 from sentry.options.store import OptionsStore
@@ -22,7 +22,7 @@ class OptionsStoreTest(TestCase):
     def key(self):
         return self.make_key()
 
-    @before
+    @pytest.fixture(autouse=True)
     def flush_local_cache(self):
         self.store.flush_local_cache()
 

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.exceptions import PluginError
 from sentry.models import Rule

--- a/tests/sentry/profiles/test_consumer.py
+++ b/tests/sentry/profiles/test_consumer.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest.mock import Mock
 
 import msgpack
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.profiles.consumer import ProfilesConsumer
 from sentry.testutils.cases import SnubaTestCase, TestCase

--- a/tests/sentry/profiles/test_task.py
+++ b/tests/sentry/profiles/test_task.py
@@ -4,7 +4,7 @@ from zipfile import ZipFile
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Project
 from sentry.profiles.task import _deobfuscate, _normalize

--- a/tests/sentry/quotas/test_redis.py
+++ b/tests/sentry/quotas/test_redis.py
@@ -1,7 +1,8 @@
 import time
 from unittest import mock
 
-from exam import fixture, patcher
+from django.utils.functional import cached_property as fixture
+from exam import patcher
 
 from sentry.constants import DataCategory
 from sentry.quotas.base import QuotaConfig, QuotaScope

--- a/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
+++ b/tests/sentry/ratelimits/utils/test_enforce_rate_limit.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url
-from django.test import override_settings
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.permissions import AllowAny
@@ -7,6 +6,7 @@ from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 

--- a/tests/sentry/receivers/test_transactions.py
+++ b/tests/sentry/receivers/test_transactions.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import OrganizationMember, Project
 from sentry.signals import event_processed, transaction_processed

--- a/tests/sentry/release_health/release_monitor/__init__.py
+++ b/tests/sentry/release_health/release_monitor/__init__.py
@@ -1,4 +1,4 @@
-class BaseFetchProjectsWithRecentSessionsTest:
+class FetchProjectsWithRecentSessionsTestBase:
     backend_class = None
 
     def setUp(self):
@@ -37,7 +37,7 @@ class BaseFetchProjectsWithRecentSessionsTest:
         }
 
 
-class BaseFetchProjectReleaseHealthTotalsTest:
+class FetchProjectReleaseHealthTotalsTestBase:
     backend_class = None
 
     def setUp(self):

--- a/tests/sentry/release_health/release_monitor/test_metrics.py
+++ b/tests/sentry/release_health/release_monitor/test_metrics.py
@@ -1,18 +1,18 @@
 from sentry.release_health.release_monitor.metrics import MetricReleaseMonitorBackend
 from sentry.testutils import SessionMetricsTestCase, TestCase
 from tests.sentry.release_health.release_monitor import (
-    BaseFetchProjectReleaseHealthTotalsTest,
-    BaseFetchProjectsWithRecentSessionsTest,
+    FetchProjectReleaseHealthTotalsTestBase,
+    FetchProjectsWithRecentSessionsTestBase,
 )
 
 
 class MetricFetchProjectsWithRecentSessionsTest(
-    BaseFetchProjectsWithRecentSessionsTest, TestCase, SessionMetricsTestCase
+    FetchProjectsWithRecentSessionsTestBase, TestCase, SessionMetricsTestCase
 ):
     backend_class = MetricReleaseMonitorBackend
 
 
 class SessionFetchProjectReleaseHealthTotalsTest(
-    BaseFetchProjectReleaseHealthTotalsTest, TestCase, SessionMetricsTestCase
+    FetchProjectReleaseHealthTotalsTestBase, TestCase, SessionMetricsTestCase
 ):
     backend_class = MetricReleaseMonitorBackend

--- a/tests/sentry/release_health/release_monitor/test_sessions.py
+++ b/tests/sentry/release_health/release_monitor/test_sessions.py
@@ -1,18 +1,18 @@
 from sentry.release_health.release_monitor.sessions import SessionReleaseMonitorBackend
 from sentry.testutils import SnubaTestCase, TestCase
 from tests.sentry.release_health.release_monitor import (
-    BaseFetchProjectReleaseHealthTotalsTest,
-    BaseFetchProjectsWithRecentSessionsTest,
+    FetchProjectReleaseHealthTotalsTestBase,
+    FetchProjectsWithRecentSessionsTestBase,
 )
 
 
 class SessionFetchProjectsWithRecentSessionsTest(
-    BaseFetchProjectsWithRecentSessionsTest, TestCase, SnubaTestCase
+    FetchProjectsWithRecentSessionsTestBase, TestCase, SnubaTestCase
 ):
     backend_class = SessionReleaseMonitorBackend
 
 
 class SessionFetchProjectReleaseHealthTotalsTest(
-    BaseFetchProjectReleaseHealthTotalsTest, TestCase, SnubaTestCase
+    FetchProjectReleaseHealthTotalsTestBase, TestCase, SnubaTestCase
 ):
     backend_class = SessionReleaseMonitorBackend

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import pytest
-from exam import before
 from rest_framework import serializers
 
 from sentry.rules.actions.sentry_apps import NotifyEventSentryAppAction
@@ -19,7 +18,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
         {"name": "summary", "value": "circle triangle square"},
     ]
 
-    @before
+    @pytest.fixture(autouse=True)
     def create_schema(self):
         self.schema = {"elements": [self.create_alert_rule_action_schema()]}
 

--- a/tests/sentry/services/test_http.py
+++ b/tests/sentry/services/test_http.py
@@ -1,7 +1,6 @@
-from django.test.utils import override_settings
-
 from sentry.services.http import SentryHTTPServer, convert_options_to_env
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 
 
 class HTTPServiceTest(TestCase):

--- a/tests/sentry/similarity/backends/test_redis.py
+++ b/tests/sentry/similarity/backends/test_redis.py
@@ -1,7 +1,7 @@
 import time
 
 import msgpack
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.similarity.backends.redis import RedisScriptMinHashIndexBackend
 from sentry.similarity.signatures import MinHashSignatureBuilder

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -7,7 +7,8 @@ import pytest
 import pytz
 from dateutil.parser import parse as parse_date
 from django.conf import settings
-from exam import fixture, patcher
+from django.utils.functional import cached_property as fixture
+from exam import patcher
 
 from sentry.snuba.dataset import EntityKey
 from sentry.snuba.models import QueryDatasets, QuerySubscription

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -36,7 +36,7 @@ def _indexer_record(org_id: int, string: str) -> int:
     return indexer.record(use_case_id=UseCaseKey.RELEASE_HEALTH, org_id=org_id, string=string)
 
 
-class BaseSnubaTaskTest(metaclass=abc.ABCMeta):
+class SnubaTaskTestBase(metaclass=abc.ABCMeta):
     metrics = patcher("sentry.snuba.tasks.metrics")
 
     status_translations = {
@@ -108,7 +108,7 @@ class BaseSnubaTaskTest(metaclass=abc.ABCMeta):
         )
 
 
-class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
+class CreateSubscriptionInSnubaTest(SnubaTaskTestBase, TestCase):
     expected_status = QuerySubscription.Status.CREATING
     task = create_subscription_in_snuba
 
@@ -191,7 +191,7 @@ class CreateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
                     assert request_body["granularity"] == expected_granularity
 
 
-class UpdateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
+class UpdateSubscriptionInSnubaTest(SnubaTaskTestBase, TestCase):
     expected_status = QuerySubscription.Status.UPDATING
     task = update_subscription_in_snuba
 
@@ -215,7 +215,7 @@ class UpdateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
         assert sub.subscription_id is not None
 
 
-class DeleteSubscriptionFromSnubaTest(BaseSnubaTaskTest, TestCase):
+class DeleteSubscriptionFromSnubaTest(SnubaTaskTestBase, TestCase):
     expected_status = QuerySubscription.Status.DELETING
     task = delete_subscription_from_snuba
 

--- a/tests/sentry/sudo/test_forms.py
+++ b/tests/sentry/sudo/test_forms.py
@@ -1,8 +1,8 @@
 import pytest
 from django.forms import ValidationError
-from django.test import override_settings
 
 from fixtures.sudo_testutils import BaseTestCase, EmailUser
+from sentry.testutils.helpers.django import override_settings
 from sudo.forms import SudoForm
 
 

--- a/tests/sentry/sudo/test_views.py
+++ b/tests/sentry/sudo/test_views.py
@@ -1,7 +1,7 @@
 from django.template.response import TemplateResponse
-from django.test import override_settings
 
 from fixtures.sudo_testutils import BaseTestCase
+from sentry.testutils.helpers.django import override_settings
 from sudo.forms import SudoForm
 from sudo.settings import REDIRECT_FIELD_NAME, REDIRECT_TO_FIELD_NAME, REDIRECT_URL
 from sudo.views import redirect_to_sudo, sudo

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 from unittest import mock
 from unittest.mock import Mock, patch
 
-from django.test import override_settings
 from django.utils import timezone
 
 from sentry import buffer
@@ -28,6 +27,7 @@ from sentry.tasks.post_process import post_process_group
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.django import override_settings
 from sentry.testutils.helpers.eventprocessing import write_event_to_cache
 from sentry.types.activity import ActivityType
 from sentry.utils.cache import cache

--- a/tests/sentry/tasks/test_store.py
+++ b/tests/sentry/tasks/test_store.py
@@ -2,7 +2,6 @@ from time import time
 from unittest import mock
 
 import pytest
-from django.test.utils import override_settings
 
 from sentry import quotas
 from sentry.event_manager import EventManager, HashDiscarded
@@ -13,6 +12,7 @@ from sentry.tasks.store import (
     save_event,
     time_synthetic_monitoring_event,
 )
+from sentry.testutils.helpers.django import override_settings
 
 EVENT_ID = "cc3e6c2bb6b6498097f336d1e6979f4b"
 

--- a/tests/sentry/test_stacktraces.py
+++ b/tests/sentry/test_stacktraces.py
@@ -1,3 +1,5 @@
+from unittest import TestCase
+
 import pytest
 
 from sentry.grouping.api import get_default_grouping_config_dict, load_grouping_config
@@ -6,7 +8,6 @@ from sentry.stacktraces.processing import (
     get_crash_frame_from_event_data,
     normalize_stacktraces_for_grouping,
 )
-from sentry.testutils import TestCase
 
 
 class FindStacktracesTest(TestCase):
@@ -157,7 +158,7 @@ class FindStacktracesTest(TestCase):
         assert len(infos[0].stacktrace["frames"]) == 3
 
 
-class NormalizeInApptest(TestCase):
+class NormalizeInAppTest(TestCase):
     def test_normalize_with_system_frames(self):
         data = {
             "stacktrace": {

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -3,9 +3,9 @@ from datetime import datetime, timedelta
 
 import pytest
 import pytz
-from django.test import override_settings
 
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.tsdb.base import ONE_DAY, ONE_HOUR, ONE_MINUTE, TSDBModel
 from sentry.tsdb.redis import CountMinScript, RedisTSDB, SuppressionWrapper
 from sentry.utils.dates import to_datetime, to_timestamp

--- a/tests/sentry/utils/locking/backends/test_redis.py
+++ b/tests/sentry/utils/locking/backends/test_redis.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 import pytest
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.utils.locking.backends.redis import RedisLockBackend
 from sentry.utils.redis import clusters

--- a/tests/sentry/utils/test_geo.py
+++ b/tests/sentry/utils/test_geo.py
@@ -1,7 +1,7 @@
-from django.test.utils import override_settings
+from unittest import TestCase
 
-from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import get_fixture_path
+from sentry.testutils.helpers.django import override_settings
 
 
 @override_settings(GEOIP_PATH_MMDB=get_fixture_path("test.mmdb"))

--- a/tests/sentry/utils/test_kafka_config.py
+++ b/tests/sentry/utils/test_kafka_config.py
@@ -2,8 +2,8 @@ import os
 
 import pytest
 from django.conf import settings
-from django.test import override_settings
 
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils.kafka_config import (
     get_kafka_admin_cluster_options,
     get_kafka_consumer_cluster_options,

--- a/tests/sentry/utils/test_linksign.py
+++ b/tests/sentry/utils/test_linksign.py
@@ -1,7 +1,7 @@
-from django.test import override_settings
 from django.test.client import RequestFactory
 
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import linksign
 
 

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -1,8 +1,7 @@
 import os
 
-from django.test.utils import override_settings
-
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.testutils.helpers.response import close_streaming_response
 from sentry.utils.assets import get_frontend_app_asset_url
 from sentry.web.frontend.generic import FOREVER_CACHE, NEVER_CACHE, NO_CACHE

--- a/tests/sentry/web/frontend/test_account_identity.py
+++ b/tests/sentry/web/frontend/test_account_identity.py
@@ -1,6 +1,6 @@
+import pytest
 from django.urls import reverse
 from django.utils.encoding import force_bytes
-from exam import before
 
 from sentry import identity
 from sentry.identity.providers.dummy import DummyProvider
@@ -9,7 +9,7 @@ from sentry.testutils.cases import TestCase
 
 
 class AccountIdentityTest(TestCase):
-    @before
+    @pytest.fixture(autouse=True)
     def setup_dummy_identity_provider(self):
         identity.register(DummyProvider)
         self.addCleanup(identity.unregister, DummyProvider)

--- a/tests/sentry/web/frontend/test_accounts.py
+++ b/tests/sentry/web/frontend/test_accounts.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import LostPasswordHash
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_auth_close.py
+++ b/tests/sentry/web/frontend/test_auth_close.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
+from django.utils.functional import cached_property as fixture
 from django.utils.http import urlquote
-from exam import fixture
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -3,15 +3,15 @@ from urllib.parse import urlencode
 
 import pytest
 from django.conf import settings
-from django.test import override_settings
 from django.urls import reverse
+from django.utils.functional import cached_property as fixture
 from django.utils.http import urlquote
-from exam import fixture
 
 from sentry import newsletter, options
 from sentry.auth.authenticators import RecoveryCodeInterface, TotpInterface
 from sentry.models import OrganizationMember, User
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 from sentry.utils.client_state import get_client_state_key, get_redis_client
 

--- a/tests/sentry/web/frontend/test_auth_logout.py
+++ b/tests/sentry/web/frontend/test_auth_logout.py
@@ -1,7 +1,7 @@
 from urllib.parse import quote
 
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -3,7 +3,7 @@ from unittest import mock
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.auth.providers.oauth2 import OAuth2Callback, OAuth2Login, OAuth2Provider
 from sentry.models import AuthProvider

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -1,10 +1,9 @@
 from unittest import mock
 from urllib.parse import urlencode
 
-from django.test import override_settings
 from django.urls import reverse
+from django.utils.functional import cached_property as fixture
 from django.utils.http import urlquote
-from exam import fixture
 
 from sentry.auth.authenticators import RecoveryCodeInterface, TotpInterface
 from sentry.models import (
@@ -16,6 +15,7 @@ from sentry.models import (
 )
 from sentry.testutils import AuthProviderTestCase
 from sentry.testutils.helpers import with_feature
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 
 

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -6,7 +6,7 @@ import pytest
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry import audit_log
 from sentry.auth.authenticators import TotpInterface

--- a/tests/sentry/web/frontend/test_csrf_failure.py
+++ b/tests/sentry/web/frontend/test_csrf_failure.py
@@ -1,7 +1,7 @@
-from django.test import override_settings
 from django.urls import reverse
 
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 
 
 @override_settings(ROOT_URLCONF="sentry.conf.urls")

--- a/tests/sentry/web/frontend/test_disabled_member_view.py
+++ b/tests/sentry/web/frontend/test_disabled_member_view.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import OrganizationMember
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_error_404.py
+++ b/tests/sentry/web/frontend/test_error_404.py
@@ -1,7 +1,7 @@
-from django.test import override_settings
 from django.urls import reverse
 
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 
 
 @override_settings(ROOT_URLCONF="sentry.conf.urls")

--- a/tests/sentry/web/frontend/test_error_500.py
+++ b/tests/sentry/web/frontend/test_error_500.py
@@ -1,7 +1,7 @@
-from django.test import override_settings
 from django.urls import reverse
 
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 
 
 @override_settings(ROOT_URLCONF="sentry.conf.urls")

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -2,15 +2,14 @@ import logging
 from urllib.parse import quote, urlencode
 from uuid import uuid4
 
-from django.test import override_settings
 from django.urls import reverse
 
 from sentry.models import Environment, UserReport
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.django import override_settings
 
 
-@override_settings(ROOT_URLCONF="sentry.conf.urls")
 class ErrorPageEmbedTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/web/frontend/test_group_event_json.py
+++ b/tests/sentry/web/frontend/test_group_event_json.py
@@ -1,4 +1,4 @@
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/sentry/web/frontend/test_home.py
+++ b/tests/sentry/web/frontend/test_home.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import TestCase
 from sentry.utils import json

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -1,15 +1,16 @@
 from unittest import mock
 from unittest.mock import patch
 
+import pytest
 from django.conf import settings
 from django.urls import reverse
-from exam import before, fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import TestCase
 
 
 class JavaScriptSdkLoaderTest(TestCase):
-    @before
+    @pytest.fixture(autouse=True)
     def set_settings(self):
         settings.JS_SDK_LOADER_SDK_VERSION = "0.5.2"
         settings.JS_SDK_LOADER_DEFAULT_SDK_URL = (

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -1,6 +1,6 @@
 from urllib.parse import parse_qs, urlparse
 
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import ApiApplication, ApiAuthorization, ApiGrant, ApiToken
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -1,5 +1,5 @@
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import ApiApplication, ApiGrant, ApiToken
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_reactivate_account.py
+++ b/tests/sentry/web/frontend/test_reactivate_account.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -3,7 +3,7 @@ from hashlib import sha256
 from unittest.mock import patch
 
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import ProjectOption
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_unsubscribe_notifications.py
+++ b/tests/sentry/web/frontend/test_unsubscribe_notifications.py
@@ -4,7 +4,7 @@ from sentry.testutils import TestCase
 from sentry.utils.linksign import generate_signed_link
 
 
-class UnsubscribeNotificationsBaseTest:
+class UnsubscribeNotificationsTestBase:
     def create_instance(self):
         raise NotImplementedError()
 
@@ -44,7 +44,7 @@ class UnsubscribeNotificationsBaseTest:
         assert resp.status_code == 404
 
 
-class UnsubscribeIssueNotificationsTest(UnsubscribeNotificationsBaseTest, TestCase):
+class UnsubscribeIssueNotificationsTest(UnsubscribeNotificationsTestBase, TestCase):
     view_name = "sentry-account-email-unsubscribe-issue"
 
     def create_instance(self):
@@ -58,7 +58,7 @@ class UnsubscribeIssueNotificationsTest(UnsubscribeNotificationsBaseTest, TestCa
         assert GroupSubscription.objects.filter(user=user, group=instance, is_active=False).exists()
 
 
-class UnsubscribeIncidentNotificationsTest(UnsubscribeNotificationsBaseTest, TestCase):
+class UnsubscribeIncidentNotificationsTest(UnsubscribeNotificationsTestBase, TestCase):
     view_name = "sentry-account-email-unsubscribe-incident"
 
     def create_instance(self):

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import TestCase
 from sentry.utils import json

--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from botocore.client import ClientError
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import PluginTestCase
 from sentry.utils import json

--- a/tests/sentry_plugins/asana/test_plugin.py
+++ b/tests/sentry_plugins/asana/test_plugin.py
@@ -2,7 +2,7 @@ import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.plugins.bases.issue2 import PluginError
 from sentry.testutils import PluginTestCase

--- a/tests/sentry_plugins/bitbucket/test_plugin.py
+++ b/tests/sentry_plugins/bitbucket/test_plugin.py
@@ -2,7 +2,7 @@ import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.plugins.bases.issue2 import PluginError
 from sentry.testutils import PluginTestCase

--- a/tests/sentry_plugins/bitbucket/test_repository_provider.py
+++ b/tests/sentry_plugins/bitbucket/test_repository_provider.py
@@ -1,5 +1,5 @@
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Repository
 from sentry.testutils import TestCase

--- a/tests/sentry_plugins/github/test_plugin.py
+++ b/tests/sentry_plugins/github/test_plugin.py
@@ -2,7 +2,7 @@ import pytest
 import responses
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.plugins.bases.issue2 import PluginError
 from sentry.testutils import PluginTestCase

--- a/tests/sentry_plugins/github/test_provider.py
+++ b/tests/sentry_plugins/github/test_provider.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Integration, OrganizationIntegration, Repository
 from sentry.testutils import TestCase

--- a/tests/sentry_plugins/gitlab/test_plugin.py
+++ b/tests/sentry_plugins/gitlab/test_plugin.py
@@ -1,7 +1,7 @@
 import responses
 from django.test import RequestFactory
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import PluginTestCase
 from sentry.utils import json

--- a/tests/sentry_plugins/jira/test_plugin.py
+++ b/tests/sentry_plugins/jira/test_plugin.py
@@ -2,7 +2,7 @@ import responses
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import TestCase
 from sentry.utils import json

--- a/tests/sentry_plugins/opgsenie/test_plugin.py
+++ b/tests/sentry_plugins/opgsenie/test_plugin.py
@@ -1,5 +1,5 @@
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Rule
 from sentry.plugins.base import Notification

--- a/tests/sentry_plugins/pagerduty/test_plugin.py
+++ b/tests/sentry_plugins/pagerduty/test_plugin.py
@@ -1,6 +1,6 @@
 import responses
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Rule
 from sentry.plugins.base import Notification

--- a/tests/sentry_plugins/phabricator/test_plugin.py
+++ b/tests/sentry_plugins/phabricator/test_plugin.py
@@ -1,6 +1,6 @@
 import responses
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import PluginTestCase
 from sentry_plugins.phabricator.plugin import PhabricatorPlugin

--- a/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
+++ b/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import PluginTestCase
 from sentry.utils import json

--- a/tests/sentry_plugins/pushover/test_plugin.py
+++ b/tests/sentry_plugins/pushover/test_plugin.py
@@ -2,7 +2,7 @@ from urllib.parse import parse_qs
 
 import responses
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Rule
 from sentry.plugins.base import Notification

--- a/tests/sentry_plugins/segment/test_plugin.py
+++ b/tests/sentry_plugins/segment/test_plugin.py
@@ -1,5 +1,5 @@
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import PluginTestCase
 from sentry.utils import json

--- a/tests/sentry_plugins/sessionstack/test_plugin.py
+++ b/tests/sentry_plugins/sessionstack/test_plugin.py
@@ -1,5 +1,5 @@
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import PluginTestCase
 from sentry_plugins.sessionstack.plugin import SessionStackPlugin

--- a/tests/sentry_plugins/slack/test_plugin.py
+++ b/tests/sentry_plugins/slack/test_plugin.py
@@ -2,7 +2,7 @@ from urllib.parse import parse_qs
 
 import pytest
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR
 from sentry.models import Rule

--- a/tests/sentry_plugins/splunk/test_plugin.py
+++ b/tests/sentry_plugins/splunk/test_plugin.py
@@ -1,6 +1,6 @@
 import pytest
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils import PluginTestCase

--- a/tests/sentry_plugins/trello/test_plugin.py
+++ b/tests/sentry_plugins/trello/test_plugin.py
@@ -2,7 +2,7 @@ from urllib.parse import parse_qsl, urlparse
 
 import responses
 from django.test import RequestFactory
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.testutils import PluginTestCase
 from sentry.utils import json

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -1,7 +1,7 @@
 from urllib.parse import parse_qs
 
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Rule
 from sentry.plugins.base import Notification

--- a/tests/sentry_plugins/victorops/test_plugin.py
+++ b/tests/sentry_plugins/victorops/test_plugin.py
@@ -1,5 +1,5 @@
 import responses
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import Rule
 from sentry.plugins.base import Notification

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -1,10 +1,10 @@
 import pytest
-from django.test import override_settings
 from django.urls import NoReverseMatch, reverse
 from freezegun import freeze_time
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.django import override_settings
 
 
 class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -3,7 +3,6 @@ from base64 import b64encode
 from unittest import mock
 
 import pytest
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -23,6 +22,7 @@ from sentry.search.events import constants
 from sentry.testutils import APITestCase, MetricsEnhancedPerformanceTestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.django import override_settings
 from sentry.testutils.skips import requires_not_arm64
 from sentry.utils import json
 from sentry.utils.samples import load_data

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -3,7 +3,6 @@ from unittest.mock import Mock, patch
 from uuid import uuid4
 
 from dateutil.parser import parse as parse_datetime
-from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
@@ -50,6 +49,7 @@ from sentry.search.events.constants import (
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.django import override_settings
 from sentry.types.activity import ActivityType
 from sentry.utils import json
 

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.urls import reverse
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.search.events.constants import RELEASE_ALIAS, SEMVER_ALIAS
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.utils import timezone
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.models import (
     Activity,

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -4,8 +4,7 @@ from uuid import uuid4
 from confluent_kafka import Producer
 from django.conf import settings
 from django.core import mail
-from django.test.utils import override_settings
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 from freezegun import freeze_time
 
 from sentry.incidents.action_handlers import (
@@ -27,6 +26,7 @@ from sentry.incidents.models import (
 from sentry.incidents.tasks import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.snuba.query_subscription_consumer import QuerySubscriptionConsumer, subscriber_registry
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 
 

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -9,8 +9,7 @@ import pytz
 from confluent_kafka import Producer
 from dateutil.parser import parse as parse_date
 from django.conf import settings
-from django.test.utils import override_settings
-from exam import fixture
+from django.utils.functional import cached_property as fixture
 
 from sentry.snuba.models import QueryDatasets
 from sentry.snuba.query_subscription_consumer import (
@@ -20,6 +19,7 @@ from sentry.snuba.query_subscription_consumer import (
 )
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils.cases import SnubaTestCase, TestCase
+from sentry.testutils.helpers.django import override_settings
 from sentry.utils import json
 
 


### PR DESCRIPTION
Our current TestCase baseclass prevents us from using some pytest features even when they would come in really handy. the most obvious one is pytest.mark.parametrize (for which, as opposed to many other things that pytest offers, there's no serious replacement), but it also affects some pytest plugins like pytest-repeat.

explicit non-goal: change how you write tests, at least not in a fundamental way. `self.assertEquals` and `mock` can surely stay. we wouldn't have time to change the tests anyway.

https://hackweek.getsentry.net/years/2022/projects/-N6P4TNF2BigABkF54i_

----

This is a big messy PR that will probably have to be split up. A few changes that can be separate PRs are:

* remove usage of Django's override_settings and use our own function instead that works on all testclasses
* remove usage of exam. this is required because apparently exam only works on unittest-style classes. `exam.fixture` can be replaced with `cached_property`, `exam.before/after/around` can be autouse fixtures (if setup order matters, the fixture can depend on the `unittest_compat` fixture), and `patcher` i am not sure about.

Those and any other changes that affect a lot of test files and pull in a ton of codeowners should probably be sent out in batched PRs.