### PR TITLE
fix(discover): Check tertiarySlug type since it can be undefined

### DIFF
--- a/static/app/utils/requestError/sanitizePath.tsx
+++ b/static/app/utils/requestError/sanitizePath.tsx
@@ -24,7 +24,7 @@ export function sanitizePath(path: string) {
       // `tertiarySlug` can be undefined
       let suffix = `${tertiarySlug ?? ''}${end}`;
 
-      if (isOrg && contentType === 'events/') {
+      if (isOrg && contentType === 'events/' && typeof tertiarySlug === 'string') {
         // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1004
         // r"^(?P<organization_slug>[^\/]+)/events/(?P<project_slug>[^\/]+):(?P<event_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
         suffix = tertiarySlug.replace(/[^:]+(.*)/, '{projectSlug}$1');

--- a/tests/js/spec/utils/requestError/sanitizePath.spec.tsx
+++ b/tests/js/spec/utils/requestError/sanitizePath.spec.tsx
@@ -14,6 +14,11 @@ describe('sanitizePath', function () {
       '/organizations/{orgSlug}/events/{projectSlug}:123/',
     ],
 
+    [
+      'https://sentry.io/api/0/organizations/sentry-test/events/',
+      'https://sentry.io/api/0/organizations/{orgSlug}/events/',
+    ],
+
     // https://github.com/getsentry/sentry/blob/8d4482f01aa2122c6f6670ab84f9263e6f021467/src/sentry/api/urls.py#L1235
     // r"^(?P<organization_slug>[^\/]+)/members/(?P<member_id>[^\/]+)/teams/(?P<team_slug>[^\/]+)/$",
     [


### PR DESCRIPTION
The publication of the events endpoint adds a case to this sanitizePath
helper. Originally the code was to sanitize the path for the events detail
endpoint which has a tertiary slug. Using `events/` now also triggers this
case but the API doesn't contain a tertiary slug, so it returns `undefined`

Downstream code expects tertiarySlug to be a string to call .replace()