### PR TITLE
chore(trace): Reword the trace alert

### DIFF
--- a/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
@@ -129,7 +129,7 @@ class IssueQuickTrace extends Component<Props, State> {
             </Button>
           }
         >
-          {tct('The [type] for this error cannot be found. [link]', {
+          {tct('The [type] for this event cannot be found. [link]', {
             type: type === 'missing' ? t('transaction') : t('trace'),
             link: (
               <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#troubleshooting">


### PR DESCRIPTION
- this updates the alert when a trace is missing, since "error" being so close to "trace" can be confused with a "stacktrace"
