### PR TITLE
fix(dashboard-filters): Unselecting all filters causes loading

### DIFF
--- a/static/app/views/dashboardsV2/orgDashboards.tsx
+++ b/static/app/views/dashboardsV2/orgDashboards.tsx
@@ -188,11 +188,11 @@ class OrgDashboards extends AsyncComponent<Props, State> {
     }
 
     if (
-      loading ||
-      (organization.features.includes('dashboards-top-level-filter') &&
-        selectedDashboard &&
-        hasSavedPageFilters(selectedDashboard) &&
-        isEmpty(location.query))
+      loading &&
+      organization.features.includes('dashboards-top-level-filter') &&
+      selectedDashboard &&
+      hasSavedPageFilters(selectedDashboard) &&
+      isEmpty(location.query)
     ) {
       // Block dashboard from rendering if the dashboard has filters and
       // the URL does not contain filters yet. The filters can either match the

--- a/tests/js/spec/views/dashboardsV2/orgDashboards.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/orgDashboards.spec.tsx
@@ -1,7 +1,7 @@
 import {browserHistory} from 'react-router';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import DashboardDetail from 'sentry/views/dashboardsV2/detail';
 import OrgDashboards from 'sentry/views/dashboardsV2/orgDashboards';
@@ -136,5 +136,80 @@ describe('OrgDashboards', () => {
     );
 
     expect(browserHistory.replace).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect to add query params if location is cleared manually', async () => {
+    const mockDashboardWithFilters = {
+      dateCreated: '2021-08-10T21:20:46.798237Z',
+      id: '1',
+      title: 'Test Dashboard',
+      widgets: [],
+      projects: [1],
+      filters: {},
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/dashboards/1/`,
+      method: 'GET',
+      body: mockDashboardWithFilters,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [mockDashboardWithFilters],
+    });
+    const {rerender} = render(
+      <OrgDashboards
+        api={api}
+        location={TestStubs.location()}
+        organization={initialData.organization}
+        params={{orgId: 'org-slug', dashboardId: '1'}}
+      >
+        {({dashboard, dashboards}) => {
+          return dashboard ? (
+            <DashboardDetail
+              api={api}
+              initialState={DashboardState.VIEW}
+              location={initialData.routerContext.location}
+              router={initialData.router}
+              dashboard={dashboard}
+              dashboards={dashboards}
+              {...initialData.router}
+            />
+          ) : (
+            <div>loading</div>
+          );
+        }}
+      </OrgDashboards>,
+      {context: initialData.routerContext}
+    );
+
+    await waitFor(() => expect(browserHistory.replace).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <OrgDashboards
+        api={api}
+        location={{...initialData.routerContext.location, query: {}}}
+        organization={initialData.organization}
+        params={{orgId: 'org-slug', dashboardId: '1'}}
+      >
+        {({dashboard, dashboards}) => {
+          return dashboard ? (
+            <DashboardDetail
+              api={api}
+              initialState={DashboardState.VIEW}
+              location={initialData.routerContext.location}
+              router={initialData.router}
+              dashboard={dashboard}
+              dashboards={dashboards}
+              {...initialData.router}
+            />
+          ) : (
+            <div>loading</div>
+          );
+        }}
+      </OrgDashboards>
+    );
+
+    expect(screen.queryByTestId('loading-indicator')).not.toBeInTheDocument();
+    expect(browserHistory.replace).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
We only want to redirect at the beginning of the render. Deselecting
everything in page filters would remove values from the query params and
trigger a loading state. Instead we should only block rendering if we're
loading and meet those redirect conditions.

How to trigger this case:
1. Save a dashboard filter (e.g. select a single project)
2. Unselect the project in the page filter
3. See a loading state that doesn't disappear

The expected behaviour is to see the Save and Cancel buttons.