### PR TITLE
ref(ci): Increase acceptance / frontend test parallelization

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # XXX: When updating this, make sure you also update CI_NODE_TOTAL.
-        instance: [0, 1, 2, 3]
+        instance: [0, 1, 2, 3, 4, 5, 6, 7]
 
     env:
       VISUAL_HTML_ENABLE: 1
@@ -72,7 +72,7 @@ jobs:
           # XXX: CI_NODE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
           #      Otherwise, if there are other things in the matrix, using strategy.job-total
           #      wouldn't be correct.
-          CI_NODE_TOTAL: 4
+          CI_NODE_TOTAL: 8
           CI_NODE_INDEX: ${{ matrix.instance }}
         run: |
           JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit
@@ -115,11 +115,11 @@ jobs:
       matrix:
         python-version: [3.8.12]
         # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
-        instance: [0, 1, 2, 3]
+        instance: [0, 1, 2, 3, 4, 5, 6, 7]
         pg-version: ['9.6']
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
-      MATRIX_INSTANCE_TOTAL: 4
+      MATRIX_INSTANCE_TOTAL: 8
       VISUAL_SNAPSHOT_ENABLE: 1
       TEST_GROUP_STRATEGY: roundrobin
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -115,11 +115,11 @@ jobs:
       matrix:
         python-version: [3.8.12]
         # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
-        instance: [0, 1, 2, 3, 4, 5, 6, 7]
+        instance: [0, 1, 2, 3]
         pg-version: ['9.6']
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
-      MATRIX_INSTANCE_TOTAL: 8
+      MATRIX_INSTANCE_TOTAL: 4
       VISUAL_SNAPSHOT_ENABLE: 1
       TEST_GROUP_STRATEGY: roundrobin
 


### PR DESCRIPTION
### Summary
Increasing parallelization should help uncover any remaining isolation issues (certain kinds, anyway), on top of providing a benefit of reduced time in PR. 

Bringing this up since if we move to frontend-only deploys we can potentially get code-to-mainline times down into the minutes range, increasing parallelization and reduce parallelization overhead will get us there. 

Again, we should be doing work to reduce our overhead and test times etc. but we will also need to increase parallelization, which we might as well do now.

#### Overhead
Going to be measuring after running this a few times, but it should roughly be around 30s-1min * 4 more nodes of additional overhead, which would only be what matters in terms of cost, the actual parallel work doesn't count. 

The overhead time / costs can be reduced later in a few different ways (eg. moving build steps in a build image on gchr as a precursor step to the parallelization stage, and re-using that build image when yarn.lock is the same) but we might as well take advantage of the wall time savings now. 


