### PR TITLE
feat(mep): Make some changes to landing for e2e

### DIFF
--- a/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
@@ -1,12 +1,11 @@
 import {ReactNode, useCallback, useState} from 'react';
 
 import Tag from 'sentry/components/tag';
-import {t} from 'sentry/locale';
 import useOrganization from 'sentry/utils/useOrganization';
 import {WIDGET_MAP_DENY_LIST} from 'sentry/views/performance/landing/widgets/utils';
 import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets/widgetDefinitions';
 
-import {AutoSampleState, MEPState, useMEPSettingContext} from './metricsEnhancedSetting';
+import {AutoSampleState, useMEPSettingContext} from './metricsEnhancedSetting';
 import {createDefinedContext} from './utils';
 
 interface MetricsEnhancedPerformanceDataContext {
@@ -42,7 +41,7 @@ export const MEPDataProvider = ({
       }
       _setIsMetricsData(value);
     },
-    [setAutoSampleState, _setIsMetricsData]
+    [setAutoSampleState, _setIsMetricsData, chartSetting]
   );
 
   return (
@@ -56,27 +55,18 @@ export const useMEPDataContext = _useMEPDataContext;
 
 export const MEPTag = () => {
   const {isMetricsData} = useMEPDataContext();
-  const {metricSettingState} = useMEPSettingContext();
   const organization = useOrganization();
 
   if (!organization.features.includes('performance-use-metrics')) {
     // Separate if for easier flag deletion
     return null;
   }
-  if (organization.features.includes('transaction-name-only-search')) {
-    return null;
+
+  if (isMetricsData === undefined) {
+    return <span data-test-id="no-metrics-data-tag" />;
   }
-  if (metricSettingState === MEPState.auto && isMetricsData === false) {
-    return (
-      <Tag
-        tooltipText={t(
-          'These search conditions are only applicable to sampled transaction data. To edit sampling rates, go to Filters & Sampling in settings.'
-        )}
-        data-test-id="has-metrics-data-tag"
-      >
-        {'Sampled'}
-      </Tag>
-    );
-  }
-  return <span data-test-id="no-metrics-data-tag" />;
+
+  const tagText = isMetricsData ? 'metrics' : 'transactions';
+
+  return <Tag data-test-id="has-metrics-data-tag">{tagText}</Tag>;
 };

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -145,14 +145,10 @@ function PerformanceContent({selection, location, demoMode}: Props) {
     });
   }
 
-  const forceMetricsOnly = organization.features.includes(
-    'performance-transaction-name-only-search'
-  );
-
   return (
     <SentryDocumentTitle title={t('Performance')} orgSlug={organization.slug}>
       <PerformanceEventViewProvider value={{eventView}}>
-        <MEPSettingProvider forceMetricsOnly={forceMetricsOnly}>
+        <MEPSettingProvider location={location}>
           <PageFiltersContainer
             defaultSelection={{
               datetime: {

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -153,11 +153,9 @@ export function PerformanceLanding(props: Props) {
     pageFilters = <SearchContainerWithFilter>{pageFilters}</SearchContainerWithFilter>;
   }
 
-  const SearchFilterContainer =
-    organization.features.includes('performance-use-metrics') &&
-    !organization.features.includes('performance-transaction-name-only-search')
-      ? SearchContainerWithFilterAndMetrics
-      : SearchContainerWithFilter;
+  const SearchFilterContainer = organization.features.includes('performance-use-metrics')
+    ? SearchContainerWithFilterAndMetrics
+    : SearchContainerWithFilter;
 
   return (
     <StyledPageContent data-test-id="performance-landing-v3">
@@ -254,11 +252,7 @@ export function PerformanceLanding(props: Props) {
                       )
                     }
                   </Feature>
-                  <Feature
-                    features={['organizations:performance-transaction-name-only-search']}
-                  >
-                    {({hasFeature}) => !hasFeature && <MetricsEventsDropdown />}
-                  </Feature>
+                  <MetricsEventsDropdown />
                 </SearchFilterContainer>
                 {initiallyLoaded ? (
                   <TeamKeyTransactionManager.Provider

--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -96,7 +96,8 @@ function QueryResultSaver<T extends WidgetDataConstraint>(
 
   useEffect(() => {
     const isMetricsData =
-      results?.seriesAdditionalInfo?.[props.queryProps.fields[0]]?.isMetricsData;
+      results?.seriesAdditionalInfo?.[props.queryProps.fields[0]]?.isMetricsData ??
+      results?.histograms?.meta?.isMetricsData;
     mepContext.setIsMetricsData(isMetricsData);
     props.setWidgetDataForKey(query.queryKey, transformed);
   }, [transformed?.hasData, transformed?.isLoading, transformed?.isErrored]);

--- a/static/app/views/performance/landing/widgets/transforms/transformDiscoverToList.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformDiscoverToList.tsx
@@ -1,10 +1,24 @@
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {defined} from 'sentry/utils';
-import {TableData} from 'sentry/utils/discover/discoverQuery';
+import {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {GenericChildrenProps} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DEFAULT_STATS_PERIOD} from 'sentry/views/performance/data';
 
 import {QueryDefinitionWithKey, WidgetDataConstraint, WidgetPropUnion} from '../types';
+
+/**
+ * Cleans up lists to remove 'null' transactions rows from metrics-backed data.
+ */
+function removeEmptyTransactionsFromList(data: TableDataRow[]) {
+  const transactionColumnExists = data.some(
+    d => typeof d === 'object' && 'transaction' in d
+  );
+  return transactionColumnExists
+    ? data.filter(d =>
+        typeof d === 'object' && 'transaction' in d ? d.transaction : true
+      )
+    : data;
+}
 
 export function transformDiscoverToList<T extends WidgetDataConstraint>(
   widgetProps: WidgetPropUnion<T>,
@@ -18,7 +32,8 @@ export function transformDiscoverToList<T extends WidgetDataConstraint>(
     }
   );
 
-  const data = results.tableData?.data ?? [];
+  const _data = results.tableData?.data ?? [];
+  const data = removeEmptyTransactionsFromList(_data);
 
   const childData = {
     ...results,

--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -25,7 +25,7 @@ function setWidgetStorageObject(localObject: Record<string, string>) {
 export function getMEPQueryParams(mepContext: MetricsEnhancedSettingContext) {
   let queryParams = {};
   const base = {preventMetricAggregates: '1'};
-  if (mepContext.shouldQueryProvideMEPParams) {
+  if (mepContext.shouldQueryProvideMEPAutoParams) {
     queryParams = {
       ...queryParams,
       ...base,

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -230,7 +230,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
               selectedIndex={selectedListIndex}
               setSelectedIndex={setSelectListIndex}
               items={provided.widgetData.list.data.map(listItem => () => {
-                const transaction = listItem.transaction as string;
+                const transaction = (listItem.transaction as string | undefined) ?? '';
 
                 const additionalQuery: Record<string, string> = {};
 

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -113,6 +113,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
           }));
 
           _eventView.sorts = [{kind: 'desc', field: sortField}];
+          _eventView.additionalConditions.setFilterValues('!transaction', ['']);
 
           _eventView.fields = [
             {field: 'transaction'},
@@ -127,7 +128,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
               {...provided}
               eventView={_eventView}
               location={props.location}
-              limit={3}
+              limit={4}
               cursor="0:0:1"
               noPagination
               queryExtras={getMEPQueryParams(mepSetting)}
@@ -272,8 +273,8 @@ export function VitalWidget(props: PerformanceWidgetProps) {
             <SelectableList
               selectedIndex={selectedListIndex}
               setSelectedIndex={setSelectListIndex}
-              items={provided.widgetData.list.data.map(listItem => () => {
-                const transaction = listItem?.transaction as string;
+              items={provided.widgetData.list.data.slice(0, 3).map(listItem => () => {
+                const transaction = (listItem?.transaction as string | undefined) ?? '';
                 const _eventView = eventView.clone();
 
                 const initialConditions = new MutableSearch(_eventView.query);

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -113,7 +113,13 @@ export function VitalWidget(props: PerformanceWidgetProps) {
           }));
 
           _eventView.sorts = [{kind: 'desc', field: sortField}];
-          _eventView.additionalConditions.setFilterValues('!transaction', ['']);
+          if (
+            props.organization.features.includes(
+              'performance-transaction-name-only-search'
+            )
+          ) {
+            _eventView.additionalConditions.setFilterValues('!transaction', ['']);
+          }
 
           _eventView.fields = [
             {field: 'transaction'},

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -54,7 +54,6 @@ import {
   TransactionFilterOptions,
 } from '../utils';
 
-import {MetricsEventsDropdown} from './metricEvents/metricsEventsDropdown';
 import TransactionSummaryCharts from './charts';
 import RelatedIssues from './relatedIssues';
 import SidebarCharts from './sidebarCharts';
@@ -296,7 +295,6 @@ function SummaryContent({
             onSearch={handleSearch}
             maxQueryLength={MAX_QUERY_LENGTH}
           />
-          <MetricsEventsDropdown />
         </FilterActions>
         <TransactionSummaryCharts
           organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionOverview/metricEvents/metricsEventsDropdown.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/metricEvents/metricsEventsDropdown.tsx
@@ -1,3 +1,5 @@
+import {ReactNode} from 'react';
+
 import Feature from 'sentry/components/acl/feature';
 import CompactSelect from 'sentry/components/forms/compactSelect';
 import {t} from 'sentry/locale';
@@ -10,19 +12,20 @@ import {
 
 interface MetricsEventsOption {
   label: string;
-  prefix: string;
+  prefix: ReactNode;
   value: MEPState;
 }
 
 const autoTextMap: Record<AutoSampleState, string> = {
   [AutoSampleState.unset]: t('Auto'),
-  [AutoSampleState.metrics]: t('Auto (ingested)'),
-  [AutoSampleState.transactions]: t('Auto (stored)'),
+  [AutoSampleState.metrics]: t('Auto (metrics)'),
+  [AutoSampleState.transactions]: t('Auto (transactions)'),
 };
 
 function getOptions(mepContext: MetricsEnhancedSettingContext): MetricsEventsOption[] {
   const autoText = autoTextMap[mepContext.autoSampleState];
-  const prefix = t('Sample');
+
+  const prefix = <span>{t('Dataset')}</span>;
 
   return [
     {
@@ -33,12 +36,12 @@ function getOptions(mepContext: MetricsEnhancedSettingContext): MetricsEventsOpt
     {
       value: MEPState.metricsOnly,
       prefix,
-      label: t('Ingested only'),
+      label: t('Metrics'),
     },
     {
       value: MEPState.transactionsOnly,
       prefix,
-      label: t('Stored only'),
+      label: t('Transactions'),
     },
   ];
 }

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -22,7 +22,6 @@ import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import EventView, {fromSorts, isFieldSortable} from 'sentry/utils/discover/eventView';
 import {fieldAlignment} from 'sentry/utils/discover/fields';
 import {formatPercentage} from 'sentry/utils/formatters';
-import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import SegmentExplorerQuery, {
   TableData,
   TableDataRow,
@@ -185,7 +184,7 @@ type Props = {
 type State = {
   widths: number[];
 };
-class _TagExplorer extends Component<Props> {
+export class TagExplorer extends Component<Props> {
   state: State = {
     widths: [],
   };
@@ -554,13 +553,3 @@ const Header = styled('div')`
 const StyledPagination = styled(Pagination)`
   margin: 0 0 0 ${space(1)};
 `;
-
-export const TagExplorer = (props: Props) => {
-  const {hideSinceMetricsOnly} = useMEPSettingContext();
-
-  if (hideSinceMetricsOnly) {
-    return null;
-  }
-
-  return <_TagExplorer {...props} />;
-};

--- a/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.tsx
+++ b/tests/js/spec/views/performance/landing/widgets/widgetContainer.spec.tsx
@@ -352,7 +352,9 @@ describe('Performance > Widgets > WidgetContainer', function () {
         }),
       })
     );
-    expect(await screen.findByTestId('no-metrics-data-tag')).toBeInTheDocument();
+    expect(await screen.findByTestId('has-metrics-data-tag')).toHaveTextContent(
+      'metrics'
+    );
   });
 
   it('Widget with MEP enabled and metric meta set to undefined', async function () {
@@ -429,7 +431,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
       })
     );
     expect(await screen.findByTestId('has-metrics-data-tag')).toHaveTextContent(
-      'Sampled'
+      'transactions'
     );
   });
 
@@ -492,7 +494,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'count_web_vitals(measurements.lcp, meh)',
             'count_web_vitals(measurements.lcp, good)',
           ],
-          per_page: 3,
+          per_page: 4,
           project: ['-42'],
           query: 'transaction.op:pageload',
           sort: '-count_web_vitals(measurements.lcp, poor)',
@@ -537,7 +539,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'count_web_vitals(measurements.lcp, meh)',
             'count_web_vitals(measurements.lcp, good)',
           ],
-          per_page: 3,
+          per_page: 4,
           project: ['-42'],
           query: 'transaction.op:pageload',
           sort: '-count_web_vitals(measurements.lcp, poor)',
@@ -579,7 +581,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'count_web_vitals(measurements.fcp, meh)',
             'count_web_vitals(measurements.fcp, good)',
           ],
-          per_page: 3,
+          per_page: 4,
           project: ['-42'],
           query: 'transaction.op:pageload',
           sort: '-count_web_vitals(measurements.fcp, poor)',
@@ -618,7 +620,7 @@ describe('Performance > Widgets > WidgetContainer', function () {
             'count_web_vitals(measurements.fid, meh)',
             'count_web_vitals(measurements.fid, good)',
           ],
-          per_page: 3,
+          per_page: 4,
           project: ['-42'],
           query: 'transaction.op:pageload',
           sort: '-count_web_vitals(measurements.fid, poor)',


### PR DESCRIPTION
### Summary
This splits some of the UX between transaction-name-only-search and performance-use-metrics, leaving the rename of those flags / generation to a new more sensible flag name for later.

This removes / modifies some of the original experimental ux to be used for testing the difference between the datasets.