### PR TITLE
feat(search-parser): Parse partial aggregate filters to highlight and show operators

### DIFF
--- a/fixtures/search-syntax/invalid_aggregate_column_with_duration_filter.json
+++ b/fixtures/search-syntax/invalid_aggregate_column_with_duration_filter.json
@@ -11,7 +11,7 @@
         "filter": "aggregateGeneric",
         "negated": false,
         "invalid": {
-          "reason": "Aggregate filter is incomplete."
+          "reason": "'500s' is not a valid aggregate filter value."
         },
         "key": {
           "type": "keyAggregate",

--- a/fixtures/search-syntax/invalid_aggregate_column_with_duration_filter.json
+++ b/fixtures/search-syntax/invalid_aggregate_column_with_duration_filter.json
@@ -2,9 +2,57 @@
   {
     "query": "avg(stack.colno):>500s",
     "result": [
-      {"type": "spaces", "value": ""},
-      {"type": "freeText", "quoted": false, "value": "avg(stack.colno):>500s"},
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      },
+      {
+        "type": "filter",
+        "filter": "aggregateGeneric",
+        "negated": false,
+        "invalid": {
+          "reason": "Aggregate filter is incomplete."
+        },
+        "key": {
+          "type": "keyAggregate",
+          "name": {
+            "type": "keySimple",
+            "value": "avg",
+            "quoted": false
+          },
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "stack.colno",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {
+            "type": "spaces",
+            "value": ""
+          },
+          "argsSpaceAfter": {
+            "type": "spaces",
+            "value": ""
+          }
+        },
+        "operator": ">",
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "500s"
+        }
+      },
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   }
 ]

--- a/fixtures/search-syntax/invalid_aggregate_duration_filter.json
+++ b/fixtures/search-syntax/invalid_aggregate_duration_filter.json
@@ -2,9 +2,57 @@
   {
     "query": "avg(transaction.duration):>..500s",
     "result": [
-      {"type": "spaces", "value": ""},
-      {"type": "freeText", "value": "avg(transaction.duration):>..500s", "quoted": false},
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      },
+      {
+        "type": "filter",
+        "filter": "aggregateGeneric",
+        "negated": false,
+        "invalid": {
+          "reason": "Aggregate filter is incomplete."
+        },
+        "key": {
+          "type": "keyAggregate",
+          "name": {
+            "type": "keySimple",
+            "value": "avg",
+            "quoted": false
+          },
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "transaction.duration",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {
+            "type": "spaces",
+            "value": ""
+          },
+          "argsSpaceAfter": {
+            "type": "spaces",
+            "value": ""
+          }
+        },
+        "operator": ">",
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "..500s"
+        }
+      },
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   }
 ]

--- a/fixtures/search-syntax/invalid_aggregate_duration_filter.json
+++ b/fixtures/search-syntax/invalid_aggregate_duration_filter.json
@@ -11,7 +11,7 @@
         "filter": "aggregateGeneric",
         "negated": false,
         "invalid": {
-          "reason": "Aggregate filter is incomplete."
+          "reason": "'..500s' is not a valid aggregate filter value."
         },
         "key": {
           "type": "keyAggregate",

--- a/fixtures/search-syntax/invalid_aggregate_percentage_filter.json
+++ b/fixtures/search-syntax/invalid_aggregate_percentage_filter.json
@@ -2,13 +2,65 @@
   {
     "query": "percentage(transaction.duration, transaction.duration):>..500%",
     "result": [
-      {"type": "spaces", "value": ""},
       {
-        "type": "freeText",
-        "value": "percentage(transaction.duration, transaction.duration):>..500%",
-        "quoted": false
+        "type": "spaces",
+        "value": ""
       },
-      {"type": "spaces", "value": ""}
+      {
+        "type": "filter",
+        "filter": "aggregateGeneric",
+        "negated": false,
+        "invalid": {
+          "reason": "Aggregate filter is incomplete."
+        },
+        "key": {
+          "type": "keyAggregate",
+          "name": {
+            "type": "keySimple",
+            "value": "percentage",
+            "quoted": false
+          },
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "transaction.duration",
+                  "quoted": false
+                }
+              },
+              {
+                "separator": ", ",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "transaction.duration",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {
+            "type": "spaces",
+            "value": ""
+          },
+          "argsSpaceAfter": {
+            "type": "spaces",
+            "value": ""
+          }
+        },
+        "operator": ">",
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "..500%"
+        }
+      },
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   }
 ]

--- a/fixtures/search-syntax/invalid_aggregate_percentage_filter.json
+++ b/fixtures/search-syntax/invalid_aggregate_percentage_filter.json
@@ -11,7 +11,7 @@
         "filter": "aggregateGeneric",
         "negated": false,
         "invalid": {
-          "reason": "Aggregate filter is incomplete."
+          "reason": "'..500%' is not a valid aggregate filter value."
         },
         "key": {
           "type": "keyAggregate",

--- a/fixtures/search-syntax/invalid_numeric_aggregate_filter.json
+++ b/fixtures/search-syntax/invalid_numeric_aggregate_filter.json
@@ -11,7 +11,7 @@
         "filter": "aggregateGeneric",
         "negated": false,
         "invalid": {
-          "reason": "Aggregate filter is incomplete."
+          "reason": "'3s' is not a valid aggregate filter value."
         },
         "key": {
           "type": "keyAggregate",

--- a/fixtures/search-syntax/invalid_numeric_aggregate_filter.json
+++ b/fixtures/search-syntax/invalid_numeric_aggregate_filter.json
@@ -2,9 +2,57 @@
   {
     "query": "min(measurements.size):3s",
     "result": [
-      {"type": "spaces", "value": ""},
-      {"type": "freeText", "quoted": false, "value": "min(measurements.size):3s"},
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      },
+      {
+        "type": "filter",
+        "filter": "aggregateGeneric",
+        "negated": false,
+        "invalid": {
+          "reason": "Aggregate filter is incomplete."
+        },
+        "key": {
+          "type": "keyAggregate",
+          "name": {
+            "type": "keySimple",
+            "value": "min",
+            "quoted": false
+          },
+          "args": {
+            "type": "keyAggregateArgs",
+            "args": [
+              {
+                "separator": "",
+                "value": {
+                  "type": "keyAggregateParam",
+                  "value": "measurements.size",
+                  "quoted": false
+                }
+              }
+            ]
+          },
+          "argsSpaceBefore": {
+            "type": "spaces",
+            "value": ""
+          },
+          "argsSpaceAfter": {
+            "type": "spaces",
+            "value": ""
+          }
+        },
+        "operator": "",
+        "value": {
+          "quoted": false,
+          "type": "valueText",
+          "value": "3s"
+        }
+      },
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   }
 ]

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -820,7 +820,12 @@ class SearchVisitor(NodeVisitor):
         (negation, search_key, _, operator, search_value) = children
         operator = handle_negation(negation, operator)
 
-        raise InvalidSearchQuery("Aggregate filter is incomplete.")
+        if search_value.raw_value == "":
+            raise InvalidSearchQuery("No value provided to the aggregate filter.")
+
+        raise InvalidSearchQuery(
+            f"'{search_value.raw_value}' is not a valid aggregate filter value."
+        )
 
     def visit_has_filter(self, node, children):
         # the key is has here, which we don't need

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -69,6 +69,7 @@ filter = date_filter
        / aggregate_numeric_filter
        / aggregate_date_filter
        / aggregate_rel_date_filter
+       / aggregate_generic_filter
        / has_filter
        / is_filter
        / text_in_filter
@@ -109,6 +110,9 @@ aggregate_date_filter = negation? aggregate_key sep operator? iso_8601_date_form
 
 # aggregate for relative dates
 aggregate_rel_date_filter = negation? aggregate_key sep operator? rel_date_format
+
+# aggregate generic filter to capture partial values
+aggregate_generic_filter = negation? aggregate_key sep operator? search_value
 
 # has filter for not null type checks
 has_filter = negation? &"has:" search_key sep (search_key / search_value)
@@ -811,6 +815,12 @@ class SearchVisitor(NodeVisitor):
         # Invalid formats fall back to text match
         search_value = operator + search_value.text if operator != "=" else search_value
         return AggregateFilter(search_key, "=", SearchValue(search_value))
+
+    def visit_aggregate_generic_filter(self, node, children):
+        (negation, search_key, _, operator, search_value) = children
+        operator = handle_negation(negation, operator)
+
+        raise InvalidSearchQuery("Aggregate filter is incomplete.")
 
     def visit_has_filter(self, node, children):
         # the key is has here, which we don't need

--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -54,6 +54,7 @@ filter
   / aggregate_percentage_filter
   / aggregate_date_filter
   / aggregate_rel_date_filter
+  / aggregate_generic_filter
   / has_filter
   / is_filter
   / text_in_filter
@@ -145,6 +146,14 @@ aggregate_date_filter
       return tc.predicateFilter(FilterType.AggregateDate, key)
     } {
       return tc.tokenFilter(FilterType.AggregateDate, key, value, op, !!negation);
+    }
+
+// aggregate generic filter to capture partial values.
+aggregate_generic_filter
+  = negation:negation? key:aggregate_key sep op:operator? value:search_value &{
+      return tc.predicateFilter(FilterType.AggregateGeneric, key)
+    } {
+      return tc.tokenFilter(FilterType.AggregateGeneric, key, value, op, !!negation);
     }
 
 // filter for relative dates

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -93,6 +93,7 @@ export enum FilterType {
   AggregateNumeric = 'aggregateNumeric',
   AggregateDate = 'aggregateDate',
   AggregateRelativeDate = 'aggregateRelativeDate',
+  AggregateGeneric = 'aggregateGeneric',
   Has = 'has',
   Is = 'is',
 }
@@ -217,6 +218,12 @@ export const filterTypeConfig = {
     validKeys: [Token.KeyAggregate],
     validOps: allOperators,
     validValues: [Token.ValueRelativeDate],
+    canNegate: true,
+  },
+  [FilterType.AggregateGeneric]: {
+    validKeys: [Token.KeyAggregate],
+    validOps: allOperators,
+    validValues: [Token.ValueText],
     canNegate: true,
   },
   [FilterType.Has]: {
@@ -598,6 +605,10 @@ export class TokenConverter {
 
     if ([FilterType.TextIn, FilterType.NumericIn].includes(filter)) {
       return this.checkInvalidInFilter(value as InFilter['value']);
+    }
+
+    if (filter === FilterType.AggregateGeneric) {
+      return {reason: 'Aggregate filter is incomplete.'};
     }
 
     return null;

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -608,7 +608,9 @@ export class TokenConverter {
     }
 
     if (filter === FilterType.AggregateGeneric) {
-      return {reason: 'Aggregate filter is incomplete.'};
+      return this.checkInvalidAggregateFilter(
+        value as FilterMap['aggregateGeneric']['value']
+      );
     }
 
     return null;
@@ -693,6 +695,17 @@ export class TokenConverter {
     }
 
     return null;
+  };
+
+  /**
+   * Aggregate filters are either incomplete or invalid aggregates, so they will always be invalid.
+   */
+  checkInvalidAggregateFilter = (value: FilterMap['aggregateGeneric']['value']) => {
+    if (value.text === '') {
+      return {reason: 'No value provided to the aggregate filter.'};
+    }
+
+    return {reason: `'${value.text}' is not a valid aggregate filter value.`};
   };
 }
 

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -641,8 +641,9 @@ class ParseBooleanSearchQueryTest(TestCase):
             "failure_rate():>0.003&& users:>10 event.type:transaction",
             params={"organization_id": self.organization.id, "project_id": [self.project.id]},
         )
+        assert result.condition_aggregates == ["failure_rate()"]
+        assert result.having == [["failure_rate", ">", "0.003&&"]]
         assert result.conditions == [
-            _om("failure_rate():>0.003&&"),
             [["ifNull", ["users", "''"]], "=", ">10"],
             ["event.type", "=", "transaction"],
         ]
@@ -2450,11 +2451,10 @@ def _project(x):
             "aggregate_like_message_and_columns",
             "failure_rate():>0.003&& users:>10 event.type:transaction",
             [
-                _message("failure_rate():>0.003&&"),
                 _tag("users", ">10"),
                 _cond("type", Op.EQ, "transaction"),
             ],
-            [],
+            [Condition(Function("failure_rate", [], "failure_rate"), Op.GT, "0.003&&")],
         ),
         (
             "message_with_parens",

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -3591,10 +3591,6 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         )
 
     def test_messed_up_function_values(self):
-        # TODO (evanh): It would be nice if this surfaced an error to the user.
-        # The problem: The && causes the parser to treat that term not as a bad
-        # function call but a valid raw search with parens in it. It's not trivial
-        # to change the parser to recognize "bad function values" and surface them.
         for v in ["a", "b"]:
             self.store_event(
                 data={
@@ -3624,9 +3620,8 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
             "statsPeriod": "24h",
         }
         response = self.do_request(query, features=features)
-        assert response.status_code == 200, response.content
-        data = response.data["data"]
-        assert len(data) == 0
+        assert response.status_code == 400
+        assert response.data["detail"] == "'0.003&&' is not a valid aggregate filter value."
 
     def test_context_fields_between_datasets(self):
         event_data = load_data("android")


### PR DESCRIPTION
Partial aggregate filters (such as `count():` or `any(...):`) were not parsed as filters, meaning they weren't highlighted and didn't have shortcuts or operator helper suggestions. 

Achieved this via introducing a new `FilterType.AggregateGeneric` before the value is present in the query as an intermediate filter type before the value is typed just so partial aggregate keys are considered filters. On both frontend and backend, all `AggregateGeneric`s are marked invalid. If they have a value, the invalid message will say the value is not a valid aggregate value, if there is no value, the invalid message will say that the aggregate filter is incomplete.

## Before:
<img width="1465" alt="Screen Shot 2022-07-12 at 2 09 10 PM" src="https://user-images.githubusercontent.com/30991498/178595989-2f237b56-0189-4e82-808d-9b32c75d185a.png">
<img width="1476" alt="Screen Shot 2022-07-12 at 2 09 00 PM" src="https://user-images.githubusercontent.com/30991498/178595996-1af81cd3-9c93-412d-89e9-ecd8dba9cf35.png">

## After:
<img width="1485" alt="Screen Shot 2022-07-12 at 2 10 14 PM" src="https://user-images.githubusercontent.com/30991498/178596014-334d9630-de8c-4eb5-8a9c-918d1fe01e6f.png">
<img width="1461" alt="Screen Shot 2022-07-12 at 2 10 04 PM" src="https://user-images.githubusercontent.com/30991498/178596018-20095e5f-70b7-48e6-bc41-8f07caa9532e.png">

