### PR TITLE
fix(issues): Filter unresolved issues in release details all/new/unhandled issues tabs

### DIFF
--- a/static/app/views/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/releases/detail/overview/releaseIssues.tsx
@@ -180,7 +180,10 @@ class ReleaseIssues extends Component<Props, State> {
           path: `/organizations/${organization.slug}/issues/`,
           queryParams: {
             ...queryParams,
-            query: new MutableSearch([`${IssuesQuery.ALL}:${version}`]).formatString(),
+            query: new MutableSearch([
+              `${IssuesQuery.ALL}:${version}`,
+              'is:unresolved',
+            ]).formatString(),
           },
         };
       case IssuesType.RESOLVED:
@@ -198,6 +201,7 @@ class ReleaseIssues extends Component<Props, State> {
             query: new MutableSearch([
               `${IssuesQuery.ALL}:${version}`,
               IssuesQuery.UNHANDLED,
+              'is:unresolved',
             ]).formatString(),
           },
         };
@@ -217,7 +221,10 @@ class ReleaseIssues extends Component<Props, State> {
           path: `/organizations/${organization.slug}/issues/`,
           queryParams: {
             ...queryParams,
-            query: new MutableSearch([`${IssuesQuery.NEW}:${version}`]).formatString(),
+            query: new MutableSearch([
+              `${IssuesQuery.NEW}:${version}`,
+              'is:unresolved',
+            ]).formatString(),
           },
         };
     }
@@ -237,12 +244,13 @@ class ReleaseIssues extends Component<Props, State> {
       ]).then(([issueResponse, resolvedResponse]) => {
         this.setState({
           count: {
-            all: issueResponse[`${IssuesQuery.ALL}:"${version}"`] || 0,
-            new: issueResponse[`${IssuesQuery.NEW}:"${version}"`] || 0,
+            all: issueResponse[`${IssuesQuery.ALL}:"${version}" is:unresolved`] || 0,
+            new: issueResponse[`${IssuesQuery.NEW}:"${version}" is:unresolved`] || 0,
             resolved: resolvedResponse.length,
             unhandled:
-              issueResponse[`${IssuesQuery.UNHANDLED} ${IssuesQuery.ALL}:"${version}"`] ||
-              0,
+              issueResponse[
+                `${IssuesQuery.UNHANDLED} ${IssuesQuery.ALL}:"${version}" is:unresolved`
+              ] || 0,
             regressed: issueResponse[`${IssuesQuery.REGRESSED}:"${version}"`] || 0,
           },
         });
@@ -257,9 +265,9 @@ class ReleaseIssues extends Component<Props, State> {
     const issuesCountPath = `/organizations/${organization.slug}/issues-count/`;
 
     const params = [
-      `${IssuesQuery.NEW}:"${version}"`,
-      `${IssuesQuery.ALL}:"${version}"`,
-      `${IssuesQuery.UNHANDLED} ${IssuesQuery.ALL}:"${version}"`,
+      `${IssuesQuery.NEW}:"${version}" is:unresolved`,
+      `${IssuesQuery.ALL}:"${version}" is:unresolved`,
+      `${IssuesQuery.UNHANDLED} ${IssuesQuery.ALL}:"${version}" is:unresolved`,
       `${IssuesQuery.REGRESSED}:"${version}"`,
     ];
     const queryParams = params.map(param => param);

--- a/tests/js/spec/views/releases/detail/overview/releaseIssues.spec.jsx
+++ b/tests/js/spec/views/releases/detail/overview/releaseIssues.spec.jsx
@@ -27,21 +27,21 @@ describe('ReleaseIssues', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues-count/?end=2020-03-24T02%3A04%3A59Z&query=first-release%3A%221.0.0%22&query=release%3A%221.0.0%22&query=error.handled%3A0%20release%3A%221.0.0%22&query=regressed_in_release%3A%221.0.0%22&start=2020-03-23T01%3A02%3A00Z`,
+      url: `/organizations/${props.organization.slug}/issues-count/?end=2020-03-24T02%3A04%3A59Z&query=first-release%3A%221.0.0%22%20is%3Aunresolved&query=release%3A%221.0.0%22%20is%3Aunresolved&query=error.handled%3A0%20release%3A%221.0.0%22%20is%3Aunresolved&query=regressed_in_release%3A%221.0.0%22&start=2020-03-23T01%3A02%3A00Z`,
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues-count/?query=first-release%3A%221.0.0%22&query=release%3A%221.0.0%22&query=error.handled%3A0%20release%3A%221.0.0%22&query=regressed_in_release%3A%221.0.0%22&statsPeriod=24h`,
+      url: `/organizations/${props.organization.slug}/issues-count/?query=first-release%3A%221.0.0%22%20is%3Aunresolved&query=release%3A%221.0.0%22%20is%3Aunresolved&query=error.handled%3A0%20release%3A%221.0.0%22%20is%3Aunresolved&query=regressed_in_release%3A%221.0.0%22&statsPeriod=24h`,
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${props.organization.slug}/releases/1.0.0/resolved/`,
     });
 
     newIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&limit=10&query=first-release%3A1.0.0&sort=freq&start=2020-03-23T01%3A02%3A00Z`,
+      url: `/organizations/${props.organization.slug}/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&limit=10&query=first-release%3A1.0.0%20is%3Aunresolved&sort=freq&start=2020-03-23T01%3A02%3A00Z`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/?groupStatsPeriod=auto&limit=10&query=first-release%3A1.0.0&sort=freq&statsPeriod=24h`,
+      url: `/organizations/${props.organization.slug}/issues/?groupStatsPeriod=auto&limit=10&query=first-release%3A1.0.0%20is%3Aunresolved&sort=freq&statsPeriod=24h`,
       body: [],
     });
     resolvedIssuesEndpoint = MockApiClient.addMockResponse({
@@ -49,15 +49,15 @@ describe('ReleaseIssues', function () {
       body: [],
     });
     unhandledIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&limit=10&query=release%3A1.0.0%20error.handled%3A0&sort=freq&start=2020-03-23T01%3A02%3A00Z`,
+      url: `/organizations/${props.organization.slug}/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&limit=10&query=release%3A1.0.0%20error.handled%3A0%20is%3Aunresolved&sort=freq&start=2020-03-23T01%3A02%3A00Z`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/?groupStatsPeriod=auto&limit=10&query=release%3A1.0.0%20error.handled%3A0&sort=freq&statsPeriod=24h`,
+      url: `/organizations/${props.organization.slug}/issues/?groupStatsPeriod=auto&limit=10&query=release%3A1.0.0%20error.handled%3A0%20is%3Aunresolved&sort=freq&statsPeriod=24h`,
       body: [],
     });
     allIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.organization.slug}/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&limit=10&query=release%3A1.0.0&sort=freq&start=2020-03-23T01%3A02%3A00Z`,
+      url: `/organizations/${props.organization.slug}/issues/?end=2020-03-24T02%3A04%3A59Z&groupStatsPeriod=auto&limit=10&query=release%3A1.0.0%20is%3Aunresolved&sort=freq&start=2020-03-23T01%3A02%3A00Z`,
       body: [],
     });
   });


### PR DESCRIPTION
This filters all/new/unhandled issues tabs in release details with `is:unresolved` to filter out ignored and resolved issues, the greyed out ones.

Please see screenshots in the jira card linked below.

JIRA: [WOR-1981](https://getsentry.atlassian.net/browse/WOR-1981)