### PR TITLE
feat(replays): Create the new DOM tab for Replays

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -5,6 +5,7 @@ import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
 
 export const ReplayTabs = {
   console: t('Console'),
+  dom: t('DOM'),
   network: t('Network'),
   trace: t('Trace'),
   issues: t('Issues'),

--- a/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
@@ -30,6 +30,8 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
   const [breadcrumbRefs, setBreadcrumbReferences] = useState<Extraction[]>([]);
 
   useEffect(() => {
+    let isMounted = true;
+
     const domRoot = document.createElement('div');
     domRoot.className = 'sr-block';
     const {style} = domRoot;
@@ -69,7 +71,9 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
           crumbs,
           isFinished: isLastRRWebEvent,
           onFinish: rows => {
-            setBreadcrumbReferences(rows);
+            if (isMounted) {
+              setBreadcrumbReferences(rows);
+            }
             document.body.removeChild(domRoot);
           },
         }),
@@ -79,6 +83,10 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
 
     // Run the replay to the end, we will capture data as it streams into the plugin
     replayerRef.pause(replay.getEvent().endTimestamp);
+
+    return () => {
+      isMounted = false;
+    };
   }, [replay]);
 
   return {

--- a/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
@@ -1,0 +1,120 @@
+import {useEffect, useState} from 'react';
+import first from 'lodash/first';
+import {Replayer} from 'rrweb'; // , ReplayerEvents
+import {eventWithTime} from 'rrweb/typings/types';
+
+import type {Crumb} from 'sentry/types/breadcrumbs';
+import type ReplayReader from 'sentry/utils/replays/replayReader';
+
+const IncrementalSnapshot = 3;
+
+type Extraction = {
+  crumb: Crumb;
+  html: string;
+  timestamp: number;
+};
+
+type HookOpts = {
+  domRoot: null | HTMLDivElement;
+  replay: ReplayReader;
+};
+function useExtractedCrumbHtml({replay, domRoot}: HookOpts) {
+  const [breadcrumbRefs, setBreadcrumbReferences] = useState<Extraction[]>([]);
+
+  useEffect(() => {
+    if (!domRoot) {
+      setBreadcrumbReferences([]);
+      return;
+    }
+
+    // Get a list of the breadcrumbs that relate directly to the DOM, for each
+    // crumb we will extract the referenced HTML.
+    const crumbs = replay
+      .getRawCrumbs()
+      .filter(crumb => crumb.data && 'nodeId' in crumb.data);
+
+    const rrwebEvents = replay.getRRWebEvents();
+
+    // Grab the last event, but skip the synthetic `replay-end` event that the
+    // ReplayerReader added. RRWeb will skip that event when it comes time to render
+    const lastEvent = rrwebEvents[rrwebEvents.length - 2];
+    const lastTimestamp = lastEvent.timestamp;
+
+    const isLastRRWebEvent = (event: eventWithTime) => lastTimestamp === event.timestamp;
+
+    const replayerRef = new Replayer(rrwebEvents, {
+      root: domRoot,
+      loadTimeout: 1,
+      showWarning: false,
+      blockClass: 'sr-block',
+      speed: 99999,
+      skipInactive: true,
+      triggerFocus: false,
+      plugins: [
+        new BreadcrumbReferencesPlugin({
+          crumbs,
+          isFinished: isLastRRWebEvent,
+          onFinish: setBreadcrumbReferences,
+        }),
+      ],
+      mouseTail: false,
+    });
+
+    // Run the replay to the end, we will capture data as it streams into the plugin
+    replayerRef.pause(replay.getEvent().endTimestamp);
+  }, [domRoot, replay]);
+
+  return {
+    isLoading: false,
+    actions: breadcrumbRefs,
+  };
+}
+
+type PluginOpts = {
+  crumbs: Crumb[];
+  isFinished: (event: eventWithTime) => boolean;
+  onFinish: (mutations: Extraction[]) => void;
+};
+
+class BreadcrumbReferencesPlugin {
+  crumbs: Crumb[];
+  isFinished: (event: eventWithTime) => boolean;
+  onFinish: (mutations: Extraction[]) => void;
+
+  activites: Extraction[] = [];
+
+  constructor({crumbs, isFinished, onFinish}: PluginOpts) {
+    this.crumbs = crumbs;
+    this.isFinished = isFinished;
+    this.onFinish = onFinish;
+  }
+
+  handler(event: eventWithTime, _isSync: boolean, {replayer}: {replayer: Replayer}) {
+    if (event.type === IncrementalSnapshot) {
+      const crumb = first(this.crumbs);
+      const nextTimestamp = +new Date(crumb?.timestamp || '');
+
+      if (crumb && nextTimestamp && nextTimestamp < event.timestamp) {
+        // we passed the next one, grab the dom, and pop the timestamp off
+        const mirror = replayer.getMirror();
+        // @ts-expect-error
+        const node = mirror.getNode(crumb.data?.nodeId || '');
+        // @ts-expect-error
+        const html = node?.outerHTML || node?.textContent || '';
+
+        this.activites.push({
+          crumb,
+          html,
+          timestamp: nextTimestamp,
+        });
+        this.crumbs.shift();
+      }
+    }
+
+    if (this.isFinished(event)) {
+      this.onFinish(this.activites);
+    }
+  }
+}
+
+export default useExtractedCrumbHtml;

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -1,0 +1,132 @@
+import {Fragment, useRef} from 'react';
+import styled from '@emotion/styled';
+
+import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
+import {PanelTable} from 'sentry/components/panels';
+import {getDetails} from 'sentry/components/replays/breadcrumbs/utils';
+import PlayerRelativeTime from 'sentry/components/replays/playerRelativeTime';
+import Truncate from 'sentry/components/truncate';
+import {SVGIconProps} from 'sentry/icons/svgIcon';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import useExtractedCrumbHtml from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
+import type ReplayReader from 'sentry/utils/replays/replayReader';
+
+type Props = {
+  replay: ReplayReader;
+};
+
+function DomMutations({replay}: Props) {
+  const hiddenDivRef = useRef<HTMLDivElement>(null);
+  const {isLoading, actions} = useExtractedCrumbHtml({
+    replay,
+    domRoot: hiddenDivRef.current,
+  });
+
+  const startTimestamp = replay.getEvent().startTimestamp;
+
+  return (
+    <Fragment>
+      <HiddenReplayMountpoint ref={hiddenDivRef} />
+      <StyledPanelTable
+        isEmpty={actions.length === 0}
+        emptyMessage={t('No DOM actions found.')}
+        isLoading={isLoading}
+        headers={[t('Action'), t('Selector'), t('HTML'), t('Timestamp')]}
+      >
+        {actions.map((mutation, i) => (
+          <Fragment key={i}>
+            <TitleContainer>
+              <IconWrapper color={mutation.crumb.color}>
+                <BreadcrumbIcon type={mutation.crumb.type} />
+              </IconWrapper>
+              <Title>{getDetails(mutation.crumb).title}</Title>
+            </TitleContainer>
+
+            <Column>
+              <Truncate
+                maxLength={30}
+                leftTrim={(mutation.crumb.message || '').includes('>')}
+                value={mutation.crumb.message || ''}
+              />
+            </Column>
+
+            <Column>
+              <HTMLCode>{mutation.html}</HTMLCode>
+            </Column>
+
+            <Column>
+              <PlayerRelativeTime
+                relativeTime={startTimestamp}
+                timestamp={mutation.crumb.timestamp}
+              />
+              {}
+            </Column>
+          </Fragment>
+        ))}
+      </StyledPanelTable>
+    </Fragment>
+  );
+}
+
+const HiddenReplayMountpoint = styled('div')`
+  position: fixed;
+  inset: 0;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+`;
+
+const StyledPanelTable = styled(PanelTable)`
+  grid-template-columns: max-content max-content 1fr max-content;
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const Column = styled('div')`
+  display: flex;
+  align-items: flex-start;
+`;
+
+/**
+ * Taken `from events/interfaces/.../breadcrumbs/types`
+ */
+const IconWrapper = styled('div')<Required<Pick<SVGIconProps, 'color'>>>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  color: ${p => p.theme.white};
+  background: ${p => p.theme[p.color] ?? p.color};
+  box-shadow: ${p => p.theme.dropShadowLightest};
+`;
+
+const TitleContainer = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  gap: ${space(1)};
+`;
+
+const Title = styled('span')`
+  ${p => p.theme.overflowEllipsis};
+  text-transform: capitalize;
+  color: ${p => p.theme.gray400};
+  line-height: ${p => p.theme.text.lineHeightBody};
+`;
+
+const HTMLCode = styled(
+  ({children, className}: {children: string; className?: string}) => (
+    <textarea className={className} readOnly>
+      {children}
+    </textarea>
+  )
+)`
+  border: none;
+  width: 100%;
+  resize: vertical;
+
+  font-family: ${p => p.theme.text.familyMono};
+`;
+
+export default DomMutations;

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useRef} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
@@ -17,17 +17,12 @@ type Props = {
 };
 
 function DomMutations({replay}: Props) {
-  const hiddenDivRef = useRef<HTMLDivElement>(null);
-  const {isLoading, actions} = useExtractedCrumbHtml({
-    replay,
-    domRoot: hiddenDivRef.current,
-  });
+  const {isLoading, actions} = useExtractedCrumbHtml({replay});
 
   const startTimestamp = replay.getEvent().startTimestamp;
 
   return (
     <Fragment>
-      <HiddenReplayMountpoint className="sr-block" ref={hiddenDivRef} />
       <StyledPanelTable
         isEmpty={actions.length === 0}
         emptyMessage={t('No DOM actions found.')}
@@ -69,14 +64,6 @@ function DomMutations({replay}: Props) {
   );
 }
 
-const HiddenReplayMountpoint = styled('div')`
-  position: fixed;
-  inset: 0;
-  width: 0;
-  height: 0;
-  overflow: hidden;
-`;
-
 const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: max-content max-content 1fr max-content;
   font-size: ${p => p.theme.fontSizeSmall};
@@ -117,9 +104,7 @@ const Title = styled('span')`
 
 const HTMLCode = styled(
   ({children, className}: {children: string; className?: string}) => (
-    <textarea className={className} readOnly>
-      {children}
-    </textarea>
+    <textarea className={className} readOnly value={children} />
   )
 )`
   border: none;

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -27,7 +27,7 @@ function DomMutations({replay}: Props) {
 
   return (
     <Fragment>
-      <HiddenReplayMountpoint ref={hiddenDivRef} />
+      <HiddenReplayMountpoint className="sr-block" ref={hiddenDivRef} />
       <StyledPanelTable
         isEmpty={actions.length === 0}
         emptyMessage={t('No DOM actions found.')}

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -8,6 +8,7 @@ import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import Console from './console';
+import DomMutations from './domMutations';
 import IssueList from './issueList';
 import MemoryChart from './memoryChart';
 import NetworkList from './networkList';
@@ -61,6 +62,8 @@ function FocusArea({}: Props) {
       return <Trace organization={organization} event={event} />;
     case 'issues':
       return <IssueList replayId={event.id} projectId={event.projectID} />;
+    case 'dom':
+      return <DomMutations replay={replay} />;
     case 'memory':
       return (
         <MemoryChart


### PR DESCRIPTION
Adds a new DOM table where we can see a table listing each breadcrumb that has interacted with the DOM. For each crumb we can see the actual HTML snippet that the breadcrumb refers to, so for a 'click' event we can see the full html of the button that was clicked.

<img width="1550" alt="Screen Shot 2022-07-20 at 3 16 17 PM" src="https://user-images.githubusercontent.com/187460/180091987-2cec4ea1-c66e-4db4-8ee0-648c01a7ceea.png">


This PR has minimal styling for the table so far. It can improve with help from:
- #36587 should give an example for base table styles, so all our replay tables look part of the family
- #36880 promises to supply an html formatter for use

The react hook seems to be quick enough on the examples i've tested.  RRweb has an option [`useVirtualDom`](https://github.com/rrweb-io/rrweb/blob/master/guide.md#options-1) which should be kicking in on the line `replayerRef.pause(replay.getEvent().endTimestamp);` because that line we're asking to scrub right to the end of the video, so no need to actual change the live dom.
I tried to construct the Replayer instance without attached `domRoot` to the document, but it wasn't possible, there are some codepaths inside rrweb that call `scrollTo` which are failing. An upstream fix for that is https://github.com/rrweb-io/rrweb/pull/939. If that gets merged then things might get more isolated, but it's not required afaik now.

Relates to: #36892