### PR TITLE
fix(test): Use correct url prefix for minidump test

### DIFF
--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -28,7 +28,8 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
         new_prefix = live_server.url
 
         with patch("sentry.auth.system.is_internal_ip", return_value=True), self.options(
-            {"system.internal-url-prefix": new_prefix}
+            # Do not change to internal-url-prefix, otherwise tests break on docker for mac
+            {"system.url-prefix": new_prefix}
         ):
 
             # Run test case:


### PR DESCRIPTION
if the wrong url prefix is used, this test won't pass using symbolicator in docker for mac. you should still be able to set internal-url-prefix such that you can use your local symbolicator.