### PR TITLE
fix(perf): Fix asset measurements sending NaN/null

### DIFF
--- a/static/app/utils/performanceForSentry.tsx
+++ b/static/app/utils/performanceForSentry.tsx
@@ -362,11 +362,11 @@ const measureAssetsOnTransaction = () => {
         const filtered = spans.filter(s => s.op === op);
         const count = filtered.length;
         const transfered = filtered.reduce(
-          (acc, curr) => acc + curr.data['Transfer Size'] ?? 0,
+          (acc, curr) => acc + (curr.data['Transfer Size'] ?? 0),
           0
         );
         const encoded = filtered.reduce(
-          (acc, curr) => acc + curr.data['Encoded Body Size'] ?? 0,
+          (acc, curr) => acc + (curr.data['Encoded Body Size'] ?? 0),
           0
         );
 


### PR DESCRIPTION
### Summary
The nullish coalescing wasn't wrapped in parens so it was ambiguous. This should fix this specific case happening again, but we should also look into why the transfer sizes aren't even defined, which was unexpected.
