### PR TITLE
fix(slack): Use get methods for channel name

### DIFF
--- a/src/sentry/integrations/slack/utils/channel.py
+++ b/src/sentry/integrations/slack/utils/channel.py
@@ -93,8 +93,9 @@ def validate_channel_id(name: str, integration_id: Optional[int], input_channel_
         raise IntegrationError("Bad slack channel list response.")
 
     stripped_channel_name = strip_channel_name(name)
-    if not stripped_channel_name == results["channel"]["name"]:
-        channel_name = results["channel"]["name"]
+    results_channel_name = results.get("channel", {}).get("name")
+    if not stripped_channel_name == results_channel_name:
+        channel_name = results_channel_name
         raise ValidationError(
             f"Received channel name {channel_name} does not match inputted channel name {stripped_channel_name}."
         )

--- a/src/sentry/integrations/slack/utils/channel.py
+++ b/src/sentry/integrations/slack/utils/channel.py
@@ -94,7 +94,9 @@ def validate_channel_id(name: str, integration_id: Optional[int], input_channel_
 
     stripped_channel_name = strip_channel_name(name)
     results_channel_name = results.get("channel", {}).get("name")
-    if not stripped_channel_name == results_channel_name:
+    if not results_channel_name:
+        raise ValidationError("Did not receive channel name from API results")
+    if stripped_channel_name != results_channel_name:
         channel_name = results_channel_name
         raise ValidationError(
             f"Received channel name {channel_name} does not match inputted channel name {stripped_channel_name}."


### PR DESCRIPTION
Fixes [SENTRY-VDD](https://sentry.io/organizations/sentry/issues/3406993100/?project=1&referrer=slack)



Checked out the [API response from Slack](https://api.slack.com/methods/conversations.info) and if they try to use DMs instead of a channel.