### PR TITLE
ref(sampling): Attempt to fix e2e flaky test - frontend

### DIFF
--- a/static/app/actionCreators/serverSideSampling.tsx
+++ b/static/app/actionCreators/serverSideSampling.tsx
@@ -28,10 +28,17 @@ export function fetchSamplingSdkVersions({
     }
   );
 
-  promise.then(ServerSideSamplingStore.loadSamplingSdkVersionsSuccess).catch(response => {
-    const errorMessage = t('Unable to fetch sampling sdk versions');
-    handleXhrErrorResponse(errorMessage)(response);
-  });
+  ServerSideSamplingStore.setFetching(true);
+
+  promise
+    .then(ServerSideSamplingStore.loadSamplingSdkVersionsSuccess)
+    .catch(response => {
+      const errorMessage = t('Unable to fetch sampling sdk versions');
+      handleXhrErrorResponse(errorMessage)(response);
+    })
+    .finally(() => {
+      ServerSideSamplingStore.setFetching(false);
+    });
 
   return promise;
 }
@@ -47,6 +54,8 @@ export function fetchSamplingDistribution({
 }): Promise<SamplingDistribution> {
   ServerSideSamplingStore.reset();
 
+  ServerSideSamplingStore.setFetching(true);
+
   const promise = api.requestPromise(
     `/projects/${orgSlug}/${projSlug}/dynamic-sampling/distribution/`,
     {
@@ -61,6 +70,9 @@ export function fetchSamplingDistribution({
     .catch(response => {
       const errorMessage = t('Unable to fetch sampling distribution');
       handleXhrErrorResponse(errorMessage)(response);
+    })
+    .finally(() => {
+      ServerSideSamplingStore.setFetching(false);
     });
 
   return promise;

--- a/static/app/stores/serverSideSamplingStore.tsx
+++ b/static/app/stores/serverSideSamplingStore.tsx
@@ -6,6 +6,7 @@ import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 import {CommonStoreDefinition} from './types';
 
 type State = {
+  fetching: boolean;
   samplingDistribution: SamplingDistribution;
   samplingSdkVersions: SamplingSdkVersion[];
 };
@@ -14,12 +15,14 @@ interface ServerSideSamplingStoreDefinition extends CommonStoreDefinition<State>
   loadSamplingDistributionSuccess(data: SamplingDistribution): void;
   loadSamplingSdkVersionsSuccess(data: SamplingSdkVersion[]): void;
   reset(): void;
+  setFetching(fetching: boolean): void;
 }
 
 const storeConfig: ServerSideSamplingStoreDefinition = {
   state: {
     samplingDistribution: {},
     samplingSdkVersions: [],
+    fetching: false,
   },
 
   reset() {
@@ -32,6 +35,11 @@ const storeConfig: ServerSideSamplingStoreDefinition = {
 
   getState() {
     return this.state;
+  },
+
+  setFetching(fetching: boolean) {
+    this.state.fetching = fetching;
+    this.trigger(this.state);
   },
 
   loadSamplingSdkVersionsSuccess(data: SamplingSdkVersion[]) {

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -86,11 +86,12 @@ function UniformRateModal({
     statsPeriod: '30d',
   });
 
-  const {recommendedSdkUpgrades} = useRecommendedSdkUpgrades({
-    orgSlug: organization.slug,
-  });
+  const {recommendedSdkUpgrades, fetching: fetchingRecommendedSdkUpgrades} =
+    useRecommendedSdkUpgrades({
+      orgSlug: organization.slug,
+    });
 
-  const loading = loading30d || !projectStats;
+  const loading = loading30d || !projectStats || fetchingRecommendedSdkUpgrades;
 
   const [activeStep, setActiveStep] = useState<Step>(Step.SET_UNIFORM_SAMPLE_RATE);
 

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -113,9 +113,10 @@ export function ServerSideSampling({project}: Props) {
     statsPeriod: '48h',
   });
 
-  const {recommendedSdkUpgrades} = useRecommendedSdkUpgrades({
-    orgSlug: organization.slug,
-  });
+  const {recommendedSdkUpgrades, fetching: fetchingRecommendedSdkUpgrades} =
+    useRecommendedSdkUpgrades({
+      orgSlug: organization.slug,
+    });
 
   async function handleActivateToggle(rule: SamplingRule) {
     const newRules = rules.map(r => {
@@ -410,7 +411,7 @@ export function ServerSideSampling({project}: Props) {
             'These settings can only be edited by users with the organization owner, manager, or admin role.'
           )}
         />
-        {!!rules.length && (
+        {!!rules.length && !fetchingRecommendedSdkUpgrades && (
           <SamplingSDKAlert
             organization={organization}
             projectId={project.id}

--- a/static/app/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.tsx
@@ -9,7 +9,7 @@ type Props = {
 };
 
 export function useRecommendedSdkUpgrades({orgSlug}: Props) {
-  const {samplingSdkVersions} = useLegacyStore(ServerSideSamplingStore);
+  const {samplingSdkVersions, fetching} = useLegacyStore(ServerSideSamplingStore);
 
   const notSendingSampleRateSdkUpgrades = samplingSdkVersions.filter(
     samplingSdkVersion => !samplingSdkVersion.isSendingSampleRate
@@ -39,5 +39,5 @@ export function useRecommendedSdkUpgrades({orgSlug}: Props) {
     })
     .filter(defined);
 
-  return {recommendedSdkUpgrades};
+  return {recommendedSdkUpgrades, fetching};
 }

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
@@ -153,6 +153,7 @@ useRecommendedSdkUpgrades.mockImplementation(() => ({
       latestSDKVersion: mockedSamplingSdkVersions[1].latestSDKVersion,
     },
   ],
+  fetching: false,
 }));
 
 export function getMockData({


### PR DESCRIPTION
**What this PR does:**

~- Add a loading indicator component to the main sampling page~
- Add fetching to the `ServerSideSamplingStore` and based on it, updated the logic to display the `SDKUpdateAlert` component
- Update e2e tests, removing the skip notation