### PR TITLE
fix(dashboards): Fixed widgetQueries series results not properly determining if a widget isMetricsData

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -124,14 +124,15 @@ function WidgetQueries({
   const isSeriesMetricsDataResults: boolean[] = [];
   const afterFetchSeriesData = (rawResults: SeriesResult) => {
     if (rawResults.data) {
+      rawResults = rawResults as EventsStats;
       if (rawResults.isMetricsData !== undefined) {
-        isSeriesMetricsDataResults.push((rawResults as EventsStats).isMetricsData!);
+        isSeriesMetricsDataResults.push(rawResults.isMetricsData);
       }
     } else {
       Object.keys(rawResults).forEach(key => {
         const rawResult: EventsStats = rawResults[key];
         if (rawResult.isMetricsData !== undefined) {
-          isSeriesMetricsDataResults.push(rawResult.isMetricsData!);
+          isSeriesMetricsDataResults.push(rawResult.isMetricsData);
         }
       });
     }

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useContext} from 'react';
+import {useContext} from 'react';
 import omit from 'lodash/omit';
 
 import {Client} from 'sentry/api';
@@ -115,31 +115,37 @@ function WidgetQueries({
   const config = ErrorsAndTransactionsConfig;
   const context = useContext(DashboardsMEPContext);
 
-  let isMetricsData: undefined | boolean;
   let setIsMetricsData: undefined | ((value?: boolean) => void);
 
   if (context) {
-    isMetricsData = context.isMetricsData;
     setIsMetricsData = context.setIsMetricsData;
   }
 
-  const afterFetchSeriesData = useCallback(
-    (rawResults: SeriesResult) => {
-      // If one of the queries is sampled, then mark the whole thing as sampled
-      const currentResultIsMetricsData =
-        isMetricsData === false ? false : getIsMetricsDataFromSeriesResponse(rawResults);
-      setIsMetricsData?.(currentResultIsMetricsData);
-    },
-    [isMetricsData, setIsMetricsData]
-  );
-
-  const isMetricsDataResults: boolean[] = [];
-  const afterFetchTableData = (rawResults: TableResult) => {
-    if (rawResults.meta?.isMetricsData !== undefined) {
-      isMetricsDataResults.push(rawResults.meta.isMetricsData);
+  const isSeriesMetricsDataResults: boolean[] = [];
+  const afterFetchSeriesData = (rawResults: SeriesResult) => {
+    if (rawResults.data) {
+      if (rawResults.isMetricsData !== undefined) {
+        isSeriesMetricsDataResults.push((rawResults as EventsStats).isMetricsData!);
+      }
+    } else {
+      Object.keys(rawResults).forEach(key => {
+        const rawResult: EventsStats = rawResults[key];
+        if (rawResult.isMetricsData !== undefined) {
+          isSeriesMetricsDataResults.push(rawResult.isMetricsData!);
+        }
+      });
     }
     // If one of the queries is sampled, then mark the whole thing as sampled
-    setIsMetricsData?.(!isMetricsDataResults.includes(false));
+    setIsMetricsData?.(!isSeriesMetricsDataResults.includes(false));
+  };
+
+  const isTableMetricsDataResults: boolean[] = [];
+  const afterFetchTableData = (rawResults: TableResult) => {
+    if (rawResults.meta?.isMetricsData !== undefined) {
+      isTableMetricsDataResults.push(rawResults.meta.isMetricsData);
+    }
+    // If one of the queries is sampled, then mark the whole thing as sampled
+    setIsMetricsData?.(!isTableMetricsDataResults.includes(false));
   };
 
   return (

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -62,7 +62,7 @@ describe('Dashboards > WidgetCard', function () {
   beforeEach(function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
-      body: [],
+      body: {meta: {isMetricsData: false}},
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-geo/',
@@ -112,6 +112,7 @@ describe('Dashboards > WidgetCard', function () {
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     userEvent.click(screen.getByText('Open in Discover'));
     expect(spy).toHaveBeenCalledWith({
+      isMetricsData: false,
       organization,
       widget: multipleQueryWidget,
     });


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry/pull/36394 but for series/events-stats requests

The `afterFetchSeriesData` isn't determining `isMetricsData` correctly since it uses the previous value of `isMetricsData` in any previous requests. Refactored this so that it only checks the results of each series of the current request.