### PR TITLE
feat(msteams): Add default installation_type for new integrations

### DIFF
--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -94,6 +94,8 @@ class MsTeamsIntegrationProvider(IntegrationProvider):
                 "access_token": token_data["access_token"],
                 "expires_at": token_data["expires_at"],
                 "service_url": service_url,
+                # TODO: Default to 'team' installation type for now.
+                "installation_type": "team",
             },
             # TODO: Use user id for external_id in user_identity
             "user_identity": {"type": "msteams", "external_id": team_id, "scopes": [], "data": {}},

--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -94,7 +94,7 @@ class MsTeamsIntegrationProvider(IntegrationProvider):
                 "access_token": token_data["access_token"],
                 "expires_at": token_data["expires_at"],
                 "service_url": service_url,
-                # TODO: Default to 'team' installation type for now.
+                # TODO: Determine if installation type is 'team' or 'tenant'
                 "installation_type": "team",
             },
             # TODO: Use user id for external_id in user_identity

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -68,6 +68,7 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
                 "access_token": "my_token",
                 "service_url": "https://smba.trafficmanager.net/amer/",
                 "expires_at": self.start_time + 86399 - 60 * 5,
+                "installation_type": "team",
             }
             assert OrganizationIntegration.objects.get(
                 integration=integration, organization=self.organization


### PR DESCRIPTION
## Objective:
New rows in sentry_integration created for MS Teams should have installation_type field in the metadata column. It should default to “team“ right now.
