### PR TITLE
fix(dyn-sampling): Discards irrelevant sdk names and versions

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -138,23 +138,22 @@ class OrganizationDynamicSamplingSDKVersionsEndpoint(OrganizationEndpoint):
         project_to_sdk_version_to_info_dict = {}
         for row in data:
             project = row["project"]
+            sdk_name = row["sdk.name"]
+            sdk_version = row["sdk.version"]
             # Filter 1: Discard any sdk name that accounts less than or equal to the value
             # `SDK_NAME_FILTER_THRESHOLD` of total count per project
             # Filter 2: Discard any sdk version that accounts less than or equal to
             # `SDK_VERSION_FILTER_THRESHOLD` of total count in that sdk_name in that project
             if (
-                total_sdk_name_count_per_project[project][row["sdk.name"]]
+                total_sdk_name_count_per_project[project][sdk_name]
                 > SDK_NAME_FILTER_THRESHOLD * total_count_per_project[project]
                 and row["count()"]
-                > SDK_VERSION_FILTER_THRESHOLD
-                * total_sdk_name_count_per_project[project][row["sdk.name"]]
+                > SDK_VERSION_FILTER_THRESHOLD * total_sdk_name_count_per_project[project][sdk_name]
             ):
-                project_to_sdk_version_to_info_dict.setdefault(row["project"], {})[
-                    row["sdk.version"]
-                ] = {
-                    "project": row["project"],
-                    "latestSDKName": row["sdk.name"],
-                    "latestSDKVersion": row["sdk.version"],
+                project_to_sdk_version_to_info_dict.setdefault(project, {})[sdk_version] = {
+                    "project": project,
+                    "latestSDKName": sdk_name,
+                    "latestSDKVersion": sdk_version,
                     "isSendingSampleRate": bool(row[f"equation|{avg_equation}"]),
                 }
 

--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -109,8 +109,9 @@ class OrganizationDynamicSamplingSDKVersionsEndpoint(OrganizationEndpoint):
             #     "wind": {"sentry.javascript.react": 3},
             #     "earth": {"sentry.javascript.react": 45, "sentry.javascript.browser": 4},
             # }
-            total_sdk_name_count_per_project.setdefault(row["project"], {})
-            total_sdk_name_count_per_project[row["project"]].setdefault(row["sdk.name"], 0)
+            total_sdk_name_count_per_project.setdefault(row["project"], {}).setdefault(
+                row["sdk.name"], 0
+            )
             total_sdk_name_count_per_project[row["project"]][row["sdk.name"]] += row["count()"]
 
         # Creates a dictionary that has the first level key as project id and values (second

--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -113,20 +113,6 @@ class OrganizationDynamicSamplingSDKVersionsEndpoint(OrganizationEndpoint):
             total_sdk_name_count_per_project[row["project"]].setdefault(row["sdk.name"], 0)
             total_sdk_name_count_per_project[row["project"]][row["sdk.name"]] += row["count()"]
 
-        # Aggregates the statistically relevant sdk names per project. As an example:
-        # {
-        #     "wind": {"sentry.javascript.react"},
-        #     "earth": {"sentry.javascript.react"},
-        # }
-        relevant_project_and_sdk_names = {}
-        for project, sdk_name_counts in total_sdk_name_count_per_project.items():
-            for sdk_name, count in sdk_name_counts.items():
-                # Filter 1: Discard any sdk name that accounts less than or equal to the value
-                # `SDK_NAME_FILTER_THRESHOLD` of total count per project
-                if count > SDK_NAME_FILTER_THRESHOLD * total_count_per_project[project]:
-                    relevant_project_and_sdk_names.setdefault(project, set())
-                    relevant_project_and_sdk_names[project].add(sdk_name)
-
         # Creates a dictionary that has the first level key as project id and values (second
         # level key) as SDK versions, and finally that maps to the expected resulting project
         # sdk version info if that SDKVersion was actually the latest observed, and that info
@@ -152,10 +138,13 @@ class OrganizationDynamicSamplingSDKVersionsEndpoint(OrganizationEndpoint):
         project_to_sdk_version_to_info_dict = {}
         for row in data:
             project = row["project"]
+            # Filter 1: Discard any sdk name that accounts less than or equal to the value
+            # `SDK_NAME_FILTER_THRESHOLD` of total count per project
             # Filter 2: Discard any sdk version that accounts less than or equal to
             # `SDK_VERSION_FILTER_THRESHOLD` of total count in that sdk_name in that project
             if (
-                row["sdk.name"] in relevant_project_and_sdk_names[project]
+                total_sdk_name_count_per_project[project][row["sdk.name"]]
+                > SDK_NAME_FILTER_THRESHOLD * total_count_per_project[project]
                 and row["count()"]
                 > SDK_VERSION_FILTER_THRESHOLD
                 * total_sdk_name_count_per_project[project][row["sdk.name"]]

--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -99,20 +99,22 @@ class OrganizationDynamicSamplingSDKVersionsEndpoint(OrganizationEndpoint):
         # Create a dictionary of total count per sdk name per project
         total_sdk_name_count_per_project = {}
         for row in data:
+            project = row["project"]
+            sdk_name = row["sdk.name"]
+            count = row["count()"]
             # Aggregates total counts for each project
             # As an example: {'wind': 3, 'earth': 49, 'heart': 3, 'fire': 21, 'water': 102}
-            total_count_per_project.setdefault(row["project"], 0)
-            total_count_per_project[row["project"]] += row["count()"]
+            total_count_per_project[project] = total_count_per_project.get(project, 0) + count
 
             # Aggregates total counts for each sdk name per project. As an example:
             # {
             #     "wind": {"sentry.javascript.react": 3},
             #     "earth": {"sentry.javascript.react": 45, "sentry.javascript.browser": 4},
             # }
-            total_sdk_name_count_per_project.setdefault(row["project"], {}).setdefault(
-                row["sdk.name"], 0
+            total_sdk_name_count_per_project.setdefault(project, {})
+            total_sdk_name_count_per_project[project][sdk_name] = (
+                total_sdk_name_count_per_project[project].get(sdk_name, 0) + count
             )
-            total_sdk_name_count_per_project[row["project"]][row["sdk.name"]] += row["count()"]
 
         # Creates a dictionary that has the first level key as project id and values (second
         # level key) as SDK versions, and finally that maps to the expected resulting project

--- a/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
+++ b/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
@@ -191,7 +191,6 @@ class OrganizationDynamicSamplingSDKVersionsTest(APITestCase):
         mock_query.return_value = mocked_discover_query()
         with Feature({"organizations:server-side-sampling": True}):
             response = self.client.get(f"{self.endpoint}?project={self.project.id}")
-            print(response.json())
             assert response.json() == [
                 {
                     "project": "wind",

--- a/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
+++ b/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
@@ -13,71 +13,139 @@ from sentry.testutils.helpers import Feature
 def mocked_discover_query():
     return {
         "data": [
+            # project: wind
             {
-                "project": "fire",
-                "sdk.name": "javascript",
-                "sdk.version": "7.1.6",
+                "sdk.version": "7.1.4",
+                "sdk.name": "sentry.javascript.react",
+                "project": "wind",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                "count()": 2,
+            },
+            {
+                "sdk.version": "7.1.3",
+                "sdk.name": "sentry.javascript.react",
+                "project": "wind",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                "count()": 1,
+            },
+            # project: earth
+            {
+                "sdk.version": "7.1.5",
+                "sdk.name": "sentry.javascript.react",
+                "project": "earth",
                 'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 7,
+                "count()": 23,
+            },
+            # Accounts for less than 10% of total count for this project, and so should be discarded
+            {
+                "sdk.version": "7.1.6",
+                "sdk.name": "sentry.javascript.browser",
+                "project": "earth",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 5,
                 "count()": 4,
-                'count_if(trace.client_sample_rate, notEquals, "")': 4,
             },
+            # Accounts for less than 5% of total count for this project and sdk.name so should be
+            # discarded
             {
-                "project": "water",
-                "sdk.name": "javascript",
-                "sdk.version": "7.1.4",
-                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
-                "count()": 1,
-                'count_if(trace.client_sample_rate, notEquals, "")': 0,
-            },
-            {
-                "project": "water",
-                "sdk.name": "javascript",
                 "sdk.version": "7.1.6",
+                "sdk.name": "sentry.javascript.react",
+                "project": "earth",
                 'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 5,
                 "count()": 2,
-                'count_if(trace.client_sample_rate, notEquals, "")': 2,
             },
             {
-                "project": "wind",
-                "sdk.name": "javascript",
-                "sdk.version": "7.1.5",
-                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
-                "count()": 2,
-                'count_if(trace.client_sample_rate, notEquals, "")': 0,
-            },
-            {
-                "project": "wind",
-                "sdk.name": "javascript",
-                "sdk.version": "7.1.3",
-                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
-                "count()": 1,
-                'count_if(trace.client_sample_rate, notEquals, "")': 0,
-            },
-            {
-                "project": "fire",
-                "sdk.name": "javascript",
                 "sdk.version": "7.1.4",
+                "sdk.name": "sentry.javascript.react",
+                "project": "earth",
                 'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
-                "count()": 6,
                 'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                "count()": 11,
             },
             {
-                "project": "fire",
-                "sdk.name": "javascript",
-                "sdk.version": "7.1.5",
-                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
-                "count()": 3,
-                'count_if(trace.client_sample_rate, notEquals, "")': 0,
-            },
-            {
-                "project": "fire",
-                "sdk.name": "javascript",
                 "sdk.version": "7.1.3",
+                "sdk.name": "sentry.javascript.react",
+                "project": "earth",
                 'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
-                "count()": 8,
                 'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                "count()": 9,
             },
-        ]
+            # project: heart
+            {
+                "sdk.version": "7.1.5",
+                "sdk.name": "sentry.javascript.react",
+                "project": "heart",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 3,
+                "count()": 3,
+            },
+            # project: fire
+            {
+                "sdk.version": "7.1.6",
+                "sdk.name": "sentry.javascript.react",
+                "project": "fire",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 5,
+                "count()": 5,
+            },
+            {
+                "sdk.version": "7.1.5",
+                "sdk.name": "sentry.javascript.react",
+                "project": "fire",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 5,
+                "count()": 5,
+            },
+            {
+                "sdk.version": "7.1.3",
+                "sdk.name": "sentry.javascript.react",
+                "project": "fire",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                "count()": 6,
+            },
+            {
+                "sdk.version": "7.1.4",
+                "sdk.name": "sentry.javascript.react",
+                "project": "fire",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                "count()": 5,
+            },
+            # project: water
+            {
+                "sdk.version": "7.1.4",
+                "sdk.name": "sentry.javascript.react",
+                "project": "water",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                "count()": 100,
+            },
+            # Accounts for less than 5% of total count for this project and sdk.name so should be
+            # discarded
+            {
+                "sdk.version": "7.1.3",
+                "sdk.name": "sentry.javascript.react",
+                "project": "water",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                "count()": 1,
+            },
+            # Accounts for less than 5% of total count for this project and sdk.name so should be
+            # discarded
+            {
+                "sdk.version": "7.1.6",
+                "sdk.name": "sentry.javascript.react",
+                "project": "water",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 1,
+                "count()": 1,
+            },
+        ],
     }
 
 
@@ -123,23 +191,36 @@ class OrganizationDynamicSamplingSDKVersionsTest(APITestCase):
         mock_query.return_value = mocked_discover_query()
         with Feature({"organizations:server-side-sampling": True}):
             response = self.client.get(f"{self.endpoint}?project={self.project.id}")
+            print(response.json())
             assert response.json() == [
                 {
+                    "project": "wind",
+                    "latestSDKName": "sentry.javascript.react",
+                    "latestSDKVersion": "7.1.4",
+                    "isSendingSampleRate": False,
+                },
+                {
+                    "project": "earth",
+                    "latestSDKName": "sentry.javascript.react",
+                    "latestSDKVersion": "7.1.5",
+                    "isSendingSampleRate": True,
+                },
+                {
+                    "project": "heart",
+                    "latestSDKName": "sentry.javascript.react",
+                    "latestSDKVersion": "7.1.5",
+                    "isSendingSampleRate": True,
+                },
+                {
                     "project": "fire",
-                    "latestSDKName": "javascript",
+                    "latestSDKName": "sentry.javascript.react",
                     "latestSDKVersion": "7.1.6",
                     "isSendingSampleRate": True,
                 },
                 {
                     "project": "water",
-                    "latestSDKName": "javascript",
-                    "latestSDKVersion": "7.1.6",
-                    "isSendingSampleRate": True,
-                },
-                {
-                    "project": "wind",
-                    "latestSDKName": "javascript",
-                    "latestSDKVersion": "7.1.5",
+                    "latestSDKName": "sentry.javascript.react",
+                    "latestSDKVersion": "7.1.4",
                     "isSendingSampleRate": False,
                 },
             ]


### PR DESCRIPTION
Modifies dynamic sampling sdk versions endpoint
so that per project, it discards sdk names that
account for less than or equal to 10% of transaction
volume in that period, and then discards sdk versions
that account for less than 5% within than sdk


