### PR TITLE
fix: Fix unbound variable if DEVENV_NO_REPORT=1

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -139,6 +139,7 @@ fi
 ## Notify of reporting to Sentry
 if [ -n "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
     debug "No development environment errors will be reported (since you've defined SENTRY_DEVENV_NO_REPORT)."
+    _SENTRY_LOG_FILE=''
 else
     # Since direnv traps the EXIT signal we place the temp file under /tmp for the odd time
     # the script will use the EXIT path

--- a/.envrc
+++ b/.envrc
@@ -256,4 +256,4 @@ else
 fi
 
 # Since we can't use an EXIT routine we need to guarantee we delete the file here
-rm -f "$_SENTRY_LOG_FILE"
+[ -z "$_SENTRY_LOG_FILE" ] || rm -f "$_SENTRY_LOG_FILE"


### PR DESCRIPTION
At the end of this file, we will reference an unbound variable, which
apparently makes the script fail.
