### PR TITLE
ref: ColumnType uses values from FieldValueType instead of literals

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -9,6 +9,8 @@ import {
   SESSIONS_OPERATIONS,
 } from 'sentry/views/dashboardsV2/widgetBuilder/releaseWidget/fields';
 
+import {FieldValueType} from '../fields';
+
 export type Sort = {
   field: string;
   kind: 'asc' | 'desc';
@@ -23,16 +25,9 @@ export type Field = {
   width?: number;
 };
 
-export type ColumnType =
-  | 'boolean'
-  | 'date'
-  | 'duration'
-  | 'integer'
-  | 'number'
-  | 'percentage'
-  | 'string';
+export type ColumnType = `${Exclude<FieldValueType, FieldValueType.NEVER>}`;
 
-export type ColumnValueType = ColumnType | 'never'; // Matches to nothing
+export type ColumnValueType = ColumnType | `${FieldValueType.NEVER}`; // Matches to nothing
 
 export type ParsedFunction = {
   arguments: string[];

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -25,9 +25,10 @@ export type Field = {
   width?: number;
 };
 
+// ColumnType is kept as a string literal union instead of an enum due to the countless uses of it and refactoring would take huge effort.
 export type ColumnType = `${Exclude<FieldValueType, FieldValueType.NEVER>}`;
 
-export type ColumnValueType = ColumnType | `${FieldValueType.NEVER}`; // Matches to nothing
+export type ColumnValueType = ColumnType | `${FieldValueType.NEVER}`;
 
 export type ParsedFunction = {
   arguments: string[];

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -104,6 +104,7 @@ export enum FieldValueType {
   NUMBER = 'number',
   PERCENTAGE = 'percentage',
   STRING = 'string',
+  NEVER = 'never',
 }
 
 export interface FieldDefinition {


### PR DESCRIPTION
Refactor `ColumnType` to use values from `FieldValueType` this is a stopgap instead of using the enum to avoid having to completely refactor the tons of times `ColumnType` is used.