### PR TITLE
ref(mep): Rename the dataset to generic_metrics

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1889,7 +1889,10 @@ class MetricsQueryBuilder(QueryBuilder):
                 )
 
         return Request(
-            dataset=self.dataset.value,
+            # TODO: Actually introduce this as a dataset
+            dataset="generic_metrics"
+            if self.dataset.value is Dataset.Metrics
+            else self.dataset.value,
             app_id="default",
             query=Query(
                 match=primary_framework.entity,
@@ -2084,7 +2087,10 @@ class MetricsQueryBuilder(QueryBuilder):
                     granularity=self.granularity,
                 )
                 request = Request(
-                    dataset=self.dataset.value,
+                    # TODO: Actually introduce this as a dataset
+                    dataset="generic_metrics"
+                    if self.dataset.value is Dataset.Metrics
+                    else self.dataset.value,
                     app_id="default",
                     query=query,
                     flags=Flags(turbo=self.turbo),

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1890,9 +1890,7 @@ class MetricsQueryBuilder(QueryBuilder):
 
         return Request(
             # TODO: Actually introduce this as a dataset
-            dataset="generic_metrics"
-            if self.dataset.value is Dataset.Metrics
-            else self.dataset.value,
+            dataset="generic_metrics" if self.dataset is Dataset.Metrics else self.dataset.value,
             app_id="default",
             query=Query(
                 match=primary_framework.entity,
@@ -2089,7 +2087,7 @@ class MetricsQueryBuilder(QueryBuilder):
                 request = Request(
                     # TODO: Actually introduce this as a dataset
                     dataset="generic_metrics"
-                    if self.dataset.value is Dataset.Metrics
+                    if self.dataset is Dataset.Metrics
                     else self.dataset.value,
                     app_id="default",
                     query=query,
@@ -2283,7 +2281,9 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
             if len(query_details.functions) > 0:
                 queries.append(
                     Request(
-                        dataset=self.dataset.value,
+                        dataset="generic_metrics"
+                        if self.dataset is Dataset.Metrics
+                        else self.dataset.value,
                         app_id="default",
                         query=Query(
                             match=query_details.entity,

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1252,7 +1252,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_get_snql_query(self):
         query = MetricsQueryBuilder(self.params, "", selected_columns=["p90(transaction.duration)"])
         snql_request = query.get_snql_query()
-        assert snql_request.dataset == "genreic_metrics"
+        assert snql_request.dataset == "generic_metrics"
         snql_query = snql_request.query
         self.assertCountEqual(
             snql_query.select,

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1252,7 +1252,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
     def test_get_snql_query(self):
         query = MetricsQueryBuilder(self.params, "", selected_columns=["p90(transaction.duration)"])
         snql_request = query.get_snql_query()
-        assert snql_request.dataset == "metrics"
+        assert snql_request.dataset == "genreic_metrics"
         snql_query = snql_request.query
         self.assertCountEqual(
             snql_query.select,


### PR DESCRIPTION
- This is a quick hacky way to update the dataset name, will do a larger change later to properly introduce it as a dataset separate from "release health" (`metrics` instead of `generic_metrics`)
