### PR TITLE
fix(dashboards): topEvents missing in TOP_N request

### DIFF
--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -505,6 +505,7 @@ function getEventsSeriesRequest(
       field: [...widgetQuery.columns, ...widgetQuery.aggregates],
       queryExtras: getDashboardsMEPQueryParams(isMEPEnabled),
       includeAllArgs: true,
+      topEvents: TOP_N,
     };
     if (widgetQuery.orderby) {
       requestData.orderby = widgetQuery.orderby;


### PR DESCRIPTION
topEvents should be passed for legacy TOP_N display types or else only a
single series will be returned.