### PR TITLE
feat(dashboard): widget custom measurement chart formatters

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -221,6 +221,12 @@ export type EventsStats = {
   data: EventsStatsData;
   end?: number;
   isMetricsData?: boolean;
+  meta?: {
+    fields: Record<string, string>;
+    isMetricsData: boolean;
+    tips: {columns?: string; query?: string};
+    units: Record<string, string>;
+  };
   order?: number;
   start?: number;
   totals?: {count: number};

--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -23,7 +23,7 @@ export function tooltipFormatter(value: number | null, seriesName: string = ''):
   if (!defined(value)) {
     return '\u2014';
   }
-  return tooltipFormatter(value, aggregateOutputType(seriesName));
+  return tooltipFormatterUsingAggregateOutputType(value, aggregateOutputType(seriesName));
 }
 
 /**

--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -23,7 +23,20 @@ export function tooltipFormatter(value: number | null, seriesName: string = ''):
   if (!defined(value)) {
     return '\u2014';
   }
-  switch (aggregateOutputType(seriesName)) {
+  return tooltipFormatter(value, aggregateOutputType(seriesName));
+}
+
+/**
+ * Formatter for chart tooltips that takes the aggregate output type directly
+ */
+export function tooltipFormatterUsingAggregateOutputType(
+  value: number | null,
+  type: string
+): string {
+  if (!defined(value)) {
+    return '\u2014';
+  }
+  switch (type) {
     case 'integer':
     case 'number':
       return value.toLocaleString();
@@ -46,7 +59,25 @@ export function axisLabelFormatter(
   abbreviation: boolean = false,
   durationUnit?: number
 ): string {
-  switch (aggregateOutputType(seriesName)) {
+  return axisLabelFormatterUsingAggregateOutputType(
+    value,
+    aggregateOutputType(seriesName),
+    abbreviation,
+    durationUnit
+  );
+}
+
+/**
+ * Formatter for chart axis labels that takes the aggregate output type directly
+ */
+export function axisLabelFormatterUsingAggregateOutputType(
+  value: number,
+  type: string,
+  abbreviation: boolean = false,
+  durationUnit?: number
+): string {
+  // TODO: Add formatter for size type
+  switch (type) {
     case 'integer':
     case 'number':
       return abbreviation ? formatAbbreviatedNumber(value) : value.toLocaleString();

--- a/static/app/views/dashboardsV2/datasetConfig/base.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/base.tsx
@@ -137,6 +137,13 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     referrer?: string
   ) => Promise<[SeriesResponse, string | undefined, ResponseMeta | undefined]>;
   /**
+   * Get the result type of the series. ie duration, size, percentage, etc
+   */
+  getSeriesResultType?: (
+    data: SeriesResponse,
+    widgetQuery: WidgetQuery
+  ) => string | undefined;
+  /**
    * Generate the request promises for fetching
    * tabular data.
    */

--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -24,7 +24,12 @@ import {IconWarning} from 'sentry/icons';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
 import {EChartDataZoomHandler, EChartEventHandler} from 'sentry/types/echarts';
-import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
+import {
+  axisLabelFormatter,
+  axisLabelFormatterUsingAggregateOutputType,
+  tooltipFormatter,
+  tooltipFormatterUsingAggregateOutputType,
+} from 'sentry/utils/discover/charts';
 import {getFieldFormatter} from 'sentry/utils/discover/fieldRenderers';
 import {
   getAggregateArg,
@@ -82,6 +87,7 @@ type WidgetCardChartProps = Pick<
   }>;
   onZoom?: AugmentedEChartDataZoomHandler;
   showSlider?: boolean;
+  timeseriesResultsType?: string;
   windowWidth?: number;
 };
 
@@ -290,6 +296,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       showSlider,
       noPadding,
       chartZoomOptions,
+      timeseriesResultsType,
     } = this.props;
 
     if (widget.displayType === 'table') {
@@ -401,12 +408,18 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       },
       tooltip: {
         trigger: 'axis',
-        valueFormatter: tooltipFormatter,
+        valueFormatter: (value: number, seriesName: string) =>
+          timeseriesResultsType
+            ? tooltipFormatterUsingAggregateOutputType(value, timeseriesResultsType)
+            : tooltipFormatter(value, seriesName),
       },
       yAxis: {
         axisLabel: {
           color: theme.chartLabel,
-          formatter: (value: number) => axisLabelFormatter(value, axisLabel),
+          formatter: (value: number) =>
+            timeseriesResultsType
+              ? axisLabelFormatterUsingAggregateOutputType(value, timeseriesResultsType)
+              : axisLabelFormatter(value, axisLabel),
         },
       },
     };

--- a/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
@@ -47,6 +47,7 @@ export type GenericWidgetQueriesChildrenProps = {
   pageLinks?: string;
   tableResults?: TableDataWithTitle[];
   timeseriesResults?: Series[];
+  timeseriesResultsType?: string;
   totalCount?: string;
 };
 
@@ -86,6 +87,7 @@ type State<SeriesResponse> = {
   rawResults?: SeriesResponse[];
   tableResults?: GenericWidgetQueriesChildrenProps['tableResults'];
   timeseriesResults?: GenericWidgetQueriesChildrenProps['timeseriesResults'];
+  timeseriesResultsType?: string;
 };
 
 class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
@@ -100,6 +102,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
     rawResults: undefined,
     tableResults: undefined,
     pageLinks: undefined,
+    timeseriesResultsType: undefined,
   };
 
   componentDidMount() {
@@ -334,11 +337,19 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       });
     });
 
+    // Get series result type
+    // Only used by custom measurements in errorsAndTransactions at the moment
+    const timeseriesResultsType = config.getSeriesResultType?.(
+      responses[0][0],
+      widget.queries[0]
+    );
+
     if (this._isMounted && this.state.queryFetchID === queryFetchID) {
       onDataFetched?.({timeseriesResults: transformedTimeseriesResults});
       this.setState({
         timeseriesResults: transformedTimeseriesResults,
         rawResults: rawResultsClone,
+        timeseriesResultsType,
       });
     }
   }
@@ -381,10 +392,23 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
 
   render() {
     const {children} = this.props;
-    const {loading, tableResults, timeseriesResults, errorMessage, pageLinks} =
-      this.state;
+    const {
+      loading,
+      tableResults,
+      timeseriesResults,
+      errorMessage,
+      pageLinks,
+      timeseriesResultsType,
+    } = this.state;
 
-    return children({loading, tableResults, timeseriesResults, errorMessage, pageLinks});
+    return children({
+      loading,
+      tableResults,
+      timeseriesResults,
+      errorMessage,
+      pageLinks,
+      timeseriesResultsType,
+    });
   }
 }
 

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -156,7 +156,13 @@ export function WidgetCardChartContainer({
       onDataFetched={onDataFetched}
       dashboardFilters={dashboardFilters}
     >
-      {({tableResults, timeseriesResults, errorMessage, loading}) => {
+      {({
+        tableResults,
+        timeseriesResults,
+        errorMessage,
+        loading,
+        timeseriesResultsType,
+      }) => {
         return (
           <Fragment>
             {typeof renderErrorMessage === 'function'
@@ -181,6 +187,7 @@ export function WidgetCardChartContainer({
               showSlider={showSlider}
               noPadding={noPadding}
               chartZoomOptions={chartZoomOptions}
+              timeseriesResultsType={timeseriesResultsType}
             />
           </Fragment>
         );

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -66,7 +66,7 @@ export function transformSeries(
  * }
  */
 export function flattenMultiSeriesDataWithGrouping(
-  result: EventsStats | MultiSeriesEventsStats,
+  result: SeriesResult,
   queryAlias: string
 ): SeriesWithOrdering[] {
   const seriesWithOrdering: SeriesWithOrdering[] = [];

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.tsx
@@ -1,4 +1,5 @@
 import {useContext} from 'react';
+import omit from 'lodash/omit';
 
 import {Client} from 'sentry/api';
 import {isMultiSeriesStats} from 'sentry/components/charts/utils';
@@ -8,7 +9,10 @@ import {
   Organization,
   PageFilters,
 } from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
 import {EventsTableData, TableData} from 'sentry/utils/discover/discoverQuery';
+import {DURATION_UNITS, SIZE_UNITS} from 'sentry/utils/discover/fieldRenderers';
+import {getAggregateAlias} from 'sentry/utils/discover/fields';
 
 import {ErrorsAndTransactionsConfig} from '../datasetConfig/errorsAndTransactions';
 import {DashboardFilters, Widget} from '../types';
@@ -21,6 +25,71 @@ import GenericWidgetQueries, {
 
 type SeriesResult = EventsStats | MultiSeriesEventsStats;
 type TableResult = TableData | EventsTableData;
+
+type SeriesWithOrdering = [order: number, series: Series];
+
+export function transformSeries(
+  stats: EventsStats,
+  seriesName: string,
+  field: string
+): Series {
+  const unit = stats.meta?.units?.[getAggregateAlias(field)];
+  // Scale series values to milliseconds or bytes depending on units from meta
+  const scale = (unit && (DURATION_UNITS[unit] ?? SIZE_UNITS[unit])) ?? 1;
+  return {
+    seriesName,
+    data:
+      stats?.data?.map(([timestamp, counts]) => {
+        return {
+          name: timestamp * 1000,
+          value: counts.reduce((acc, {count}) => acc + count, 0) * scale,
+        };
+      }) ?? [],
+  };
+}
+
+/**
+ * Multiseries data with a grouping needs to be "flattened" because the aggregate data
+ * are stored under the group names. These names need to be combined with the aggregate
+ * names to show a series.
+ *
+ * e.g. count() and count_unique() grouped by environment
+ * {
+ *    "local": {
+ *      "count()": {...},
+ *      "count_unique()": {...}
+ *    },
+ *    "prod": {
+ *      "count()": {...},
+ *      "count_unique()": {...}
+ *    }
+ * }
+ */
+export function flattenMultiSeriesDataWithGrouping(
+  result: EventsStats | MultiSeriesEventsStats,
+  queryAlias: string
+): SeriesWithOrdering[] {
+  const seriesWithOrdering: SeriesWithOrdering[] = [];
+  const groupNames = Object.keys(result);
+
+  groupNames.forEach(groupName => {
+    // Each group contains an order key which we should ignore
+    const aggregateNames = Object.keys(omit(result[groupName], 'order'));
+
+    aggregateNames.forEach(aggregate => {
+      const seriesName = `${groupName} : ${aggregate}`;
+      const prefixedName = queryAlias ? `${queryAlias} > ${seriesName}` : seriesName;
+      const seriesData: EventsStats = result[groupName][aggregate];
+
+      seriesWithOrdering.push([
+        result[groupName].order || 0,
+        transformSeries(seriesData, prefixedName, seriesName),
+      ]);
+    });
+  });
+
+  return seriesWithOrdering;
+}
 
 export function getIsMetricsDataFromSeriesResponse(
   result: SeriesResult

--- a/tests/js/spec/utils/discover/charts.spec.tsx
+++ b/tests/js/spec/utils/discover/charts.spec.tsx
@@ -3,10 +3,12 @@ import {LegendComponentOption} from 'echarts';
 import {Series} from 'sentry/types/echarts';
 import {
   axisLabelFormatter,
+  axisLabelFormatterUsingAggregateOutputType,
   categorizeDuration,
   findRangeOfMultiSeries,
   getDurationUnit,
   tooltipFormatter,
+  tooltipFormatterUsingAggregateOutputType,
 } from 'sentry/utils/discover/charts';
 import {HOUR, MINUTE, SECOND} from 'sentry/utils/formatters';
 
@@ -24,6 +26,24 @@ describe('tooltipFormatter()', () => {
     ];
     for (const scenario of cases) {
       expect(tooltipFormatter(scenario[1], scenario[0])).toEqual(scenario[2]);
+    }
+  });
+});
+
+describe('tooltipFormatterUsingAggregateOutputType()', () => {
+  it('formats values', () => {
+    const cases: [string, number, string][] = [
+      // function, input, expected
+      ['number', 0.1, '0.1'],
+      ['integer', 0.125, '0.125'],
+      ['percentage', 0.6612, '66.12%'],
+      ['duration', 321, '321.00ms'],
+      ['', 444, '444'],
+    ];
+    for (const scenario of cases) {
+      expect(tooltipFormatterUsingAggregateOutputType(scenario[1], scenario[0])).toEqual(
+        scenario[2]
+      );
     }
   });
 });
@@ -74,6 +94,24 @@ describe('axisLabelFormatter()', () => {
       const labels = getAxisLabels(axisValues, durationUnit);
       expect(labels.length).toBe(labels.filter(label => label.endsWith('hr')).length);
     });
+  });
+});
+
+describe('axisLabelFormatterUsingAggregateOutputType()', () => {
+  it('formats values', () => {
+    const cases: [string, number, string][] = [
+      // type, input, expected
+      ['number', 0.1, '0.1'],
+      ['integer', 0.125, '0.125'],
+      ['percentage', 0.6612, '66%'],
+      ['duration', 321, '321ms'],
+      ['', 444, '444'],
+    ];
+    for (const scenario of cases) {
+      expect(
+        axisLabelFormatterUsingAggregateOutputType(scenario[1], scenario[0])
+      ).toEqual(scenario[2]);
+    }
   });
 });
 

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -889,8 +889,12 @@ describe('Dashboards > WidgetCard', function () {
       await waitFor(function () {
         expect(eventsStatsMock).toHaveBeenCalled();
       });
-      const {tooltip, yAxis} = spy.mock.calls.pop()[0];
+      const {tooltip, yAxis} = spy.mock.calls.pop()?.[0] ?? {};
+      expect(tooltip).toBeDefined();
+      expect(yAxis).toBeDefined();
+      // @ts-ignore
       expect(tooltip.valueFormatter(24, 'duration')).toEqual('24.00ms');
+      // @ts-ignore
       expect(yAxis.axisLabel.formatter(24, 'duration')).toEqual('24ms');
     });
   });


### PR DESCRIPTION
Widgets with `events-stats` responses containing output type and units in the meta will be formatted using those types and units. This mostly applies to custom performance metrics where we do not know their output type beforehand and have to rely on the `events-stats` meta

![image](https://user-images.githubusercontent.com/83961295/181111138-e36539c6-b7e4-4766-a245-53dee40adcab.png)
