### PR TITLE
feat(mep): Restructure how we determine entity subscription for alerts

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -41,7 +41,7 @@ from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
     EntitySubscription,
     get_entity_key_from_query_builder,
-    get_entity_subscription_for_dataset,
+    get_entity_subscription_from_snuba_query,
 )
 from sentry.snuba.models import QueryDatasets
 from sentry.snuba.subscriptions import (
@@ -371,11 +371,9 @@ def get_incident_aggregates(
     Calculates aggregate stats across the life of an incident, or the provided range.
     """
     snuba_query = incident.alert_rule.snuba_query
-    entity_subscription = get_entity_subscription_for_dataset(
-        dataset=QueryDatasets(snuba_query.dataset),
-        aggregate=snuba_query.aggregate,
-        time_window=snuba_query.time_window,
-        extra_fields={"org_id": incident.organization.id, "event_types": snuba_query.event_types},
+    entity_subscription = get_entity_subscription_from_snuba_query(
+        snuba_query,
+        incident.organization_id,
     )
     query_builder = build_incident_query_builder(
         incident, entity_subscription, start, end, windowed_stats

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -28,9 +28,10 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
     get_entity_key_from_query_builder,
-    get_entity_subscription_for_dataset,
+    get_entity_subscription,
 )
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
+from sentry.snuba.subscriptions import query_datasets_to_type
 from sentry.snuba.tasks import build_query_builder
 
 from . import CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS, DATASET_VALID_EVENT_TYPES, UNSUPPORTED_QUERIES
@@ -214,6 +215,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
     def _validate_query(self, data):
         data.setdefault("dataset", QueryDatasets.EVENTS)
         dataset = QueryDatasets(data["dataset"])
+        query_type = query_datasets_to_type[dataset]
         projects = data.get("projects")
         if not projects:
             # We just need a valid project id from the org so that we can verify
@@ -221,8 +223,12 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             # matter which.
             projects = list(self.context["organization"].project_set.all()[:1])
 
+        # TODO: Need to change this to fetch an entity subscription for an alert_type + dataset.
+        # Loop through all options for a alert rule, and throw an error only if we run out of
+        # options to try.
         try:
-            entity_subscription = get_entity_subscription_for_dataset(
+            entity_subscription = get_entity_subscription(
+                query_type,
                 dataset=dataset,
                 aggregate=data["aggregate"],
                 time_window=int(timedelta(minutes=data["time_window"]).total_seconds()),

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -34,9 +34,10 @@ from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
     BaseMetricsEntitySubscription,
     get_entity_key_from_query_builder,
+    get_entity_subscription_from_snuba_query,
 )
 from sentry.snuba.models import QueryDatasets
-from sentry.snuba.tasks import build_query_builder, get_entity_subscription_for_dataset
+from sentry.snuba.tasks import build_query_builder
 from sentry.utils import metrics, redis
 from sentry.utils.dates import to_datetime, to_timestamp
 
@@ -172,14 +173,9 @@ class SubscriptionProcessor:
         snuba_query = self.subscription.snuba_query
         start = end - timedelta(seconds=snuba_query.time_window)
 
-        entity_subscription = get_entity_subscription_for_dataset(
-            dataset=QueryDatasets(snuba_query.dataset),
-            aggregate=snuba_query.aggregate,
-            time_window=snuba_query.time_window,
-            extra_fields={
-                "org_id": self.subscription.project.organization,
-                "event_types": snuba_query.event_types,
-            },
+        entity_subscription = get_entity_subscription_from_snuba_query(
+            snuba_query,
+            self.subscription.project.organization_id,
         )
         try:
             project_ids = [self.subscription.project_id]

--- a/src/sentry/migrations/0293_restore_metrics_based_alerts.py
+++ b/src/sentry/migrations/0293_restore_metrics_based_alerts.py
@@ -2,15 +2,19 @@
 # Based on https://github.com/getsentry/getsentry/blob/89ff1453be755ddef31f2b99de09bd03badeb25e/getsentry/migrations/0141_migrate_sessions_subs_to_metrics.py
 
 import logging
+import re
 
 from django.db import migrations
 
 from sentry.new_migrations.migrations import CheckedMigration
 from sentry.snuba.dataset import EntityKey
-from sentry.snuba.entity_subscription import map_aggregate_to_entity_key
 from sentry.snuba.models import QueryDatasets
 from sentry.snuba.tasks import _create_in_snuba, _delete_from_snuba
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
+
+CRASH_RATE_ALERT_AGGREGATE_RE = (
+    r"^percentage\([ ]*(sessions_crashed|users_crashed)[ ]*\,[ ]*(sessions|users)[ ]*\)"
+)
 
 
 def create_subscription_in_snuba(subscription):
@@ -21,6 +25,31 @@ def create_subscription_in_snuba(subscription):
 @property
 def event_types(self):
     return [type.event_type for type in self.snubaqueryeventtype_set.all()]
+
+
+def map_aggregate_to_entity_key(dataset: QueryDatasets, aggregate: str) -> EntityKey:
+    if dataset == QueryDatasets.EVENTS:
+        entity_key = EntityKey.Events
+    elif dataset == QueryDatasets.TRANSACTIONS:
+        entity_key = EntityKey.Transactions
+    elif dataset in [QueryDatasets.METRICS, QueryDatasets.SESSIONS]:
+        match = re.match(CRASH_RATE_ALERT_AGGREGATE_RE, aggregate)
+        if not match:
+            raise Exception(
+                f"Only crash free percentage queries are supported for subscriptions"
+                f"over the {dataset.value} dataset"
+            )
+        if dataset == QueryDatasets.METRICS:
+            count_col_matched = match.group(2)
+            if count_col_matched == "sessions":
+                entity_key = EntityKey.MetricsCounters
+            else:
+                entity_key = EntityKey.MetricsSets
+        else:
+            entity_key = EntityKey.Sessions
+    else:
+        raise Exception(f"{dataset} dataset does not have an entity key mapped to it")
+    return entity_key
 
 
 def update_metrics_subscriptions(apps, schema_editor):

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -550,7 +550,9 @@ def get_entity_key_from_query_builder(query_builder: QueryBuilder) -> EntityKey:
     return EntityKey(query_builder.get_snql_query().query.match.name)
 
 
-def get_entity_subscription_from_snuba_query(snuba_query, organization_id):
+def get_entity_subscription_from_snuba_query(
+    snuba_query: SnubaQuery, organization_id: int
+) -> EntitySubscription:
     query_dataset = QueryDatasets(snuba_query.dataset)
     return get_entity_subscription(
         SnubaQuery.Type(snuba_query.type),
@@ -564,7 +566,9 @@ def get_entity_subscription_from_snuba_query(snuba_query, organization_id):
     )
 
 
-def get_entity_key_from_snuba_query(snuba_query, organization_id, project_id):
+def get_entity_key_from_snuba_query(
+    snuba_query: SnubaQuery, organization_id: int, project_id: int
+) -> EntityKey:
     entity_subscription = get_entity_subscription_from_snuba_query(
         snuba_query,
         organization_id,

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -766,8 +766,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
             )
         assert (
             resp.data["nonFieldErrors"][0]
-            == f"Only crash free percentage queries are supported for subscriptions"
-            f"over the {self.valid_alert_rule['dataset']} dataset"
+            == "Only crash free percentage queries are supported for crash rate alerts"
         )
 
     @patch(

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -14,8 +14,8 @@ from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import resolve, resolve_many_weak, resolve_tag_key, resolve_weak
 from sentry.snuba.entity_subscription import (
     apply_dataset_query_conditions,
-    get_entity_subscription_for_dataset,
-    map_aggregate_to_entity_key,
+    get_entity_key_from_query_builder,
+    get_entity_subscription,
 )
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
@@ -355,6 +355,7 @@ class BuildSnqlQueryTest(TestCase):
 
     def run_test(
         self,
+        query_type,
         dataset,
         aggregate,
         query,
@@ -364,13 +365,14 @@ class BuildSnqlQueryTest(TestCase):
         granularity=None,
     ):
         time_window = 3600
-        entity_subscription = get_entity_subscription_for_dataset(
+        entity_subscription = get_entity_subscription(
+            query_type=query_type,
             dataset=dataset,
             aggregate=aggregate,
             time_window=time_window,
             extra_fields=entity_extra_fields,
         )
-        snql_query = build_query_builder(
+        query_builder = build_query_builder(
             entity_subscription,
             query,
             (self.project.id,),
@@ -379,7 +381,8 @@ class BuildSnqlQueryTest(TestCase):
                 "organization_id": self.organization.id,
                 "project_id": [self.project.id],
             },
-        ).get_snql_query()
+        )
+        snql_query = query_builder.get_snql_query()
         select = self.string_aggregate_to_snql(dataset, aggregate)
         if dataset == QueryDatasets.SESSIONS:
             col_name = "sessions" if "sessions" in aggregate else "users"
@@ -392,7 +395,7 @@ class BuildSnqlQueryTest(TestCase):
         # Select order seems to be unstable, so just arbitrarily sort by name, alias so that it's consistent
         snql_query.query.select.sort(key=lambda q: (q.function, q.alias))
         expected_query = Query(
-            match=Entity(map_aggregate_to_entity_key(dataset, aggregate).value),
+            match=Entity(get_entity_key_from_query_builder(query_builder).value),
             select=select,
             where=expected_conditions,
             groupby=[],
@@ -413,6 +416,7 @@ class BuildSnqlQueryTest(TestCase):
 
     def test_simple_events(self):
         self.run_test(
+            SnubaQuery.Type.ERROR,
             QueryDatasets.EVENTS,
             "count_unique(user)",
             "",
@@ -424,6 +428,7 @@ class BuildSnqlQueryTest(TestCase):
 
     def test_simple_transactions(self):
         self.run_test(
+            SnubaQuery.Type.PERFORMANCE,
             QueryDatasets.TRANSACTIONS,
             "count_unique(user)",
             "",
@@ -451,7 +456,11 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
         ]
         self.run_test(
-            QueryDatasets.EVENTS, "count_unique(user)", "release:latest", expected_conditions
+            SnubaQuery.Type.ERROR,
+            QueryDatasets.EVENTS,
+            "count_unique(user)",
+            "release:latest",
+            expected_conditions,
         )
 
     def test_aliased_query_transactions(self):
@@ -461,6 +470,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column("project_id"), Op.IN, (self.project.id,)),
         ]
         self.run_test(
+            SnubaQuery.Type.PERFORMANCE,
             QueryDatasets.TRANSACTIONS,
             "percentile(transaction.duration,.95)",
             "release:latest",
@@ -485,7 +495,11 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
         ]
         self.run_test(
-            QueryDatasets.EVENTS, "count()", "user:anengineer@work.io", expected_conditions
+            SnubaQuery.Type.ERROR,
+            QueryDatasets.EVENTS,
+            "count()",
+            "user:anengineer@work.io",
+            expected_conditions,
         )
 
     def test_user_query_transactions(self):
@@ -494,6 +508,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column("project_id"), Op.IN, (self.project.id,)),
         ]
         self.run_test(
+            SnubaQuery.Type.PERFORMANCE,
             QueryDatasets.TRANSACTIONS,
             "p95()",
             "user:anengineer@work.io",
@@ -529,6 +544,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
         ]
         self.run_test(
+            SnubaQuery.Type.ERROR,
             QueryDatasets.EVENTS,
             "count_unique(user)",
             "release:latest OR release:123",
@@ -569,6 +585,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
         ]
         self.run_test(
+            SnubaQuery.Type.ERROR,
             QueryDatasets.EVENTS,
             "count_unique(user)",
             "release:latest OR release:123",
@@ -596,6 +613,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column(name="project_id"), Op.IN, (self.project.id,)),
         ]
         self.run_test(
+            SnubaQuery.Type.ERROR,
             QueryDatasets.EVENTS,
             "count_unique(user)",
             f"issue.id:[{self.group.id}, 2]",
@@ -609,6 +627,7 @@ class BuildSnqlQueryTest(TestCase):
         ]
 
         self.run_test(
+            SnubaQuery.Type.CRASH_RATE,
             QueryDatasets.SESSIONS,
             "percentage(sessions_crashed, sessions) as _crash_rate_alert_aggregate",
             "",
@@ -622,6 +641,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column(name="org_id"), Op.EQ, self.organization.id),
         ]
         self.run_test(
+            SnubaQuery.Type.CRASH_RATE,
             QueryDatasets.SESSIONS,
             "percentage(users_crashed, users) as _crash_rate_alert_aggregate",
             "",
@@ -638,6 +658,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column(name="org_id"), Op.EQ, self.organization.id),
         ]
         self.run_test(
+            SnubaQuery.Type.CRASH_RATE,
             QueryDatasets.SESSIONS,
             "percentage(sessions_crashed, sessions) as _crash_rate_alert_aggregate",
             "release:ahmed@12.2",
@@ -655,6 +676,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column(name="org_id"), Op.EQ, self.organization.id),
         ]
         self.run_test(
+            SnubaQuery.Type.CRASH_RATE,
             QueryDatasets.SESSIONS,
             "percentage(users_crashed, users) as _crash_rate_alert_aggregate",
             "release:ahmed@12.2",
@@ -682,6 +704,7 @@ class BuildSnqlQueryTest(TestCase):
             ),
         ]
         self.run_test(
+            SnubaQuery.Type.CRASH_RATE,
             QueryDatasets.METRICS,
             "percentage(sessions_crashed, sessions) as _crash_rate_alert_aggregate",
             "",
@@ -705,6 +728,7 @@ class BuildSnqlQueryTest(TestCase):
             ),
         ]
         self.run_test(
+            SnubaQuery.Type.CRASH_RATE,
             QueryDatasets.METRICS,
             "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
             "",
@@ -753,6 +777,7 @@ class BuildSnqlQueryTest(TestCase):
             ),
         ]
         self.run_test(
+            SnubaQuery.Type.CRASH_RATE,
             QueryDatasets.METRICS,
             "percentage(sessions_crashed, sessions) as _crash_rate_alert_aggregate",
             "release:ahmed@12.2",
@@ -797,6 +822,7 @@ class BuildSnqlQueryTest(TestCase):
             ),
         ]
         self.run_test(
+            SnubaQuery.Type.CRASH_RATE,
             QueryDatasets.METRICS,
             "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
             "release:ahmed@12.2",


### PR DESCRIPTION
Previously we mapped a specific `EntityKey` to all `EntitySubscription` classes. As part of
introducing metric based performance alerts, we want to have the `EntitySubscription` determine the
specific entity that the subscription will run on. This allows us to automatically determine the
correct entity for metric based alerts without having to duplicate logic that parses
aggregates/datasets/etc.
