### PR TITLE
feat(mep): Switch `PerformanceMetricsEntitySubscription` to use `generic_metrics` dataset

### DIFF
--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -367,7 +367,7 @@ class PerformanceMetricsEntitySubscription(BaseMetricsEntitySubscription):
         # Time windows > 24h -> Granularity 1 day
         if self.time_window <= 3600:
             return 60
-        elif 4 * 3600 < self.time_window <= 24 * 3600:
+        elif 3600 < self.time_window <= 24 * 3600:
             return 3600
         else:
             return 24 * 3600

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -304,6 +304,10 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
     def get_snql_extra_conditions(self) -> List[Condition]:
         raise NotImplementedError
 
+    @abstractmethod
+    def get_granularity(self) -> int:
+        pass
+
     def get_entity_extra_params(self) -> Mapping[str, Any]:
         return {
             "organization": self.org_id,

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -24,7 +24,9 @@ class QueryDatasets(Enum):
     EVENTS = "events"
     TRANSACTIONS = "transactions"
     SESSIONS = "sessions"
+    # Actually Release Health
     METRICS = "metrics"
+    PERFORMANCE_METRICS = "generic_metrics"
 
 
 class SnubaQuery(Model):

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -299,9 +299,9 @@ class EntitySubscriptionTestCase(TestCase):
         assert entity_subscription.aggregate == aggregate
         assert entity_subscription.get_entity_extra_params() == {
             "organization": self.organization.id,
-            "granularity": 10,
+            "granularity": 60,
         }
-        assert entity_subscription.dataset == QueryDatasets.METRICS
+        assert entity_subscription.dataset == QueryDatasets.PERFORMANCE_METRICS
         snql_query = entity_subscription.build_query_builder(
             "",
             [self.project.id],
@@ -336,6 +336,7 @@ class EntitySubscriptionTestCase(TestCase):
             Condition(Column("project_id"), Op.IN, [self.project.id]),
             Condition(Column("org_id"), Op.EQ, self.organization.id),
             Condition(Column("metric_id"), Op.IN, [metric_id]),
+            Condition(Column("granularity"), Op.EQ, 1),
         ]
 
     def test_get_entity_subscription_for_events_dataset(self) -> None:
@@ -439,14 +440,14 @@ class GetEntityKeyFromSnubaQueryTest(TestCase):
                 "",
             ),
             (
-                EntityKey.MetricsDistributions,
+                EntityKey.GenericMetricsDistributions,
                 SnubaQuery.Type.PERFORMANCE,
                 QueryDatasets.METRICS,
                 "count()",
                 "",
             ),
             (
-                EntityKey.MetricsSets,
+                EntityKey.GenericMetricsSets,
                 SnubaQuery.Type.PERFORMANCE,
                 QueryDatasets.METRICS,
                 "count_unique(user)",

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -336,7 +336,6 @@ class EntitySubscriptionTestCase(TestCase):
             Condition(Column("project_id"), Op.IN, [self.project.id]),
             Condition(Column("org_id"), Op.EQ, self.organization.id),
             Condition(Column("metric_id"), Op.IN, [metric_id]),
-            Condition(Column("granularity"), Op.EQ, 1),
         ]
 
     def test_get_entity_subscription_for_events_dataset(self) -> None:

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -513,10 +513,11 @@ class BuildSnqlQueryTest(TestCase):
                 Condition(Column("project_id"), Op.IN, (self.project.id,)),
                 Condition(Column("org_id"), Op.EQ, self.organization.id),
                 Condition(Column("metric_id"), Op.IN, [metric_id]),
+                Condition(Column("granularity"), Op.EQ, 1),
             ],
             entity_extra_fields={"org_id": self.organization.id},
             aggregate_kwargs={"metric_id": metric_id},
-            granularity=10,
+            granularity=60,
         )
 
     def test_aliased_query_events(self):
@@ -574,6 +575,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column("project_id"), Op.IN, (self.project.id,)),
             Condition(Column("org_id"), Op.EQ, self.organization.id),
             Condition(Column("metric_id"), Op.IN, [metric_id]),
+            Condition(Column("granularity"), Op.EQ, 1),
         ]
 
         self.run_test(
@@ -584,7 +586,7 @@ class BuildSnqlQueryTest(TestCase):
             expected_conditions,
             entity_extra_fields={"org_id": self.organization.id},
             aggregate_kwargs={"metric_id": metric_id},
-            granularity=10,
+            granularity=60,
         )
 
     def test_user_query(self):
@@ -643,6 +645,7 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column("project_id"), Op.IN, (self.project.id,)),
             Condition(Column("org_id"), Op.EQ, self.organization.id),
             Condition(Column("metric_id"), Op.IN, [metric_id]),
+            Condition(Column("granularity"), Op.EQ, 1),
         ]
 
         self.run_test(
@@ -653,7 +656,7 @@ class BuildSnqlQueryTest(TestCase):
             expected_conditions,
             entity_extra_fields={"org_id": self.organization.id},
             aggregate_kwargs={"metric_id": metric_id},
-            granularity=10,
+            granularity=60,
         )
 
     def test_boolean_query(self):

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -513,7 +513,6 @@ class BuildSnqlQueryTest(TestCase):
                 Condition(Column("project_id"), Op.IN, (self.project.id,)),
                 Condition(Column("org_id"), Op.EQ, self.organization.id),
                 Condition(Column("metric_id"), Op.IN, [metric_id]),
-                Condition(Column("granularity"), Op.EQ, 1),
             ],
             entity_extra_fields={"org_id": self.organization.id},
             aggregate_kwargs={"metric_id": metric_id},
@@ -575,7 +574,6 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column("project_id"), Op.IN, (self.project.id,)),
             Condition(Column("org_id"), Op.EQ, self.organization.id),
             Condition(Column("metric_id"), Op.IN, [metric_id]),
-            Condition(Column("granularity"), Op.EQ, 1),
         ]
 
         self.run_test(
@@ -645,7 +643,6 @@ class BuildSnqlQueryTest(TestCase):
             Condition(Column("project_id"), Op.IN, (self.project.id,)),
             Condition(Column("org_id"), Op.EQ, self.organization.id),
             Condition(Column("metric_id"), Op.IN, [metric_id]),
-            Condition(Column("granularity"), Op.EQ, 1),
         ]
 
         self.run_test(


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/36623 adds in the ability to use the
`Dataset.PerformanceMetrics` dataset to `MetricsQueryBuilder`. This pr switches the new
`PerformanceMetricsEntitySubscription` entity subscription over to use this dataset, makes sure
`BaseCrashRateMetricsEntitySubscription` is still using the old metrics dataset, and ensures that we
pass the dataset to the querybuilder when constructing it, rather than relying on the default.

At some point we should consolidate `QueryDatasets` into just `Dataset` as well.

