### PR TITLE
   feat(multi-region): Update Discover events fetch to consume resolveUrl

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -8,6 +8,7 @@ export class Request {}
 
 export const initApiClientErrorHandling = RealApi.initApiClientErrorHandling;
 export const hasProjectBeenRenamed = RealApi.hasProjectBeenRenamed;
+export const resolveUrl = RealApi.resolveUrl;
 
 const respond = (isAsync: boolean, fn?: Function, ...args: any[]): void => {
   if (!fn) {

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -245,6 +245,8 @@ type HandleRequestErrorOptions = {
   requestOptions: Readonly<RequestOptions>;
 };
 
+const DEFAULT_BASE_URL = '/api/0';
+
 /**
  * The API client is used to make HTTP requests to Sentry's backend.
  *
@@ -255,7 +257,7 @@ export class Client {
   activeRequests: Record<string, Request>;
 
   constructor(options: ClientOptions = {}) {
-    this.baseUrl = options.baseUrl ?? '/api/0';
+    this.baseUrl = options.baseUrl ?? DEFAULT_BASE_URL;
     this.activeRequests = {};
   }
 

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -11,9 +11,11 @@ import {
   SUDO_REQUIRED,
   SUPERUSER_REQUIRED,
 } from 'sentry/constants/apiErrorCodes';
+import {OrganizationSummary} from 'sentry/types';
 import {metric} from 'sentry/utils/analytics';
 import getCsrfToken from 'sentry/utils/getCsrfToken';
 import {uniqueId} from 'sentry/utils/guid';
+import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 import createRequestError from 'sentry/utils/requestError/createRequestError';
 
 export class Request {
@@ -582,4 +584,47 @@ export class Client {
       })
     );
   }
+}
+
+function generateOrganizationBaseUrl(organizationUrl: string) {
+  return `${organizationUrl}${DEFAULT_BASE_URL}`;
+}
+
+type APIRouteType = 'organization-events';
+
+type LegacyRoute = string;
+type RouteTuple = [LegacyRoute];
+
+const routeRenderMap: Record<APIRouteType, RouteTuple> = {
+  'organization-events': ['/organizations/:org_slug/events/'],
+};
+
+export function resolveUrl(
+  routeType: APIRouteType,
+  organization: OrganizationSummary,
+  routeParams: {[key: string]: string | number | undefined} = {}
+) {
+  const [route] = routeRenderMap[routeType];
+  const {organizationUrl} = organization;
+
+  const shouldUseLegacyRoute =
+    !organizationUrl || !organization.features.includes('customer-domains');
+
+  const renderedRoute = replaceRouterParams(route, {
+    org_slug: organization.slug,
+    ...routeParams,
+  });
+
+  const result = shouldUseLegacyRoute
+    ? renderedRoute
+    : `${generateOrganizationBaseUrl(organizationUrl)}${renderedRoute}`;
+
+  const currentTransaction = Sentry.getCurrentHub().getScope()?.getTransaction();
+  if (currentTransaction && currentTransaction.tags.hasOrganizationUrl !== String(true)) {
+    const hasOrganizationUrl =
+      organizationUrl !== undefined ? result.includes(organizationUrl) : false;
+    currentTransaction.setTag('hasOrganizationUrl', String(hasOrganizationUrl));
+  }
+
+  return result;
 }

--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {EventQuery} from 'sentry/actionCreators/events';
-import {Client} from 'sentry/api';
+import {Client, resolveUrl} from 'sentry/api';
 import Pagination from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
@@ -95,7 +95,7 @@ class Table extends PureComponent<TableProps, TableState> {
       'discover-frontend-use-events-endpoint'
     );
     const url = shouldUseEvents
-      ? `/organizations/${organization.slug}/events/`
+      ? resolveUrl('organization-events', organization)
       : `/organizations/${organization.slug}/eventsv2/`;
     const tableFetchID = Symbol('tableFetchID');
 


### PR DESCRIPTION
Alternative to https://github.com/getsentry/sentry/pull/36444.

Depends on https://github.com/getsentry/sentry/pull/36994

This adds `resolveUrl()` and other utility functions to be able to dynamically make use of `organizationsURL` from an organization's props to make API calls.

This hooks into the Discover events API call.