### PR TITLE
feat: Flip `eventstream.kafka-headers` option default

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -409,7 +409,7 @@ register("relay.drop-transaction-metrics", default=[])
 register("relay.transaction-metrics-org-sample-rate", default=0.0)
 
 # Write new kafka headers in eventstream
-register("eventstream:kafka-headers", default=False)
+register("eventstream:kafka-headers", default=True)
 
 # Post process forwarder options
 # Gets data from Kafka headers


### PR DESCRIPTION
This has already been set to True in Sentry production for a long
time. This change makes it default in all environments. It is preferable
to always send the headers as it allows the post process forwarder to avoid
parsing message bodies (which can be very large) entirely and only read the
message headers.