### PR TITLE
feat(web-vitals): adds a 24 hour org level cache

### DIFF
--- a/src/sentry/api/endpoints/organization_vitals_overview.py
+++ b/src/sentry/api/endpoints/organization_vitals_overview.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import experiments
+from sentry.api.base import ONE_DAY
 from sentry.api.bases import OrganizationEventsEndpointBase
 from sentry.api.serializers.models.project import get_access_by_project
 from sentry.models import Organization, Project, ProjectStatus
@@ -55,10 +56,6 @@ NO_RESULT_RESPONSE = {
 }
 
 
-# one day cache
-CACHE_TTL = 24 * 60 * 60
-
-
 def get_vital_data_for_org_no_cache(organization: Organization, projects: Sequence[Project]):
     project_ids = list(map(lambda x: x.id, projects))
 
@@ -96,7 +93,7 @@ def get_vital_data_for_org(organization: Organization, projects: Sequence[Projec
     # cache miss, lookup and store value
     if cache_value is None:
         cache_value = get_vital_data_for_org_no_cache(organization, projects)
-        cache.set(cache_key, cache_value, CACHE_TTL)
+        cache.set(cache_key, cache_value, ONE_DAY)
     return cache_value
 
 

--- a/src/sentry/api/endpoints/organization_vitals_overview.py
+++ b/src/sentry/api/endpoints/organization_vitals_overview.py
@@ -121,7 +121,7 @@ class OrganizationVitalsOverviewEndpoint(OrganizationEventsEndpointBase):
             return self.respond(NO_RESULT_RESPONSE)
 
         with self.handle_query_errors():
-            # find data we might have cahced
+            # find data we might have cached
             org_data, project_data = get_vital_data_for_org(organization, projects)
             # no data at all for any vital
             if not org_data:

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2137,7 +2137,7 @@ class CdcEventsSnubaSearchTest(TestCase, SnubaTestCase):
             [self.group2, self.group1],
             None,
             sort_by="freq",
-            # Change the date range to bust the cache
+            # Change the date range to bust the
             date_from=self.base_datetime - timedelta(days=29),
         )
 
@@ -2163,7 +2163,7 @@ class CdcEventsSnubaSearchTest(TestCase, SnubaTestCase):
             [group3, self.group2, self.group1],
             None,
             sort_by="new",
-            # Change the date range to bust the cache
+            # Change the date range to bust the
             date_from=self.base_datetime - timedelta(days=29),
         )
 
@@ -2222,7 +2222,7 @@ class CdcEventsSnubaSearchTest(TestCase, SnubaTestCase):
             [self.group2, self.group1, group3],
             None,
             sort_by="user",
-            # Change the date range to bust the cache
+            # Change the date range to bust the
             date_from=self.base_datetime - timedelta(days=29),
         )
 


### PR DESCRIPTION
This PR adds a 24 hour org level cache for the new vitals overview endpoint. Even though the projects for each user within an org might be different, we can still get a cache hit because we store all project data in the cache and filter later.