### PR TITLE
feat(profiling): allow table to be positioned to left, bottom or right side of the chart.

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -2,11 +2,13 @@ import {memo, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
+import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {filterFlamegraphTree} from 'sentry/utils/profiling/filterFlamegraphTree';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/useFlamegraphPreferences';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {useVerticallyResizableDrawer} from 'sentry/utils/profiling/hooks/useResizableDrawer';
@@ -24,6 +26,7 @@ interface FrameStackProps {
 
 const FrameStack = memo(function FrameStack(props: FrameStackProps) {
   const theme = useFlamegraphTheme();
+  const [_, dispatchFlamegraphPreferences] = useFlamegraphPreferences();
 
   const [tab, setTab] = useState<'bottom up' | 'call order'>('call order');
   const [treeType, setTreeType] = useState<'all' | 'application' | 'system'>('all');
@@ -73,6 +76,18 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
   const onSystemsClick = useCallback(() => {
     setTreeType('system');
   }, []);
+
+  const onTableLeftClick = useCallback(() => {
+    dispatchFlamegraphPreferences({type: 'set layout', payload: 'table_left'});
+  }, [dispatchFlamegraphPreferences]);
+
+  const onTableBottomClick = useCallback(() => {
+    dispatchFlamegraphPreferences({type: 'set layout', payload: 'table_bottom'});
+  }, [dispatchFlamegraphPreferences]);
+
+  const onTableRightClick = useCallback(() => {
+    dispatchFlamegraphPreferences({type: 'set layout', payload: 'table_right'});
+  }, [dispatchFlamegraphPreferences]);
 
   const {height, onMouseDown} = useVerticallyResizableDrawer({
     initialHeight: (theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET + 2) * theme.SIZES.BAR_HEIGHT,
@@ -149,6 +164,19 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
           </FrameDrawerLabel>
         </li>
         <li style={{flex: '1 1 100%', cursor: 'ns-resize'}} onMouseDown={onMouseDown} />
+        <li>
+          <LayoutSelectionContainer>
+            <Button onClick={onTableLeftClick} size="xs" title={t('Table left')}>
+              <IconArrow size="xs" direction="left" />
+            </Button>
+            <Button onClick={onTableBottomClick} size="xs" title={t('Table bottom')}>
+              <IconArrow size="xs" direction="down" />
+            </Button>
+            <Button onClick={onTableRightClick} size="xs" title={t('Table right')}>
+              <IconArrow size="xs" direction="right" />
+            </Button>
+          </LayoutSelectionContainer>
+        </li>
       </FrameTabs>
       <FrameStackTable
         {...props}
@@ -232,6 +260,11 @@ const FrameTabs = styled('ul')`
       border-bottom: 2px solid ${prop => prop.theme.active};
     }
   }
+`;
+
+const LayoutSelectionContainer = styled('div')`
+  display: flex;
+  align-items: center;
 `;
 
 const FRAME_WEIGHT_CELL_WIDTH_PX = 164;

--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -26,7 +26,8 @@ interface FrameStackProps {
 
 const FrameStack = memo(function FrameStack(props: FrameStackProps) {
   const theme = useFlamegraphTheme();
-  const [_, dispatchFlamegraphPreferences] = useFlamegraphPreferences();
+  const [flamegraphPreferences, dispatchFlamegraphPreferences] =
+    useFlamegraphPreferences();
 
   const [tab, setTab] = useState<'bottom up' | 'call order'>('call order');
   const [treeType, setTreeType] = useState<'all' | 'application' | 'system'>('all');
@@ -97,7 +98,8 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
   return (
     <FrameDrawer
       style={{
-        height,
+        // If the table is not at the bottom, the height should not be managed
+        height: flamegraphPreferences.layout === 'table_bottom' ? height : undefined,
       }}
     >
       <FrameTabs>
@@ -163,7 +165,16 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
             {t('Collapse recursion')}
           </FrameDrawerLabel>
         </li>
-        <li style={{flex: '1 1 100%', cursor: 'ns-resize'}} onMouseDown={onMouseDown} />
+        <li
+          style={{
+            flex: '1 1 100%',
+            cursor:
+              flamegraphPreferences.layout === 'table_bottom' ? 'ns-resize' : undefined,
+          }}
+          onMouseDown={
+            flamegraphPreferences.layout === 'table_bottom' ? onMouseDown : undefined
+          }
+        />
         <li>
           <LayoutSelectionContainer>
             <Button onClick={onTableLeftClick} size="xs" title={t('Table left')}>

--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -303,7 +303,6 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
       </FlamegraphToolbar>
 
       <ProfilingFlamechartLayout
-        layoutType="minimap_top"
         minimap={
           <FlamegraphZoomViewMinimap
             canvasPoolManager={canvasPoolManager}

--- a/static/app/components/profiling/profilingFlamechartLayout.tsx
+++ b/static/app/components/profiling/profilingFlamechartLayout.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {FlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences';
@@ -8,7 +9,7 @@ import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegrap
 
 interface ProfilingFlamechartLayoutProps {
   flamechart: React.ReactNode;
-  frameStack: React.ReactNode | null;
+  frameStack: React.ReactNode;
   minimap: React.ReactNode;
 }
 
@@ -24,9 +25,7 @@ export function ProfilingFlamechartLayout(props: ProfilingFlamechartLayoutProps)
             {props.minimap}
           </MinimapContainer>
           <ZoomViewContainer>{props.flamechart}</ZoomViewContainer>
-          {props.frameStack ? (
-            <FrameStackContainer>{props.frameStack}</FrameStackContainer>
-          ) : null}
+          <FrameStackContainer layout={layout}>{props.frameStack}</FrameStackContainer>
         </ProfilingFlamechartGrid>
       </ProfilingFlamechartLayoutContainer>
     </Fragment>
@@ -47,8 +46,10 @@ const ProfilingFlamechartGrid = styled('div')<{
     layout === 'table_bottom'
       ? 'auto 1fr'
       : layout === 'table_right'
-      ? 'auto 1fr'
-      : '1fr auto'};
+      ? '100px auto'
+      : '100px auto'};
+  grid-template-columns: ${({layout}) =>
+    layout === 'table_bottom' ? '100%' : '50% 50%'};
 
   /* false positive for grid layout */
   /* stylelint-disable */
@@ -61,7 +62,7 @@ const ProfilingFlamechartGrid = styled('div')<{
         `
       : layout === 'table_right'
       ? `
-        "minimap frame-stack"
+        "minimap    frame-stack"
         "flamegraph frame-stack"
       `
       : layout === 'table_left'
@@ -87,6 +88,26 @@ const ZoomViewContainer = styled('div')`
   grid-area: flamegraph;
 `;
 
-const FrameStackContainer = styled('div')`
+const FrameStackContainer = styled('div')<{layout: FlamegraphPreferences['layout']}>`
   grid-area: frame-stack;
+  position: relative;
+
+  ${({layout}) => {
+    if (layout === 'table_left' || layout === 'table_right') {
+      // If the table is left/right, the height is no longer managed
+      // and this grid area will fill the screen. We absolutely position
+      // the child so that it cannot overgrow the container.
+      return css`
+        > div {
+          position: absolute;
+          left: 0;
+          top: 0;
+          width: 100%;
+          height: 100%;
+        }
+      `;
+    }
+
+    return ``;
+  }}
 `;

--- a/static/app/components/profiling/profilingFlamechartLayout.tsx
+++ b/static/app/components/profiling/profilingFlamechartLayout.tsx
@@ -1,23 +1,25 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {FlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences';
 import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {useFlamegraphPreferencesValue} from 'sentry/utils/profiling/flamegraph/useFlamegraphPreferences';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 
 interface ProfilingFlamechartLayoutProps {
   flamechart: React.ReactNode;
   frameStack: React.ReactNode | null;
-  layoutType: 'minimap_top';
   minimap: React.ReactNode;
 }
 
 export function ProfilingFlamechartLayout(props: ProfilingFlamechartLayoutProps) {
   const flamegraphTheme = useFlamegraphTheme();
+  const {layout} = useFlamegraphPreferencesValue();
 
   return (
     <Fragment>
       <ProfilingFlamechartLayoutContainer>
-        <ProfilingFlamechartGrid layoutType="minimap_top">
+        <ProfilingFlamechartGrid layout={layout}>
           <MinimapContainer height={flamegraphTheme.SIZES.MINIMAP_HEIGHT}>
             {props.minimap}
           </MinimapContainer>
@@ -37,36 +39,37 @@ const ProfilingFlamechartLayoutContainer = styled('div')`
 `;
 
 const ProfilingFlamechartGrid = styled('div')<{
-  layoutType?: ProfilingFlamechartLayoutProps['layoutType'];
+  layout?: FlamegraphPreferences['layout'];
 }>`
   display: grid;
   width: 100%;
-  grid-template-rows: ${({layoutType}) =>
-    layoutType === 'minimap_top'
+  grid-template-rows: ${({layout}) =>
+    layout === 'table_bottom'
       ? 'auto 1fr'
-      : layoutType === 'table_right'
+      : layout === 'table_right'
       ? 'auto 1fr'
       : '1fr auto'};
 
   /* false positive for grid layout */
   /* stylelint-disable */
-  grid-template-areas: ${({layoutType}) =>
-    layoutType === 'minimap_top'
+  grid-template-areas: ${({layout}) =>
+    layout === 'table_bottom'
       ? `
         "minimap"
         "flamegraph"
         "frame-stack"
         `
-      : layoutType === 'table_right'
+      : layout === 'table_right'
       ? `
         "minimap frame-stack"
         "flamegraph frame-stack"
       `
-      : `
-        "flamegraph"
-        "frame-stack"
-        "minimap"
-    `};
+      : layout === 'table_left'
+      ? `
+        "frame-stack minimap"
+        "frame-stack flamegraph"
+    `
+      : ''};
 `;
 
 const MinimapContainer = styled('div')<{

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
@@ -11,6 +11,7 @@ export type FlamegraphAxisOptions = ['standalone', 'transaction'];
 
 export interface FlamegraphPreferences {
   colorCoding: FlamegraphColorCodings[number];
+  layout: 'table_right' | 'table_bottom' | 'table_left';
   sorting: FlamegraphSorting[number];
   view: FlamegraphViewOptions[number];
   xAxis: FlamegraphAxisOptions[number];
@@ -20,6 +21,7 @@ type FlamegraphPreferencesAction =
   | {payload: FlamegraphPreferences['colorCoding']; type: 'set color coding'}
   | {payload: FlamegraphPreferences['sorting']; type: 'set sorting'}
   | {payload: FlamegraphPreferences['view']; type: 'set view'}
+  | {payload: FlamegraphPreferences['layout']; type: 'set layout'}
   | {
       payload: FlamegraphPreferences['xAxis'];
       type: 'set xAxis';
@@ -30,6 +32,12 @@ export function flamegraphPreferencesReducer(
   action: FlamegraphPreferencesAction
 ): FlamegraphPreferences {
   switch (action.type) {
+    case 'set layout': {
+      return {
+        ...state,
+        layout: action.payload,
+      };
+    }
     case 'set color coding': {
       return {
         ...state,

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphSearch.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphSearch.tsx
@@ -1,6 +1,6 @@
 import type Fuse from 'fuse.js';
 
-import {FlamegraphFrame} from '../../flamegraphFrame';
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 
 export type FlamegraphSearchResult = {
   frame: FlamegraphFrame;

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -174,7 +174,7 @@ const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
     sorting: 'call order',
     view: 'top down',
     xAxis: 'standalone',
-    layout: 'table_bottom',
+    layout: 'table_left',
   },
   search: {
     index: null,

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -11,8 +11,8 @@ import {
   UndoableReducerAction,
   useUndoableReducer,
 } from 'sentry/utils/useUndoableReducer';
+import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
 
-import {useProfileGroup} from '../../../../views/profiling/profileGroupProvider';
 import {useFlamegraphStateValue} from '../useFlamegraphState';
 
 import {
@@ -174,6 +174,7 @@ const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
     sorting: 'call order',
     view: 'top down',
     xAxis: 'standalone',
+    layout: 'table_bottom',
   },
   search: {
     index: null,
@@ -198,6 +199,9 @@ export function FlamegraphStateProvider(
         DEFAULT_FLAMEGRAPH_STATE.position.view) as Rect,
     },
     preferences: {
+      layout:
+        props.initialState?.preferences?.layout ??
+        DEFAULT_FLAMEGRAPH_STATE.preferences.layout,
       colorCoding:
         props.initialState?.preferences?.colorCoding ??
         DEFAULT_FLAMEGRAPH_STATE.preferences.colorCoding,

--- a/static/app/views/profiling/profileFlamegraph.tsx
+++ b/static/app/views/profiling/profileFlamegraph.tsx
@@ -52,34 +52,32 @@ function ProfileFlamegraph(): React.ReactElement {
   }, []);
 
   return (
-    <Fragment>
-      <SentryDocumentTitle
-        title={t('Profiling \u2014 Flamegraph')}
-        orgSlug={organization.slug}
-      >
-        <FlamegraphStateProvider initialState={initialFlamegraphPreferencesState}>
-          <FlamegraphThemeProvider>
-            <FlamegraphStateQueryParamSync />
-            <FlamegraphContainer>
-              {profileGroup.type === 'errored' ? (
-                <Alert type="error" showIcon>
-                  {profileGroup.error}
-                </Alert>
-              ) : profileGroup.type === 'loading' ? (
-                <Fragment>
-                  <Flamegraph onImport={onImport} profiles={LoadingGroup} />
-                  <LoadingIndicatorContainer>
-                    <LoadingIndicator />
-                  </LoadingIndicatorContainer>
-                </Fragment>
-              ) : profileGroup.type === 'resolved' ? (
-                <Flamegraph onImport={onImport} profiles={profileGroup.data} />
-              ) : null}
-            </FlamegraphContainer>
-          </FlamegraphThemeProvider>
-        </FlamegraphStateProvider>
-      </SentryDocumentTitle>
-    </Fragment>
+    <SentryDocumentTitle
+      title={t('Profiling \u2014 Flamegraph')}
+      orgSlug={organization.slug}
+    >
+      <FlamegraphStateProvider initialState={initialFlamegraphPreferencesState}>
+        <FlamegraphThemeProvider>
+          <FlamegraphStateQueryParamSync />
+          <FlamegraphContainer>
+            {profileGroup.type === 'errored' ? (
+              <Alert type="error" showIcon>
+                {profileGroup.error}
+              </Alert>
+            ) : profileGroup.type === 'loading' ? (
+              <Fragment>
+                <Flamegraph onImport={onImport} profiles={LoadingGroup} />
+                <LoadingIndicatorContainer>
+                  <LoadingIndicator />
+                </LoadingIndicatorContainer>
+              </Fragment>
+            ) : profileGroup.type === 'resolved' ? (
+              <Flamegraph onImport={onImport} profiles={profileGroup.data} />
+            ) : null}
+          </FlamegraphContainer>
+        </FlamegraphThemeProvider>
+      </FlamegraphStateProvider>
+    </SentryDocumentTitle>
   );
 }
 


### PR DESCRIPTION
Temporary buttons for now as we wait for the final design (I'll add them to the iconbuttons then), until then and in the spirit of done is better than perfect, this is a good start that allows users to change the layout as they please (I'll add a separate PR to store their preference in localstorage, so they dont need to update it each time)

https://user-images.githubusercontent.com/9317857/178310866-6adcfa26-a703-456d-a2af-66a4c84f50ee.mp4

 