### PR TITLE
fix(replays): header styles and project badge icon

### DIFF
--- a/static/app/views/replays/detail/eventMetaData.tsx
+++ b/static/app/views/replays/detail/eventMetaData.tsx
@@ -11,7 +11,6 @@ import type {Crumb} from 'sentry/types/breadcrumbs';
 import type {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import useProjects from 'sentry/utils/useProjects';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 type Props = {
   crumbs: Crumb[] | undefined;
@@ -20,24 +19,24 @@ type Props = {
 };
 
 function EventMetaData({crumbs, duration, event}: Props) {
-  const {
-    params: {eventSlug},
-  } = useRouteContext();
   const {projects} = useProjects();
   const errors = crumbs?.filter(crumb => crumb.type === 'error').length;
 
-  const project = eventSlug.split(':')[0] || '';
-
   return (
     <KeyMetrics>
-      <ProjectBadge
-        project={
-          projects.find(p => p.slug === project) || {
-            slug: event?.projectSlug || '',
+      {event ? (
+        <ProjectBadge
+          project={
+            projects.find(p => p.id === event.projectID) || {
+              slug: event.projectSlug || '',
+            }
           }
-        }
-        avatarSize={16}
-      />
+          avatarSize={16}
+        />
+      ) : (
+        <HeaderPlaceholder />
+      )}
+
       <KeyMetricData>
         {event ? (
           <React.Fragment>

--- a/static/app/views/replays/detail/eventMetaData.tsx
+++ b/static/app/views/replays/detail/eventMetaData.tsx
@@ -11,6 +11,7 @@ import type {Crumb} from 'sentry/types/breadcrumbs';
 import type {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import useProjects from 'sentry/utils/useProjects';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 type Props = {
   crumbs: Crumb[] | undefined;
@@ -19,14 +20,19 @@ type Props = {
 };
 
 function EventMetaData({crumbs, duration, event}: Props) {
+  const {
+    params: {eventSlug},
+  } = useRouteContext();
   const {projects} = useProjects();
   const errors = crumbs?.filter(crumb => crumb.type === 'error').length;
+
+  const project = eventSlug.split(':')[0] || '';
 
   return (
     <KeyMetrics>
       <ProjectBadge
         project={
-          projects.find(p => p.id === event?.projectID) || {
+          projects.find(p => p.slug === project) || {
             slug: event?.projectSlug || '',
           }
         }

--- a/static/app/views/replays/detail/eventMetaData.tsx
+++ b/static/app/views/replays/detail/eventMetaData.tsx
@@ -5,12 +5,12 @@ import Duration from 'sentry/components/duration';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Placeholder from 'sentry/components/placeholder';
 import TimeSince from 'sentry/components/timeSince';
-import {PlatformKey} from 'sentry/data/platformCategories';
 import {IconCalendar, IconClock, IconFire} from 'sentry/icons';
 import space from 'sentry/styles/space';
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import type {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
+import useProjects from 'sentry/utils/useProjects';
 
 type Props = {
   crumbs: Crumb[] | undefined;
@@ -19,16 +19,17 @@ type Props = {
 };
 
 function EventMetaData({crumbs, duration, event}: Props) {
+  const {projects} = useProjects();
   const errors = crumbs?.filter(crumb => crumb.type === 'error').length;
 
   return (
     <KeyMetrics>
       <ProjectBadge
-        project={{
-          slug: event?.projectSlug || '',
-          id: event?.projectID,
-          platform: event?.platform as PlatformKey,
-        }}
+        project={
+          projects.find(p => p.id === event?.projectID) || {
+            slug: event?.projectSlug || '',
+          }
+        }
         avatarSize={16}
       />
       <KeyMetricData>
@@ -73,10 +74,10 @@ function msToSec(ms: number) {
   return ms / 1000;
 }
 
-const HeaderPlaceholder = styled(function HeaderPlaceholder(
+export const HeaderPlaceholder = styled(function HeaderPlaceholder(
   props: React.ComponentProps<typeof Placeholder>
 ) {
-  return <Placeholder width="100%" height="19px" {...props} />;
+  return <Placeholder width="80px" height="19px" {...props} />;
 })`
   background-color: ${p => p.theme.background};
 `;
@@ -97,6 +98,7 @@ const KeyMetricData = styled('div')`
   grid-template-columns: repeat(2, max-content);
   align-items: center;
   gap: ${space(1)};
+  line-height: ${p => p.theme.text.lineHeightBody};
 `;
 
 export default EventMetaData;

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -10,7 +10,7 @@ import type {Crumb} from 'sentry/types/breadcrumbs';
 import type {EventTransaction} from 'sentry/types/event';
 import getUrlPathname from 'sentry/utils/getUrlPathname';
 
-import EventMetaData from './eventMetaData';
+import EventMetaData, {HeaderPlaceholder} from './eventMetaData';
 
 type Props = {
   children: ReactNode;
@@ -34,7 +34,7 @@ function Page({children, crumbs, duration, event, orgId}: Props) {
       <ButtonActionsWrapper>
         <FeatureFeedback featureName="replay" buttonProps={{size: 'sm'}} />
       </ButtonActionsWrapper>
-      <SubHeading>{pathname}</SubHeading>
+      <SubHeading>{pathname || <HeaderPlaceholder />}</SubHeading>
       <MetaDataColumn>
         <EventMetaData crumbs={crumbs} duration={duration} event={event} />
       </MetaDataColumn>
@@ -53,7 +53,7 @@ function Page({children, crumbs, duration, event, orgId}: Props) {
 
 const Header = styled(Layout.Header)`
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    padding-bottom: ${space(1.5)};
+    padding: ${space(2)} ${space(2)} ${space(1.5)} ${space(2)};
   }
 `;
 


### PR DESCRIPTION
Fix styles and project badge icon using the hook `useProjects()` in order to get the correct data for `<ProjectBadge>`. 

Closes #36771 
Closes #36772
Closes #36110

![image](https://user-images.githubusercontent.com/39612839/180496168-884be106-299f-4f74-af58-d8a1f43e54b1.png)

<img width="1002" alt="Screen Shot 2022-07-25 at 2 27 28 PM" src="https://user-images.githubusercontent.com/187460/180877007-a8e046f5-d38f-42d0-9e0e-9d139fc1fba5.png">




<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
