### PR TITLE
feat(perf): Aggregate column selector in tags views

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -161,6 +161,8 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Transaction Summary status breakdown option clicked',
   'performance_views.all_events.open_in_discover':
     'Performance Views: All Events page open in Discover button clicked',
+  'performance_views.tags.change_aggregate_column':
+    'Performance Views: Tags page changed aggregate column',
   'performance_views.tags.change_tag':
     'Performance Views: Tags Page changed selected tag',
   'performance_views.tags.jump_to_release':

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -71,6 +71,9 @@ export type PerformanceEventParameters = {
   'performance_views.spans.change_sort': {
     sort_column?: string;
   };
+  'performance_views.tags.change_aggregate_column': {
+    value: string;
+  };
   'performance_views.tags.change_tag': {
     from_tag: string;
     is_other_tag: boolean;

--- a/static/app/views/performance/transactionSummary/transactionTags/constants.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/constants.tsx
@@ -1,0 +1,9 @@
+import {t} from 'sentry/locale';
+import {SelectValue} from 'sentry/types';
+
+import {XAxisOption} from './types';
+
+export const X_AXIS_SELECT_OPTIONS: SelectValue<XAxisOption>[] = [
+  {label: t('LCP'), value: XAxisOption.LCP},
+  {label: t('Duration'), value: XAxisOption.DURATION},
+];

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsDisplay.tsx
@@ -10,14 +10,12 @@ import SegmentExplorerQuery from 'sentry/utils/performance/segmentExplorer/segme
 import TagKeyHistogramQuery from 'sentry/utils/performance/segmentExplorer/tagKeyHistogramQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 
-import {SpanOperationBreakdownFilter} from '../filter';
-import {getTransactionField} from '../transactionOverview/tagExplorer';
-
 import TagsHeatMap from './tagsHeatMap';
 import {TagValueTable} from './tagValueTable';
 import {getTagSortForTagsPage} from './utils';
 
 type Props = {
+  aggregateColumn: string;
   eventView: EventView;
   location: Location;
   organization: Organization;
@@ -99,14 +97,8 @@ export const TAGS_TABLE_COLUMN_ORDER: TagsTableColumn[] = [
 ];
 
 const TagsDisplay = (props: Props) => {
-  const {eventView: _eventView, location, organization, projects, tagKey} = props;
+  const {eventView: _eventView, location, organization, aggregateColumn, tagKey} = props;
   const eventView = _eventView.clone();
-
-  const aggregateColumn = getTransactionField(
-    SpanOperationBreakdownFilter.None,
-    projects,
-    eventView
-  );
 
   const handleCursor: CursorHandler = (cursor, pathname, query) =>
     browserHistory.push({

--- a/static/app/views/performance/transactionSummary/transactionTags/types.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/types.tsx
@@ -1,0 +1,4 @@
+export enum XAxisOption {
+  DURATION = 'transaction.duration',
+  LCP = 'measurements.lcp',
+}


### PR DESCRIPTION

![Screen Shot 2022-07-20 at 4 33 43 PM](https://user-images.githubusercontent.com/989898/180076640-350df314-bb05-4061-997c-04a6022e0436.png)

https://user-images.githubusercontent.com/989898/180076641-a4884c13-83cc-4aa4-b191-a42b0b9bf902.mov



## Changes

- add "X-Axis" dropdown to the tag view page. The options are "Duration"
  and "LCP"
- pass `aggregateColumn` (AKA the x-axis) down as a prop from the page
  component through the hierarchy

Closes [PERF-1616](https://getsentry.atlassian.net/browse/PERF-1616)
