### PR TITLE
fix(mep): Fix message error for metrics backed data

### DIFF
--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -42,6 +42,9 @@ function SearchBar(props: SearchBarProps) {
 
   const getSuggestedTransactions = debounce(
     async query => {
+      if (query.length === 0) {
+        onSearch('');
+      }
       if (query.length < 3) {
         setSearchResults([]);
         return;
@@ -110,7 +113,7 @@ function SearchBar(props: SearchBarProps) {
     const transactionName = query.slice(0, lastIndex);
     setSearchResults([]);
     setSearchString(transactionName);
-    onSearch(transactionName);
+    onSearch(`transaction:${transactionName}`);
   };
 
   const navigateToTransactionSummary = (name: string) => {

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -31,7 +31,6 @@ import {
   PageErrorAlert,
   PageErrorProvider,
 } from 'sentry/utils/performance/contexts/pageError';
-import {decodeScalar} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useTeams from 'sentry/utils/useTeams';
 
@@ -115,7 +114,11 @@ export function PerformanceLanding(props: Props) {
 
   const getFreeTextFromQuery = (query: string) => {
     const conditions = new MutableSearch(query);
-    return decodeScalar(conditions.freeText, '');
+    const transactionValues = conditions.getFilterValues('transaction');
+    if (transactionValues.length) {
+      return transactionValues[0];
+    }
+    return '';
   };
 
   const derivedQuery = getTransactionSearchQuery(location, eventView.query);


### PR DESCRIPTION
### Summary
We were using free text, but since we're not searching anymore we should just explicitly use the clicked transaction name, this also lets us populate it when navigating back here from sharing a link. This isn't amazing, but just trying to clean this up enough to turn on for internal.