### PR TITLE
feat(profiling): persist selectedNode state in querystring

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStackTable.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackTable.tsx
@@ -129,6 +129,7 @@ export function FrameStackTable({
     ) => {
       return (
         <FrameStackTableRow
+          key={r.key}
           ref={n => {
             r.ref = n;
           }}

--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -11,7 +11,7 @@ import {FlamegraphSearchResult} from 'sentry/utils/profiling/flamegraph/flamegra
 import {useFlamegraphSearch} from 'sentry/utils/profiling/flamegraph/useFlamegraphSearch';
 import {
   FlamegraphFrame,
-  getFlamegraphFrameSearchId,
+  getFlamegraphFrameId,
 } from 'sentry/utils/profiling/flamegraphFrame';
 import {memoizeByReference} from 'sentry/utils/profiling/profile/utils';
 import {isRegExpString, parseRegExp} from 'sentry/utils/profiling/validators/regExp';
@@ -54,7 +54,7 @@ function frameSearch(
         const re = new RegExp(lookup, flags ?? 'g');
         const reMatches = Array.from(frame.frame.name.trim().matchAll(re));
         if (reMatches.length > 0) {
-          const frameId = getFlamegraphFrameSearchId(frame);
+          const frameId = getFlamegraphFrameId(frame);
           results[frameId] = {
             frame,
             matchIndices: reMatches.reduce((acc, match) => {
@@ -90,7 +90,7 @@ function frameSearch(
   for (let i = 0; i < fuseResults.length; i++) {
     const fuseFrameResult = fuseResults[i];
     const frame = fuseFrameResult.item;
-    const frameId = getFlamegraphFrameSearchId(frame);
+    const frameId = getFlamegraphFrameId(frame);
     results[frameId] = {
       frame,
       // matches will be defined when using 'includeMatches' in FuseOptions

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -413,10 +413,6 @@ function FlamegraphZoomView({
 
   const handleSelectNode = useCallback(
     (node: FlamegraphFrame | null, zoomIntoFrame?: boolean) => {
-      if (!node) {
-        return;
-      }
-
       if (zoomIntoFrame) {
         canvasPoolManager.dispatch('zoomIntoFrame', [node]);
       }
@@ -442,6 +438,7 @@ function FlamegraphZoomView({
       }
     }
   }, [handleSelectNode, flamegraphState, flamegraph]);
+
   const onCanvasMouseUp = useCallback(
     (evt: React.MouseEvent<HTMLCanvasElement>) => {
       evt.preventDefault();

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
@@ -1,4 +1,7 @@
-import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+import {
+  FlamegraphFrame,
+  getFlamegraphFrameId,
+} from 'sentry/utils/profiling/flamegraphFrame';
 
 type SetProfilesActiveIndex = {
   payload: number;
@@ -14,6 +17,7 @@ type FlamegraphProfilesAction = SetProfilesActiveIndex | SetSelectedNode;
 
 type FlamegraphProfilesState = {
   selectedNode: FlamegraphFrame | null;
+  selectedNodeId: string | null;
   threadId: number | null;
 };
 
@@ -23,7 +27,11 @@ export function flamegraphProfilesReducer(
 ): FlamegraphProfilesState {
   switch (action.type) {
     case 'set selected node': {
-      return {...state, selectedNode: action.payload};
+      return {
+        ...state,
+        selectedNode: action.payload,
+        selectedNodeId: getFlamegraphFrameId(action.payload!),
+      };
     }
     case 'set thread id': {
       // When the profile index changes, we want to drop the selected and hovered nodes

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphProfiles.tsx
@@ -30,7 +30,7 @@ export function flamegraphProfilesReducer(
       return {
         ...state,
         selectedNode: action.payload,
-        selectedNodeId: getFlamegraphFrameId(action.payload!),
+        selectedNodeId: action.payload ? getFlamegraphFrameId(action.payload!) : null,
       };
     }
     case 'set thread id': {
@@ -38,6 +38,7 @@ export function flamegraphProfilesReducer(
       return {
         ...state,
         selectedNode: null,
+        selectedNodeId: null,
         threadId: action.payload,
       };
     }

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -75,6 +75,10 @@ export function decodeFlamegraphStateFromQueryParams(
         typeof query.tid === 'string' && !isNaN(parseInt(query.tid, 10))
           ? parseInt(query.tid, 10)
           : null,
+      selectedNodeId:
+        typeof query.selectedNodeId === 'string'
+          ? query.selectedNodeId
+          : DEFAULT_FLAMEGRAPH_STATE.profiles.selectedNodeId,
     },
     position: {view: Rect.decode(query.fov) ?? Rect.Empty()},
     preferences: {
@@ -102,6 +106,11 @@ export function encodeFlamegraphStateToQueryParams(state: FlamegraphState) {
     view: state.preferences.view,
     xAxis: state.preferences.xAxis,
     query: state.search.query,
+    ...(state.profiles.selectedNode
+      ? {
+          selectedNodeId: state.profiles.selectedNodeId,
+        }
+      : {}),
     ...(state.position.view.isEmpty()
       ? {fov: undefined}
       : {fov: Rect.encode(state.position.view)}),
@@ -165,6 +174,7 @@ const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
   profiles: {
     threadId: null,
     selectedNode: null,
+    selectedNodeId: null,
   },
   position: {
     view: Rect.Empty(),
@@ -189,6 +199,10 @@ export function FlamegraphStateProvider(
   const reducer = useUndoableReducer(combinedReducers, {
     profiles: {
       selectedNode: null,
+
+      selectedNodeId:
+        props.initialState?.profiles?.selectedNodeId ??
+        DEFAULT_FLAMEGRAPH_STATE.profiles.selectedNodeId,
       threadId:
         props.initialState?.profiles?.threadId ??
         DEFAULT_FLAMEGRAPH_STATE.profiles.threadId,

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -106,11 +106,7 @@ export function encodeFlamegraphStateToQueryParams(state: FlamegraphState) {
     view: state.preferences.view,
     xAxis: state.preferences.xAxis,
     query: state.search.query,
-    ...(state.profiles.selectedNode
-      ? {
-          selectedNodeId: state.profiles.selectedNodeId,
-        }
-      : {}),
+    selectedNodeId: state.profiles.selectedNodeId || undefined,
     ...(state.position.view.isEmpty()
       ? {fov: undefined}
       : {fov: Rect.encode(state.position.view)}),

--- a/static/app/utils/profiling/flamegraphFrame.tsx
+++ b/static/app/utils/profiling/flamegraphFrame.tsx
@@ -14,7 +14,7 @@ export interface FlamegraphFrame {
   threadId?: number;
 }
 
-export function getFlamegraphFrameSearchId(frame: FlamegraphFrame) {
+export function getFlamegraphFrameId(frame: FlamegraphFrame) {
   return (
     frame.frame.name + (frame.frame.file ? frame.frame.file : '') + String(frame.start)
   );

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -3,7 +3,7 @@ import {mat3, vec2} from 'gl-matrix';
 import {Flamegraph} from '../flamegraph';
 import {FlamegraphSearch} from '../flamegraph/flamegraphStateProvider/flamegraphSearch';
 import {FlamegraphTheme} from '../flamegraph/flamegraphTheme';
-import {FlamegraphFrame, getFlamegraphFrameSearchId} from '../flamegraphFrame';
+import {FlamegraphFrame, getFlamegraphFrameId} from '../flamegraphFrame';
 import {
   createProgram,
   createShader,
@@ -445,7 +445,7 @@ class FlamegraphRenderer {
       for (let i = 0; i < length; i++) {
         frame = this.frames[i];
         const vertexOffset = i * VERTICES;
-        const frameId = getFlamegraphFrameSearchId(frame);
+        const frameId = getFlamegraphFrameId(frame);
         this.gl.uniform1i(
           this.uniforms.u_is_search_result,
           searchResults[frameId] ? 1 : 0

--- a/static/app/utils/profiling/renderers/textRenderer.benchmark.ts
+++ b/static/app/utils/profiling/renderers/textRenderer.benchmark.ts
@@ -14,7 +14,7 @@ import {Rect, Transform} from '../gl/utils';
 import typescriptTrace from '../profile/formats/typescript/trace.json';
 import {importProfile} from '../profile/importProfile';
 
-import {FlamegraphFrame, getFlamegraphFrameSearchId} from './../flamegraphFrame';
+import {FlamegraphFrame, getFlamegraphFrameId} from './../flamegraphFrame';
 
 // This logs an error which is annoying to see in the outputs
 initializeLocale({} as any);
@@ -143,7 +143,7 @@ const [word, data] = maxBy(
 
 const searchResults: FlamegraphSearch = {
   results: Array.from(data.frames.values()).reduce((acc, frame) => {
-    acc[getFlamegraphFrameSearchId(frame)] = frame;
+    acc[getFlamegraphFrameId(frame)] = frame;
     return acc;
   }, {}),
   query: word,

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -3,7 +3,7 @@ import {mat3} from 'gl-matrix';
 import {Flamegraph} from '../flamegraph';
 import {FlamegraphSearch} from '../flamegraph/flamegraphStateProvider/flamegraphSearch';
 import {FlamegraphTheme} from '../flamegraph/flamegraphTheme';
-import {FlamegraphFrame, getFlamegraphFrameSearchId} from '../flamegraphFrame';
+import {FlamegraphFrame, getFlamegraphFrameId} from '../flamegraphFrame';
 import {
   computeHighlightedBounds,
   ELLIPSIS,
@@ -142,7 +142,7 @@ class TextRenderer {
       const {text: trimText} = trim;
 
       if (flamegraphSearchResults) {
-        const frameId = getFlamegraphFrameSearchId(frame);
+        const frameId = getFlamegraphFrameId(frame);
         const frameSearchResult = flamegraphSearchResults[frameId];
 
         if (frameSearchResult && frameSearchResult.matchIndices.length > 0) {


### PR DESCRIPTION
## Summary
This PR persists `selectedNode` state in the querystring.

This PR is a precursor to enabling the ability of users clicking into a frame from previous page, such as clicking a row in the suspect functions table etc.


**Important:**
- The `frameId` is naive, we need to figure out a better solution to this.