### PR TITLE
fix(projectconfig): Bring back metric with request version

### DIFF
--- a/src/sentry/api/endpoints/relay/project_configs.py
+++ b/src/sentry/api/endpoints/relay/project_configs.py
@@ -86,12 +86,17 @@ class RelayProjectConfigsEndpoint(Endpoint):
             # considering them v3.
             use_v3 = False
             reason = "fullConfig"
+            version = "2"  # Downgrade to 2 for reporting metrics
         elif no_cache:
             use_v3 = False
             reason = "noCache"
+            version = "2"  # Downgrade to 2 for reporting metrics
 
         set_tag("relay_use_v3", use_v3)
         set_tag("relay_use_v3_rejected", reason)
+        metrics.incr(
+            "api.endpoints.relay.project_configs.post", tags={"version": version, "reason": reason}
+        )
 
         return use_v3
 


### PR DESCRIPTION
This was accidentally deleted but rather important to understand our
requests.



