### PR TITLE
fix(parser): Correctly parse firstSeen and lastSeen on frontend

### DIFF
--- a/fixtures/search-syntax/rel_time_filter.json
+++ b/fixtures/search-syntax/rel_time_filter.json
@@ -1,47 +1,91 @@
 [
   {
-    "query": "first_seen:+7d",
+    "query": "firstSeen:+7d",
     "result": [
-      {"type": "spaces", "value": ""},
+      {
+        "type": "spaces",
+        "value": ""
+      },
       {
         "type": "filter",
         "filter": "relativeDate",
         "negated": false,
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {
+          "type": "keySimple",
+          "value": "firstSeen",
+          "quoted": false
+        },
         "operator": "",
-        "value": {"type": "valueRelativeDate", "value": 7, "sign": "+", "unit": "d"}
+        "value": {
+          "type": "valueRelativeDate",
+          "value": 7,
+          "sign": "+",
+          "unit": "d"
+        }
       },
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   },
   {
-    "query": "first_seen:-2w",
+    "query": "firstSeen:-2w",
     "result": [
-      {"type": "spaces", "value": ""},
+      {
+        "type": "spaces",
+        "value": ""
+      },
       {
         "type": "filter",
         "filter": "relativeDate",
         "negated": false,
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {
+          "type": "keySimple",
+          "value": "firstSeen",
+          "quoted": false
+        },
         "operator": "",
-        "value": {"type": "valueRelativeDate", "value": 2, "sign": "-", "unit": "w"}
+        "value": {
+          "type": "valueRelativeDate",
+          "value": 2,
+          "sign": "-",
+          "unit": "w"
+        }
       },
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   },
   {
     "query": "random:-2w",
     "result": [
-      {"type": "spaces", "value": ""},
+      {
+        "type": "spaces",
+        "value": ""
+      },
       {
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "key": {"type": "keySimple", "value": "random", "quoted": false},
+        "key": {
+          "type": "keySimple",
+          "value": "random",
+          "quoted": false
+        },
         "operator": "",
-        "value": {"type": "valueText", "value": "-2w", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "-2w",
+          "quoted": false
+        }
       },
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   }
 ]

--- a/fixtures/search-syntax/specific_time_filter.json
+++ b/fixtures/search-syntax/specific_time_filter.json
@@ -1,62 +1,115 @@
 [
   {
-    "query": "first_seen:2018-01-01",
+    "query": "firstSeen:2018-01-01",
     "result": [
-      {"type": "spaces", "value": ""},
+      {
+        "type": "spaces",
+        "value": ""
+      },
       {
         "type": "filter",
         "filter": "specificDate",
         "negated": false,
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {
+          "type": "keySimple",
+          "value": "firstSeen",
+          "quoted": false
+        },
         "operator": "",
-        "value": {"type": "valueIso8601Date", "value": "2018-01-01T00:00:00.000Z"}
+        "value": {
+          "type": "valueIso8601Date",
+          "value": "2018-01-01T00:00:00.000Z"
+        }
       },
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   },
   {
-    "query": "first_seen:2018-01-01T05:06:07Z",
+    "query": "lastSeen:2018-01-01T05:06:07Z",
     "result": [
-      {"type": "spaces", "value": ""},
+      {
+        "type": "spaces",
+        "value": ""
+      },
       {
         "type": "filter",
         "filter": "specificDate",
         "negated": false,
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {
+          "type": "keySimple",
+          "value": "lastSeen",
+          "quoted": false
+        },
         "operator": "",
-        "value": {"type": "valueIso8601Date", "value": "2018-01-01T05:06:07.000Z"}
+        "value": {
+          "type": "valueIso8601Date",
+          "value": "2018-01-01T05:06:07.000Z"
+        }
       },
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   },
   {
-    "query": "first_seen:2018-01-01T05:06:07+00:00",
+    "query": "firstSeen:2018-01-01T05:06:07+00:00",
     "result": [
-      {"type": "spaces", "value": ""},
+      {
+        "type": "spaces",
+        "value": ""
+      },
       {
         "type": "filter",
         "filter": "specificDate",
         "negated": false,
-        "key": {"type": "keySimple", "value": "first_seen", "quoted": false},
+        "key": {
+          "type": "keySimple",
+          "value": "firstSeen",
+          "quoted": false
+        },
         "operator": "",
-        "value": {"type": "valueIso8601Date", "value": "2018-01-01T05:06:07.000Z"}
+        "value": {
+          "type": "valueIso8601Date",
+          "value": "2018-01-01T05:06:07.000Z"
+        }
       },
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   },
   {
     "query": "random:2018-01-01T05:06:07",
     "result": [
-      {"type": "spaces", "value": ""},
+      {
+        "type": "spaces",
+        "value": ""
+      },
       {
         "type": "filter",
         "filter": "text",
         "negated": false,
-        "key": {"type": "keySimple", "value": "random", "quoted": false},
+        "key": {
+          "type": "keySimple",
+          "value": "random",
+          "quoted": false
+        },
         "operator": "",
-        "value": {"type": "valueText", "value": "2018-01-01T05:06:07", "quoted": false}
+        "value": {
+          "type": "valueText",
+          "value": "2018-01-01T05:06:07",
+          "quoted": false
+        }
       },
-      {"type": "spaces", "value": ""}
+      {
+        "type": "spaces",
+        "value": ""
+      }
     ]
   }
 ]

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -779,15 +779,14 @@ const defaultConfig: SearchConfig = {
   dateKeys: new Set([
     'start',
     'end',
-    'first_seen',
-    'last_seen',
+    'firstSeen',
+    'lastSeen',
+    'last_seen()',
     'time',
     'event.timestamp',
     'timestamp',
     'timestamp.to_hour',
     'timestamp.to_day',
-    'transaction.start_time',
-    'transaction.end_time',
   ]),
   booleanKeys: new Set([
     'error.handled',


### PR DESCRIPTION
Replaces `first_seen` and `last_seen` in the frontend parser with `firstSeen` and `lastSeen`. Adds `last_seen():` into the date key list as well but for some reason date aggregates aren't being parsed correctly. Will look into with a followup PR fix.

Updates fixture tests

Aligns with backend changes #30757
