### PR TITLE
feat(discover): lowers rate limit for events endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -55,9 +55,9 @@ ALLOWED_EVENTS_GEO_REFERRERS = {
 
 API_TOKEN_REFERRER = "api.auth-token.events"
 
-RATE_LIMIT = 50
+RATE_LIMIT = 25
 RATE_LIMIT_WINDOW = 1
-CONCURRENT_RATE_LIMIT = 50
+CONCURRENT_RATE_LIMIT = 25
 
 
 def rate_limit_events(request: Request, organization_slug=None, *args, **kwargs) -> RateLimitConfig:

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -11069,7 +11069,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
             "project": [self.project.id],
         }
         with freeze_time("2000-01-01"):
-            for _ in range(50):
+            for _ in range(25):
                 self.do_request(query, features={"organizations:discover-events-rate-limit": True})
             response = self.do_request(
                 query, features={"organizations:discover-events-rate-limit": True}


### PR DESCRIPTION
Sets rate limit for eventsv2 and events api to 25 concurrent and 25 in 1 second.