### PR TITLE
fix(ui): Change behaviour of AsyncSelect field for SentryApps

### DIFF
--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -137,7 +137,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
   getDefaultFieldValue = (field: FieldFromSchema) => {
     // Interpret the default if a getFieldDefault function is provided.
     const {resetValues, getFieldDefault} = this.props;
-    let defaultValue;
+    let defaultValue = field?.defaultValue;
 
     // Override this default if a reset value is provided
     if (field.default && getFieldDefault) {

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -274,7 +274,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
       flexibleControlStateSize: true,
       required,
     };
-    if (field?.uri || field?.async) {
+    if (field?.uri && field?.async) {
       fieldToPass.type = 'select_async';
     }
     if (['select', 'select_async'].includes(fieldToPass.type || '')) {

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -296,6 +296,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
         defaultOptions,
         filterOption,
         allowClear,
+        placeholder: 'Type to search',
       } as Field;
       if (field.depends_on) {
         // check if this is dependent on other fields which haven't been set yet

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -17,7 +17,7 @@ const hasValue = value => !!value || value === 0;
 
 // See docs: https://docs.sentry.io/product/integrations/integration-platform/ui-components/formfield/
 export type FieldFromSchema = Omit<Field, 'choices' | 'type'> & {
-  type: string;
+  type: 'select' | 'textarea' | 'text';
   async?: boolean;
   choices?: Array<[any, string]>;
   default?: 'issue.title' | 'issue.description';
@@ -267,7 +267,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
   renderField = (field: FieldFromSchema, required: boolean) => {
     // This function converts the field we get from the backend into
     // the field we need to pass down
-    let fieldToPass: any = {
+    let fieldToPass: Field = {
       ...field,
       inline: false,
       stacked: true,
@@ -296,7 +296,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
         defaultOptions,
         filterOption,
         allowClear,
-      };
+      } as Field;
       if (field.depends_on) {
         // check if this is dependent on other fields which haven't been set yet
         const shouldDisable = field.depends_on.some(

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -154,6 +154,25 @@ export class SentryAppExternalForm extends Component<Props, State> {
     return defaultValue;
   };
 
+  getDefaultOptions = (field: FieldFromSchema) => {
+    const savedOption = ((this.props.resetValues || {}).settings || []).find(
+      value => value.name === field.name
+    );
+    const currentOptions = (field.choices || []).map(([value, label]) => ({
+      value,
+      label,
+    }));
+
+    const hasSavedOption =
+      savedOption && currentOptions.some(option => option.value === savedOption.value);
+
+    // XXX(Ecosystem): Since we don't save the label associated with selections,
+    //                 we must use the value as a fallback label.
+    return hasSavedOption
+      ? currentOptions
+      : [{value: savedOption?.value, label: savedOption?.value ?? ''}, ...currentOptions];
+  };
+
   debouncedOptionLoad = debounce(
     // debounce is used to prevent making a request for every input change and
     // instead makes the requests every 200ms
@@ -278,10 +297,7 @@ export class SentryAppExternalForm extends Component<Props, State> {
     const isAsync = typeof field.async === 'undefined' ? true : !!field.async; // default to true
     if (fieldToPass.type === 'select') {
       // find the options from state to pass down
-      const defaultOptions = (field.choices || []).map(([value, label]) => ({
-        value,
-        label,
-      }));
+      const defaultOptions = this.getDefaultOptions(field);
       const options = this.state.optionsByField.get(field.name) || defaultOptions;
       const allowClear = !required;
       const defaultValue = this.getDefaultFieldValue(field);

--- a/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppExternalForm.tsx
@@ -158,16 +158,23 @@ export class SentryAppExternalForm extends Component<Props, State> {
     const savedOption = ((this.props.resetValues || {}).settings || []).find(
       value => value.name === field.name
     );
+
     const currentOptions = (field.choices || []).map(([value, label]) => ({
       value,
       label,
     }));
 
+    if (!savedOption?.value) {
+      return currentOptions;
+    }
+
     const hasSavedOption =
-      savedOption && currentOptions.some(option => option.value === savedOption.value);
+      savedOption?.value &&
+      currentOptions.some(option => option.value === savedOption.value);
 
     // XXX(Ecosystem): Since we don't save the label associated with selections,
     //                 we must use the value as a fallback label.
+
     return hasSavedOption
       ? currentOptions
       : [{value: savedOption?.value, label: savedOption?.value ?? ''}, ...currentOptions];

--- a/tests/js/spec/views/alerts/issueRules/sentryAppRuleModal.spec.jsx
+++ b/tests/js/spec/views/alerts/issueRules/sentryAppRuleModal.spec.jsx
@@ -105,7 +105,7 @@ describe('SentryAppRuleModal', function () {
       const descriptionInput = screen.getByTestId('description');
       userEvent.type(titleInput, 'v');
       userEvent.type(descriptionInput, 'v');
-      openSelectMenu('--');
+      openSelectMenu('Type to search');
       userEvent.click(screen.getByText('valor'));
       submitSuccess();
     });


### PR DESCRIPTION
This PR addresses a few bugs with the Async Select fields used by Sentry Apps

---

1. The default value provided by async select options is now respected if provided in [the correct format](https://docs.sentry.io/product/integrations/integration-platform/ui-components/formfield#uri-response-format) (i.e. not only `issue.title` and `issue.description`.
![image](https://user-images.githubusercontent.com/35509934/180808878-b23491d3-74c5-4750-a3cd-c2263283e12a.png)

Addresses https://github.com/getsentry/sentry/issues/36761


---

2. Selecting queried results persists even after another search, or if it's not on the first response of results. Addresses https://github.com/getsentry/sentry/issues/36764


