### PR TITLE
feat(sampling): Round sampling rates to the common ones [TET-211]

### DIFF
--- a/static/app/utils/findClosestNumber.tsx
+++ b/static/app/utils/findClosestNumber.tsx
@@ -1,0 +1,8 @@
+// Finds the closest match to the number from the provided numbers array
+export function findClosestNumber(number: number, numbersArray: number[]) {
+  return numbersArray.reduce((previousBest: number, currentNumber) => {
+    return Math.abs(currentNumber - number) < Math.abs(previousBest - number)
+      ? currentNumber
+      : previousBest;
+  });
+}

--- a/tests/js/spec/utils/findClosestNumber.spec.tsx
+++ b/tests/js/spec/utils/findClosestNumber.spec.tsx
@@ -1,0 +1,16 @@
+import {findClosestNumber} from 'sentry/utils/findClosestNumber';
+
+describe('findClosestNumber()', function () {
+  it('returns the closest number', function () {
+    expect(
+      findClosestNumber(
+        0.63,
+        [
+          0.01, 0.015, 0.02, 0.025, 0.03, 0.035, 0.04, 0.045, 0.05, 0.06, 0.07, 0.08,
+          0.09, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7,
+          0.75, 0.8, 0.85, 0.9, 0.95, 1,
+        ]
+      )
+    ).toBe(0.65);
+  });
+});

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.spec.tsx
@@ -4,7 +4,7 @@ describe('projectStatsToSampleRates', function () {
   it('returns correct sample rates', function () {
     expect(projectStatsToSampleRates(TestStubs.Outcomes())).toEqual({
       hoursOverLimit: 18,
-      maxSafeSampleRate: 0.3249,
+      maxSafeSampleRate: 0.3,
       trueSampleRate: 1,
     });
   });


### PR DESCRIPTION
We are right now recommending sample rates based on the outcomes. 

The recommendation today returns very precise number like 0.994 - this PR rounds that to the closest common sample rate, which is usually pretty and round number. Something human would actually enter.