### PR TITLE
test(aceptance): Skip flaky project setting sampling test

### DIFF
--- a/tests/acceptance/test_project_settings_sampling.py
+++ b/tests/acceptance/test_project_settings_sampling.py
@@ -78,6 +78,7 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
         self.browser.get(self.path)
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
+    @pytest.mark.skip(reason="Flaky")
     def test_add_uniform_rule_with_recommended_sampling_values(self):
         with self.feature(FEATURE_NAME):
             self.wait_until_page_loaded()


### PR DESCRIPTION
Seems to be flaking as well, similar to https://github.com/getsentry/sentry/pull/36767

Skipping until there is time to re-visit