### PR TITLE
feat(hybrid-cloud): Adjust CORS for customer domains

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -78,7 +78,8 @@ def allow_cors_options(func):
         response["Access-Control-Allow-Methods"] = allow
         response["Access-Control-Allow-Headers"] = (
             "X-Sentry-Auth, X-Requested-With, Origin, Accept, "
-            "Content-Type, Authentication, Authorization, Content-Encoding"
+            "Content-Type, Authentication, Authorization, Content-Encoding, "
+            "sentry-trace, baggage"
         )
         response["Access-Control-Expose-Headers"] = "X-Sentry-Error, Retry-After"
 

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -448,7 +448,7 @@ export class Client {
       method,
       body,
       headers,
-      credentials: 'same-origin',
+      credentials: 'include',
       signal: aborter?.signal,
     });
 

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -53,6 +53,13 @@ class EndpointTest(APITestCase):
         assert response.status_code == 200, response.content
 
         assert response["Access-Control-Allow-Origin"] == "http://example.com"
+        assert response["Access-Control-Allow-Headers"] == (
+            "X-Sentry-Auth, X-Requested-With, Origin, Accept, "
+            "Content-Type, Authentication, Authorization, Content-Encoding, "
+            "sentry-trace, baggage"
+        )
+        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After"
+        assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
 
     def test_invalid_cors_without_auth(self):
         request = self.make_request(method="GET")
@@ -86,6 +93,13 @@ class EndpointTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response["Access-Control-Allow-Origin"] == "http://example.com"
+        assert response["Access-Control-Allow-Headers"] == (
+            "X-Sentry-Auth, X-Requested-With, Origin, Accept, "
+            "Content-Type, Authentication, Authorization, Content-Encoding, "
+            "sentry-trace, baggage"
+        )
+        assert response["Access-Control-Expose-Headers"] == "X-Sentry-Error, Retry-After"
+        assert response["Access-Control-Allow-Methods"] == "GET, HEAD, OPTIONS"
 
 
 class PaginateTest(APITestCase):


### PR DESCRIPTION
1. Add `sentry-trace` and `baggage` to the header [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) as these custom headers are attached by the JavaScript SDK. Otherwise, making a request to `orgslug.region.sentry.io` from `orgslug.sentry.io` will be rejected by the browser as per the CORS policy.
2. I've changed the value for the `credentials` setting for `fetch()` from `same-origin` to `include` as per https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#sending_a_request_with_credentials_included
We want to do this to pass along any cookies to authenticate cross origin requests.