### PR TITLE
feat(projectconfig): Sample rate for project config compression [INGEST-1505]

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -447,8 +447,12 @@ register("kafka.send-project-events-to-random-partitions", default=[])
 register("relay.project-config-v3-enable", default=0.0)
 
 # Use zstandard compression in redis project config cache
-# Set this value to either a list of DSNs or a sample rate.
+# Set this value to a list of DSNs.
 register("relay.project-config-cache-compress", default=[])
+
+# Use zstandard compression in redis project config cache
+# Set this value of the fraction of config writes you want to compress.
+register("relay.project-config-cache-compress-sample-rate", default=0.0)
 
 # Mechanism for dialing up the last-seen-updater, which isn't needed outside
 # of SaaS (last_seen is a marker for deleting stale customer data)


### PR DESCRIPTION
Sample rate option to enable compression for project configs in redis. Unfortunately we cannot reuse the same option for the sample rate, because setting the option with `sentry config set` will validate the value's type.

See #36926 and https://github.com/getsentry/sentry/pull/36963 for details.