### PR TITLE
bug(replays): Fix resizing the video player area

### DIFF
--- a/static/app/components/events/eventReplay.tsx
+++ b/static/app/components/events/eventReplay.tsx
@@ -22,7 +22,7 @@ export default function EventReplay({replayId, orgSlug, projectSlug}: Props) {
     orgId: orgSlug,
   });
 
-  const {ref: fullscreenRef, isFullscreen, toggle: toggleFullscreen} = useFullscreen();
+  const {ref: fullscreenRef, toggle: toggleFullscreen} = useFullscreen();
 
   return (
     <EventDataSection type="replay" title={t('Replay')}>
@@ -35,12 +35,7 @@ export default function EventReplay({replayId, orgSlug, projectSlug}: Props) {
           {fetching ? (
             <Placeholder height="350px" width="100%" />
           ) : (
-            replay && (
-              <ReplayView
-                toggleFullscreen={toggleFullscreen}
-                isFullscreen={isFullscreen}
-              />
-            )
+            <ReplayView toggleFullscreen={toggleFullscreen} />
           )}
         </PlayerContainer>
       </ReplayContextProvider>
@@ -51,4 +46,12 @@ export default function EventReplay({replayId, orgSlug, projectSlug}: Props) {
 const PlayerContainer = styled('div')`
   max-width: 420px;
   margin-top: ${space(2)};
+
+  background: ${p => p.theme.background};
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  flex-grow: 1;
+  overflow: hidden;
+  gap: ${space(1)};
 `;

--- a/static/app/components/events/eventReplay.tsx
+++ b/static/app/components/events/eventReplay.tsx
@@ -9,6 +9,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import useFullscreen from 'sentry/utils/replays/hooks/useFullscreen';
 import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
+import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
 type Props = {
   orgSlug: string;
@@ -43,15 +44,10 @@ export default function EventReplay({replayId, orgSlug, projectSlug}: Props) {
   );
 }
 
-const PlayerContainer = styled('div')`
+const PlayerContainer = styled(FluidHeight)`
   max-width: 420px;
   margin-top: ${space(2)};
 
   background: ${p => p.theme.background};
-  display: flex;
-  flex-direction: column;
-  flex-wrap: nowrap;
-  flex-grow: 1;
-  overflow: hidden;
   gap: ${space(1)};
 `;

--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -125,6 +125,10 @@ export const PlayerScrubber = styled(Scrubber)`
     height: ${space(1)};
   }
 
+  ${Meter} {
+    border-radius: ${p => p.theme.borderRadiusBottom};
+  }
+
   ${RangeWrapper} {
     height: ${space(0.5)};
   }
@@ -134,7 +138,7 @@ export const PlayerScrubber = styled(Scrubber)`
 
   ${PlaybackTimeValue} {
     background: ${p => p.theme.purple200};
-    border-bottom-left-radius: 3px;
+    border-bottom-left-radius: ${p => p.theme.borderRadius};
   }
 
   /**

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -80,14 +80,13 @@ function BasePlayerRoot({className}: Props) {
 // Center the viewEl inside the windowEl.
 // This is useful when the window is inside a container that has large fixed
 // dimensions, like when in fullscreen mode.
-// If the container has a dimensions that can grow/shrink then it could be
+// If the container has a dimensions that can grow/shrink then it is
 // important to also set `overflow: hidden` on the container, so that the
 // SizingWindow can calculate size as things shrink.
 const SizingWindow = styled('div')`
   width: 100%;
-  height: 100%;
-
   display: flex;
+  flex-grow: 1;
   justify-content: center;
   align-items: center;
   position: relative;

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -7,6 +7,7 @@ import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import space from 'sentry/styles/space';
+import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
 type Props = {
   toggleFullscreen: () => void;
@@ -29,29 +30,17 @@ function ReplayView({toggleFullscreen}: Props) {
   );
 }
 
-const PlayerContainer = styled('div')`
-  display: flex;
-  flex-direction: column;
-  flex-wrap: nowrap;
-  flex-grow: 1;
-  overflow: hidden;
-
+const PlayerContainer = styled(FluidHeight)`
   padding-bottom: ${space(1)};
   margin-bottom: -${space(1)};
 `;
 
-const Panel = styled('div')`
+const Panel = styled(FluidHeight)`
   background: ${p => p.theme.background};
   border-radius: ${p => p.theme.borderRadiusTop};
   border: 1px solid ${p => p.theme.border};
   border-bottom: none;
   box-shadow: ${p => p.theme.dropShadowLight};
-
-  display: flex;
-  flex-direction: column;
-  flex-wrap: nowrap;
-  flex-grow: 1;
-  overflow: hidden;
 `;
 
 export default ReplayView;

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Panel, PanelBody, PanelHeader as _PanelHeader} from 'sentry/components/panels';
 import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
 import ScrubberMouseTracking from 'sentry/components/replays/player/scrubberMouseTracking';
 import ReplayController from 'sentry/components/replays/replayController';
@@ -10,54 +9,48 @@ import ReplayPlayer from 'sentry/components/replays/replayPlayer';
 import space from 'sentry/styles/space';
 
 type Props = {
-  isFullscreen: boolean;
   toggleFullscreen: () => void;
 };
 
-function ReplayView({isFullscreen, toggleFullscreen}: Props) {
+function ReplayView({toggleFullscreen}: Props) {
   return (
     <Fragment>
       <ReplayCurrentUrl />
-      <PanelNoMargin isFullscreen={isFullscreen}>
-        <PanelHeader disablePadding noBorder>
+      <PlayerContainer>
+        <Panel>
           <ReplayPlayer />
-        </PanelHeader>
+        </Panel>
         <ScrubberMouseTracking>
           <PlayerScrubber />
         </ScrubberMouseTracking>
-      </PanelNoMargin>
-      <ReplayControllerWrapper>
-        <ReplayController toggleFullscreen={toggleFullscreen} />
-      </ReplayControllerWrapper>
+      </PlayerContainer>
+      <ReplayController toggleFullscreen={toggleFullscreen} />
     </Fragment>
   );
 }
 
-const ReplayControllerWrapper = styled(PanelBody)`
-  padding-top: ${space(1)};
+const PlayerContainer = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  flex-grow: 1;
+  overflow: hidden;
+
+  padding-bottom: ${space(1)};
+  margin-bottom: -${space(1)};
 `;
 
-const PanelNoMargin = styled(Panel)<{isFullscreen: boolean}>`
-  margin-top: ${space(1)};
-  margin-bottom: 0;
-  height: 100%;
-  display: grid;
-  grid-template-rows: 1fr auto;
-`;
+const Panel = styled('div')`
+  background: ${p => p.theme.background};
+  border-radius: ${p => p.theme.borderRadiusTop};
+  border: 1px solid ${p => p.theme.border};
+  border-bottom: none;
+  box-shadow: ${p => p.theme.dropShadowLight};
 
-const PanelHeader = styled(_PanelHeader)<{noBorder?: boolean}>`
-  display: block;
-  padding: 0;
-  ${p => (p.noBorder ? 'border-bottom: none;' : '')}
-
-  /*
-  This style ensures that this PanelHeader grows and shrinks based on it's
-  parent, not the content inside.
-
-  The content inside will be set to height: 100% and then there's some code in
-  there to measure the size in pixels. If this was normal overflow then measured
-  size would never shrink.
-  */
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  flex-grow: 1;
   overflow: hidden;
 `;
 

--- a/static/app/views/replays/detail/layout/fluidHeight.tsx
+++ b/static/app/views/replays/detail/layout/fluidHeight.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+const FluidHeight = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  flex-grow: 1;
+  overflow: hidden;
+`;
+
+export default FluidHeight;

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -10,6 +10,7 @@ import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import FocusArea from 'sentry/views/replays/detail/focusArea';
 import FocusTabs from 'sentry/views/replays/detail/focusTabs';
+import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import FluidPanel from 'sentry/views/replays/detail/layout/fluidPanel';
 import SplitPanel from 'sentry/views/replays/detail/layout/splitPanel';
 import SideTabs from 'sentry/views/replays/detail/sideTabs';
@@ -219,15 +220,10 @@ const BodyContent = styled('main')`
   padding: ${space(2)};
 `;
 
-const VideoSection = styled('section')`
+const VideoSection = styled(FluidHeight)`
   height: 100%;
 
   background: ${p => p.theme.background};
-  display: flex;
-  flex-direction: column;
-  flex-wrap: nowrap;
-  flex-grow: 1;
-  overflow: hidden;
   gap: ${space(1)};
 `;
 

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -75,7 +75,7 @@ function ReplayLayout({
   showTimeline = true,
   showVideo = true,
 }: Props) {
-  const {ref: fullscreenRef, isFullscreen, toggle: toggleFullscreen} = useFullscreen();
+  const {ref: fullscreenRef, toggle: toggleFullscreen} = useFullscreen();
 
   const timeline = showTimeline ? (
     <ErrorBoundary mini>
@@ -86,7 +86,7 @@ function ReplayLayout({
   const video = showVideo ? (
     <VideoSection ref={fullscreenRef}>
       <ErrorBoundary mini>
-        <ReplayView toggleFullscreen={toggleFullscreen} isFullscreen={isFullscreen} />
+        <ReplayView toggleFullscreen={toggleFullscreen} />
       </ErrorBoundary>
     </VideoSection>
   ) : null;
@@ -219,12 +219,16 @@ const BodyContent = styled('main')`
   padding: ${space(2)};
 `;
 
-export const VideoSection = styled('section')`
+const VideoSection = styled('section')`
   height: 100%;
+
+  background: ${p => p.theme.background};
   display: flex;
-  flex-grow: 1;
-  flex-wrap: nowrap;
   flex-direction: column;
+  flex-wrap: nowrap;
+  flex-grow: 1;
+  overflow: hidden;
+  gap: ${space(1)};
 `;
 
 export default ReplayLayout;


### PR DESCRIPTION
This fixes an issue where the video area can be cutoff by the resize handler

**Before:**
<img width="595" alt="Screen Shot 2022-07-22 at 1 49 14 PM" src="https://user-images.githubusercontent.com/187460/180566339-d5611d19-73e0-4fef-8fef-3510db099f14.png">

What was happening is that that area is composed of 3 parts top to bottom: url bar + video + play/pause controls.

The area was sized with flexbox, so it didn't have an explicit height. The inner bits of the video did use `height: 100%` however, so when resizing the make things smaller the video stay equal to the height of the overall area. It would then shrink after the height of the url bar + play/pause controls was hidden.

TL/DR: use flexbox for all inner elements. `flex-direction: column; flex-grow: 1;` achieves the same as `height: 100%;` in there.

Other Changes
1. Quick thing that's caused a lot of lines to be changed: `isFullscreen` wasn't needed by anything anymore. So that prop is removed from a bunch of layers.
2. Fixed the background color when in fullscreen mode, this bug was copy+pasted into `eventReplay.tsx` too.
3. Tested the player that appears on the Event Details page, and it still looks proper.
Issues:
1. The Scrubber isn't inside a `<Panel>` anymore. So there's no border around it. It functions as the bottom-border for the player area which I think is kind of neat. The reason for this is that the `overflow:hidden` was cutting off the bottom of the circular nub, so i had to +padding -margin shift to make space.
3. Open issue: The scrubber nub is cutoff on the left+right edge. This is because of the `overflow:hidden` we need everywhere in order to force containers to shrink their content.
It looks like this, I don't think it's the end of the world. There are ways to fix it, like rendering that elem (much much) higher up in the dom.
<img width="158" alt="Screen Shot 2022-07-22 at 1 55 17 PM" src="https://user-images.githubusercontent.com/187460/180567338-e92b4fbf-2e43-44c4-877d-268487777c53.png">


Fixes #36778 
Fixes #36780