### PR TITLE
feat(hybrid-cloud): Fix slugifying long org names

### DIFF
--- a/src/sentry/db/models/utils.py
+++ b/src/sentry/db/models/utils.py
@@ -57,6 +57,7 @@ def slugify_instance(
     **kwargs: Any,
 ) -> None:
     base_value = slugify(label)[:max_length]
+    base_value = base_value.strip("-")
 
     if base_value is not None:
         base_value = base_value.strip()

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -196,6 +196,9 @@ class Organization(Model):
             with TimedRetryPolicy(10)(lock.acquire):
                 slugify_target = slugify_target.replace("_", "-").strip("-")
                 slugify_instance(self, slugify_target, reserved=RESERVED_ORGANIZATION_SLUGS)
+                if self.slug.endswith("-"):
+                    slugify_target = self.slug.strip("-")
+                    slugify_instance(self, slugify_target, reserved=RESERVED_ORGANIZATION_SLUGS)
         super().save(*args, **kwargs)
 
     def delete(self, **kwargs):

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -196,9 +196,6 @@ class Organization(Model):
             with TimedRetryPolicy(10)(lock.acquire):
                 slugify_target = slugify_target.replace("_", "-").strip("-")
                 slugify_instance(self, slugify_target, reserved=RESERVED_ORGANIZATION_SLUGS)
-                if self.slug.endswith("-"):
-                    slugify_target = self.slug.strip("-")
-                    slugify_instance(self, slugify_target, reserved=RESERVED_ORGANIZATION_SLUGS)
         super().save(*args, **kwargs)
 
     def delete(self, **kwargs):

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -52,6 +52,17 @@ class OrganizationTest(TestCase):
         org = Organization.objects.create(name="---foo_bar---")
         assert org.slug == "foo-bar"
 
+    def test_slugify_long_org_names(self):
+        # Org name is longer than allowed org slug, and should be trimmed when slugified.
+        org = Organization.objects.create(name="Stove, Electrical, and Catering Stuff")
+        assert org.slug == "stove-electrical-and-catering"
+
+        # Ensure org slugs are unique
+        org2 = Organization.objects.create(name="Stove, Electrical, and Catering Stuff")
+        assert org2.slug.startswith("stove-electrical-and-cateri-")
+        assert len(org2.slug) > len("stove-electrical-and-cateri-")
+        assert org.slug != org2.slug
+
     def test_merge_to(self):
         from_owner = self.create_user("foo@example.com")
         from_org = self.create_organization(owner=from_owner)


### PR DESCRIPTION
Organization names are typically used as a source for generating slugs. These generated org slugs are capped at certain length, especially when an organization name is sufficiently long.

When capping a generated org slug, the resulting org slug may end in a hyphen (`-`); which is an illegal org slug.

This pull request addresses that.