### PR TITLE
fix(ci): include workdir to cache-dependency-path in setup-sentry

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -104,7 +104,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip
-        cache-dependency-path: requirements-dev-frozen.txt
+        cache-dependency-path: ${{ inputs.workdir }}/requirements-dev-frozen.txt
 
     - name: Install system dependencies
       shell: bash


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/36687 broke snuba CI: https://github.com/getsentry/snuba/runs/7349071821?check_suite_focus=true
