### PR TITLE
feat(replays): Update controller button style to match designs

### DIFF
--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -55,7 +55,7 @@ function ReplayPlayPauseBar({isCompact}: {isCompact: boolean}) {
     <ButtonBar merged>
       {!isCompact && (
         <Button
-          size="xs"
+          size="sm"
           title={t('Rewind 10s')}
           icon={<IconRewind10 size="sm" />}
           onClick={() => setCurrentTime(currentTime - 10 * SECOND)}
@@ -64,7 +64,7 @@ function ReplayPlayPauseBar({isCompact}: {isCompact: boolean}) {
       )}
       {isFinished ? (
         <Button
-          size="xs"
+          size="sm"
           title={t('Restart Replay')}
           icon={<IconPrevious size="sm" />}
           onClick={restart}
@@ -72,7 +72,7 @@ function ReplayPlayPauseBar({isCompact}: {isCompact: boolean}) {
         />
       ) : (
         <Button
-          size="xs"
+          size="sm"
           title={isPlaying ? t('Pause') : t('Play')}
           icon={isPlaying ? <IconPause size="sm" /> : <IconPlay size="sm" />}
           onClick={() => togglePlayPause(!isPlaying)}
@@ -81,7 +81,7 @@ function ReplayPlayPauseBar({isCompact}: {isCompact: boolean}) {
       )}
       {!isCompact && (
         <Button
-          size="xs"
+          size="sm"
           title={t('Next breadcrumb')}
           icon={<IconNext size="sm" />}
           onClick={() => {
@@ -129,7 +129,7 @@ function ReplayOptionsMenu({speedOptions}: {speedOptions: number[]}) {
         <Button
           ref={ref}
           {...props}
-          size="xs"
+          size="sm"
           title={t('Settings')}
           aria-label={t('Settings')}
           icon={<IconSettings size="sm" />}
@@ -197,7 +197,7 @@ const ReplayControls = ({
       <ReplayOptionsMenu speedOptions={speedOptions} />
 
       <Button
-        size="xs"
+        size="sm"
         title={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
         aria-label={isFullscreen ? t('Exit full screen') : t('Enter full screen')}
         icon={isFullscreen ? <IconContract size="sm" /> : <IconExpand size="sm" />}
@@ -210,7 +210,7 @@ const ReplayControls = ({
 const ButtonGrid = styled('div')`
   display: grid;
   grid-column-gap: ${space(1)};
-  grid-template-columns: max-content auto max-content max-content max-content;
+  grid-template-columns: max-content auto max-content max-content;
   align-items: center;
 `;
 

--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import TextCopyInput, {
-  StyledCopyButton,
-  StyledInput,
-} from 'sentry/components/forms/textCopyInput';
+import TextCopyInput from 'sentry/components/forms/textCopyInput';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import space from 'sentry/styles/space';
 import getCurrentUrl from 'sentry/utils/replays/getCurrentUrl';
 
 function ReplayCurrentUrl() {
@@ -22,25 +18,7 @@ function ReplayCurrentUrl() {
 }
 
 const UrlCopyInput = styled(TextCopyInput)`
-  ${StyledInput} {
-    background: ${p => p.theme.background};
-    border: none;
-    padding: 0 ${space(0.75)};
-    font-size: ${p => p.theme.fontSizeMedium};
-    border-bottom-left-radius: 0;
-    height: ${space(4)};
-  }
-  ${StyledInput}[disabled] {
-    border: none;
-  }
-
-  ${StyledCopyButton} {
-    border-top: none;
-    border-right: none;
-    border-bottom: none;
-    height: ${space(4)};
-    min-height: ${space(4)};
-  }
+  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 export default ReplayCurrentUrl;

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Panel, PanelBody, PanelHeader as _PanelHeader} from 'sentry/components/panels';
@@ -15,32 +16,33 @@ type Props = {
 
 function ReplayView({isFullscreen, toggleFullscreen}: Props) {
   return (
-    <PanelNoMargin isFullscreen={isFullscreen}>
-      <PanelHeader>
-        <ReplayCurrentUrl />
-      </PanelHeader>
-      <PanelHeader disablePadding noBorder>
-        <ReplayPlayer />
-      </PanelHeader>
-      <ScrubberMouseTracking>
-        <PlayerScrubber />
-      </ScrubberMouseTracking>
+    <Fragment>
+      <ReplayCurrentUrl />
+      <PanelNoMargin isFullscreen={isFullscreen}>
+        <PanelHeader disablePadding noBorder>
+          <ReplayPlayer />
+        </PanelHeader>
+        <ScrubberMouseTracking>
+          <PlayerScrubber />
+        </ScrubberMouseTracking>
+      </PanelNoMargin>
       <ReplayControllerWrapper>
         <ReplayController toggleFullscreen={toggleFullscreen} />
       </ReplayControllerWrapper>
-    </PanelNoMargin>
+    </Fragment>
   );
 }
 
 const ReplayControllerWrapper = styled(PanelBody)`
-  padding: ${space(1)};
+  padding-top: ${space(1)};
 `;
 
 const PanelNoMargin = styled(Panel)<{isFullscreen: boolean}>`
+  margin-top: ${space(1)};
   margin-bottom: 0;
   height: 100%;
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: 1fr auto;
 `;
 
 const PanelHeader = styled(_PanelHeader)<{noBorder?: boolean}>`


### PR DESCRIPTION
Changes:

- Added space between the a) URL bar b) Video + Scrubber c) Play/Pause buttons
- Play/Pause buttons are a little bigger now: `xs` to `sm`
- The URL and Play/Pause rows are outside of the Panel now, so no border contains them
- The "Copy URL" button is _not_ separate from the input box, because that required a bunch of custom css and i'm claiming it's low impact high effort to do it.

**After**
<img width="555" alt="Screen Shot 2022-07-15 at 4 38 19 PM" src="https://user-images.githubusercontent.com/187460/179324667-dd607d52-b868-47d6-b6ec-2d283684f864.png">

**Mock**
<img width="457" alt="Screen Shot 2022-07-15 at 4 43 44 PM" src="https://user-images.githubusercontent.com/187460/179325001-c8129375-0a32-4f0f-a965-426e2a5a18c2.png">


**Before**
<img width="555" alt="Screen Shot 2022-07-15 at 4 39 48 PM" src="https://user-images.githubusercontent.com/187460/179324763-c24f50ad-d29a-47cd-9773-005bbe7d8026.png">
