### PR TITLE
bug(ui): Fix TextOverflow when there are special characters at the end of the string

### DIFF
--- a/docs-ui/stories/utilities/textOverflow.stories.js
+++ b/docs-ui/stories/utilities/textOverflow.stories.js
@@ -3,6 +3,8 @@ import TextOverflow from 'sentry/components/textOverflow';
 export default {
   title: 'Utilities/Text/Overflow',
   args: {
+    width: 150,
+    text: 'https://example.com/foo/',
     isParagraph: false,
     ellipsisDirection: 'right',
   },
@@ -16,9 +18,9 @@ export default {
   },
 };
 
-export const _TextOverflow = ({...args}) => (
-  <div style={{width: 50}}>
-    <TextOverflow {...args}>AReallyLongTextString</TextOverflow>
+export const _TextOverflow = ({text, width, ...args}) => (
+  <div style={{width}}>
+    <TextOverflow {...args}>{text}</TextOverflow>
   </div>
 );
 

--- a/static/app/components/textOverflow.tsx
+++ b/static/app/components/textOverflow.tsx
@@ -4,6 +4,18 @@ type Props = {
   children: React.ReactNode;
   className?: string;
   ['data-test-id']?: string;
+  /**
+   * Change which side of the text is elided.
+   * Default: 'right'
+   *
+   * BROWSER COMPAT:
+   * When set to `left` the intention is for something like: `...xample.com/foo/`
+   * In FF/Chrome this is what happens.
+   *
+   * In Safari you will see this instead: `...https://exmaple.co`
+   *
+   * See: https://stackoverflow.com/a/24800788
+   */
   ellipsisDirection?: 'left' | 'right';
   isParagraph?: boolean;
 };
@@ -13,7 +25,7 @@ const TextOverflow = styled(
     const Component = isParagraph ? 'p' : 'div';
     return (
       <Component className={className} data-test-id={dataTestId}>
-        {children}
+        <bdi>{children}</bdi>
       </Component>
     );
   }
@@ -24,6 +36,7 @@ const TextOverflow = styled(
     `
       direction: rtl;
       text-align: left;
+      overflow: hidden;
     `};
   width: auto;
   line-height: 1.2;


### PR DESCRIPTION
**Before:**
<img width="803" alt="Screen Shot 2022-07-26 at 11 26 45 AM" src="https://user-images.githubusercontent.com/187460/181090296-5c56a1ef-7146-4372-ad01-0cf2e60b5b6a.png">

**After:**
<img width="805" alt="Screen Shot 2022-07-26 at 11 27 06 AM" src="https://user-images.githubusercontent.com/187460/181090301-6d7e8f35-c05f-42f3-9d13-d2a180737dbe.png">

The `ellipsisDirection='left'` didn't seem to work on Safari before, it's unchanged now.