### PR TITLE
feat(repays): Add a dropdown so we can toggle between layouts

### DIFF
--- a/static/app/views/replays/detail/layout/chooseLayout.tsx
+++ b/static/app/views/replays/detail/layout/chooseLayout.tsx
@@ -21,26 +21,31 @@ type Props = {};
 function ChooseLayout({}: Props) {
   const {getParamValue, setParamValue} = useUrlParam('l_page', 'topbar');
   return (
-    <DropdownControl
-      label={getLayoutIcon(getParamValue())}
-      buttonProps={{size: 'sm'}}
-      alwaysRenderMenu={false}
-      alignRight
-    >
-      {LAYOUT_NAMES.map(key => (
-        <DropdownItem
-          key={key}
-          href={`#${key}`}
-          onClick={() => {
-            setParamValue(key);
-          }}
-        >
-          <Icon>{getLayoutIcon(key)}</Icon>
-        </DropdownItem>
-      ))}
-    </DropdownControl>
+    <RelativeContainer>
+      <DropdownControl
+        label={getLayoutIcon(getParamValue())}
+        buttonProps={{size: 'sm'}}
+        alwaysRenderMenu={false}
+        alignRight
+      >
+        {LAYOUT_NAMES.map(key => (
+          <DropdownItem
+            key={key}
+            href={`#${key}`}
+            onClick={() => {
+              setParamValue(key);
+            }}
+          >
+            <Icon>{getLayoutIcon(key)}</Icon>
+          </DropdownItem>
+        ))}
+      </DropdownControl>
+    </RelativeContainer>
   );
 }
+const RelativeContainer = styled('div')`
+  position: relative;
+`;
 
 const Icon = styled('div')`
   text-align: center;

--- a/static/app/views/replays/detail/layout/chooseLayout.tsx
+++ b/static/app/views/replays/detail/layout/chooseLayout.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+
+import DropdownControl, {DropdownItem} from 'sentry/components/dropdownControl';
+import {IconPanel} from 'sentry/icons';
+import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
+
+const LAYOUT_NAMES = ['topbar', 'sidebar_left', 'sidebar_right'];
+
+function getLayoutIcon(layout: string) {
+  const layoutToDir = {
+    sidebar_right: 'right',
+    sidebar_left: 'left',
+    topbar: 'up',
+  };
+  const dir = layout in layoutToDir ? layoutToDir[layout] : 'up';
+  return <IconPanel color="gray500" size="sm" direction={dir} />;
+}
+
+type Props = {};
+
+function ChooseLayout({}: Props) {
+  const {getParamValue, setParamValue} = useUrlParam('l_page', 'topbar');
+  return (
+    <DropdownControl
+      label={getLayoutIcon(getParamValue())}
+      buttonProps={{size: 'sm'}}
+      alwaysRenderMenu={false}
+      alignRight
+    >
+      {LAYOUT_NAMES.map(key => (
+        <DropdownItem
+          key={key}
+          href={`#${key}`}
+          onClick={() => {
+            setParamValue(key);
+          }}
+        >
+          <Icon>{getLayoutIcon(key)}</Icon>
+        </DropdownItem>
+      ))}
+    </DropdownControl>
+  );
+}
+
+const Icon = styled('div')`
+  text-align: center;
+`;
+
+export default ChooseLayout;

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -9,6 +9,7 @@ import space from 'sentry/styles/space';
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import type {EventTransaction} from 'sentry/types/event';
 import getUrlPathname from 'sentry/utils/getUrlPathname';
+import ChooseLayout from 'sentry/views/replays/detail/layout/chooseLayout';
 
 import EventMetaData from './eventMetaData';
 
@@ -33,6 +34,7 @@ function Page({children, crumbs, duration, event, orgId}: Props) {
       </HeaderContent>
       <ButtonActionsWrapper>
         <FeatureFeedback featureName="replay" buttonProps={{size: 'sm'}} />
+        <ChooseLayout />
       </ButtonActionsWrapper>
       <SubHeading>{pathname}</SubHeading>
       <MetaDataColumn>
@@ -66,6 +68,7 @@ const ButtonActionsWrapper = styled(Layout.HeaderActions)`
   display: grid;
   grid-template-columns: repeat(2, max-content);
   justify-content: flex-end;
+  gap: ${space(2)};
 `;
 
 const SubHeading = styled('div')`


### PR DESCRIPTION
Just a quick toggle to move between the different layouts. 

I want people to try the different ones, and maybe then we can pick the winner.

<img width="218" alt="Screen Shot 2022-07-25 at 11 33 12 AM" src="https://user-images.githubusercontent.com/187460/180850276-4c234c3f-1865-47dc-b379-f78ff955d2ca.png">

