### PR TITLE
fix(projectconfig): Give the build task debounce key a short TTL

### DIFF
--- a/src/sentry/relay/projectconfig_debounce_cache/__init__.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/__init__.py
@@ -9,7 +9,12 @@ from .base import ProjectConfigDebounceCache
 backend = LazyServiceWrapper(
     ProjectConfigDebounceCache,
     settings.SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE,
-    settings.SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE_OPTIONS,
+    {
+        # The sentry.tasks.relay.build_project_config tasks scheduled on here has a deadline
+        # of 10s.  This debounce_ttl should match.
+        "debounce_ttl": 10,
+        **settings.SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE_OPTIONS,
+    },
 )
 
 backend.expose(locals())

--- a/src/sentry/relay/projectconfig_debounce_cache/redis.py
+++ b/src/sentry/relay/projectconfig_debounce_cache/redis.py
@@ -8,6 +8,7 @@ REDIS_CACHE_TIMEOUT = 3600  # 1 hr
 class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
     def __init__(self, **options):
         self._key_prefix = options.pop("key_prefix", "relayconfig-debounce")
+        self._debounce_ttl = options.pop("debounce_ttl", REDIS_CACHE_TIMEOUT)
         self.is_redis_cluster, self.cluster, options = get_dynamic_cluster_from_options(
             "SENTRY_RELAY_PROJECTCONFIG_DEBOUNCE_CACHE_OPTIONS", options
         )
@@ -56,7 +57,7 @@ class RedisProjectConfigDebounceCache(ProjectConfigDebounceCache):
     def debounce(self, *, public_key, project_id, organization_id):
         key = self._get_redis_key(public_key, project_id, organization_id)
         client = self._get_redis_client(key)
-        client.setex(key, REDIS_CACHE_TIMEOUT, 1)
+        client.setex(key, self._debounce_ttl, 1)
         metrics.incr("relay.projectconfig_debounce_cache.debounce")
 
     def mark_task_done(self, *, public_key, project_id, organization_id):


### PR DESCRIPTION
The TTL of the debounce key is made to match the hard timeout of the
celery task.  This ensures that a debounce key can not live longer
than the task can, and thus no sticky debounce key occurs when a task
times out.  Because the schedule time is ignored this could result in
unnecessary duplicate tasks, however if a task already took this long
it probably wasn't going to succeed anyway.

Secondly this sets a global expiry time for the task itself, an
expired task will stay in RabbitMQ but the Celery worker will ack it
without running the task.  This ensures that if workers are shut down
during incidents or similar previous tasks will not be consuming
computation resources.

INGEST-1441
INGEST-1442