### PR TITLE
test(event_manager): Fix incorrect invocations of manager.save

### DIFF
--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -74,18 +74,18 @@ class EventManagerTest(TestCase):
         # generate a hash per letter
         manager = EventManager(make_event(event_id="a", message="foo bar"))
         manager.normalize()
-        event1 = manager.save(1)
+        event1 = manager.save(self.project.id)
 
         manager = EventManager(make_event(event_id="b", message="foo baz"))
         manager.normalize()
-        event2 = manager.save(1)
+        event2 = manager.save(self.project.id)
 
         assert event1.group_id != event2.group_id
 
     def test_ephemeral_interfaces_removed_on_save(self):
         manager = EventManager(make_event(platform="python"))
         manager.normalize()
-        event = manager.save(1)
+        event = manager.save(self.project.id)
 
         group = event.group
         assert group.platform == "python"
@@ -116,7 +116,7 @@ class EventManagerTest(TestCase):
             make_event(message="foo", event_id="a" * 32, checksum="a" * 32, timestamp=timestamp)
         )
         manager.normalize()
-        event = manager.save(1)
+        event = manager.save(self.project.id)
 
         manager = EventManager(
             make_event(
@@ -126,7 +126,7 @@ class EventManagerTest(TestCase):
         manager.normalize()
 
         with self.tasks():
-            event2 = manager.save(1)
+            event2 = manager.save(self.project.id)
 
         group = Group.objects.get(id=event.group_id)
 
@@ -295,13 +295,13 @@ class EventManagerTest(TestCase):
             make_event(message="foo", event_id="a" * 32, fingerprint=["a" * 32], timestamp=ts)
         )
         with self.tasks():
-            event = manager.save(1)
+            event = manager.save(self.project.id)
 
         manager = EventManager(
             make_event(message="foo bar", event_id="b" * 32, fingerprint=["a" * 32], timestamp=ts)
         )
         with self.tasks():
-            event2 = manager.save(1)
+            event2 = manager.save(self.project.id)
 
         group = Group.objects.get(id=event.group_id)
 
@@ -315,14 +315,14 @@ class EventManagerTest(TestCase):
         )
         with self.tasks():
             manager.normalize()
-            event = manager.save(1)
+            event = manager.save(self.project.id)
 
         manager = EventManager(
             make_event(message="foo bar", event_id="b" * 32, fingerprint=["a" * 32])
         )
         with self.tasks():
             manager.normalize()
-            event2 = manager.save(1)
+            event2 = manager.save(self.project.id)
 
         assert event.group_id != event2.group_id
 
@@ -334,7 +334,7 @@ class EventManagerTest(TestCase):
         # later timestamp than event1.
         manager = EventManager(make_event(event_id="a" * 32, checksum="a" * 32, timestamp=ts))
         with self.tasks():
-            event = manager.save(1)
+            event = manager.save(self.project.id)
 
         group = Group.objects.get(id=event.group_id)
         group.status = GroupStatus.RESOLVED
@@ -342,7 +342,7 @@ class EventManagerTest(TestCase):
         assert group.is_resolved()
 
         manager = EventManager(make_event(event_id="b" * 32, checksum="a" * 32, timestamp=ts + 50))
-        event2 = manager.save(1)
+        event2 = manager.save(self.project.id)
         assert event.group_id == event2.group_id
 
         group = Group.objects.get(id=group.id)
@@ -360,7 +360,7 @@ class EventManagerTest(TestCase):
         )
         with self.tasks():
             manager.normalize()
-            event = manager.save(1)
+            event = manager.save(self.project.id)
 
         group = Group.objects.get(id=event.group_id)
         group.status = GroupStatus.RESOLVED
@@ -371,7 +371,7 @@ class EventManagerTest(TestCase):
             make_event(event_id="b" * 32, checksum="a" * 32, timestamp=1403007315)
         )
         manager.normalize()
-        event2 = manager.save(1)
+        event2 = manager.save(self.project.id)
         assert event.group_id == event2.group_id
 
         group = Group.objects.get(id=group.id)
@@ -399,7 +399,7 @@ class EventManagerTest(TestCase):
                 release=old_release.version,
             )
         )
-        event = manager.save(1)
+        event = manager.save(self.project.id)
 
         group = event.group
 
@@ -419,7 +419,7 @@ class EventManagerTest(TestCase):
                 event_id="b" * 32, checksum="a" * 32, timestamp=time(), release=old_release.version
             )
         )
-        event = manager.save(1)
+        event = manager.save(self.project.id)
         assert event.group_id == group.id
 
         group = Group.objects.get(id=group.id)
@@ -433,7 +433,7 @@ class EventManagerTest(TestCase):
         manager = EventManager(
             make_event(event_id="c" * 32, checksum="a" * 32, timestamp=time(), release="b")
         )
-        event = manager.save(1)
+        event = manager.save(self.project.id)
         assert event.group_id == group.id
 
         group = Group.objects.get(id=group.id)
@@ -472,7 +472,7 @@ class EventManagerTest(TestCase):
                 release=old_release.version,
             )
         )
-        event = manager.save(1)
+        event = manager.save(self.project.id)
         group = event.group
         group.update(status=GroupStatus.RESOLVED)
 
@@ -490,7 +490,7 @@ class EventManagerTest(TestCase):
         manager = EventManager(
             make_event(event_id="c" * 32, checksum="a" * 32, timestamp=time(), release="b")
         )
-        event = manager.save(1)
+        event = manager.save(self.project.id)
         assert event.group_id == group.id
 
         group = Group.objects.get(id=group.id)
@@ -530,7 +530,7 @@ class EventManagerTest(TestCase):
                 release=old_release.version,
             )
         )
-        event = manager.save(1)
+        event = manager.save(self.project.id)
         group = event.group
         group.update(status=GroupStatus.RESOLVED)
 
@@ -548,7 +548,7 @@ class EventManagerTest(TestCase):
         manager = EventManager(
             make_event(event_id="c" * 32, checksum="a" * 32, timestamp=time(), release="b")
         )
-        event = manager.save(1)
+        event = manager.save(self.project.id)
         assert event.group_id == group.id
 
         group = Group.objects.get(id=group.id)
@@ -771,7 +771,7 @@ class EventManagerTest(TestCase):
                 release=old_release.version,
             )
         )
-        event = manager.save(1)
+        event = manager.save(self.project.id)
 
         group = event.group
 
@@ -822,7 +822,7 @@ class EventManagerTest(TestCase):
 
         with self.tasks():
             with self.feature({"organizations:integrations-issue-sync": True}):
-                event = manager.save(1)
+                event = manager.save(self.project.id)
                 assert event.group_id == group.id
 
                 group = Group.objects.get(id=group.id)
@@ -836,7 +836,7 @@ class EventManagerTest(TestCase):
                 manager = EventManager(
                     make_event(event_id="c" * 32, checksum="a" * 32, timestamp=time(), release="b")
                 )
-                event = manager.save(1)
+                event = manager.save(self.project.id)
                 mock_sync_status_outbound.assert_called_once_with(
                     external_issue, False, event.group.project_id
                 )
@@ -937,12 +937,12 @@ class EventManagerTest(TestCase):
         mock_is_resolved.return_value = False
         manager = EventManager(make_event(event_id="a" * 32, checksum="a" * 32, timestamp=ts))
         with self.tasks():
-            event = manager.save(1)
+            event = manager.save(self.project.id)
 
         mock_is_resolved.return_value = True
         manager = EventManager(make_event(event_id="b" * 32, checksum="a" * 32, timestamp=ts + 100))
         with self.tasks():
-            event2 = manager.save(1)
+            event2 = manager.save(self.project.id)
         assert event.group_id == event2.group_id
 
         group = Group.objects.get(id=event.group.id)
@@ -953,20 +953,20 @@ class EventManagerTest(TestCase):
         dict_input = {"messages": "foo"}
         manager = EventManager(make_event(transaction=dict_input))
         manager.normalize()
-        event = manager.save(1)
+        event = manager.save(self.project.id)
         assert event.transaction is None
 
     def test_transaction_as_culprit(self):
         manager = EventManager(make_event(transaction="foobar"))
         manager.normalize()
-        event = manager.save(1)
+        event = manager.save(self.project.id)
         assert event.transaction == "foobar"
         assert event.culprit == "foobar"
 
     def test_culprit_is_not_transaction(self):
         manager = EventManager(make_event(culprit="foobar"))
         manager.normalize()
-        event1 = manager.save(1)
+        event1 = manager.save(self.project.id)
         assert event1.transaction is None
         assert event1.culprit == "foobar"
 
@@ -1007,20 +1007,20 @@ class EventManagerTest(TestCase):
             "enhancements": enhancement.dumps(),
             "id": "legacy:2019-03-12",
         }
-        event1 = manager.save(1)
+        event1 = manager.save(self.project.id)
         assert event1.transaction is None
         assert event1.culprit == "in_app_function"
 
     def test_inferred_culprit_from_empty_stacktrace(self):
         manager = EventManager(make_event(stacktrace={"frames": []}))
         manager.normalize()
-        event = manager.save(1)
+        event = manager.save(self.project.id)
         assert event.culprit == ""
 
     def test_transaction_and_culprit(self):
         manager = EventManager(make_event(transaction="foobar", culprit="baz"))
         manager.normalize()
-        event1 = manager.save(1)
+        event1 = manager.save(self.project.id)
         assert event1.transaction == "foobar"
         assert event1.culprit == "baz"
 
@@ -1084,7 +1084,7 @@ class EventManagerTest(TestCase):
     def test_group_release_with_env(self):
         manager = EventManager(make_event(release="1.0", environment="prod", event_id="a" * 32))
         manager.normalize()
-        event = manager.save(1)
+        event = manager.save(self.project.id)
 
         release = Release.objects.get(version="1.0", projects=event.project_id)
 
@@ -1093,7 +1093,7 @@ class EventManagerTest(TestCase):
         ).exists()
 
         manager = EventManager(make_event(release="1.0", environment="staging", event_id="b" * 32))
-        event = manager.save(1)
+        event = manager.save(self.project.id)
 
         release = Release.objects.get(version="1.0", projects=event.project_id)
 
@@ -1573,7 +1573,7 @@ class EventManagerTest(TestCase):
     def test_throws_when_matches_discarded_hash(self):
         manager = EventManager(make_event(message="foo", event_id="a" * 32, fingerprint=["a" * 32]))
         with self.tasks():
-            event = manager.save(1)
+            event = manager.save(self.project.id)
 
         group = Group.objects.get(id=event.group_id)
         tombstone = GroupTombstone.objects.create(
@@ -1605,7 +1605,7 @@ class EventManagerTest(TestCase):
             with self.feature("organizations:event-attachments"):
                 with self.tasks():
                     with pytest.raises(HashDiscarded):
-                        event = manager.save(1, cache_key=cache_key)
+                        event = manager.save(self.project.id, cache_key=cache_key)
 
         assert mock_track_outcome.call_count == 3
 
@@ -1682,7 +1682,7 @@ class EventManagerTest(TestCase):
 
         mock_track_outcome = mock.Mock()
         with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
-            manager.save(1)
+            manager.save(self.project.id)
 
         assert_mock_called_once_with_partial(
             mock_track_outcome, outcome=Outcome.ACCEPTED, category=DataCategory.ERROR
@@ -1702,7 +1702,7 @@ class EventManagerTest(TestCase):
         mock_track_outcome = mock.Mock()
         with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
             with self.feature("organizations:event-attachments"):
-                manager.save(1, cache_key=cache_key)
+                manager.save(self.project.id, cache_key=cache_key)
 
         assert mock_track_outcome.call_count == 3
 
@@ -1731,7 +1731,7 @@ class EventManagerTest(TestCase):
         mock_track_outcome = mock.Mock()
         with mock.patch("sentry.event_manager.track_outcome", mock_track_outcome):
             with self.feature("organizations:event-attachments"):
-                manager.save(1, cache_key=cache_key)
+                manager.save(self.project.id, cache_key=cache_key)
 
         assert mock_track_outcome.call_count == 3
 
@@ -1770,7 +1770,7 @@ class EventManagerTest(TestCase):
             event_id=uuid.uuid1().hex,
         )
         manager = EventManager(event)
-        event = manager.save(1)
+        event = manager.save(self.project.id)
 
         # release and environment stay toplevel
         assert event.data["release"] == "my-release"
@@ -1897,7 +1897,7 @@ class EventManagerTest(TestCase):
             "enhancements": enhancement.dumps(),
             "id": "mobile:2021-02-12",
         }
-        event1 = manager.save(1)
+        event1 = manager.save(self.project.id)
         assert event1.data["exception"]["values"][0]["stacktrace"]["frames"][0]["in_app"] is False
 
         event = make_event(
@@ -1926,7 +1926,7 @@ class EventManagerTest(TestCase):
             "enhancements": enhancement.dumps(),
             "id": "mobile:2021-02-12",
         }
-        event2 = manager.save(1)
+        event2 = manager.save(self.project.id)
         assert event2.data["exception"]["values"][0]["stacktrace"]["frames"][0]["in_app"] is False
         assert event1.group_id == event2.group_id
 
@@ -1974,7 +1974,7 @@ class EventManagerTest(TestCase):
         }
 
         manager.get_data()["grouping_config"] = grouping_config
-        event1 = manager.save(1)
+        event1 = manager.save(self.project.id)
 
         event2 = Event(event1.project_id, event1.event_id, data=event1.data)
 
@@ -2010,7 +2010,7 @@ class EventManagerTest(TestCase):
         manager.get_data()["grouping_config"] = {
             "id": "mobile:2021-02-12",
         }
-        event = manager.save(1)
+        event = manager.save(self.project.id)
 
         assert event.data["hierarchical_tree_labels"] == [None]
 
@@ -2036,7 +2036,7 @@ class EventManagerTest(TestCase):
         manager.get_data()["grouping_config"] = {
             "id": "mobile:2021-02-12",
         }
-        event = manager.save(1)
+        event = manager.save(self.project.id)
 
         mechanism = event.interfaces["exception"].values[0].mechanism
         assert mechanism is not None


### PR DESCRIPTION
These tests pass the hardcoded project id of 1. For some reason the actual project it is now 2. Instead of hardcoding this now passes the project id explicitly.