### PR TITLE
fix(mep): Fix a bug with event type validation

### DIFF
--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -737,7 +737,7 @@ class AlertRuleCreateEndpointTestCrashRateAlert(APITestCase):
         assert resp.data == serialize(alert_rule, self.user)
 
     def test_simple_crash_rate_alerts_for_sessions_drops_event_types(self):
-        self.valid_alert_rule["eventTypes"] = ["sessions", "events"]
+        self.valid_alert_rule["eventTypes"] = ["error"]
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp = self.get_success_response(
                 self.organization.slug, self.project.slug, status_code=201, **self.valid_alert_rule

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -177,6 +177,7 @@ class TestAlertRuleSerializer(TestCase):
         with self.feature("organizations:metrics-performance-alerts"):
             base_params = self.valid_params.copy()
             base_params["queryType"] = SnubaQuery.Type.PERFORMANCE.value
+            base_params["eventTypes"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
             base_params["dataset"] = QueryDatasets.PERFORMANCE_METRICS.value
             base_params["query"] = ""
             serializer = AlertRuleSerializer(context=self.context, data=base_params)


### PR DESCRIPTION
Make sure that we don't set the event types for mep alerts to an empty list.
