### PR TITLE
feat(metrics): Transaction metrics extraction version [INGEST-1478]

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -388,6 +388,13 @@ def _filter_option_to_config_setting(flt, setting):
     return ret_val
 
 
+#: Version of the transaction metrics extraction.
+#: When you increment this version, outdated Relays will stop extracting
+#: transaction metrics.
+#: See https://github.com/getsentry/relay/blob/4f3e224d5eeea8922fe42163552e8f20db674e86/relay-server/src/metrics_extraction/transactions.rs#L71
+TRANSACTION_METRICS_EXTRACTION_VERSION = 1
+
+
 #: Top-level metrics for transactions
 TRANSACTION_METRICS = frozenset(
     [
@@ -426,6 +433,7 @@ class CustomMeasurementSettings(TypedDict):
 
 
 class TransactionMetricsSettings(TypedDict):
+    version: int
     extractMetrics: Collection[str]
     extractCustomTags: Collection[str]
     customMeasurements: CustomMeasurementSettings
@@ -480,6 +488,7 @@ def get_transaction_metrics_settings(
         capture_exception()
 
     return {
+        "version": TRANSACTION_METRICS_EXTRACTION_VERSION,
         "extractMetrics": metrics,
         "extractCustomTags": custom_tags,
         "customMeasurements": {"limit": CUSTOM_MEASUREMENT_LIMIT},

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2022-06-29T14:13:27.057078Z'
+created: '2022-07-22T12:59:33.487327Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -887,3 +887,4 @@ transactionMetrics:
   - d:transactions/breakdowns.ops.browser
   - d:transactions/breakdowns.ops.resource
   - d:transactions/breakdowns.ops.ui
+  version: 1


### PR DESCRIPTION
Just like we did for session metrics extraction, add a version to the project config protocol such that older Relays will stop extracting metrics when the version supplied by Sentry is too high.

This is a prerequisite for https://github.com/getsentry/relay/pull/1344.