### PR TITLE
fix(mep): Remove the granularity hacks

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1611,14 +1611,6 @@ class MetricsQueryBuilder(QueryBuilder):
             *args,
             **kwargs,
         )
-        if dataset is Dataset.PerformanceMetrics:
-            # Hack while granularity isn't being handled by snuba
-            granularity = {
-                60: 1,
-                3600: 2,
-                86400: 3,
-            }[self.granularity.granularity]
-            self.where.append(Condition(Column("granularity"), Op.EQ, granularity))
         if "organization_id" in self.params:
             self.organization_id = self.params["organization_id"]
         else:
@@ -2235,18 +2227,6 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
             for granularity in METRICS_GRANULARITIES:
                 if granularity < interval:
                     self.granularity = Granularity(granularity)
-                    if dataset is Dataset.PerformanceMetrics:
-                        # Hack until snuba can handle granularities
-                        for condition in self.where:
-                            if condition.lhs == Column("granularity"):
-                                self.where.remove(condition)
-                                break
-                        granularity = {
-                            60: 1,
-                            3600: 2,
-                            86400: 3,
-                        }[self.granularity.granularity]
-                        self.where.append(Condition(Column("granularity"), Op.EQ, granularity))
                     break
 
         self.time_column = self.resolve_time_column(interval)

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -771,8 +771,6 @@ class MetricBuilderBaseTest(MetricsEnhancedPerformanceTestCase):
             Condition(Column("timestamp"), Op.LT, self.end),
             Condition(Column("project_id"), Op.IN, self.projects),
             Condition(Column("org_id"), Op.EQ, self.organization.id),
-            # Hack cause snuba isn't handling granularity right now
-            Condition(Column("granularity"), Op.EQ, 2),
         ]
 
         for string in self.METRIC_STRINGS:
@@ -1350,6 +1348,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
                 {"name": "p100_measurements_lcp", "type": "Float64"},
             ],
         )
+        assert False
 
     def test_run_query_multiple_tables(self):
         self.store_metric(
@@ -2161,8 +2160,6 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         snql_query = query.get_snql_query()
         assert len(snql_query) == 1
         query = snql_query[0].query
-        del self.default_conditions[-1]
-        self.default_conditions.append(Condition(Column("granularity"), Op.EQ, 1))
         self.assertCountEqual(
             query.where,
             [
@@ -2182,8 +2179,6 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             query="",
             selected_columns=[],
         )
-        del self.default_conditions[-1]
-        self.default_conditions.append(Condition(Column("granularity"), Op.EQ, 1))
         self.assertCountEqual(query.where, self.default_conditions)
 
     def test_granularity(self):
@@ -2245,8 +2240,6 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         transaction_name1 = indexer.resolve(self.organization.id, "foo_transaction")
         transaction_name2 = indexer.resolve(self.organization.id, "bar_transaction")
         transaction = Column(f"tags[{transaction_index}]")
-        del self.default_conditions[-1]
-        self.default_conditions.append(Condition(Column("granularity"), Op.EQ, 1))
         self.assertCountEqual(
             query.where,
             [
@@ -2290,8 +2283,6 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
             query=f"project:{self.project.slug}",
             selected_columns=["p95(transaction.duration)"],
         )
-        del self.default_conditions[-1]
-        self.default_conditions.append(Condition(Column("granularity"), Op.EQ, 1))
         self.assertCountEqual(
             query.where,
             [

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1348,7 +1348,6 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
                 {"name": "p100_measurements_lcp", "type": "Float64"},
             ],
         )
-        assert False
 
     def test_run_query_multiple_tables(self):
         self.store_metric(


### PR DESCRIPTION
- These hacks were temporary, snuba can now handle non-enum granularities so I've removed them
