### PR TITLE
feat(dashboard-filters): Add saved filter keys to type

### DIFF
--- a/static/app/views/dashboardsV2/data.tsx
+++ b/static/app/views/dashboardsV2/data.tsx
@@ -13,6 +13,8 @@ export const EMPTY_DASHBOARD: DashboardDetails = {
   createdBy: undefined,
   title: t('Untitled dashboard'),
   widgets: [],
+  projects: [],
+  filters: {},
 };
 
 export const DASHBOARDS_TEMPLATES: DashboardTemplate[] = [
@@ -22,6 +24,8 @@ export const DASHBOARDS_TEMPLATES: DashboardTemplate[] = [
     createdBy: undefined,
     title: t('General Template'),
     description: t('Various Frontend and Backend Widgets'),
+    projects: [],
+    filters: {},
     widgets: [
       {
         title: t('Number of Errors'),
@@ -383,6 +387,8 @@ export const DASHBOARDS_TEMPLATES: DashboardTemplate[] = [
     dateCreated: '',
     createdBy: undefined,
     description: t('Erroring URLs and Web Vitals'),
+    projects: [],
+    filters: {},
     widgets: [
       {
         title: t('Top 5 Issues by Unique Users Over Time'),
@@ -758,6 +764,8 @@ export const DASHBOARDS_TEMPLATES: DashboardTemplate[] = [
     dateCreated: '',
     createdBy: undefined,
     description: t('Issues and Performance'),
+    projects: [],
+    filters: {},
     widgets: [
       {
         title: t('Top 5 Issues by Unique Users Over Time'),
@@ -1121,6 +1129,8 @@ export const DASHBOARDS_TEMPLATES: DashboardTemplate[] = [
     dateCreated: '',
     createdBy: undefined,
     description: t('Crash Details and Performance Vitals'),
+    projects: [],
+    filters: {},
     widgets: [
       {
         title: t('Total Crashes'),

--- a/static/app/views/dashboardsV2/types.tsx
+++ b/static/app/views/dashboardsV2/types.tsx
@@ -81,10 +81,18 @@ export type DashboardListItem = {
  */
 export type DashboardDetails = {
   dateCreated: string;
+  filters: {
+    releases?: string[];
+  };
   id: string;
+  projects: number[];
   title: string;
   widgets: Widget[];
   createdBy?: User;
+  end?: string;
+  environment?: string[];
+  period?: string;
+  start?: string;
 };
 
 export enum DashboardState {

--- a/tests/js/spec/components/modals/addToDashboardModal.spec.tsx
+++ b/tests/js/spec/components/modals/addToDashboardModal.spec.tsx
@@ -37,6 +37,8 @@ describe('add to dashboard modal', () => {
     createdBy: undefined,
     dateCreated: '2020-01-01T00:00:00.000Z',
     widgets: [],
+    projects: [],
+    filters: {},
   };
   let widget = {
     title: 'Test title',

--- a/tests/js/spec/views/dashboardsV2/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/dashboard.spec.tsx
@@ -13,6 +13,8 @@ describe('Dashboards > Dashboard', () => {
     id: '1',
     title: 'Test Dashboard',
     widgets: [],
+    projects: [],
+    filters: {},
   };
   const newWidget = {
     title: 'Test Query',

--- a/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/dashboard.spec.tsx
@@ -18,6 +18,8 @@ describe('Dashboards > Dashboard', () => {
     id: '1',
     title: 'Test Dashboard',
     widgets: [],
+    projects: [],
+    filters: {},
   };
   const newWidget: Widget = {
     id: '1',

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -83,6 +83,8 @@ describe('VisualizationStep', function () {
           createdBy: undefined,
           dateCreated: '2020-01-01T00:00:00.000Z',
           widgets: [],
+          projects: [],
+          filters: {},
         }}
         onSave={jest.fn()}
         params={{
@@ -132,6 +134,8 @@ describe('VisualizationStep', function () {
           createdBy: undefined,
           dateCreated: '2020-01-01T00:00:00.000Z',
           widgets: [],
+          projects: [],
+          filters: {},
         }}
         onSave={jest.fn()}
         params={{

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -29,6 +29,19 @@ const defaultOrgFeatures = [
 // Mocking worldMapChart to avoid act warnings
 jest.mock('sentry/components/charts/worldMapChart');
 
+function mockDashboard(dashboard: Partial<DashboardDetails>): DashboardDetails {
+  return {
+    id: '1',
+    title: 'Dashboard',
+    createdBy: undefined,
+    dateCreated: '2020-01-01T00:00:00.000Z',
+    widgets: [],
+    projects: [],
+    filters: {},
+    ...dashboard,
+  };
+}
+
 function renderTestComponent({
   dashboard,
   query,
@@ -70,6 +83,8 @@ function renderTestComponent({
         createdBy: undefined,
         dateCreated: '2020-01-01T00:00:00.000Z',
         widgets: [],
+        projects: [],
+        filters: {},
         ...dashboard,
       }}
       onSave={onSave ?? jest.fn()}
@@ -95,6 +110,8 @@ describe('WidgetBuilder', function () {
     createdBy: undefined,
     dateCreated: '2020-01-01T00:00:00.000Z',
     widgets: [],
+    projects: [],
+    filters: {},
   };
 
   const testDashboard: DashboardDetails = {
@@ -103,6 +120,8 @@ describe('WidgetBuilder', function () {
     createdBy: undefined,
     dateCreated: '2020-01-01T00:00:00.000Z',
     widgets: [],
+    projects: [],
+    filters: {},
   };
 
   let eventsStatsMock: jest.Mock | undefined;
@@ -264,13 +283,7 @@ describe('WidgetBuilder', function () {
         id: '1',
       };
 
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+      const dashboard = mockDashboard({widgets: [widget]});
 
       renderTestComponent({
         dashboard,
@@ -303,13 +316,7 @@ describe('WidgetBuilder', function () {
         id: '1',
       };
 
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+      const dashboard = mockDashboard({widgets: [widget]});
 
       renderTestComponent({
         dashboard,
@@ -673,13 +680,7 @@ describe('WidgetBuilder', function () {
         ],
       };
 
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+      const dashboard = mockDashboard({widgets: [widget]});
 
       renderTestComponent({dashboard, params: {widgetIndex: '0'}});
 
@@ -755,13 +756,7 @@ describe('WidgetBuilder', function () {
         ],
       };
 
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+      const dashboard = mockDashboard({widgets: [widget]});
 
       const handleSave = jest.fn();
 
@@ -812,13 +807,7 @@ describe('WidgetBuilder', function () {
         ],
       };
 
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+      const dashboard = mockDashboard({widgets: [widget]});
 
       renderTestComponent({dashboard, params: {widgetIndex: '0'}});
 
@@ -855,13 +844,7 @@ describe('WidgetBuilder', function () {
         ],
       };
 
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+      const dashboard = mockDashboard({widgets: [widget]});
 
       const handleSave = jest.fn();
 
@@ -1006,13 +989,8 @@ describe('WidgetBuilder', function () {
           },
         ],
       };
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+
+      const dashboard = mockDashboard({widgets: [widget]});
 
       renderTestComponent({onSave: handleSave, dashboard, params: {widgetIndex: '0'}});
 
@@ -1046,13 +1024,8 @@ describe('WidgetBuilder', function () {
           },
         ],
       };
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+
+      const dashboard = mockDashboard({widgets: [widget]});
 
       const {router} = renderTestComponent({
         dashboard,
@@ -1096,13 +1069,7 @@ describe('WidgetBuilder', function () {
         ],
       };
 
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+      const dashboard = mockDashboard({widgets: [widget]});
 
       const handleSave = jest.fn();
 
@@ -1379,13 +1346,7 @@ describe('WidgetBuilder', function () {
           ],
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
@@ -1439,13 +1400,7 @@ describe('WidgetBuilder', function () {
           ],
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
@@ -1490,13 +1445,7 @@ describe('WidgetBuilder', function () {
           ],
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
@@ -1720,13 +1669,7 @@ describe('WidgetBuilder', function () {
           ],
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
         renderTestComponent({
           orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
           query: {
@@ -1907,13 +1850,7 @@ describe('WidgetBuilder', function () {
             ],
           };
 
-          const dashboard: DashboardDetails = {
-            id: '1',
-            title: 'Dashboard',
-            createdBy: undefined,
-            dateCreated: '2020-01-01T00:00:00.000Z',
-            widgets: [widget],
-          };
+          const dashboard = mockDashboard({widgets: [widget]});
 
           renderTestComponent({
             orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
@@ -1945,13 +1882,7 @@ describe('WidgetBuilder', function () {
           ],
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
@@ -2038,13 +1969,7 @@ describe('WidgetBuilder', function () {
           ],
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           dashboard,
@@ -2216,13 +2141,7 @@ describe('WidgetBuilder', function () {
         ],
       };
 
-      const dashboard: DashboardDetails = {
-        id: '1',
-        title: 'Dashboard',
-        createdBy: undefined,
-        dateCreated: '2020-01-01T00:00:00.000Z',
-        widgets: [widget],
-      };
+      const dashboard = mockDashboard({widgets: [widget]});
 
       renderTestComponent({
         orgFeatures: [...defaultOrgFeatures, 'new-widget-builder-experience-design'],
@@ -2782,13 +2701,7 @@ describe('WidgetBuilder', function () {
           id: '1',
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           orgFeatures: releaseHealthFeatureFlags,
@@ -3110,13 +3023,7 @@ describe('WidgetBuilder', function () {
           id: '1',
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           dashboard,
@@ -3159,13 +3066,7 @@ describe('WidgetBuilder', function () {
           limit: 1,
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           dashboard,
@@ -3208,13 +3109,7 @@ describe('WidgetBuilder', function () {
           limit: 1,
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           dashboard,
@@ -3298,13 +3193,7 @@ describe('WidgetBuilder', function () {
           ],
         };
 
-        const dashboard: DashboardDetails = {
-          id: '1',
-          title: 'Dashboard',
-          createdBy: undefined,
-          dateCreated: '2020-01-01T00:00:00.000Z',
-          widgets: [widget],
-        };
+        const dashboard = mockDashboard({widgets: [widget]});
 
         renderTestComponent({
           orgFeatures: [


### PR DESCRIPTION
Now that the API exposes some saved filter keys, we need to update the
DashboardDetails type to consume the filters.