### PR TITLE
fix(alerts): Remove eventTypes from request for crash free

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -613,6 +613,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
           ...(organization.features.includes('metrics-performance-alerts')
             ? {queryType: DatasetMEPAlertQueryTypes[dataset]}
             : {}),
+          // Remove eventTypes as it is no longer requred for crash free
+          eventTypes: isCrashFreeAlert(rule.dataset) ? undefined : rule.eventTypes,
         },
         {
           duplicateRule: this.isDuplicateRule ? 'true' : 'false',


### PR DESCRIPTION
Just stops it from submitting the eventTypes, right now we're still using the event types to tell the form if its a crash free alert. Need to remove alert builder v2 to fix