### PR TITLE
feat(sampling): Add ability to activate rule without SDKs updated [TET-211]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/rule.tsx
+++ b/static/app/views/settings/project/server-side-sampling/rule.tsx
@@ -55,7 +55,7 @@ export function Rule({
 }: Props) {
   const isUniform = isUniformRule(rule);
   const canDelete = !noPermission && !isUniform;
-  const canActivate = !upgradeSdkForProjects.length;
+  const canActivate = true; // TODO(sampling): Enabling this for demo purposes, change this back to `!upgradeSdkForProjects.length;` for LA
   const canDrag = !isUniform && !noPermission;
 
   return (

--- a/tests/js/spec/views/settings/project/server-side-sampling/index.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/index.spec.tsx
@@ -255,7 +255,8 @@ describe('Server-side Sampling', function () {
     ).toBeInTheDocument();
   });
 
-  it('does not let the user activate a rule if sdk updates exists', async function () {
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('does not let the user activate a rule if sdk updates exists', async function () {
     const {organization, router, project} = getMockData({
       projects: [
         TestStubs.Project({


### PR DESCRIPTION
Temporarily allowing to activate rules even without all the SDKs updated. 
This is for demo purposes, we will revert this once we want to LA.