### PR TITLE
feat(smartSearch): Update autocomplete with each word

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -864,22 +864,32 @@ class SmartSearchBar extends Component<Props, State> {
       return null;
     }
 
+    const LIMITER_CHARS = [' ', ':'];
+
     const innerStart = cursorPosition - cursorToken.location.start.offset;
 
     let tokenStart = innerStart;
-    while (tokenStart > 0 && cursorToken.text[tokenStart - 1] !== ' ') {
+    while (tokenStart > 0 && !LIMITER_CHARS.includes(cursorToken.text[tokenStart - 1])) {
       tokenStart--;
     }
     let tokenEnd = innerStart;
-    while (tokenEnd < cursorToken.text.length && cursorToken.text[tokenEnd] !== ' ') {
+    while (
+      tokenEnd < cursorToken.text.length &&
+      !LIMITER_CHARS.includes(cursorToken.text[tokenEnd])
+    ) {
       tokenEnd++;
     }
 
-    const term = cursorToken.text.slice(tokenStart, tokenEnd);
+    let searchTerm = cursorToken.text.slice(tokenStart, tokenEnd);
+
+    if (searchTerm.startsWith(NEGATION_OPERATOR)) {
+      tokenStart++;
+    }
+    searchTerm = searchTerm.replace(new RegExp(`^${NEGATION_OPERATOR}`), '');
 
     return {
       end: cursorToken.location.start.offset + tokenEnd,
-      searchTerm: term.replace(new RegExp(`^${NEGATION_OPERATOR}`), ''),
+      searchTerm,
       start: cursorToken.location.start.offset + tokenStart,
     };
   }

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1254,7 +1254,13 @@ class SmartSearchBar extends Component<Props, State> {
         }
 
         if (cursor === this.cursorPosition) {
-          this.setState({searchTerm: tagName, searchTermLocation: null});
+          this.setState({
+            searchTerm: tagName,
+            searchTermLocation: {
+              start: cursorToken.key.location.start.offset,
+              end: cursorToken.key.location.end.offset,
+            },
+          });
           this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
         }
         return;

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -855,6 +855,102 @@ describe('SmartSearchBar', function () {
         'nested.child2'
       );
     });
+
+    it('selects the correct free text word', async function () {
+      jest.useRealTimers();
+
+      const props = {
+        query: '',
+        organization,
+        location,
+        supportedTags,
+      };
+      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = smartSearchBar.instance();
+      const textarea = smartSearchBar.find('textarea');
+
+      textarea.simulate('focus');
+      mockCursorPosition(searchBar, 6);
+      textarea.simulate('change', {target: {value: 'typ testest    err'}});
+      await tick();
+
+      // Expect the correct search term to be selected
+      expect(searchBar.state.searchTerm).toEqual('testest');
+      expect(searchBar.state.searchTermLocation.start).toBe(4);
+      expect(searchBar.state.searchTermLocation.end).toBe(11);
+    });
+
+    it('selects the correct free text word (last word)', async function () {
+      jest.useRealTimers();
+
+      const props = {
+        query: '',
+        organization,
+        location,
+        supportedTags,
+      };
+      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = smartSearchBar.instance();
+      const textarea = smartSearchBar.find('textarea');
+
+      textarea.simulate('focus');
+      mockCursorPosition(searchBar, 15);
+      textarea.simulate('change', {target: {value: 'typ testest    err'}});
+      await tick();
+
+      // Expect the correct search term to be selected
+      expect(searchBar.state.searchTerm).toEqual('err');
+      expect(searchBar.state.searchTermLocation.start).toBe(15);
+      expect(searchBar.state.searchTermLocation.end).toBe(18);
+    });
+
+    it('selects the correct free text word (first word)', async function () {
+      jest.useRealTimers();
+
+      const props = {
+        query: '',
+        organization,
+        location,
+        supportedTags,
+      };
+      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = smartSearchBar.instance();
+      const textarea = smartSearchBar.find('textarea');
+
+      textarea.simulate('focus');
+      mockCursorPosition(searchBar, 1);
+      textarea.simulate('change', {target: {value: 'typ testest    err'}});
+      await tick();
+
+      // Expect the correct search term to be selected
+      expect(searchBar.state.searchTerm).toEqual('typ');
+      expect(searchBar.state.searchTermLocation.start).toBe(0);
+      expect(searchBar.state.searchTermLocation.end).toBe(3);
+    });
+
+    it('search term location correctly selects key of filter tokens', async function () {
+      jest.useRealTimers();
+
+      const props = {
+        query: '',
+        organization,
+        location,
+        supportedTags,
+      };
+      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = smartSearchBar.instance();
+      const textarea = smartSearchBar.find('textarea');
+
+      textarea.simulate('focus');
+      mockCursorPosition(searchBar, 6);
+      textarea.simulate('change', {target: {value: 'typ device:123'}});
+      await tick();
+
+      // Expect the correct search term to be selected
+      expect(searchBar.state.searchTerm).toEqual('device');
+      expect(searchBar.state.searchTermLocation.start).toBe(4);
+      expect(searchBar.state.searchTermLocation.end).toBe(10);
+    });
   });
 
   describe('onAutoComplete()', function () {
@@ -916,7 +1012,8 @@ describe('SmartSearchBar', function () {
       );
     });
 
-    it('keeps the negation operator is present', function () {
+    it('keeps the negation operator present', async function () {
+      jest.useRealTimers();
       const props = {
         query: '',
         organization,
@@ -927,8 +1024,14 @@ describe('SmartSearchBar', function () {
       const searchBar = smartSearchBar.instance();
       const textarea = smartSearchBar.find('textarea');
       // start typing part of the tag prefixed by the negation operator!
+      textarea.simulate('focus');
       textarea.simulate('change', {target: {value: 'event.type:error !ti'}});
       mockCursorPosition(searchBar, 20);
+      await tick();
+      // Expect the correct search term to be selected
+      expect(searchBar.state.searchTerm).toEqual('ti');
+      expect(searchBar.state.searchTermLocation.start).toBe(18);
+      expect(searchBar.state.searchTermLocation.end).toBe(20);
       // use autocompletion to do the rest
       searchBar.onAutoComplete('title:', {});
       expect(searchBar.state.query).toEqual('event.type:error !title:');
@@ -1137,6 +1240,32 @@ describe('SmartSearchBar', function () {
           'is:unresolved sdk.name:sentry-cocoa has:key '
         );
       }
+    });
+
+    it('replaces the correct word', async function () {
+      const props = {
+        query: '',
+        organization,
+        location,
+        supportedTags,
+      };
+      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = smartSearchBar.instance();
+      const textarea = smartSearchBar.find('textarea');
+
+      textarea.simulate('focus');
+      mockCursorPosition(searchBar, 4);
+      textarea.simulate('change', {target: {value: 'typ ti err'}});
+
+      await tick();
+
+      // Expect the correct search term to be selected
+      expect(searchBar.state.searchTerm).toEqual('ti');
+      expect(searchBar.state.searchTermLocation.start).toBe(4);
+      expect(searchBar.state.searchTermLocation.end).toBe(6);
+      // use autocompletion to do the rest
+      searchBar.onAutoComplete('title:', {});
+      expect(searchBar.state.query).toEqual('typ title: err');
     });
   });
 

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -855,7 +855,9 @@ describe('SmartSearchBar', function () {
         'nested.child2'
       );
     });
+  });
 
+  describe('cursorSearchTerm', function () {
     it('selects the correct free text word', async function () {
       jest.useRealTimers();
 
@@ -875,9 +877,10 @@ describe('SmartSearchBar', function () {
       await tick();
 
       // Expect the correct search term to be selected
-      expect(searchBar.state.searchTerm).toEqual('testest');
-      expect(searchBar.state.searchTermLocation.start).toBe(4);
-      expect(searchBar.state.searchTermLocation.end).toBe(11);
+      const cursorSearchTerm = searchBar.cursorSearchTerm;
+      expect(cursorSearchTerm.searchTerm).toEqual('testest');
+      expect(cursorSearchTerm.start).toBe(4);
+      expect(cursorSearchTerm.end).toBe(11);
     });
 
     it('selects the correct free text word (last word)', async function () {
@@ -899,9 +902,10 @@ describe('SmartSearchBar', function () {
       await tick();
 
       // Expect the correct search term to be selected
-      expect(searchBar.state.searchTerm).toEqual('err');
-      expect(searchBar.state.searchTermLocation.start).toBe(15);
-      expect(searchBar.state.searchTermLocation.end).toBe(18);
+      const cursorSearchTerm = searchBar.cursorSearchTerm;
+      expect(cursorSearchTerm.searchTerm).toEqual('err');
+      expect(cursorSearchTerm.start).toBe(15);
+      expect(cursorSearchTerm.end).toBe(18);
     });
 
     it('selects the correct free text word (first word)', async function () {
@@ -923,12 +927,13 @@ describe('SmartSearchBar', function () {
       await tick();
 
       // Expect the correct search term to be selected
-      expect(searchBar.state.searchTerm).toEqual('typ');
-      expect(searchBar.state.searchTermLocation.start).toBe(0);
-      expect(searchBar.state.searchTermLocation.end).toBe(3);
+      const cursorSearchTerm = searchBar.cursorSearchTerm;
+      expect(cursorSearchTerm.searchTerm).toEqual('typ');
+      expect(cursorSearchTerm.start).toBe(0);
+      expect(cursorSearchTerm.end).toBe(3);
     });
 
-    it('search term location correctly selects key of filter tokens', async function () {
+    it('search term location correctly selects key of filter token', async function () {
       jest.useRealTimers();
 
       const props = {
@@ -947,9 +952,35 @@ describe('SmartSearchBar', function () {
       await tick();
 
       // Expect the correct search term to be selected
-      expect(searchBar.state.searchTerm).toEqual('device');
-      expect(searchBar.state.searchTermLocation.start).toBe(4);
-      expect(searchBar.state.searchTermLocation.end).toBe(10);
+      const cursorSearchTerm = searchBar.cursorSearchTerm;
+      expect(cursorSearchTerm.searchTerm).toEqual('device');
+      expect(cursorSearchTerm.start).toBe(4);
+      expect(cursorSearchTerm.end).toBe(10);
+    });
+
+    it('search term location correctly selects value of filter token', async function () {
+      jest.useRealTimers();
+
+      const props = {
+        query: '',
+        organization,
+        location,
+        supportedTags,
+      };
+      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
+      const searchBar = smartSearchBar.instance();
+      const textarea = smartSearchBar.find('textarea');
+
+      textarea.simulate('focus');
+      mockCursorPosition(searchBar, 11);
+      textarea.simulate('change', {target: {value: 'typ device:123'}});
+      await tick();
+
+      // Expect the correct search term to be selected
+      const cursorSearchTerm = searchBar.cursorSearchTerm;
+      expect(cursorSearchTerm.searchTerm).toEqual('123');
+      expect(cursorSearchTerm.start).toBe(11);
+      expect(cursorSearchTerm.end).toBe(14);
     });
   });
 
@@ -1029,9 +1060,10 @@ describe('SmartSearchBar', function () {
       mockCursorPosition(searchBar, 20);
       await tick();
       // Expect the correct search term to be selected
-      expect(searchBar.state.searchTerm).toEqual('ti');
-      expect(searchBar.state.searchTermLocation.start).toBe(18);
-      expect(searchBar.state.searchTermLocation.end).toBe(20);
+      const cursorSearchTerm = searchBar.cursorSearchTerm;
+      expect(cursorSearchTerm.searchTerm).toEqual('ti');
+      expect(cursorSearchTerm.start).toBe(18);
+      expect(cursorSearchTerm.end).toBe(20);
       // use autocompletion to do the rest
       searchBar.onAutoComplete('title:', {});
       expect(searchBar.state.query).toEqual('event.type:error !title:');
@@ -1260,9 +1292,10 @@ describe('SmartSearchBar', function () {
       await tick();
 
       // Expect the correct search term to be selected
-      expect(searchBar.state.searchTerm).toEqual('ti');
-      expect(searchBar.state.searchTermLocation.start).toBe(4);
-      expect(searchBar.state.searchTermLocation.end).toBe(6);
+      const cursorSearchTerm = searchBar.cursorSearchTerm;
+      expect(cursorSearchTerm.searchTerm).toEqual('ti');
+      expect(cursorSearchTerm.start).toBe(4);
+      expect(cursorSearchTerm.end).toBe(6);
       // use autocompletion to do the rest
       searchBar.onAutoComplete('title:', {});
       expect(searchBar.state.query).toEqual('typ title: err');


### PR DESCRIPTION
When moving the cursor position, update the autocomplete to use the curently selected word

Also replace only the currently selected word this fixes the issue where free text in front is ignored

Before:
https://user-images.githubusercontent.com/30991498/180571043-6c95eef4-a262-4792-85eb-593916fe112d.mov


After:
https://user-images.githubusercontent.com/30991498/180564238-c9befa5b-65f2-43b1-b772-3cea04671538.mov




