### PR TITLE
fix(widget-builder): Pin tags request to 14d

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -277,7 +277,12 @@ function WidgetBuilder({
     });
 
     if (objectIsEmpty(tags)) {
-      loadOrganizationTags(api, organization.slug, selection);
+      loadOrganizationTags(api, organization.slug, {
+        ...selection,
+        // Pin the request to 14d to avoid timeouts, see DD-967 for
+        // more information
+        datetime: {period: '14d', start: null, end: null, utc: null},
+      });
     }
 
     if (isEditing && isValidWidgetIndex) {


### PR DESCRIPTION
Avoids timing out the request and makes the experience more consistent
until we prioritize work to load more tags better