### PR TITLE
refs(metric_alerts): Consolidate `QueryDatasets` and `Dataset` (#36894)

### DIFF
--- a/src/sentry/incidents/charts.py
+++ b/src/sentry/incidents/charts.py
@@ -15,8 +15,9 @@ from sentry.charts.types import ChartSize, ChartType
 from sentry.incidents.logic import translate_aggregate_field
 from sentry.incidents.models import AlertRule, Incident, User
 from sentry.models import ApiKey, Organization
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import apply_dataset_query_conditions
-from sentry.snuba.models import QueryDatasets, SnubaQuery
+from sentry.snuba.models import SnubaQuery
 
 CRASH_FREE_SESSIONS = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
 CRASH_FREE_USERS = "percentage(users_crashed, users) AS _crash_rate_alert_aggregate"
@@ -156,7 +157,7 @@ def build_metric_alert_chart(
 ) -> Optional[str]:
     """Builds the dataset required for metric alert chart the same way the frontend would"""
     snuba_query: SnubaQuery = alert_rule.snuba_query
-    dataset = QueryDatasets(snuba_query.dataset)
+    dataset = Dataset(snuba_query.dataset)
     query_type = SnubaQuery.Type(snuba_query.type)
     is_crash_free_alert = query_type == SnubaQuery.Type.CRASH_RATE
     style = (
@@ -218,10 +219,7 @@ def build_metric_alert_chart(
             user,
         )
     else:
-        if (
-            query_type == SnubaQuery.Type.PERFORMANCE
-            and dataset == QueryDatasets.PERFORMANCE_METRICS
-        ):
+        if query_type == SnubaQuery.Type.PERFORMANCE and dataset == Dataset.PerformanceMetrics:
             query_params["dataset"] = "metrics"
         else:
             query_params["dataset"] = "discover"

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -37,13 +37,14 @@ from sentry.models import Integration, PagerDutyService, Project, SentryApp
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.fields import resolve_field
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
     EntitySubscription,
     get_entity_key_from_query_builder,
     get_entity_subscription_from_snuba_query,
 )
-from sentry.snuba.models import QueryDatasets, SnubaQuery
+from sentry.snuba.models import SnubaQuery
 from sentry.snuba.subscriptions import (
     bulk_create_snuba_subscriptions,
     bulk_delete_snuba_subscriptions,
@@ -419,14 +420,14 @@ DEFAULT_ALERT_RULE_RESOLUTION = 1
 DEFAULT_CMP_ALERT_RULE_RESOLUTION = 2
 
 
-# Temporary mapping of `QueryDatasets` to `AlertRule.Type`. In the future, `Performance` will be
+# Temporary mapping of `Dataset` to `AlertRule.Type`. In the future, `Performance` will be
 # able to be run on `METRICS` as well.
 query_datasets_to_type = {
-    QueryDatasets.EVENTS: SnubaQuery.Type.ERROR,
-    QueryDatasets.TRANSACTIONS: SnubaQuery.Type.PERFORMANCE,
-    QueryDatasets.PERFORMANCE_METRICS: SnubaQuery.Type.PERFORMANCE,
-    QueryDatasets.SESSIONS: SnubaQuery.Type.CRASH_RATE,
-    QueryDatasets.METRICS: SnubaQuery.Type.CRASH_RATE,
+    Dataset.Events: SnubaQuery.Type.ERROR,
+    Dataset.Transactions: SnubaQuery.Type.PERFORMANCE,
+    Dataset.PerformanceMetrics: SnubaQuery.Type.PERFORMANCE,
+    Dataset.Sessions: SnubaQuery.Type.CRASH_RATE,
+    Dataset.Metrics: SnubaQuery.Type.CRASH_RATE,
 }
 
 
@@ -445,7 +446,7 @@ def create_alert_rule(
     include_all_projects=False,
     excluded_projects=None,
     query_type: SnubaQuery.Type = SnubaQuery.Type.ERROR,
-    dataset=QueryDatasets.EVENTS,
+    dataset=Dataset.Events,
     user=None,
     event_types=None,
     comparison_delta: Optional[int] = None,
@@ -486,10 +487,10 @@ def create_alert_rule(
         # Since comparison alerts make twice as many queries, run the queries less frequently.
         resolution = DEFAULT_CMP_ALERT_RULE_RESOLUTION
         comparison_delta = int(timedelta(minutes=comparison_delta).total_seconds())
-    if dataset == QueryDatasets.SESSIONS and features.has(
+    if dataset == Dataset.Sessions and features.has(
         "organizations:alert-crash-free-metrics", organization, actor=user
     ):
-        dataset = QueryDatasets.METRICS
+        dataset = Dataset.Metrics
     with transaction.atomic():
         snuba_query = create_snuba_query(
             query_type,
@@ -652,10 +653,10 @@ def update_alert_rule(
     if include_all_projects is not None:
         updated_fields["include_all_projects"] = include_all_projects
     if dataset is not None:
-        if dataset == QueryDatasets.SESSIONS and features.has(
+        if dataset == Dataset.Sessions and features.has(
             "organizations:alert-crash-free-metrics", alert_rule.organization, actor=user
         ):
-            dataset = QueryDatasets.METRICS
+            dataset = Dataset.Metrics
 
         if dataset.value != alert_rule.snuba_query.dataset:
             updated_query_fields["dataset"] = dataset
@@ -689,7 +690,7 @@ def update_alert_rule(
         if updated_query_fields or environment != alert_rule.snuba_query.environment:
             snuba_query = alert_rule.snuba_query
             updated_query_fields.setdefault("query_type", SnubaQuery.Type(snuba_query.type))
-            updated_query_fields.setdefault("dataset", QueryDatasets(snuba_query.dataset))
+            updated_query_fields.setdefault("dataset", Dataset(snuba_query.dataset))
             updated_query_fields.setdefault("query", snuba_query.query)
             updated_query_fields.setdefault("aggregate", snuba_query.aggregate)
             updated_query_fields.setdefault(

--- a/src/sentry/incidents/serializers/__init__.py
+++ b/src/sentry/incidents/serializers/__init__.py
@@ -1,5 +1,6 @@
 from sentry.incidents.models import AlertRuleTriggerAction
-from sentry.snuba.models import QueryDatasets, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 
 __all__ = (
     "AlertRuleSerializer",
@@ -29,9 +30,9 @@ QUERY_TYPE_VALID_EVENT_TYPES = {
     SnubaQuery.Type.PERFORMANCE: {SnubaQueryEventType.EventType.TRANSACTION},
 }
 QUERY_TYPE_VALID_DATASETS = {
-    SnubaQuery.Type.ERROR: {QueryDatasets.EVENTS},
-    SnubaQuery.Type.PERFORMANCE: {QueryDatasets.TRANSACTIONS, QueryDatasets.PERFORMANCE_METRICS},
-    SnubaQuery.Type.CRASH_RATE: {QueryDatasets.METRICS, QueryDatasets.SESSIONS},
+    SnubaQuery.Type.ERROR: {Dataset.Events},
+    SnubaQuery.Type.PERFORMANCE: {Dataset.Transactions, Dataset.PerformanceMetrics},
+    SnubaQuery.Type.CRASH_RATE: {Dataset.Metrics, Dataset.Sessions},
 }
 
 # TODO(davidenwang): eventually we should pass some form of these to the event_search parser to raise an error

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -32,7 +32,7 @@ from sentry.snuba.entity_subscription import (
     get_entity_key_from_query_builder,
     get_entity_subscription,
 )
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import build_query_builder
 
 from . import (
@@ -151,10 +151,10 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
     def validate_dataset(self, dataset):
         try:
-            return QueryDatasets(dataset)
+            return Dataset(dataset)
         except ValueError:
             raise serializers.ValidationError(
-                "Invalid dataset, valid values are %s" % [item.value for item in QueryDatasets]
+                "Invalid dataset, valid values are %s" % [item.value for item in Dataset]
             )
 
     def validate_event_types(self, event_types):
@@ -229,7 +229,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
         return data
 
     def _validate_query(self, data):
-        dataset = data.setdefault("dataset", QueryDatasets.EVENTS)
+        dataset = data.setdefault("dataset", Dataset.Events)
         query_type = data.setdefault("query_type", query_datasets_to_type[dataset])
 
         valid_datasets = QUERY_TYPE_VALID_DATASETS[query_type]
@@ -245,7 +245,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 self.context["organization"],
                 actor=self.context.get("user", None),
             )
-            and dataset == QueryDatasets.PERFORMANCE_METRICS
+            and dataset == Dataset.PerformanceMetrics
             and query_type == SnubaQuery.Type.PERFORMANCE
         ):
             raise serializers.ValidationError(

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -30,13 +30,13 @@ from sentry.incidents.models import (
 )
 from sentry.incidents.tasks import handle_trigger_action
 from sentry.models import Project
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.entity_subscription import (
     ENTITY_TIME_COLUMNS,
     BaseCrashRateMetricsEntitySubscription,
     get_entity_key_from_query_builder,
     get_entity_subscription_from_snuba_query,
 )
-from sentry.snuba.models import QueryDatasets
 from sentry.snuba.tasks import build_query_builder
 from sentry.utils import metrics, redis
 from sentry.utils.dates import to_datetime, to_timestamp
@@ -365,9 +365,9 @@ class SubscriptionProcessor:
         return aggregation_value
 
     def get_aggregation_value(self, subscription_update):
-        if self.subscription.snuba_query.dataset == QueryDatasets.SESSIONS.value:
+        if self.subscription.snuba_query.dataset == Dataset.Sessions.value:
             aggregation_value = self.get_crash_rate_alert_aggregation_value(subscription_update)
-        elif self.subscription.snuba_query.dataset == QueryDatasets.METRICS.value:
+        elif self.subscription.snuba_query.dataset == Dataset.Metrics.value:
             aggregation_value = self.get_crash_rate_alert_metrics_aggregation_value(
                 subscription_update
             )
@@ -424,7 +424,7 @@ class SubscriptionProcessor:
 
         if (
             len(subscription_update["values"]["data"]) > 1
-            and self.subscription.snuba_query.dataset != QueryDatasets.METRICS.value
+            and self.subscription.snuba_query.dataset != Dataset.Metrics.value
         ):
             logger.warning(
                 "Subscription returned more than 1 row of data",
@@ -437,7 +437,7 @@ class SubscriptionProcessor:
             )
 
         aggregation_value = self.get_aggregation_value(subscription_update)
-        if self.subscription.snuba_query.dataset == QueryDatasets.SESSIONS.value:
+        if self.subscription.snuba_query.dataset == Dataset.Sessions.value:
             try:
                 # Temporarily logging results from session updates for comparison with data from metric
                 # updates

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -16,7 +16,7 @@ from sentry.incidents.models import (
     IncidentStatusMethod,
 )
 from sentry.models import Project
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.dataset import Dataset
 from sentry.snuba.query_subscription_consumer import register_subscriber
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -113,7 +113,7 @@ def handle_subscription_metrics_logger(subscription_update, subscription):
     from sentry.incidents.subscription_processor import SubscriptionProcessor
 
     try:
-        if subscription.snuba_query.dataset == QueryDatasets.METRICS.value:
+        if subscription.snuba_query.dataset == Dataset.Metrics.value:
             processor = SubscriptionProcessor(subscription)
             # XXX: Temporary hack so that we can extract these values without raising an exception
             processor.reset_trigger_counts = lambda *arg, **kwargs: None

--- a/src/sentry/migrations/0233_recreate_subscriptions_in_snuba.py
+++ b/src/sentry/migrations/0233_recreate_subscriptions_in_snuba.py
@@ -4,7 +4,8 @@ import logging
 
 from django.db import migrations
 
-from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQueryEventType
 from sentry.snuba.tasks import _create_in_snuba, _delete_from_snuba
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
 
@@ -33,14 +34,14 @@ def migrate_subscriptions(apps, schema_editor):
 
             try:
                 _delete_from_snuba(
-                    QueryDatasets(subscription.snuba_query.dataset),
+                    Dataset(subscription.snuba_query.dataset),
                     subscription.subscription_id,
                 )
             except Exception as e:
                 try:
                     # Delete the subscription we just created to avoid orphans
                     _delete_from_snuba(
-                        QueryDatasets(subscription.snuba_query.dataset),
+                        Dataset(subscription.snuba_query.dataset),
                         subscription_id,
                     )
                 except Exception as oe:

--- a/src/sentry/migrations/0237_recreate_subscriptions_in_snuba.py
+++ b/src/sentry/migrations/0237_recreate_subscriptions_in_snuba.py
@@ -4,7 +4,8 @@ import logging
 
 from django.db import migrations
 
-from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQueryEventType
 from sentry.snuba.tasks import _create_in_snuba, _delete_from_snuba
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
 
@@ -33,14 +34,14 @@ def migrate_subscriptions(apps, schema_editor):
 
             try:
                 _delete_from_snuba(
-                    QueryDatasets(subscription.snuba_query.dataset),
+                    Dataset(subscription.snuba_query.dataset),
                     subscription.subscription_id,
                 )
             except Exception as e:
                 try:
                     # Delete the subscription we just created to avoid orphans
                     _delete_from_snuba(
-                        QueryDatasets(subscription.snuba_query.dataset),
+                        Dataset(subscription.snuba_query.dataset),
                         subscription_id,
                     )
                 except Exception as oe:

--- a/src/sentry/migrations/0295_backfill_alertrule_type.py
+++ b/src/sentry/migrations/0295_backfill_alertrule_type.py
@@ -5,7 +5,7 @@ from django.db import migrations
 from sentry.new_migrations.migrations import CheckedMigration
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
 
-# Keys from `QueryDatasets`, values from `AlertRule.Type`
+# Keys from `Dataset`, values from `AlertRule.Type`
 dataset_to_type_map = {
     "events": 0,
     "transactions": 1,

--- a/src/sentry/migrations/0302_mep_backfill_and_not_null_snuba_query_type.py
+++ b/src/sentry/migrations/0302_mep_backfill_and_not_null_snuba_query_type.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 from sentry.new_migrations.migrations import CheckedMigration
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBar
 
-# Keys from `QueryDatasets`, values from `SnubaQuery.Type`
+# Keys from `Dataset`, values from `SnubaQuery.Type`
 dataset_to_type_map = {
     "events": 0,
     "transactions": 1,

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -32,11 +32,10 @@ from sentry.sentry_metrics.utils import (
     resolve_tag_values,
     reverse_resolve_tag_value,
 )
-from sentry.snuba.dataset import EntityKey
+from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
-from sentry.snuba.models import QueryDatasets, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.utils import metrics
-from sentry.utils.snuba import Dataset
 
 if TYPE_CHECKING:
     from sentry.search.events.builder import QueryBuilder
@@ -86,7 +85,7 @@ def apply_dataset_query_conditions(
     :param query: A string containing query to apply conditions to
     :param event_types: A list of EventType(s) to apply to the query
     :param discover: Whether this is intended for use with the discover dataset or not.
-    When False, we won't modify queries for `QueryDatasets.TRANSACTIONS` at all. This is
+    When False, we won't modify queries for `Dataset.Transactions` at all. This is
     because the discover dataset requires that we always specify `event.type` so we can
     differentiate between errors and transactions, but the TRANSACTIONS dataset doesn't
     need it specified, and `event.type` ends up becoming a tag search.
@@ -117,7 +116,7 @@ class _EntitySpecificParams(TypedDict, total=False):
 @dataclass
 class _EntitySubscription:
     query_type: SnubaQuery.Type
-    dataset: QueryDatasets
+    dataset: Dataset
 
 
 class BaseEntitySubscription(ABC, _EntitySubscription):
@@ -207,17 +206,17 @@ class BaseEventsAndTransactionEntitySubscription(BaseEntitySubscription, ABC):
 
 class EventsEntitySubscription(BaseEventsAndTransactionEntitySubscription):
     query_type = SnubaQuery.Type.ERROR
-    dataset = QueryDatasets.EVENTS
+    dataset = Dataset.Events
 
 
 class PerformanceTransactionsEntitySubscription(BaseEventsAndTransactionEntitySubscription):
     query_type = SnubaQuery.Type.PERFORMANCE
-    dataset = QueryDatasets.TRANSACTIONS
+    dataset = Dataset.Transactions
 
 
 class SessionsEntitySubscription(BaseEntitySubscription):
     query_type = SnubaQuery.Type.CRASH_RATE
-    dataset = QueryDatasets.SESSIONS
+    dataset = Dataset.Sessions
 
     def __init__(
         self, aggregate: str, time_window: int, extra_fields: Optional[_EntitySpecificParams] = None
@@ -362,7 +361,7 @@ class BaseMetricsEntitySubscription(BaseEntitySubscription, ABC):
 
 class PerformanceMetricsEntitySubscription(BaseMetricsEntitySubscription):
     query_type = SnubaQuery.Type.PERFORMANCE
-    dataset = QueryDatasets.PERFORMANCE_METRICS
+    dataset = Dataset.PerformanceMetrics
 
     def get_snql_aggregations(self) -> List[str]:
         return [self.aggregate]
@@ -390,7 +389,7 @@ class PerformanceMetricsEntitySubscription(BaseMetricsEntitySubscription):
 
 class BaseCrashRateMetricsEntitySubscription(BaseMetricsEntitySubscription):
     query_type = SnubaQuery.Type.CRASH_RATE
-    dataset = QueryDatasets.METRICS
+    dataset = Dataset.Metrics
     metric_key: SessionMRI
 
     def __init__(
@@ -565,7 +564,7 @@ EntitySubscription = Union[
 
 def get_entity_subscription(
     query_type: SnubaQuery.Type,
-    dataset: QueryDatasets,
+    dataset: Dataset,
     aggregate: str,
     time_window: int,
     extra_fields: Optional[_EntitySpecificParams] = None,
@@ -579,13 +578,13 @@ def get_entity_subscription(
     if query_type == SnubaQuery.Type.ERROR:
         entity_subscription_cls = EventsEntitySubscription
     if query_type == SnubaQuery.Type.PERFORMANCE:
-        if dataset == QueryDatasets.TRANSACTIONS:
+        if dataset == Dataset.Transactions:
             entity_subscription_cls = PerformanceTransactionsEntitySubscription
-        elif dataset in (QueryDatasets.METRICS, QueryDatasets.PERFORMANCE_METRICS):
+        elif dataset in (Dataset.Metrics, Dataset.PerformanceMetrics):
             entity_subscription_cls = PerformanceMetricsEntitySubscription
     if query_type == SnubaQuery.Type.CRASH_RATE:
         entity_key = determine_crash_rate_alert_entity(aggregate)
-        if dataset == QueryDatasets.METRICS:
+        if dataset == Dataset.Metrics:
             if entity_key == EntityKey.MetricsCounters:
                 entity_subscription_cls = MetricsCountersEntitySubscription
             if entity_key == EntityKey.MetricsSets:
@@ -618,7 +617,7 @@ def get_entity_key_from_query_builder(query_builder: QueryBuilder) -> EntityKey:
 def get_entity_subscription_from_snuba_query(
     snuba_query: SnubaQuery, organization_id: int
 ) -> EntitySubscription:
-    query_dataset = QueryDatasets(snuba_query.dataset)
+    query_dataset = Dataset(snuba_query.dataset)
     return get_entity_subscription(
         SnubaQuery.Type(snuba_query.type),
         query_dataset,

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -20,15 +20,6 @@ query_aggregation_to_snuba = {
 }
 
 
-class QueryDatasets(Enum):
-    EVENTS = "events"
-    TRANSACTIONS = "transactions"
-    SESSIONS = "sessions"
-    # Actually Release Health
-    METRICS = "metrics"
-    PERFORMANCE_METRICS = "generic_metrics"
-
-
 class SnubaQuery(Model):
     __include_in_export__ = True
 

--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -20,6 +20,16 @@ query_aggregation_to_snuba = {
 }
 
 
+# TODO: Remove this once we've removed usage from getsentry
+class QueryDatasets(Enum):
+    EVENTS = "events"
+    TRANSACTIONS = "transactions"
+    SESSIONS = "sessions"
+    # Actually Release Health
+    METRICS = "metrics"
+    PERFORMANCE_METRICS = "generic_metrics"
+
+
 class SnubaQuery(Model):
     __include_in_export__ = True
 

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -12,9 +12,9 @@ from dateutil.parser import parse as parse_date
 from django.conf import settings
 
 from sentry import options
-from sentry.snuba.dataset import EntityKey
+from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.json_schemas import SUBSCRIPTION_PAYLOAD_VERSIONS, SUBSCRIPTION_WRAPPER_SCHEMA
-from sentry.snuba.models import QueryDatasets, QuerySubscription
+from sentry.snuba.models import QuerySubscription
 from sentry.snuba.tasks import _delete_from_snuba
 from sentry.utils import json, kafka_config, metrics
 from sentry.utils.batching_kafka_consumer import create_topics
@@ -53,11 +53,11 @@ class QuerySubscriptionConsumer:
     These values are passed along to a callback associated with the subscription.
     """
 
-    topic_to_dataset: Dict[str, QueryDatasets] = {
-        settings.KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS: QueryDatasets.EVENTS,
-        settings.KAFKA_TRANSACTIONS_SUBSCRIPTIONS_RESULTS: QueryDatasets.TRANSACTIONS,
-        settings.KAFKA_SESSIONS_SUBSCRIPTIONS_RESULTS: QueryDatasets.SESSIONS,
-        settings.KAFKA_METRICS_SUBSCRIPTIONS_RESULTS: QueryDatasets.METRICS,
+    topic_to_dataset: Dict[str, Dataset] = {
+        settings.KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS: Dataset.Events,
+        settings.KAFKA_TRANSACTIONS_SUBSCRIPTIONS_RESULTS: Dataset.Transactions,
+        settings.KAFKA_SESSIONS_SUBSCRIPTIONS_RESULTS: Dataset.Sessions,
+        settings.KAFKA_METRICS_SUBSCRIPTIONS_RESULTS: Dataset.Metrics,
     }
 
     def __init__(

--- a/src/sentry/snuba/subscriptions.py
+++ b/src/sentry/snuba/subscriptions.py
@@ -2,7 +2,8 @@ import logging
 
 from django.db import transaction
 
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.tasks import (
     create_subscription_in_snuba,
     delete_subscription_from_snuba,
@@ -40,9 +41,9 @@ def create_snuba_query(
         environment=environment,
     )
     if not event_types:
-        if dataset == QueryDatasets.EVENTS:
+        if dataset == Dataset.Events:
             event_types = [SnubaQueryEventType.EventType.ERROR]
-        elif dataset == QueryDatasets.TRANSACTIONS:
+        elif dataset == Dataset.Transactions:
             event_types = [SnubaQueryEventType.EventType.TRANSACTION]
 
     if event_types:
@@ -88,7 +89,7 @@ def update_snuba_query(
     new_event_types = set(event_types) - current_event_types
     removed_event_types = current_event_types - set(event_types)
     old_query_type = SnubaQuery.Type(snuba_query.type)
-    old_dataset = QueryDatasets(snuba_query.dataset)
+    old_dataset = Dataset(snuba_query.dataset)
     with transaction.atomic():
         query_subscriptions = list(snuba_query.subscriptions.all())
         snuba_query.update(

--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -8,7 +8,7 @@ import sentry_sdk
 from django.utils import timezone
 
 from sentry.models import Any, Environment, Mapping, Optional
-from sentry.snuba.dataset import EntityKey
+from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.entity_subscription import (
     BaseEntitySubscription,
     get_entity_key_from_query_builder,
@@ -16,7 +16,7 @@ from sentry.snuba.entity_subscription import (
     get_entity_subscription,
     get_entity_subscription_from_snuba_query,
 )
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery
+from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json, metrics
 from sentry.utils.snuba import SnubaError, _snuba_pool
@@ -54,7 +54,7 @@ def create_subscription_in_snuba(query_subscription_id, **kwargs):
         # This mostly shouldn't happen, but it's possible that a subscription can get
         # into this state. Just attempt to delete the existing subscription and then
         # create a new one.
-        query_dataset = QueryDatasets(subscription.snuba_query.dataset)
+        query_dataset = Dataset(subscription.snuba_query.dataset)
         entity_key = get_entity_key_from_snuba_query(
             subscription.snuba_query, subscription.project.organization_id, subscription.project_id
         )
@@ -98,7 +98,7 @@ def update_subscription_in_snuba(
         return
 
     if subscription.subscription_id is not None:
-        dataset = QueryDatasets(
+        dataset = Dataset(
             old_dataset if old_dataset is not None else subscription.snuba_query.dataset
         )
         query_type = SnubaQuery.Type(
@@ -123,7 +123,7 @@ def update_subscription_in_snuba(
             ),
         )
         _delete_from_snuba(
-            QueryDatasets(dataset),
+            Dataset(dataset),
             subscription.subscription_id,
             old_entity_key,
         )
@@ -161,7 +161,7 @@ def delete_subscription_from_snuba(query_subscription_id, **kwargs):
         return
 
     if subscription.subscription_id is not None:
-        query_dataset = QueryDatasets(subscription.snuba_query.dataset)
+        query_dataset = Dataset(subscription.snuba_query.dataset)
         entity_key = get_entity_key_from_snuba_query(
             subscription.snuba_query, subscription.project.organization_id, subscription.project_id
         )
@@ -228,7 +228,7 @@ def _create_snql_in_snuba(subscription, snuba_query, snql_query, entity_subscrip
     return json.loads(response.data)["subscription_id"]
 
 
-def _delete_from_snuba(dataset: QueryDatasets, subscription_id: str, entity_key: EntityKey) -> None:
+def _delete_from_snuba(dataset: Dataset, subscription_id: str, entity_key: EntityKey) -> None:
     response = _snuba_pool.urlopen(
         "DELETE", f"/{dataset.value}/{entity_key.value}/subscriptions/{subscription_id}"
     )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -90,7 +90,7 @@ from sentry.models import (
 from sentry.models.integrations.integration_feature import Feature, IntegrationTypes
 from sentry.models.releasefile import update_artifact_index
 from sentry.signals import project_created
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.dataset import Dataset
 from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json, loremipsum
@@ -1044,7 +1044,7 @@ class Factories:
         excluded_projects=None,
         date_added=None,
         query_type=None,
-        dataset=QueryDatasets.EVENTS,
+        dataset=Dataset.Events,
         threshold_type=AlertRuleThresholdType.ABOVE,
         resolve_threshold=None,
         user=None,

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import DetailedIncidentSerializer
 from sentry.incidents.logic import subscribe_to_incident
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.dataset import Dataset
 from sentry.testutils import TestCase
 
 
@@ -60,7 +60,7 @@ class DetailedIncidentSerializerTest(TestCase):
 
     def test_transaction_alert_rule(self):
         query = "test query"
-        alert_rule = self.create_alert_rule(dataset=QueryDatasets.TRANSACTIONS, query=query)
+        alert_rule = self.create_alert_rule(dataset=Dataset.Transactions, query=query)
         incident = self.create_incident(alert_rule=alert_rule)
 
         serializer = DetailedIncidentSerializer()

--- a/tests/sentry/incidents/action_handlers/test_email.py
+++ b/tests/sentry/incidents/action_handlers/test_email.py
@@ -22,7 +22,8 @@ from sentry.incidents.models import (
 )
 from sentry.models import NotificationSetting, UserEmail, UserOption
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
-from sentry.snuba.models import QueryDatasets, SnubaQuery
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQuery
 from sentry.testutils import TestCase
 from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
@@ -352,7 +353,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
     def test_metric_chart_mep(self, mock_generate_chart, mock_fetch_metric_alert_events_timeseries):
         trigger_status = TriggerStatus.ACTIVE
         alert_rule = self.create_alert_rule(
-            query_type=SnubaQuery.Type.PERFORMANCE, dataset=QueryDatasets.PERFORMANCE_METRICS
+            query_type=SnubaQuery.Type.PERFORMANCE, dataset=Dataset.PerformanceMetrics
         )
         incident = self.create_incident(alert_rule=alert_rule)
         action = self.create_alert_rule_trigger_action(triggered_for_incident=incident)

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -16,7 +16,8 @@ from sentry.incidents.models import (
 )
 from sentry.models import AuditLogEntry, Rule, RuleFireHistory
 from sentry.models.organizationmember import OrganizationMember
-from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQueryEventType
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils import json
@@ -365,7 +366,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])
         self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
+        perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug)

--- a/tests/sentry/incidents/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_index.py
@@ -6,7 +6,7 @@ from exam import fixture
 from sentry.api.serializers import serialize
 from sentry.incidents.logic import update_incident_status
 from sentry.incidents.models import IncidentStatus
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.dataset import Dataset
 from sentry.testutils import APITestCase
 
 
@@ -83,7 +83,7 @@ class IncidentListEndpointTest(APITestCase):
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])
         # alert_rule = self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
+        perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
 
         perf_incident = self.create_incident(alert_rule=perf_alert_rule)
         incident = self.create_incident()

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -16,7 +16,6 @@ from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
-from sentry.snuba.models import QueryDatasets
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils import json
@@ -56,7 +55,7 @@ class AlertRuleListEndpointTest(APITestCase):
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])
         alert_rule = self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
+        perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, self.project.slug)
@@ -471,7 +470,7 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
     def test_no_perf_alerts(self):
         self.create_team(organization=self.organization, members=[self.user])
         self.create_alert_rule()
-        perf_alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
+        perf_alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
         self.login_as(self.user)
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(self.organization.slug, self.project.slug)

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -25,7 +25,8 @@ from sentry.incidents.serializers import (
     AlertRuleTriggerSerializer,
 )
 from sentry.models import ACTOR_TYPES, Environment, Integration
-from sentry.snuba.models import QueryDatasets, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.testutils import TestCase
 from sentry.utils import json
 
@@ -39,7 +40,7 @@ class TestAlertRuleSerializer(TestCase):
             "name": "hello",
             "owner": self.user.id,
             "time_window": 10,
-            "dataset": QueryDatasets.EVENTS.value,
+            "dataset": Dataset.Events.value,
             "query": "level:error",
             "threshold_type": 0,
             "resolve_threshold": 100,
@@ -69,7 +70,7 @@ class TestAlertRuleSerializer(TestCase):
     @fixture
     def valid_transaction_params(self):
         params = self.valid_params.copy()
-        params["dataset"] = QueryDatasets.TRANSACTIONS.value
+        params["dataset"] = Dataset.Transactions.value
         params["event_types"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
         return params
 
@@ -132,9 +133,7 @@ class TestAlertRuleSerializer(TestCase):
         )
 
     def test_dataset(self):
-        invalid_values = [
-            "Invalid dataset, valid values are %s" % [item.value for item in QueryDatasets]
-        ]
+        invalid_values = ["Invalid dataset, valid values are %s" % [item.value for item in Dataset]]
         self.run_fail_validation_test({"dataset": "events_wrong"}, {"dataset": invalid_values})
         valid_datasets_for_type = sorted(
             dataset.name.lower()
@@ -143,7 +142,7 @@ class TestAlertRuleSerializer(TestCase):
         self.run_fail_validation_test(
             {
                 "queryType": SnubaQuery.Type.PERFORMANCE.value,
-                "dataset": QueryDatasets.EVENTS.value,
+                "dataset": Dataset.Events.value,
             },
             {
                 "nonFieldErrors": [
@@ -157,7 +156,7 @@ class TestAlertRuleSerializer(TestCase):
         self.run_fail_validation_test(
             {
                 "queryType": SnubaQuery.Type.ERROR.value,
-                "dataset": QueryDatasets.METRICS.value,
+                "dataset": Dataset.Metrics.value,
             },
             {
                 "nonFieldErrors": [
@@ -168,7 +167,7 @@ class TestAlertRuleSerializer(TestCase):
         self.run_fail_validation_test(
             {
                 "queryType": SnubaQuery.Type.PERFORMANCE.value,
-                "dataset": QueryDatasets.PERFORMANCE_METRICS.value,
+                "dataset": Dataset.PerformanceMetrics.value,
             },
             {
                 "nonFieldErrors": [
@@ -180,13 +179,13 @@ class TestAlertRuleSerializer(TestCase):
             base_params = self.valid_params.copy()
             base_params["queryType"] = SnubaQuery.Type.PERFORMANCE.value
             base_params["eventTypes"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
-            base_params["dataset"] = QueryDatasets.PERFORMANCE_METRICS.value
+            base_params["dataset"] = Dataset.PerformanceMetrics.value
             base_params["query"] = ""
             serializer = AlertRuleSerializer(context=self.context, data=base_params)
             assert serializer.is_valid(), serializer.errors
             alert_rule = serializer.save()
             assert alert_rule.snuba_query.type == SnubaQuery.Type.PERFORMANCE.value
-            assert alert_rule.snuba_query.dataset == QueryDatasets.PERFORMANCE_METRICS.value
+            assert alert_rule.snuba_query.dataset == Dataset.PerformanceMetrics.value
 
     def test_aggregate(self):
         self.run_fail_validation_test(
@@ -248,7 +247,7 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=self.valid_transaction_params)
         assert serializer.is_valid(), serializer.errors
         alert_rule = serializer.save()
-        assert alert_rule.snuba_query.dataset == QueryDatasets.TRANSACTIONS.value
+        assert alert_rule.snuba_query.dataset == Dataset.Transactions.value
         assert alert_rule.snuba_query.aggregate == "count()"
 
     def test_decimal(self):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -68,7 +68,8 @@ from sentry.incidents.models import (
 )
 from sentry.models import ActorTuple, Integration, PagerDutyService
 from sentry.shared_integrations.exceptions import ApiRateLimitedError
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.testutils import BaseIncidentsTest, SnubaTestCase, TestCase
 from sentry.testutils.cases import BaseMetricsTestCase
 from sentry.utils import json
@@ -276,7 +277,7 @@ class GetCrashRateIncidentAggregatesTest(TestCase, SnubaTestCase):
         self.now = timezone.now().replace(minute=0, second=0, microsecond=0)
         for _ in range(2):
             self.store_session(self.build_session(status="exited"))
-        self.dataset = QueryDatasets.SESSIONS
+        self.dataset = Dataset.Sessions
 
     def test_sessions(self):
         incident = self.create_incident(
@@ -301,7 +302,7 @@ class GetCrashRateMetricsIncidentAggregatesTest(
 ):
     def setUp(self):
         super().setUp()
-        self.dataset = QueryDatasets.METRICS
+        self.dataset = Dataset.Metrics
 
 
 @freeze_time()
@@ -438,7 +439,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.status == AlertRuleStatus.PENDING.value
         assert alert_rule.snuba_query.subscriptions.all().count() == 1
         assert alert_rule.snuba_query.type == SnubaQuery.Type.ERROR.value
-        assert alert_rule.snuba_query.dataset == QueryDatasets.EVENTS.value
+        assert alert_rule.snuba_query.dataset == Dataset.Events.value
         assert alert_rule.snuba_query.query == query
         assert alert_rule.snuba_query.aggregate == aggregate
         assert alert_rule.snuba_query.time_window == time_window * 60
@@ -475,7 +476,7 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.status == AlertRuleStatus.PENDING.value
         assert alert_rule.snuba_query.subscriptions.all().count() == 1
         assert alert_rule.snuba_query.type == SnubaQuery.Type.ERROR.value
-        assert alert_rule.snuba_query.dataset == QueryDatasets.EVENTS.value
+        assert alert_rule.snuba_query.dataset == Dataset.Events.value
         assert alert_rule.snuba_query.query == query
         assert alert_rule.snuba_query.aggregate == aggregate
         assert alert_rule.snuba_query.time_window == time_window * 60
@@ -587,10 +588,10 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             AlertRuleThresholdType.ABOVE,
             1,
             query_type=SnubaQuery.Type.CRASH_RATE,
-            dataset=QueryDatasets.SESSIONS,
+            dataset=Dataset.Sessions,
         )
         assert alert_rule.snuba_query.type == SnubaQuery.Type.CRASH_RATE.value
-        assert alert_rule.snuba_query.dataset == QueryDatasets.SESSIONS.value
+        assert alert_rule.snuba_query.dataset == Dataset.Sessions.value
 
         with self.feature("organizations:alert-crash-free-metrics"):
             alert_rule = create_alert_rule(
@@ -603,10 +604,10 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
                 AlertRuleThresholdType.ABOVE,
                 1,
                 query_type=SnubaQuery.Type.CRASH_RATE,
-                dataset=QueryDatasets.SESSIONS,
+                dataset=Dataset.Sessions,
             )
         assert alert_rule.snuba_query.type == SnubaQuery.Type.CRASH_RATE.value
-        assert alert_rule.snuba_query.dataset == QueryDatasets.METRICS.value
+        assert alert_rule.snuba_query.dataset == Dataset.Metrics.value
 
     def test_performance_metric_alert(self):
         alert_rule = create_alert_rule(
@@ -619,10 +620,10 @@ class CreateAlertRuleTest(TestCase, BaseIncidentsTest):
             AlertRuleThresholdType.ABOVE,
             1,
             query_type=SnubaQuery.Type.PERFORMANCE,
-            dataset=QueryDatasets.PERFORMANCE_METRICS,
+            dataset=Dataset.PerformanceMetrics,
         )
         assert alert_rule.snuba_query.type == SnubaQuery.Type.PERFORMANCE.value
-        assert alert_rule.snuba_query.dataset == QueryDatasets.PERFORMANCE_METRICS.value
+        assert alert_rule.snuba_query.dataset == Dataset.PerformanceMetrics.value
 
 
 class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
@@ -898,16 +899,16 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             AlertRuleThresholdType.ABOVE,
             1,
             query_type=SnubaQuery.Type.CRASH_RATE,
-            dataset=QueryDatasets.SESSIONS,
+            dataset=Dataset.Sessions,
         )
-        alert_rule = update_alert_rule(alert_rule, dataset=QueryDatasets.SESSIONS)
+        alert_rule = update_alert_rule(alert_rule, dataset=Dataset.Sessions)
         assert alert_rule.snuba_query.type == SnubaQuery.Type.CRASH_RATE.value
-        assert alert_rule.snuba_query.dataset == QueryDatasets.SESSIONS.value
+        assert alert_rule.snuba_query.dataset == Dataset.Sessions.value
 
         with self.feature("organizations:alert-crash-free-metrics"):
-            alert_rule = update_alert_rule(alert_rule, dataset=QueryDatasets.SESSIONS)
+            alert_rule = update_alert_rule(alert_rule, dataset=Dataset.Sessions)
         assert alert_rule.snuba_query.type == SnubaQuery.Type.CRASH_RATE.value
-        assert alert_rule.snuba_query.dataset == QueryDatasets.METRICS.value
+        assert alert_rule.snuba_query.dataset == Dataset.Metrics.value
 
     def test_performance_metric_alert(self):
         alert_rule = create_alert_rule(
@@ -920,15 +921,15 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
             AlertRuleThresholdType.ABOVE,
             1,
             query_type=SnubaQuery.Type.ERROR,
-            dataset=QueryDatasets.EVENTS,
+            dataset=Dataset.Events,
         )
         alert_rule = update_alert_rule(
             alert_rule,
             query_type=SnubaQuery.Type.PERFORMANCE,
-            dataset=QueryDatasets.PERFORMANCE_METRICS,
+            dataset=Dataset.PerformanceMetrics,
         )
         assert alert_rule.snuba_query.type == SnubaQuery.Type.PERFORMANCE.value
-        assert alert_rule.snuba_query.dataset == QueryDatasets.PERFORMANCE_METRICS.value
+        assert alert_rule.snuba_query.dataset == Dataset.PerformanceMetrics.value
 
 
 class DeleteAlertRuleTest(TestCase, BaseIncidentsTest):

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -42,7 +42,8 @@ from sentry.models import Integration
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.models import MetricsKeyIndexer
 from sentry.sentry_metrics.utils import resolve_tag_key, resolve_tag_value
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import QuerySubscription, SnubaQueryEventType
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.cases import BaseMetricsTestCase
 from sentry.testutils.helpers.datetime import iso_format
@@ -1624,7 +1625,7 @@ class MetricsCrashRateAlertProcessUpdateTest(ProcessUpdateBaseClass, BaseMetrics
     def crash_rate_alert_rule(self):
         rule = self.create_alert_rule(
             projects=[self.project],
-            dataset=QueryDatasets.METRICS,
+            dataset=Dataset.Metrics,
             name="JustAValidRule",
             query="",
             aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -32,7 +32,8 @@ from sentry.incidents.tasks import (
 )
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import resolve_tag_key, resolve_tag_value
-from sentry.snuba.models import QueryDatasets, SnubaQuery
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQuery
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
 from sentry.testutils import TestCase
 from sentry.utils.http import absolute_uri
@@ -209,7 +210,7 @@ class TestHandleSubscriptionMetricsLogger(TestCase):
     def subscription(self):
         snuba_query = create_snuba_query(
             SnubaQuery.Type.CRASH_RATE,
-            QueryDatasets.METRICS,
+            Dataset.Metrics,
             "hello",
             "count()",
             timedelta(minutes=1),

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -14,7 +14,7 @@ from sentry.integrations.slack.message_builder.discover import SlackDiscoverMess
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.integrations.slack.unfurl import LinkType, UnfurlableUrl, link_handlers, match_link
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.dataset import Dataset
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import install_slack
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -235,7 +235,7 @@ class UnfurlTest(TestCase):
     @patch("sentry.incidents.charts.generate_chart", return_value="chart-url")
     def test_unfurl_metric_alerts_chart_transaction(self, mock_generate_chart):
         # Using the transactions dataset
-        alert_rule = self.create_alert_rule(query="p95", dataset=QueryDatasets.TRANSACTIONS)
+        alert_rule = self.create_alert_rule(query="p95", dataset=Dataset.Transactions)
         incident = self.create_incident(
             status=2,
             organization=self.organization,
@@ -289,7 +289,7 @@ class UnfurlTest(TestCase):
         alert_rule = self.create_alert_rule(
             query="",
             aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
-            dataset=QueryDatasets.SESSIONS,
+            dataset=Dataset.Sessions,
             time_window=60,
             resolve_threshold=10,
             threshold_period=1,

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
 from sentry.incidents.models import IncidentStatus, IncidentTrigger
 from sentry.integrations.metric_alerts import incident_attachment_info
-from sentry.snuba.models import QueryDatasets
+from sentry.snuba.dataset import Dataset
 from sentry.testutils import BaseIncidentsTest, SnubaTestCase, TestCase
 from sentry.testutils.cases import BaseMetricsTestCase
 from sentry.utils.dates import to_timestamp
@@ -140,7 +140,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, SnubaTestCase):
         self.alert_rule = self.create_alert_rule(
             query="",
             aggregate=f"percentage({field}_crashed, {field}) AS _crash_rate_alert_aggregate",
-            dataset=QueryDatasets.SESSIONS,
+            dataset=Dataset.Sessions,
             time_window=60,
         )
         self.incident = self.create_incident(
@@ -211,7 +211,7 @@ class IncidentAttachmentInfoTestForCrashRateAlerts(TestCase, SnubaTestCase):
         alert_rule = self.create_alert_rule(
             query="",
             aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
-            dataset=QueryDatasets.SESSIONS,
+            dataset=Dataset.Sessions,
             time_window=60,
         )
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 95)
@@ -241,7 +241,7 @@ class IncidentAttachmentInfoTestForMetricsCrashRateAlerts(
         self.alert_rule = self.create_alert_rule(
             query="",
             aggregate=f"percentage({field}_crashed, {field}) AS _crash_rate_alert_aggregate",
-            dataset=QueryDatasets.METRICS,
+            dataset=Dataset.Metrics,
             time_window=60,
         )
         self.incident = self.create_incident(

--- a/tests/sentry/migrations/test_0295_backfill_alertrule_type.py
+++ b/tests/sentry/migrations/test_0295_backfill_alertrule_type.py
@@ -1,7 +1,7 @@
 # It seems like when we unapply NOT NULL as part of rolling back the migration in this test that
 # the zero downtime migrations library has some problem that causes the not null constraint to not
 # be removed. Disabling this test for now.
-# from sentry.snuba.models import QueryDatasets
+# from sentry.snuba.dataset import Dataset
 # from sentry.testutils.cases import TestMigrations
 #
 #
@@ -11,7 +11,7 @@
 #
 #     def setup_initial_state(self):
 #         self.alerts = [
-#             self.create_alert_rule(query="", dataset=dataset) for dataset in QueryDatasets
+#             self.create_alert_rule(query="", dataset=dataset) for dataset in Dataset
 #         ]
 #
 #     def setup_before_migration(self, apps):

--- a/tests/sentry/migrations/test_0301_mep_backfill_and_not_null_snuba_query_type.py
+++ b/tests/sentry/migrations/test_0301_mep_backfill_and_not_null_snuba_query_type.py
@@ -3,7 +3,8 @@
 # be removed. Disabling this test for now.
 # from datetime import timedelta
 #
-# from sentry.snuba.models import QueryDatasets, SnubaQuery
+# from sentry.snuba.dataset import Dataset
+# from sentry.snuba.models import SnubaQuery
 # from sentry.snuba.subscriptions import create_snuba_query
 # from sentry.testutils.cases import TestMigrations
 #
@@ -17,7 +18,7 @@
 #             create_snuba_query(
 #                 dataset, "", "count()", timedelta(seconds=60), timedelta(seconds=60), None
 #             )
-#             for dataset in QueryDatasets
+#             for dataset in Dataset
 #         ]
 #
 #     def setup_before_migration(self, apps):

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -10,7 +10,7 @@ from sentry.search.events.constants import METRICS_MAP
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import resolve, resolve_tag_key, resolve_tag_value
-from sentry.snuba.dataset import EntityKey
+from sentry.snuba.dataset import Dataset, EntityKey
 from sentry.snuba.entity_subscription import (
     EventsEntitySubscription,
     MetricsCountersEntitySubscription,
@@ -23,7 +23,7 @@ from sentry.snuba.entity_subscription import (
     get_entity_subscription_from_snuba_query,
 )
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
-from sentry.snuba.models import QueryDatasets, SnubaQuery
+from sentry.snuba.models import SnubaQuery
 from sentry.testutils import TestCase
 
 pytestmark = pytest.mark.sentry_metrics
@@ -48,7 +48,7 @@ class EntitySubscriptionTestCase(TestCase):
         with pytest.raises(UnsupportedQuerySubscription):
             get_entity_subscription(
                 query_type=SnubaQuery.Type.CRASH_RATE,
-                dataset=QueryDatasets.SESSIONS,
+                dataset=Dataset.Sessions,
                 aggregate=aggregate,
                 time_window=3600,
                 extra_fields={"org_id": self.organization.id},
@@ -59,7 +59,7 @@ class EntitySubscriptionTestCase(TestCase):
         with pytest.raises(InvalidQuerySubscription):
             get_entity_subscription(
                 query_type=SnubaQuery.Type.CRASH_RATE,
-                dataset=QueryDatasets.SESSIONS,
+                dataset=Dataset.Sessions,
                 aggregate=aggregate,
                 time_window=3600,
             )
@@ -68,14 +68,14 @@ class EntitySubscriptionTestCase(TestCase):
         entities = [
             get_entity_subscription(
                 query_type=SnubaQuery.Type.CRASH_RATE,
-                dataset=QueryDatasets.SESSIONS,
+                dataset=Dataset.Sessions,
                 aggregate="percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
                 time_window=3600,
                 extra_fields={"org_id": self.organization.id},
             ),
             get_entity_subscription(
                 query_type=SnubaQuery.Type.ERROR,
-                dataset=QueryDatasets.EVENTS,
+                dataset=Dataset.Events,
                 aggregate="count_unique(user)",
                 time_window=3600,
             ),
@@ -88,7 +88,7 @@ class EntitySubscriptionTestCase(TestCase):
         aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
         entity_subscription = get_entity_subscription(
             query_type=SnubaQuery.Type.CRASH_RATE,
-            dataset=QueryDatasets.SESSIONS,
+            dataset=Dataset.Sessions,
             aggregate=aggregate,
             time_window=3600,
             extra_fields={"org_id": self.organization.id},
@@ -98,7 +98,7 @@ class EntitySubscriptionTestCase(TestCase):
         assert entity_subscription.get_entity_extra_params() == {
             "organization": self.organization.id
         }
-        assert entity_subscription.dataset == QueryDatasets.SESSIONS
+        assert entity_subscription.dataset == Dataset.Sessions
         snql_query = entity_subscription.build_query_builder(
             "", [self.project.id], None
         ).get_snql_query()
@@ -130,7 +130,7 @@ class EntitySubscriptionTestCase(TestCase):
         with pytest.raises(UnsupportedQuerySubscription):
             get_entity_subscription(
                 query_type=SnubaQuery.Type.CRASH_RATE,
-                dataset=QueryDatasets.METRICS,
+                dataset=Dataset.Metrics,
                 aggregate=aggregate,
                 time_window=3600,
                 extra_fields={"org_id": self.organization.id},
@@ -141,7 +141,7 @@ class EntitySubscriptionTestCase(TestCase):
         with pytest.raises(InvalidQuerySubscription):
             get_entity_subscription(
                 query_type=SnubaQuery.Type.CRASH_RATE,
-                dataset=QueryDatasets.METRICS,
+                dataset=Dataset.Metrics,
                 aggregate=aggregate,
                 time_window=3600,
             )
@@ -153,7 +153,7 @@ class EntitySubscriptionTestCase(TestCase):
         aggregate = "percentage(users_crashed, users) AS _crash_rate_alert_aggregate"
         entity_subscription = get_entity_subscription(
             query_type=SnubaQuery.Type.CRASH_RATE,
-            dataset=QueryDatasets.METRICS,
+            dataset=Dataset.Metrics,
             aggregate=aggregate,
             time_window=3600,
             extra_fields={"org_id": self.organization.id},
@@ -164,7 +164,7 @@ class EntitySubscriptionTestCase(TestCase):
             "organization": self.organization.id,
             "granularity": 10,
         }
-        assert entity_subscription.dataset == QueryDatasets.METRICS
+        assert entity_subscription.dataset == Dataset.Metrics
         session_status = resolve_tag_key(use_case_id, org_id, "session.status")
         session_status_crashed = resolve_tag_value(use_case_id, org_id, "crashed")
         snql_query = entity_subscription.build_query_builder(
@@ -211,7 +211,7 @@ class EntitySubscriptionTestCase(TestCase):
         aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
         entity_subscription = get_entity_subscription(
             query_type=SnubaQuery.Type.CRASH_RATE,
-            dataset=QueryDatasets.METRICS,
+            dataset=Dataset.Metrics,
             aggregate=aggregate,
             time_window=3600,
             extra_fields={"org_id": self.organization.id},
@@ -222,7 +222,7 @@ class EntitySubscriptionTestCase(TestCase):
             "organization": self.organization.id,
             "granularity": 10,
         }
-        assert entity_subscription.dataset == QueryDatasets.METRICS
+        assert entity_subscription.dataset == Dataset.Metrics
         session_status = resolve_tag_key(use_case_id, org_id, "session.status")
         session_status_crashed = resolve_tag_value(use_case_id, org_id, "crashed")
         session_status_init = resolve_tag_value(use_case_id, org_id, "init")
@@ -274,14 +274,14 @@ class EntitySubscriptionTestCase(TestCase):
         aggregate = "percentile(transaction.duration,.95)"
         entity_subscription = get_entity_subscription(
             query_type=SnubaQuery.Type.PERFORMANCE,
-            dataset=QueryDatasets.TRANSACTIONS,
+            dataset=Dataset.Transactions,
             aggregate=aggregate,
             time_window=3600,
         )
         assert isinstance(entity_subscription, PerformanceTransactionsEntitySubscription)
         assert entity_subscription.aggregate == aggregate
         assert entity_subscription.get_entity_extra_params() == {}
-        assert entity_subscription.dataset == QueryDatasets.TRANSACTIONS
+        assert entity_subscription.dataset == Dataset.Transactions
         snql_query = entity_subscription.build_query_builder(
             "", [self.project.id], None
         ).get_snql_query()
@@ -298,7 +298,7 @@ class EntitySubscriptionTestCase(TestCase):
         aggregate = "percentile(transaction.duration,.95)"
         entity_subscription = get_entity_subscription(
             query_type=SnubaQuery.Type.PERFORMANCE,
-            dataset=QueryDatasets.METRICS,
+            dataset=Dataset.Metrics,
             aggregate=aggregate,
             time_window=3600,
             extra_fields={"org_id": self.organization.id},
@@ -309,7 +309,7 @@ class EntitySubscriptionTestCase(TestCase):
             "organization": self.organization.id,
             "granularity": 60,
         }
-        assert entity_subscription.dataset == QueryDatasets.PERFORMANCE_METRICS
+        assert entity_subscription.dataset == Dataset.PerformanceMetrics
         snql_query = entity_subscription.build_query_builder(
             "",
             [self.project.id],
@@ -352,14 +352,14 @@ class EntitySubscriptionTestCase(TestCase):
         aggregate = "count_unique(user)"
         entity_subscription = get_entity_subscription(
             query_type=SnubaQuery.Type.ERROR,
-            dataset=QueryDatasets.EVENTS,
+            dataset=Dataset.Events,
             aggregate=aggregate,
             time_window=3600,
         )
         assert isinstance(entity_subscription, EventsEntitySubscription)
         assert entity_subscription.aggregate == aggregate
         assert entity_subscription.get_entity_extra_params() == {}
-        assert entity_subscription.dataset == QueryDatasets.EVENTS
+        assert entity_subscription.dataset == Dataset.Events
 
         snql_query = entity_subscription.build_query_builder(
             "release:latest", [self.project.id], None
@@ -391,47 +391,47 @@ class EntitySubscriptionTestCase(TestCase):
 class GetEntitySubscriptionFromSnubaQueryTest(TestCase):
     def test(self):
         cases = [
-            (EventsEntitySubscription, SnubaQuery.Type.ERROR, QueryDatasets.EVENTS, "count()"),
+            (EventsEntitySubscription, SnubaQuery.Type.ERROR, Dataset.Events, "count()"),
             (
                 PerformanceTransactionsEntitySubscription,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.TRANSACTIONS,
+                Dataset.Transactions,
                 "count()",
             ),
             (
                 PerformanceMetricsEntitySubscription,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.METRICS,
+                Dataset.Metrics,
                 "count()",
             ),
             (
                 PerformanceMetricsEntitySubscription,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.PERFORMANCE_METRICS,
+                Dataset.PerformanceMetrics,
                 "count()",
             ),
             (
                 PerformanceMetricsEntitySubscription,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.METRICS,
+                Dataset.Metrics,
                 "count_unique(user)",
             ),
             (
                 PerformanceMetricsEntitySubscription,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.PERFORMANCE_METRICS,
+                Dataset.PerformanceMetrics,
                 "count_unique(user)",
             ),
             (
                 MetricsCountersEntitySubscription,
                 SnubaQuery.Type.CRASH_RATE,
-                QueryDatasets.METRICS,
+                Dataset.Metrics,
                 "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
             ),
             (
                 MetricsSetsEntitySubscription,
                 SnubaQuery.Type.CRASH_RATE,
-                QueryDatasets.METRICS,
+                Dataset.Metrics,
                 "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
             ),
         ]
@@ -452,53 +452,53 @@ class GetEntitySubscriptionFromSnubaQueryTest(TestCase):
 class GetEntityKeyFromSnubaQueryTest(TestCase):
     def test(self):
         cases = [
-            (EntityKey.Events, SnubaQuery.Type.ERROR, QueryDatasets.EVENTS, "count()", ""),
+            (EntityKey.Events, SnubaQuery.Type.ERROR, Dataset.Events, "count()", ""),
             (
                 EntityKey.Transactions,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.TRANSACTIONS,
+                Dataset.Transactions,
                 "count()",
                 "",
             ),
             (
                 EntityKey.GenericMetricsDistributions,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.METRICS,
+                Dataset.Metrics,
                 "count()",
                 "",
             ),
             (
                 EntityKey.GenericMetricsSets,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.METRICS,
+                Dataset.Metrics,
                 "count_unique(user)",
                 "",
             ),
             (
                 EntityKey.GenericMetricsDistributions,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.PERFORMANCE_METRICS,
+                Dataset.PerformanceMetrics,
                 "count()",
                 "",
             ),
             (
                 EntityKey.GenericMetricsSets,
                 SnubaQuery.Type.PERFORMANCE,
-                QueryDatasets.PERFORMANCE_METRICS,
+                Dataset.PerformanceMetrics,
                 "count_unique(user)",
                 "",
             ),
             (
                 EntityKey.MetricsCounters,
                 SnubaQuery.Type.CRASH_RATE,
-                QueryDatasets.METRICS,
+                Dataset.Metrics,
                 "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate",
                 "",
             ),
             (
                 EntityKey.MetricsSets,
                 SnubaQuery.Type.CRASH_RATE,
-                QueryDatasets.METRICS,
+                Dataset.Metrics,
                 "percentage(users_crashed, users) AS _crash_rate_alert_aggregate",
                 "",
             ),

--- a/tests/sentry/snuba/test_models.py
+++ b/tests/sentry/snuba/test_models.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
-from sentry.snuba.models import QueryDatasets, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query
 from sentry.testutils import TestCase
 
@@ -9,7 +10,7 @@ class SnubaQueryEventTypesTest(TestCase):
     def test(self):
         snuba_query = create_snuba_query(
             SnubaQuery.Type.ERROR,
-            QueryDatasets.EVENTS,
+            Dataset.Events,
             "release:123",
             "count()",
             timedelta(minutes=10),

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -9,8 +9,8 @@ from dateutil.parser import parse as parse_date
 from django.conf import settings
 from exam import fixture, patcher
 
-from sentry.snuba.dataset import EntityKey
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery
+from sentry.snuba.dataset import Dataset, EntityKey
+from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.snuba.query_subscription_consumer import (
     InvalidMessageError,
     InvalidSchemaError,
@@ -78,7 +78,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
             pool.urlopen.assert_called_once_with(
                 "DELETE",
                 "/{}/{}/subscriptions/{}".format(
-                    QueryDatasets.METRICS.value,
+                    Dataset.Metrics.value,
                     EntityKey.MetricsCounters.value,
                     self.valid_payload["subscription_id"],
                 ),
@@ -105,7 +105,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
         with self.tasks():
             snuba_query = create_snuba_query(
                 SnubaQuery.Type.ERROR,
-                QueryDatasets.EVENTS,
+                Dataset.Events,
                 "hello",
                 "count()",
                 timedelta(minutes=10),

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
-from sentry.snuba.models import QueryDatasets, QuerySubscription, SnubaQuery, SnubaQueryEventType
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import (
     bulk_delete_snuba_subscriptions,
     create_snuba_query,
@@ -15,7 +16,7 @@ from sentry.testutils import TestCase
 class CreateSnubaQueryTest(TestCase):
     def test(self):
         query_type = SnubaQuery.Type.ERROR
-        dataset = QueryDatasets.EVENTS
+        dataset = Dataset.Events
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -34,7 +35,7 @@ class CreateSnubaQueryTest(TestCase):
 
     def test_environment(self):
         query_type = SnubaQuery.Type.ERROR
-        dataset = QueryDatasets.EVENTS
+        dataset = Dataset.Events
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -53,7 +54,7 @@ class CreateSnubaQueryTest(TestCase):
 
     def test_event_types(self):
         query_type = SnubaQuery.Type.ERROR
-        dataset = QueryDatasets.EVENTS
+        dataset = Dataset.Events
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -79,7 +80,7 @@ class CreateSnubaQueryTest(TestCase):
 
     def test_event_types_metrics(self):
         query_type = SnubaQuery.Type.CRASH_RATE
-        dataset = QueryDatasets.METRICS
+        dataset = Dataset.Metrics
         query = ""
         aggregate = "percentage(sessions_crashed, sessions) AS _crash_rate_alert_aggregate"
         time_window = timedelta(minutes=10)
@@ -108,7 +109,7 @@ class CreateSnubaSubscriptionTest(TestCase):
     def test(self):
         query_type = SnubaQuery.Type.ERROR
         type = "something"
-        dataset = QueryDatasets.EVENTS
+        dataset = Dataset.Events
         query = "level:error"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
@@ -126,7 +127,7 @@ class CreateSnubaSubscriptionTest(TestCase):
         with self.tasks():
             type = "something"
             query_type = SnubaQuery.Type.ERROR
-            dataset = QueryDatasets.EVENTS
+            dataset = Dataset.Events
             query = "level:error"
             time_window = timedelta(minutes=10)
             resolution = timedelta(minutes=1)
@@ -143,7 +144,7 @@ class CreateSnubaSubscriptionTest(TestCase):
     def test_translated_query(self):
         type = "something"
         query_type = SnubaQuery.Type.ERROR
-        dataset = QueryDatasets.EVENTS
+        dataset = Dataset.Events
         query = "event.type:error"
         time_window = timedelta(minutes=10)
         resolution = timedelta(minutes=1)
@@ -163,7 +164,7 @@ class UpdateSnubaQueryTest(TestCase):
     def test(self):
         snuba_query = create_snuba_query(
             SnubaQuery.Type.ERROR,
-            QueryDatasets.EVENTS,
+            Dataset.Events,
             "hello",
             "count_unique(tags[sentry:user])",
             timedelta(minutes=100),
@@ -172,7 +173,7 @@ class UpdateSnubaQueryTest(TestCase):
             [SnubaQueryEventType.EventType.ERROR],
         )
         query_type = SnubaQuery.Type.PERFORMANCE
-        dataset = QueryDatasets.TRANSACTIONS
+        dataset = Dataset.Transactions
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -215,7 +216,7 @@ class UpdateSnubaQueryTest(TestCase):
     def test_environment(self):
         snuba_query = create_snuba_query(
             SnubaQuery.Type.ERROR,
-            QueryDatasets.EVENTS,
+            Dataset.Events,
             "hello",
             "count_unique(tags[sentry:user])",
             timedelta(minutes=100),
@@ -225,7 +226,7 @@ class UpdateSnubaQueryTest(TestCase):
 
         new_env = self.create_environment()
         query_type = SnubaQuery.Type.PERFORMANCE
-        dataset = QueryDatasets.TRANSACTIONS
+        dataset = Dataset.Transactions
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -254,7 +255,7 @@ class UpdateSnubaQueryTest(TestCase):
     def test_subscriptions(self):
         snuba_query = create_snuba_query(
             SnubaQuery.Type.ERROR,
-            QueryDatasets.EVENTS,
+            Dataset.Events,
             "hello",
             "count_unique(tags[sentry:user])",
             timedelta(minutes=100),
@@ -265,7 +266,7 @@ class UpdateSnubaQueryTest(TestCase):
 
         new_env = self.create_environment()
         query_type = SnubaQuery.Type.PERFORMANCE
-        dataset = QueryDatasets.TRANSACTIONS
+        dataset = Dataset.Transactions
         query = "level:error"
         aggregate = "count()"
         time_window = timedelta(minutes=10)
@@ -288,7 +289,7 @@ class UpdateSnubaQueryTest(TestCase):
 
 class UpdateSnubaSubscriptionTest(TestCase):
     def test(self):
-        old_dataset = QueryDatasets.EVENTS
+        old_dataset = Dataset.Events
         with self.tasks():
             snuba_query = create_snuba_query(
                 SnubaQuery.Type.ERROR,
@@ -302,7 +303,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
             subscription = create_snuba_subscription(self.project, "something", snuba_query)
         old_type = SnubaQuery.Type(snuba_query.type)
 
-        dataset = QueryDatasets.TRANSACTIONS
+        dataset = Dataset.Transactions
         query = "level:warning"
         aggregate = "count_unique(tags[sentry:user])"
         time_window = timedelta(minutes=20)
@@ -330,7 +331,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
 
     def test_with_task(self):
         with self.tasks():
-            old_dataset = QueryDatasets.EVENTS
+            old_dataset = Dataset.Events
             snuba_query = create_snuba_query(
                 SnubaQuery.Type.ERROR,
                 old_dataset,
@@ -343,7 +344,7 @@ class UpdateSnubaSubscriptionTest(TestCase):
             subscription = create_snuba_subscription(self.project, "something", snuba_query)
             old_type = SnubaQuery.Type(snuba_query.type)
 
-            dataset = QueryDatasets.TRANSACTIONS
+            dataset = Dataset.Transactions
             query = "level:warning"
             aggregate = "count_unique(tags[sentry:user])"
             time_window = timedelta(minutes=20)
@@ -372,7 +373,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
         with self.tasks():
             snuba_query = create_snuba_query(
                 SnubaQuery.Type.ERROR,
-                QueryDatasets.EVENTS,
+                Dataset.Events,
                 "level:error",
                 "count()",
                 timedelta(minutes=10),
@@ -382,7 +383,7 @@ class BulkDeleteSnubaSubscriptionTest(TestCase):
             subscription = create_snuba_subscription(self.project, "something", snuba_query)
             snuba_query = create_snuba_query(
                 SnubaQuery.Type.ERROR,
-                QueryDatasets.EVENTS,
+                Dataset.Events,
                 "level:error",
                 "count()",
                 timedelta(minutes=10),
@@ -409,7 +410,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
         with self.tasks():
             snuba_query = create_snuba_query(
                 SnubaQuery.Type.ERROR,
-                QueryDatasets.EVENTS,
+                Dataset.Events,
                 "level:error",
                 "count()",
                 timedelta(minutes=10),
@@ -429,7 +430,7 @@ class DeleteSnubaSubscriptionTest(TestCase):
         with self.tasks():
             snuba_query = create_snuba_query(
                 SnubaQuery.Type.ERROR,
-                QueryDatasets.EVENTS,
+                Dataset.Events,
                 "level:error",
                 "count()",
                 timedelta(minutes=10),

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -12,7 +12,8 @@ from django.conf import settings
 from django.test.utils import override_settings
 from exam import fixture
 
-from sentry.snuba.models import QueryDatasets, SnubaQuery
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.models import SnubaQuery
 from sentry.snuba.query_subscription_consumer import (
     QuerySubscriptionConsumer,
     register_subscriber,
@@ -97,7 +98,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
         with self.tasks():
             snuba_query = create_snuba_query(
                 SnubaQuery.Type.ERROR,
-                QueryDatasets.EVENTS,
+                Dataset.Events,
                 "hello",
                 "count()",
                 timedelta(minutes=1),


### PR DESCRIPTION
Putting this up again since it broke getsentry. Just leaving `QueryDatasets` in place temporarily 
so that getsentry won't break.

This refactor pr removes `QueryDatasets` and just uses `Dataset` everywhere. `QueryDatasets` existed
before `Dataset`, but `Dataset` is now more widely used and is more up to date. The values here are
the same, `Dataset` just supports a few more datasets.

We already make sure that only datasets that are valid for alerts can be passed to the alert rules
api, so this won't allow people to attempt to create alerts on datasets that don't support them.