### PR TITLE
feat: Make string indexer cache backend configurable

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2709,3 +2709,10 @@ SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS = {
 
 # maximum number of projects allowed to query snuba with for the organization_vitals_overview endpoint
 ORGANIZATION_VITALS_OVERVIEW_PROJECT_LIMIT = 300
+
+
+# Default string indexer cache options
+SENTRY_STRING_INDEXER_CACHE_OPTIONS = {
+    "version": 1,
+    "cache_name": "default",
+}


### PR DESCRIPTION
Allows configuring cache backend name and version for the cache key of string indexer cache through Django settings.