### PR TITLE
fix(selectAllNotice): Use Alert component, not alertStyles

### DIFF
--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -5,7 +5,7 @@ import uniq from 'lodash/uniq';
 import {bulkDelete, bulkUpdate, mergeGroups} from 'sentry/actionCreators/group';
 import {addLoadingMessage, clearIndicators} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
-import {alertStyles} from 'sentry/components/alert';
+import Alert from 'sentry/components/alert';
 import Checkbox from 'sentry/components/checkbox';
 import {t, tct, tn} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
@@ -295,42 +295,44 @@ class IssueListActions extends Component<Props, State> {
           />
         </StyledFlex>
         {!allResultsVisible && pageSelected && (
-          <SelectAllNotice>
-            {allInQuerySelected ? (
-              queryCount >= BULK_LIMIT ? (
-                tct(
-                  'Selected up to the first [count] issues that match this search query.',
-                  {
-                    count: BULK_LIMIT_STR,
-                  }
+          <Alert type="warning" system>
+            <SelectAllNotice>
+              {allInQuerySelected ? (
+                queryCount >= BULK_LIMIT ? (
+                  tct(
+                    'Selected up to the first [count] issues that match this search query.',
+                    {
+                      count: BULK_LIMIT_STR,
+                    }
+                  )
+                ) : (
+                  tct('Selected all [count] issues that match this search query.', {
+                    count: queryCount,
+                  })
                 )
               ) : (
-                tct('Selected all [count] issues that match this search query.', {
-                  count: queryCount,
-                })
-              )
-            ) : (
-              <Fragment>
-                {tn(
-                  '%s issue on this page selected.',
-                  '%s issues on this page selected.',
-                  numIssues
-                )}
-                <SelectAllLink onClick={this.handleApplyToAll}>
-                  {queryCount >= BULK_LIMIT
-                    ? tct(
-                        'Select the first [count] issues that match this search query.',
-                        {
-                          count: BULK_LIMIT_STR,
-                        }
-                      )
-                    : tct('Select all [count] issues that match this search query.', {
-                        count: queryCount,
-                      })}
-                </SelectAllLink>
-              </Fragment>
-            )}
-          </SelectAllNotice>
+                <Fragment>
+                  {tn(
+                    '%s issue on this page selected.',
+                    '%s issues on this page selected.',
+                    numIssues
+                  )}
+                  <SelectAllLink onClick={this.handleApplyToAll}>
+                    {queryCount >= BULK_LIMIT
+                      ? tct(
+                          'Select the first [count] issues that match this search query.',
+                          {
+                            count: BULK_LIMIT_STR,
+                          }
+                        )
+                      : tct('Select all [count] issues that match this search query.', {
+                          count: queryCount,
+                        })}
+                  </SelectAllLink>
+                </Fragment>
+              )}
+            </SelectAllNotice>
+          </Alert>
         )}
       </Sticky>
     );
@@ -368,15 +370,9 @@ const ActionsCheckbox = styled('div')<{isReprocessingQuery: boolean}>`
 `;
 
 const SelectAllNotice = styled('div')`
-  ${p => alertStyles({theme: p.theme, type: 'warning', system: true, opaque: true})}
-  flex-direction: row;
+  display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  padding: ${space(0.5)} ${space(1.5)};
-  border-top-width: 1px;
-
-  text-align: center;
-  font-size: ${p => p.theme.fontSizeMedium};
 
   a:not([role='button']) {
     color: ${p => p.theme.linkColor};


### PR DESCRIPTION
Fix a visual bug that cropped up after https://github.com/getsentry/sentry/pull/36592.

Before:
<img width="1134" alt="Screen Shot 2022-07-13 at 11 01 10 AM" src="https://user-images.githubusercontent.com/44172267/178800351-c4c8a323-a4d5-4bd4-b13d-53ec759d6933.png">

After:
<img width="1134" alt="Screen Shot 2022-07-13 at 11 00 50 AM" src="https://user-images.githubusercontent.com/44172267/178800299-dbe7c37f-0366-40ab-b5d4-fb84a9d0a3a5.png">

