### PR TITLE
tests(mep): Add missing tests for entity subscription helper functions

### DIFF
--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -10,6 +10,7 @@ from sentry.search.events.constants import METRICS_MAP
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import resolve, resolve_tag_key
+from sentry.snuba.dataset import EntityKey
 from sentry.snuba.entity_subscription import (
     EventsEntitySubscription,
     MetricsCountersEntitySubscription,
@@ -17,7 +18,9 @@ from sentry.snuba.entity_subscription import (
     PerformanceMetricsEntitySubscription,
     PerformanceTransactionsEntitySubscription,
     SessionsEntitySubscription,
+    get_entity_key_from_snuba_query,
     get_entity_subscription,
+    get_entity_subscription_from_snuba_query,
 )
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.models import QueryDatasets, SnubaQuery
@@ -373,3 +376,106 @@ class EntitySubscriptionTestCase(TestCase):
             ),
             Condition(Column("project_id"), Op.IN, [self.project.id]),
         ]
+
+
+class GetEntitySubscriptionFromSnubaQueryTest(TestCase):
+    def test(self):
+        cases = [
+            (EventsEntitySubscription, SnubaQuery.Type.ERROR, QueryDatasets.EVENTS, "count()"),
+            (
+                PerformanceTransactionsEntitySubscription,
+                SnubaQuery.Type.PERFORMANCE,
+                QueryDatasets.TRANSACTIONS,
+                "count()",
+            ),
+            (
+                PerformanceMetricsEntitySubscription,
+                SnubaQuery.Type.PERFORMANCE,
+                QueryDatasets.METRICS,
+                "count()",
+            ),
+            (
+                PerformanceMetricsEntitySubscription,
+                SnubaQuery.Type.PERFORMANCE,
+                QueryDatasets.METRICS,
+                "count_unique(user)",
+            ),
+            (
+                MetricsCountersEntitySubscription,
+                SnubaQuery.Type.CRASH_RATE,
+                QueryDatasets.METRICS,
+                "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+            ),
+            (
+                MetricsSetsEntitySubscription,
+                SnubaQuery.Type.CRASH_RATE,
+                QueryDatasets.METRICS,
+                "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+            ),
+        ]
+
+        for expected_entity_subscription, query_type, dataset, aggregate in cases:
+            snuba_query = SnubaQuery(
+                time_window=60,
+                type=query_type.value,
+                dataset=dataset.value,
+                aggregate=aggregate,
+            )
+            assert isinstance(
+                get_entity_subscription_from_snuba_query(snuba_query, self.organization.id),
+                expected_entity_subscription,
+            )
+
+
+class GetEntityKeyFromSnubaQueryTest(TestCase):
+    def test(self):
+        cases = [
+            (EntityKey.Events, SnubaQuery.Type.ERROR, QueryDatasets.EVENTS, "count()", ""),
+            (
+                EntityKey.Transactions,
+                SnubaQuery.Type.PERFORMANCE,
+                QueryDatasets.TRANSACTIONS,
+                "count()",
+                "",
+            ),
+            (
+                EntityKey.MetricsDistributions,
+                SnubaQuery.Type.PERFORMANCE,
+                QueryDatasets.METRICS,
+                "count()",
+                "",
+            ),
+            (
+                EntityKey.MetricsSets,
+                SnubaQuery.Type.PERFORMANCE,
+                QueryDatasets.METRICS,
+                "count_unique(user)",
+                "",
+            ),
+            (
+                EntityKey.MetricsCounters,
+                SnubaQuery.Type.CRASH_RATE,
+                QueryDatasets.METRICS,
+                "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
+                "",
+            ),
+            (
+                EntityKey.MetricsSets,
+                SnubaQuery.Type.CRASH_RATE,
+                QueryDatasets.METRICS,
+                "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
+                "",
+            ),
+        ]
+
+        for expected_entity_key, query_type, dataset, aggregate, query in cases:
+            snuba_query = SnubaQuery(
+                time_window=60,
+                type=query_type.value,
+                dataset=dataset.value,
+                aggregate=aggregate,
+                query=query,
+            )
+            assert expected_entity_key == get_entity_key_from_snuba_query(
+                snuba_query, self.organization.id, self.project.id
+            )


### PR DESCRIPTION
I missed adding tests to `get_entity_subscription_from_snuba_query` and
`get_entity_key_from_snuba_query` when I added them. Including here.
