### PR TITLE
build(ui): Add experimental `lazyCompilation` webpack setting

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -75,6 +75,7 @@ const HAS_WEBPACK_DEV_SERVER_CONFIG =
 const NO_DEV_SERVER = !!env.NO_DEV_SERVER; // Do not run webpack dev server
 const SHOULD_FORK_TS = DEV_MODE && !env.NO_TS_FORK; // Do not run fork-ts plugin (or if not dev env)
 const SHOULD_HOT_MODULE_RELOAD = DEV_MODE && !!env.SENTRY_UI_HOT_RELOAD;
+const SHOULD_LAZY_LOAD = SHOULD_HOT_MODULE_RELOAD && !!env.SENTRY_UI_LAZY_LOAD;
 
 // Deploy previews are built using vercel. We can check if we're in vercel's
 // build process by checking the existence of the PULL_REQUEST env var.
@@ -480,6 +481,17 @@ if (
     // TODO: figure out why defining output breaks hot reloading
     if (IS_UI_DEV_ONLY) {
       appConfig.output = {};
+    }
+
+    if (SHOULD_LAZY_LOAD) {
+      appConfig.experiments = {
+        lazyCompilation: {
+          // enable lazy compilation for dynamic imports
+          imports: true,
+          // disable lazy compilation for entries
+          entries: false,
+        },
+      };
     }
   }
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -75,7 +75,7 @@ const HAS_WEBPACK_DEV_SERVER_CONFIG =
 const NO_DEV_SERVER = !!env.NO_DEV_SERVER; // Do not run webpack dev server
 const SHOULD_FORK_TS = DEV_MODE && !env.NO_TS_FORK; // Do not run fork-ts plugin (or if not dev env)
 const SHOULD_HOT_MODULE_RELOAD = DEV_MODE && !!env.SENTRY_UI_HOT_RELOAD;
-const SHOULD_LAZY_LOAD = SHOULD_HOT_MODULE_RELOAD && !!env.SENTRY_UI_LAZY_LOAD;
+const SHOULD_LAZY_LOAD = DEV_MODE && !!env.SENTRY_UI_LAZY_LOAD;
 
 // Deploy previews are built using vercel. We can check if we're in vercel's
 // build process by checking the existence of the PULL_REQUEST env var.


### PR DESCRIPTION
Should compile only the route you are currently using. You can tell its much slower going from issues to alerts for the first time as it lazy compiles it.

Off by default, enable the setting with `export SENTRY_UI_LAZY_LOAD=1`

Improves webpack startup time, hot reload time, memory use. Seems to use ~750mb memory instead of 1.7gb

docs - https://webpack.js.org/configuration/experiments/#experimentslazycompilation
