### PR TITLE
feat: Validate referrer tags with existing subset

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -19,40 +19,38 @@ from sentry.models.organization import Organization
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.search.events.fields import is_function
 from sentry.snuba import discover, metrics_enhanced_performance
+from sentry.snuba.referrer import Referrer
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
 
-METRICS_ENHANCED_REFERRERS = {
-    "api.performance.landing-table",
-}
+METRICS_ENHANCED_REFERRERS = {Referrer.API_PERFORMANCE_LANDING_TABLE.value}
 
 ALLOWED_EVENTS_REFERRERS = {
-    "api.organization-events",
-    "api.organization-events-v2",
-    "api.dashboards.tablewidget",
-    "api.dashboards.bignumberwidget",
-    "api.discover.transactions-list",
-    "api.discover.query-table",
-    "api.performance.vitals-cards",
-    "api.performance.landing-table",
-    "api.performance.transaction-summary",
-    "api.performance.transaction-spans",
-    "api.performance.status-breakdown",
-    "api.performance.vital-detail",
-    "api.performance.durationpercentilechart",
-    "api.performance.tag-page",
-    "api.trace-view.span-detail",
-    "api.trace-view.errors-view",
-    "api.trace-view.hover-card",
+    Referrer.API_ORGANIZATION_EVENTS.value,
+    Referrer.API_ORGANIZATION_EVENTS_V2.value,
+    Referrer.API_DASHBOARDS_TABLEWIDGET.value,
+    Referrer.API_DASHBOARDS_BIGNUMBERWIDGET.value,
+    Referrer.API_DISCOVER_TRANSACTIONS_LIST.value,
+    Referrer.API_DISCOVER_QUERY_TABLE.value,
+    Referrer.API_PERFORMANCE_VITALS_CARDS.value,
+    Referrer.API_PERFORMANCE_LANDING_TABLE.value,
+    Referrer.API_PERFORMANCE_TRANSACTION_SUMMARY.value,
+    Referrer.API_PERFORMANCE_TRANSACTION_SPANS.value,
+    Referrer.API_PERFORMANCE_STATUS_BREAKDOWN.value,
+    Referrer.API_PERFORMANCE_VITAL_DETAIL.value,
+    Referrer.API_PERFORMANCE_DURATIONPERCENTILECHART.value,
+    Referrer.API_TRACE_VIEW_SPAN_DETAIL.value,
+    Referrer.API_TRACE_VIEW_ERRORS_VIEW.value,
+    Referrer.API_TRACE_VIEW_HOVER_CARD.value,
 }
 
 ALLOWED_EVENTS_GEO_REFERRERS = {
-    "api.organization-events-geo",
-    "api.dashboards.worldmapwidget",
+    Referrer.API_ORGANIZATION_EVENTS_GEO.value,
+    Referrer.API_DASHBOARDS_WORLDMAPWIDGET.value,
 }
 
-API_TOKEN_REFERRER = "api.auth-token.events"
+API_TOKEN_REFERRER = Referrer.API_AUTH_TOKEN_EVENTS.value
 
 RATE_LIMIT = 15
 RATE_LIMIT_WINDOW = 1
@@ -145,7 +143,9 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
         allow_metric_aggregates = request.GET.get("preventMetricAggregates") != "1"
 
         referrer = (
-            referrer if referrer in ALLOWED_EVENTS_REFERRERS else "api.organization-events-v2"
+            referrer
+            if referrer in ALLOWED_EVENTS_REFERRERS
+            else Referrer.API_ORGANIZATION_EVENTS_V2.value
         )
 
         def data_fn(offset, limit):
@@ -308,7 +308,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
         if request.auth:
             referrer = API_TOKEN_REFERRER
         elif referrer not in ALLOWED_EVENTS_REFERRERS:
-            referrer = "api.organization-events"
+            referrer = Referrer.API_ORGANIZATION_EVENTS.value
 
         def data_fn(offset, limit):
             query_details = {
@@ -380,7 +380,9 @@ class OrganizationEventsGeoEndpoint(OrganizationEventsV2EndpointBase):
 
         referrer = request.GET.get("referrer")
         referrer = (
-            referrer if referrer in ALLOWED_EVENTS_GEO_REFERRERS else "api.organization-events-geo"
+            referrer
+            if referrer in ALLOWED_EVENTS_GEO_REFERRERS
+            else Referrer.API_ORGANIZATION_EVENTS_GEO.value
         )
 
         def data_fn(offset, limit):

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -11,63 +11,64 @@ from sentry.api.bases import OrganizationEventsV2EndpointBase
 from sentry.constants import MAX_TOP_EVENTS
 from sentry.models import Organization
 from sentry.snuba import discover, metrics_enhanced_performance
+from sentry.snuba.referrer import Referrer
 from sentry.utils.snuba import SnubaTSResult
 
 METRICS_ENHANCED_REFERRERS: Set[str] = {
-    "api.performance.homepage.widget-chart",
-    "api.performance.generic-widget-chart.duration-histogram",
-    "api.performance.generic-widget-chart.lcp-histogram",
-    "api.performance.generic-widget-chart.fcp-histogram",
-    "api.performance.generic-widget-chart.fid-histogram",
-    "api.performance.generic-widget-chart.apdex-area",
-    "api.performance.generic-widget-chart.p50-duration-area",
-    "api.performance.generic-widget-chart.p75-duration-area",
-    "api.performance.generic-widget-chart.p95-duration-area",
-    "api.performance.generic-widget-chart.p99-duration-area",
-    "api.performance.generic-widget-chart.p75-lcp-area",
-    "api.performance.generic-widget-chart.tpm-area",
-    "api.performance.generic-widget-chart.failure-rate-area",
-    "api.performance.generic-widget-chart.user-misery-area",
-    "api.performance.generic-widget-chart.worst-lcp-vitals",
-    "api.performance.generic-widget-chart.worst-fcp-vitals",
-    "api.performance.generic-widget-chart.worst-cls-vitals",
-    "api.performance.generic-widget-chart.worst-fid-vitals",
-    "api.performance.generic-widget-chart.most-improved",
-    "api.performance.generic-widget-chart.most-regressed",
-    "api.performance.generic-widget-chart.most-related-errors",
-    "api.performance.generic-widget-chart.most-related-issues",
-    "api.performance.generic-widget-chart.slow-http-ops",
-    "api.performance.generic-widget-chart.slow-db-ops",
-    "api.performance.generic-widget-chart.slow-resource-ops",
-    "api.performance.generic-widget-chart.slow-browser-ops",
-    "api.performance.generic-widget-chart.cold-startup-area",
-    "api.performance.generic-widget-chart.warm-startup-area",
-    "api.performance.generic-widget-chart.slow-frames-area",
-    "api.performance.generic-widget-chart.frozen-frames-area",
-    "api.performance.generic-widget-chart.most-slow-frames",
-    "api.performance.generic-widget-chart.most-frozen-frames",
+    Referrer.API_PERFORMANCE_HOMEPAGE_WIDGET_CHART.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_DURATION_HISTOGRAM.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_LCP_HISTOGRAM.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_FCP_HISTOGRAM.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_FID_HISTOGRAM.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_APDEX_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_P50_DURATION_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_P75_DURATION_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_P95_DURATION_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_P99_DURATION_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_P75_LCP_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_TPM_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_FAILURE_RATE_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_USER_MISERY_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_WORST_LCP_VITALS.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_WORST_FCP_VITALS.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_WORST_CLS_VITALS.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_WORST_FID_VITALS.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_IMRPOVED.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_REGRESSED.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_RELATED_ERRORS.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_RELATED_ISSUES.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_HTTP_OPS.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_DB_OPS.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_RESOURCE_OPS.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_BROWSER_OPS.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_COLD_STARTUP_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_WARM_STARTUP_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_FRAMES_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_FROZEN_FRAMES_AREA.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_SLOW_FRAMES.value,
+    Referrer.API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_FROZEN_FRAMES.value,
 }
 
 
 ALLOWED_EVENTS_STATS_REFERRERS: Set[str] = {
-    "api.alerts.alert-rule-chart",
-    "api.dashboards.widget.area-chart",
-    "api.dashboards.widget.bar-chart",
-    "api.dashboards.widget.line-chart",
-    "api.dashboards.top-events",
-    "api.discover.prebuilt-chart",
-    "api.discover.previous-chart",
-    "api.discover.default-chart",
-    "api.discover.daily-chart",
-    "api.discover.top5-chart",
-    "api.discover.dailytop5-chart",
-    "api.performance.homepage.duration-chart",
-    "api.performance.homepage.widget-chart",
-    "api.performance.transaction-summary.sidebar-chart",
-    "api.performance.transaction-summary.vitals-chart",
-    "api.performance.transaction-summary.trends-chart",
-    "api.performance.transaction-summary.duration",
-    "api.releases.release-details-chart",
+    Referrer.API_ALERTS_ALERT_RULE_CHART.value,
+    Referrer.API_DASHBOARDS_WIDGET_AREA_CHART.value,
+    Referrer.API_DASHBOARDS_WIDGET_BAR_CHART.value,
+    Referrer.API_DASHBOARDS_WIDGET_LINE_CHART.value,
+    Referrer.API_DASHBOARDS_TOP_EVENTS.value,
+    Referrer.API_DISCOVER_PREBUILT_CHART.value,
+    Referrer.API_DISCOVER_PREVIOUS_CHART.value,
+    Referrer.API_DISCOVER_DEFAULT_CHART.value,
+    Referrer.API_DISCOVER_DAILY_CHART.value,
+    Referrer.API_DISCOVER_TOP5_CHART.value,
+    Referrer.API_DISCOVER_DAILYTOP5_CHART.value,
+    Referrer.API_PERFORMANCE_HOMEPAGE_DURATION_CHART.value,
+    Referrer.API_PERFORMANCE_HOMEPAGE_WIDGET_CHART.value,
+    Referrer.API_PERFORMANCE_TRANSACTION_SUMMARY_SIDEBAR_CHART.value,
+    Referrer.API_PERFORMANCE_TRANSACTION_SUMMARY_VITALS_CHART.value,
+    Referrer.API_PERFORMANCE_TRANSACTION_SUMMARY_TRENDS_CHART.value,
+    Referrer.API_PERFORMANCE_TRANSACTION_SUMMARY_DURATION.value,
+    Referrer.API_RELEASES_RELEASE_DETAILS_CHART.value,
 }
 
 
@@ -132,7 +133,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):  # type
             referrer = (
                 referrer
                 if referrer in ALLOWED_EVENTS_STATS_REFERRERS.union(METRICS_ENHANCED_REFERRERS)
-                else "api.organization-event-stats"
+                else Referrer.API_ORGANIZATION_EVENT_STATS.value
             )
             batch_features = self.get_features(organization, request)
             has_chart_interpolation = batch_features.get(

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -1,0 +1,304 @@
+from enum import Enum, unique
+from typing import Optional
+
+from sentry.utils import metrics
+
+
+@unique
+class Referrer(Enum):
+    ALERTRULESERIALIZER_TEST_QUERY = "alertruleserializer.test_query"
+    ALERTRULESERIALIZER_TEST_QUERY_PRIMARY = "alertruleserializer.test_query.primary"
+    API_ALERTS_ALERT_RULE_CHART = "api.alerts.alert-rule-chart"
+    API_AUTH_TOKEN_EVENTS = "api.auth-token.events"
+    API_DASHBOARDS_BIGNUMBERWIDGET = "api.dashboards.bignumberwidget"
+    API_DASHBOARDS_TABLEWIDGET = "api.dashboards.tablewidget"
+    API_DASHBOARDS_TABLEWIDGET_METRICS_ENHANCED_PRIMARY = (
+        "api.dashboards.tablewidget.metrics-enhanced.primary"
+    )
+    API_DASHBOARDS_TOP_EVENTS = "api.dashboards.top-events"
+    API_DASHBOARDS_WIDGET_AREA_CHART = "api.dashboards.widget.area-chart"
+    API_DASHBOARDS_WIDGET_AREA_CHART_FIND_TOPN = "api.dashboards.widget.area-chart.find-topn"
+    API_DASHBOARDS_WIDGET_AREA_CHART_METRICS_ENHANCED = (
+        "api.dashboards.widget.area-chart.metrics-enhanced"
+    )
+    API_DASHBOARDS_WIDGET_BAR_CHART = "api.dashboards.widget.bar-chart"
+    API_DASHBOARDS_WIDGET_BAR_CHART_FIND_TOPN = "api.dashboards.widget.bar-chart.find-topn"
+    API_DASHBOARDS_WIDGET_LINE_CHART = "api.dashboards.widget.line-chart"
+    API_DASHBOARDS_WIDGET_LINE_CHART_FIND_TOPN = "api.dashboards.widget.line-chart.find-topn"
+    API_DASHBOARDS_WORLDMAPWIDGET = "api.dashboards.worldmapwidget"
+    API_DISCOVER_DAILY_CHART = "api.discover.daily-chart"
+    API_DISCOVER_DAILYTOP5_CHART = "api.discover.dailytop5-chart"
+    API_DISCOVER_DAILYTOP5_CHART_FIND_TOPN = "api.discover.dailytop5-chart.find-topn"
+    API_DISCOVER_DEFAULT_CHART = "api.discover.default-chart"
+    API_DISCOVER_PREBUILT_CHART = "api.discover.prebuilt-chart"
+    API_DISCOVER_PREVIOUS_CHART = "api.discover.previous-chart"
+    API_DISCOVER_QUERY_TABLE = "api.discover.query-table"
+    API_DISCOVER_TOP5_CHART = "api.discover.top5-chart"
+    API_DISCOVER_TOP5_CHART_FIND_TOPN = "api.discover.top5-chart.find-topn"
+    API_DISCOVER_TRANSACTIONS_LIST = "api.discover.transactions-list"
+    API_EVENTS_MEASUREMENTS = "api.events.measurements"
+    API_EVENTS_VITALS = "api.events.vitals"
+    API_GROUP_HASHES_LEVELS_GET_LEVEL_NEW_ISSUES = "api.group_hashes_levels.get_level_new_issues"
+    API_GROUP_HASHES_LEVELS_GET_LEVELS_OVERVIEW = "api.group_hashes_levels.get_levels_overview"
+    API_GROUP_EVENTS = "api.group-events"
+    API_GROUP_HASHES = "api.group-hashes"
+    API_ORGANIZATION_EVENT_STATS = "api.organization-event-stats"
+    API_ORGANIZATION_EVENT_STATS_FIND_TOPN = "api.organization-event-stats.find-topn"
+    API_ORGANIZATION_EVENTS = "api.organization-events"
+    API_ORGANIZATION_EVENTS_FACETS_PERFORMANCE_HISTOGRAM = (
+        "api.organization-events-facets-performance-histogram"
+    )
+    API_ORGANIZATION_EVENTS_FACETS_PERFORMANCE_HISTOGRAM_TOP_TAGS = (
+        "api.organization-events-facets-performance-histogram.top_tags"
+    )
+    API_ORGANIZATION_EVENTS_FACETS_PERFORMANCE_TOP_TAGS_ALL_TRANSACTIONS = (
+        "api.organization-events-facets-performance.top-tags.all_transactions"
+    )
+    API_ORGANIZATION_EVENTS_FACETS_PERFORMANCE_TOP_TAGS_TAG_VALUES = (
+        "api.organization-events-facets-performance.top-tags.tag_values"
+    )
+    API_ORGANIZATION_EVENTS_FACETS_TOP_TAGS = "api.organization-events-facets.top-tags"
+    API_ORGANIZATION_EVENTS_GEO = "api.organization-events-geo"
+    API_ORGANIZATION_EVENTS_HISTOGRAM = "api.organization-events-histogram"
+    API_ORGANIZATION_EVENTS_HISTOGRAM_MIN_MAX = "api.organization-events-histogram-min-max"
+    API_ORGANIZATION_EVENTS_META = "api.organization-events-meta"
+    API_ORGANIZATION_EVENTS_SPAN_OPS = "api.organization-events-span-ops"
+    API_ORGANIZATION_EVENTS_SPANS_HISTOGRAM = "api.organization-events-spans-histogram"
+    API_ORGANIZATION_EVENTS_SPANS_PERFORMANCE_EXAMPLES = (
+        "api.organization-events-spans-performance-examples"
+    )
+    API_ORGANIZATION_EVENTS_SPANS_PERFORMANCE_STATS = (
+        "api.organization-events-spans-performance-stats"
+    )
+    API_ORGANIZATION_EVENTS_SPANS_PERFORMANCE_SUSPECTS = (
+        "api.organization-events-spans-performance-suspects"
+    )
+    API_ORGANIZATION_EVENTS_V2 = "api.organization-events-v2"
+    API_ORGANIZATION_SDK_UPDATES = "api.organization-sdk-updates"
+    API_ORGANIZATION_SPANS_HISTOGRAM_MIN_MAX = "api.organization-spans-histogram-min-max"
+    API_PERFORMANCE_DURATIONPERCENTILECHART = "api.performance.durationpercentilechart"
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_APDEX_AREA = (
+        "api.performance.generic-widget-chart.apdex-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_COLD_STARTUP_AREA = (
+        "api.performance.generic-widget-chart.cold-startup-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_DURATION_HISTOGRAM = (
+        "api.performance.generic-widget-chart.duration-histogram"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_FAILURE_RATE_AREA = (
+        "api.performance.generic-widget-chart.failure-rate-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_FCP_HISTOGRAM = (
+        "api.performance.generic-widget-chart.fcp-histogram"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_FID_HISTOGRAM = (
+        "api.performance.generic-widget-chart.fid-histogram"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_FROZEN_FRAMES_AREA = (
+        "api.performance.generic-widget-chart.frozen-frames-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_LCP_HISTOGRAM = (
+        "api.performance.generic-widget-chart.lcp-histogram"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_FROZEN_FRAMES = (
+        "api.performance.generic-widget-chart.most-frozen-frames"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_IMRPOVED = (
+        "api.performance.generic-widget-chart.most-improved"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_RELATED_ERRORS = (
+        "api.performance.generic-widget-chart.most-related-errors"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_RELATED_ISSUES = (
+        "api.performance.generic-widget-chart.most-related-issues"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_REGRESSED = (
+        "api.performance.generic-widget-chart.most-regressed"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_MOST_SLOW_FRAMES = (
+        "api.performance.generic-widget-chart.most-slow-frames"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_P50_DURATION_AREA = (
+        "api.performance.generic-widget-chart.p50-duration-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_P75_DURATION_AREA = (
+        "api.performance.generic-widget-chart.p75-duration-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_P75_LCP_AREA = (
+        "api.performance.generic-widget-chart.p75-lcp-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_P95_DURATION_AREA = (
+        "api.performance.generic-widget-chart.p95-duration-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_P99_DURATION_AREA = (
+        "api.performance.generic-widget-chart.p99-duration-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_BROWSER_OPS = (
+        "api.performance.generic-widget-chart.slow-browser-ops"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_DB_OPS = (
+        "api.performance.generic-widget-chart.slow-db-ops"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_FRAMES_AREA = (
+        "api.performance.generic-widget-chart.slow-frames-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_HTTP_OPS = (
+        "api.performance.generic-widget-chart.slow-http-ops"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_SLOW_RESOURCE_OPS = (
+        "api.performance.generic-widget-chart.slow-resource-ops"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_TPM_AREA = "api.performance.generic-widget-chart.tpm-area"
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_USER_MISERY_AREA = (
+        "api.performance.generic-widget-chart.user-misery-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_WARM_STARTUP_AREA = (
+        "api.performance.generic-widget-chart.warm-startup-area"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_WORST_CLS_VITALS = (
+        "api.performance.generic-widget-chart.worst-cls-vitals"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_WORST_FCP_VITALS = (
+        "api.performance.generic-widget-chart.worst-fcp-vitals"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_WORST_FID_VITALS = (
+        "api.performance.generic-widget-chart.worst-fid-vitals"
+    )
+    API_PERFORMANCE_GENERIC_WIDGET_CHART_WORST_LCP_VITALS = (
+        "api.performance.generic-widget-chart.worst-lcp-vitals"
+    )
+    API_PERFORMANCE_HOMEPAGE_DURATION_CHART = "api.performance.homepage.duration-chart"
+    API_PERFORMANCE_HOMEPAGE_WIDGET_CHART = "api.performance.homepage.widget-chart"
+    API_PERFORMANCE_LANDING_TABLE = "api.performance.landing-table"
+    API_PERFORMANCE_STATUS_BREAKDOWN = "api.performance.status-breakdown"
+    API_PERFORMANCE_TAG_PAGE = "api.performance.tag-page"
+    API_PERFORMANCE_TRANSACTION_SPANS = "api.performance.transaction-spans"
+    API_PERFORMANCE_TRANSACTION_SUMMARY = "api.performance.transaction-summary"
+    API_PERFORMANCE_TRANSACTION_SUMMARY_DURATION = "api.performance.transaction-summary.duration"
+    API_PERFORMANCE_TRANSACTION_SUMMARY_SIDEBAR_CHART = (
+        "api.performance.transaction-summary.sidebar-chart"
+    )
+    API_PERFORMANCE_TRANSACTION_SUMMARY_TRENDS_CHART = (
+        "api.performance.transaction-summary.trends-chart"
+    )
+    API_PERFORMANCE_TRANSACTION_SUMMARY_VITALS_CHART = (
+        "api.performance.transaction-summary.vitals-chart"
+    )
+    API_PERFORMANCE_VITAL_DETAIL = "api.performance.vital-detail"
+    API_PERFORMANCE_VITALS_CARDS = "api.performance.vitals-cards"
+    API_PROJECT_EVENTS = "api.project-events"
+    API_RELEASES_RELEASE_DETAILS_CHART = "api.releases.release-details-chart"
+    API_SERIALIZER_PROJECTS_GET_STATS = "api.serializer.projects.get_stats"
+    API_TRACE_VIEW_ERRORS_VIEW = "api.trace-view.errors-view"
+    API_TRACE_VIEW_GET_EVENTS = "api.trace-view.get-events"
+    API_TRACE_VIEW_GET_META = "api.trace-view.get-meta"
+    API_TRACE_VIEW_HOVER_CARD = "api.trace-view.hover-card"
+    API_TRACE_VIEW_SPAN_DETAIL = "api.trace-view.span-detail"
+    API_TRENDS_GET_EVENT_STATS = "api.trends.get-event-stats"
+    API_TRENDS_GET_PERCENTAGE_CHANGE = "api.trends.get-percentage-change"
+    API_VROOM = "api.vroom"
+    DATA_EXPORT_TASKS_DISCOVER = "data_export.tasks.discover"
+    DELETIONS_GROUP = "deletions.group"
+    DISCOVER = "discover"
+    DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PARENT_TRANSACTIONS = (
+        "dynamic-sampling.distribution.fetch-parent-transactions"
+    )
+    DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PARENT_TRANSACTIONS_COUNT = (
+        "dynamic-sampling.distribution.fetch-parent-transactions-count"
+    )
+    DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PROJECT_BREAKDOWN = (
+        "dynamic-sampling.distribution.fetch-project-breakdown"
+    )
+    DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PROJECT_SDK_VERSIONS_INFO = (
+        "dynamic-sampling.distribution.fetch-project-sdk-versions-info"
+    )
+    EVENTSTORE_GET_EVENT_BY_ID_NODESTORE = "eventstore.get_event_by_id_nodestore"
+    EVENTSTORE_GET_EVENTS = "eventstore.get_events"
+    EVENTSTORE_GET_NEXT_OR_PREV_EVENT_ID = "eventstore.get_next_or_prev_event_id"
+    GETSENTRY_API_PENDO_DETAILS = "getsentry.api.pendo-details"
+    GROUP_FILTER_BY_EVENT_ID = "group.filter_by_event_id"
+    GROUP_GET_LATEST = "group.get_latest"
+    GROUP_UNHANDLED_FLAG = "group.unhandled-flag"
+    INCIDENTS_GET_INCIDENT_AGGREGATES = "incidents.get_incident_aggregates"
+    OUTCOMES_TIMESERIES = "outcomes.timeseries"
+    OUTCOMES_TOTALS = "outcomes.totals"
+    SEARCH = "search"
+    SEARCH_SAMPLE = "search_sample"
+    SERIALIZERS_GROUPSERIALIZERSNUBA__EXECUTE_SEEN_STATS_QUERY = (
+        "serializers.groupserializersnuba._execute_seen_stats_query"
+    )
+    SESSIONS_CRASH_FREE_BREAKDOWN = "sessions.crash-free-breakdown"
+    SESSIONS_GET_PROJECT_SESSIONS_COUNT = "sessions.get_project_sessions_count"
+    SESSIONS_GET_ADOPTION = "sessions.get-adoption"
+    SESSIONS_HEALTH_DATA_CHECK = "sessions.health-data-check"
+    SESSIONS_OLDEST_DATA_BACKFILL = "sessions.oldest-data-backfill"
+    SESSIONS_RELEASE_ADOPTION_LIST = "sessions.release-adoption-list"
+    SESSIONS_RELEASE_ADOPTION_TOTAL_USERS_AND_SESSIONS = (
+        "sessions.release-adoption-total-users-and-sessions"
+    )
+    SESSIONS_RELEASE_OVERVIEW = "sessions.release-overview"
+    SESSIONS_RELEASE_SESSIONS_TIME_BOUNDS = "sessions.release-sessions-time-bounds"
+    SESSIONS_RELEASE_STATS = "sessions.release-stats"
+    SESSIONS_RELEASE_STATS_DETAILS = "sessions.release-stats-details"
+    SESSIONS_STABILITY_SORT = "sessions.stability-sort"
+    SESSIONS_TIMESERIES = "sessions.timeseries"
+    SESSIONS_TOTALS = "sessions.totals"
+    SNUBA_METRICS_GET_METRICS_NAMES_FOR_ENTITY = "snuba.metrics.get_metrics_names_for_entity"
+    SNUBA_SESSIONS_CHECK_RELEASES_HAVE_HEALTH_DATA = (
+        "snuba.sessions.check_releases_have_health_data"
+    )
+    SNUBA_SESSIONS_GET_PROJECT_RELEASES_COUNT = "snuba.sessions.get_project_releases_count"
+    SUBSCRIPTION_PROCESSOR_COMPARISON_QUERY = "subscription_processor.comparison_query"
+    SUBSCRIPTIONS_EXECUTOR = "subscriptions_executor"
+    TAGSTORE__GET_TAG_KEY_AND_TOP_VALUES = "tagstore._get_tag_key_and_top_values"
+    TAGSTORE__GET_TAG_KEYS = "tagstore._get_tag_keys"
+    TAGSTORE__GET_TAG_KEYS_AND_TOP_VALUES = "tagstore._get_tag_keys_and_top_values"
+    TAGSTORE_GET_GROUP_LIST_TAG_VALUE = "tagstore.get_group_list_tag_value"
+    TAGSTORE_GET_GROUP_TAG_VALUE_ITER = "tagstore.get_group_tag_value_iter"
+    TAGSTORE_GET_GROUPS_USER_COUNTS = "tagstore.get_groups_user_counts"
+    TAGSTORE_GET_RELEASE_TAGS = "tagstore.get_release_tags"
+    TAGSTORE_GET_TAG_VALUE_PAGINATOR_FOR_PROJECTS = "tagstore.get_tag_value_paginator_for_projects"
+    TASKS_MONITOR_RELEASE_ADOPTION = "tasks.monitor_release_adoption"
+    TASKS_PROCESS_PROJECTS_WITH_SESSIONS_SESSION_COUNT = (
+        "tasks.process_projects_with_sessions.session_count"
+    )
+    TRANSACTION_ANOMALY_DETECTION = "transaction-anomaly-detection"
+    TSDB_MODELID_1 = "tsdb-modelid:1"
+    TSDB_MODELID_100 = "tsdb-modelid:100"
+    TSDB_MODELID_101 = "tsdb-modelid:101"
+    TSDB_MODELID_104 = "tsdb-modelid:104"
+    TSDB_MODELID_200 = "tsdb-modelid:200"
+    TSDB_MODELID_201 = "tsdb-modelid:201"
+    TSDB_MODELID_202 = "tsdb-modelid:202"
+    TSDB_MODELID_300 = "tsdb-modelid:300"
+    TSDB_MODELID_4 = "tsdb-modelid:4"
+    TSDB_MODELID_407 = "tsdb-modelid:407"
+    TSDB_MODELID_601 = "tsdb-modelid:601"
+    TSDB_MODELID_602 = "tsdb-modelid:602"
+    TSDB_MODELID_603 = "tsdb-modelid:603"
+    TSDB_MODELID_604 = "tsdb-modelid:604"
+    TSDB_MODELID_605 = "tsdb-modelid:605"
+    TSDB_MODELID_606 = "tsdb-modelid:606"
+    TSDB_MODELID_607 = "tsdb-modelid:607"
+    TSDB_MODELID_608 = "tsdb-modelid:608"
+    TSDB_MODELID_609 = "tsdb-modelid:609"
+    TSDB_MODELID_610 = "tsdb-modelid:610"
+    UNKNOWN = "unknown"
+    UNMERGE = "unmerge"
+
+    # Referrers in tests
+    API_METRICS_TOTALS = "api.metrics.totals"
+    TESTING_GET_FACETS_TEST = "testing.get-facets-test"
+    TESTING_TEST = "testing.test"
+    TEST_QUERY_PRIMARY = "test_query.primary"
+    TEST_QUERY = "test_query"
+
+
+def validate_referrer(referrer: Optional[str]):
+    if not referrer:
+        return
+
+    referrers = {referrer.value for referrer in Referrer}
+    if referrer not in referrers:
+        metrics.incr("snql.sdk.api.new_referrers", tags={"referrer": referrer})

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -36,6 +36,7 @@ from sentry.models import (
 from sentry.net.http import connection_from_url
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
+from sentry.snuba.referrer import validate_referrer
 from sentry.utils import json, metrics
 from sentry.utils.dates import outside_retention_with_modified_start, to_timestamp
 
@@ -735,6 +736,7 @@ def _apply_cache_and_build_results(
     use_cache: Optional[bool] = False,
 ) -> ResultSet:
     headers = {}
+    validate_referrer(referrer)
     if referrer:
         headers["referer"] = referrer
 

--- a/tests/snuba/test_snql_snuba.py
+++ b/tests/snuba/test_snql_snuba.py
@@ -2,6 +2,7 @@ import time
 import uuid
 from datetime import datetime, timedelta
 from typing import Optional
+from unittest import mock
 
 from django.utils import timezone
 from snuba_sdk import Request
@@ -39,7 +40,8 @@ class SnQLTest(TestCase, SnubaTestCase):
         )
         return event_id
 
-    def test_basic(self) -> None:
+    @mock.patch("sentry.utils.metrics.incr")
+    def test_basic(self, mock_metrics_incr) -> None:
         now = datetime.now()
         self._insert_event_for_time(now)
 
@@ -56,9 +58,12 @@ class SnQLTest(TestCase, SnubaTestCase):
             )
         )
         request = Request(dataset="events", app_id="tests", query=query)
-        result = snuba.raw_snql_query(request)
+        result = snuba.raw_snql_query(request, referrer="referrer_not_in_enum")
         assert len(result["data"]) == 1
         assert result["data"][0] == {"count": 1, "project_id": self.project.id}
+        mock_metrics_incr.assert_any_call(
+            "snql.sdk.api.new_referrers", tags={"referrer": "referrer_not_in_enum"}
+        )
 
     def test_cache(self):
         """Minimal test to verify if use_cache works"""


### PR DESCRIPTION
Currently, sentry can send arbitrary referrer strings to Snuba. This
is a problem because these referrers are placed in our transaction names
and datadog metrics.

The following code is responsible for validating referrers with a enum
set. Eventually we would like to enforce this enum whenever a referrer
is define; however, for now, it can just check and record a metric
when a new referrer is used.