### PR TITLE
feat(ui): Add collapsible panels

### DIFF
--- a/docs-ui/stories/components/panels.stories.js
+++ b/docs-ui/stories/components/panels.stories.js
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {AnimatePresence} from 'framer-motion';
 
 import Button from 'sentry/components/button';
 import Field from 'sentry/components/forms/field';
@@ -10,6 +11,8 @@ import {
   PanelItem,
   PanelTable,
 } from 'sentry/components/panels';
+import {CollapsePanelBody} from 'sentry/components/panels/panelBody';
+import {CollapsePanelHeader} from 'sentry/components/panels/panelHeader';
 import {IconTelescope} from 'sentry/icons';
 
 import {_BulkController} from './bulkController.stories';
@@ -38,6 +41,31 @@ BasicPanel.parameters = {
       story: 'Basic Panel component used in most settings',
     },
   },
+};
+
+export const CollapsePanel = ({collapsed, ...args}) => (
+  <Panel {...args}>
+    <CollapsePanelHeader collapsed={collapsed}>Panel Header</CollapsePanelHeader>
+    <AnimatePresence>
+      {!collapsed && (
+        <CollapsePanelBody>
+          <PanelItem>Panel Item</PanelItem>
+          <PanelItem>Panel Item</PanelItem>
+          <PanelItem>Panel Item</PanelItem>
+        </CollapsePanelBody>
+      )}
+    </AnimatePresence>
+  </Panel>
+);
+CollapsePanel.parameters = {
+  docs: {
+    description: {
+      story: 'Collapsible Panel component',
+    },
+  },
+};
+CollapsePanel.args = {
+  collapsed: false,
 };
 
 export const PanelAlerts = ({...args}) => (

--- a/static/app/components/panels/panelBody.tsx
+++ b/static/app/components/panels/panelBody.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
 
 import space from 'sentry/styles/space';
 import textStyles from 'sentry/styles/text';
@@ -13,3 +14,20 @@ const PanelBody = styled('div')<BaseProps>`
 `;
 
 export default PanelBody;
+
+export const CollapsePanelBody = styled(motion.div)`
+  ${textStyles};
+  overflow: hidden;
+`;
+
+CollapsePanelBody.defaultProps = {
+  initial: {
+    height: 0,
+  },
+  animate: {
+    height: 'auto',
+  },
+  exit: {
+    height: 0,
+  },
+};

--- a/static/app/components/panels/panelHeader.tsx
+++ b/static/app/components/panels/panelHeader.tsx
@@ -1,6 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {IconChevron} from 'sentry/icons';
 import space from 'sentry/styles/space';
 
 type Props = {
@@ -41,3 +42,21 @@ const PanelHeader = styled('div')<Props>`
 `;
 
 export default PanelHeader;
+
+const ClickablePanelHeader = styled(PanelHeader)`
+  user-select: none;
+  cursor: pointer;
+`;
+
+export function CollapsePanelHeader(props: {
+  children: React.ReactNode;
+  collapsed?: boolean;
+  onClick?: () => void;
+}) {
+  return (
+    <ClickablePanelHeader onClick={props.onClick}>
+      {props.children}
+      <IconChevron direction={props.collapsed ? 'right' : 'down'} />
+    </ClickablePanelHeader>
+  );
+}

--- a/static/app/components/panels/panelHeader.tsx
+++ b/static/app/components/panels/panelHeader.tsx
@@ -54,7 +54,7 @@ export function CollapsePanelHeader(props: {
   onClick?: () => void;
 }) {
   return (
-    <ClickablePanelHeader onClick={props.onClick} collapsed={props.collapsed}>
+    <ClickablePanelHeader onClick={props.onClick} collapsed={!!props.collapsed}>
       {props.children}
       <IconChevron direction={props.collapsed ? 'right' : 'down'} />
     </ClickablePanelHeader>

--- a/static/app/components/panels/panelHeader.tsx
+++ b/static/app/components/panels/panelHeader.tsx
@@ -43,9 +43,9 @@ const PanelHeader = styled('div')<Props>`
 
 export default PanelHeader;
 
-const ClickablePanelHeader = styled(PanelHeader)`
-  user-select: none;
+const ClickablePanelHeader = styled(PanelHeader)<{collapsed: boolean}>`
   cursor: pointer;
+  ${p => p.collapsed && 'border-bottom: none;'}
 `;
 
 export function CollapsePanelHeader(props: {
@@ -54,7 +54,7 @@ export function CollapsePanelHeader(props: {
   onClick?: () => void;
 }) {
   return (
-    <ClickablePanelHeader onClick={props.onClick}>
+    <ClickablePanelHeader onClick={props.onClick} collapsed={props.collapsed}>
       {props.children}
       <IconChevron direction={props.collapsed ? 'right' : 'down'} />
     </ClickablePanelHeader>


### PR DESCRIPTION
https://user-images.githubusercontent.com/8980455/181135307-773f9e59-26f1-4f4b-982a-d87e410abfcf.mov

Standard collapsible panels. By clicking on the header, the body can retract or expand with an animation.

Supports https://github.com/getsentry/sentry/pull/37087