### PR TITLE
fix(ui): Disallow arbitrary time ranges on releases page

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -5,6 +5,7 @@ import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import DropdownAutoComplete from 'sentry/components/dropdownAutoComplete';
+import autoCompleteFilter from 'sentry/components/dropdownAutoComplete/autoCompleteFilter';
 import {Item} from 'sentry/components/dropdownAutoComplete/types';
 import {GetActorPropsFn} from 'sentry/components/dropdownMenu';
 import HookOrDefault from 'sentry/components/hookOrDefault';
@@ -136,6 +137,11 @@ type Props = WithRouterProps & {
    * Disable the dropdown
    */
   disabled?: boolean;
+
+  /**
+   * Forces the user to select from the set of defined relative options
+   */
+  disallowArbitraryRelativeRanges?: boolean;
 
   /**
    * Small info icon with tooltip hint text
@@ -405,6 +411,7 @@ class TimeRangeSelector extends PureComponent<Props, State> {
 
   render() {
     const {
+      disallowArbitraryRelativeRanges,
       defaultPeriod,
       showAbsolute,
       showRelative,
@@ -447,7 +454,11 @@ class TimeRangeSelector extends PureComponent<Props, State> {
             {({css}) => (
               <StyledDropdownAutoComplete
                 allowActorToggle
-                autoCompleteFilter={timeRangeAutoCompleteFilter}
+                autoCompleteFilter={
+                  disallowArbitraryRelativeRanges
+                    ? autoCompleteFilter
+                    : timeRangeAutoCompleteFilter
+                }
                 alignMenu={alignDropdown ?? (isAbsoluteSelected ? 'right' : 'left')}
                 isOpen={this.state.isOpen}
                 inputValue={this.state.inputValue}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -534,6 +534,7 @@ class ReleasesList extends AsyncView<Props, State> {
               <EnvironmentPageFilter />
               <DatePageFilter
                 alignDropdown="left"
+                disallowArbitraryRelativeRanges
                 hint={t('Changing this date range will recalculate the release metrics.')}
               />
             </ReleasesPageFilterBar>

--- a/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/tests/js/spec/components/organizations/timeRangeSelector/index.spec.jsx
@@ -390,4 +390,19 @@ describe('TimeRangeSelector', function () {
       end: undefined,
     });
   });
+
+  it('cannot select arbitrary relative time ranges with disallowArbitraryRelativeRanges', () => {
+    renderComponent({disallowArbitraryRelativeRanges: true});
+
+    userEvent.click(screen.getByRole('button'));
+
+    const input = screen.getByRole('textbox');
+    userEvent.type(input, '5');
+
+    expect(screen.getByText('No items found')).toBeInTheDocument();
+
+    userEvent.type(input, '{Enter}');
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Selecting an arbitrary time range on the releases page gave this error:

> "Invalid summaryStatsPeriod. Valid choices are '1h', '24h', '1d', '48h', '2d', '7d', '14d', '30d', '90d'"

So I've added the `disallowArbitraryRelativeRanges` prop to disable the functionality here.

Hoping this is the only place that doesn't accept arbitrary ranges, but if you know of others please comment.