### PR TITLE
feat(mep): Add queryType to rule type and alert rule create/edit

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -36,7 +36,10 @@ import TriggersChart from 'sentry/views/alerts/rules/metric/triggers/chart';
 import {getEventTypeFilter} from 'sentry/views/alerts/rules/metric/utils/getEventTypeFilter';
 import hasThresholdValue from 'sentry/views/alerts/rules/metric/utils/hasThresholdValue';
 import {AlertRuleType} from 'sentry/views/alerts/types';
-import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
+import {
+  AlertWizardAlertNames,
+  MetricQueryTypeMap,
+} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 
 import {isCrashFreeAlert} from './utils/isCrashFreeAlert';
@@ -540,6 +543,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const {
       project,
       aggregate,
+      dataset,
       resolveThreshold,
       triggers,
       thresholdType,
@@ -588,6 +592,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
           comparisonDelta: comparisonDelta ?? null,
           timeWindow,
           aggregate,
+          queryType:
+            MetricQueryTypeMap[getAlertTypeFromAggregateDataset({aggregate, dataset})],
         },
         {
           duplicateRule: this.isDuplicateRule ? 'true' : 'false',

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -1,4 +1,5 @@
 import {t} from 'sentry/locale';
+import {QueryType} from 'sentry/views/alerts/wizard/options';
 import type {SchemaFormConfig} from 'sentry/views/organizationIntegrations/sentryAppExternalForm';
 
 import type {Incident} from '../../types';
@@ -91,6 +92,7 @@ export type UnsavedMetricRule = {
   comparisonDelta?: number | null;
   eventTypes?: EventTypes[];
   owner?: string | null;
+  queryType?: QueryType | null;
 };
 
 export interface SavedMetricRule extends UnsavedMetricRule {

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -194,16 +194,16 @@ export default function WizardField({
         const dataset: Dataset = model.getValue('dataset');
         const eventTypes = [...(model.getValue('eventTypes') ?? [])];
 
-        const selectedTemplate =
+        const selectedTemplate: AlertType =
           alertType === 'custom'
             ? alertType
-            : findKey(
+            : (findKey(
                 AlertWizardRuleTemplates,
                 template =>
                   matchTemplateAggregate(template, aggregate) &&
                   matchTemplateDataset(template, dataset) &&
                   matchTemplateEventTypes(template, eventTypes, aggregate)
-              ) || 'num_errors';
+              ) as AlertType) || 'num_errors';
 
         const {fieldOptionsConfig, hidePrimarySelector, hideParameterSelector} =
           getFieldOptionConfig({

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -21,7 +21,28 @@ export type AlertType =
   | 'crash_free_sessions'
   | 'crash_free_users';
 
+export enum QueryType {
+  ERROR = 0,
+  PERFORMANCE = 1,
+  CRASH_RATE = 2,
+}
+
 export type MetricAlertType = Exclude<AlertType, 'issues'>;
+
+export const MetricQueryTypeMap: Record<MetricAlertType, QueryType> = {
+  num_errors: QueryType.ERROR,
+  users_experiencing_errors: QueryType.ERROR,
+  throughput: QueryType.PERFORMANCE,
+  trans_duration: QueryType.PERFORMANCE,
+  apdex: QueryType.PERFORMANCE,
+  failure_rate: QueryType.PERFORMANCE,
+  lcp: QueryType.PERFORMANCE,
+  fid: QueryType.PERFORMANCE,
+  cls: QueryType.PERFORMANCE,
+  custom: QueryType.PERFORMANCE,
+  crash_free_sessions: QueryType.CRASH_RATE,
+  crash_free_users: QueryType.CRASH_RATE,
+};
 
 export const AlertWizardAlertNames: Record<AlertType, string> = {
   issues: t('Issues'),

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -1,9 +1,9 @@
 import {Dataset, SessionsAggregate} from 'sentry/views/alerts/rules/metric/types';
 
-import {AlertType, WizardRuleTemplate} from './options';
+import {MetricAlertType, WizardRuleTemplate} from './options';
 
 // A set of unique identifiers to be able to tie aggregate and dataset back to a wizard alert type
-const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> = {
+const alertTypeIdentifiers: Record<Dataset, Partial<Record<MetricAlertType, string>>> = {
   [Dataset.ERRORS]: {
     num_errors: 'count()',
     users_experiencing_errors: 'count_unique(user)',
@@ -35,11 +35,12 @@ const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> 
 export function getAlertTypeFromAggregateDataset({
   aggregate,
   dataset,
-}: Pick<WizardRuleTemplate, 'aggregate' | 'dataset'>): AlertType {
+}: Pick<WizardRuleTemplate, 'aggregate' | 'dataset'>): MetricAlertType {
   const identifierForDataset = alertTypeIdentifiers[dataset];
   const matchingAlertTypeEntry = Object.entries(identifierForDataset).find(
     ([_alertType, identifier]) => identifier && aggregate.includes(identifier)
   );
-  const alertType = matchingAlertTypeEntry && (matchingAlertTypeEntry[0] as AlertType);
+  const alertType =
+    matchingAlertTypeEntry && (matchingAlertTypeEntry[0] as MetricAlertType);
   return alertType ? alertType : 'custom';
 }


### PR DESCRIPTION
This adds `queryType` to `MetricRule` and to create/edit metric rule requests. Part of the FE for #36750