### PR TITLE
fix(analytics): update hook deps

### DIFF
--- a/static/app/components/globalSdkUpdateAlert.tsx
+++ b/static/app/components/globalSdkUpdateAlert.tsx
@@ -44,7 +44,7 @@ function InnerGlobalSdkUpdateAlert(
   const handleReviewUpdatesClick = useCallback(() => {
     SidebarPanelStore.activatePanel(SidebarPanelKey.Broadcasts);
     trackAdvancedAnalyticsEvent('sdk_updates.clicked', {organization});
-  }, []);
+  }, [organization]);
 
   useEffect(() => {
     trackAdvancedAnalyticsEvent('sdk_updates.seen', {organization});

--- a/static/app/views/onboarding/welcome.tsx
+++ b/static/app/views/onboarding/welcome.tsx
@@ -46,14 +46,14 @@ function InnerAction({title, subText, cta, src}: TextWrapperProps) {
   );
 }
 
+const source = 'targeted_onboarding';
 function TargetedOnboardingWelcome({organization, ...props}: StepProps) {
-  const source = 'targeted_onboarding';
   useEffect(() => {
     trackAdvancedAnalyticsEvent('growth.onboarding_start_onboarding', {
       organization,
       source,
     });
-  }, []);
+  }, [organization]);
 
   const onComplete = () => {
     trackAdvancedAnalyticsEvent('growth.onboarding_clicked_instrument_app', {

--- a/static/app/views/organizationStats/teamInsights/health.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.tsx
@@ -47,7 +47,7 @@ function TeamStatsHealth({location, router}: Props) {
     trackAdvancedAnalyticsEvent('team_insights.viewed', {
       organization,
     });
-  }, []);
+  }, [organization]);
 
   const {period, start, end, utc} = dataDatetime(query);
 

--- a/static/app/views/organizationStats/teamInsights/issues.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.tsx
@@ -48,7 +48,7 @@ function TeamStatsIssues({location, router}: Props) {
     trackAdvancedAnalyticsEvent('team_insights.viewed', {
       organization,
     });
-  }, []);
+  }, [organization]);
 
   const {period, start, end, utc} = dataDatetime(query);
 


### PR DESCRIPTION
Fixes a couple of react warnings related to analytics. @scefali these should be relatively safe to update as organization is tracked as a dependency in other trackAdvancedAnalyticsEvent effects. 

I think we should also think of the possibility od adding a custom hook like useTrackAdvancedAnalyticsEvent(..args) that would track deps and make this slightly easier to consume. We would benefit from having exact same analytics tracking logic all over the app so data quality could be a bit better (right now we sort of trust folks to properly use effects)