### PR TITLE
ref(replays): Refactor MouseTracking component into a react hook

### DIFF
--- a/static/app/components/replays/player/scrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/scrubberMouseTracking.tsx
@@ -1,11 +1,7 @@
 import {useCallback} from 'react';
 
-import MouseTracking, {
-  Props as MouseTrackingProps,
-} from 'sentry/components/replays/mouseTracking';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-
-type OnMouseMoveParams = Parameters<MouseTrackingProps['onMouseMove']>;
+import useMouseTracking from 'sentry/utils/replays/hooks/useMouseTracking';
 
 type Props = {
   children: React.ReactNode;
@@ -14,8 +10,8 @@ type Props = {
 function ScrubberMouseTracking({children}: Props) {
   const {duration = 0, setCurrentHoverTime} = useReplayContext();
 
-  const handleMouseMove = useCallback(
-    (params: OnMouseMoveParams[0]) => {
+  const handlePositionChange = useCallback(
+    params => {
       if (!params || duration === undefined) {
         setCurrentHoverTime(undefined);
         return;
@@ -33,7 +29,9 @@ function ScrubberMouseTracking({children}: Props) {
     [duration, setCurrentHoverTime]
   );
 
-  return <MouseTracking onMouseMove={handleMouseMove}>{children}</MouseTracking>;
+  const mouseTrackingProps = useMouseTracking({onPositionChange: handlePositionChange});
+
+  return <div {...mouseTrackingProps}>{children}</div>;
 }
 
 export default ScrubberMouseTracking;

--- a/static/app/components/replays/player/scrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/scrubberMouseTracking.tsx
@@ -29,7 +29,9 @@ function ScrubberMouseTracking({children}: Props) {
     [duration, setCurrentHoverTime]
   );
 
-  const mouseTrackingProps = useMouseTracking({onPositionChange: handlePositionChange});
+  const mouseTrackingProps = useMouseTracking<HTMLDivElement>({
+    onPositionChange: handlePositionChange,
+  });
 
   return <div {...mouseTrackingProps}>{children}</div>;
 }


### PR DESCRIPTION
Refactor the MouseTracking component into a hook which is actually more re-usable. 

Tested the change by making sure that the Replay Timeline still works properly, i can hover my mouse over and see the `hoverTime` updated in all the places on the page, and importantly the purple hoverTime bar is visible.


<img width="757" alt="Screen Shot 2022-07-14 at 2 59 14 PM" src="https://user-images.githubusercontent.com/187460/179095873-aa202548-9d1c-48b9-89ca-f762a4830fc6.png">

