### PR TITLE
ref(sampling): Update column width

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -551,7 +551,7 @@ const RulesPanelLayout = styled('div')<{isContent?: boolean}>`
   grid-template-columns: 1fr 0.5fr 74px;
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: 48px 95px 1fr 0.5fr 77px 74px;
+    grid-template-columns: 48px 97px 1fr 0.5fr 77px 74px;
   }
 
   ${p =>


### PR DESCRIPTION
Sometimes when loading the sampling page, the Operator column seems to not have enough space, breaking the title word. This PR fixes the issue

**Before:**

![image](https://user-images.githubusercontent.com/29228205/179473008-2d30ed13-f051-413a-a8ef-3dfa7c34c012.png)

**After:**

![image](https://user-images.githubusercontent.com/29228205/179472940-451b23d4-8ff7-4768-acd7-1594160d432d.png)
