### PR TITLE
fix(hybrid-cloud): Do not bork at subdomain middleware if the host name is not RFC 1034/1035 compliant

### DIFF
--- a/src/sentry/middleware/subdomain.py
+++ b/src/sentry/middleware/subdomain.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+from django.core.exceptions import DisallowedHost
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -30,7 +31,10 @@ class SubdomainMiddleware:
         if not self.base_hostname:
             return self.get_response(request)
 
-        host = request.get_host().lower()
+        try:
+            host = request.get_host().lower()
+        except DisallowedHost:
+            return self.get_response(request)
 
         if not host.endswith(f".{self.base_hostname}"):
             return self.get_response(request)

--- a/tests/sentry/middleware/test_subdomain.py
+++ b/tests/sentry/middleware/test_subdomain.py
@@ -24,6 +24,8 @@ class SubdomainMiddlewareTest(TestCase):
             assert request_with_host("FOOBAR.us.dev.getsentry.net:8000").subdomain == "foobar"
             assert request_with_host("foo.bar.us.dev.getsentry.net:8000").subdomain == "foo.bar"
             assert request_with_host("foo.BAR.us.dev.getsentry.net:8000").subdomain == "foo.bar"
+            # Invalid subdomain according to RFC 1034/1035.
+            assert request_with_host("_smtp._tcp.us.dev.getsentry.net:8000").subdomain is None
 
         with self.options({}):
             assert request_with_host("foobar").subdomain is None
@@ -31,3 +33,4 @@ class SubdomainMiddlewareTest(TestCase):
             assert request_with_host("us.dev.getsentry.net:8000").subdomain is None
             assert request_with_host("foobar.us.dev.getsentry.net:8000").subdomain is None
             assert request_with_host("foo.bar.us.dev.getsentry.net:8000").subdomain is None
+            assert request_with_host("_smtp._tcp.us.dev.getsentry.net:8000").subdomain is None


### PR DESCRIPTION
[`HttpRequest.get_host()`](https://docs.djangoproject.com/en/4.0/ref/request-response/#django.http.HttpRequest.get_host) will raise `django.core.exceptions.DisallowedHost` if the `HTTP_HOST` header does not comply with [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034.html)/[1035](https://datatracker.ietf.org/doc/html/rfc1035.html). In this case, we just bail out of the subdomain middleware early and continue processing the request.
 
Fixes SENTRY-VJD and others.