### PR TITLE
feat(hybrid-cloud): Add resolve_region

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -504,3 +504,12 @@ def create_region_endpoint_class(endpoint_class):
             exclude=True,
         )
     return extend_schema_view(**schema)(region_endpoint_class)
+
+
+def resolve_region(request: Request):
+    subdomain = request.subdomain
+    if subdomain is None:
+        return None
+    if subdomain in {"us", "eu"}:
+        return subdomain
+    return None

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -3,7 +3,7 @@ import base64
 from django.http import HttpRequest
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint
+from sentry.api.base import Endpoint, resolve_region
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.models import ApiKey
 from sentry.testutils import APITestCase
@@ -163,3 +163,15 @@ class EndpointJSONBodyTest(APITestCase):
         Endpoint().load_json_body(self.request)
 
         assert not self.request.json_body
+
+
+class CustomerDomainTest(APITestCase):
+    def test_resolve_region(self):
+        def request_with_subdomain(subdomain):
+            request = self.make_request(method="GET")
+            request.subdomain = subdomain
+            return resolve_region(request)
+
+        assert request_with_subdomain("us") == "us"
+        assert request_with_subdomain("eu") == "eu"
+        assert request_with_subdomain("sentry") is None


### PR DESCRIPTION
Add `resolve_region()` that resolves `request.subdomain` into a valid region. I plan to replace any and all instances of `resolve_org_slug_region()` with `resolve_region()` in both the `sentry` and `getsentry` repos.