### PR TITLE
feat(ui): Add multiple checkbox component

### DIFF
--- a/docs-ui/stories/components/form-fields.stories.js
+++ b/docs-ui/stories/components/form-fields.stories.js
@@ -10,6 +10,7 @@ import DatePickerField from 'sentry/components/forms/datePickerField';
 import FileField from 'sentry/components/forms/fileField';
 import Form from 'sentry/components/forms/form';
 import FormField from 'sentry/components/forms/formField';
+import MultipleCheckboxField from 'sentry/components/forms/MultipleCheckboxField';
 import RadioBooleanField from 'sentry/components/forms/radioBooleanField';
 import RadioField from 'sentry/components/forms/radioField';
 import SelectField from 'sentry/components/forms/selectField';
@@ -172,6 +173,28 @@ export const _CheckboxField = () => (
 );
 
 _CheckboxField.storyName = 'Checkbox';
+
+export const _MultipleCheckboxField = () => (
+  <Form>
+    <MultipleCheckboxField
+      choices={[
+        {title: 'Checkbox', value: 0},
+        {title: 'Disabled Checkbox', value: 1},
+        {title: 'Checked Checkbox', value: 2, checked: true},
+        {title: 'Intermediate Checkbox', value: 3, intermediate: true},
+        {title: 'Disabled Checked Checkbox', value: 4, checked: true, disabled: true},
+        {
+          title: 'Disabled Intermediate Checkbox',
+          value: 5,
+          intermediate: true,
+          disabled: true,
+        },
+      ]}
+    />
+  </Form>
+);
+
+_MultipleCheckboxField.storyName = 'MultipleCheckbox';
 
 export const _DatePickerField = () => (
   <Form>

--- a/static/app/components/checkboxFancy/checkboxFancy.tsx
+++ b/static/app/components/checkboxFancy/checkboxFancy.tsx
@@ -50,7 +50,7 @@ const CheckboxFancy = styled(
   border-radius: 5px;
   background: ${p => (p.isChecked || p.isIndeterminate ? p.theme.active : 'transparent')};
   border: 2px solid
-    ${p => (p.isChecked || p.isIndeterminate ? p.theme.active : p.theme.gray300)};
+    ${p => (p.isChecked || p.isIndeterminate ? p.theme.active : p.theme.gray200)};
   cursor: ${p => (p.isDisabled ? 'not-allowed' : 'pointer')};
   ${p => (!p.isChecked || !p.isIndeterminate) && 'transition: 500ms border ease-out'};
 

--- a/static/app/components/forms/MultipleCheckboxField.tsx
+++ b/static/app/components/forms/MultipleCheckboxField.tsx
@@ -34,7 +34,7 @@ export default function MultipleCheckboxField<T extends Key>(props: Props<T>) {
               props.onClick?.(option.value);
             }}
           />
-          {option.title}
+          <CheckboxText>{option.title}</CheckboxText>
         </CheckboxWrapper>
       ))}
     </div>
@@ -46,7 +46,8 @@ const CheckboxWrapper = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: center;
-  ${CheckboxFancy} {
-    margin-right: ${space(1)};
-  }
+`;
+
+const CheckboxText = styled('span')`
+  margin-left: ${space(1)};
 `;

--- a/static/app/components/forms/MultipleCheckboxField.tsx
+++ b/static/app/components/forms/MultipleCheckboxField.tsx
@@ -1,0 +1,52 @@
+import {Key} from 'react';
+import styled from '@emotion/styled';
+
+import space from 'sentry/styles/space';
+
+import CheckboxFancy from '../checkboxFancy/checkboxFancy';
+
+type CheckboxOption<T> = {
+  title: string;
+  value: T;
+  checked?: boolean;
+  disabled?: boolean;
+  intermediate?: boolean;
+};
+
+type Props<T> = {
+  choices: CheckboxOption<T>[];
+  className?: string;
+  onClick?(item: T);
+  size?: string;
+};
+
+export default function MultipleCheckboxField<T extends Key>(props: Props<T>) {
+  return (
+    <div className={props.className}>
+      {props.choices.map(option => (
+        <CheckboxWrapper key={option.value.toString()}>
+          <CheckboxFancy
+            size={props.size}
+            isDisabled={option.disabled}
+            isChecked={option.checked}
+            isIndeterminate={option.intermediate}
+            onClick={() => {
+              props.onClick?.(option.value);
+            }}
+          />
+          {option.title}
+        </CheckboxWrapper>
+      ))}
+    </div>
+  );
+}
+
+const CheckboxWrapper = styled('div')`
+  margin-bottom: ${space(2)};
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  ${CheckboxFancy} {
+    margin-right: ${space(1)};
+  }
+`;


### PR DESCRIPTION
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/8980455/178847237-7324c7b5-4294-4daa-85d2-196a875828f6.png">

This component wraps the `CheckboxFancy` component and allow the user to specify the options to render, similar to the old deprecated `MultipleCheckboxField`.

<img width="319" alt="image" src="https://user-images.githubusercontent.com/8980455/178856368-259327cf-5a85-4c70-98df-6c7ef460da4c.png">
