### PR TITLE
feat(dashboards): Metric Widgets use units provided from events request meta

### DIFF
--- a/static/app/components/charts/simpleTableChart.tsx
+++ b/static/app/components/charts/simpleTableChart.tsx
@@ -68,12 +68,13 @@ function SimpleTableChart({
         getCustomFieldRenderer?.(column.key, tableMeta, organization) ??
         getFieldRenderer(column.key, tableMeta);
 
+      const unit = tableMeta.units?.[column.key];
       return (
         <TableCell key={`${index}-${columnIndex}:${column.name}`}>
           {topResultsIndicators && columnIndex === 0 && (
             <TopResultsIndicator count={topResultsIndicators} index={index} />
           )}
-          {fieldRenderer(row, {organization, location, eventView})}
+          {fieldRenderer(row, {organization, location, eventView, unit})}
         </TableCell>
       );
     });

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -52,7 +52,11 @@ import {MutableSearch} from '../tokenizeSearch';
 import {getSortField} from './fieldRenderers';
 
 // Metadata mapping for discover results.
-export type MetaType = Record<string, ColumnType> & {isMetricsData?: boolean};
+export type MetaType = Record<string, ColumnType> & {
+  isMetricsData?: boolean;
+  tips?: {columns: string; query: string};
+  units?: Record<string, string>;
+};
 export type EventsMetaType = {fields: Record<string, ColumnType>} & {
   isMetricsData?: boolean;
 };

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -110,24 +110,24 @@ export function nullableValue(value: string | null): string | React.ReactElement
 }
 
 const SIZE_UNITS = {
-  bit: {scale: 1 / 8},
-  byte: {scale: 1},
-  kibibyte: {scale: 1024},
-  mebibyte: {scale: 1024 ** 2},
-  gibibyte: {scale: 1024 ** 3},
-  tebibyte: {scale: 1024 ** 4},
-  pebibyte: {scale: 1024 ** 5},
-  exbibyte: {scale: 1024 ** 6},
+  bit: 1 / 8,
+  byte: 1,
+  kibibyte: 1024,
+  mebibyte: 1024 ** 2,
+  gibibyte: 1024 ** 3,
+  tebibyte: 1024 ** 4,
+  pebibyte: 1024 ** 5,
+  exbibyte: 1024 ** 6,
 };
 const DURATION_UNITS = {
-  nanosecond: {scale: 1 / 1000 ** 2},
-  microsecond: {scale: 1 / 1000},
-  millisecond: {scale: 1},
-  second: {scale: 1000},
-  minute: {scale: 1000 * 60},
-  hour: {scale: 1000 * 60 * 60},
-  day: {scale: 1000 * 60 * 60 * 24},
-  week: {scale: 1000 * 60 * 60 * 24 * 7},
+  nanosecond: 1 / 1000 ** 2,
+  microsecond: 1 / 1000,
+  millisecond: 1,
+  second: 1000,
+  minute: 1000 * 60,
+  hour: 1000 * 60 * 60,
+  day: 1000 * 60 * 60 * 24,
+  week: 1000 * 60 * 60 * 24 * 7,
 };
 /**
  * A mapping of field types to their rendering function.
@@ -165,9 +165,7 @@ export const FIELD_FORMATTERS: FieldFormatters = {
         <NumberContainer>
           {typeof data[field] === 'number' ? (
             <Duration
-              seconds={
-                (data[field] * ((unit && DURATION_UNITS[unit]?.scale) ?? 1)) / 1000
-              }
+              seconds={(data[field] * ((unit && DURATION_UNITS[unit]) ?? 1)) / 1000}
               fixedDigits={2}
               abbreviation
             />
@@ -209,7 +207,7 @@ export const FIELD_FORMATTERS: FieldFormatters = {
       return (
         <NumberContainer>
           {unit && SIZE_UNITS[unit] && typeof data[field] === 'number' ? (
-            <FileSize bytes={data[field] * SIZE_UNITS[unit].scale} />
+            <FileSize bytes={data[field] * SIZE_UNITS[unit]} />
           ) : (
             emptyValue
           )}

--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -266,10 +266,10 @@ function transformEventsResponseToTable(
   );
   // events api uses a different response format so we need to construct tableData differently
   if (shouldUseEvents) {
-    const fieldsMeta = (data as EventsTableData).meta?.fields;
+    const {fields, ...otherMeta} = (data as EventsTableData).meta ?? {};
     tableData = {
       ...data,
-      meta: {...fieldsMeta, isMetricsData: data.meta?.isMetricsData},
+      meta: {...fields, ...otherMeta},
     } as TableData;
   }
   return tableData as TableData;

--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -193,7 +193,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
     }
 
     const {containerHeight} = this.state;
-    const {organization, widget, isMobile, expandNumbers} = this.props;
+    const {location, organization, widget, isMobile, expandNumbers} = this.props;
     const isAlias =
       !organization.features.includes('discover-frontend-use-events-endpoint') &&
       widget.widgetType !== WidgetType.RELEASE;
@@ -217,8 +217,10 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       const dataRow = result.data[0];
       const fieldRenderer = getFieldFormatter(field, tableMeta, isAlias);
 
+      const unit = tableMeta.units?.[field];
       const rendered = fieldRenderer(
-        shouldExpandInteger ? {[field]: dataRow[field].toLocaleString()} : dataRow
+        shouldExpandInteger ? {[field]: dataRow[field].toLocaleString()} : dataRow,
+        {location, organization, unit}
       );
 
       const isModalWidget = !!!(widget.id || widget.tempId);

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -3624,6 +3624,102 @@ describe('WidgetBuilder', function () {
           screen.queryByText('measurements.custom.measurement')
         ).not.toBeInTheDocument();
       });
+
+      it('renders custom performance metric using duration units from events meta', async function () {
+        eventsMock = MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/events/',
+          method: 'GET',
+          statusCode: 200,
+          body: {
+            meta: {
+              fields: {'p99(measurements.custom.measurement)': 'duration'},
+              isMetricsData: true,
+              units: {'p99(measurements.custom.measurement)': 'hour'},
+            },
+            data: [{'p99(measurements.custom.measurement)': 12}],
+          },
+        });
+
+        renderTestComponent({
+          query: {source: DashboardWidgetSource.DISCOVERV2},
+          dashboard: {
+            ...testDashboard,
+            widgets: [
+              {
+                title: 'Custom Measurement Widget',
+                interval: '1d',
+                id: '1',
+                widgetType: WidgetType.DISCOVER,
+                displayType: DisplayType.TABLE,
+                queries: [
+                  {
+                    conditions: '',
+                    name: '',
+                    fields: ['p99(measurements.custom.measurement)'],
+                    columns: [],
+                    aggregates: ['p99(measurements.custom.measurement)'],
+                    orderby: '-p99(measurements.custom.measurement)',
+                  },
+                ],
+              },
+            ],
+          },
+          params: {
+            widgetIndex: '0',
+          },
+          orgFeatures: [...defaultOrgFeatures, 'discover-frontend-use-events-endpoint'],
+        });
+
+        await screen.findByText('12.00hr');
+      });
+
+      it('renders custom performance metric using size units from events meta', async function () {
+        eventsMock = MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/events/',
+          method: 'GET',
+          statusCode: 200,
+          body: {
+            meta: {
+              fields: {'p99(measurements.custom.measurement)': 'size'},
+              isMetricsData: true,
+              units: {'p99(measurements.custom.measurement)': 'kibibyte'},
+            },
+            data: [{'p99(measurements.custom.measurement)': 12}],
+          },
+        });
+
+        renderTestComponent({
+          query: {source: DashboardWidgetSource.DISCOVERV2},
+          dashboard: {
+            ...testDashboard,
+            widgets: [
+              {
+                title: 'Custom Measurement Widget',
+                interval: '1d',
+                id: '1',
+                widgetType: WidgetType.DISCOVER,
+                displayType: DisplayType.TABLE,
+                queries: [
+                  {
+                    conditions: '',
+                    name: '',
+                    fields: ['p99(measurements.custom.measurement)'],
+                    columns: [],
+                    aggregates: ['p99(measurements.custom.measurement)'],
+                    orderby: '-p99(measurements.custom.measurement)',
+                  },
+                ],
+              },
+            ],
+          },
+          params: {
+            widgetIndex: '0',
+          },
+          orgFeatures: [...defaultOrgFeatures, 'discover-frontend-use-events-endpoint'],
+        });
+
+        await screen.findByText('12.0 KiB');
+      });
     });
   });
 });


### PR DESCRIPTION
Updates Discover Table and Big Number charts to use duration and size units from `events` request meta when rendering values.