### PR TITLE
fix(mep): Timeseries limit

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -2221,6 +2221,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
         allow_metric_aggregates: Optional[bool] = False,
         functions_acl: Optional[List[str]] = None,
         dry_run: Optional[bool] = False,
+        limit: Optional[int] = 10000,
     ):
         super().__init__(
             params=params,
@@ -2239,6 +2240,7 @@ class TimeseriesMetricQueryBuilder(MetricsQueryBuilder):
                     break
 
         self.time_column = self.resolve_time_column(interval)
+        self.limit = None if limit is None else Limit(limit)
 
         # This is a timeseries, the groupby will always be time
         self.groupby = [self.time_column]


### PR DESCRIPTION
- This sets the default limit for timeseries queries to 10k since that's what's needed to render graphs
  - there's a known TODO to eventually change this limit to be calculated based on interval & timerange
