### PR TITLE
ref(projectconfig): Always compress cache [INGEST-1505 INGEST-1512 INGEST-1514]

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -446,13 +446,13 @@ register("kafka.send-project-events-to-random-partitions", default=[])
 # Rate to project_configs_v3, no longer used.
 register("relay.project-config-v3-enable", default=0.0)
 
-# Use zstandard compression in redis project config cache
+# [Unused] Use zstandard compression in redis project config cache
 # Set this value to a list of DSNs.
-register("relay.project-config-cache-compress", default=[])
+register("relay.project-config-cache-compress", default=[])  # unused
 
-# Use zstandard compression in redis project config cache
+# [Unused] Use zstandard compression in redis project config cache
 # Set this value of the fraction of config writes you want to compress.
-register("relay.project-config-cache-compress-sample-rate", default=0.0)
+register("relay.project-config-cache-compress-sample-rate", default=0.0)  # unused
 
 # Mechanism for dialing up the last-seen-updater, which isn't needed outside
 # of SaaS (last_seen is a marker for deleting stale customer data)

--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -33,10 +33,8 @@ class RedisProjectConfigCache(ProjectConfigCache):
         for public_key, config in configs.items():
             serialized = json.dumps(config).encode()
             compressed = zstandard.compress(serialized, level=COMPRESSION_LEVEL)
-            compressed_size = len(compressed)
-            compression_ratio = len(serialized) / compressed_size
-            metrics.timing("relay.projectconfig_cache.size", compressed_size)
-            metrics.timing("relay.projectconfig_cache.compression_ratio", compression_ratio)
+            metrics.timing("relay.projectconfig_cache.uncompressed_size", len(serialized))
+            metrics.timing("relay.projectconfig_cache.size", len(compressed))
 
             p.setex(self.__get_redis_key(public_key), REDIS_CACHE_TIMEOUT, compressed)
 

--- a/tests/relay_integration/test_integration.py
+++ b/tests/relay_integration/test_integration.py
@@ -10,7 +10,6 @@ from sentry.tasks.relay import invalidate_project_config
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
 from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now, iso_format, timestamp_format
-from sentry.testutils.helpers.options import override_options
 
 
 class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
@@ -222,8 +221,7 @@ class SentryRemoteTest(RelayStoreHelper, TransactionTestCase):
 
     def test_project_config_compression(self):
         # Populate redis cache with compressed config:
-        with override_options({"relay.project-config-cache-compress-sample-rate": 1.0}):
-            invalidate_project_config(public_key=self.projectkey, trigger="test")
+        invalidate_project_config(public_key=self.projectkey, trigger="test")
 
         # Disable project config endpoint, to make sure Relay gets its data
         # from redis:

--- a/tests/sentry/relay/test_projectconfig_cache.py
+++ b/tests/sentry/relay/test_projectconfig_cache.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 
 from sentry.relay.projectconfig_cache import redis
-from sentry.testutils.helpers import override_options
 
 
 def test_delete_count(monkeypatch):
@@ -20,24 +19,8 @@ def test_delete_count(monkeypatch):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "enabled_dsns, sample_rate, should_use_compression",
-    [
-        (["fake-dsn-1", "fake-dsn-2"], 0.0, True),
-        (["fake-dsn-1", "fake-dsn-2"], 1.0, True),
-        ([], 1.0, True),
-        ([], 0.0, False),
-    ],
-)
-def test_read_write(enabled_dsns, sample_rate, should_use_compression):
+def test_read_write():
     cache = redis.RedisProjectConfigCache()
     my_key = "fake-dsn-1"
-    with override_options(
-        {
-            "relay.project-config-cache-compress": enabled_dsns,
-            "relay.project-config-cache-compress-sample-rate": sample_rate,
-        }
-    ):
-        assert redis._use_compression(my_key) == should_use_compression
-        cache.set_many({my_key: "my-value"})
-        assert cache.get(my_key) == "my-value"
+    cache.set_many({my_key: "my-value"})
+    assert cache.get(my_key) == "my-value"


### PR DESCRIPTION
Always compress redis cache entries for project config, obsolete the corresponding options. Note that you need a recent Relay version to successfully read from the cache.

Also in this PR: Collect a statsd metric for the compression ratio.