### PR TITLE
chore: Update in-app attachment link

### DIFF
--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -429,7 +429,7 @@ export function getDocsLinkForEventType(event: 'error' | 'transaction' | 'attach
     case 'transaction':
       return 'https://docs.sentry.io/product/performance/transaction-summary/#what-is-a-transaction';
     case 'attachment':
-      return 'https://docs.sentry.io/product/accounts/quotas/#attachment-limits';
+      return 'https://docs.sentry.io/product/accounts/quotas/manage-attachments-quota/#2-rate-limiting';
     default:
       return 'https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#common-workflows-for-managing-your-event-stream';
   }


### PR DESCRIPTION
There's a docs [PR](https://github.com/getsentry/sentry-docs/pull/5181) that's still being reviewed
and this change needs to go in when that's ready.


