### PR TITLE
fix(smartSearch): Fix autocomplete race conditions

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1216,7 +1216,10 @@ class SmartSearchBar extends Component<Props, State> {
       const [tagKeys, tagType] = this.getTagKeys('');
       const recentSearches = await this.getRecentSearches();
 
-      this.updateAutoCompleteState(tagKeys, recentSearches ?? [], '', tagType);
+      if (this.state.query === query) {
+        this.updateAutoCompleteState(tagKeys, recentSearches ?? [], '', tagType);
+      }
+
       return;
     }
     // cursor on whitespace show default "help" search terms
@@ -1260,7 +1263,11 @@ class SmartSearchBar extends Component<Props, State> {
             autocompleteGroups.unshift(opGroup);
           }
         }
-        this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
+
+        if (cursor === this.cursorPosition) {
+          this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
+        }
+
         return;
       }
 
@@ -1272,8 +1279,11 @@ class SmartSearchBar extends Component<Props, State> {
           const opGroup = generateOpAutocompleteGroup(getValidOps(cursorToken), tagName);
           autocompleteGroups.unshift(opGroup);
         }
-        this.setState({searchTerm: tagName});
-        this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
+
+        if (cursor === this.cursorPosition) {
+          this.setState({searchTerm: tagName});
+          this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
+        }
         return;
       }
 
@@ -1287,8 +1297,11 @@ class SmartSearchBar extends Component<Props, State> {
       const lastToken = cursorToken.text.trim().split(' ').pop() ?? '';
       const keyText = lastToken.replace(new RegExp(`^${NEGATION_OPERATOR}`), '');
       const autocompleteGroups = [await this.generateTagAutocompleteGroup(keyText)];
-      this.setState({searchTerm: keyText});
-      this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
+
+      if (cursor === this.cursorPosition) {
+        this.setState({searchTerm: keyText});
+        this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
+      }
       return;
     }
   };

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -708,7 +708,7 @@ describe('SmartSearchBar', function () {
       });
     });
 
-    it('handles race conditions', async function () {
+    it('handles autocomplete race conditions when cursor position changed', async function () {
       const props = {
         query: 'is:',
         organization,
@@ -749,7 +749,7 @@ describe('SmartSearchBar', function () {
       expect(searchBar.state.searchGroups).toHaveLength(0);
     });
 
-    it('handles race conditions (default case)', async function () {
+    it('handles race conditions when query changes from default state', async function () {
       const props = {
         query: '',
         organization,

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2414,13 +2414,14 @@ describe('WidgetBuilder', function () {
       it('issue query does not work on default search bar', async function () {
         renderTestComponent();
 
-        userEvent.paste(
-          await screen.findByPlaceholderText('Search for events, users, tags, and more'),
-          'bookmarks',
-          {
-            clipboardData: {getData: () => ''},
-          } as unknown as React.ClipboardEvent<HTMLTextAreaElement>
-        );
+        const input = (await screen.findByPlaceholderText(
+          'Search for events, users, tags, and more'
+        )) as HTMLTextAreaElement;
+        userEvent.paste(input, 'bookmarks', {
+          clipboardData: {getData: () => ''},
+        } as unknown as React.ClipboardEvent<HTMLTextAreaElement>);
+        input.setSelectionRange(9, 9);
+
         expect(await screen.findByText('No items found')).toBeInTheDocument();
       });
 
@@ -2430,13 +2431,15 @@ describe('WidgetBuilder', function () {
         userEvent.click(
           await screen.findByText('Issues (States, Assignment, Time, etc.)')
         );
-        userEvent.paste(
-          screen.getByPlaceholderText('Search for issues, status, assigned, and more'),
-          'is:',
-          {
-            clipboardData: {getData: () => ''},
-          } as unknown as React.ClipboardEvent<HTMLTextAreaElement>
-        );
+
+        const input = (await screen.findByPlaceholderText(
+          'Search for issues, status, assigned, and more'
+        )) as HTMLTextAreaElement;
+        userEvent.paste(input, 'is:', {
+          clipboardData: {getData: () => ''},
+        } as unknown as React.ClipboardEvent<HTMLTextAreaElement>);
+        input.setSelectionRange(3, 3);
+
         expect(await screen.findByText('resolved')).toBeInTheDocument();
       });
 


### PR DESCRIPTION
Fix race conditions in the smart search bar's autocomplete by ensuring that the cursor position and query is still the same as the one that made the async request.

Examples to induce a race condition in prior versions include
- typing a key with colon `device.arch:` and then quickly moving the cursor out or deleting the token before the autocomplete updates.
- Typing something then quickly deleting it back to an empty query. The default state is then overwritten