### PR TITLE
fix(search): Fix search not updating with latest tags after fetching

### DIFF
--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -51,6 +51,20 @@ const SEARCH_ITEMS: SearchItem[] = [
   },
 ];
 
+const getSupportedTags = (supportedTags: {[key: string]: Tag}) => {
+  const newTags = Object.fromEntries(
+    Object.keys(supportedTags).map(key => [
+      key,
+      {
+        ...supportedTags[key],
+        kind: supportedTags[key].predefined ? FieldValueKind.TAG : FieldValueKind.FIELD,
+      },
+    ])
+  );
+
+  return newTags;
+};
+
 type Props = React.ComponentProps<typeof SmartSearchBar> & {
   api: Client;
   onSidebarToggle: (e: React.MouseEvent) => void;
@@ -79,29 +93,11 @@ class IssueListSearchBar extends Component<Props, State> {
     supportedTags: {},
   };
 
-  componentDidMount() {
-    // Ideally, we would fetch on demand (e.g. when input gets focus)
-    // but `<SmartSearchBar>` is a bit complicated and this is the easiest route
-    this.getSupportedTags();
+  static getDerivedStateFromProps(props: Props) {
+    return {
+      supportedTags: getSupportedTags(props.supportedTags),
+    };
   }
-
-  getSupportedTags = () => {
-    const {supportedTags} = this.props;
-
-    const newTags = Object.fromEntries(
-      Object.keys(supportedTags).map(key => [
-        key,
-        {
-          ...supportedTags[key],
-          kind: supportedTags[key].predefined ? FieldValueKind.TAG : FieldValueKind.FIELD,
-        },
-      ])
-    );
-
-    this.setState({
-      supportedTags: newTags,
-    });
-  };
 
   /**
    * @returns array of tag values that substring match `query`

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -57,7 +57,7 @@ const getSupportedTags = (supportedTags: {[key: string]: Tag}) => {
       key,
       {
         ...supportedTags[key],
-        kind: supportedTags[key].predefined ? FieldValueKind.TAG : FieldValueKind.FIELD,
+        kind: supportedTags[key].predefined ? FieldValueKind.FIELD : FieldValueKind.TAG,
       },
     ])
   );


### PR DESCRIPTION
Fixes a regression introduced in #35859 with derived `supportedTags` not updating when the props change after the TagStore fetches. 

This PR makes `supportedTags` into a derived state computed on every prop change instead.