### PR TITLE
fix(api): increase CommitPatchSetSerializer.path max_length limit 

### DIFF
--- a/src/sentry/api/serializers/rest_framework/commit.py
+++ b/src/sentry/api/serializers/rest_framework/commit.py
@@ -5,7 +5,7 @@ from sentry.models import CommitFileChange
 
 
 class CommitPatchSetSerializer(serializers.Serializer):
-    path = serializers.CharField(max_length=255)
+    path = serializers.CharField(max_length=510)
     type = serializers.CharField(max_length=1)
 
     def validate_type(self, value):

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -829,6 +829,47 @@ class UpdateReleaseDetailsTest(APITestCase):
         for rc in rc_list:
             assert rc.organization_id == org.id
 
+    def test_commits_patchset_character_limit_255(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team = self.create_team(organization=org)
+        project = self.create_project(teams=[team], organization=org)
+        release = Release.objects.create(organization_id=org.id, version="abcabcabc")
+        release.add_project(project)
+        self.create_member(teams=[team], user=user, organization=org)
+
+        self.login_as(user=user)
+
+        url = reverse(
+            "sentry-api-0-organization-release-details",
+            kwargs={"organization_slug": org.slug, "version": release.version},
+        )
+        response = self.client.put(
+            url,
+            data={
+                "commits": [
+                    {
+                        "id": "a" * 40,
+                        "patch_set": [{"path": "/a/really/long/path/" + ("z" * 255), "type": "A"}],
+                    }
+                ]
+            },
+        )
+
+        assert response.status_code == 200, (response.status_code, response.content)
+
+        rc_list = list(
+            ReleaseCommit.objects.filter(release=release)
+            .select_related("commit", "commit__author")
+            .order_by("order")
+        )
+        assert len(rc_list) == 1
+        for rc in rc_list:
+            assert rc.organization_id == org.id
+
     def test_commits_lock_conflict(self):
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.create_organization()


### PR DESCRIPTION
Related to this [PR](https://github.com/getsentry/sentry/pull/36450)

The appropriate DB column was updated to reflect the limit increase, but the validation serializer wasn't updated accordingly to allow for larger filepaths. This should fix that.

