### PR TITLE
feat(dashboards): Rename releases key in filters to release

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -145,7 +145,7 @@ class DashboardDetailsSerializer(Serializer):
 
     def serialize(self, obj, attrs, user, **kwargs):
         page_filter_keys = ["environment", "period"]
-        dashboard_filter_keys = ["releases"]
+        dashboard_filter_keys = ["release"]
         data = {
             "id": str(obj.id),
             "title": obj.title,

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -321,7 +321,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
 
     def update_dashboard_filters(self, instance, validated_data):
         page_filter_keys = ["environment", "period", "start", "end"]
-        dashboard_filter_keys = ["releases"]
+        dashboard_filter_keys = ["release"]
 
         if "projects" in validated_data:
             instance.projects.set(validated_data["projects"])

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -153,7 +153,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert "period" not in response.data
 
     def test_dashboard_filters_are_returned_in_response(self):
-        filters = {"environment": ["alpha"], "period": "24hr", "releases": ["test-release"]}
+        filters = {"environment": ["alpha"], "period": "24hr", "release": ["test-release"]}
         dashboard = Dashboard.objects.create(
             title="Dashboard With Filters",
             created_by=self.user,
@@ -166,7 +166,7 @@ class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
         assert response.data["projects"] == list(dashboard.projects.values_list("id", flat=True))
         assert response.data["environment"] == filters["environment"]
         assert response.data["period"] == filters["period"]
-        assert response.data["filters"]["releases"] == filters["releases"]
+        assert response.data["filters"]["release"] == filters["release"]
 
     def test_start_and_end_filters_are_returned_in_response(self):
         start = iso_format(datetime.now() - timedelta(seconds=10))
@@ -1358,7 +1358,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             "projects": [project1.id, project2.id],
             "environment": ["alpha"],
             "period": "7d",
-            "filters": {"releases": ["v1"]},
+            "filters": {"release": ["v1"]},
         }
 
         response = self.do_request("put", self.url(self.dashboard.id), data=data)
@@ -1366,7 +1366,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         assert response.data["projects"] == [project1.id, project2.id]
         assert response.data["environment"] == ["alpha"]
         assert response.data["period"] == "7d"
-        assert response.data["filters"]["releases"] == ["v1"]
+        assert response.data["filters"]["release"] == ["v1"]
 
     def test_update_dashboard_with_invalid_project_filter(self):
         other_project = self.create_project(name="other", organization=self.create_organization())

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -489,14 +489,14 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 "projects": [project1.id, project2.id],
                 "environment": ["alpha"],
                 "period": "7d",
-                "filters": {"releases": ["v1"]},
+                "filters": {"release": ["v1"]},
             },
         )
         assert response.status_code == 201
         assert response.data["projects"] == [project1.id, project2.id]
         assert response.data["environment"] == ["alpha"]
         assert response.data["period"] == "7d"
-        assert response.data["filters"]["releases"] == ["v1"]
+        assert response.data["filters"]["release"] == ["v1"]
 
     def test_post_with_start_and_end_filter(self):
         start = iso_format(datetime.now() - timedelta(seconds=10))


### PR DESCRIPTION
Rename releases to release in dashboard filters because that is the
key used in query conditions and it will make it easier to map.

These fields are currently not being used in production so no migration is
required to switch values over to `release`.

This PR will fix the FE types to use `release` https://github.com/getsentry/sentry/pull/36782