### PR TITLE
Sentry Functions: Fetching data, editing, deletion for Frontend

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -819,6 +819,16 @@ function buildRoutes() {
                 )
             )}
           />
+          <Route
+            path=":functionSlug/"
+            name={t('Edit Sentry Function')}
+            component={make(
+              () =>
+                import(
+                  'sentry/views/settings/organizationDeveloperSettings/sentryFunctionDetails'
+                )
+            )}
+          />
         </Route>
       </Route>
     </Route>

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -526,3 +526,11 @@ export type ServerlessFunction = {
   runtime: string;
   version: number;
 };
+
+export type SentryFunction = {
+  author: string;
+  code: string;
+  name: string;
+  slug: string;
+  overview?: string;
+};

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
@@ -100,7 +100,7 @@ function SentryFunctionDetails(props: Props) {
       // TODO: Not sure where to redirect to, so just redirect to the unbuilt Sentry Functions page
       browserHistory.push(`/settings/${orgId}/developer-settings/sentry-functions/`);
     } catch (err) {
-      addErrorMessage(t(err.responseJSON.detail));
+      addErrorMessage(err?.responseJSON?.detail || t('Unknown Error'));
     }
   }
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
@@ -65,7 +65,7 @@ function SentryFunctionDetails(props: Props) {
     console.log('Body: ' + req.body);
     res.status(200).send(message);
   };`;
-  // TODO: This doesn't work, figure this out
+
   useEffect(() => {
     form.current.setValue('code', defaultCode);
   }, [defaultCode]);

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
@@ -15,11 +15,13 @@ import JsonForm from 'sentry/components/forms/jsonForm';
 import FormModel from 'sentry/components/forms/model';
 import {Field} from 'sentry/components/forms/type';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {SentryFunction} from 'sentry/types';
 import useApi from 'sentry/utils/useApi';
 
-type Props = WrapperProps;
+type Props = {
+  sentryFunction?: SentryFunction;
+} & WrapperProps;
 const formFields: Field[] = [
   {
     name: 'name',
@@ -102,7 +104,9 @@ function SentryFunctionDetails(props: Props) {
       <Feature features={['organizations:sentry-functions']}>
         <h1>{t('Sentry Function Details')}</h1>
         <h2>
-          {t(sentryFunction ? "Editing  '" + sentryFunction.name + "'" : 'New Function')}
+          {sentryFunction
+            ? tct('Editing [name] + ', {name: sentryFunction.name})
+            : t('New Function')}
         </h2>
         <Form
           apiMethod={method}
@@ -159,7 +163,6 @@ type WrapperState = {
 
 type WrapperProps = {
   params: {orgId: string; functionSlug?: string};
-  sentryFunction?: SentryFunction;
 } & AsyncComponent['props'];
 
 class SentryFunctionsWrapper extends AsyncComponent<WrapperProps, WrapperState> {

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useRef} from 'react';
 import {browserHistory} from 'react-router';
 import Editor from '@monaco-editor/react';
 
@@ -66,10 +66,6 @@ function SentryFunctionDetails(props: Props) {
     res.status(200).send(message);
   };`;
 
-  useEffect(() => {
-    form.current.setValue('code', defaultCode);
-  }, [defaultCode]);
-
   const handleSubmitError = err => {
     let errorMessage = t('Unknown Error');
     if (err.status >= 400 && err.status < 500) {
@@ -104,7 +100,7 @@ function SentryFunctionDetails(props: Props) {
       // TODO: Not sure where to redirect to, so just redirect to the unbuilt Sentry Functions page
       browserHistory.push(`/settings/${orgId}/developer-settings/sentry-functions/`);
     } catch (err) {
-      addErrorMessage(t(err.responseJSON));
+      addErrorMessage(t(err.responseJSON.detail));
     }
   }
 
@@ -125,6 +121,7 @@ function SentryFunctionDetails(props: Props) {
             addLoadingMessage(t('Saving changes..'));
           }}
           initialData={{
+            code: defaultCode,
             ...props.sentryFunction,
           }}
           onSubmitError={handleSubmitError}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
@@ -93,10 +93,15 @@ function SentryFunctionDetails(props: Props) {
 
   async function handleDelete() {
     // figure out how to send a delete request
-    await api.requestPromise(endpoint, {
+    const response = await api.requestPromise(endpoint, {
       method: 'DELETE',
     });
-    browserHistory.push(`/settings/${orgId}/developer-settings/`);
+    if (response.status === 204) {
+      browserHistory.push(`/settings/${orgId}/developer-settings/`);
+      // TODO: Maybe show a success message?
+    } else if (response.status >= 400 && response.status < 500) {
+      addErrorMessage(t('Error deleting Sentry Function, try again later.'));
+    }
   }
 
   return (

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
@@ -1,4 +1,5 @@
 import React, {useRef} from 'react';
+import {browserHistory} from 'react-router';
 import Editor from '@monaco-editor/react';
 
 import {
@@ -8,12 +9,15 @@ import {
 } from 'sentry/actionCreators/indicator';
 import Feature from 'sentry/components/acl/feature';
 import AsyncComponent from 'sentry/components/asyncComponent';
+import Button from 'sentry/components/button';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import FormModel from 'sentry/components/forms/model';
 import {Field} from 'sentry/components/forms/type';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
+import {SentryFunction} from 'sentry/types';
+import useApi from 'sentry/utils/useApi';
 
 type Props = WrapperProps;
 const formFields: Field[] = [
@@ -42,10 +46,24 @@ const formFields: Field[] = [
 ];
 
 function SentryFunctionDetails(props: Props) {
+  const api = useApi();
   const form = useRef(new FormModel());
   const {orgId, functionSlug} = props.params;
+  const {sentryFunction} = props;
   const method = functionSlug ? 'PUT' : 'POST';
-  const endpoint = `/organizations/${orgId}/functions/`;
+  let endpoint = `/organizations/${orgId}/functions/`;
+  if (functionSlug) {
+    endpoint += `${functionSlug}/`;
+  }
+  const defaultCode = sentryFunction
+    ? sentryFunction.code
+    : `exports.yourFunction = (req, res) => {
+    let message = req.query.message || req.body.message || 'Hello World!';
+    console.log('Query: ' + req.query);
+    console.log('Body: ' + req.body);
+    res.status(200).send(message);
+};`;
+  const [code, setCode] = React.useState(defaultCode);
 
   const handleSubmitError = err => {
     let errorMessage = t('Unknown Error');
@@ -57,29 +75,46 @@ function SentryFunctionDetails(props: Props) {
 
   const handleSubmitSuccess = data => {
     addSuccessMessage(t('Sentry Function successfully saved.', data.name));
+    const baseUrl = `/settings/${orgId}/developer-settings/sentry-functions/`;
+    // TODO: should figure out where to redirect this
+    const url = `${baseUrl}${data.slug}/`;
+    if (sentryFunction) {
+      addSuccessMessage(t('%s successfully saved.', data.name));
+    } else {
+      addSuccessMessage(t('%s successfully created.', data.name));
+    }
+    browserHistory.push(url);
   };
 
   function handleEditorChange(value, _event) {
-    form.current.setValue('code', value);
+    setCode(value);
   }
 
-  const defaultCode = `exports.yourFunction = (req, res) => {
-    let message = req.query.message || req.body.message || 'Hello World!';
-    console.log('Query: ' + req.query);
-    console.log('Body: ' + req.body);
-    res.status(200).send(message);
-};`;
+  async function handleDelete() {
+    // figure out how to send a delete request
+    await api.requestPromise(endpoint, {
+      method: 'DELETE',
+    });
+    browserHistory.push(`/settings/${orgId}/developer-settings/`);
+  }
+
   return (
     <div>
       <Feature features={['organizations:sentry-functions']}>
         <h1>{t('Sentry Function Details')}</h1>
-        <h2>{props.params.orgId}</h2>
+        <h2>
+          {sentryFunction ? "Editing  '" + sentryFunction.name + "'" : 'New Function'}
+        </h2>
         <Form
           apiMethod={method}
           apiEndpoint={endpoint}
           model={form.current}
           onPreSubmit={() => {
+            form.current.setValue('code', code);
             addLoadingMessage(t('Saving changes..'));
+          }}
+          initialData={{
+            ...props.sentryFunction,
           }}
           onSubmitError={handleSubmitError}
           onSubmitSuccess={handleSubmitSuccess}
@@ -104,20 +139,43 @@ function SentryFunctionDetails(props: Props) {
             </PanelBody>
           </Panel>
         </Form>
+        {sentryFunction && (
+          <Button
+            onClick={handleDelete}
+            title={t('Delete Sentry Function')}
+            aria-label={t('Delete Sentry Function')}
+            type="button"
+            priority="danger"
+          >
+            Delete Sentry Function
+          </Button>
+        )}
       </Feature>
     </div>
   );
 }
 
-type WrapperState = {} & AsyncComponent['state'];
+type WrapperState = {
+  sentryFunction: SentryFunction;
+} & AsyncComponent['state'];
 
 type WrapperProps = {
   params: {orgId: string; functionSlug?: string};
+  sentryFunction?: SentryFunction;
 } & AsyncComponent['props'];
 
 class SentryFunctionsWrapper extends AsyncComponent<WrapperProps, WrapperState> {
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {functionSlug, orgId} = this.props.params;
+    if (functionSlug) {
+      return [['sentryFunction', `/organizations/${orgId}/functions/${functionSlug}/`]];
+    }
+    return [];
+  }
   renderBody() {
-    return <SentryFunctionDetails {...this.props} />;
+    return (
+      <SentryFunctionDetails sentryFunction={this.state.sentryFunction} {...this.props} />
+    );
   }
 }
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react';
+import React, {useEffect, useRef} from 'react';
 import {browserHistory} from 'react-router';
 import Editor from '@monaco-editor/react';
 
@@ -65,6 +65,10 @@ function SentryFunctionDetails(props: Props) {
     console.log('Body: ' + req.body);
     res.status(200).send(message);
   };`;
+  // TODO: This doesn't work, figure this out
+  useEffect(() => {
+    form.current.setValue('code', defaultCode);
+  }, [defaultCode]);
 
   const handleSubmitError = err => {
     let errorMessage = t('Unknown Error');
@@ -92,15 +96,15 @@ function SentryFunctionDetails(props: Props) {
   }
 
   async function handleDelete() {
-    // figure out how to send a delete request
-    const response = await api.requestPromise(endpoint, {
-      method: 'DELETE',
-    });
-    if (response.status === 204) {
-      browserHistory.push(`/settings/${orgId}/developer-settings/`);
-      // TODO: Maybe show a success message?
-    } else if (response.status >= 400 && response.status < 500) {
-      addErrorMessage(t('Error deleting Sentry Function, try again later.'));
+    try {
+      await api.requestPromise(endpoint, {
+        method: 'DELETE',
+      });
+      addSuccessMessage(t('Sentry Function successfully deleted.'));
+      // TODO: Not sure where to redirect to, so just redirect to the unbuilt Sentry Functions page
+      browserHistory.push(`/settings/${orgId}/developer-settings/sentry-functions/`);
+    } catch (err) {
+      addErrorMessage(t(err.responseJSON));
     }
   }
 
@@ -110,7 +114,7 @@ function SentryFunctionDetails(props: Props) {
         <h1>{t('Sentry Function Details')}</h1>
         <h2>
           {sentryFunction
-            ? tct('Editing [name] + ', {name: sentryFunction.name})
+            ? tct('Editing [name]', {name: sentryFunction.name})
             : t('New Function')}
         </h2>
         <Form

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionDetails.tsx
@@ -62,8 +62,7 @@ function SentryFunctionDetails(props: Props) {
     console.log('Query: ' + req.query);
     console.log('Body: ' + req.body);
     res.status(200).send(message);
-};`;
-  const [code, setCode] = React.useState(defaultCode);
+  };`;
 
   const handleSubmitError = err => {
     let errorMessage = t('Unknown Error');
@@ -87,7 +86,7 @@ function SentryFunctionDetails(props: Props) {
   };
 
   function handleEditorChange(value, _event) {
-    setCode(value);
+    form.current.setValue('code', value);
   }
 
   async function handleDelete() {
@@ -103,14 +102,13 @@ function SentryFunctionDetails(props: Props) {
       <Feature features={['organizations:sentry-functions']}>
         <h1>{t('Sentry Function Details')}</h1>
         <h2>
-          {sentryFunction ? "Editing  '" + sentryFunction.name + "'" : 'New Function'}
+          {t(sentryFunction ? "Editing  '" + sentryFunction.name + "'" : 'New Function')}
         </h2>
         <Form
           apiMethod={method}
           apiEndpoint={endpoint}
           model={form.current}
           onPreSubmit={() => {
-            form.current.setValue('code', code);
             addLoadingMessage(t('Saving changes..'));
           }}
           initialData={{
@@ -147,7 +145,7 @@ function SentryFunctionDetails(props: Props) {
             type="button"
             priority="danger"
           >
-            Delete Sentry Function
+            {t('Delete Sentry Function')}
           </Button>
         )}
       </Feature>
@@ -156,7 +154,7 @@ function SentryFunctionDetails(props: Props) {
 }
 
 type WrapperState = {
-  sentryFunction: SentryFunction;
+  sentryFunction?: SentryFunction;
 } & AsyncComponent['state'];
 
 type WrapperProps = {


### PR DESCRIPTION
We can now see created Sentry Functions! In this PR, a new page is made for editing Sentry Functions and a delete button is also included. Not yet fully styled, so a little rough, but trying to ensure functionality. Redirects also included.