### PR TITLE
fix(discover): Coalesce using ip in UserBadge title 

### DIFF
--- a/static/app/components/idBadge/userBadge.tsx
+++ b/static/app/components/idBadge/userBadge.tsx
@@ -31,6 +31,7 @@ const UserBadge = ({
         // Because this can be used to render EventUser models, or User *interface*
         // objects from serialized Event models. we try both ipAddress and ip_address.
         user.ip_address ||
+        user.ip ||
         user.id));
 
   return (

--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -13,6 +13,7 @@ export type AvatarUser = {
   username: string;
   avatar?: Avatar;
   avatarUrl?: string;
+  ip?: string;
   // Compatibility shim with EventUser serializer
   ipAddress?: string;
   lastSeen?: string;

--- a/tests/js/spec/components/idBadge/userBadge.spec.tsx
+++ b/tests/js/spec/components/idBadge/userBadge.spec.tsx
@@ -66,4 +66,16 @@ describe('UserBadge', function () {
     render(<UserBadge user={user} hideEmail />);
     expect(screen.queryByText(user.email)).not.toBeInTheDocument();
   });
+
+  it('can coalesce using ip', function () {
+    const ipUser = TestStubs.User({
+      name: null,
+      email: null,
+      username: null,
+      ip: '127.0.0.1',
+    });
+    render(<UserBadge user={ipUser} />);
+
+    expect(screen.getByText(ipUser.ip)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Allow user.ip to be used as the UserBadge title if other titles are not applicable