### PR TITLE
chore(platformicons): updated to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "papaparse": "^5.3.2",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.6",
-    "platformicons": "5.0.3",
+    "platformicons": "^5.2.0",
     "po-catalog-loader": "2.0.0",
     "prettier": "2.7.1",
     "prism-sentry": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11416,10 +11416,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-platformicons@5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.0.3.tgz#526b88396d9347abbfe6d9ddc460f82fdf0bbb6e"
-  integrity sha512-P6paDW62nuARnx6ZaohYhRjMBrHwqcDhJJqVi3rGLoVhq2dDLD9DaPfTg9ynj4/W/yLNqkUwoQwRW49yLrH92w==
+platformicons@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.2.0.tgz#822854b965514840b7c3effe27a9f824d834dc0a"
+  integrity sha512-VlWDzwo2naHGRSK3sAMDv9lv+A82K5SXFObio647TyqXDfot5cSPckYvG9B27kUTPYYtzuZjKPoaiL6UwUvZnQ==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Updating to latest 5.2.0 https://github.com/getsentry/platformicons/pull/73