### PR TITLE
feat(replays): Make the replay video resize in all directions to match its container size

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -10,10 +10,9 @@ import FastForwardBadge from './player/fastForwardBadge';
 
 interface Props {
   className?: string;
-  height?: number;
 }
 
-function BasePlayerRoot({className, height = Infinity}: Props) {
+function BasePlayerRoot({className}: Props) {
   const {
     initRoot,
     dimensions: videoDimensions,
@@ -55,11 +54,9 @@ function BasePlayerRoot({className, height = Infinity}: Props) {
   // Update the scale of the view whenever dimensions have changed.
   useEffect(() => {
     if (viewEl.current) {
-      const windowHeight = height === Infinity ? windowDimensions.height : height;
-
       const scale = Math.min(
         windowDimensions.width / videoDimensions.width,
-        windowHeight / videoDimensions.height,
+        windowDimensions.height / videoDimensions.height,
         1
       );
       if (scale) {
@@ -69,14 +66,10 @@ function BasePlayerRoot({className, height = Infinity}: Props) {
         viewEl.current.style.height = `${videoDimensions.height * scale}px`;
       }
     }
-  }, [windowDimensions, videoDimensions, height]);
+  }, [windowDimensions, videoDimensions]);
+
   return (
-    <SizingWindow
-      ref={windowEl}
-      className="sr-block"
-      minHeight={height}
-      isLoaded={videoDimensions.height !== 0}
-    >
+    <SizingWindow ref={windowEl} className="sr-block">
       <div ref={viewEl} className={className} />
       {fastForwardSpeed ? <PositionedFastForward speed={fastForwardSpeed} /> : null}
       {isBuffering ? <PositionedBuffering /> : null}
@@ -87,15 +80,9 @@ function BasePlayerRoot({className, height = Infinity}: Props) {
 // Center the viewEl inside the windowEl.
 // This is useful when the window is inside a container that has large fixed
 // dimensions, like when in fullscreen mode.
-const SizingWindow = styled('div')<{isLoaded: boolean; minHeight: number}>`
+const SizingWindow = styled('div')`
   width: 100%;
   height: 100%;
-  ${p =>
-    p.isLoaded
-      ? ''
-      : p.minHeight !== Infinity
-      ? `min-height: ${p.minHeight}px !important;`
-      : ''}
 
   display: flex;
   justify-content: center;

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -80,6 +80,9 @@ function BasePlayerRoot({className}: Props) {
 // Center the viewEl inside the windowEl.
 // This is useful when the window is inside a container that has large fixed
 // dimensions, like when in fullscreen mode.
+// If the container has a dimensions that can grow/shrink then it could be
+// important to also set `overflow: hidden` on the container, so that the
+// SizingWindow can calculate size as things shrink.
 const SizingWindow = styled('div')`
   width: 100%;
   height: 100%;
@@ -88,6 +91,7 @@ const SizingWindow = styled('div')`
   justify-content: center;
   align-items: center;
   position: relative;
+  overflow: hidden;
 
   background-color: ${p => p.theme.backgroundSecondary};
   background-image: repeating-linear-gradient(

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -47,6 +47,15 @@ const PanelHeader = styled(_PanelHeader)<{noBorder?: boolean}>`
   display: block;
   padding: 0;
   ${p => (p.noBorder ? 'border-bottom: none;' : '')}
+
+  /*
+  This style ensures that this PanelHeader grows and shrinks based on it's
+  parent, not the content inside.
+
+  The content inside will be set to height: 100% and then there's some code in
+  there to measure the size in pixels. If this was normal overflow then measured
+  size would never shrink.
+  */
   overflow: hidden;
 `;
 

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -1,6 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import debounce from 'lodash/debounce';
 
 import {Panel, PanelBody, PanelHeader as _PanelHeader} from 'sentry/components/panels';
 import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
@@ -10,50 +8,19 @@ import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import space from 'sentry/styles/space';
 
-// How much to reveal under the player, so people can see the 'pagefold' and
-// know that they can scroll the page.
-const BOTTOM_REVEAL_PIXELS = 70;
-
-const SCREEN_HEIGHT_DIVISOR = 2;
-
 type Props = {
   isFullscreen: boolean;
   toggleFullscreen: () => void;
 };
 
 function ReplayView({isFullscreen, toggleFullscreen}: Props) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const playerRef = useRef<HTMLDivElement>(null);
-
-  const [windowInnerHeight, setWindowInnerHeight] = useState(window.innerHeight);
-  const [playerHeight, setPlayerHeight] = useState(0);
-
-  useEffect(() => {
-    const onResize = debounce(() => {
-      setWindowInnerHeight(window.innerHeight);
-    });
-    window.addEventListener('resize', onResize);
-    return () => {
-      window.removeEventListener('resize', onResize);
-    };
-  }, []);
-
-  useEffect(() => {
-    const containerBottom =
-      (containerRef.current?.offsetTop || 0) + (containerRef.current?.offsetHeight || 0);
-    const playerOffsetHeight = playerRef.current?.offsetHeight || 0;
-    const calc =
-      windowInnerHeight - (containerBottom - playerOffsetHeight) - BOTTOM_REVEAL_PIXELS;
-    setPlayerHeight(Math.max(200, calc / SCREEN_HEIGHT_DIVISOR));
-  }, [windowInnerHeight]);
-
   return (
-    <PanelNoMargin ref={containerRef} isFullscreen={isFullscreen}>
+    <PanelNoMargin isFullscreen={isFullscreen}>
       <PanelHeader>
         <ReplayCurrentUrl />
       </PanelHeader>
-      <PanelHeader ref={playerRef} disablePadding noBorder>
-        <ReplayPlayer height={isFullscreen ? Infinity : playerHeight} />
+      <PanelHeader disablePadding noBorder>
+        <ReplayPlayer />
       </PanelHeader>
       <ScrubberMouseTracking>
         <PlayerScrubber />
@@ -72,19 +39,15 @@ const ReplayControllerWrapper = styled(PanelBody)`
 const PanelNoMargin = styled(Panel)<{isFullscreen: boolean}>`
   margin-bottom: 0;
   height: 100%;
-  ${p =>
-    p.isFullscreen
-      ? `
-      display: grid;
-      grid-template-rows: auto 1fr auto;
-      `
-      : ''}
+  display: grid;
+  grid-template-rows: auto 1fr auto;
 `;
 
 const PanelHeader = styled(_PanelHeader)<{noBorder?: boolean}>`
   display: block;
   padding: 0;
   ${p => (p.noBorder ? 'border-bottom: none;' : '')}
+  overflow: hidden;
 `;
 
 export default ReplayView;


### PR DESCRIPTION
Previously the ReplayPlayer has props to help it manage minimum sizes, but it was buggy and prevented the player from shrinking after being pulled taller.

Now the Player computes it's own size based on it's container, and there are no props that can get in the way of that. 

Potential problem with this is that if the replay data isn't loaded yet, then the Player window will become `0px` tall. The work-around is to use a `<Placeholder>` and swap in the Player when data is ready.

Fixes #36271