### PR TITLE
ref(sampling): Dynamic sampling feature flag cleanup [TET-190]

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -438,7 +438,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         result = serializer.validated_data
 
         allow_dynamic_sampling = features.has(
-            "organizations:filters-and-sampling", project.organization, actor=request.user
+            "organizations:server-side-sampling", project.organization, actor=request.user
         )
 
         if not allow_dynamic_sampling and result.get("dynamicSampling"):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -965,8 +965,6 @@ SENTRY_FEATURES = {
     "organizations:duplicate-alert-rule": True,
     # Enable attaching arbitrary files to events.
     "organizations:event-attachments": True,
-    # Enable Filters & Sampling in the project settings
-    "organizations:filters-and-sampling": False,
     # Allow organizations to configure all symbol sources.
     "organizations:symbol-sources": True,
     # Allow organizations to configure custom external symbol sources.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -82,7 +82,7 @@ default_manager.add(
 default_manager.add("organizations:discover-events-rate-limit", OrganizationFeature, True)
 default_manager.add("organizations:duplicate-alert-rule", OrganizationFeature, True)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)
-default_manager.add("organizations:filters-and-sampling", OrganizationFeature, True)
+default_manager.add("organizations:server-side-sampling", OrganizationFeature, True)
 default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-title-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-tree-ui", OrganizationFeature, True)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -82,7 +82,6 @@ default_manager.add(
 default_manager.add("organizations:discover-events-rate-limit", OrganizationFeature, True)
 default_manager.add("organizations:duplicate-alert-rule", OrganizationFeature, True)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)
-default_manager.add("organizations:server-side-sampling", OrganizationFeature, True)
 default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-title-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-tree-ui", OrganizationFeature, True)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -172,7 +172,7 @@ def _get_project_config(project, full_config=True, project_keys=None):
             "projectId": project.id,  # XXX: Unused by Relay, required by Python store
         }
     allow_dynamic_sampling = features.has(
-        "organizations:filters-and-sampling",
+        "organizations:server-side-sampling",
         project.organization,
     )
     if allow_dynamic_sampling:

--- a/tests/acceptance/test_project_settings_sampling.py
+++ b/tests/acceptance/test_project_settings_sampling.py
@@ -2,7 +2,7 @@ from selenium.webdriver.common.action_chains import ActionChains
 
 from sentry.testutils import AcceptanceTestCase
 
-FEATURE_NAME = "organizations:filters-and-sampling"
+FEATURE_NAME = "organizations:server-side-sampling"
 
 
 class ProjectSettingsSamplingTest(AcceptanceTestCase):

--- a/tests/acceptance/test_project_settings_sampling.py
+++ b/tests/acceptance/test_project_settings_sampling.py
@@ -18,15 +18,6 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
                 "next_id": 4,
                 "rules": [
                     {
-                        "sampleRate": 0.7,
-                        "type": "trace",
-                        "condition": {
-                            "op": "and",
-                            "inner": [],
-                        },
-                        "id": 1,
-                    },
-                    {
                         "sampleRate": 0.8,
                         "type": "trace",
                         "condition": {
@@ -57,12 +48,21 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
                         },
                         "id": 3,
                     },
+                    {
+                        "sampleRate": 0.7,
+                        "type": "trace",
+                        "condition": {
+                            "op": "and",
+                            "inner": [],
+                        },
+                        "id": 1,
+                    },
                 ],
             },
         )
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = f"/settings/{self.org.slug}/projects/{self.project.slug}/sampling/trace/"
+        self.path = f"/settings/{self.org.slug}/projects/{self.project.slug}/server-side-sampling/"
 
     def wait_until_loaded(self):
         self.browser.get(self.path)

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -630,7 +630,7 @@ class ProjectUpdateTest(APITestCase):
         """
         Test that we can set sampling rules
         """
-        with Feature({"organizations:filters-and-sampling": True}):
+        with Feature({"organizations:server-side-sampling": True}):
             self.get_success_response(
                 self.org_slug, self.proj_slug, dynamicSampling=_dyn_sampling_data()
             )
@@ -654,7 +654,7 @@ class ProjectUpdateTest(APITestCase):
         Tests that we get the same dynamic sampling rules that previously set
         """
         data = _dyn_sampling_data()
-        with Feature({"organizations:filters-and-sampling": True}):
+        with Feature({"organizations:server-side-sampling": True}):
             self.get_success_response(self.org_slug, self.proj_slug, dynamicSampling=data)
             response = self.get_success_response(self.org_slug, self.proj_slug, method="get")
         saved_config = _remove_ids_from_dynamic_rules(response.data["dynamicSampling"])
@@ -702,7 +702,7 @@ class ProjectUpdateTest(APITestCase):
                 },
             ]
         }
-        with Feature({"organizations:filters-and-sampling": True}):
+        with Feature({"organizations:server-side-sampling": True}):
             self.get_success_response(self.org_slug, self.proj_slug, dynamicSampling=config)
         response = self.get_success_response(self.org_slug, self.proj_slug, method="get")
         saved_config = response.data["dynamicSampling"]
@@ -745,7 +745,7 @@ class ProjectUpdateTest(APITestCase):
         }
 
         saved_config["rules"].append(new_rule_2)
-        with Feature({"organizations:filters-and-sampling": True}):
+        with Feature({"organizations:server-side-sampling": True}):
             # turn it back from ordered dict to dict (both main obj and rules)
             saved_config = dict(saved_config)
             saved_config["rules"] = [dict(rule) for rule in saved_config["rules"]]
@@ -764,7 +764,7 @@ class ProjectUpdateTest(APITestCase):
         Tests that the active flag is set for all rules
         """
         data = _dyn_sampling_data()
-        with Feature({"organizations:filters-and-sampling": True}):
+        with Feature({"organizations:server-side-sampling": True}):
             self.get_success_response(self.org_slug, self.proj_slug, dynamicSampling=data)
             response = self.get_success_response(self.org_slug, self.proj_slug, method="get")
         saved_config = response.data["dynamicSampling"]

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -169,7 +169,7 @@ def test_relays_dyamic_sampling(client, call_endpoint, default_project, dyn_samp
     """
     default_project.update_option("sentry:dynamic_sampling", dyn_sampling_data())
 
-    with Feature({"organizations:filters-and-sampling": True}):
+    with Feature({"organizations:server-side-sampling": True}):
         result, status_code = call_endpoint(full_config=False)
         assert status_code < 400
         dynamic_sampling = safe.get_path(

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -172,7 +172,7 @@ def test_relays_dyamic_sampling(
     """
     default_project.update_option("sentry:dynamic_sampling", dyn_sampling_data())
 
-    with Feature({"organizations:filters-and-sampling": True}):
+    with Feature({"organizations:server-side-sampling": True}):
         result, status_code = call_endpoint(full_config=False)
         assert status_code < 400
         dynamic_sampling = safe.get_path(

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -84,11 +84,11 @@ def test_project_config_uses_filters_and_sampling_feature(
 ):
     """
     Tests that dynamic sampling information is retrieved for both "full config" and "restricted config"
-    but only when the organization has "organizations:filters-and-sampling" feature enabled.
+    but only when the organization has "organizations:server-side-sampling" feature enabled.
     """
     default_project.update_option("sentry:dynamic_sampling", dyn_sampling_data())
 
-    with Feature({"organizations:filters-and-sampling": has_dyn_sampling}):
+    with Feature({"organizations:server-side-sampling": has_dyn_sampling}):
         cfg = get_project_config(default_project, full_config=full_config)
 
     cfg = cfg.to_dict()
@@ -110,7 +110,7 @@ def test_project_config_filters_out_non_active_rules_in_dynamic_sampling(
     """
     default_project.update_option("sentry:dynamic_sampling", dyn_sampling_data(active))
 
-    with Feature({"organizations:filters-and-sampling": True}):
+    with Feature({"organizations:server-side-sampling": True}):
         cfg = get_project_config(default_project)
 
     cfg = cfg.to_dict()


### PR DESCRIPTION
This PR depricate `filters-and-sampling` feature flag 
and replace it with `organizations:server-side-sampling`

depends on https://github.com/getsentry/sentry/pull/36504