### PR TITLE
fix(slack): Fix broken url formatting

### DIFF
--- a/src/sentry/notifications/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/notifications/activity/new_processing_issues.py
@@ -58,7 +58,7 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
         project_url = absolute_uri(
             f"/settings/{self.organization.slug}/projects/{self.project.slug}/processing-issues/"
         )
-        return f"Processing issues on <{self.project.slug}|{project_url}"
+        return f"Processing issues on <{project_url}|{self.project.slug}>"
 
     def build_attachment_title(self, recipient: Team | User) -> str:
         return self.get_subject()

--- a/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
+++ b/tests/sentry/integrations/slack/notifications/test_new_processing_issues.py
@@ -35,7 +35,7 @@ class SlackNewProcessingIssuesNotificationTest(SlackActivityNotificationTest):
         attachment, text = get_attachment()
         assert (
             text
-            == f"Processing issues on <{self.project.slug}|http://testserver/settings/{self.organization.slug}/projects/{self.project.slug}/processing-issues/"
+            == f"Processing issues on <http://testserver/settings/{self.organization.slug}/projects/{self.project.slug}/processing-issues/|{self.project.slug}>"
         )
         assert (
             attachment["text"]


### PR DESCRIPTION
Fixed the URL format, it should be `<url|text>`.