### PR TITLE
test(ui): Fix flake in threadsv2 test

### DIFF
--- a/tests/js/spec/components/events/interfaces/threadsV2.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/threadsV2.spec.tsx
@@ -299,7 +299,7 @@ describe('ThreadsV2', function () {
 
         userEvent.click(screen.getByRole('button', {name: 'Options'}));
 
-        expect(screen.getByText('Display')).toBeInTheDocument();
+        expect(await screen.findByText('Display')).toBeInTheDocument();
 
         Object.entries(displayOptions).forEach(([key, value]) => {
           if (key === 'minified') {
@@ -933,7 +933,7 @@ describe('ThreadsV2', function () {
 
         userEvent.click(screen.getByRole('button', {name: 'Options'}));
 
-        expect(screen.getByText('Display')).toBeInTheDocument();
+        expect(await screen.findByText('Display')).toBeInTheDocument();
 
         Object.values(displayOptions).forEach(value => {
           expect(screen.getByText(value)).toBeInTheDocument();


### PR DESCRIPTION
Seems to happen only rarely, wait for the element instead of getBy.

fixes https://sentry.io/organizations/sentry/issues/3364586633/events/6f4d6320aaa84f8eaa24300347ec5f9a/?project=4857230
