### PR TITLE
fix(selectedEnvs): fix eslint deps

### DIFF
--- a/static/app/components/organizations/environmentSelector.tsx
+++ b/static/app/components/organizations/environmentSelector.tsx
@@ -78,10 +78,12 @@ function EnvironmentSelector({
   const [selectedEnvs, setSelectedEnvs] = useState(value);
   const hasChanges = !isEqual(selectedEnvs, value);
 
-  // Update selected envs value on change
+  // Update selected envs value on changew
   useEffect(() => {
-    setSelectedEnvs(value);
-    lastSelectedEnvs.current = selectedEnvs;
+    setSelectedEnvs(previousSelectedEnvs => {
+      lastSelectedEnvs.current = previousSelectedEnvs;
+      return value;
+    });
   }, [value]);
 
   // We keep a separate list of selected environments to use for sorting. This

--- a/static/app/components/organizations/environmentSelector.tsx
+++ b/static/app/components/organizations/environmentSelector.tsx
@@ -78,7 +78,7 @@ function EnvironmentSelector({
   const [selectedEnvs, setSelectedEnvs] = useState(value);
   const hasChanges = !isEqual(selectedEnvs, value);
 
-  // Update selected envs value on changew
+  // Update selected envs value on change
   useEffect(() => {
     setSelectedEnvs(previousSelectedEnvs => {
       lastSelectedEnvs.current = previousSelectedEnvs;


### PR DESCRIPTION
Fixes the eslint deps warning by assigning to ref from state callback. I'm actually not sure if this ever worked as intended (or maybe it just wasnt clear to me that lastSelectedEnvs is the previous value) because setState calls are not synchronous, so lastSelectedEnvs is always trailing. See [example](https://codesandbox.io/s/optimistic-cherry-ue54nm?file=/src/App.tsx)