### PR TITLE
fix(ui): Clear TimeRangeSelector input value when item is selected or menu is closed

### DIFF
--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -115,12 +115,11 @@ type Props<T> = typeof defaultProps & {
   disabled: boolean;
   defaultHighlightedIndex?: number;
   defaultInputValue?: string;
-  /**
-   * Currently, this does not act as a "controlled" prop, only for initial state of dropdown
-   */
+  inputValue?: string;
   isOpen?: boolean;
   itemToString?: (item?: T) => string;
   onClose?: (...args: Array<any>) => void;
+  onInputValueChange?: (value: string) => void;
   onMenuOpen?: () => void;
   onOpen?: (...args: Array<any>) => void;
   onSelect?: (
@@ -140,11 +139,11 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
   state: State<T> = this.getInitialState();
 
   getInitialState() {
-    const {defaultHighlightedIndex, isOpen, defaultInputValue} = this.props;
+    const {defaultHighlightedIndex, isOpen, inputValue, defaultInputValue} = this.props;
     return {
       isOpen: !!isOpen,
       highlightedIndex: defaultHighlightedIndex || 0,
-      inputValue: defaultInputValue || '',
+      inputValue: inputValue ?? defaultInputValue ?? '',
       selectedItem: undefined,
     };
   }
@@ -183,12 +182,20 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
   blurTimeout: number | undefined = undefined;
   cancelCloseTimeout: number | undefined = undefined;
 
-  get isControlled() {
+  get inputValueIsControlled() {
+    return typeof this.props.inputValue !== 'undefined';
+  }
+
+  get isOpenIsControlled() {
     return typeof this.props.isOpen !== 'undefined';
   }
 
+  get inputValue() {
+    return this.props.inputValue ?? this.state.inputValue;
+  }
+
   get isOpen() {
-    return this.isControlled ? this.props.isOpen : this.state.isOpen;
+    return this.isOpenIsControlled ? this.props.isOpen : this.state.isOpen;
   }
 
   /**
@@ -221,10 +228,14 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
       // 1) it's possible to have menu closed but input with focus (i.e. hitting "Esc")
       // 2) you select an item, input still has focus, and then change input
       this.openMenu();
-      this.setState({
-        inputValue: value,
-      });
 
+      if (!this.inputValueIsControlled) {
+        this.setState({
+          inputValue: value,
+        });
+      }
+
+      this.props.onInputValueChange?.(value);
       onChange?.(changeEvent);
     };
   }
@@ -380,7 +391,7 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
 
     onOpen?.(...args);
 
-    if (disabled || this.isControlled) {
+    if (disabled || this.isOpenIsControlled) {
       return;
     }
 
@@ -400,12 +411,12 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
 
     onClose?.(...args);
 
-    if (this.isControlled || !this._mounted) {
+    if (!this._mounted) {
       return;
     }
 
     this.setState(state => ({
-      isOpen: false,
+      isOpen: !this.isOpenIsControlled ? false : state.isOpen,
       inputValue: resetInputOnClose ? '' : state.inputValue,
     }));
   };
@@ -416,7 +427,7 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
     const {onChange, onKeyDown, onFocus, onBlur, ...rest} = inputProps ?? {};
     return {
       ...rest,
-      value: this.state.inputValue,
+      value: this.inputValue,
       onChange: this.makeHandleInputChange<E>(onChange),
       onKeyDown: this.makeHandleInputKeydown<E>(onKeyDown),
       onFocus: this.makeHandleInputFocus<E>(onFocus),
@@ -446,7 +457,7 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
 
   render() {
     const {children, onMenuOpen, inputIsActor} = this.props;
-    const {selectedItem, inputValue, highlightedIndex} = this.state;
+    const {selectedItem, highlightedIndex} = this.state;
     const isOpen = this.isOpen;
 
     return (
@@ -476,7 +487,7 @@ class AutoComplete<T extends Item> extends Component<Props<T>, State<T>> {
             getItemProps: this.getItemProps,
             registerVisibleItem: this.registerVisibleItem,
             registerItemCount: this.registerItemCount,
-            inputValue,
+            inputValue: this.inputValue,
             selectedItem,
             highlightedIndex,
             actions: {

--- a/static/app/components/dropdownAutoComplete/menu.tsx
+++ b/static/app/components/dropdownAutoComplete/menu.tsx
@@ -115,6 +115,11 @@ type Props = {
   inputProps?: {style: React.CSSProperties};
 
   /**
+   * Used to control the input value (optional)
+   */
+  inputValue?: string;
+
+  /**
    * Used to control dropdown state (optional)
    */
   isOpen?: boolean;
@@ -154,6 +159,11 @@ type Props = {
    * Callback for when dropdown menu closes
    */
   onClose?: () => void;
+
+  /**
+   * Callback for when the input value changes
+   */
+  onInputValueChange?: (value: string) => void;
 
   /**
    * Callback for when dropdown menu opens

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -164,6 +164,7 @@ type Props = WithRouterProps & {
 type State = {
   hasChanges: boolean;
   hasDateRangeErrors: boolean;
+  inputValue: string;
   isOpen: boolean;
   relative: string | null;
   end?: Date;
@@ -189,6 +190,7 @@ class TimeRangeSelector extends PureComponent<Props, State> {
       // if utc is not null and not undefined, then use value of `props.utc` (it can be false)
       // otherwise if no value is supplied, the default should be the user's timezone preference
       utc: defined(props.utc) ? props.utc : getUserTimezone() === 'UTC',
+      inputValue: '',
       isOpen: false,
       hasChanges: false,
       hasDateRangeErrors: false,
@@ -232,7 +234,7 @@ class TimeRangeSelector extends PureComponent<Props, State> {
       // Only call update if we close when absolute date is selected
       this.handleUpdate({relative, start, end, utc});
     } else {
-      this.setState({isOpen: false});
+      this.setState({isOpen: false, inputValue: ''});
     }
   };
 
@@ -242,6 +244,7 @@ class TimeRangeSelector extends PureComponent<Props, State> {
     this.setState(
       {
         isOpen: false,
+        inputValue: '',
         hasChanges: false,
       },
       () => {
@@ -386,6 +389,10 @@ class TimeRangeSelector extends PureComponent<Props, State> {
     import('../timeRangeSelector/dateRange/index');
   };
 
+  onInputValueChange = inputValue => {
+    this.setState({inputValue});
+  };
+
   render() {
     const {
       defaultPeriod,
@@ -431,6 +438,8 @@ class TimeRangeSelector extends PureComponent<Props, State> {
                 allowActorToggle
                 alignMenu={alignDropdown ?? (isAbsoluteSelected ? 'right' : 'left')}
                 isOpen={this.state.isOpen}
+                inputValue={this.state.inputValue}
+                onInputValueChange={this.onInputValueChange}
                 onOpen={this.handleOpen}
                 onClose={this.handleCloseMenu}
                 hideInput={!shouldShowRelative}

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
@@ -89,6 +89,7 @@ class BreadcrumbDropdown extends Component<BreadcrumbDropdownProps, State> {
 
   render() {
     const {hasMenu, route, isLast, name, items, onSelect, ...dropdownProps} = this.props;
+
     return (
       <DropdownAutoCompleteMenu
         blendCorner={false}

--- a/tests/js/spec/components/autoComplete.spec.jsx
+++ b/tests/js/spec/components/autoComplete.spec.jsx
@@ -320,7 +320,7 @@ describe('AutoComplete', function () {
     });
   });
 
-  describe('Controlled', function () {
+  describe('isOpen controlled', function () {
     beforeEach(function () {
       wrapper = createWrapper({isOpen: true});
     });
@@ -495,6 +495,97 @@ describe('AutoComplete', function () {
       );
       expect(mocks.onClose).toHaveBeenCalledTimes(1);
       expect(wrapper.state('inputValue')).toBe('Pineapple');
+    });
+
+    it('can reset input value when menu closes', function () {
+      jest.useFakeTimers();
+      wrapper.setProps({resetInputOnClose: true});
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+
+      input.simulate('change', {target: {value: 'a'}});
+      expect(wrapper.state('inputValue')).toBe('a');
+
+      input.simulate('blur');
+      jest.runAllTimers();
+      expect(wrapper.state('inputValue')).toBe('');
+    });
+  });
+
+  describe('inputValue controlled', () => {
+    beforeEach(function () {
+      wrapper = createWrapper({inputValue: 'initial value'});
+    });
+
+    it('follows the inputValue prop', () => {
+      expect(input.instance().value).toBe('initial value');
+
+      wrapper.setProps({inputValue: 'new value'});
+
+      expect(input.instance().value).toBe('new value');
+    });
+
+    it('calls onInputValueChange on input', () => {
+      const onInputValueChange = jest.fn();
+      wrapper.setProps({onInputValueChange});
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+
+      input.simulate('change', {target: {value: 'a'}});
+
+      expect(onInputValueChange).toHaveBeenCalledWith('a');
+    });
+
+    it('input value does not change when typed into', () => {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+
+      input.simulate('change', {target: {value: 'a'}});
+      expect(wrapper.state('inputValue')).toBe('initial value');
+    });
+
+    it('input value does not change when blurred', () => {
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+
+      input.simulate('blur');
+      expect(input.instance().value).toBe('initial value');
+    });
+
+    it('can search for and select an item without changing the input value', () => {
+      input.simulate('focus');
+      wrapper.setProps({inputValue: 'apple'});
+      expect(wrapper.state('isOpen')).toBe(true);
+
+      expect(wrapper.instance().items.size).toBe(2);
+
+      wrapper.find('li').at(1).simulate('click');
+
+      expect(wrapper.state('isOpen')).toBe(false);
+      expect(input.instance().value).toBe('apple');
+    });
+
+    it('can filter and navigate dropdown items with keyboard and select with "Enter" keypress without changing input value', function () {
+      wrapper.setProps({inputValue: 'apple'});
+      input.simulate('focus');
+      expect(wrapper.state('isOpen')).toBe(true);
+      expect(wrapper.state('highlightedIndex')).toBe(0);
+      expect(wrapper.instance().items.size).toBe(2);
+
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      input.simulate('keyDown', {key: 'ArrowDown'});
+      expect(wrapper.state('highlightedIndex')).toBe(1);
+
+      input.simulate('keyDown', {key: 'Enter'});
+
+      expect(mocks.onSelect).toHaveBeenCalledWith(
+        items[1],
+        expect.objectContaining({highlightedIndex: 1}),
+        expect.anything()
+      );
+      expect(mocks.onClose).toHaveBeenCalledTimes(1);
+      expect(input.instance().value).toBe('apple');
     });
   });
 


### PR DESCRIPTION
While working on improving `<TimeRangeSelector />`, I came across some unintended behavior: the input value is never cleared unless the user does it manually.

This happens due to the `isOpen` state being controlled. There are a couple issues here:

1. the `resetInputOnClose` prop wasn't resetting the input value when `isOpen` is being controlled
2. even after fixing the issue above, there are still situations where `<TimeRangeSelector />` needs control over the input value (e.g. when selecting an absolute date and clicking "Apply", `<TimeRangeSelector />` calls the onChange and closes the menu without going through `<AutoComplete />` at all)

So in order to fix this issue, I added a controlled `inputValue` prop to `<AutoComplete />`, along with `onInputValueChanged`, mirroring the Downshift API. Now `<TimeRangeSelector />` controls both `isOpen` and `inputValue` and can reset the input value whenever it pleases.

[Before
](https://user-images.githubusercontent.com/10888943/178580595-870639b1-fda0-4932-a052-437e5808e4b1.mov
)

[After](https://user-images.githubusercontent.com/10888943/178580608-87e17477-0db1-4f74-a1a9-dd9438059123.mov
)

