### PR TITLE
fix(discover): immediate csv download

### DIFF
--- a/static/app/views/eventsV2/table/tableActions.tsx
+++ b/static/app/views/eventsV2/table/tableActions.tsx
@@ -39,12 +39,15 @@ function handleDownloadAsCsv(title: string, {organization, eventView, tableData}
 }
 
 function renderDownloadButton(canEdit: boolean, props: Props) {
+  const {tableData} = props;
   return (
     <Feature
       features={['organizations:discover-query']}
       renderDisabled={() => renderBrowserExportButton(canEdit, props)}
     >
-      {renderAsyncExportButton(canEdit, props)}
+      {tableData?.data && tableData.data.length < 50
+        ? renderBrowserExportButton(canEdit, props)
+        : renderAsyncExportButton(canEdit, props)}
     </Feature>
   );
 }
@@ -61,8 +64,11 @@ function renderBrowserExportButton(canEdit: boolean, props: Props) {
       onClick={onClick}
       data-test-id="grid-download-csv"
       icon={<IconDownload size="xs" />}
+      title={t(
+        "There aren't that many results, start your export and it'll download immediately"
+      )}
     >
-      {t('Export')}
+      {t('Export All')}
     </Button>
   );
 }

--- a/static/app/views/eventsV2/table/tableActions.tsx
+++ b/static/app/views/eventsV2/table/tableActions.tsx
@@ -65,7 +65,7 @@ function renderBrowserExportButton(canEdit: boolean, props: Props) {
       data-test-id="grid-download-csv"
       icon={<IconDownload size="xs" />}
       title={t(
-        "There aren't that many results, start your export and it'll download immediately"
+        "There aren't that many results, start your export and it'll download immediately."
       )}
     >
       {t('Export All')}

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -184,7 +184,6 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
     fields: headings,
     data: data.map(row =>
       headings.map(col => {
-        col = getAggregateAlias(col);
         return disableMacros(row[col]);
       })
     ),


### PR DESCRIPTION
- This re-introduces the browser export button
  - We used to have the behaviour where we'd download csvs immediately if there was less than 50 results, but removed it in https://github.com/getsentry/sentry/pull/20027 cause it was causing visual jank
  - I think this removes the visual jank just by making both buttons `export all` 🤷?
- fix: Don't need `getAggregateAlias` anymore with events api