### PR TITLE
feat: Try very hard to auto-activate virtualenv in legacy git hook

### DIFF
--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -4,6 +4,17 @@ import os
 import sys
 from glob import glob
 
+if "VIRTUAL_ENV" not in os.environ:
+    sys.stderr.write(
+        "WARNING: You're executing outside of the venv. Trying to load direnv for you.\n\n"
+    )
+    # even if a user has direnv properly installed, pycharm is completely
+    # ignoring bashrc for executing git hooks. there is no way for the user to
+    # fix this.
+    # The syntax of this file is intentionally python2 compatible because we
+    # really have no idea which Python we're running.
+    os.execvp("direnv", ["direnv", "exec", "."] + sys.argv)
+
 # If we're using Python 2, that means that direnv has not been activated
 if sys.version_info.major < 3:
     sys.stderr.write(
@@ -12,6 +23,15 @@ if sys.version_info.major < 3:
         "To re-enter the sentry Python virtual environment\n"
     )
     sys.exit(1)
+
+
+# git usurbs your bin path for hooks and will always run system python
+# If pre-commit is not installed outside of the virtualenv, glob will return []
+try:
+    site_packages = glob("%s/lib/*/site-packages" % os.environ["VIRTUAL_ENV"])[0]
+    sys.path.insert(0, site_packages)
+except IndexError:
+    pass
 
 try:
     import sentry_sdk
@@ -25,34 +45,12 @@ except ModuleNotFoundError:
 
 text_type = str
 
-# git usurbs your bin path for hooks and will always run system python
-if "VIRTUAL_ENV" in os.environ:
-    # If pre-commit is not installed outside of the virtualenv, glob will return []
-    try:
-        site_packages = glob("%s/lib/*/site-packages" % os.environ["VIRTUAL_ENV"])[0]
-        sys.path.insert(0, site_packages)
-    except IndexError:
-        pass
+try:
+    from sentry.lint.engine import get_modified_files, run
+except ModuleNotFoundError as e:
+    sys.stdout.write("ERROR: You may be able to fix this by executing: make install-py-dev.\n")
+    raise e
 
+files_modified = [text_type(f) for f in get_modified_files(os.getcwd()) if os.path.exists(f)]
 
-def main():
-    try:
-        from sentry.lint.engine import get_modified_files, run
-    except ModuleNotFoundError as e:
-        if "VIRTUAL_ENV" not in os.environ:
-            sys.stderr.write(
-                "ERROR: You're executing outside of the venv. Try this command: direnv allow\n"
-            )
-            sys.exit(1)
-
-        sys.stdout.write("ERROR: You may be able to fix this by executing: make install-py-dev.\n")
-
-        raise (e)
-
-    files_modified = [text_type(f) for f in get_modified_files(os.getcwd()) if os.path.exists(f)]
-
-    return run(files_modified)
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+sys.exit(run(files_modified))


### PR DESCRIPTION
On @RaduW's machine, I remember that pycharm's git UI would execute the
git hooks without loading direnv (or anything in bashrc) at all, and
there was no way to work around this. At the time I recommended him to
modify the shebang in config/hooks/pre-commit to directly point to the
python interpreter of the venv.

But we can be a little bit smarter. Since everybody uses direnv now
(right??), we can try and use direnv to execute ourselves before we
continue.

pre-commit is much smarter in how it handles this situation since it
hardcodes the effective python path into the launch script.

Tagging @wedamija and @RyanSkonnord on this change since iirc they use
pycharm. Maybe this problem isn't inherent to pycharm and I'm just
misremembering.