### PR TITLE
fix(widget-builder): Query alias not being set in chart

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
@@ -312,9 +312,11 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
         );
       })
     );
+    const rawResultsClone = cloneDeep(this.state.rawResults) ?? [];
     const transformedTimeseriesResults: Series[] = [];
     responses.forEach(([data], requestIndex) => {
       afterFetchSeriesData?.(data);
+      rawResultsClone[requestIndex] = data;
       const transformedResult = config.transformSeries!(
         data,
         widget.queries[requestIndex],
@@ -334,7 +336,10 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
 
     if (this._isMounted && this.state.queryFetchID === queryFetchID) {
       onDataFetched?.({timeseriesResults: transformedTimeseriesResults});
-      this.setState({timeseriesResults: transformedTimeseriesResults});
+      this.setState({
+        timeseriesResults: transformedTimeseriesResults,
+        rawResults: rawResultsClone,
+      });
     }
   }
 


### PR DESCRIPTION
There was some code missed in the refactor to a generic widget queries
component that caches rawResults and modifies it in the case of changing
a filter alias
