### PR TITLE
fix(profiling): Show unkonwn for packages with no name

### DIFF
--- a/static/app/components/profiling/functionsTable.tsx
+++ b/static/app/components/profiling/functionsTable.tsx
@@ -169,6 +169,7 @@ function ProfilingFunctionsTableCell({
     case 'examples':
       return <ArrayLinks items={value} />;
     case 'name':
+    case 'package':
       const name = value || <EmptyValueContainer>{t('Unknown')}</EmptyValueContainer>;
       return <Container>{name}</Container>;
     default:

--- a/tests/js/spec/components/profiling/functionsTable.spec.tsx
+++ b/tests/js/spec/components/profiling/functionsTable.spec.tsx
@@ -109,6 +109,72 @@ describe('FunctionsTable', function () {
     expect(screen.getByText('P99 Duration')).toBeInTheDocument();
     expect(screen.getByText('12.50ms')).toBeInTheDocument();
   });
+
+  it('renders empty name', function () {
+    const func = {
+      count: 10,
+      examples: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'],
+      fingerprint: 1234,
+      name: '',
+      p75: 10000000,
+      p95: 12000000,
+      p99: 12500000,
+      package: 'bar',
+      path: 'baz',
+      worst: 'cccccccccccccccccccccccccccccccc',
+    };
+
+    render(
+      <TestContext>
+        <FunctionsTable
+          isLoading={false}
+          error={null}
+          functions={[func]}
+          project={project}
+          sort="-p99"
+        />
+      </TestContext>
+    );
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+
+    expect(screen.getByText('Package')).toBeInTheDocument();
+    expect(screen.getByText('bar')).toBeInTheDocument();
+  });
+
+  it('renders empty package', function () {
+    const func = {
+      count: 10,
+      examples: ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'],
+      fingerprint: 1234,
+      name: 'foo',
+      p75: 10000000,
+      p95: 12000000,
+      p99: 12500000,
+      package: '',
+      path: 'baz',
+      worst: 'cccccccccccccccccccccccccccccccc',
+    };
+
+    render(
+      <TestContext>
+        <FunctionsTable
+          isLoading={false}
+          error={null}
+          functions={[func]}
+          project={project}
+          sort="-p99"
+        />
+      </TestContext>
+    );
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('foo')).toBeInTheDocument();
+
+    expect(screen.getByText('Package')).toBeInTheDocument();
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
 });
 
 describe('LegacyFunctionsTable', function () {


### PR DESCRIPTION
Some packages don't have names even after symbolication. Show unknown instead of
nothing in these cases.