### PR TITLE
feat(msteams): Add tenant_id to integration.metadata on install

### DIFF
--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -83,6 +83,7 @@ class MsTeamsIntegrationProvider(IntegrationProvider):
         team_id = data["team_id"]
         team_name = data["team_name"]
         service_url = data["service_url"]
+        tenant_id = data["tenant_id"]
 
         # TODO: add try/except for request errors
         token_data = get_token_data()
@@ -96,6 +97,7 @@ class MsTeamsIntegrationProvider(IntegrationProvider):
                 "service_url": service_url,
                 # TODO: Determine if installation type is 'team' or 'tenant'
                 "installation_type": "team",
+                "tenant_id": tenant_id,
             },
             # TODO: Use user id for external_id in user_identity
             "user_identity": {"type": "msteams", "external_id": team_id, "scopes": [], "data": {}},

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -194,6 +194,7 @@ class MsTeamsWebhookEndpoint(Endpoint):
             "team_id": team["id"],
             "team_name": team["name"],
             "service_url": data["serviceUrl"],
+            "tenant_id": channel_data["tenant"]["id"],
         }
 
         # sign the params so this can't be forged

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -9,6 +9,7 @@ from sentry.testutils import IntegrationTestCase
 from sentry.utils.signing import sign
 
 team_id = "19:8d46058cda57449380517cc374727f2a@thread.tacv2"
+tenant_id = "50cccd00-7c9c-4b32-8cda-58a084f9334a"
 
 
 class MsTeamsIntegrationTest(IntegrationTestCase):
@@ -21,6 +22,7 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
             "team_id": team_id,
             "service_url": "https://smba.trafficmanager.net/amer/",
             "team_name": "my_team",
+            "tenant_id": tenant_id,
         }
 
     def assert_setup_flow(self):
@@ -69,6 +71,7 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
                 "service_url": "https://smba.trafficmanager.net/amer/",
                 "expires_at": self.start_time + 86399 - 60 * 5,
                 "installation_type": "team",
+                "tenant_id": tenant_id,
             }
             assert OrganizationIntegration.objects.get(
                 integration=integration, organization=self.organization


### PR DESCRIPTION
Add `tenant_id` to `integration.metadata` field for new installations of the Sentry Microsoft Teams app. This is important to identify what tenant each `team` falls under. It will also be used for personal installations of the app which are bound to `tenants` and not `teams`.