### PR TITLE
fix(tagstore): change empty list -> empty dict

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -558,7 +558,7 @@ class SnubaTagStorage(TagStorage):
 
         for keyobj in keys_with_counts:
             key = keyobj.key
-            values = values_by_key.get(key, [])
+            values = values_by_key.get(key, dict())
             keyobj.top_values = [
                 value_ctor(
                     key=keyobj.key,


### PR DESCRIPTION
This is a bit hard to test because we're not doing any Snuba mock output here, and I'm not sure how to generate this data condition locally.

But this should fix the immediate cause of broken page load for a very small number of users