### PR TITLE
fix(mep): Apdex and misery were calculated wrong

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -193,11 +193,10 @@ METRICS_MAP = {
 # 50 to match the size of tables in the UI + 1 for pagination reasons
 METRICS_MAX_LIMIT = 101
 METRICS_GRANULARITIES = [86400, 3600, 60, 10]
-METRIC_TOLERATED_TAG_KEY = "is_tolerated"
-METRIC_SATISFIED_TAG_KEY = "is_satisfied"
-METRIC_MISERABLE_TAG_KEY = "is_user_miserable"
-METRIC_TRUE_TAG_VALUE = "true"
-METRIC_FALSE_TAG_VALUE = "false"
+METRIC_TOLERATED_TAG_VALUE = "tolerated"
+METRIC_SATISFIED_TAG_VALUE = "satisfied"
+METRIC_FRUSTRATED_TAG_VALUE = "frustrated"
+METRIC_SATISFACTION_TAG_KEY = "satisfaction"
 # Only the metrics that are on the distributions & are in milliseconds
 METRIC_DURATION_COLUMNS = {
     key
@@ -206,11 +205,10 @@ METRIC_DURATION_COLUMNS = {
 }
 # So we can dry run some queries to see how often they'd be compatible
 DRY_RUN_COLUMNS = {
-    METRIC_TOLERATED_TAG_KEY,
-    METRIC_SATISFIED_TAG_KEY,
-    METRIC_MISERABLE_TAG_KEY,
-    METRIC_TRUE_TAG_VALUE,
-    METRIC_FALSE_TAG_VALUE,
+    METRIC_TOLERATED_TAG_VALUE,
+    METRIC_SATISFIED_TAG_VALUE,
+    METRIC_FRUSTRATED_TAG_VALUE,
+    METRIC_SATISFACTION_TAG_KEY,
     "environment",
     "http.method",
     "measurement_rating",

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -102,11 +102,10 @@ from sentry.models import (
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.plugins.base import plugins
 from sentry.search.events.constants import (
-    METRIC_FALSE_TAG_VALUE,
-    METRIC_MISERABLE_TAG_KEY,
-    METRIC_SATISFIED_TAG_KEY,
-    METRIC_TOLERATED_TAG_KEY,
-    METRIC_TRUE_TAG_VALUE,
+    METRIC_FRUSTRATED_TAG_VALUE,
+    METRIC_SATISFACTION_TAG_KEY,
+    METRIC_SATISFIED_TAG_VALUE,
+    METRIC_TOLERATED_TAG_VALUE,
     METRICS_MAP,
 )
 from sentry.sentry_metrics import indexer
@@ -1216,11 +1215,10 @@ class MetricsEnhancedPerformanceTestCase(SessionMetricsTestCase, TestCase):
             "environment",
             "http.status",
             "transaction.status",
-            METRIC_SATISFIED_TAG_KEY,
-            METRIC_TOLERATED_TAG_KEY,
-            METRIC_MISERABLE_TAG_KEY,
-            METRIC_TRUE_TAG_VALUE,
-            METRIC_FALSE_TAG_VALUE,
+            METRIC_TOLERATED_TAG_VALUE,
+            METRIC_SATISFIED_TAG_VALUE,
+            METRIC_FRUSTRATED_TAG_VALUE,
+            METRIC_SATISFACTION_TAG_KEY,
             *self.METRIC_STRINGS,
             *list(SPAN_STATUS_NAME_TO_CODE.keys()),
             *list(METRICS_MAP.values()),

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -5310,8 +5310,7 @@ class OrganizationEventsV2MetricsEnhancedPerformanceEndpointTest(
             1,
             tags={
                 "transaction": "foo_transaction",
-                "is_tolerated": "false",
-                "is_satisfied": "true",
+                constants.METRIC_SATISFACTION_TAG_KEY: constants.METRIC_SATISFIED_TAG_VALUE,
             },
             timestamp=self.min_ago,
         )
@@ -5342,7 +5341,10 @@ class OrganizationEventsV2MetricsEnhancedPerformanceEndpointTest(
         self.store_metric(
             1,
             "user",
-            tags={"transaction": "foo_transaction", "is_user_miserable": "true"},
+            tags={
+                "transaction": "foo_transaction",
+                constants.METRIC_SATISFACTION_TAG_KEY: constants.METRIC_FRUSTRATED_TAG_VALUE,
+            },
             timestamp=self.min_ago,
         )
         for dataset in ["metrics", "metricsEnhanced"]:
@@ -11408,8 +11410,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             1,
             tags={
                 "transaction": "foo_transaction",
-                "is_tolerated": "false",
-                "is_satisfied": "true",
+                constants.METRIC_SATISFACTION_TAG_KEY: constants.METRIC_SATISFIED_TAG_VALUE,
             },
             timestamp=self.min_ago,
         )
@@ -11440,7 +11441,10 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         self.store_metric(
             1,
             "user",
-            tags={"transaction": "foo_transaction", "is_user_miserable": "true"},
+            tags={
+                "transaction": "foo_transaction",
+                constants.METRIC_SATISFACTION_TAG_KEY: constants.METRIC_FRUSTRATED_TAG_VALUE,
+            },
             timestamp=self.min_ago,
         )
         for dataset in ["metrics", "metricsEnhanced"]:


### PR DESCRIPTION
- Was using the wrong tags/values for apdex and misery. This updates both to use the correct ones so we're calculating both correctly now
