### PR TITLE
feat(runner): Add sendmail command to send emails from sentry command

### DIFF
--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -54,6 +54,7 @@ for cmd in map(
         "sentry.runner.commands.devserver.devserver",
         "sentry.runner.commands.django.django",
         "sentry.runner.commands.exec.exec_",
+        "sentry.runner.commands.sendmail.sendmail",
         "sentry.runner.commands.execfile.execfile",
         "sentry.runner.commands.files.files",
         "sentry.runner.commands.help.help",

--- a/src/sentry/runner/commands/sendmail.py
+++ b/src/sentry/runner/commands/sendmail.py
@@ -1,0 +1,41 @@
+import email
+
+import click
+
+
+def send_prepared_email(input, fail_silently=False):
+    from sentry import options
+    from sentry.utils.email import send_mail
+
+    msg = email.message_from_string(input)
+    headers = {k: v for (k, v) in msg.items() if k.lower() not in ("to", "reply-to", "subject")}
+    send_mail(
+        subject=msg["subject"],
+        message=msg.get_payload(),
+        from_email=options.get("mail.from"),
+        recipient_list=[msg["to"]],
+        fail_silently=fail_silently,
+        reply_to=msg.get("reply-to"),
+        headers=headers,
+    )
+
+
+@click.command()
+@click.argument("files", nargs=-1)
+@click.option("--fail-silently", is_flag=True)
+def sendmail(files, fail_silently):
+    """
+    Sends emails from the default notification mail address.
+
+    This functionality can be used to send a text email to users from the default
+    send location.  The emails to be sent must be prepaired in plain text format
+    with headers separated by body with double newlines.  Mandatory headers are
+    `To` and `Subject`.
+    """
+    from sentry.runner import configure
+
+    configure()
+
+    for file in files:
+        with open(file) as f:
+            send_prepared_email(f.read(), fail_silently=fail_silently)


### PR DESCRIPTION
This adds a command to quickly send prepared emails from the default sender email.