### PR TITLE
fix: Remove potentially unnecessary pip installs

### DIFF
--- a/scripts/bootstrap-py3-venv
+++ b/scripts/bootstrap-py3-venv
@@ -50,19 +50,11 @@ if [ -z "${SENTRY_PYTHON_VERSION-}" ] && ! query-valid-python-version; then
     return 1
 fi
 
-python3 -m pip install -U pip || {
-    echo "bootstrap failed!"
-    return 1
-}
 python3 -m venv "${venv_name}" || {
     echo "bootstrap failed!"
     return 1
 }
 source "${venv_name}/bin/activate" || {
-    echo "bootstrap failed!"
-    return 1
-}
-python3 -m pip install -U pip wheel || {
     echo "bootstrap failed!"
     return 1
 }


### PR DESCRIPTION
I have PIP_REQUIRE_VIRTUALENV=true set in order to avoid bigger
problems. As a result of that the bootstrapping script doesn't actually
run for me.

I don't think what we're doing here is strictly necessary? If we can
assume that venv exists, surely pip will work well enough to create a
venv. Within the venv, we don't need to upgrade pip again, because we're
gonna do that via install-py-dev.
