### PR TITLE
feat(replays): add how-to-config message for self-hosted

### DIFF
--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -63,13 +63,12 @@ function FocusArea({}: Props) {
       return <NetworkList event={event} networkSpans={getNetworkSpans()} />;
     case 'trace':
       const features = ['organizations:performance-view'];
-      const noFeatureMessage = t('Requires performance monitoring.');
 
       const renderDisabled = () => (
         <FeatureDisabled
-          featureName={noFeatureMessage}
+          featureName={t('Performance monitoring')}
           features={features}
-          message={noFeatureMessage}
+          message={t('Requires Performance monitoring.')}
           hideHelpToggle
         />
       );

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -1,7 +1,10 @@
 import {useMemo} from 'react';
 
+import Feature from 'sentry/components/acl/feature';
+import FeatureDisabled from 'sentry/components/acl/featureDisabled';
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {t} from 'sentry/locale';
 import type {RawCrumb} from 'sentry/types/breadcrumbs';
 import {isBreadcrumbTypeDefault} from 'sentry/types/breadcrumbs';
 import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
@@ -59,7 +62,27 @@ function FocusArea({}: Props) {
     case 'network':
       return <NetworkList event={event} networkSpans={getNetworkSpans()} />;
     case 'trace':
-      return <Trace organization={organization} event={event} />;
+      const features = ['organizations:performance-views'];
+      const noFeatureMessage = t('Requires performance monitoring.');
+
+      const renderDisabled = () => (
+        <FeatureDisabled
+          featureName={noFeatureMessage}
+          features={features}
+          alert
+          message={noFeatureMessage}
+        />
+      );
+      return (
+        <Feature
+          organization={organization}
+          hookName="feature-disabled:configure-distributed-tracing"
+          features={features}
+          renderDisabled={renderDisabled}
+        >
+          <Trace organization={organization} event={event} />
+        </Feature>
+      );
     case 'issues':
       return <IssueList replayId={event.id} projectId={event.projectID} />;
     case 'dom':

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -62,7 +62,7 @@ function FocusArea({}: Props) {
     case 'network':
       return <NetworkList event={event} networkSpans={getNetworkSpans()} />;
     case 'trace':
-      const features = ['organizations:performance-views'];
+      const features = ['organizations:performance-view'];
       const noFeatureMessage = t('Requires performance monitoring.');
 
       const renderDisabled = () => (

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -66,9 +66,9 @@ function FocusArea({}: Props) {
 
       const renderDisabled = () => (
         <FeatureDisabled
-          featureName={t('Performance monitoring')}
+          featureName={t('Performance Monitoring')}
           features={features}
-          message={t('Requires Performance monitoring.')}
+          message={t('Requires performance monitoring.')}
           hideHelpToggle
         />
       );

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -69,8 +69,8 @@ function FocusArea({}: Props) {
         <FeatureDisabled
           featureName={noFeatureMessage}
           features={features}
-          alert
           message={noFeatureMessage}
+          hideHelpToggle
         />
       );
       return (


### PR DESCRIPTION


<!-- Describe your PR here. -->
Added a feature check in order to show a how-to-config message for self-hosted in case trace is disabled. Closes #36584 

![image](https://user-images.githubusercontent.com/39612839/181069286-319d3ebe-6d4a-420c-83dd-9a0f86c3d4f1.png)

![image](https://user-images.githubusercontent.com/39612839/181069309-966c4c93-a966-4d8f-92f6-8c7f192f679d.png)



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
