### PR TITLE
feat(hybrid-cloud): Return 404 if the customer domain does not match with the requested org slug

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -472,7 +472,7 @@ class ReleaseAnalyticsMixin:
 
 
 def resolve_region(request: Request):
-    subdomain = getattr(request, 'subdomain', None)
+    subdomain = getattr(request, "subdomain", None)
     if subdomain is None:
         return None
     if subdomain in {"us", "eu"}:

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -472,7 +472,7 @@ class ReleaseAnalyticsMixin:
 
 
 def resolve_region(request: Request):
-    subdomain = request.subdomain
+    subdomain = getattr(request, 'subdomain', None)
     if subdomain is None:
         return None
     if subdomain in {"us", "eu"}:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.request import Request
 
 from sentry import options
-from sentry.api.base import Endpoint
+from sentry.api.base import Endpoint, resolve_region
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
 from sentry.api.permissions import SentryPermission
@@ -366,6 +366,9 @@ class OrganizationEndpoint(Endpoint):
         return params
 
     def convert_args(self, request: Request, organization_slug=None, *args, **kwargs):
+        if resolve_region(request) is None and request.subdomain is not None and request.subdomain != organization_slug:
+            raise ResourceDoesNotExist
+
         if not organization_slug:
             raise ResourceDoesNotExist
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -366,12 +366,10 @@ class OrganizationEndpoint(Endpoint):
         return params
 
     def convert_args(self, request: Request, organization_slug=None, *args, **kwargs):
-        if (
-            resolve_region(request) is None
-            and request.subdomain is not None
-            and request.subdomain != organization_slug
-        ):
-            raise ResourceDoesNotExist
+        if resolve_region(request) is None:
+            subdomain = getattr(request, "subdomain", None)
+            if subdomain is not None and subdomain != organization_slug:
+                raise ResourceDoesNotExist
 
         if not organization_slug:
             raise ResourceDoesNotExist

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -366,7 +366,11 @@ class OrganizationEndpoint(Endpoint):
         return params
 
     def convert_args(self, request: Request, organization_slug=None, *args, **kwargs):
-        if resolve_region(request) is None and request.subdomain is not None and request.subdomain != organization_slug:
+        if (
+            resolve_region(request) is None
+            and request.subdomain is not None
+            and request.subdomain != organization_slug
+        ):
             raise ResourceDoesNotExist
 
         if not organization_slug:

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -66,6 +66,27 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         assert len(response.data["teams"]) == 0
         assert len(response.data["projects"]) == 0
 
+    def test_simple_customer_domain(self):
+        HTTP_HOST = f"{self.organization.slug}.testserver"
+        response = self.get_success_response(
+            self.organization.slug, extra_headers={"HTTP_HOST": HTTP_HOST}
+        )
+
+        assert response.data["slug"] == self.organization.slug
+        assert response.data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
+        assert response.data["onboardingTasks"] == []
+        assert response.data["id"] == str(self.organization.id)
+        assert response.data["role"] == "owner"
+        assert response.data["orgRole"] == "owner"
+        assert len(response.data["teams"]) == 0
+        assert len(response.data["projects"]) == 0
+
+    def test_org_mismatch_customer_domain(self):
+        HTTP_HOST = f"{self.organization.slug}-apples.testserver"
+        self.get_error_response(
+            self.organization.slug, status_code=404, extra_headers={"HTTP_HOST": HTTP_HOST}
+        )
+
     def test_with_projects(self):
         # Create non-member team to test response shape
         self.create_team(name="no-member", organization=self.organization)


### PR DESCRIPTION
For any org slug mismatch between a customer domain (e.g. `acme.sentry.io`) and the requested org slug, we return 404 Not Found error response.