### PR TITLE
fix(copy): renamed participants to subscribers

### DIFF
--- a/static/app/components/group/participants.tsx
+++ b/static/app/components/group/participants.tsx
@@ -12,7 +12,7 @@ type Props = {
 };
 
 const GroupParticipants = ({participants}: Props) => (
-  <SidebarSection title={tn('%s Participant', '%s Participants', participants.length)}>
+  <SidebarSection title={tn('%s Subscribed', '%s Subscribed', participants.length)}>
     <Faces>
       {participants.map(user => (
         <Face key={user.username}>

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -9,8 +9,8 @@ import {Client} from 'sentry/api';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalIssueList from 'sentry/components/group/externalIssuesList';
-import GroupParticipants from 'sentry/components/group/participants';
 import GroupReleaseStats from 'sentry/components/group/releaseStats';
+import GroupSubscribed from 'sentry/components/group/subscribed';
 import SuggestedOwners from 'sentry/components/group/suggestedOwners/suggestedOwners';
 import GroupTagDistributionMeter from 'sentry/components/group/tagDistributionMeter';
 import LoadingError from 'sentry/components/loadingError';
@@ -41,7 +41,7 @@ type Props = {
 
 type State = {
   environments: Environment[];
-  participants: Group['participants'];
+  subscribed: Group['participants'];
   allEnvironmentsGroupData?: Group;
   currentRelease?: CurrentRelease;
   error?: boolean;
@@ -50,7 +50,7 @@ type State = {
 
 class BaseGroupSidebar extends Component<Props, State> {
   state: State = {
-    participants: [],
+    subscribed: [],
     environments: this.props.environments,
   };
 
@@ -102,12 +102,12 @@ class BaseGroupSidebar extends Component<Props, State> {
     const {group, api} = this.props;
 
     try {
-      const participants = await api.requestPromise(`/issues/${group.id}/participants/`);
+      const subscribed = await api.requestPromise(`/issues/${group.id}/participants/`);
       this.setState({
-        participants,
+        subscribed,
         error: false,
       });
-      return participants;
+      return subscribed;
     } catch {
       this.setState({
         error: true,
@@ -163,17 +163,17 @@ class BaseGroupSidebar extends Component<Props, State> {
   }
 
   renderParticipantData() {
-    const {error, participants = []} = this.state;
+    const {error, subscribed = []} = this.state;
 
     if (error) {
       return (
         <LoadingError
-          message={t('There was an error while trying to load participants.')}
+          message={t('There was an error while trying to load subscribers.')}
         />
       );
     }
 
-    return participants.length !== 0 && <GroupParticipants participants={participants} />;
+    return subscribed.length !== 0 && <GroupSubscribed subscribed={subscribed} />;
   }
 
   render() {

--- a/static/app/components/group/subscribed.tsx
+++ b/static/app/components/group/subscribed.tsx
@@ -8,13 +8,13 @@ import {Group} from 'sentry/types';
 import SidebarSection from './sidebarSection';
 
 type Props = {
-  participants: Group['participants'];
+  subscribed: Group['participants'];
 };
 
-const GroupParticipants = ({participants}: Props) => (
-  <SidebarSection title={tn('%s Subscribed', '%s Subscribed', participants.length)}>
+const GroupSubscribed = ({subscribed}: Props) => (
+  <SidebarSection title={tn('%s Subscribed', '%s Subscribed', subscribed.length)}>
     <Faces>
-      {participants.map(user => (
+      {subscribed.map(user => (
         <Face key={user.username}>
           <UserAvatar size={28} user={user} hasTooltip />
         </Face>
@@ -23,7 +23,7 @@ const GroupParticipants = ({participants}: Props) => (
   </SidebarSection>
 );
 
-export default GroupParticipants;
+export default GroupSubscribed;
 
 const Faces = styled('div')`
   display: flex;


### PR DESCRIPTION
Changing issue "participants" to "subscribed".

Participants is a bad name for what this feature is because it shows which members are subscribed to an issue (with that bell icon in the top) and so we should keep the language the same in order to avoid confusion.


## Before 
![CleanShot 2022-07-14 at 13 49 06](https://user-images.githubusercontent.com/1900676/179086358-88d4aba1-3346-4599-8eb3-07f4654b4ade.png)

## After
![CleanShot 2022-07-14 at 13 49 26](https://user-images.githubusercontent.com/1900676/179086380-2837a5a6-9188-4efa-b7a8-43b28784c10e.png)

