### PR TITLE
fix(replays): Fix border radius on the last Console row

### DIFF
--- a/static/app/views/replays/detail/console/consoleMessage.tsx
+++ b/static/app/views/replays/detail/console/consoleMessage.tsx
@@ -191,7 +191,25 @@ const Common = styled('div')<{
     return 'inherit';
   }};
   ${p => (!p.isLast ? `border-bottom: 1px solid ${p.theme.innerBorder}` : '')};
+
   transition: color 0.5s ease;
+
+  /*
+  Using radius of 3px instead of p.theme.borderRadius (4px) because this is an
+  inner radius to the border, and needs to be smaller to avoid gaps in the turn.
+  */
+  &:nth-child(1) {
+    border-top-left-radius: 3px;
+  }
+  &:nth-child(3) {
+    border-top-right-radius: 3px;
+  }
+  &:nth-last-child(1) {
+    border-bottom-right-radius: 3px;
+  }
+  &:nth-last-child(3) {
+    border-bottom-left-radius: 3px;
+  }
 `;
 
 const ConsoleTimestamp = styled(Common)<{isLast: boolean; level: string}>`
@@ -201,7 +219,24 @@ const ConsoleTimestamp = styled(Common)<{isLast: boolean; level: string}>`
 
 const Icon = styled(Common)<{isActive: boolean}>`
   padding: ${space(0.5)} ${space(1)};
-  border-left: 4px solid ${p => (p.isActive ? p.theme.focus : 'transparent')};
+  position: relative;
+
+  &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    height: 100%;
+    width: ${space(0.5)};
+    background-color: ${p => (p.isActive ? p.theme.focus : 'transparent')};
+  }
+  &:nth-child(1):after {
+    border-top-left-radius: 3px;
+  }
+  &:nth-last-child(3):after {
+    border-bottom-left-radius: 3px;
+  }
 `;
 const Message = styled(Common)`
   padding: ${space(0.25)} 0;


### PR DESCRIPTION
Set an inner border-radius for console rows, so the top and bottom row no longer overlap background with the border:

**Before (using red to highlight the issue):**
<img width="489" alt="Screen Shot 2022-07-18 at 10 29 57 AM" src="https://user-images.githubusercontent.com/187460/179569229-3476927d-01ad-4955-a598-919391b755fd.png">


**After (using red to highlight the issue):**
<img width="369" alt="Screen Shot 2022-07-18 at 10 30 02 AM" src="https://user-images.githubusercontent.com/187460/179569248-30c11c51-a62e-4e36-bcde-b9186846532d.png">

--- 

I also changed the `isActive` styling to use an `:after` pseudo-element instead of using `border`.
- One consequence of this is that the icon will now be 4px closer to the purple highlight bar, because the transparent border before was taking up that space and i took the border out without adding to the padding.
- Border radius is accounted for.

**Before:**
<img width="319" alt="Screen Shot 2022-07-18 at 10 30 29 AM" src="https://user-images.githubusercontent.com/187460/179569431-08a338c0-ef15-4d8a-a98e-0b433228a9eb.png">
<img width="630" alt="Screen Shot 2022-07-18 at 10 34 11 AM" src="https://user-images.githubusercontent.com/187460/179569895-ae0f25ce-d817-470e-ab25-8774d06c94b3.png">


**After:**
<img width="281" alt="Screen Shot 2022-07-18 at 10 30 34 AM" src="https://user-images.githubusercontent.com/187460/179569466-d921bf21-15b7-48c3-9355-b06d9e274c14.png">

<img width="486" alt="Screen Shot 2022-07-18 at 10 31 09 AM" src="https://user-images.githubusercontent.com/187460/179569923-10848586-8b6c-4dfd-a042-1a415b450a53.png">


Fixes #36738