### PR TITLE
feat(sampling): Format and round sample rates [TET-211]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
@@ -71,9 +71,7 @@ export function RecommendedStepsModal({
     disable: !!clientSampleRate,
   });
   const {maxSafeSampleRate} = projectStatsToSampleRates(projectStats);
-  const suggestedClientSampleRate = clientSampleRate
-    ? clientSampleRate / 100
-    : maxSafeSampleRate;
+  const suggestedClientSampleRate = clientSampleRate ?? maxSafeSampleRate;
 
   const isValid =
     isValidSampleRate(clientSampleRate) && isValidSampleRate(serverSampleRate);

--- a/static/app/views/settings/project/server-side-sampling/rule.tsx
+++ b/static/app/views/settings/project/server-side-sampling/rule.tsx
@@ -15,6 +15,7 @@ import {t, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Project} from 'sentry/types';
 import {SamplingRule, SamplingRuleOperator} from 'sentry/types/sampling';
+import {formatPercentage} from 'sentry/utils/formatters';
 
 import {getInnerNameLabel, isUniformRule} from './utils';
 
@@ -118,7 +119,7 @@ export function Rule({
             ))}
       </ConditionColumn>
       <RateColumn>
-        <SampleRate>{`${rule.sampleRate * 100}\u0025`}</SampleRate>
+        <SampleRate>{formatPercentage(rule.sampleRate)}</SampleRate>
       </RateColumn>
       <ActiveColumn>
         <GuideAnchor

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -283,7 +283,7 @@ export function ServerSideSampling({project}: Props) {
     trackAdvancedAnalyticsEvent('sampling.settings.rule.specific_delete', {
       organization,
       project_id: project.id,
-      sampling_rate: rule.sampleRate * 100,
+      sampling_rate: rule.sampleRate,
       conditions,
       conditions_stringified: conditions.sort().join(', '),
     });
@@ -328,7 +328,7 @@ export function ServerSideSampling({project}: Props) {
         op: SamplingConditionOperator.AND,
         inner: [],
       },
-      sampleRate: sampleRate / 100,
+      sampleRate,
     };
 
     trackAdvancedAnalyticsEvent(
@@ -348,8 +348,8 @@ export function ServerSideSampling({project}: Props) {
       {
         organization: organization.slug,
         project_id: project.id,
-        sampling_rate: newRule.sampleRate * 100,
-        old_sampling_rate: rule ? rule.sampleRate * 100 : null,
+        sampling_rate: newRule.sampleRate,
+        old_sampling_rate: rule ? rule.sampleRate : null,
       }
     );
 

--- a/static/app/views/settings/project/server-side-sampling/utils/index.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/index.tsx
@@ -1,3 +1,5 @@
+import round from 'lodash/round';
+
 import {t} from 'sentry/locale';
 import {SamplingInnerName, SamplingRule, SamplingRuleType} from 'sentry/types/sampling';
 import {defined} from 'sentry/utils';
@@ -35,4 +37,20 @@ export function isValidSampleRate(sampleRate: number | undefined) {
   }
 
   return !isNaN(sampleRate) && sampleRate <= 100 && sampleRate >= 0;
+}
+
+export function rateToPercentage(rate: number | undefined, decimalPlaces: number = 2) {
+  if (!defined(rate)) {
+    return rate;
+  }
+
+  return round(rate * 100, decimalPlaces);
+}
+
+export function percentageToRate(rate: number | undefined, decimalPlaces: number = 4) {
+  if (!defined(rate)) {
+    return rate;
+  }
+
+  return round(rate / 100, decimalPlaces);
 }

--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.tsx
@@ -15,12 +15,15 @@ import {quantityField} from '.';
 
 export function projectStatsToPredictedSeries(
   projectStats?: SeriesApi,
-  clientRate?: number,
-  serverRate?: number
+  client?: number,
+  server?: number
 ): Series[] {
-  if (!projectStats || !defined(clientRate) || !defined(serverRate)) {
+  if (!projectStats || !defined(client) || !defined(server)) {
     return [];
   }
+
+  const clientRate = Math.max(Math.min(client, 1), 0);
+  let serverRate = Math.max(Math.min(server, 1), 0);
 
   const commonSeriesConfig = {
     barMinHeight: 1,

--- a/tests/js/spec/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
@@ -41,7 +41,7 @@ describe('Server-side Sampling - Recommended Steps Modal', function () {
         ]}
         onReadDocs={jest.fn()}
         onSubmit={jest.fn()}
-        clientSampleRate={50}
+        clientSampleRate={0.5}
       />
     ));
 


### PR DESCRIPTION
This PR makes sure that we always display the sample rate rounded and in a nice format.

Before this PR we used to use the range 0-1 and 0-100 inconsistently resulting in doing a lot of manual `x / 100` and `x * 100`.
Now we are always in the 0-1 range and using the 0-100 only for display purposes.