### PR TITLE
feat(active-release): separate out active release notification away from issue alerts

### DIFF
--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -1,7 +1,6 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.rules import rules
 
@@ -20,19 +19,12 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
 
             return context
 
-        has_active_release_condition = features.has(
-            "organizations:alert-release-notification-workflow", organization
-        )
-
         return Response(
             [
                 info_extractor(rule_cls)
                 for rule_type, rule_cls in rules
                 if rule_type.startswith("condition/")
-                and (
-                    has_active_release_condition
-                    or rule_cls.id
-                    != "sentry.rules.conditions.active_release.ActiveReleaseEventCondition"
-                )
+                and rule_cls.id
+                != "sentry.rules.conditions.active_release.ActiveReleaseEventCondition"
             ]
         )

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -21,9 +21,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         can_create_tickets = features.has(
             "organizations:integrations-ticket-rules", project.organization
         )
-        org_release_notifications = features.has(
-            "organizations:alert-release-notification-workflow", project.organization
-        )
 
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
@@ -64,8 +61,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
 
             if rule_type.startswith("condition/"):
                 if (
-                    org_release_notifications
-                    or context["id"]
+                    context["id"]
                     != "sentry.rules.conditions.active_release.ActiveReleaseEventCondition"
                 ):
                     condition_list.append(context)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1160,6 +1160,8 @@ SENTRY_FEATURES = {
     "organizations:team-insights": True,
     # Enable setting team-level roles and receiving permissions from them
     "organizations:team-roles": False,
+    # Enable sending Active release notifications without creating an explicit rule in DB
+    "projects:active-release-monitor-default-on": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -949,8 +949,6 @@ SENTRY_FEATURES = {
     "organizations:advanced-search": True,
     # Use metrics as the dataset for crash free metric alerts
     "organizations:alert-crash-free-metrics": False,
-    # Workflow 2.0 notifications following a release
-    "organizations:alert-release-notification-workflow": False,
     # Alert wizard redesign version 3
     "organizations:alert-wizard-v3": True,
     "organizations:api-keys": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -61,7 +61,6 @@ default_manager.add("organizations:active-release-monitor-alpha", OrganizationFe
 default_manager.add("organizations:active-release-notification-opt-in", OrganizationFeature, True)
 default_manager.add("organizations:alert-filters", OrganizationFeature)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, True)
-default_manager.add("organizations:alert-release-notification-workflow", OrganizationFeature, True)
 default_manager.add("organizations:alert-wizard-v3", OrganizationFeature, True)
 default_manager.add("organizations:api-keys", OrganizationFeature)
 default_manager.add("organizations:breadcrumb-linked-event", OrganizationFeature, True)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -193,6 +193,7 @@ default_manager.add("organizations:sso-saml2", OrganizationFeature)
 default_manager.add("organizations:team-insights", OrganizationFeature)
 
 # Project scoped features
+default_manager.add("projects:active-release-monitor-default-on", ProjectFeature, True)
 default_manager.add("projects:alert-filters", ProjectFeature)
 default_manager.add("projects:custom-inbound-filters", ProjectFeature)
 default_manager.add("projects:data-forwarding", ProjectFeature)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -371,7 +371,7 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
 
         issue_title = build_attachment_title(obj)
         event_id = self.event.event_id if self.event else None
-        # TODO(workflow): Remove referrer experiement with flag "organizations:alert-release-notification-workflow"
+        # TODO(workflow): Remove referrer experiement with flag "organizations:active-release-monitor-alpha"
         title_url = self.group.get_absolute_url(
             params={"referrer": "alert_slack_release"}, event_id=event_id
         )

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -30,10 +30,7 @@ from sentry.models import (
     User,
 )
 from sentry.notifications.notifications.active_release import CommitData
-from sentry.notifications.notifications.base import (
-    BaseNotification,
-    ProjectNotification,
-)
+from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.actions import MessageAction
 from sentry.types.integrations import ExternalProviders

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -29,8 +29,12 @@ from sentry.models import (
     Team,
     User,
 )
-from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
-from sentry.notifications.notifications.rules import AlertRuleNotification, CommitData
+from sentry.notifications.notifications.active_release import CommitData
+from sentry.notifications.notifications.base import (
+    BaseNotification,
+    ProjectNotification,
+)
+from sentry.notifications.notifications.rules import AlertRuleNotification
 from sentry.notifications.utils.actions import MessageAction
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -41,7 +41,13 @@ class NotifyEmailAction(EventAction):
 
 
 class NotifyActiveReleaseEmailAction(NotifyEmailAction):
-    """Send an 'active_release' notification to all release committers when a new issue is seen."""
+    """Send an 'active_release' notification to all release committers when a new issue is seen.
+    This is a specialized form of `NotifyEmailAction` in that:
+        1. This action should never be configurable as a rule action by a user.
+        2. The `target_type` is pinned to `RELEASE_MEMBERS`
+        3. The callback invoked in `after()` does not make any use of the `RuleFuture`s since
+            this action is not rule-aware.
+    """
 
     id = "sentry.mail.actions.NotifyActiveReleaseEmailAction"
     form_cls = NotifyEmailForm

--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -41,7 +41,8 @@ class NotifyEmailAction(EventAction):
 
 
 class NotifyActiveReleaseEmailAction(NotifyEmailAction):
-    """Send an 'active_release' notification to all release committers when a new issue is seen.
+    """
+    Send an 'active_release' notification to all release committers when a new issue is seen.
     This is a specialized form of `NotifyEmailAction` in that:
         1. This action should never be configurable as a rule action by a user.
         2. The `target_type` is pinned to `RELEASE_MEMBERS`

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -7,7 +7,7 @@ from sentry.digests import Digest
 from sentry.digests import get_option_key as get_digest_option_key
 from sentry.digests.notifications import event_to_record, unsplit_key
 from sentry.models import NotificationSetting, Project, ProjectOption
-from sentry.notifications.notifications.active_release import ActiveReleaseAlertNotification
+from sentry.notifications.notifications.active_release import ActiveReleaseIssueNotification
 from sentry.notifications.notifications.activity import EMAIL_CLASSES_BY_TYPE
 from sentry.notifications.notifications.digest import DigestNotification
 from sentry.notifications.notifications.rules import AlertRuleNotification
@@ -125,7 +125,7 @@ class MailAdapter:
 
     @staticmethod
     def notify_active_release(notification):
-        ActiveReleaseAlertNotification(
+        ActiveReleaseIssueNotification(
             notification, target_type=ActionTargetType.RELEASE_MEMBERS
         ).send()
 

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -99,8 +99,7 @@ class MailAdapter:
         project = event.group.project
         extra["project_id"] = project.id
 
-        notification = Notification(event=event, rules=None)
-        self.notify(notification, ActionTargetType.RELEASE_MEMBERS)
+        self.notify_active_release(Notification(event=event, rules=None))
 
         logger.info("mail.adapter.notification.active_release.%s" % log_event, extra=extra)
 
@@ -124,10 +123,13 @@ class MailAdapter:
 
     @staticmethod
     def notify(notification, target_type, target_identifier=None, **kwargs):
-        if target_type == ActionTargetType.RELEASE_MEMBERS:
-            ActiveReleaseAlertNotification(notification, target_type, target_identifier).send()
-        else:
-            AlertRuleNotification(notification, target_type, target_identifier).send()
+        AlertRuleNotification(notification, target_type, target_identifier).send()
+
+    @staticmethod
+    def notify_active_release(notification):
+        ActiveReleaseAlertNotification(
+            notification, target_type=ActionTargetType.RELEASE_MEMBERS
+        ).send()
 
     @staticmethod
     def notify_digest(

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -49,7 +49,7 @@ class MailAdapter:
             "target_identifier": target_identifier,
         }
         log_event = "dispatched"
-        for future in filter(lambda f: f.rule, futures):
+        for future in futures:
             rules.append(future.rule)
             extra["rule_id"] = future.rule.id
             if not future.kwargs:

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -90,18 +90,16 @@ class MailAdapter:
         event: Any,
     ) -> None:
         metrics.incr("mail_adapter.active_release_notify")
-        extra = {
-            "event_id": event.event_id,
-            "group_id": event.group_id,
-            "is_from_mail_action_adapter": True,
-        }
-        log_event = "dispatched"
-        project = event.group.project
-        extra["project_id"] = project.id
-
         self.notify_active_release(Notification(event=event, rules=None))
-
-        logger.info("mail.adapter.notification.active_release.%s" % log_event, extra=extra)
+        logger.info(
+            "mail.adapter.notification.active_release.dispatched",
+            extra={
+                "event_id": event.event_id,
+                "group_id": event.group_id,
+                "is_from_mail_action_adapter": True,
+                "project_id": event.group.project.id,
+            },
+        )
 
     @staticmethod
     def get_sendable_user_objects(project):

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -8,8 +8,8 @@ from django.utils.encoding import force_text
 
 from sentry import options
 from sentry.models import Project, ProjectOption, Team, User
+from sentry.notifications.notifications.active_release import ActiveReleaseAlertNotification
 from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
-from sentry.notifications.notifications.rules import ActiveReleaseAlertNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -8,7 +8,7 @@ from django.utils.encoding import force_text
 
 from sentry import options
 from sentry.models import Project, ProjectOption, Team, User
-from sentry.notifications.notifications.active_release import ActiveReleaseAlertNotification
+from sentry.notifications.notifications.active_release import ActiveReleaseIssueNotification
 from sentry.notifications.notifications.base import BaseNotification, ProjectNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.types.integrations import ExternalProviders
@@ -54,7 +54,7 @@ def get_subject_with_prefix(
     if isinstance(notification, ProjectNotification):
         prefix = f"{build_subject_prefix(notification.project).rstrip()} "
 
-    if isinstance(notification, ActiveReleaseAlertNotification):
+    if isinstance(notification, ActiveReleaseIssueNotification):
         prefix = f"**ARM** {prefix}"
 
     return f"{prefix}{notification.get_subject(context)}".encode()

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -93,7 +93,7 @@ def where_should_recipient_be_notified(
         Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
     recipient: Team | User,
-    type: NotificationSettingTypes = NotificationSettingTypes.ISSUE_ALERTS,
+    type: NotificationSettingTypes = NotificationSettingTypes.ACTIVE_RELEASE,
 ) -> list[ExternalProviders]:
     """
     Given a mapping of default and specific notification settings by user,

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -93,7 +93,7 @@ def where_should_recipient_be_notified(
         Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
     ],
     recipient: Team | User,
-    type: NotificationSettingTypes = NotificationSettingTypes.ACTIVE_RELEASE,
+    type: NotificationSettingTypes = NotificationSettingTypes.ISSUE_ALERTS,
 ) -> list[ExternalProviders]:
     """
     Given a mapping of default and specific notification settings by user,

--- a/src/sentry/notifications/notifications/active_release.py
+++ b/src/sentry/notifications/notifications/active_release.py
@@ -31,7 +31,7 @@ from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
 
 
-class ActiveReleaseAlertNotification(AlertRuleNotification):
+class ActiveReleaseIssueNotification(AlertRuleNotification):
     message_builder = "ActiveReleaseIssueNotificationMessageBuilder"
     metrics_key = "release_issue_alert"
     notification_setting_type = NotificationSettingTypes.ACTIVE_RELEASE

--- a/src/sentry/notifications/notifications/active_release.py
+++ b/src/sentry/notifications/notifications/active_release.py
@@ -56,7 +56,9 @@ class ActiveReleaseIssueNotification(AlertRuleNotification):
         )
         self.event_state = event_state
 
-    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
+    def get_notification_title(
+        self, provider: ExternalProviders, context: Mapping[str, Any] | None = None
+    ) -> str:
         return "Active Release alert triggered"
 
     def send(self) -> None:

--- a/src/sentry/notifications/notifications/active_release.py
+++ b/src/sentry/notifications/notifications/active_release.py
@@ -59,9 +59,9 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
     def send(self) -> None:
         from sentry.notifications.notify import notify
 
-        metrics.incr("mail_adapter.notify")
+        metrics.incr("mail_adapter.notify_active_release")
         logger.info(
-            "mail.adapter.notify",
+            "mail.adapter.notify_active_release",
             extra={
                 "target_type": self.target_type.value,
                 "target_identifier": self.target_identifier,
@@ -73,7 +73,7 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
         participants_by_provider = self.get_participants()
         if not participants_by_provider:
             logger.info(
-                "notifications.notification.rules.activereleasealertrulenotification.skip.no_participants",
+                "notifications.notification.rules.active_release.skip.no_participants",
                 extra={
                     "target_type": self.target_type.value,
                     "target_identifier": self.target_identifier,
@@ -83,9 +83,7 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
             )
             return
 
-        # Only calculate shared context once.
         shared_context = self.get_context()
-
         for provider, participants in participants_by_provider.items():
             if self.target_type == ActionTargetType.RELEASE_MEMBERS:
                 last_release = shared_context.get("last_release", None)

--- a/src/sentry/notifications/notifications/active_release.py
+++ b/src/sentry/notifications/notifications/active_release.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping, Optional, Sequence, TypedDict
+from urllib.parse import quote, urlencode
+
+from sentry import features
+from sentry.models import Release, ReleaseActivity, ReleaseCommit, User
+from sentry.notifications.notifications.rules import AlertRuleNotification, logger
+from sentry.notifications.types import ActionTargetType, NotificationSettingTypes
+from sentry.notifications.utils import (
+    get_group_settings_link,
+    get_integration_link,
+    get_interface_list,
+    get_rules,
+    has_alert_integration,
+    has_integrations,
+)
+from sentry.plugins.base import Notification
+from sentry.types.integrations import EXTERNAL_PROVIDERS
+from sentry.types.releaseactivity import ReleaseActivityType
+from sentry.utils import metrics
+from sentry.utils.http import absolute_uri
+
+
+class ActiveReleaseAlertNotification(AlertRuleNotification):
+    message_builder = "ActiveReleaseIssueNotificationMessageBuilder"
+    metrics_key = "release_issue_alert"
+    notification_setting_type = NotificationSettingTypes.ACTIVE_RELEASE
+    template_path = "sentry/emails/release_alert"
+
+    def __init__(
+        self,
+        notification: Notification,
+        target_type: ActionTargetType,
+        target_identifier: int | None = None,
+        last_release: Optional[Release] = None,
+    ) -> None:
+        from sentry.rules.conditions.active_release import ActiveReleaseEventCondition
+
+        super().__init__(notification, target_type, target_identifier)
+        self.last_release = (
+            last_release
+            if last_release
+            else ActiveReleaseEventCondition.latest_release(notification.event)
+        )
+
+    def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
+        from sentry.integrations.message_builder import build_rule_url
+
+        title_str = "Active Release alert triggered"
+
+        if self.rules:
+            rule_url = build_rule_url(self.rules[0], self.group, self.project)
+            title_str += f" <{rule_url}|{self.rules[0].label}>"
+
+            if len(self.rules) > 1:
+                title_str += f" (+{len(self.rules) - 1} other)"
+
+        return title_str
+
+    def send(self) -> None:
+        from sentry.notifications.notify import notify
+
+        metrics.incr("mail_adapter.notify")
+        logger.info(
+            "mail.adapter.notify",
+            extra={
+                "target_type": self.target_type.value,
+                "target_identifier": self.target_identifier,
+                "group": self.group.id,
+                "project_id": self.project.id,
+            },
+        )
+
+        participants_by_provider = self.get_participants()
+        if not participants_by_provider:
+            logger.info(
+                "notifications.notification.rules.activereleasealertrulenotification.skip.no_participants",
+                extra={
+                    "target_type": self.target_type.value,
+                    "target_identifier": self.target_identifier,
+                    "group": self.group.id,
+                    "project_id": self.project.id,
+                },
+            )
+            return
+
+        # Only calculate shared context once.
+        shared_context = self.get_context()
+
+        for provider, participants in participants_by_provider.items():
+            if self.target_type == ActionTargetType.RELEASE_MEMBERS:
+                last_release = shared_context.get("last_release", None)
+                release_version = last_release.version if last_release else None
+                event = shared_context.get("event", None)
+                for participant in participants:
+                    self.record_active_release_notification_sent(
+                        participant, event, provider, release_version
+                    )
+                if (
+                    features.has("organizations:active-release-monitor-alpha", self.organization)
+                    and last_release
+                ):
+                    ReleaseActivity.objects.create(
+                        type=ReleaseActivityType.ISSUE.value,
+                        data={
+                            "provider": EXTERNAL_PROVIDERS[provider],
+                            "group_id": self.group.id,
+                        },
+                        release=last_release,
+                    )
+            notify(provider, self, participants, shared_context)
+
+    def get_context(self) -> MutableMapping[str, Any]:
+        environment = self.event.get_tag("environment")
+        enhanced_privacy = self.organization.flags.enhanced_privacy
+        rule_details = get_rules(self.rules, self.organization, self.project)
+        group = self.group
+        context = {
+            "project_label": self.project.get_full_name(),
+            "group": group,
+            "users_seen": self.group.count_users_seen(),
+            "event": self.event,
+            "link": get_group_settings_link(
+                self.group, environment, rule_details, referrer="alert_email_release"
+            ),
+            "rules": rule_details,
+            "has_integrations": has_integrations(self.organization, self.project),
+            "enhanced_privacy": enhanced_privacy,
+            "last_release": self.last_release,
+            "last_release_link": self.release_url(self.last_release),
+            "last_release_slack_link": self.slack_release_url(self.last_release),
+            "environment": environment,
+            "slack_link": get_integration_link(self.organization, "slack"),
+            "has_alert_integration": has_alert_integration(self.project),
+            "regression": False,
+        }
+
+        # if the organization has enabled enhanced privacy controls we don't send
+        # data which may show PII or source code
+        if not enhanced_privacy:
+            contexts = (
+                self.event.data["contexts"].items() if "contexts" in self.event.data else None
+            )
+            event_user = self.event.data["event_user"] if "event_user" in self.event.data else None
+            context.update(
+                {
+                    "tags": self.event.tags,
+                    "interfaces": get_interface_list(self.event),
+                    "contexts": contexts,
+                    "event_user": event_user,
+                }
+            )
+
+        return context
+
+    @staticmethod
+    def get_release_commits(release: Release) -> Sequence[CommitData]:
+        if not release:
+            return []
+
+        release_commits = (
+            ReleaseCommit.objects.filter(release_id=release.id)
+            .select_related("commit", "commit__author")
+            .order_by("-order")
+        )
+
+        return [
+            {
+                "author": rc.commit.author,
+                "subject": rc.commit.message.split("\n", 1)[0]
+                if rc.commit.message
+                else "no subject",
+                "key": rc.commit.key,
+            }
+            for rc in release_commits
+        ]
+
+    @staticmethod
+    def release_url(release: Release) -> str:
+        params = {"project": release.project_id, "referrer": "alert_email_release"}
+        url = "/organizations/{org}/releases/{version}/{params}".format(
+            org=release.organization.slug,
+            version=release.version,
+            params="?" + urlencode(params),
+        )
+
+        return str(absolute_uri(url))
+
+    @staticmethod
+    def slack_release_url(release: Release) -> str:
+        params = {"project": release.project_id, "referrer": "alert_slack_release"}
+        url = "/organizations/{org}/releases/{version}/{params}".format(
+            org=release.organization.slug,
+            version=quote(release.version),
+            params="?" + urlencode(params),
+        )
+
+        return str(absolute_uri(url))
+
+
+class CommitData(TypedDict):
+    author: User
+    subject: str
+    key: str

--- a/src/sentry/notifications/notifications/active_release.py
+++ b/src/sentry/notifications/notifications/active_release.py
@@ -11,7 +11,6 @@ from sentry.notifications.utils import (
     get_group_settings_link,
     get_integration_link,
     get_interface_list,
-    get_rules,
     has_alert_integration,
     has_integrations,
 )
@@ -45,18 +44,7 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
         )
 
     def get_notification_title(self, context: Mapping[str, Any] | None = None) -> str:
-        from sentry.integrations.message_builder import build_rule_url
-
-        title_str = "Active Release alert triggered"
-
-        if self.rules:
-            rule_url = build_rule_url(self.rules[0], self.group, self.project)
-            title_str += f" <{rule_url}|{self.rules[0].label}>"
-
-            if len(self.rules) > 1:
-                title_str += f" (+{len(self.rules) - 1} other)"
-
-        return title_str
+        return "Active Release alert triggered"
 
     def send(self) -> None:
         from sentry.notifications.notify import notify
@@ -114,7 +102,6 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
     def get_context(self) -> MutableMapping[str, Any]:
         environment = self.event.get_tag("environment")
         enhanced_privacy = self.organization.flags.enhanced_privacy
-        rule_details = get_rules(self.rules, self.organization, self.project)
         group = self.group
         context = {
             "project_label": self.project.get_full_name(),
@@ -122,9 +109,8 @@ class ActiveReleaseAlertNotification(AlertRuleNotification):
             "users_seen": self.group.count_users_seen(),
             "event": self.event,
             "link": get_group_settings_link(
-                self.group, environment, rule_details, referrer="alert_email_release"
+                self.group, environment, rule_details=None, referrer="alert_email_release"
             ),
-            "rules": rule_details,
             "has_integrations": has_integrations(self.organization, self.project),
             "enhanced_privacy": enhanced_privacy,
             "last_release": self.last_release,

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -166,7 +166,11 @@ class AlertRuleNotification(ProjectNotification):
         }
 
     def record_active_release_notification_sent(
-        self, participant: Team | User, event: Event, provider: str, release_version: str
+        self,
+        participant: Team | User,
+        event: Event,
+        provider: ExternalProviders,
+        release_version: str,
     ) -> None:
         suspect_committer_ids = [
             go.owner_id()

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -5,11 +5,8 @@ from typing import Any, Iterable, Mapping, MutableMapping
 
 import pytz
 
-from sentry import analytics
 from sentry.db.models import Model
-from sentry.eventstore.models import Event
 from sentry.models import Team, User, UserOption
-from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.types import ActionTargetType, NotificationSettingTypes
 from sentry.notifications.utils import (
@@ -21,9 +18,9 @@ from sentry.notifications.utils import (
     has_alert_integration,
     has_integrations,
 )
-from sentry.notifications.utils.participants import get_owners, get_send_to
+from sentry.notifications.utils.participants import get_send_to
 from sentry.plugins.base.structs import Notification
-from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -57,6 +54,7 @@ class AlertRuleNotification(ProjectNotification):
             target_type=self.target_type,
             target_identifier=self.target_identifier,
             event=self.event,
+            notification_type=self.notification_setting_type,
         )
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
@@ -164,40 +162,3 @@ class AlertRuleNotification(ProjectNotification):
             "target_identifier": self.target_identifier,
             **super().get_log_params(recipient),
         }
-
-    def record_active_release_notification_sent(
-        self,
-        participant: Team | User,
-        event: Event,
-        provider: ExternalProviders,
-        release_version: str,
-    ) -> None:
-        suspect_committer_ids = [
-            go.owner_id()
-            for go in GroupOwner.objects.filter(
-                group_id=self.group.id,
-                project=self.project.id,
-                organization_id=self.project.organization_id,
-                type=GroupOwnerType.SUSPECT_COMMIT.value,
-            )
-        ]
-        code_owner_ids = [o.id for o in get_owners(self.project, event)]
-        team_ids = (
-            [t.id for t in Team.objects.get_for_user(self.organization, participant)]
-            if type(participant) == User
-            else None
-        )
-
-        analytics.record(
-            "active_release_notification.sent",
-            organization_id=self.project.organization_id,
-            project_id=self.project.id,
-            group_id=self.group.id,
-            provider=EXTERNAL_PROVIDERS[provider],
-            release_version=release_version,
-            recipient_email=participant.email,
-            recipient_username=participant.username,
-            suspect_committer_ids=suspect_committer_ids,
-            code_owner_ids=code_owner_ids,
-            team_ids=team_ids,
-        )

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Iterable, Mapping, MutableMapping, Optional, Sequence, TypedDict
-from urllib.parse import quote
+from typing import Any, Iterable, Mapping, MutableMapping
 
 import pytz
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.db.models import Model
 from sentry.eventstore.models import Event
-from sentry.models import Release, ReleaseActivity, ReleaseCommit, Team, User, UserOption
+from sentry.models import Team, User, UserOption
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.notifications.notifications.base import ProjectNotification
 from sentry.notifications.types import ActionTargetType, NotificationSettingTypes
@@ -25,9 +24,7 @@ from sentry.notifications.utils import (
 from sentry.notifications.utils.participants import get_owners, get_send_to
 from sentry.plugins.base.structs import Notification
 from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
-from sentry.types.releaseactivity import ReleaseActivityType
 from sentry.utils import metrics
-from sentry.utils.http import absolute_uri, urlencode
 
 logger = logging.getLogger(__name__)
 
@@ -159,26 +156,6 @@ class AlertRuleNotification(ProjectNotification):
         shared_context = self.get_context()
 
         for provider, participants in participants_by_provider.items():
-            if self.target_type == ActionTargetType.RELEASE_MEMBERS:
-                last_release = shared_context.get("last_release", None)
-                release_version = last_release.version if last_release else None
-                event = shared_context.get("event", None)
-                for participant in participants:
-                    self.record_active_release_notification_sent(
-                        participant, event, provider, release_version
-                    )
-                if (
-                    features.has("organizations:active-release-monitor-alpha", self.organization)
-                    and last_release
-                ):
-                    ReleaseActivity.objects.create(
-                        type=ReleaseActivityType.ISSUE.value,
-                        data={
-                            "provider": EXTERNAL_PROVIDERS[provider],
-                            "group_id": self.group.id,
-                        },
-                        release=last_release,
-                    )
             notify(provider, self, participants, shared_context)
 
     def get_log_params(self, recipient: Team | User) -> Mapping[str, Any]:
@@ -220,137 +197,3 @@ class AlertRuleNotification(ProjectNotification):
             code_owner_ids=code_owner_ids,
             team_ids=team_ids,
         )
-
-
-class CommitData(TypedDict):
-    author: User
-    subject: str
-    key: str
-
-
-class ActiveReleaseAlertNotification(AlertRuleNotification):
-    message_builder = "ActiveReleaseIssueNotificationMessageBuilder"
-    metrics_key = "release_issue_alert"
-    notification_setting_type = NotificationSettingTypes.ISSUE_ALERTS
-    template_path = "sentry/emails/release_alert"
-
-    def __init__(
-        self,
-        notification: Notification,
-        target_type: ActionTargetType,
-        target_identifier: int | None = None,
-        last_release: Optional[Release] = None,
-    ) -> None:
-        from sentry.rules.conditions.active_release import ActiveReleaseEventCondition
-
-        super().__init__(notification, target_type, target_identifier)
-        self.last_release = (
-            last_release
-            if last_release
-            else ActiveReleaseEventCondition.latest_release(notification.event)
-        )
-
-    def get_notification_title(
-        self, provider: ExternalProviders, context: Mapping[str, Any] | None = None
-    ) -> str:
-        from sentry.integrations.message_builder import build_rule_url
-
-        title_str = "Active Release alert triggered"
-
-        if self.rules:
-            rule_url = build_rule_url(self.rules[0], self.group, self.project)
-            title_str += (
-                f" {self.format_url(text=self.rules[0].label, url=rule_url, provider=provider)}"
-            )
-
-            if len(self.rules) > 1:
-                title_str += f" (+{len(self.rules) - 1} other)"
-
-        return title_str
-
-    def get_context(self) -> MutableMapping[str, Any]:
-        environment = self.event.get_tag("environment")
-        enhanced_privacy = self.organization.flags.enhanced_privacy
-        rule_details = get_rules(self.rules, self.organization, self.project)
-        group = self.group
-        context = {
-            "project_label": self.project.get_full_name(),
-            "group": group,
-            "users_seen": self.group.count_users_seen(),
-            "event": self.event,
-            "link": get_group_settings_link(
-                self.group, environment, rule_details, referrer="alert_email_release"
-            ),
-            "rules": rule_details,
-            "has_integrations": has_integrations(self.organization, self.project),
-            "enhanced_privacy": enhanced_privacy,
-            "last_release": self.last_release,
-            "last_release_link": self.release_url(self.last_release),
-            "last_release_slack_link": self.slack_release_url(self.last_release),
-            "environment": environment,
-            "slack_link": get_integration_link(self.organization, "slack"),
-            "has_alert_integration": has_alert_integration(self.project),
-            "regression": False,
-        }
-
-        # if the organization has enabled enhanced privacy controls we don't send
-        # data which may show PII or source code
-        if not enhanced_privacy:
-            contexts = (
-                self.event.data["contexts"].items() if "contexts" in self.event.data else None
-            )
-            event_user = self.event.data["event_user"] if "event_user" in self.event.data else None
-            context.update(
-                {
-                    "tags": self.event.tags,
-                    "interfaces": get_interface_list(self.event),
-                    "contexts": contexts,
-                    "event_user": event_user,
-                }
-            )
-
-        return context
-
-    @staticmethod
-    def get_release_commits(release: Release) -> Sequence[CommitData]:
-        if not release:
-            return []
-
-        release_commits = (
-            ReleaseCommit.objects.filter(release_id=release.id)
-            .select_related("commit", "commit__author")
-            .order_by("-order")
-        )
-
-        return [
-            {
-                "author": rc.commit.author,
-                "subject": rc.commit.message.split("\n", 1)[0]
-                if rc.commit.message
-                else "no subject",
-                "key": rc.commit.key,
-            }
-            for rc in release_commits
-        ]
-
-    @staticmethod
-    def release_url(release: Release) -> str:
-        params = {"project": release.project_id, "referrer": "alert_email_release"}
-        url = "/organizations/{org}/releases/{version}/{params}".format(
-            org=release.organization.slug,
-            version=release.version,
-            params="?" + urlencode(params),
-        )
-
-        return str(absolute_uri(url))
-
-    @staticmethod
-    def slack_release_url(release: Release) -> str:
-        params = {"project": release.project_id, "referrer": "alert_slack_release"}
-        url = "/organizations/{org}/releases/{version}/{params}".format(
-            org=release.organization.slug,
-            version=quote(release.version),
-            params="?" + urlencode(params),
-        )
-
-        return str(absolute_uri(url))

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -296,9 +296,10 @@ def get_send_to(
     target_type: ActionTargetType,
     target_identifier: int | None = None,
     event: Event | None = None,
+    notification_type: NotificationSettingTypes = NotificationSettingTypes.ISSUE_ALERTS,
 ) -> Mapping[ExternalProviders, set[Team | User]]:
     recipients = determine_eligible_recipients(project, target_type, target_identifier, event)
-    return get_recipients_by_provider(project, recipients)
+    return get_recipients_by_provider(project, recipients, notification_type)
 
 
 def get_user_from_identifier(project: Project, target_identifier: str | int | None) -> User | None:
@@ -373,13 +374,17 @@ def combine_recipients_by_provider(
 
 
 def get_recipients_by_provider(
-    project: Project, recipients: Iterable[Team | User]
+    project: Project,
+    recipients: Iterable[Team | User],
+    notification_type: NotificationSettingTypes = NotificationSettingTypes.ISSUE_ALERTS,
 ) -> Mapping[ExternalProviders, set[Team | User]]:
     """Get the lists of recipients that should receive an Issue Alert by ExternalProvider."""
     teams, users = partition_recipients(recipients)
 
     # First evaluate the teams.
-    teams_by_provider = NotificationSetting.objects.filter_to_accepting_recipients(project, teams)
+    teams_by_provider = NotificationSetting.objects.filter_to_accepting_recipients(
+        project, teams, notification_type
+    )
 
     # Teams cannot receive emails so omit EMAIL settings.
     teams_by_provider = {
@@ -392,6 +397,8 @@ def get_recipients_by_provider(
     users = set(users).union(get_users_from_team_fall_back(teams, teams_by_provider))
 
     # Repeat for users.
-    users_by_provider = NotificationSetting.objects.filter_to_accepting_recipients(project, users)
+    users_by_provider = NotificationSetting.objects.filter_to_accepting_recipients(
+        project, users, notification_type
+    )
 
     return combine_recipients_by_provider(teams_by_provider, users_by_provider)

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -86,7 +86,7 @@ class NotificationPlugin(Plugin):
     def rule_notify(self, event, futures):
         rules = []
         extra = {"event_id": event.event_id, "group_id": event.group_id, "plugin": self.slug}
-        for future in filter(lambda f: f.rule, futures):
+        for future in futures:
             rules.append(future.rule)
             extra["rule_id"] = future.rule.id
             if not future.kwargs:

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -99,7 +99,7 @@ class NotificationPlugin(Plugin):
         extra["project_id"] = project.id
         notification = Notification(event=event, rules=rules)
         self.notify(notification)
-        self.logger.info("notification.%s" % "dispatched", extra=extra)
+        self.logger.info("notification.dispatched", extra=extra)
 
     def notify_users(self, group, event, triggering_rules, fail_silently=False, **kwargs):
         raise NotImplementedError

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -86,8 +86,7 @@ class NotificationPlugin(Plugin):
     def rule_notify(self, event, futures):
         rules = []
         extra = {"event_id": event.event_id, "group_id": event.group_id, "plugin": self.slug}
-        log_event = "dispatched"
-        for future in futures:
+        for future in filter(lambda f: f.rule, futures):
             rules.append(future.rule)
             extra["rule_id"] = future.rule.id
             if not future.kwargs:
@@ -100,7 +99,7 @@ class NotificationPlugin(Plugin):
         extra["project_id"] = project.id
         notification = Notification(event=event, rules=rules)
         self.notify(notification)
-        self.logger.info("notification.%s" % log_event, extra=extra)
+        self.logger.info("notification.%s" % "dispatched", extra=extra)
 
     def notify_users(self, group, event, triggering_rules, fail_silently=False, **kwargs):
         raise NotImplementedError

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 
 from sentry import analytics, features
 from sentry.eventstore.models import Event
-from sentry.mail.actions import NotifyEmailAction
+from sentry.mail.actions import NotifyActiveReleaseEmailAction
 from sentry.models import GroupRuleStatus, Rule
 from sentry.notifications.types import ActionTargetType
 from sentry.rules import EventState, history, rules
@@ -259,7 +259,11 @@ class RuleProcessor:
 
     def _get_active_release_rule_actions(self) -> Sequence[EventAction]:
         # TODO: we need this to be configurable on a pre-project level?
-        return [NotifyEmailAction(data={"targetType": ActionTargetType.RELEASE_MEMBERS.value})]
+        return [
+            NotifyActiveReleaseEmailAction(
+                data={"targetType": ActionTargetType.RELEASE_MEMBERS.value}
+            )
+        ]
 
     def _get_last_active_time_for_active_release(self) -> str | None:
         # TODO:
@@ -313,11 +317,7 @@ class RuleProcessor:
 
     def apply(
         self,
-    ) -> Iterable[Tuple[Callable[[Event, Sequence[RuleFuture]], None], List[RuleFuture]]]:  #
-        # [ ((Callable(param: [Event, Sequence[RuleFuture]]) -> None), (RuleFuture, RuleFuture, ...))
-        #   ()
-        # ]
-
+    ) -> Iterable[Tuple[Callable[[Event, Sequence[RuleFuture]], None], List[RuleFuture]]]:
         # we should only apply rules on unresolved issues
         if not self.event.group.is_unresolved():
             return {}.values()

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -281,8 +281,10 @@ class RuleProcessor:
         last_eval_cache_key = "{}:p-{}:g-{}".format(
             "active-release-last-eval", self.event.project_id, self.event.group_id
         )
-        last_action_time = cache.get(last_action_cache_key)
-        last_eval_time = cache.get(last_eval_cache_key)
+
+        bulk = cache.get_many([last_action_cache_key, last_eval_cache_key])
+        last_action_time = bulk.get(last_action_cache_key) if bulk else None
+        last_eval_time = bulk.get(last_eval_cache_key) if bulk else None
 
         if last_action_time and last_action_time > freq_offset:
             return

--- a/tests/sentry/integrations/slack/notifications/test_active_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_active_release.py
@@ -1,0 +1,83 @@
+from datetime import timedelta
+from unittest import mock
+
+import responses
+from django.utils import timezone
+
+from sentry.models import GroupRelease, NotificationSetting, Release, Rule
+from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.rules.processor import RuleProcessor
+from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.helpers.slack import get_attachment, send_notification
+from sentry.types.integrations import ExternalProviders
+
+
+class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
+    def setUp(self):
+        super().setUp()
+        Rule.objects.filter(project=self.event.project).delete()
+        self.event.group._times_seen_pending = 0
+        self.event.group.save()
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.SLACK,
+            NotificationSettingTypes.ACTIVE_RELEASE,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
+        )
+        self.newRelease = Release.objects.create(
+            organization_id=self.organization.id,
+            version="2",
+            date_added=timezone.now() - timedelta(minutes=30),
+            date_released=timezone.now() - timedelta(minutes=30),
+        )
+        GroupRelease.objects.create(
+            project_id=self.project.id,
+            group_id=self.event.group.id,
+            release_id=self.newRelease.id,
+            first_seen=timezone.now(),
+            last_seen=timezone.now(),
+        )
+        self.newRelease.add_project(self.project)
+        self.event.data["tags"] = (("sentry:release", self.newRelease.version),)
+
+    @responses.activate
+    @mock.patch("sentry.notifications.utils.participants.get_release_committers")
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_no_notify(self, mock_func, mock_get_release_committers):
+        mock_get_release_committers.return_value = [self.user]
+        with self.tasks():
+            rp = RuleProcessor(
+                self.event,
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                has_reappeared=False,
+            )
+            results = list(rp.apply())
+            assert len(results) == 0
+            assert len(responses.calls) == 0
+
+    @responses.activate
+    @mock.patch("sentry.notifications.utils.participants.get_release_committers")
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_notify_user(self, mock_func, mock_get_release_committers):
+        mock_get_release_committers.return_value = [self.user]
+        with self.tasks(), self.feature("projects:active-release-monitor-default-on"):
+            rp = RuleProcessor(
+                self.event,
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                has_reappeared=False,
+            )
+            results = list(rp.apply())
+            assert len(results) == 0
+
+            attachment, text = get_attachment()
+
+            assert "has a new issue" in attachment["title"]
+            assert (
+                attachment["footer"]
+                == f"{self.project.slug} | <http://testserver/settings/account/notifications/activeRelease/?referrer=release_issue_alert-slack-user|Notification Settings>"
+            )
+            assert text == "Active Release alert triggered"

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -16,7 +16,7 @@ from sentry.integrations.slack.message_builder.issues import (
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.models import Group, Team, User
-from sentry.notifications.notifications.rules import ActiveReleaseAlertNotification
+from sentry.notifications.notifications.active_release import ActiveReleaseAlertNotification
 from sentry.testutils import TestCase
 from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -16,7 +16,7 @@ from sentry.integrations.slack.message_builder.issues import (
 )
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.models import Group, Team, User
-from sentry.notifications.notifications.active_release import ActiveReleaseAlertNotification
+from sentry.notifications.notifications.active_release import ActiveReleaseIssueNotification
 from sentry.testutils import TestCase
 from sentry.utils.dates import to_timestamp
 from sentry.utils.http import absolute_uri
@@ -150,7 +150,7 @@ class BuildGroupAttachmentTest(TestCase):
         )
         release = self.create_release(version="1.0.0", project=self.project)
 
-        release_link = ActiveReleaseAlertNotification.slack_release_url(release)
+        release_link = ActiveReleaseIssueNotification.slack_release_url(release)
         attachments = SlackReleaseIssuesMessageBuilder(
             group, last_release=release, last_release_link=release_link
         ).build()
@@ -164,7 +164,7 @@ class BuildGroupAttachmentTest(TestCase):
         group = self.create_group(project=self.project)
         release = self.create_release(version="1.0.0", project=self.project)
 
-        release_link = ActiveReleaseAlertNotification.slack_release_url(release)
+        release_link = ActiveReleaseIssueNotification.slack_release_url(release)
         release_commits = [
             {"author": None, "key": "sha789", "subject": "third commit"},
             {"author": self.user, "key": "sha456", "subject": "second commit"},

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -81,12 +81,20 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
     @mock.patch("sentry.notifications.utils.participants.get_release_committers")
     def test_simple(self, mock_get_release_committers, record):
         new_user = self.create_user(email="test@example.com", username="foo")
-        mock_get_release_committers.return_value = [new_user]
-        self.team = self.create_team(
-            name="Team Name", organization=self.organization, members=[new_user]
+        new_team = self.create_team(name="Team Name", organization=self.organization)
+        new_project = self.create_project(organization=self.organization, teams=[new_team])
+        self.create_member(
+            user=new_user, organization=self.organization, role="owner", teams=[new_team]
+        )
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ACTIVE_RELEASE,
+            NotificationSettingOptionValues.ALWAYS,
+            user=new_user,
+            project=new_project,
         )
         event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
+            data={"message": "Hello world", "level": "error"}, project_id=new_project.id
         )
         GroupOwner.objects.create(
             group_id=event.group.id,
@@ -97,7 +105,7 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
         )
         newRelease = Release.objects.create(
             organization_id=self.organization.id,
-            project_id=self.project.id,
+            project_id=new_project.id,
             version="2",
             date_added=timezone.now() - timedelta(days=1),
             date_released=None,
@@ -111,21 +119,20 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
             date_started=timezone.now() - timedelta(minutes=37),
             date_finished=timezone.now() - timedelta(minutes=20),
         )
-        newRelease.add_project(self.project)
+        newRelease.add_project(new_project)
 
         event.data["tags"] = (("sentry:release", newRelease.version),)
+        mock_get_release_committers.return_value = [new_user]
 
         mail.outbox = []
-        with self.options({"system.url-prefix": "http://example.com"}), self.tasks(), self.feature(
-            "organizations:active-release-monitor-alpha"
-        ):
+        with self.tasks(), self.feature("organizations:active-release-monitor-alpha"):
             self.adapter.notify_active_release(Notification(event=event))
 
         assert len(mail.outbox) == 1
         to_committer = mail.outbox[0]
-
-        assert to_committer
-        assert to_committer.subject == "**ARM** [Sentry] BAR-1 - Hello world"
+        assert to_committer.subject == "**ARM** [Sentry] {} - Hello world".format(
+            event.group.qualified_short_id
+        )
 
         notification_record = [
             r for r in record.call_args_list if r[0][0] == "active_release_notification.sent"
@@ -134,7 +141,7 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
             mock.call(
                 "active_release_notification.sent",
                 organization_id=self.organization.id,
-                project_id=self.project.id,
+                project_id=new_project.id,
                 group_id=event.group.id,
                 provider="email",
                 release_version="2",
@@ -142,7 +149,7 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
                 recipient_username="foo",
                 suspect_committer_ids=[f"user:{new_user.id}"],
                 code_owner_ids=[new_user.id],
-                team_ids=[self.team.id],
+                team_ids=[new_team.id],
             )
         ]
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -119,7 +119,7 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
         with self.options({"system.url-prefix": "http://example.com"}), self.tasks(), self.feature(
             "organizations:active-release-monitor-alpha"
         ):
-            self.adapter.notify(Notification(event=event), ActionTargetType.RELEASE_MEMBERS, None)
+            self.adapter.notify_active_release(Notification(event=event))
 
         assert len(mail.outbox) == 1
         to_committer = mail.outbox[0]

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -47,6 +47,7 @@ from sentry.notifications.utils.digest import get_digest_subject
 from sentry.ownership import grammar
 from sentry.ownership.grammar import Matcher, Owner, dump_schema
 from sentry.plugins.base import Notification
+from sentry.rules import EventState
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.types.activity import ActivityType
@@ -126,7 +127,15 @@ class MailAdapterActiveReleaseTest(BaseMailAdapterTest):
 
         mail.outbox = []
         with self.tasks(), self.feature("organizations:active-release-monitor-alpha"):
-            self.adapter.notify_active_release(Notification(event=event))
+            self.adapter.notify_active_release(
+                Notification(event=event),
+                EventState(
+                    is_new=True,
+                    is_regression=False,
+                    is_new_group_environment=False,
+                    has_reappeared=False,
+                ),
+            )
 
         assert len(mail.outbox) == 1
         to_committer = mail.outbox[0]

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -427,12 +427,14 @@ class RuleProcessorTestFilters(TestCase):
 
 class RuleProcessorActiveReleaseTest(TestCase):
     def setUp(self):
-        self.event = self.store_event(data={"message": "Hello world"}, project_id=self.project.id)
-        # self.event.title = "Hello world"
+        self.event = self.store_event(
+            data={"message": "Hello world"},
+            project_id=self.project.id,
+        )
         self.event.group._times_seen_pending = 0
         self.event.group.save()
 
-        oldRelease = Release.objects.create(
+        self.oldRelease = Release.objects.create(
             organization_id=self.organization.id,
             version="1",
             date_added=timezone.now() - timedelta(hours=2),
@@ -441,12 +443,11 @@ class RuleProcessorActiveReleaseTest(TestCase):
         GroupRelease.objects.create(
             project_id=self.project.id,
             group_id=self.event.group.id,
-            release_id=oldRelease.id,
-            environment=self.environment.name,
+            release_id=self.oldRelease.id,
             first_seen=timezone.now(),
             last_seen=timezone.now(),
         )
-        newRelease = Release.objects.create(
+        self.newRelease = Release.objects.create(
             organization_id=self.organization.id,
             version="2",
             date_added=timezone.now() - timedelta(minutes=30),
@@ -455,15 +456,14 @@ class RuleProcessorActiveReleaseTest(TestCase):
         GroupRelease.objects.create(
             project_id=self.project.id,
             group_id=self.event.group.id,
-            release_id=newRelease.id,
-            environment=self.environment.name,
+            release_id=self.newRelease.id,
             first_seen=timezone.now(),
             last_seen=timezone.now(),
         )
-        oldRelease.add_project(self.project)
-        newRelease.add_project(self.project)
+        self.oldRelease.add_project(self.project)
+        self.newRelease.add_project(self.project)
 
-        self.event.data["tags"] = (("sentry:release", newRelease.version),)
+        self.event.data["tags"] = (("sentry:release", self.newRelease.version),)
 
         Rule.objects.filter(project=self.event.project).delete()
 
@@ -486,3 +486,38 @@ class RuleProcessorActiveReleaseTest(TestCase):
             assert len(mail.outbox) == 1
             assert mail.outbox[0]
             assert mail.outbox[0].subject == "**ARM** [Sentry] BAR-1 - Hello world"
+            assert mail.outbox[0].to == [x.email for x in mock_get_release_committers.return_value]
+
+    @mock.patch("sentry.notifications.utils.participants.get_release_committers")
+    def test_one_extra_rule(self, mock_get_release_committers):
+        mock_get_release_committers.return_value = [self.user]
+        Rule.objects.create(
+            project=self.event.project,
+            data={
+                "actions": [EMAIL_ACTION_DATA],
+                "filter_match": "any",
+                "conditions": [
+                    {
+                        "id": "sentry.rules.filters.latest_release.LatestReleaseFilter",
+                        "name": "The event is from the latest release",
+                    },
+                ],
+            },
+        )
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks(), self.feature(
+            "projects:active-release-monitor-default-on"
+        ):
+            mail.outbox = []
+            rp = RuleProcessor(
+                self.event,
+                is_new=True,
+                is_regression=False,
+                is_new_group_environment=True,
+                has_reappeared=False,
+            )
+            results = list(rp.apply())
+            assert len(results) == 1
+            assert len(mail.outbox) == 1
+            assert mail.outbox[0]
+            assert mail.outbox[0].subject == "**ARM** [Sentry] BAR-1 - Hello world"
+            assert mail.outbox[0].to == [x.email for x in mock_get_release_committers.return_value]

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -444,8 +444,8 @@ class RuleProcessorActiveReleaseTest(TestCase):
             data={"message": "Hello world"},
             project_id=self.project.id,
         )
-        self.event.group._times_seen_pending = 0
-        self.event.group.save()
+        # self.event.group._times_seen_pending = 0
+        # self.event.group.save()
 
         self.oldRelease = Release.objects.create(
             organization_id=self.organization.id,


### PR DESCRIPTION
As part of WF2.0 experimentation, we introduced the concept of Active Release Monitoring(ARM). This heavily relied on Issue Alert Rules to send a notification within 1 hour of a release-deployment to the committers of a release. 

This PR attempts to separate out ARM into its own concept/feature so we can avoid introducing more coupling between Issue Alerts and ARM (and begin to revert some of the coupling we had to introduce as part of the experiment). 

In addition to the above, we also want to enable ARM by default to already created projects. Originally, our experiment required feature toggling the option to create a special type of Issue Alert rule that enabled the functionality of ARM. With this change, ARM should be on by default and users could disable these notifications, personally, if they choose.