### PR TITLE
fix(hybrid-cloud): Fix org slugify on saving new instances of Organization

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -186,14 +186,17 @@ class Organization(Model):
         return f"{self.name} ({self.slug})"
 
     def save(self, *args, **kwargs):
+        slugify_target = None
         if not self.slug:
+            slugify_target = self.name
+        elif not self.id:
+            slugify_target = self.slug
+        if slugify_target is not None:
             lock = locks.get("slug:organization", duration=5, name="organization_slug")
             with TimedRetryPolicy(10)(lock.acquire):
-                slugify_target = self.name.replace("_", "-").strip("-")
+                slugify_target = slugify_target.replace("_", "-").strip("-")
                 slugify_instance(self, slugify_target, reserved=RESERVED_ORGANIZATION_SLUGS)
-            super().save(*args, **kwargs)
-        else:
-            super().save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     def delete(self, **kwargs):
         from sentry.models import NotificationSetting

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -256,7 +256,7 @@ class GroupTest(TestCase, SnubaTestCase):
                 "\u00F6rg3",
                 86,
                 {"env\u00EDronment": "d\u00E9v"},
-                "http://testserver/organizations/%C3%B6rg3/issues/86/?env%C3%ADronment=d%C3%A9v",
+                "http://testserver/organizations/org3/issues/86/?env%C3%ADronment=d%C3%A9v",
             ),
         ]:
             org = self.create_organization(slug=org_slug)

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -39,6 +39,18 @@ from sentry.utils.audit import create_system_audit_entry
 
 
 class OrganizationTest(TestCase):
+    def test_slugify_on_new_orgs(self):
+        org = Organization.objects.create(name="name", slug="---downtown_canada---")
+        assert org.slug == "downtown-canada"
+
+        # Only slugify on new instances of Organization
+        org.slug = "---downtown_canada---"
+        org.save()
+        assert org.slug == "---downtown_canada---"
+
+        org = Organization.objects.create(name="---foo_bar---")
+        assert org.slug == "foo-bar"
+
     def test_merge_to(self):
         from_owner = self.create_user("foo@example.com")
         from_org = self.create_organization(owner=from_owner)

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -46,6 +46,7 @@ class OrganizationTest(TestCase):
         # Only slugify on new instances of Organization
         org.slug = "---downtown_canada---"
         org.save()
+        org.refresh_from_db()
         assert org.slug == "---downtown_canada---"
 
         org = Organization.objects.create(name="---foo_bar---")


### PR DESCRIPTION
Somehow users are creating new organizations with illegal org slugs. I've refactored how we're slugifying on new instances of Organization, even when `self.slug` is provided.