### PR TITLE
fix(dashboards): Styling on release filter in dashboard

### DIFF
--- a/static/app/views/dashboardsV2/releasesSelectControl.tsx
+++ b/static/app/views/dashboardsV2/releasesSelectControl.tsx
@@ -67,7 +67,7 @@ const StyledBadge = styled(Badge)`
 const ButtonLabelWrapper = styled('span')`
   width: 100%;
   text-align: left;
-  display: flex;
-  justify-content: space-between;
   align-items: center;
+  display: inline-grid;
+  grid-template-columns: 1fr auto;
 `;


### PR DESCRIPTION
Using flexbox in the label was causing it to overflow the button,
revert to using grid and style using grid-template-columns

Before:
![Screen Shot 2022-07-19 at 10 02 29 AM](https://user-images.githubusercontent.com/22846452/179770403-ba9c07b6-ffa9-4572-b805-68a200422f56.png)

After:
![Screen Shot 2022-07-19 at 10 02 02 AM](https://user-images.githubusercontent.com/22846452/179770434-02978a93-a0d4-4c69-a0a6-f33d57937d18.png)

