### PR TITLE
feat(mep): Hide histograms on metrics side of landing

### DIFF
--- a/static/app/views/performance/landing/views/backendView.tsx
+++ b/static/app/views/performance/landing/views/backendView.tsx
@@ -5,28 +5,32 @@ import Table from '../../table';
 import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
 import {BACKEND_COLUMN_TITLES} from '../data';
 import {DoubleChartRow, TripleChartRow} from '../widgets/components/widgetChartRow';
+import {filterAllowedChartsMetrics} from '../widgets/utils';
 import {PerformanceWidgetSetting} from '../widgets/widgetDefinitions';
 
 import {BasePerformanceViewProps} from './types';
+
+function getAllowedChartsSmall(props: BasePerformanceViewProps) {
+  const charts = [
+    PerformanceWidgetSetting.APDEX_AREA,
+    PerformanceWidgetSetting.TPM_AREA,
+    PerformanceWidgetSetting.FAILURE_RATE_AREA,
+    PerformanceWidgetSetting.USER_MISERY_AREA,
+    PerformanceWidgetSetting.P50_DURATION_AREA,
+    PerformanceWidgetSetting.P75_DURATION_AREA,
+    PerformanceWidgetSetting.P95_DURATION_AREA,
+    PerformanceWidgetSetting.P99_DURATION_AREA,
+    PerformanceWidgetSetting.DURATION_HISTOGRAM,
+  ];
+
+  return filterAllowedChartsMetrics(props.organization, charts);
+}
 
 export function BackendView(props: BasePerformanceViewProps) {
   return (
     <PerformanceDisplayProvider value={{performanceType: PROJECT_PERFORMANCE_TYPE.ANY}}>
       <div>
-        <TripleChartRow
-          {...props}
-          allowedCharts={[
-            PerformanceWidgetSetting.APDEX_AREA,
-            PerformanceWidgetSetting.TPM_AREA,
-            PerformanceWidgetSetting.FAILURE_RATE_AREA,
-            PerformanceWidgetSetting.USER_MISERY_AREA,
-            PerformanceWidgetSetting.P50_DURATION_AREA,
-            PerformanceWidgetSetting.P75_DURATION_AREA,
-            PerformanceWidgetSetting.P95_DURATION_AREA,
-            PerformanceWidgetSetting.P99_DURATION_AREA,
-            PerformanceWidgetSetting.DURATION_HISTOGRAM,
-          ]}
-        />
+        <TripleChartRow {...props} allowedCharts={getAllowedChartsSmall(props)} />
         <DoubleChartRow
           {...props}
           allowedCharts={[

--- a/static/app/views/performance/landing/views/frontendOtherView.tsx
+++ b/static/app/views/performance/landing/views/frontendOtherView.tsx
@@ -5,9 +5,23 @@ import Table from '../../table';
 import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
 import {FRONTEND_OTHER_COLUMN_TITLES} from '../data';
 import {DoubleChartRow, TripleChartRow} from '../widgets/components/widgetChartRow';
+import {filterAllowedChartsMetrics} from '../widgets/utils';
 import {PerformanceWidgetSetting} from '../widgets/widgetDefinitions';
 
 import {BasePerformanceViewProps} from './types';
+
+function getAllowedChartsSmall(props: BasePerformanceViewProps) {
+  const charts = [
+    PerformanceWidgetSetting.TPM_AREA,
+    PerformanceWidgetSetting.DURATION_HISTOGRAM,
+    PerformanceWidgetSetting.P50_DURATION_AREA,
+    PerformanceWidgetSetting.P75_DURATION_AREA,
+    PerformanceWidgetSetting.P95_DURATION_AREA,
+    PerformanceWidgetSetting.P99_DURATION_AREA,
+  ];
+
+  return filterAllowedChartsMetrics(props.organization, charts);
+}
 
 export function FrontendOtherView(props: BasePerformanceViewProps) {
   return (
@@ -15,17 +29,7 @@ export function FrontendOtherView(props: BasePerformanceViewProps) {
       value={{performanceType: PROJECT_PERFORMANCE_TYPE.FRONTEND_OTHER}}
     >
       <div>
-        <TripleChartRow
-          {...props}
-          allowedCharts={[
-            PerformanceWidgetSetting.TPM_AREA,
-            PerformanceWidgetSetting.DURATION_HISTOGRAM,
-            PerformanceWidgetSetting.P50_DURATION_AREA,
-            PerformanceWidgetSetting.P75_DURATION_AREA,
-            PerformanceWidgetSetting.P95_DURATION_AREA,
-            PerformanceWidgetSetting.P99_DURATION_AREA,
-          ]}
-        />
+        <TripleChartRow {...props} allowedCharts={getAllowedChartsSmall(props)} />
         <DoubleChartRow
           {...props}
           allowedCharts={[

--- a/static/app/views/performance/landing/views/frontendPageloadView.tsx
+++ b/static/app/views/performance/landing/views/frontendPageloadView.tsx
@@ -5,9 +5,22 @@ import Table from '../../table';
 import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
 import {FRONTEND_PAGELOAD_COLUMN_TITLES} from '../data';
 import {DoubleChartRow, TripleChartRow} from '../widgets/components/widgetChartRow';
+import {filterAllowedChartsMetrics} from '../widgets/utils';
 import {PerformanceWidgetSetting} from '../widgets/widgetDefinitions';
 
 import {BasePerformanceViewProps} from './types';
+
+function getAllowedChartsSmall(props: BasePerformanceViewProps) {
+  const charts = [
+    PerformanceWidgetSetting.P75_LCP_AREA,
+    PerformanceWidgetSetting.LCP_HISTOGRAM,
+    PerformanceWidgetSetting.FCP_HISTOGRAM,
+    PerformanceWidgetSetting.USER_MISERY_AREA,
+    PerformanceWidgetSetting.TPM_AREA,
+  ];
+
+  return filterAllowedChartsMetrics(props.organization, charts);
+}
 
 export function FrontendPageloadView(props: BasePerformanceViewProps) {
   return (
@@ -15,16 +28,7 @@ export function FrontendPageloadView(props: BasePerformanceViewProps) {
       value={{performanceType: PROJECT_PERFORMANCE_TYPE.FRONTEND}}
     >
       <div data-test-id="frontend-pageload-view">
-        <TripleChartRow
-          {...props}
-          allowedCharts={[
-            PerformanceWidgetSetting.P75_LCP_AREA,
-            PerformanceWidgetSetting.LCP_HISTOGRAM,
-            PerformanceWidgetSetting.FCP_HISTOGRAM,
-            PerformanceWidgetSetting.USER_MISERY_AREA,
-            PerformanceWidgetSetting.TPM_AREA,
-          ]}
-        />
+        <TripleChartRow {...props} allowedCharts={getAllowedChartsSmall(props)} />
         <DoubleChartRow
           {...props}
           allowedCharts={[

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -18,7 +18,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import {GenericPerformanceWidgetDataType} from '../types';
-import {_setChartSetting, getChartSetting} from '../utils';
+import {_setChartSetting, filterAllowedChartsMetrics, getChartSetting} from '../utils';
 import {
   ChartDefinition,
   PerformanceWidgetSetting,
@@ -65,7 +65,6 @@ const _WidgetContainer = (props: Props) => {
     organization,
     index,
     chartHeight,
-    allowedCharts,
     rowChartSettings,
     setRowChartSettings,
     ...rest
@@ -77,6 +76,10 @@ const _WidgetContainer = (props: Props) => {
     performanceType,
     rest.defaultChartSetting,
     rest.forceDefaultChartSetting
+  );
+  const allowedCharts = filterAllowedChartsMetrics(
+    props.organization,
+    props.allowedCharts
   );
 
   if (!allowedCharts.includes(_chartSetting)) {
@@ -103,7 +106,7 @@ const _WidgetContainer = (props: Props) => {
 
   useEffect(() => {
     setChartSettingState(_chartSetting);
-  }, [rest.defaultChartSetting]);
+  }, [rest.defaultChartSetting, _chartSetting]);
 
   const chartDefinition = WIDGET_DEFINITIONS({organization})[chartSetting];
 
@@ -119,7 +122,7 @@ const _WidgetContainer = (props: Props) => {
       <WidgetContainerActions
         {...containerProps}
         eventView={widgetEventView}
-        allowedCharts={props.allowedCharts}
+        allowedCharts={allowedCharts}
         chartSetting={chartSetting}
         setChartSetting={setChartSetting}
         rowChartSettings={rowChartSettings}

--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -1,6 +1,10 @@
+import {Organization} from 'sentry/types';
 import {objectIsEmpty} from 'sentry/utils';
 import localStorage from 'sentry/utils/localStorage';
-import {MetricsEnhancedSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import {
+  canUseMetricsData,
+  MetricsEnhancedSettingContext,
+} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 
 import {PROJECT_PERFORMANCE_TYPE} from '../../utils';
 
@@ -119,3 +123,21 @@ export const _setChartSetting = (
 
   setWidgetStorageObject(localObject);
 };
+
+const DISALLOWED_CHARTS_METRICS = [
+  PerformanceWidgetSetting.DURATION_HISTOGRAM,
+  PerformanceWidgetSetting.FCP_HISTOGRAM,
+  PerformanceWidgetSetting.LCP_HISTOGRAM,
+  PerformanceWidgetSetting.FID_HISTOGRAM,
+];
+
+export function filterAllowedChartsMetrics(
+  organization: Organization,
+  allowedCharts: PerformanceWidgetSetting[]
+) {
+  if (!canUseMetricsData(organization)) {
+    return allowedCharts;
+  }
+
+  return allowedCharts.filter(c => !DISALLOWED_CHARTS_METRICS.includes(c));
+}


### PR DESCRIPTION
### Summary
Histograms still have issues with outlier data causing buckets that aren't helpful for various views, we'll put this behind the flag for now and turn histograms back on when we've confirmed they work well with outlier data.
