### PR TITLE
feat(vitals-cta): explicitly set all projects

### DIFF
--- a/static/app/components/performance/vitalsAlert/vitalsAlertCTA.tsx
+++ b/static/app/components/performance/vitalsAlert/vitalsAlertCTA.tsx
@@ -60,7 +60,13 @@ export default function VitalsAlertCTA({data, dismissAlert}: Props) {
     ? getRelativeDiff(userVitalValue, INDUSTRY_STANDARDS[vital])
     : 0;
 
-  const hasGlobalViews = organization.features.includes('global-views');
+  // must have the global-views
+  // and either be an owner/member or the org allows open membership
+  const canSeeAllProjects =
+    organization.features.includes('global-views') &&
+    (['owner', 'manager'].includes(organization.orgRole || '') ||
+      organization.features.includes('open-membership'));
+
   // find the project that has the most events of the same type
   const bestProjectData = vital
     ? maxBy(data.projectData, item => {
@@ -86,6 +92,7 @@ export default function VitalsAlertCTA({data, dismissAlert}: Props) {
       user_vital_value: userVitalValue,
       sentry_diff: sentryDiff,
       industry_diff: industryDiff,
+      can_see_all_projects: canSeeAllProjects,
     } as const;
   };
 
@@ -98,8 +105,8 @@ export default function VitalsAlertCTA({data, dismissAlert}: Props) {
     if (sentryDiff < 0) {
       return false;
     }
-    // must have either global views enabled or we can pick a specific project
-    return hasGlobalViews || bestProjectData;
+    // must either be able to see all proejcts or we can pick a specific project
+    return canSeeAllProjects || bestProjectData;
   };
 
   useEffect(() => {
@@ -152,14 +159,11 @@ export default function VitalsAlertCTA({data, dismissAlert}: Props) {
 
   const getVitalsURL = () => {
     const performanceRoot = `/organizations/${organization.slug}/performance`;
-    const baseParams: Record<string, string> = {
+    const baseParams: Record<string, string | undefined> = {
       statsPeriod: '7d',
       referrer: `vitals-alert-${vital.toLowerCase()}`,
+      project: canSeeAllProjects ? '-1' : bestProjectData?.projectId,
     };
-    // specify a specific project if we have to and we can
-    if (!hasGlobalViews && bestProjectData) {
-      baseParams.project = bestProjectData.projectId;
-    }
 
     // we can land on a specific web vital
     if (vitalsType === 'web') {

--- a/static/app/components/performance/vitalsAlert/vitalsAlertCTA.tsx
+++ b/static/app/components/performance/vitalsAlert/vitalsAlertCTA.tsx
@@ -61,7 +61,7 @@ export default function VitalsAlertCTA({data, dismissAlert}: Props) {
     : 0;
 
   // must have the global-views
-  // and either be an owner/member or the org allows open membership
+  // and either be an owner/manager or the org allows open membership
   const canSeeAllProjects =
     organization.features.includes('global-views') &&
     (['owner', 'manager'].includes(organization.orgRole || '') ||

--- a/static/app/utils/analytics/growthAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/growthAnalyticsEvents.tsx
@@ -47,6 +47,7 @@ type SampleEvent = {
 };
 
 type VitalsAlert = {
+  can_see_all_projects: boolean;
   industry_diff: number;
   sentry_diff: number;
   user_vital_value: number;


### PR DESCRIPTION
We need to explicitly set projects to `-1` if users can access all projects. Otherwise, they'll just see their team's projects which might not have projects with the correct vitals. If the user can't access all projects then we just pick a single project that has the most of the relevant vital.