### PR TITLE
feat(ui): adds a request deduper

### DIFF
--- a/static/app/requestDeduper.tsx
+++ b/static/app/requestDeduper.tsx
@@ -1,0 +1,14 @@
+export default class RequestDeduper<T> {
+  private requests: Map<string, Promise<T>> = new Map();
+  dedupe(url: string, promiseGenerator: () => Promise<T>) {
+    const inflight = this.requests.get(url);
+    if (inflight) {
+      return inflight;
+    }
+    const promise = promiseGenerator();
+    this.requests.set(url, promise);
+    return promise.finally(() => {
+      this.requests.delete(url);
+    });
+  }
+}


### PR DESCRIPTION
Basic prototype de-dupe infight requests by wrapping the promise and only evaluating it the URL matches. This only works for GET requests. Note this is not cache so if you re-refresh data then you'll get fresh data (assuming the other request is still not in-flight).