### PR TITLE
fix(dashboard-filters): Only replace query params for page filters

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -68,7 +68,7 @@ import {
   Widget,
   WidgetType,
 } from './types';
-import {cloneDashboard, hasSavedFilters} from './utils';
+import {cloneDashboard, hasSavedPageFilters} from './utils';
 
 const UNSAVED_MESSAGE = t('You have unsaved changes, are you sure you want to leave?');
 
@@ -626,7 +626,7 @@ class DashboardDetail extends Component<Props, State> {
         }}
         skipLoadLastUsed={
           organization.features.includes('dashboards-top-level-filter') &&
-          hasSavedFilters(dashboard)
+          hasSavedPageFilters(dashboard)
         }
       >
         <PageContent>
@@ -719,7 +719,7 @@ class DashboardDetail extends Component<Props, State> {
           }}
           skipLoadLastUsed={
             organization.features.includes('dashboards-top-level-filter') &&
-            hasSavedFilters(dashboard)
+            hasSavedPageFilters(dashboard)
           }
         >
           <StyledPageContent>

--- a/static/app/views/dashboardsV2/orgDashboards.tsx
+++ b/static/app/views/dashboardsV2/orgDashboards.tsx
@@ -15,7 +15,7 @@ import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 
 import {assignTempId} from './layoutUtils';
 import {DashboardDetails, DashboardListItem} from './types';
-import {hasSavedFilters} from './utils';
+import {hasSavedPageFilters} from './utils';
 
 type OrgDashboardsChildrenProps = {
   dashboard: DashboardDetails | null;
@@ -94,7 +94,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
       if (
         organization.features.includes('dashboards-top-level-filter') &&
         stateKey === 'selectedDashboard' &&
-        hasSavedFilters(data) &&
+        hasSavedPageFilters(data) &&
         isEmpty(location.query)
       ) {
         browserHistory.replace({
@@ -190,7 +190,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
       loading ||
       (organization.features.includes('dashboards-top-level-filter') &&
         selectedDashboard &&
-        hasSavedFilters(selectedDashboard) &&
+        hasSavedPageFilters(selectedDashboard) &&
         isEmpty(location.query))
     ) {
       // Block dashboard from rendering if the dashboard has filters and

--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -389,9 +389,8 @@ export function getCustomMeasurementQueryParams() {
   };
 }
 
-export function hasSavedFilters(dashboard: DashboardDetails) {
+export function hasSavedPageFilters(dashboard: DashboardDetails) {
   return !(
-    isEmpty(dashboard.filters) &&
     isEmpty(dashboard.projects) &&
     dashboard.environment === undefined &&
     dashboard.start === undefined &&

--- a/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
@@ -476,8 +476,7 @@ describe('Dashboards > Detail', function () {
       expect(openEditModal).toHaveBeenCalledTimes(1);
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('shows top level release filter', async function () {
+    it('shows top level release filter', async function () {
       const mockReleases = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',
         body: [TestStubs.Release()],


### PR DESCRIPTION
In the dashboard response, filters is only applicable to the dashboard
and is not injected into the URL. This field should not be part of the
check or else if there are filters but no page filters, we'll
continuously redirect

I removed `isEmpty(dashboard.filters)` from the `hasSavedFilters` check
and renamed the helper to `hasSavedPageFilters`