### PR TITLE
feat(sampling): Add transaction breakdown [TET-205]

### DIFF
--- a/docs-ui/stories/components/colorBar.stories.js
+++ b/docs-ui/stories/components/colorBar.stories.js
@@ -1,27 +1,12 @@
 import styled from '@emotion/styled';
 
+import Tooltip from 'sentry/components/tooltip';
 import theme from 'sentry/utils/theme';
 import ColorBar from 'sentry/views/performance/vitalDetail/colorBar.tsx';
 
 export default {
   title: 'Components/Data Visualization/Charts/Color Bar',
   component: ColorBar,
-  args: {
-    colorStops: [
-      {
-        color: theme.green300,
-        percent: 0.6,
-      },
-      {
-        color: theme.yellow300,
-        percent: 0.3,
-      },
-      {
-        color: theme.red300,
-        percent: 0.1,
-      },
-    ],
-  },
 };
 
 export const Default = ({...args}) => (
@@ -29,13 +14,64 @@ export const Default = ({...args}) => (
     <ColorBar {...args} />
   </Container>
 );
-
+Default.args = {
+  colorStops: [
+    {
+      color: theme.green300,
+      percent: 0.6,
+    },
+    {
+      color: theme.yellow300,
+      percent: 0.3,
+    },
+    {
+      color: theme.red300,
+      percent: 0.1,
+    },
+  ],
+};
 Default.storyName = 'Color Bar';
 Default.parameters = {
   docs: {
     description: {
       story:
         'Split a group of percentages or ratios into separate colors. Will stretch to cover the entire bar if missing percents',
+    },
+  },
+};
+
+export const WithTooltips = ({...args}) => (
+  <Container>
+    <ColorBar {...args} />
+  </Container>
+);
+WithTooltips.args = {
+  colorStops: [
+    {
+      color: theme.green300,
+      percent: 0.6,
+      renderBarStatus: (barStatus, key) => (
+        <Tooltip title="A - 60%" skipWrapper key={key}>
+          {barStatus}
+        </Tooltip>
+      ),
+    },
+    {
+      color: theme.yellow300,
+      percent: 0.4,
+      renderBarStatus: (barStatus, key) => (
+        <Tooltip title="B - 40%" skipWrapper key={key}>
+          {barStatus}
+        </Tooltip>
+      ),
+    },
+  ],
+};
+WithTooltips.parameters = {
+  docs: {
+    description: {
+      story:
+        'Specify a custom render function for the bars. For example you can add Tooltips via composition.',
     },
   },
 };

--- a/static/app/views/performance/vitalDetail/colorBar.tsx
+++ b/static/app/views/performance/vitalDetail/colorBar.tsx
@@ -1,11 +1,13 @@
+import {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
 import {Color} from 'sentry/utils/theme';
 
 type ColorStop = {
-  color: Color;
+  color: Color | string;
   percent: number;
+  renderBarStatus?: (barStatus: ReactNode, key: string) => ReactNode;
 };
 
 type Props = {
@@ -20,7 +22,9 @@ const ColorBar = (props: Props) => {
       fractions={props.colorStops.map(({percent}) => percent)}
     >
       {props.colorStops.map(colorStop => {
-        return <BarStatus color={colorStop.color} key={colorStop.color} />;
+        const barStatus = <BarStatus color={colorStop.color} key={colorStop.color} />;
+
+        return colorStop.renderBarStatus?.(barStatus, colorStop.color) ?? barStatus;
       })}
     </VitalBar>
   );
@@ -44,11 +48,11 @@ const VitalBar = styled('div')<VitalBarProps>`
 `;
 
 type ColorProps = {
-  color: Color;
+  color: Color | string;
 };
 
 const BarStatus = styled('div')<ColorProps>`
-  background-color: ${p => p.theme[p.color]};
+  background-color: ${p => p.theme[p.color] ?? p.color};
 `;
 
 export default ColorBar;

--- a/static/app/views/settings/project/server-side-sampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingBreakdown.tsx
@@ -1,0 +1,123 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {HeaderTitle} from 'sentry/components/charts/styles';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import ExternalLink from 'sentry/components/links/externalLink';
+import {Panel, PanelBody} from 'sentry/components/panels';
+import QuestionTooltip from 'sentry/components/questionTooltip';
+import Tooltip from 'sentry/components/tooltip';
+import {t, tct} from 'sentry/locale';
+import {ServerSideSamplingStore} from 'sentry/stores/serverSideSamplingStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import space from 'sentry/styles/space';
+import {Organization, Project} from 'sentry/types';
+import {percent} from 'sentry/utils';
+import {formatPercentage} from 'sentry/utils/formatters';
+import useProjects from 'sentry/utils/useProjects';
+import ColorBar from 'sentry/views/performance/vitalDetail/colorBar';
+
+import {SERVER_SIDE_SAMPLING_DOC_LINK} from './utils';
+
+type Props = {
+  orgSlug: Organization['slug'];
+};
+
+export function SamplingBreakdown({orgSlug}: Props) {
+  const theme = useTheme();
+  const {samplingDistribution} = useLegacyStore(ServerSideSamplingStore);
+  const projectBreakdown = samplingDistribution.project_breakdown;
+  const {projects} = useProjects({
+    slugs: projectBreakdown?.map(project => project.project) ?? [],
+    orgId: orgSlug,
+  });
+  const totalCount = projectBreakdown?.reduce(
+    (acc, project) => acc + project['count()'],
+    0
+  );
+  const projectsWithPercentages = projects
+    .map(project => ({
+      project,
+      percentage: percent(
+        projectBreakdown?.find(pb => pb.project === project.slug)?.['count()'] ?? 0,
+        totalCount ?? 0
+      ),
+    }))
+    .sort((a, z) => z.percentage - a.percentage);
+
+  if (projectsWithPercentages.length === 0) {
+    return null;
+  }
+
+  function projectWithPercentage(project: Project, percentage: number) {
+    return (
+      <ProjectWithPercentage key={project.slug}>
+        <ProjectBadge project={project} avatarSize={16} />
+        {formatPercentage(percentage / 100)}
+      </ProjectWithPercentage>
+    );
+  }
+
+  return (
+    <Panel>
+      <PanelBody withPadding>
+        <TitleWrapper>
+          <HeaderTitle>{t('Transaction Breakdown')}</HeaderTitle>
+          <QuestionTooltip
+            title={tct(
+              'Sampling rules defined here can also affect other projects. [learnMore: Learn more]',
+              {learnMore: <ExternalLink href={SERVER_SIDE_SAMPLING_DOC_LINK} />} // TODO(sampling): update docs link
+            )}
+            size="sm"
+            isHoverable
+          />
+        </TitleWrapper>
+
+        <ColorBar
+          colorStops={projectsWithPercentages.map(({project, percentage}, index) => ({
+            color: theme.charts.getColorPalette(projectsWithPercentages.length)[index],
+            percent: percentage,
+            renderBarStatus: (barStatus, key) => (
+              <Tooltip
+                title={projectWithPercentage(project, percentage)}
+                skipWrapper
+                isHoverable
+                key={key}
+              >
+                {barStatus}
+              </Tooltip>
+            ),
+          }))}
+        />
+        <Projects>
+          {projectsWithPercentages.map(({project, percentage}) =>
+            projectWithPercentage(project, percentage)
+          )}
+        </Projects>
+      </PanelBody>
+    </Panel>
+  );
+}
+
+const TitleWrapper = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
+  margin-bottom: ${space(1.5)};
+`;
+
+const Projects = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${space(1.5)};
+  justify-content: flex-start;
+  align-items: center;
+  margin-top: ${space(1.5)};
+`;
+
+const ProjectWithPercentage = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+  color: ${p => p.theme.subText};
+`;

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -55,6 +55,7 @@ import {
   RateColumn,
   Rule,
 } from './rule';
+import {SamplingBreakdown} from './samplingBreakdown';
 import {SamplingSDKAlert} from './samplingSDKAlert';
 import {isUniformRule, SERVER_SIDE_SAMPLING_DOC_LINK} from './utils';
 
@@ -419,6 +420,7 @@ export function ServerSideSampling({project}: Props) {
             onReadDocs={handleReadDocs}
           />
         )}
+        <SamplingBreakdown orgSlug={organization.slug} />
         <RulesPanel>
           <RulesPanelHeader lightText>
             <RulesPanelLayout>

--- a/tests/js/spec/views/settings/project/server-side-sampling/samplingBreakdown.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/samplingBreakdown.spec.tsx
@@ -1,0 +1,41 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {ServerSideSamplingStore} from 'sentry/stores/serverSideSamplingStore';
+import {SamplingBreakdown} from 'sentry/views/settings/project/server-side-sampling/samplingBreakdown';
+
+import {getMockData, mockedSamplingDistribution} from './utils';
+
+const headerTitle = 'Transaction Breakdown';
+
+describe('Server-side Sampling - SamplingBreakdown', function () {
+  beforeEach(function () {
+    ServerSideSamplingStore.reset();
+  });
+
+  it('does not render content', function () {
+    const {organization} = getMockData();
+
+    render(<SamplingBreakdown orgSlug={organization.slug} />);
+
+    expect(screen.queryByText(headerTitle)).not.toBeInTheDocument();
+  });
+
+  it('renders project breakdown', function () {
+    const {organization} = getMockData();
+    const projectBreakdown = mockedSamplingDistribution.project_breakdown;
+
+    ProjectsStore.loadInitialData(
+      projectBreakdown!.map(p => TestStubs.Project({id: p.project_id, slug: p.project}))
+    );
+    ServerSideSamplingStore.loadSamplingDistributionSuccess(mockedSamplingDistribution);
+
+    render(<SamplingBreakdown orgSlug={organization.slug} />);
+
+    expect(screen.getByText(headerTitle)).toBeInTheDocument();
+    expect(screen.getByText('javascript')).toBeInTheDocument();
+    expect(screen.getByText('89.88%')).toBeInTheDocument();
+    expect(screen.getByText('sentry')).toBeInTheDocument();
+    expect(screen.getByText('10.12%')).toBeInTheDocument();
+  });
+});

--- a/tests/js/spec/views/settings/project/server-side-sampling/samplingBreakdown.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/samplingBreakdown.spec.tsx
@@ -6,7 +6,7 @@ import {SamplingBreakdown} from 'sentry/views/settings/project/server-side-sampl
 
 import {getMockData, mockedSamplingDistribution} from './utils';
 
-const headerTitle = 'Transaction Breakdown';
+export const samplingBreakdownTitle = 'Transaction Breakdown';
 
 describe('Server-side Sampling - SamplingBreakdown', function () {
   beforeEach(function () {
@@ -18,7 +18,7 @@ describe('Server-side Sampling - SamplingBreakdown', function () {
 
     render(<SamplingBreakdown orgSlug={organization.slug} />);
 
-    expect(screen.queryByText(headerTitle)).not.toBeInTheDocument();
+    expect(screen.queryByText(samplingBreakdownTitle)).not.toBeInTheDocument();
   });
 
   it('renders project breakdown', function () {
@@ -32,7 +32,7 @@ describe('Server-side Sampling - SamplingBreakdown', function () {
 
     render(<SamplingBreakdown orgSlug={organization.slug} />);
 
-    expect(screen.getByText(headerTitle)).toBeInTheDocument();
+    expect(screen.getByText(samplingBreakdownTitle)).toBeInTheDocument();
     expect(screen.getByText('javascript')).toBeInTheDocument();
     expect(screen.getByText('89.88%')).toBeInTheDocument();
     expect(screen.getByText('sentry')).toBeInTheDocument();

--- a/tests/js/spec/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
@@ -8,6 +8,7 @@ import {
 
 import {SERVER_SIDE_SAMPLING_DOC_LINK} from 'sentry/views/settings/project/server-side-sampling/utils';
 
+import {samplingBreakdownTitle} from './samplingBreakdown.spec';
 import {
   getMockData,
   mockedProjects,
@@ -36,13 +37,21 @@ describe('Server-side Sampling', function () {
       method: 'GET',
       body: mockedSamplingSdkVersions,
     });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      method: 'GET',
+      body: mockedSamplingDistribution.project_breakdown!.map(p =>
+        TestStubs.Project({id: p.project_id, slug: p.project})
+      ),
+    });
   });
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
   });
 
-  it('renders onboarding promo', function () {
+  it('renders onboarding promo', async function () {
     const {router, organization, project} = getMockData();
 
     const {container} = render(
@@ -58,6 +67,9 @@ describe('Server-side Sampling', function () {
         'Server-side sampling lets you control what transactions Sentry retains by setting sample rules and rates so you see more of the transactions you want to explore further in Sentry – and less of the ones you don’t – without re-configuring the Sentry SDK and redeploying anything.'
       )
     ).toBeInTheDocument();
+
+    // Assert that project breakdown is there
+    expect(await screen.findByText(samplingBreakdownTitle)).toBeInTheDocument();
 
     expect(
       screen.getByRole('heading', {name: 'Set sample rules for your project'})
@@ -79,7 +91,7 @@ describe('Server-side Sampling', function () {
     expect(container).toSnapshot();
   });
 
-  it('renders rules panel', function () {
+  it('renders rules panel', async function () {
     const {router, organization, project} = getMockData({
       projects: [
         TestStubs.Project({
@@ -93,6 +105,9 @@ describe('Server-side Sampling', function () {
     const {container} = render(
       <TestComponent router={router} organization={organization} project={project} />
     );
+
+    // Assert that project breakdown is there
+    expect(await screen.findByText(samplingBreakdownTitle)).toBeInTheDocument();
 
     // Rule Panel Header
     expect(screen.getByText('Operator')).toBeInTheDocument();
@@ -119,7 +134,7 @@ describe('Server-side Sampling', function () {
     expect(container).toSnapshot();
   });
 
-  it('does not let you delete the base rule', function () {
+  it('does not let you delete the base rule', async function () {
     const {router, organization, project} = getMockData({
       projects: [
         TestStubs.Project({
@@ -161,6 +176,9 @@ describe('Server-side Sampling', function () {
     render(
       <TestComponent router={router} organization={organization} project={project} />
     );
+
+    // Assert that project breakdown is there (avoids 'act' warnings)
+    expect(await screen.findByText(samplingBreakdownTitle)).toBeInTheDocument();
 
     const deleteButtons = screen.getAllByLabelText('Delete');
     expect(deleteButtons[0]).not.toHaveAttribute('disabled'); // eslint-disable-line jest-dom/prefer-enabled-disabled


### PR DESCRIPTION
As a user, I want to see which projects are connected via tracing with my current project, so that I can understand how my sampling rate and different rules also impact other projects.

![image](https://user-images.githubusercontent.com/9060071/181043038-3c8ce27a-86e0-4e10-b10c-fd604f07d61b.png)