### PR TITLE
feat(hybrid-cloud): Add customer domain support for event-stats endpoint

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -11,8 +11,6 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.utils.http import urlquote
 from django.views.decorators.csrf import csrf_exempt
-from drf_spectacular.drainage import get_view_method_names, isolate_view_method
-from drf_spectacular.utils import extend_schema, extend_schema_view
 from pytz import utc
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import ParseError
@@ -478,28 +476,14 @@ def create_region_endpoint_class(endpoint_class):
     For example, if the endpoint_class's name is "OrganizationEventsEndpoint", then the extended class will be
     "RegionOrganizationEventsEndpoint".
 
-    In addition, we decorate the extended class with the extend_schema_view decorator such that the operation_id for
-    any and all methods that are decorated with the extend_schema decorator are suffixed with "(region aware)".
-    For example, if a method's operation_id value is "Query Discover Events in Table Format", then the operation_id of
-    the extended class's method will be "Query Discover Events in Table Format (region aware)".
+    In addition, we mark the extended region endpoint class as a private API, and nulling out any "public" attribute.
     """
-    region_endpoint_class = type(f"Region{endpoint_class.__name__}", (endpoint_class,), {})
-    schema = {}
-    for method_name in get_view_method_names(endpoint_class):
-        method = isolate_view_method(endpoint_class, method_name)
-        if not (method and hasattr(method, "kwargs") and "schema" in method.kwargs):
-            continue
-        extended_schema = method.kwargs["schema"]()
-        # NOTE: this is a hack to be able to retrieve the operation_id values
-        extended_schema.view = type(
-            "View",
-            (),
-            {"request": None, "kwargs": {}, "determine_version": lambda self: (None, None)},
-        )
-        schema[method_name] = extend_schema(
-            operation_id=f"{extended_schema.get_operation_id()} (region aware)",
-            # Exclude this endpoint that is specific for a region silo from the schema.
-            # In the future, we may include them once we can publicly allow users to consume these APIs.
-            exclude=True,
-        )
-    return extend_schema_view(**schema)(region_endpoint_class)
+    return type(
+        f"Region{endpoint_class.__name__}",
+        (endpoint_class,),
+        {
+            # Mark the extended region endpoint class as a private API, and nulling out any "public" attribute.
+            "public": None,
+            "private": True,
+        },
+    )

--- a/src/sentry/api/region_organization_urls.py
+++ b/src/sentry/api/region_organization_urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from sentry.api.base import create_region_endpoint_class
 
 from .endpoints.organization_events import OrganizationEventsEndpoint
+from .endpoints.organization_events_stats import OrganizationEventsStatsEndpoint
 
 urlpatterns = [  # Organizations
     # Organizations
@@ -10,5 +11,10 @@ urlpatterns = [  # Organizations
         r"^events/$",
         create_region_endpoint_class(OrganizationEventsEndpoint).as_view(),
         name="sentry-api-0-region-organization-events",
-    )
+    ),
+    url(
+        r"^events-stats/$",
+        create_region_endpoint_class(OrganizationEventsStatsEndpoint).as_view(),
+        name="sentry-api-0-region-organization-events-stats",
+    ),
 ]


### PR DESCRIPTION
This adds customer domain support for the event-stats endpoint. The frontend portion of this change will follow in another pull request.

I've also simplified the `create_region_endpoint_class()` function.