### PR TITLE
tests(discover): Improve stability of eventsv2 tests

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2773,8 +2773,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
         features = {"organizations:discover-basic": True, "organizations:global-views": True}
         query = {
-            "field": ["event.type", "p99()"],
-            "query": "event.type:transaction p99():5s",
+            "field": ["event.type", "count()"],
+            "query": "event.type:transaction count():1",
             "statsPeriod": "24h",
         }
         response = self.do_request(query, features=features)
@@ -2783,8 +2783,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(data) == 1
 
         query = {
-            "field": ["event.type", "p99()"],
-            "query": "event.type:transaction !p99():5s",
+            "field": ["event.type", "count()"],
+            "query": "event.type:transaction !count():1",
             "statsPeriod": "24h",
         }
         response = self.do_request(query, features=features)


### PR DESCRIPTION
Same motivation as #36619, this aims to improve the stability of the eventsv2
tests by moving the event timestamps further in the past.