### PR TITLE
feat(mep): Add dataset to events-stats request

### DIFF
--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -165,6 +165,10 @@ type EventsRequestPartialProps = {
   orderby?: string;
   previousSeriesNames?: string[];
   /**
+   * Optional callback to further process events request response data
+   */
+  processDataCallback?: (any) => void;
+  /**
    * List of project ids to query
    */
   project?: Readonly<number[]>;
@@ -443,6 +447,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
       currentSeriesNames,
       previousSeriesNames,
       comparisonDelta,
+      processDataCallback,
     } = this.props;
     const {current, previous} = this.getData(data);
     const transformedData = includeTransformedData
@@ -479,7 +484,8 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
               end: response.end * 1000,
             }
         : undefined;
-    return {
+
+    const processedData = {
       data: transformedData,
       comparisonData: transformedComparisonData,
       allData: data,
@@ -491,6 +497,12 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
       timeAggregatedData,
       timeframe,
     };
+
+    if (processDataCallback) {
+      processDataCallback(processedData);
+    }
+
+    return processedData;
   }
 
   render() {

--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -30,6 +30,7 @@ export const DEFAULT_TRANSACTION_AGGREGATE = 'p95(transaction.duration)';
 export const DATASET_EVENT_TYPE_FILTERS = {
   [Dataset.ERRORS]: 'event.type:error',
   [Dataset.TRANSACTIONS]: 'event.type:transaction',
+  [Dataset.GENERIC_METRICS]: 'event.type:transaction',
 } as const;
 
 export const DATASOURCE_EVENT_TYPE_FILTERS = {

--- a/static/app/views/alerts/rules/metric/types.tsx
+++ b/static/app/views/alerts/rules/metric/types.tsx
@@ -1,5 +1,5 @@
 import {t} from 'sentry/locale';
-import {QueryType} from 'sentry/views/alerts/wizard/options';
+import {MEPAlertsQueryType} from 'sentry/views/alerts/wizard/options';
 import type {SchemaFormConfig} from 'sentry/views/organizationIntegrations/sentryAppExternalForm';
 
 import type {Incident} from '../../types';
@@ -23,6 +23,8 @@ export enum AlertRuleComparisonType {
 export enum Dataset {
   ERRORS = 'events',
   TRANSACTIONS = 'transactions',
+  /** Also used for performance alerts **/
+  GENERIC_METRICS = 'generic_metrics',
   SESSIONS = 'sessions',
   /** Also used for crash free alerts */
   METRICS = 'metrics',
@@ -92,7 +94,7 @@ export type UnsavedMetricRule = {
   comparisonDelta?: number | null;
   eventTypes?: EventTypes[];
   owner?: string | null;
-  queryType?: QueryType | null;
+  queryType?: MEPAlertsQueryType | null;
 };
 
 export interface SavedMetricRule extends UnsavedMetricRule {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -21,27 +21,26 @@ export type AlertType =
   | 'crash_free_sessions'
   | 'crash_free_users';
 
-export enum QueryType {
+export enum MEPAlertsQueryType {
   ERROR = 0,
   PERFORMANCE = 1,
   CRASH_RATE = 2,
 }
 
+export enum MEPAlertsDataset {
+  DISCOVER = 'discover',
+  METRICS = 'metrics',
+  METRICS_ENHANCED = 'metricsEnhanced',
+}
+
 export type MetricAlertType = Exclude<AlertType, 'issues'>;
 
-export const MetricQueryTypeMap: Record<MetricAlertType, QueryType> = {
-  num_errors: QueryType.ERROR,
-  users_experiencing_errors: QueryType.ERROR,
-  throughput: QueryType.PERFORMANCE,
-  trans_duration: QueryType.PERFORMANCE,
-  apdex: QueryType.PERFORMANCE,
-  failure_rate: QueryType.PERFORMANCE,
-  lcp: QueryType.PERFORMANCE,
-  fid: QueryType.PERFORMANCE,
-  cls: QueryType.PERFORMANCE,
-  custom: QueryType.PERFORMANCE,
-  crash_free_sessions: QueryType.CRASH_RATE,
-  crash_free_users: QueryType.CRASH_RATE,
+export const DatasetMEPAlertQueryTypes: Record<Dataset, MEPAlertsQueryType> = {
+  [Dataset.ERRORS]: MEPAlertsQueryType.ERROR,
+  [Dataset.TRANSACTIONS]: MEPAlertsQueryType.PERFORMANCE,
+  [Dataset.GENERIC_METRICS]: MEPAlertsQueryType.PERFORMANCE,
+  [Dataset.METRICS]: MEPAlertsQueryType.CRASH_RATE,
+  [Dataset.SESSIONS]: MEPAlertsQueryType.CRASH_RATE,
 };
 
 export const AlertWizardAlertNames: Record<AlertType, string> = {
@@ -208,4 +207,24 @@ export function getFunctionHelpText(alertType: AlertType): {
     labelText: t('Select function and time interval'),
     timeWindowText,
   };
+}
+
+export function getMEPAlertsDataset(
+  dataset: Dataset,
+  newAlert: boolean
+): MEPAlertsDataset {
+  // Dataset.ERRORS overrides all cases
+  if (dataset === Dataset.ERRORS) {
+    return MEPAlertsDataset.DISCOVER;
+  }
+
+  if (newAlert) {
+    return MEPAlertsDataset.METRICS_ENHANCED;
+  }
+
+  if (dataset === Dataset.GENERIC_METRICS) {
+    return MEPAlertsDataset.METRICS;
+  }
+
+  return MEPAlertsDataset.DISCOVER;
 }

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -17,6 +17,15 @@ const alertTypeIdentifiers: Record<Dataset, Partial<Record<MetricAlertType, stri
     fid: 'measurements.fid',
     cls: 'measurements.cls',
   },
+  [Dataset.GENERIC_METRICS]: {
+    throughput: 'count()',
+    trans_duration: 'transaction.duration',
+    apdex: 'apdex',
+    failure_rate: 'failure_rate()',
+    lcp: 'measurements.lcp',
+    fid: 'measurements.fid',
+    cls: 'measurements.cls',
+  },
   [Dataset.SESSIONS]: {
     crash_free_sessions: SessionsAggregate.CRASH_FREE_SESSIONS,
     crash_free_users: SessionsAggregate.CRASH_FREE_USERS,

--- a/tests/js/spec/views/alerts/metricRules/triggersChart.spec.tsx
+++ b/tests/js/spec/views/alerts/metricRules/triggersChart.spec.tsx
@@ -6,6 +6,7 @@ import TriggersChart from 'sentry/views/alerts/rules/metric/triggers/chart';
 import {
   AlertRuleComparisonType,
   AlertRuleThresholdType,
+  Dataset,
 } from 'sentry/views/alerts/rules/metric/types';
 
 describe('Incident Rules Create', () => {
@@ -32,11 +33,14 @@ describe('Incident Rules Create', () => {
         query="event.type:error"
         timeWindow={1}
         aggregate="count()"
+        dataset={Dataset.ERRORS}
         triggers={[]}
         environment={null}
         comparisonType={AlertRuleComparisonType.COUNT}
         resolveThreshold={null}
         thresholdType={AlertRuleThresholdType.BELOW}
+        newAlertOrQuery
+        handleMEPAlertDataset={() => {}}
       />
     );
 


### PR DESCRIPTION
This updates alerts with the following MEP alerts changes:
- added `generic_metrics` to `rule.dataset` options
- updated `queryType` for rule save requests
- added `dataset` (different from `rule.dataset`) to `events-stats` request
- put all changes behind: `metrics-performance-alerts` flag

Jira: [WOR-2001](https://getsentry.atlassian.net/browse/WOR-2001)