### PR TITLE
ref(ci): Bump timeout of acceptance jobs

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -107,7 +107,7 @@ jobs:
     needs: files-changed
     name: acceptance
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)


### PR DESCRIPTION
I've hit this more than once with one of the acceptance jobs, thus, needing to re-run in order to trigger Visual Snapshots.