### PR TITLE
fix(copy): removed link text from issue tracking integrations

### DIFF
--- a/static/app/components/group/externalIssueActions.tsx
+++ b/static/app/components/group/externalIssueActions.tsx
@@ -83,7 +83,7 @@ const ExternalIssueActions = ({configurations, group, onChange, api}: Props) => 
             externalIssueDisplayName={issue.displayName}
             onClose={() => deleteIssue(config)}
             integrationType={provider.key}
-            hoverCardHeader={t('Linked %s Integration', provider.name)}
+            hoverCardHeader={t('%s Integration', provider.name)}
             hoverCardBody={
               <div>
                 <IssueTitle>{issue.title}</IssueTitle>
@@ -99,7 +99,7 @@ const ExternalIssueActions = ({configurations, group, onChange, api}: Props) => 
       {unlinked.length > 0 && (
         <IssueSyncListElement
           integrationType={unlinked[0].provider.key}
-          hoverCardHeader={t('Linked %s Integration', unlinked[0].provider.name)}
+          hoverCardHeader={t('%s Integration', unlinked[0].provider.name)}
           hoverCardBody={
             <Container>
               {unlinked.map(config => (

--- a/static/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/static/app/components/group/sentryAppExternalIssueActions.tsx
@@ -118,7 +118,7 @@ class SentryAppExternalIssueActions extends Component<Props, State> {
     const name = sentryAppComponent.sentryApp.name;
 
     let url = '#';
-    let displayName: React.ReactNode | string = tct('Link [name] Issue', {name});
+    let displayName: React.ReactNode | string = tct('[name] Issue', {name});
 
     if (externalIssue) {
       url = externalIssue.webUrl;

--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -144,18 +144,12 @@ export const IntegrationLink = styled('a')<{disabled?: boolean}>`
   padding-bottom: ${space(0.25)};
   margin-left: ${space(1)};
   color: ${p => p.theme.textColor};
-  border-bottom: 1px solid ${p => p.theme.textColor};
   cursor: pointer;
   line-height: 1;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 
-  &,
-  &:hover {
-    border-bottom: 1px solid
-      ${({disabled, theme}) => (disabled ? theme.disabled : theme.blue300)};
-  }
   &:hover {
     color: ${({disabled, theme}) => (disabled ? theme.disabled : theme.blue300)};
   }

--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -86,7 +86,7 @@ class IssueSyncListElement extends Component<Props> {
       return this.props.externalIssueKey;
     }
 
-    return `Link ${this.getPrettyName()} Issue`;
+    return `${this.getPrettyName()} Issue`;
   }
 
   render() {

--- a/tests/js/spec/components/group/externalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueActions.spec.jsx
@@ -22,7 +22,7 @@ describe('ExternalIssueActions', function () {
       expect(wrapper).toSnapshot();
     });
 
-    it('renders Link GitHub Issue when no issues currently linked', function () {
+    it('renders GitHub Issue when no issues currently linked', function () {
       expect(wrapper.find('IntegrationLink a').text()).toEqual('GitHub Issue');
     });
 
@@ -68,7 +68,7 @@ describe('ExternalIssueActions', function () {
       expect(wrapper.find('IssueSyncElement')).toHaveLength(0);
     });
 
-    it('renders Link GitHub Issue when no issues currently linked', function () {
+    it('renders GitHub Issue when no issues currently linked', function () {
       expect(wrapper.find('IntegrationLink a').text()).toEqual('getsentry/sentry#2');
     });
 

--- a/tests/js/spec/components/group/externalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueActions.spec.jsx
@@ -23,7 +23,7 @@ describe('ExternalIssueActions', function () {
     });
 
     it('renders Link GitHub Issue when no issues currently linked', function () {
-      expect(wrapper.find('IntegrationLink a').text()).toEqual('Link GitHub Issue');
+      expect(wrapper.find('IntegrationLink a').text()).toEqual('GitHub Issue');
     });
 
     it('should not have `+` icon', function () {
@@ -40,7 +40,7 @@ describe('ExternalIssueActions', function () {
       it('opens when clicking text', function () {
         wrapper.find('IntegrationLink a').simulate('click');
         expect(wrapper.find('Hovercard').first().prop('header')).toEqual(
-          'Linked GitHub Integration'
+          'GitHub Integration'
         );
       });
     });

--- a/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
@@ -54,8 +54,8 @@ describe('SentryAppExternalIssueActions', () => {
     });
 
     it('renders a link to open the modal', () => {
-      expect(wrapper.find('StyledIntegrationLink a').text()).toEqual(
-        `Link ${component.sentryApp.name} Issue`
+      expect(wrapper.find('IntegrationLink a').text()).toEqual(
+        `${component.sentryApp.name} Issue`
       );
     });
 

--- a/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
+++ b/tests/js/spec/components/group/sentryAppExternalIssueActions.spec.jsx
@@ -54,7 +54,7 @@ describe('SentryAppExternalIssueActions', () => {
     });
 
     it('renders a link to open the modal', () => {
-      expect(wrapper.find('IntegrationLink a').text()).toEqual(
+      expect(wrapper.find('StyledIntegrationLink a').text()).toEqual(
         `${component.sentryApp.name} Issue`
       );
     });

--- a/tests/js/spec/components/issueSyncListElement.spec.jsx
+++ b/tests/js/spec/components/issueSyncListElement.spec.jsx
@@ -12,7 +12,7 @@ describe('IssueSyncListElement', function () {
     const onOpen = jest.fn();
     render(<IssueSyncListElement integrationType="github" onOpen={onOpen} />);
     expect(onOpen).not.toHaveBeenCalled();
-    userEvent.click(screen.getByText('Link GitHub Issue'));
+    userEvent.click(screen.getByText('GitHub Issue'));
     expect(onOpen).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Removed duplicate "Link" copy here because it's not necessary and the blue underline to make things easier to scan.

## Before 
![CleanShot 2022-07-14 at 14 30 46](https://user-images.githubusercontent.com/1900676/179089628-84796f15-f74d-412a-a85a-032e4baa32bc.png)

## After

![CleanShot 2022-08-11 at 09 35 17](https://user-images.githubusercontent.com/1900676/184185724-98b49c4e-d825-448f-98e6-4770b7ba1d80.png)

