### PR TITLE
fix(replays): add padding for breadcrumbs

### DIFF
--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useRef} from 'react';
+import {useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {
@@ -19,11 +19,11 @@ import BreadcrumbItem from './breadcrumbItem';
 
 function CrumbPlaceholder({number}: {number: number}) {
   return (
-    <Fragment>
+    <BreadcrumbContainer>
       {[...Array(number)].map((_, i) => (
         <PlaceholderMargin key={i} height="53px" />
       ))}
-    </Fragment>
+    </BreadcrumbContainer>
   );
 }
 
@@ -106,7 +106,7 @@ function Breadcrumbs({}: Props) {
   );
 
   const content = isLoaded ? (
-    <div>
+    <BreadcrumbContainer>
       {crumbs.map(crumb => (
         <BreadcrumbItem
           key={crumb.id}
@@ -119,7 +119,7 @@ function Breadcrumbs({}: Props) {
           onClick={handleClick}
         />
       ))}
-    </div>
+    </BreadcrumbContainer>
   ) : (
     <CrumbPlaceholder number={4} />
   );
@@ -129,15 +129,16 @@ function Breadcrumbs({}: Props) {
       <FluidPanel
         bodyRef={crumbListContainerRef}
         title={<PanelHeader>{t('Breadcrumbs')}</PanelHeader>}
-        overflowBodyStyles={{
-          padding: space(0.5),
-        }}
       >
         {content}
       </FluidPanel>
     </Panel>
   );
 }
+
+const BreadcrumbContainer = styled('div')`
+  padding: ${space(0.5)};
+`;
 
 const Panel = styled(BasePanel)`
   width: 100%;
@@ -157,7 +158,7 @@ const PanelHeader = styled(BasePanelHeader)`
 `;
 
 const PlaceholderMargin = styled(Placeholder)`
-  margin: ${space(1)} 0;
+  margin-bottom: ${space(1)};
   width: auto;
   border-radius: ${p => p.theme.borderRadius};
 `;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -129,6 +129,9 @@ function Breadcrumbs({}: Props) {
       <FluidPanel
         bodyRef={crumbListContainerRef}
         title={<PanelHeader>{t('Breadcrumbs')}</PanelHeader>}
+        overflowBodyStyles={{
+          padding: space(0.5),
+        }}
       >
         {content}
       </FluidPanel>

--- a/static/app/views/replays/detail/layout/fluidPanel.tsx
+++ b/static/app/views/replays/detail/layout/fluidPanel.tsx
@@ -1,4 +1,4 @@
-import {LegacyRef, ReactChild} from 'react';
+import {CSSProperties, LegacyRef, ReactChild} from 'react';
 import styled from '@emotion/styled';
 
 type Props = {
@@ -6,14 +6,24 @@ type Props = {
   bodyRef?: LegacyRef<HTMLDivElement> | undefined;
   bottom?: ReactChild;
   className?: string;
+  overflowBodyStyles?: CSSProperties;
   title?: ReactChild;
 };
 
-function FluidPanel({className, children, bottom, title, bodyRef}: Props) {
+function FluidPanel({
+  className,
+  children,
+  bottom,
+  title,
+  bodyRef,
+  overflowBodyStyles,
+}: Props) {
   return (
     <FluidContainer className={className}>
       {title}
-      <OverflowBody ref={bodyRef}>{children}</OverflowBody>
+      <OverflowBody style={overflowBodyStyles} ref={bodyRef}>
+        {children}
+      </OverflowBody>
       {bottom}
     </FluidContainer>
   );

--- a/static/app/views/replays/detail/layout/fluidPanel.tsx
+++ b/static/app/views/replays/detail/layout/fluidPanel.tsx
@@ -1,4 +1,4 @@
-import {CSSProperties, LegacyRef, ReactChild} from 'react';
+import {LegacyRef, ReactChild} from 'react';
 import styled from '@emotion/styled';
 
 type Props = {
@@ -6,24 +6,14 @@ type Props = {
   bodyRef?: LegacyRef<HTMLDivElement> | undefined;
   bottom?: ReactChild;
   className?: string;
-  overflowBodyStyles?: CSSProperties;
   title?: ReactChild;
 };
 
-function FluidPanel({
-  className,
-  children,
-  bottom,
-  title,
-  bodyRef,
-  overflowBodyStyles,
-}: Props) {
+function FluidPanel({className, children, bottom, title, bodyRef}: Props) {
   return (
     <FluidContainer className={className}>
       {title}
-      <OverflowBody style={overflowBodyStyles} ref={bodyRef}>
-        {children}
-      </OverflowBody>
+      <OverflowBody ref={bodyRef}>{children}</OverflowBody>
       {bottom}
     </FluidContainer>
   );


### PR DESCRIPTION


<!-- Describe your PR here. -->
Added new prop to `<FluidPanel />` component in order to add different styles for the breadcrumbs.
![image](https://user-images.githubusercontent.com/39612839/179804970-642968fb-f61a-4541-aac9-c152762251dc.png)



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
