### PR TITLE
refs(metric_alerts): Remove `QueryDatasets` enum

### DIFF
--- a/src/sentry/snuba/models.py
+++ b/src/sentry/snuba/models.py
@@ -20,16 +20,6 @@ query_aggregation_to_snuba = {
 }
 
 
-# TODO: Remove this once we've removed usage from getsentry
-class QueryDatasets(Enum):
-    EVENTS = "events"
-    TRANSACTIONS = "transactions"
-    SESSIONS = "sessions"
-    # Actually Release Health
-    METRICS = "metrics"
-    PERFORMANCE_METRICS = "generic_metrics"
-
-
 class SnubaQuery(Model):
     __include_in_export__ = True
 


### PR DESCRIPTION
Kept this in place to prevent getsentry breaking ci, it can be removed now
