### PR TITLE
fix(release-notification): bypass digest for release notifications 

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -63,7 +63,12 @@ class MailAdapter:
         project = event.group.project
         extra["project_id"] = project.id
 
-        if digests.enabled(project):
+        # XXX(workflow): remove this after wf2.0 experiment over
+        if target_type == ActionTargetType.RELEASE_MEMBERS:
+            notification = Notification(event=event, rules=rules)
+            self.notify(notification, target_type, target_identifier)
+
+        elif digests.enabled(project):
 
             def get_digest_option(key):
                 return ProjectOption.objects.get_value(project, get_digest_option_key("mail", key))

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -63,12 +63,8 @@ class MailAdapter:
         project = event.group.project
         extra["project_id"] = project.id
 
-        # XXX(workflow): remove this after wf2.0 experiment over
-        if target_type == ActionTargetType.RELEASE_MEMBERS:
-            notification = Notification(event=event, rules=rules)
-            self.notify(notification, target_type, target_identifier)
-
-        elif digests.enabled(project):
+        # XXX(workflow): remove the extra condition after digests.enabled(project) when wf2.0 experiment is over
+        if digests.enabled(project) and target_type != ActionTargetType.RELEASE_MEMBERS:
 
             def get_digest_option(key):
                 return ProjectOption.objects.get_value(project, get_digest_option_key("mail", key))


### PR DESCRIPTION
For Workflow 2.0 experiment we want these notifications to be immediately sent to the committers. 

It might make sense to implement a digest for these notifications in the future, but for the purposes of gathering data and this experiment we want these notifications to fire asap.