### PR TITLE
fix(visibility): Function cell actions

### DIFF
--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -10,7 +10,6 @@ import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {
-  getAggregateAlias,
   isEquationAlias,
   isRelativeSpanOperationBreakdownField,
 } from 'sentry/utils/discover/fields';
@@ -138,9 +137,7 @@ function makeCellActions({
     return null;
   }
 
-  const fieldAlias = getAggregateAlias(column.name);
-
-  let value = dataRow[fieldAlias];
+  let value = dataRow[column.name];
 
   // error.handled is a strange field where null = true.
   if (

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -27,7 +27,6 @@ import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {
   Column,
   fieldAlignment,
-  getAggregateAlias,
   getEquationAliasIndex,
   isEquationAlias,
 } from 'sentry/utils/discover/fields';
@@ -292,7 +291,7 @@ class TableView extends Component<TableViewProps> {
       }
     }
 
-    const fieldName = getAggregateAlias(columnKey);
+    const fieldName = columnKey;
     const value = dataRow[fieldName];
     if (tableData.meta[fieldName] === 'integer' && defined(value) && value > 999) {
       return (

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -11,7 +11,7 @@ const defaultData = {
   release: 'F2520C43515BD1F0E8A6BD46233324641A370BF6',
   nullValue: null,
   'measurements.fcp': 1234,
-  percentile_measurements_fcp_0_5: 1234,
+  'percentile(measurements.fcp, 0.5)': 1234,
   'error.handled': [null],
   'error.type': [
     'ServerException',
@@ -340,7 +340,7 @@ describe('Discover -> CellAction', function () {
 
       wrapper = makeWrapper(view, handleCellAction, 6, {
         ...defaultData,
-        percentile_measurements_fcp_0_5: null,
+        'percentile(measurements.fcp, 0.5)': null,
       });
       wrapper.find('Container').simulate('mouseEnter');
       expect(wrapper.find('MenuButton').exists()).toBeFalsy();

--- a/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/tableView.spec.jsx
@@ -92,7 +92,7 @@ describe('TableView > CellActions', function () {
       meta: {
         title: 'string',
         transaction: 'string',
-        count: 'integer',
+        'count()': 'integer',
         timestamp: 'date',
         release: 'string',
         'equation[0]': 'integer',
@@ -101,7 +101,7 @@ describe('TableView > CellActions', function () {
         {
           title: 'some title',
           transaction: '/organizations/',
-          count: 9,
+          'count()': 9,
           timestamp: '2019-05-23T22:12:48+00:00',
           release: 'v1.0.2',
           'equation[0]': 109,
@@ -332,7 +332,7 @@ describe('TableView > CellActions', function () {
   });
 
   it('has tooltip on integer value greater than 999', function () {
-    rows.data[0].count = 1000;
+    rows.data[0]['count()'] = 1000;
     const wrapper = makeWrapper(initialData, rows, eventView);
     const tooltip = wrapper.find('GridBody Tooltip').at(1);
 


### PR DESCRIPTION
- This fixes the 'show less than' and 'show greater than' cell actions that weren't working since we changed events to no longer return the alias, but the same definition it was passed