### PR TITLE
Typo in documentation of "Provision a New Organization Member"

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -362,7 +362,7 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
         Create a new Organization Member via a SCIM Users POST Request.
         - `userName` should be set to the SAML field used for email, and active should be set to `true`.
         - Sentry's SCIM API doesn't currently support setting users to inactive,
-        and the member will be deleted if inactive is set to `false`.
+        and the member will be deleted if active is set to `false`.
         - The API also does not support setting secondary emails.
         """
 


### PR DESCRIPTION
There is no parameter called `inactive`, I believe the documentation has a typo

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
