### PR TITLE
feat(mep): Make sure we pass dataset correctly when rendering charts for MEP alerts

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import abc
+import logging
 from typing import Sequence, Set, Tuple
 
-import sentry_sdk
 from django.template.defaultfilters import pluralize
 from django.urls import reverse
 
@@ -222,8 +222,8 @@ def generate_incident_trigger_email_context(
                 selected_incident=incident,
                 size=ChartSize({"width": 600, "height": 200}),
             )
-        except Exception as e:
-            sentry_sdk.capture_exception(e)
+        except Exception:
+            logging.exception("Error while attempting to build_metric_alert_chart")
 
     return {
         "link": absolute_uri(

--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -15,9 +15,8 @@ from sentry.charts.types import ChartSize, ChartType
 from sentry.incidents.logic import translate_aggregate_field
 from sentry.incidents.models import AlertRule, Incident, User
 from sentry.models import ApiKey, Organization
-from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import apply_dataset_query_conditions
-from sentry.snuba.models import SnubaQuery
+from sentry.snuba.models import QueryDatasets, SnubaQuery
 
 CRASH_FREE_SESSIONS = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
 CRASH_FREE_USERS = "percentage(users_crashed, users) AS _crash_rate_alert_aggregate"
@@ -157,8 +156,9 @@ def build_metric_alert_chart(
 ) -> Optional[str]:
     """Builds the dataset required for metric alert chart the same way the frontend would"""
     snuba_query: SnubaQuery = alert_rule.snuba_query
-    dataset = snuba_query.dataset
-    is_crash_free_alert = dataset in {Dataset.Sessions.value, Dataset.Metrics.value}
+    dataset = QueryDatasets(snuba_query.dataset)
+    query_type = SnubaQuery.Type(snuba_query.type)
+    is_crash_free_alert = query_type == SnubaQuery.Type.CRASH_RATE
     style = (
         ChartType.SLACK_METRIC_ALERT_SESSIONS
         if is_crash_free_alert
@@ -218,8 +218,13 @@ def build_metric_alert_chart(
             user,
         )
     else:
-        # TODO: We need to be explicit about the query type and dataset used on this endpoint once
-        # we enabled MEP alerts
+        if (
+            query_type == SnubaQuery.Type.PERFORMANCE
+            and dataset == QueryDatasets.PERFORMANCE_METRICS
+        ):
+            query_params["dataset"] = "metrics"
+        else:
+            query_params["dataset"] = "discover"
         chart_data["timeseriesData"] = fetch_metric_alert_events_timeseries(
             organization,
             aggregate,
@@ -228,8 +233,7 @@ def build_metric_alert_chart(
         )
 
     try:
-        url = generate_chart(style, chart_data, size=size)
-        return cast(str, url)
+        return cast(str, generate_chart(style, chart_data, size=size))
     except RuntimeError as exc:
         logger.error(
             f"Failed to generate chart for metric alert: {exc}",

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -11,6 +11,7 @@ from sentry.incidents.action_handlers import (
     EmailActionHandler,
     generate_incident_trigger_email_context,
 )
+from sentry.incidents.charts import fetch_metric_alert_events_timeseries
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL
 from sentry.incidents.models import (
     INCIDENT_STATUS,
@@ -21,6 +22,7 @@ from sentry.incidents.models import (
 )
 from sentry.models import NotificationSetting, UserEmail, UserOption
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.snuba.models import QueryDatasets, SnubaQuery
 from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
@@ -308,8 +310,12 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
             self.project, incident, action.alert_rule_trigger, status, IncidentStatus.CRITICAL
         ).get("environment")
 
+    @patch(
+        "sentry.incidents.charts.fetch_metric_alert_events_timeseries",
+        side_effect=fetch_metric_alert_events_timeseries,
+    )
     @patch("sentry.incidents.charts.generate_chart", return_value="chart-url")
-    def test_metric_chart(self, mock_generate_chart):
+    def test_metric_chart(self, mock_generate_chart, mock_fetch_metric_alert_events_timeseries):
         trigger_status = TriggerStatus.ACTIVE
         incident = self.create_incident()
         action = self.create_alert_rule_trigger_action(triggered_for_incident=incident)
@@ -333,6 +339,44 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["rule"]["id"] == str(incident.alert_rule.id)
         assert chart_data["selectedIncident"]["identifier"] == str(incident.identifier)
+        assert mock_fetch_metric_alert_events_timeseries.call_args[0][2]["dataset"] == "discover"
+        series_data = chart_data["timeseriesData"][0]["data"]
+        assert len(series_data) > 0
+        assert mock_generate_chart.call_args[1]["size"] == {"width": 600, "height": 200}
+
+    @patch(
+        "sentry.incidents.charts.fetch_metric_alert_events_timeseries",
+        side_effect=fetch_metric_alert_events_timeseries,
+    )
+    @patch("sentry.incidents.charts.generate_chart", return_value="chart-url")
+    def test_metric_chart_mep(self, mock_generate_chart, mock_fetch_metric_alert_events_timeseries):
+        trigger_status = TriggerStatus.ACTIVE
+        alert_rule = self.create_alert_rule(
+            query_type=SnubaQuery.Type.PERFORMANCE, dataset=QueryDatasets.PERFORMANCE_METRICS
+        )
+        incident = self.create_incident(alert_rule=alert_rule)
+        action = self.create_alert_rule_trigger_action(triggered_for_incident=incident)
+
+        with self.feature(
+            [
+                "organizations:incidents",
+                "organizations:discover",
+                "organizations:discover-basic",
+                "organizations:metric-alert-chartcuterie",
+            ]
+        ):
+            result = generate_incident_trigger_email_context(
+                self.project,
+                incident,
+                action.alert_rule_trigger,
+                trigger_status,
+                IncidentStatus(incident.status),
+            )
+        assert result["chart_url"] == "chart-url"
+        chart_data = mock_generate_chart.call_args[0][1]
+        assert chart_data["rule"]["id"] == str(incident.alert_rule.id)
+        assert chart_data["selectedIncident"]["identifier"] == str(incident.identifier)
+        assert mock_fetch_metric_alert_events_timeseries.call_args[0][2]["dataset"] == "metrics"
         series_data = chart_data["timeseriesData"][0]["data"]
         assert len(series_data) > 0
         assert mock_generate_chart.call_args[1]["size"] == {"width": 600, "height": 200}


### PR DESCRIPTION
We need to pass `dataset` to the `events-stats` endpoint when rendering charts to make sure that we
fetch the correct data for MEP alerts.