### PR TITLE
fix(config): Ensure lastOrganization is an org that exists

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -11,7 +11,7 @@ from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
 from sentry.api.utils import generate_organization_url
 from sentry.auth.superuser import is_active_superuser
-from sentry.models import ProjectKey
+from sentry.models import Organization, ProjectKey
 from sentry.utils import auth
 from sentry.utils.assets import get_frontend_app_asset_url
 from sentry.utils.email import is_smtp_enabled
@@ -140,6 +140,12 @@ def get_client_config(request=None):
     public_dsn = _get_public_dsn()
 
     last_organization = session["activeorg"] if session and "activeorg" in session else None
+    try:
+        Organization.objects.get_from_cache(slug=last_organization)
+    except Organization.DoesNotExist:
+        last_organization = None
+        if session and "activeorg" in session:
+            del session["activeorg"]
 
     context = {
         "singleOrganization": settings.SENTRY_SINGLE_ORGANIZATION,

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -3,6 +3,8 @@ from unittest import mock
 from django.urls import reverse
 from exam import fixture
 
+from sentry.models import Organization, OrganizationStatus, ScheduledDeletion
+from sentry.tasks.deletion import run_deletion
 from sentry.testutils import TestCase
 from sentry.utils import json
 
@@ -240,3 +242,59 @@ class ClientConfigViewTest(TestCase):
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
             assert data["organizationUrl"] == f"ftp://{self.organization.slug}.us.testserver"
+
+    def test_deleted_last_organization(self):
+        self.login_as(self.user)
+
+        # Check lastOrganization
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+
+        assert data["isAuthenticated"] is True
+        assert data["lastOrganization"] is None
+        assert "activeorg" not in self.client.session
+
+        # Induce last active organization
+        resp = self.client.get(
+            reverse("sentry-api-0-organization-projects", args=[self.organization.slug])
+        )
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        # Check lastOrganization
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+
+        assert data["isAuthenticated"] is True
+        assert data["lastOrganization"] == self.organization.slug
+        assert self.client.session["activeorg"] == self.organization.slug
+
+        # Delete lastOrganization
+        assert Organization.objects.filter(slug=self.organization.slug).count() == 1
+        assert ScheduledDeletion.objects.count() == 0
+
+        self.organization.update(status=OrganizationStatus.PENDING_DELETION)
+        deletion = ScheduledDeletion.schedule(self.organization, days=0)
+        deletion.update(in_progress=True)
+
+        with self.tasks():
+            run_deletion(deletion.id)
+
+        assert Organization.objects.filter(slug=self.organization.slug).count() == 0
+
+        # Check lastOrganization
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+
+        assert data["isAuthenticated"] is True
+        assert data["lastOrganization"] is None
+        assert "activeorg" not in self.client.session


### PR DESCRIPTION
`lastOrganization` is derived from session data without any checks if the associated organization still exists. This pull request adds the fast path existence check for `lastOrganization`.

I'm doing the due diligence here as part of the customer domain work for hybrid cloud.