### PR TITLE
feat(hybrid-cloud): Revise organizationUrl to omit org slug

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -120,7 +120,7 @@ def generate_organization_hostname(org_slug: str) -> str:
     org_base_hostname_template = options.get("system.organization-base-hostname")
     if not org_base_hostname_template:
         return url_prefix_hostname
-    if "{slug}" not in org_base_hostname_template or "{region}" not in org_base_hostname_template:
+    if "{region}" not in org_base_hostname_template:
         return url_prefix_hostname
     org_hostname = org_base_hostname_template.replace("{slug}", org_slug)
     region = options.get("system.region") or None

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -145,7 +145,7 @@ def pytest_configure(config):
             "mail.backend": "django.core.mail.backends.locmem.EmailBackend",
             "system.url-prefix": "http://testserver",
             "system.base-hostname": "testserver",
-            "system.organization-base-hostname": "{slug}.{region}.testserver",
+            "system.organization-base-hostname": "{region}.testserver",
             "system.organization-url-template": "http://{hostname}",
             "system.region": "us",
             "system.secret-key": "a" * 52,

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -58,7 +58,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         response = self.get_success_response(self.organization.slug)
 
         assert response.data["slug"] == self.organization.slug
-        assert response.data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
+        assert response.data["organizationUrl"] == "http://us.testserver"
         assert response.data["onboardingTasks"] == []
         assert response.data["id"] == str(self.organization.id)
         assert response.data["role"] == "owner"

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -150,7 +150,12 @@ class ClientConfigViewTest(TestCase):
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"
 
-        with self.options({"system.region": "eu", "system.organization-base-hostname": "{region}.{slug}.testserver"}):
+        with self.options(
+            {
+                "system.region": "eu",
+                "system.organization-base-hostname": "{region}.{slug}.testserver",
+            }
+        ):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
@@ -242,7 +247,12 @@ class ClientConfigViewTest(TestCase):
             assert data["sentryUrl"] == "http://testserver"
             assert data["organizationUrl"] == "http://testserver"
 
-        with self.options({"system.organization-url-template": "ftp://{hostname}", "system.organization-base-hostname": "{slug}.{region}.testserver"}):
+        with self.options(
+            {
+                "system.organization-url-template": "ftp://{hostname}",
+                "system.organization-base-hostname": "{slug}.{region}.testserver",
+            }
+        ):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -149,12 +149,7 @@ class ClientConfigViewTest(TestCase):
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"
 
-        with self.options(
-            {
-                "system.region": "eu",
-                "system.organization-base-hostname": "{region}.{slug}.testserver",
-            }
-        ):
+        with self.options({"system.region": "eu"}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
@@ -164,7 +159,7 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == f"http://eu.{self.organization.slug}.testserver"
+            assert data["organizationUrl"] == "http://eu.testserver"
 
     def test_organization_url_organization_base_hostname(self):
         self.login_as(self.user)
@@ -200,18 +195,6 @@ class ClientConfigViewTest(TestCase):
             assert data["sentryUrl"] == "http://testserver"
             assert data["organizationUrl"] == "http://us.testserver"
 
-        with self.options({"system.organization-base-hostname": "{region}.{slug}.testserver"}):
-            resp = self.client.get(self.path)
-            assert resp.status_code == 200
-            assert resp["Content-Type"] == "application/json"
-
-            data = json.loads(resp.content)
-
-            assert data["isAuthenticated"] is True
-            assert data["lastOrganization"] == self.organization.slug
-            assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == f"http://us.{self.organization.slug}.testserver"
-
     def test_organization_url_organization_url_template(self):
         self.login_as(self.user)
 
@@ -246,12 +229,7 @@ class ClientConfigViewTest(TestCase):
             assert data["sentryUrl"] == "http://testserver"
             assert data["organizationUrl"] == "http://testserver"
 
-        with self.options(
-            {
-                "system.organization-url-template": "ftp://{hostname}",
-                "system.organization-base-hostname": "{slug}.{region}.testserver",
-            }
-        ):
+        with self.options({"system.organization-url-template": "ftp://{hostname}"}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
@@ -261,4 +239,4 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == f"ftp://{self.organization.slug}.us.testserver"
+            assert data["organizationUrl"] == "ftp://us.testserver"

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -128,16 +128,17 @@ class ClientConfigViewTest(TestCase):
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"
 
-        resp = self.client.get(self.path)
-        assert resp.status_code == 200
-        assert resp["Content-Type"] == "application/json"
+        with self.options({"system.organization-base-hostname": "{slug}.{region}.testserver"}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
 
-        data = json.loads(resp.content)
+            data = json.loads(resp.content)
 
-        assert data["isAuthenticated"] is True
-        assert data["lastOrganization"] == self.organization.slug
-        assert data["sentryUrl"] == "http://testserver"
-        assert data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
+            assert data["isAuthenticated"] is True
+            assert data["lastOrganization"] == self.organization.slug
+            assert data["sentryUrl"] == "http://testserver"
+            assert data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
 
     def test_organization_url_region(self):
         self.login_as(self.user)
@@ -149,7 +150,7 @@ class ClientConfigViewTest(TestCase):
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"
 
-        with self.options({"system.region": "eu"}):
+        with self.options({"system.region": "eu", "system.organization-base-hostname": "{region}.{slug}.testserver"}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
@@ -159,7 +160,7 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == f"http://{self.organization.slug}.eu.testserver"
+            assert data["organizationUrl"] == f"http://eu.{self.organization.slug}.testserver"
 
     def test_organization_url_organization_base_hostname(self):
         self.login_as(self.user)
@@ -182,6 +183,18 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
             assert data["organizationUrl"] == "http://testserver"
+
+        with self.options({"system.organization-base-hostname": "{region}.testserver"}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+
+            data = json.loads(resp.content)
+
+            assert data["isAuthenticated"] is True
+            assert data["lastOrganization"] == self.organization.slug
+            assert data["sentryUrl"] == "http://testserver"
+            assert data["organizationUrl"] == "http://us.testserver"
 
         with self.options({"system.organization-base-hostname": "{region}.{slug}.testserver"}):
             resp = self.client.get(self.path)
@@ -229,7 +242,7 @@ class ClientConfigViewTest(TestCase):
             assert data["sentryUrl"] == "http://testserver"
             assert data["organizationUrl"] == "http://testserver"
 
-        with self.options({"system.organization-url-template": "ftp://{hostname}"}):
+        with self.options({"system.organization-url-template": "ftp://{hostname}", "system.organization-base-hostname": "{slug}.{region}.testserver"}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -128,17 +128,16 @@ class ClientConfigViewTest(TestCase):
         assert resp.status_code == 200
         assert resp["Content-Type"] == "application/json"
 
-        with self.options({"system.organization-base-hostname": "{slug}.{region}.testserver"}):
-            resp = self.client.get(self.path)
-            assert resp.status_code == 200
-            assert resp["Content-Type"] == "application/json"
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
 
-            data = json.loads(resp.content)
+        data = json.loads(resp.content)
 
-            assert data["isAuthenticated"] is True
-            assert data["lastOrganization"] == self.organization.slug
-            assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
+        assert data["isAuthenticated"] is True
+        assert data["lastOrganization"] == self.organization.slug
+        assert data["sentryUrl"] == "http://testserver"
+        assert data["organizationUrl"] == "http://us.testserver"
 
     def test_organization_url_region(self):
         self.login_as(self.user)


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/36955

Rather than updating all the API endpoints, in the interim we plan to use `us.sentry.io` for API endpoints.

This pull request removes the slug requirement on `system.organization-base-hostname`.