### PR TITLE
feat(dyn-sampling): Add BE validation for uniform rules [TET-191]

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -780,10 +780,12 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
     @staticmethod
     def _is_uniform_sampling_rule(rule):
-        # Currently UI sends top level condition op as always 'and' so asserting this here to
-        # guarantee that it will always have an `inner` key
+        # A uniform sampling rule must be an 'and' with no rules. An 'or' with no rules will not
+        # match anything.
         assert rule["condition"]["op"] == "and"
-        # Matching the uniform sampling rule check on UI
+        # Matching the uniform sampling rule check on UI because currently we only support
+        # uniform rules on traces, not on single transactions. If we change this spec in the
+        # future, we will have to update this to also support single transactions.
         return len(rule["condition"]["inner"]) == 0 and rule["type"] == "trace"
 
     def validate_uniform_sampling_rule(self, rules):

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -796,8 +796,8 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         uniform_rule = rules[-1]
         # Guards against placing uniform sampling rule not in last position or adding multiple
         # uniform sampling rules
-        for i in range(0, len(rules) - 2):
-            if self._is_uniform_sampling_rule(rules[i]):
+        for rule in rules[:-1]:
+            if self._is_uniform_sampling_rule(rule):
                 raise UniformDynamicSamplingRuleException(
                     "Uniform rule must be in the last position only"
                 )

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -783,6 +783,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         # Currently UI sends top level condition op as always 'and' so asserting this here to
         # guarantee that it will always have an `inner` key
         assert rule["condition"]["op"] == "and"
+        # Matching the uniform sampling rule check on UI
         return len(rule["condition"]["inner"]) == 0 and rule["type"] == "trace"
 
     def validate_uniform_sampling_rule(self, rules):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -813,7 +813,10 @@ class ProjectUpdateTest(APITestCase):
                 dynamicSampling=_dyn_sampling_data(multiple_uniform_rules=True),
             )
             assert response.status_code == 400
-            assert response.json()["detail"] == "Uniform rule must be in the last position only"
+            assert (
+                response.json()["dynamicSampling"]["non_field_errors"][0] == "Uniform rule "
+                "must be in the last position only"
+            )
 
     def test_dynamic_sampling_rules_single_uniform_rule_in_last_position(self):
         """
@@ -827,7 +830,7 @@ class ProjectUpdateTest(APITestCase):
             )
             assert response.status_code == 400
             assert (
-                response.json()["detail"]
+                response.json()["dynamicSampling"]["non_field_errors"][0]
                 == "Last rule is reserved for uniform rule which must have no conditions"
             )
 
@@ -841,7 +844,8 @@ class ProjectUpdateTest(APITestCase):
             )
             assert response.status_code == 400
             assert (
-                response.json()["detail"] == "Payload must contain a uniform dynamic sampling rule"
+                response.json()["dynamicSampling"]["non_field_errors"][0]
+                == "Payload must contain a uniform dynamic sampling rule"
             )
 
     def test_cap_secondary_grouping_expiry(self):
@@ -1283,7 +1287,17 @@ def test_rule_config_serializer():
                         {"op": "glob", "name": "field1", "value": ["val"]},
                     ],
                 },
-            }
+            },
+            {
+                "sampleRate": 0.7,
+                "type": "trace",
+                "active": False,
+                "id": 2,
+                "condition": {
+                    "op": "and",
+                    "inner": [],
+                },
+            },
         ],
         "next_id": 22,
     }

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -34,35 +34,61 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
 
-def _dyn_sampling_data():
-    return {
-        "rules": [
-            {
-                "sampleRate": 0.7,
-                "type": "trace",
-                "active": True,
-                "condition": {
-                    "op": "and",
-                    "inner": [
-                        {"op": "eq", "name": "field1", "value": ["val"]},
-                        {"op": "glob", "name": "field1", "value": ["val"]},
-                    ],
-                },
-                "id": 0,
+def _dyn_sampling_data(multiple_uniform_rules=False, uniform_rule_last_position=True):
+    rules = [
+        {
+            "sampleRate": 0.7,
+            "type": "trace",
+            "active": True,
+            "condition": {
+                "op": "and",
+                "inner": [
+                    {"op": "eq", "name": "field1", "value": ["val"]},
+                    {"op": "glob", "name": "field1", "value": ["val"]},
+                ],
             },
+            "id": 0,
+        },
+        {
+            "sampleRate": 0.8,
+            "type": "trace",
+            "active": True,
+            "condition": {
+                "op": "and",
+                "inner": [
+                    {"op": "eq", "name": "field1", "value": ["val"]},
+                ],
+            },
+            "id": 0,
+        },
+    ]
+    if uniform_rule_last_position:
+        rules.append(
             {
                 "sampleRate": 0.8,
                 "type": "trace",
                 "active": True,
                 "condition": {
                     "op": "and",
-                    "inner": [
-                        {"op": "eq", "name": "field1", "value": ["val"]},
-                    ],
+                    "inner": [],
                 },
                 "id": 0,
             },
-        ]
+        )
+    if multiple_uniform_rules:
+        new_rule_1 = {
+            "sampleRate": 0.22,
+            "type": "trace",
+            "condition": {
+                "op": "and",
+                "inner": [],
+            },
+            "id": 0,
+        }
+        rules.insert(0, new_rule_1)
+
+    return {
+        "rules": rules,
     }
 
 
@@ -678,7 +704,9 @@ class ProjectUpdateTest(APITestCase):
                     "type": "trace",
                     "condition": {
                         "op": "and",
-                        "inner": [],
+                        "inner": [
+                            {"op": "eq", "name": "field1", "value": ["val"]},
+                        ],
                     },
                     "id": 0,
                 },
@@ -687,7 +715,9 @@ class ProjectUpdateTest(APITestCase):
                     "type": "trace",
                     "condition": {
                         "op": "and",
-                        "inner": [],
+                        "inner": [
+                            {"op": "eq", "name": "field1", "value": ["val"]},
+                        ],
                     },
                     "id": 0,
                 },
@@ -727,7 +757,9 @@ class ProjectUpdateTest(APITestCase):
             "type": "trace",
             "condition": {
                 "op": "and",
-                "inner": [],
+                "inner": [
+                    {"op": "eq", "name": "field1", "value": ["val"]},
+                ],
             },
             "id": 0,
         }
@@ -769,6 +801,48 @@ class ProjectUpdateTest(APITestCase):
             response = self.get_success_response(self.org_slug, self.proj_slug, method="get")
         saved_config = response.data["dynamicSampling"]
         assert all([rule["active"] for rule in saved_config["rules"]])
+
+    def test_dynamic_sampling_rules_should_contain_single_uniform_rule(self):
+        """
+        Tests that ensures you can only have one uniform rule
+        """
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.get_response(
+                self.org_slug,
+                self.proj_slug,
+                dynamicSampling=_dyn_sampling_data(multiple_uniform_rules=True),
+            )
+            assert response.status_code == 400
+            assert response.json()["detail"] == "Uniform rule must be in the last position only"
+
+    def test_dynamic_sampling_rules_single_uniform_rule_in_last_position(self):
+        """
+        Tests that ensures you can only have one uniform rule, and it is at the last position
+        """
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.get_response(
+                self.org_slug,
+                self.proj_slug,
+                dynamicSampling=_dyn_sampling_data(uniform_rule_last_position=False),
+            )
+            assert response.status_code == 400
+            assert (
+                response.json()["detail"]
+                == "Last rule is reserved for uniform rule which must have no conditions"
+            )
+
+    def test_dynamic_sampling_rules_should_contain_uniform_rule(self):
+        """
+        Tests that ensures that payload has a uniform rule i.e. guards against deletion of rule
+        """
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.get_response(
+                self.org_slug, self.proj_slug, dynamicSampling={"rules": []}
+            )
+            assert response.status_code == 400
+            assert (
+                response.json()["detail"] == "Payload must contain a uniform dynamic sampling rule"
+            )
 
     def test_cap_secondary_grouping_expiry(self):
         now = time()


### PR DESCRIPTION
Adds validation that ensures uniform sampling rule
cannot be deleted, no multiple uniform rules can
co-exist and unifrom rule is always in the last position

