### PR TITLE
ref(js): Remove broken frontend asset cache busting

### DIFF
--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -14,6 +14,6 @@
 {% endblock %}
 
 {% block scripts_main_entrypoint %}
-    {% frontend_app_asset_url "sentry" "entrypoints/pipeline.js" cache_bust=True as asset_url %}
+    {% frontend_app_asset_url "sentry" "entrypoints/pipeline.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -28,7 +28,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link href="{% frontend_app_asset_url "sentry" "entrypoints/sentry.css" cache_bust=True %}" rel="stylesheet"/>
+  <link href="{% frontend_app_asset_url "sentry" "entrypoints/sentry.css" %}" rel="stylesheet"/>
 
   {% block css %}{% endblock %}
 
@@ -57,7 +57,7 @@
 
   {% block scripts %}
   {% block scripts_main_entrypoint %}
-    {% frontend_app_asset_url "sentry" "entrypoints/app.js" cache_bust=True as asset_url %}
+    {% frontend_app_asset_url "sentry" "entrypoints/app.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
   {% endblock %}
 

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,29 +1,19 @@
 from django.conf import settings
 
 
-def get_frontend_app_asset_url(module, key, cache_bust=False):
+def get_frontend_app_asset_url(module, key):
     """
     Returns an asset URL that is unversioned. These assets should have a
     `Cache-Control: max-age=0, must-revalidate` so that clients must validate with the origin
     server before using their locally cached asset.
 
-    XXX(epurkhiser): As a temporary workaround for flakeyness with the CDN,
-    we're busting caches when version_bust is True using a query parameter with
-    the currently deployed backend SHA. This will have to change in the future
-    for frontend only deploys.
-
     Example:
       {% frontend_app_asset_url 'sentry' 'sentry.css' %}
       =>  "/_static/dist/sentry/sentry.css"
-
-      {% frontend_app_asset_url 'sentry' 'sentry.css' cache_bust=True %}
-      =>  "/_static/dist/sentry/sentry.css?v=xxx"
     """
     args = (settings.STATIC_FRONTEND_APP_URL.rstrip("/"), module, key.lstrip("/"))
 
-    if not cache_bust:
-        return "{}/{}/{}".format(*args)
-    return "{}/{}/{}?v={}".format(*args, settings.SENTRY_SDK_CONFIG["release"])
+    return "{}/{}/{}".format(*args)
 
 
 def get_asset_url(module, path):

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -63,8 +63,7 @@ class StaticMediaTest(TestCase):
 
         try:
             with open(os.path.join(dist_path, "test.js"), "a"):
-                url = get_frontend_app_asset_url("sentry", "test.js", cache_bust=True)
-                assert "?v=" in url
+                url = get_frontend_app_asset_url("sentry", "test.js")
 
                 response = self.client.get(url)
                 close_streaming_response(response)


### PR DESCRIPTION
This actually doesn't work with the split frontend deploys, since the version of the frontend may change without the version of the backend changing. So the cache busting isn't actually happening anymore.

In fact, we're actually busting the cache unnecessarily, since when we deploy the backend the frontend isn't changing, but this is causing the cached frontend entrypoint to be invalidated.

---

This was originally implemented since there were a few modules that needed to be loaded in tandum, and if the cache for both wasn't busted then sometimes one would be old and one would be new.