### PR TITLE
fix(releases): Opening TimeRangeSelector causes an exception (take 2, not a function edition)

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/timeRangeAutoCompleteFilter.tsx
+++ b/static/app/components/organizations/timeRangeSelector/timeRangeAutoCompleteFilter.tsx
@@ -1,5 +1,4 @@
 import autoCompleteFilter from 'sentry/components/dropdownAutoComplete/autoCompleteFilter';
-import {ItemsAfterFilter} from 'sentry/components/dropdownAutoComplete/types';
 import {t, tn} from 'sentry/locale';
 
 import TimeRangeItemLabel from './timeRangeItemLabel';
@@ -102,16 +101,7 @@ const timeRangeAutoCompleteFilter: typeof autoCompleteFilter = function (
   }
 
   // Otherwise, do a normal filter search
-  return items
-    ?.filter(item => {
-      // searchKey can sometimes be undefined or not a string, should look into this more
-      if (typeof item.searchKey === 'string') {
-        return item.searchKey.toLowerCase().includes(filterValue.toLowerCase());
-      }
-
-      return false;
-    })
-    .map((item, index) => ({...item, index})) as ItemsAfterFilter;
+  return autoCompleteFilter(items, filterValue);
 };
 
 export default timeRangeAutoCompleteFilter;

--- a/static/app/components/organizations/timeRangeSelector/timeRangeAutoCompleteFilter.tsx
+++ b/static/app/components/organizations/timeRangeSelector/timeRangeAutoCompleteFilter.tsx
@@ -103,7 +103,14 @@ const timeRangeAutoCompleteFilter: typeof autoCompleteFilter = function (
 
   // Otherwise, do a normal filter search
   return items
-    ?.filter(item => item.searchKey?.toLowerCase().includes(filterValue.toLowerCase()))
+    ?.filter(item => {
+      // searchKey can sometimes be undefined or not a string, should look into this more
+      if (typeof item.searchKey === 'string') {
+        return item.searchKey.toLowerCase().includes(filterValue.toLowerCase());
+      }
+
+      return false;
+    })
     .map((item, index) => ({...item, index})) as ItemsAfterFilter;
 };
 


### PR DESCRIPTION
Looking into the reason why `searchKey` isn't always a string, but figured I'm make a quick fix PR first while investigating.