### PR TITLE
ref: remove version_info filter for disabling snapshots

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -297,7 +297,7 @@ class Browser:
         """
         # TODO(dcramer): ideally this would take the executing test package
         # into account for duplicate names
-        if os.environ.get("VISUAL_SNAPSHOT_ENABLE") != "1" or sys.version_info[:2] != (3, 8):
+        if os.environ.get("VISUAL_SNAPSHOT_ENABLE") != "1":
             return self
 
         self.wait_for_images_loaded()


### PR DESCRIPTION
removing this so it's possible to try out newer python versions on a PR