### PR TITLE
Exclude files accidentally checked by Fossa

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -11,3 +11,5 @@ targets:
   exclude:
     - type: projectjson
       path: api-docs/components/schemas
+    - type: setuptools
+      path: src/sentry/templates/sentry/emails


### PR DESCRIPTION
This excludes the folder of email templates that can get picked up by Fossa. Fossa searches for `*req*.txt` so e.g. https://github.com/getsentry/sentry/blob/master/src/sentry/templates/sentry/emails/organization-invite-request.txt will match.