### PR TITLE
feat(replays): Cleanup unneeded tabs from the Replay Details page

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -5,11 +5,9 @@ import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
 
 export const ReplayTabs = {
   console: t('Console'),
-  network: t('Network Waterfall'),
-  network_table: t('Network Table'),
+  network: t('Network'),
   trace: t('Trace'),
   issues: t('Issues'),
-  tags: t('Tags'),
   memory: t('Memory'),
 };
 

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -1,14 +1,9 @@
 import {useMemo} from 'react';
-import {uuid4} from '@sentry/utils';
 
-import Spans from 'sentry/components/events/interfaces/spans';
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import TagsTable from 'sentry/components/tagsTable';
 import type {RawCrumb} from 'sentry/types/breadcrumbs';
 import {isBreadcrumbTypeDefault} from 'sentry/types/breadcrumbs';
-import type {EventTransaction} from 'sentry/types/event';
-import {EntryType} from 'sentry/types/event';
 import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -60,43 +55,12 @@ function FocusArea({}: Props) {
           startTimestamp={event?.startTimestamp}
         />
       );
-    case 'network': {
-      // Fake the span and Trace context
-      const nonMemorySpansEntry = {
-        type: EntryType.SPANS,
-        data: getNetworkSpans().map(({startTimestamp, endTimestamp, ...span}) => ({
-          ...span,
-          timestamp: endTimestamp,
-          start_timestamp: startTimestamp,
-          span_id: uuid4(), // TODO(replays): used as a React key
-          parent_span_id: 'replay_network_trace',
-        })),
-      };
-
-      const performanceEvents = {
-        ...event,
-        contexts: {
-          trace: {
-            type: 'trace',
-            op: 'Network',
-            description: 'WIP',
-            span_id: 'replay_network_trace',
-            status: 'ok',
-          },
-        },
-        entries: [nonMemorySpansEntry],
-      } as EventTransaction;
-
-      return <Spans organization={organization} event={performanceEvents} />;
-    }
-    case 'network_table':
+    case 'network':
       return <NetworkList event={event} networkSpans={getNetworkSpans()} />;
     case 'trace':
       return <Trace organization={organization} event={event} />;
     case 'issues':
       return <IssueList replayId={event.id} projectId={event.projectID} />;
-    case 'tags':
-      return <TagsTable generateUrl={() => ''} event={event} query="" />;
     case 'memory':
       return (
         <MemoryChart


### PR DESCRIPTION
Remove the "Tags" tab which got moved into the sidebar (well, not they're gone in the `topbar` layout), and also remove the "Network Waterfall" because I prefer the table and want to get that prioritized.


<img width="584" alt="Screen Shot 2022-07-14 at 2 44 23 PM" src="https://user-images.githubusercontent.com/187460/179091412-d8c81df9-9e67-43e8-88f8-bcc3c3dbeb63.png">

