### PR TITLE
fix(trace-view): Left pad root span id

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -478,7 +478,13 @@ class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
 
             spans: NodeSpans = nodestore_event.data.get("spans", [])
             # Need to include the transaction as a span as well
-            spans.append({"span_id": snuba_event["trace.span"]})
+            #
+            # Important that we left pad the span id with 0s because
+            # the span id is stored as an UInt64 and converted into
+            # a hex string when quering. However, the conversion does
+            # not ensure that the final span id is 16 chars long since
+            # it's a naive base 10 to base 16 conversion.
+            spans.append({"span_id": snuba_event["trace.span"].rjust(16, "0")})
 
             for span in spans:
                 if span["span_id"] in error_map:

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -598,8 +598,15 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
                 previous_event.nodestore_event = nodestore_event
 
                 spans: NodeSpans = nodestore_event.data.get("spans", [])
+
                 # Need to include the transaction as a span as well
-                spans.append({"span_id": previous_event.event["trace.span"]})
+                #
+                # Important that we left pad the span id with 0s because
+                # the span id is stored as an UInt64 and converted into
+                # a hex string when quering. However, the conversion does
+                # not ensure that the final span id is 16 chars long since
+                # it's a naive base 10 to base 16 conversion.
+                spans.append({"span_id": previous_event.event["trace.span"].rjust(16, "0")})
 
                 for child in spans:
                     if child["span_id"] in error_map:

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -123,7 +123,10 @@ class OrganizationEventsTraceEndpointBase(APITestCase, SnubaTestCase):
         # Second Generation
         self.gen2_span_ids = [uuid4().hex[:16] for _ in range(3)]
         self.gen2_project = self.create_project(organization=self.organization)
-        self.gen2_span_id = uuid4().hex[:16]
+
+        # Intentially pick a span id that starts with 0s
+        self.gen2_span_id = "0011" * 4
+
         self.gen2_events = [
             self.create_event(
                 trace=self.trace_id,


### PR DESCRIPTION
The root span id is stored as an UInt64 in ClickHouse. And when querying, it is
converted to a hex string using a naive base 10 to base 16 conversion. This
conversion does not take into account that some smaller values need to be left
padded with 0s in order to have a length of 16. So sometimes, the parent span
ids returned from snuba does not match the span ids retrieved from nodestore.