### PR TITLE
fix(withIssueTags): fix deps

### DIFF
--- a/static/app/utils/withIssueTags.tsx
+++ b/static/app/utils/withIssueTags.tsx
@@ -45,47 +45,44 @@ function withIssueTags<Props extends WithIssueTagsProps>(
       teams: TeamStore.getAll(),
     });
 
-    const setAssigned = useCallback(
-      (newState: Partial<WrappedComponentState>) => {
-        setState(oldState => {
-          const usernames: string[] = newState.users
-            ? newState.users.map(getUsername)
-            : oldState.users.map(getUsername);
+    const setAssigned = useCallback((newState: Partial<WrappedComponentState>) => {
+      setState(oldState => {
+        const usernames: string[] = newState.users
+          ? newState.users.map(getUsername)
+          : oldState.users.map(getUsername);
 
-          const teamnames: string[] = (newState.teams ? newState.teams : oldState.teams)
-            .filter(team => team.isMember)
-            .map(team => `#${team.slug}`);
+        const teamnames: string[] = (newState.teams ? newState.teams : oldState.teams)
+          .filter(team => team.isMember)
+          .map(team => `#${team.slug}`);
 
-          const allAssigned = ['[me, none]', ...usernames, ...teamnames];
-          allAssigned.unshift('me');
-          usernames.unshift('me');
+        const allAssigned = ['[me, none]', ...usernames, ...teamnames];
+        allAssigned.unshift('me');
+        usernames.unshift('me');
 
-          return {
-            ...oldState,
-            ...newState,
-            tags: {
-              ...oldState.tags,
-              ...newState.tags,
-              assigned: {
-                ...(newState.tags?.assigned ?? oldState.tags?.assigned ?? {}),
-                values: allAssigned,
-              },
-              bookmarks: {
-                ...(newState.tags?.bookmarks ?? oldState.tags?.bookmarks ?? {}),
-                values: usernames,
-              },
-              assigned_or_suggested: {
-                ...(newState.tags?.assigned_or_suggested ??
-                  oldState.tags.assigned_or_suggested ??
-                  {}),
-                values: allAssigned,
-              },
+        return {
+          ...oldState,
+          ...newState,
+          tags: {
+            ...oldState.tags,
+            ...newState.tags,
+            assigned: {
+              ...(newState.tags?.assigned ?? oldState.tags?.assigned ?? {}),
+              values: allAssigned,
             },
-          };
-        });
-      },
-      [state]
-    );
+            bookmarks: {
+              ...(newState.tags?.bookmarks ?? oldState.tags?.bookmarks ?? {}),
+              values: usernames,
+            },
+            assigned_or_suggested: {
+              ...(newState.tags?.assigned_or_suggested ??
+                oldState.tags.assigned_or_suggested ??
+                {}),
+              values: allAssigned,
+            },
+          },
+        };
+      });
+    }, []);
 
     // Listen to team store updates and cleanup listener on unmount
     useEffect(() => {
@@ -94,7 +91,7 @@ function withIssueTags<Props extends WithIssueTagsProps>(
       }, undefined);
 
       return () => unsubscribeTeam();
-    }, []);
+    }, [setAssigned]);
 
     // Listen to tag store updates and cleanup listener on unmount
     useEffect(() => {
@@ -110,7 +107,7 @@ function withIssueTags<Props extends WithIssueTagsProps>(
       }, undefined);
 
       return () => unsubscribeTags();
-    }, []);
+    }, [setAssigned]);
 
     // Listen to member store updates and cleanup listener on unmount
     useEffect(() => {


### PR DESCRIPTION
setAssigned was using an unnecessary state dependency and the two useEffects were missing the setAssigned dependency. Since setAssigned will in reality be stable as it has no dependencies, there is no risk to adding it as a dependency to both effects (it is unnecessary, but more bug proof for the future)