### PR TITLE
fix(test) Allow the connection name to be defined by migration tests

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1560,6 +1560,10 @@ class TestMigrations(TransactionTestCase):
     def migrate_to(self):
         raise NotImplementedError(f"implement for {type(self).__module__}.{type(self).__name__}")
 
+    @property
+    def connection(self):
+        return "default"
+
     def setUp(self):
         super().setUp()
         self.setup_initial_state()
@@ -1567,6 +1571,7 @@ class TestMigrations(TransactionTestCase):
         self.migrate_from = [(self.app, self.migrate_from)]
         self.migrate_to = [(self.app, self.migrate_to)]
 
+        connection = connections[self.connection]
         executor = MigrationExecutor(connection)
         matching_migrations = [m for m in executor.loader.applied_migrations if m[0] == self.app]
         if not matching_migrations:


### PR DESCRIPTION
In getsentry we have non-default databases that I would like to write tests for. Having an attribute for the connection name allows us to test migrations for billing data.