### PR TITLE
fix: update ios device classification

### DIFF
--- a/src/sentry/profiles/device.py
+++ b/src/sentry/profiles/device.py
@@ -44,8 +44,8 @@ def classify_device(
         frequencies = ios_cpu_core_max_frequencies_mhz(model)
         if core_frequency(frequencies) < 2000:
             return DeviceClass.LOW_END  # less than 2GHz clock speed
-        if number_of_cores(frequencies) < 6:
-            return DeviceClass.MID_END  # less than 6 cores
+        if core_frequency(frequencies) < 3000:
+            return DeviceClass.MID_END  # less than 3Ghz clock speed
         return DeviceClass.HIGH_END
 
     if platform == Platform.ANDROID_DEVICE and cpu_frequencies and physical_memory_bytes:


### PR DESCRIPTION
This classification was written some time ago and is falling out of date. Two main reasons for this to be revised:
1. There are now devices clocking over 3 GHz. 
2. Core count is no longer a useful metric as the only device with a 4-core CPU–the iPhone 8–only uses two at a time (either both performance cores or both efficiency cores). The next model has 6 cores, but only 4 that perform at the max clock speed, with 2 efficiency cores at much lower rates. Just as well, the type of work cores do have diversified into motion and image coprocessors and neural engines (in addition to the GPU, of course).

For now we'll simply use the following classification based on CPU clock rate, since we are still primarily focusing on CPU usage for profiling purposes:
- low end: < 2 GHz (iPhone 4s to iPhone 6s)
- mid: ≥ 2 and < 3 GHz (iPhone 7 to iPhone 11)
- high: ≥ 3 GHz (iPhone 12 and later)

This roughly partitions the current history of devices we support into thirds. 