### PR TITLE
fix(mep): Make sure we pass organization id when creating query builder

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -573,5 +573,10 @@ def get_entity_key_from_snuba_query(
         snuba_query,
         organization_id,
     )
-    query_builder = entity_subscription.build_query_builder(snuba_query.query, [project_id], None)
+    query_builder = entity_subscription.build_query_builder(
+        snuba_query.query,
+        [project_id],
+        None,
+        {"organization_id": organization_id},
+    )
     return get_entity_key_from_query_builder(query_builder)

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -116,7 +116,10 @@ def update_subscription_in_snuba(
         )
         old_entity_key = get_entity_key_from_query_builder(
             old_entity_subscription.build_query_builder(
-                subscription.snuba_query.query, [subscription.project_id], None
+                subscription.snuba_query.query,
+                [subscription.project_id],
+                None,
+                {"organization_id": subscription.project.organization_id},
             ),
         )
         _delete_from_snuba(


### PR DESCRIPTION
Missed passing this in a few places

Fixes SENTRY-VET
