### PR TITLE
feat(active-release): Send 1 hour deploy summary notification

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -577,6 +577,7 @@ CELERY_IMPORTS = (
     "sentry.tasks.process_buffer",
     "sentry.tasks.relay",
     "sentry.tasks.release_registry",
+    "sentry.tasks.release_summary",
     "sentry.tasks.reports",
     "sentry.tasks.reprocessing",
     "sentry.tasks.reprocessing2",
@@ -718,6 +719,11 @@ CELERYBEAT_SCHEDULE = {
         "task": "sentry.tasks.digests.schedule_digests",
         "schedule": timedelta(seconds=30),
         "options": {"expires": 30},
+    },
+    "schedule-digest-release-summary": {
+        "task": "sentry.tasks.digest.release_summary",
+        "schedule": timedelta(minutes=5),
+        "options": {"expires": 60 * 5},
     },
     "check-monitors": {
         "task": "sentry.tasks.check_monitors",

--- a/src/sentry/notifications/notifications/activity/release_summary.py
+++ b/src/sentry/notifications/notifications/activity/release_summary.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping, Sequence
+from urllib.parse import quote
+
+from django.db.models import Count, Q
+from sentry_relay import parse_release
+
+from sentry.integrations.slack.utils.escape import escape_slack_text
+from sentry.models import (
+    Activity,
+    Commit,
+    CommitFileChange,
+    Environment,
+    Group,
+    OrganizationMember,
+    Project,
+    Team,
+    User,
+)
+from sentry.notifications.types import NotificationSettingTypes
+from sentry.notifications.utils import get_deploy, get_release
+from sentry.notifications.utils.actions import MessageAction
+from sentry.notifications.utils.participants import (
+    _get_release_committers,
+    get_participants_for_release,
+)
+from sentry.types.integrations import ExternalProviders
+from sentry.utils.http import absolute_uri
+
+from .base import ActivityNotification
+
+
+class ReleaseSummaryActivityNotification(ActivityNotification):
+    metrics_key = "release_summary"
+    notification_setting_type = NotificationSettingTypes.DEPLOY
+    template_path = "sentry/emails/activity/release_summary"
+
+    def __init__(self, activity: Activity) -> None:
+        super().__init__(activity)
+        self.group = None
+        self.user_id_team_lookup: Mapping[int, list[int]] | None = None
+        self.deploy = get_deploy(activity)
+        self.release = get_release(activity, self.organization)
+
+        if not self.release or not self.deploy:
+            self.email_list: set[str] = set()
+            self.user_ids: set[int] = set()
+            self.projects: set[Project] = set()
+            self.version = "unknown"
+            self.version_parsed = self.version
+            return
+
+        self.projects = set(self.release.projects.all())
+        self.commit_list = Commit.objects.get_for_release(self.release)
+        self.email_list = {c.author.email for c in self.commit_list if c.author}
+        # TODO(workflow): Can use the same users from the commit list after active-release-notification-opt-in
+        users = _get_release_committers(self.release)
+        self.user_ids = {u.id for u in users}
+        environment = Environment.objects.filter(id=self.deploy.environment_id).first()
+        self.environment = str(environment.name) if environment else "Default Environment"
+        group_environment_filter = (
+            Q(groupenvironment__environment_id=environment.id) if environment else Q()
+        )
+        self.group_counts_by_project = dict(
+            Group.objects.filter(
+                group_environment_filter, project__in=self.projects, first_release=self.release
+            )
+            .values_list("project")
+            .annotate(num_groups=Count("id"))
+        )
+
+        self.version = self.release.version
+        self.version_parsed = parse_release(self.version)["description"]
+
+    def get_participants_with_group_subscription_reason(
+        self,
+    ) -> Mapping[ExternalProviders, Mapping[Team | User, int]]:
+        return get_participants_for_release(self.projects, self.organization, self.user_ids)
+
+    def get_users_by_teams(self) -> Mapping[int, list[int]]:
+        if not self.user_id_team_lookup:
+            lookup: Mapping[int, list[int]] = OrganizationMember.objects.get_teams_by_user(
+                self.organization
+            )
+            self.user_id_team_lookup = lookup
+        return self.user_id_team_lookup
+
+    def get_context(self) -> MutableMapping[str, Any]:
+        return {
+            **self.get_base_context(),
+            "author_count": len(self.email_list),
+            "commit_count": len(self.commit_list),
+            "file_count": CommitFileChange.objects.get_count_for_commits(self.commit_list),
+            "deploy": self.deploy,
+            "environment": self.environment,
+            "release": self.release,
+            "text_description": f"Release {self.version_parsed} has been deployed to {self.environment} for an hour",
+            "version_parsed": self.version_parsed,
+        }
+
+    def get_projects(self, recipient: Team | User) -> set[Project]:
+        if not self.release:
+            return set()
+
+        if isinstance(recipient, User):
+            if recipient.is_superuser or self.organization.flags.allow_joinleave:
+                # Admins can see all projects.
+                return self.projects
+            team_ids = self.get_users_by_teams()[recipient.id]
+        else:
+            team_ids = [recipient.id]
+
+        projects: set[Project] = Project.objects.get_for_team_ids(team_ids).filter(
+            id__in={p.id for p in self.projects}
+        )
+        return projects
+
+    def get_recipient_context(
+        self, recipient: Team | User, extra_context: Mapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        projects = self.get_projects(recipient)
+        release_links = [
+            absolute_uri(
+                f"/organizations/{self.organization.slug}/releases/{quote(self.version)}/?project={p.id}"
+            )
+            for p in projects
+        ]
+        issues_links = [
+            absolute_uri(
+                f"/organizations/{self.organization.slug}/issues/?project={p.id}&query={quote(f'firstRelease:{self.version}')}&referrer=release_summary"
+            )
+            for p in projects
+        ]
+
+        new_issue_counts = [self.group_counts_by_project.get(p.id, 0) for p in projects]
+        return {
+            **super().get_recipient_context(recipient, extra_context),
+            "projects": list(zip(projects, release_links, issues_links, new_issue_counts)),
+            "project_count": len(projects),
+        }
+
+    def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
+        return f"Deployment version {self.version_parsed} to {self.environment} one hour summary"
+
+    @property
+    def title(self) -> str:
+        return self.get_subject()
+
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
+        # TODO(workflow): Pass all projects as query parameters to issues link
+        project_query = ""
+        if self.release:
+            project = self.release.projects.first()
+            project_query = f"&project={project.id}"
+
+        release_link = absolute_uri(
+            f"/organizations/{self.organization.slug}/releases/{quote(self.version)}/?referrer=release_summary{project_query}"
+        )
+        issues_link = absolute_uri(
+            f"/organizations/{self.organization.slug}/issues/?query={quote(f'firstRelease:{self.version}')}{project_query}&referrer=release_summary"
+        )
+        new_issue_counts = sum(self.group_counts_by_project.get(p.id, 0) for p in self.projects)
+        message = f"Release <{release_link}|{escape_slack_text(self.version_parsed)}> has been deployed to {self.environment} for an hour"
+        message += f" with <{issues_link}|{new_issue_counts} issues> associated with it"
+        return message
+
+    def get_message_actions(self, recipient: Team | User) -> Sequence[MessageAction]:
+        return []
+
+    def build_attachment_title(self, recipient: Team | User) -> str:
+        return ""
+
+    def get_title_link(self, recipient: Team | User) -> str | None:
+        return None
+
+    def build_notification_footer(self, recipient: Team | User) -> str:
+        # notification footer only used for Slack for now
+        settings_url = self.get_settings_url(recipient, ExternalProviders.SLACK)
+
+        # no environment related to a deploy
+        if self.release:
+            return f"{self.release.projects.all()[0].slug} | <{settings_url}|Notification Settings>"
+        return f"<{settings_url}|Notification Settings>"
+
+    def send(self) -> None:
+        # Don't create a message when the Activity doesn't have a release and deploy.
+        if bool(self.release and self.deploy):
+            return super().send()

--- a/src/sentry/tasks/release_summary.py
+++ b/src/sentry/tasks/release_summary.py
@@ -1,0 +1,57 @@
+from datetime import timedelta
+
+from django.utils import timezone
+
+from sentry.models import Activity, Release, ReleaseCommit
+from sentry.notifications.notifications.activity.release_summary import (
+    ReleaseSummaryActivityNotification,
+)
+from sentry.notifications.utils.participants import _get_release_committers
+from sentry.tasks.base import instrumented_task
+from sentry.types.activity import ActivityType
+
+
+@instrumented_task(name="sentry.tasks.digest.release_summary")
+def prepare_release_summary():
+    """
+    Summarize new issues in a release an hour after deployment
+    """
+    now = timezone.now()
+    start = now - timedelta(hours=1, minutes=5)
+    end = now - timedelta(hours=1)
+    releases = Release.objects.filter(
+        deploy__date_finished__gte=start,
+        deploy__date_finished__lt=end,
+        deploy__notified=True,
+    )
+
+    for release in releases:
+        release_has_commits = ReleaseCommit.objects.filter(
+            organization_id=release.organization_id, release=release
+        ).exists()
+        if not release_has_commits:
+            continue
+
+        # Check if any participants are members of the feature flag
+        # TODO(workflow): can remove with active-release-notification-opt-in
+        participants = _get_release_committers(release)
+        if not participants:
+            continue
+
+        # Find the activity created in Deploy.notify_if_ready
+        activity = (
+            Activity.objects.filter(
+                type=ActivityType.DEPLOY.value,
+                project=release.projects.first(),
+                ident=Activity.get_version_ident(release.version),
+                datetime__gte=start,
+                datetime__lt=end,
+            )
+            .order_by("-datetime")
+            .first()
+        )
+        if not activity:
+            continue
+
+        release_summary = ReleaseSummaryActivityNotification(activity)
+        release_summary.send()

--- a/src/sentry/templates/sentry/emails/activity/release_summary.html
+++ b/src/sentry/templates/sentry/emails/activity/release_summary.html
@@ -1,0 +1,37 @@
+{% extends "sentry/emails/activity/generic.html" %}
+
+{% load sentry_avatars %}
+{% load sentry_helpers %}
+
+{% block action %}
+{% endblock %}
+
+{% block activity %}
+    <h2 style="margin-bottom: 10px">
+        Release {{ version_parsed }} has been deployed to {{ environment }} for an hour
+    </h2>
+    <p class="muted"><small><strong style="color: #72697d;">{{ deploy.date_finished }}</strong> <span class="divider">&nbsp;</span>  {{ commit_count }} commit{{ commit_count|pluralize }}, {{ author_count }} author{{ author_count|pluralize }}, and {{ file_count }} file{{ file_count|pluralize }} changed across {{ project_count }} project{{ project_count|pluralize }}</small></p>
+
+    <hr>
+
+    <h6>New Issues From This Release</h6>
+    <div class="table-border">
+      <table class="table projects">
+        <tbody>
+          {% for project, release_link, issues_link, new_issue_count in projects %}
+            <tr>
+              <td>
+                <h5 style="margin-bottom: 0">
+                  <a href="{{ release_link }}">{{ project.slug }}</a>
+                </h5>
+              </td>
+              <td style="text-align: right">
+                <a href="{{ issues_link }}" class="btn btn-sm btn-primary">View {{ new_issue_count }} new issue{{ new_issue_count|pluralize }}</a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+{% endblock %}

--- a/src/sentry/templates/sentry/emails/activity/release_summary.txt
+++ b/src/sentry/templates/sentry/emails/activity/release_summary.txt
@@ -1,0 +1,5 @@
+Release {{ version_parsed }} has been deployed to {{ environment }} for 1 hour
+
+{% for project, release_link, issues_link, new_issue_count in projects %}
+    {{ project.slug }} has {{ new_issue_count }} new issue{{ new_issue_count|pluralize }} {{ issues_link }}
+{% endfor %}

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -47,6 +47,7 @@ from sentry.web.frontend.debug.debug_regression_email import (
     DebugRegressionEmailView,
     DebugRegressionReleaseEmailView,
 )
+from sentry.web.frontend.debug.debug_release_summary_email import DebugReleaseSummaryEmailView
 from sentry.web.frontend.debug.debug_resolved_email import DebugResolvedEmailView
 from sentry.web.frontend.debug.debug_resolved_in_release_email import (
     DebugResolvedInReleaseEmailView,
@@ -71,6 +72,7 @@ urlpatterns = [
     url(r"^debug/mail/alert/$", sentry.web.frontend.debug.mail.alert),
     url(r"^debug/mail/note/$", DebugNoteEmailView.as_view()),
     url(r"^debug/mail/new-release/$", DebugNewReleaseEmailView.as_view()),
+    url(r"^debug/mail/release-summary/$", DebugReleaseSummaryEmailView.as_view()),
     url(r"^debug/mail/release_alert/$", sentry.web.frontend.debug.mail.release_alert),
     url(r"^debug/mail/new-user-feedback/$", DebugNewUserFeedbackEmailView.as_view()),
     url(r"^debug/mail/assigned/$", DebugAssignedEmailView.as_view()),

--- a/src/sentry/web/frontend/debug/debug_release_summary_email.py
+++ b/src/sentry/web/frontend/debug/debug_release_summary_email.py
@@ -1,0 +1,67 @@
+import datetime
+from urllib.parse import quote
+
+import pytz
+from django.views.generic import View
+from rest_framework.request import Request
+from rest_framework.response import Response
+from sentry_relay import parse_release
+
+from sentry.models import Deploy, Organization, Project, Release
+from sentry.notifications.types import GroupSubscriptionReason
+from sentry.utils.http import absolute_uri
+
+from .mail import MailPreview
+
+
+class DebugReleaseSummaryEmailView(View):
+    def get(self, request: Request) -> Response:
+        org = Organization(id=1, slug="organization", name="My Company")
+        projects = [
+            Project(id=1, organization=org, slug="project", name="My Project"),
+            Project(id=2, organization=org, slug="another-project", name="Another Project"),
+            Project(id=3, organization=org, slug="yet-another-project", name="Yet Another Project"),
+        ]
+        version = "6c998f755f304593a4713abd123eaf8833a2de5e"
+        version_parsed = parse_release(version)["description"]
+        release = Release(
+            organization_id=org.id,
+            version=version,
+            date_added=datetime.datetime(2016, 10, 12, 15, 39, tzinfo=pytz.utc),
+        )
+
+        deploy = Deploy(
+            release=release,
+            organization_id=org.id,
+            environment_id=1,
+            date_finished=datetime.datetime(2016, 10, 12, 15, 39, tzinfo=pytz.utc),
+        )
+
+        release_links = [
+            absolute_uri(f"/organizations/{org.slug}/releases/{release.version}/?project={p.id}")
+            for p in projects
+        ]
+
+        issue_links = [
+            absolute_uri(
+                f"/organizations/{org.slug}/issues/?project={p.id}&query={quote(f'firstRelease:{release.version}')}"
+            )
+            for p in projects
+        ]
+
+        return MailPreview(
+            html_template="sentry/emails/activity/release_summary.html",
+            text_template="sentry/emails/activity/release_summary.txt",
+            context={
+                "author_count": 1,
+                "commit_count": 4,
+                "deploy": deploy,
+                "environment": "production",
+                "file_count": 5,
+                "project_count": len(projects),
+                "projects": list(zip(projects, release_links, issue_links, [6, 1, 0])),
+                "reason": GroupSubscriptionReason.descriptions[GroupSubscriptionReason.committed],
+                "release": release,
+                "version_parsed": version_parsed,
+            },
+        ).render(request)

--- a/tests/sentry/mail/activity/test_release_summary.py
+++ b/tests/sentry/mail/activity/test_release_summary.py
@@ -1,0 +1,93 @@
+from urllib.parse import quote
+
+from django.core import mail
+
+from sentry.models import Activity, Environment, Repository
+from sentry.notifications.notifications.activity.release_summary import (
+    ReleaseSummaryActivityNotification,
+)
+from sentry.notifications.types import GroupSubscriptionReason
+from sentry.testutils.cases import ActivityTestCase
+from sentry.types.activity import ActivityType
+from sentry.types.integrations import ExternalProviders
+from sentry.utils.http import absolute_uri
+
+
+class ReleaseSummaryTestCase(ActivityTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.org = self.create_organization(owner=None)
+        self.org.flags.allow_joinleave = False
+        self.org.save()
+
+        self.team = self.create_team(organization=self.org)
+        self.team2 = self.create_team(organization=self.org)
+
+        self.user1 = self.another_user("user1@example.com", self.team)
+        self.user2 = self.another_user("user2@example.com")
+
+        self.project = self.create_project(organization=self.org, teams=[self.team])
+        self.project2 = self.create_project(organization=self.org, teams=[self.team2])
+
+        self.environment = Environment.objects.create(
+            name="production", organization_id=self.org.id
+        )
+
+        self.release, self.deploy = self.another_release("a")
+
+        repository = Repository.objects.create(organization_id=self.org.id, name=self.project.name)
+
+        # The commits are intentionally out of order to test commit `order`.
+        self.commit1 = self.another_commit(0, "a", self.user1, repository)
+        self.commit2 = self.another_commit(1, "b", self.user2, repository)
+
+    def test_simple(self):
+        with self.feature("organizations:active-release-notification-opt-in"):
+            release_summary = ReleaseSummaryActivityNotification(
+                Activity(
+                    project=self.project,
+                    user=self.user1,
+                    type=ActivityType.DEPLOY.value,
+                    data={"version": self.release.version, "deploy_id": self.deploy.id},
+                )
+            )
+
+        # user1 is included because they committed
+        participants = release_summary.get_participants_with_group_subscription_reason()[
+            ExternalProviders.EMAIL
+        ]
+        assert len(participants) == 1
+        assert participants == {
+            self.user1: GroupSubscriptionReason.committed,
+        }
+
+        context = release_summary.get_context()
+        assert context["environment"] == "production"
+
+        user_context = release_summary.get_recipient_context(self.user1, {})
+        # make sure this only includes projects user has access to
+        assert len(user_context["projects"]) == 1
+        assert user_context["projects"][0][0] == self.project
+
+        with self.tasks():
+            release_summary.send()
+
+        assert len(mail.outbox) == 1
+
+        sent_email_addresses = {msg.to[0] for msg in mail.outbox}
+
+        assert sent_email_addresses == {self.user1.email}
+
+        release_link = absolute_uri(
+            f"/organizations/{self.org.slug}/releases/{quote(self.release.version)}/?referrer=release_summary&project={self.project.id}"
+        )
+        issues_link = absolute_uri(
+            f"/organizations/{self.org.slug}/issues/?query={quote(f'firstRelease:{self.release.version}')}&project={self.project.id}&referrer=release_summary"
+        )
+
+        slack_message = release_summary.get_notification_title()
+        assert (
+            slack_message
+            == f"Release <{release_link}|aaaaaaaaaaaa> has been deployed to production for an hour with <{issues_link}|0 issues> associated with it"
+        )

--- a/tests/sentry/tasks/test_release_summary.py
+++ b/tests/sentry/tasks/test_release_summary.py
@@ -1,0 +1,62 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from sentry.models import Activity, Environment, Repository
+from sentry.tasks.release_summary import prepare_release_summary
+from sentry.testutils.cases import ActivityTestCase
+from sentry.types.activity import ActivityType
+
+
+class SendReleaseSummaryTest(ActivityTestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.org = self.create_organization(owner=None)
+
+        self.team = self.create_team(organization=self.org)
+        self.team2 = self.create_team(organization=self.org)
+        self.user1 = self.another_user("user1@example.com", self.team)
+        self.project = self.create_project(organization=self.org, teams=[self.team])
+        self.project2 = self.create_project(organization=self.org, teams=[self.team2])
+        self.environment = Environment.objects.create(
+            name="production", organization_id=self.org.id
+        )
+
+        self.release, self.deploy = self.another_release("a")
+
+        # Update deploy too look like it has run Deploy.notify_if_ready
+        deployed_at = timezone.now() - timedelta(hours=1, minutes=1)
+        self.deploy.update(date_finished=deployed_at, notified=True)
+        Activity.objects.create(
+            type=ActivityType.DEPLOY.value,
+            project=self.release.projects.first(),
+            ident=Activity.get_version_ident(self.release.version),
+            data={
+                "version": self.release.version,
+                "deploy_id": self.deploy.id,
+                "environment": self.environment.name,
+            },
+            datetime=deployed_at,
+        )
+
+        repository = Repository.objects.create(organization_id=self.org.id, name=self.project.name)
+        self.commit1 = self.another_commit(0, "a", self.user1, repository)
+
+    @patch(
+        "sentry.notifications.notifications.activity.release_summary.ReleaseSummaryActivityNotification.send"
+    )
+    def test_simple(self, mock_release_summary_send):
+        with self.feature("organizations:active-release-notification-opt-in"):
+            prepare_release_summary()
+
+        assert len(mock_release_summary_send.mock_calls) == 1
+
+    @patch(
+        "sentry.notifications.notifications.activity.release_summary.ReleaseSummaryActivityNotification.send"
+    )
+    def test_without_feature_flag(self, mock_release_summary_send):
+        prepare_release_summary()
+
+        assert not mock_release_summary_send.mock_calls


### PR DESCRIPTION
The notification is sent 1 hour after a deploy is finished via a task that runs every 5 minutes

email
<img width="711" alt="Screen Shot 2022-07-06 at 6 00 13 PM" src="https://user-images.githubusercontent.com/1400464/177668775-0511f79d-b882-4b92-aad7-09c3e5f46efc.png">

slack
<img width="691" alt="Screen Shot 2022-07-06 at 6 00 27 PM" src="https://user-images.githubusercontent.com/1400464/177668778-1e69dff0-7f8c-49a7-a006-dd2af8f23417.png">

blocked by #36499