### PR TITLE
Add dotnet-maui platform where appropriate

### DIFF
--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -67,7 +67,6 @@ class ErrorEvent(BaseEvent):
             "flutter",
             "dart-flutter",
             "unity",
-            "dotnet-maui",
             "dotnet-xamarin",
         )
 

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -67,6 +67,7 @@ class ErrorEvent(BaseEvent):
             "flutter",
             "dart-flutter",
             "unity",
+            "dotnet-maui",
             "dotnet-xamarin",
         )
 

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -55,6 +55,7 @@ export const mobile = [
   'flutter',
   'dart-flutter',
   'unity',
+  'dotnet-maui',
   'dotnet-xamarin',
   'unreal',
   // Old platforms
@@ -121,6 +122,7 @@ export const desktop = [
   'dotnet',
   'dotnet-winforms',
   'dotnet-wpf',
+  'dotnet-maui',
   'java',
   'electron',
   'javascript-electron',


### PR DESCRIPTION
Adds `dotnet-maui` to platform lists where appropriate for Mobile and Desktop.