### PR TITLE
fix(replays): timeline scrubber colors

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -57,14 +57,10 @@ function ReplayTimeline({}: Props) {
                   startTimestamp={startTimestamp}
                 />
               </UnderTimestamp>
-              <TimelinePosition
-                color={theme.purple300}
-                currentTime={currentTime}
-                duration={duration}
-              />
+              <TimelinePosition currentTime={currentTime} duration={duration} />
               {currentHoverTime ? (
                 <TimelinePosition
-                  color={theme.purple200}
+                  color={theme.purple300}
                   currentTime={currentHoverTime}
                   duration={duration}
                 />

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -70,11 +70,11 @@ const Range = styled(RangeSlider)`
 `;
 
 const PlaybackTimeValue = styled(Progress.Value)`
-  background: ${p => p.theme.purple300};
+  background: ${p => p.theme.purple100};
 `;
 
 const MouseTrackingValue = styled(Progress.Value)`
-  background: ${p => p.theme.purple200};
+  background: ${p => p.theme.purple100};
 `;
 
 const Wrapper = styled('div')`
@@ -112,10 +112,6 @@ export const TimelineScrubber = styled(Scrubber)`
 
   ${Meter} {
     background: transparent;
-  }
-
-  ${PlaybackTimeValue} {
-    opacity: 0.2;
   }
 
   ${RangeWrapper},

--- a/static/app/components/replays/timelinePosition.tsx
+++ b/static/app/components/replays/timelinePosition.tsx
@@ -6,9 +6,9 @@ import {divide} from 'sentry/components/replays/utils';
 import space from 'sentry/styles/space';
 
 type Props = {
-  color: string;
   currentTime: number;
   duration: number;
+  color?: string;
 };
 
 function TimelinePosition({color, currentTime, duration}: Props) {
@@ -22,7 +22,7 @@ function TimelinePosition({color, currentTime, duration}: Props) {
 }
 
 const Value = styled(Progress.Value)<Pick<Props, 'color'>>`
-  border-right: ${space(0.25)} solid ${p => p.color};
+  ${p => p.color && `border-right: ${space(0.25)} solid ${p.color};`}
 `;
 
 export default TimelinePosition;


### PR DESCRIPTION

<!-- Describe your PR here. -->
Changed the colors of the hover time and current time meters, also eliminating the timeline current time position bar - resembling the [figma](https://www.figma.com/file/3irLdrxfSf6GxtKmMOM5dq/Specs%3A-Details-v2?node-id=146%3A5858) styles . Closes #36861

![image](https://user-images.githubusercontent.com/39612839/180008117-2fe18c8d-5f56-4636-bd47-0f034f3f2274.png)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
