### PR TITLE
feat(hybrid-cloud): Set active org based on subdomain

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -36,6 +36,12 @@ class CustomerDomainMiddleware:
             return self.get_response(request)
         auth.set_active_org(request, subdomain)
         result = resolve(request.path)
-        if result.kwargs and "organization_slug" in result.kwargs and result.kwargs["organization_slug"] != subdomain:
-            return HttpResponseRedirect(reverse(result.url_name, kwargs={**result.kwargs, "organization_slug": subdomain}))
+        if (
+            result.kwargs
+            and "organization_slug" in result.kwargs
+            and result.kwargs["organization_slug"] != subdomain
+        ):
+            return HttpResponseRedirect(
+                reverse(result.url_name, kwargs={**result.kwargs, "organization_slug": subdomain})
+            )
         return self.get_response(request)

--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Callable
 
+from django.http import HttpResponseRedirect
+from django.urls import resolve, reverse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -33,4 +35,7 @@ class CustomerDomainMiddleware:
                 del session["activeorg"]
             return self.get_response(request)
         auth.set_active_org(request, subdomain)
+        result = resolve(request.path)
+        if result.kwargs and "organization_slug" in result.kwargs and result.kwargs["organization_slug"] != subdomain:
+            return HttpResponseRedirect(reverse(result.url_name, kwargs={**result.kwargs, "organization_slug": subdomain}))
         return self.get_response(request)

--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import resolve_region
+from sentry.models import Organization
+from sentry.utils import auth
+
+
+class CustomerDomainMiddleware:
+    """
+    Set active organization from request.domain.
+    """
+
+    def __init__(self, get_response: Callable[[Request], Response]):
+        self.get_response = get_response
+
+    def __call__(self, request: Request) -> Response:
+        if not hasattr(request, "subdomain"):
+            return self.get_response(request)
+        subdomain = request.subdomain
+        if subdomain is None or resolve_region(request) is not None:
+            return self.get_response(request)
+        try:
+            # Assume subdomain is an org slug being accessed
+            Organization.objects.get_from_cache(slug=subdomain)
+        except Organization.DoesNotExist:
+            session = getattr(request, "session", None)
+            if session and "activeorg" in session:
+                del session["activeorg"]
+            return self.get_response(request)
+        auth.set_active_org(request, subdomain)
+        return self.get_response(request)

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -350,7 +350,7 @@ def is_user_signed_request(request):
 def set_active_org(request: Request, org_slug: str) -> None:
     # even if the value being set is the same this will trigger a session
     # modification and reset the users expiry, so check if they are different first.
-    if request.session.get("activeorg") != org_slug:
+    if hasattr(request, "session") and request.session.get("activeorg") != org_slug:
         request.session["activeorg"] = org_slug
 
 

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -154,7 +154,9 @@ class End2EndTest(APITestCase):
             assert self.client.session["activeorg"] == "test"
 
             # 'activeorg' session key is not replaced
-            response = self.client.get(reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}))
+            response = self.client.get(
+                reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"})
+            )
             assert response.data == {
                 "organization_slug": "albertos-apples",
                 "subdomain": None,

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -1,0 +1,66 @@
+from django.test import RequestFactory
+
+from sentry.middleware.customer_domain import CustomerDomainMiddleware
+from sentry.testutils import TestCase
+
+
+class CustomerDomainMiddlewareTest(TestCase):
+    def test_sets_active_organization_if_exists(self):
+        self.create_organization(name="test")
+
+        session = {"activeorg": "albertos-apples"}
+        request = RequestFactory().get("/")
+        request.subdomain = "test"
+        request.session = session
+        CustomerDomainMiddleware(lambda request: request)(request)
+
+        assert session == {"activeorg": "test"}
+
+    def test_removes_active_organization(self):
+        session = {"activeorg": "test"}
+        request = RequestFactory().get("/")
+        request.subdomain = "does-not-exist"
+        request.session = session
+        CustomerDomainMiddleware(lambda request: request)(request)
+
+        assert session == {}
+
+    def test_no_session_dict(self):
+        request = RequestFactory().get("/")
+        request.subdomain = "test"
+        CustomerDomainMiddleware(lambda request: request)(request)
+
+        assert "session" not in request
+
+        self.create_organization(name="test")
+        request = RequestFactory().get("/")
+        request.subdomain = "test"
+        CustomerDomainMiddleware(lambda request: request)(request)
+
+        assert "session" not in request
+
+    def test_no_subdomain(self):
+        session = {"activeorg": "test"}
+        request = RequestFactory().get("/")
+        request.session = session
+        CustomerDomainMiddleware(lambda request: request)(request)
+
+        assert request.session == {"activeorg": "test"}
+
+    def test_no_op(self):
+        request = RequestFactory().get("/")
+        CustomerDomainMiddleware(lambda request: request)(request)
+
+        assert "session" not in request
+        assert "subdomain" not in request
+
+    def test_ignores_region_subdomains(self):
+        regions = {"us", "eu"}
+        for region in regions:
+            session = {"activeorg": "test"}
+            request = RequestFactory().get("/")
+            request.subdomain = region
+            request.session = session
+            CustomerDomainMiddleware(lambda request: request)(request)
+
+            assert request.session == {"activeorg": "test"}

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -51,6 +51,15 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert request.session == {"activeorg": "test"}
         assert response == request
 
+    def test_no_activeorg(self):
+        session = {}
+        request = RequestFactory().get("/")
+        request.session = session
+        response = CustomerDomainMiddleware(lambda request: request)(request)
+
+        assert request.session == {}
+        assert response == request
+
     def test_no_op(self):
         request = RequestFactory().get("/")
         response = CustomerDomainMiddleware(lambda request: request)(request)

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -8,23 +8,21 @@ class CustomerDomainMiddlewareTest(TestCase):
     def test_sets_active_organization_if_exists(self):
         self.create_organization(name="test")
 
-        session = {"activeorg": "albertos-apples"}
         request = RequestFactory().get("/")
         request.subdomain = "test"
-        request.session = session
+        request.session = {"activeorg": "albertos-apples"}
         response = CustomerDomainMiddleware(lambda request: request)(request)
 
-        assert session == {"activeorg": "test"}
+        assert request.session == {"activeorg": "test"}
         assert response == request
 
     def test_removes_active_organization(self):
-        session = {"activeorg": "test"}
         request = RequestFactory().get("/")
         request.subdomain = "does-not-exist"
-        request.session = session
+        request.session = {"activeorg": "test"}
         response = CustomerDomainMiddleware(lambda request: request)(request)
 
-        assert session == {}
+        assert request.session == {}
         assert response == request
 
     def test_no_session_dict(self):
@@ -43,18 +41,16 @@ class CustomerDomainMiddlewareTest(TestCase):
         assert response == request
 
     def test_no_subdomain(self):
-        session = {"activeorg": "test"}
         request = RequestFactory().get("/")
-        request.session = session
+        request.session = {"activeorg": "test"}
         response = CustomerDomainMiddleware(lambda request: request)(request)
 
         assert request.session == {"activeorg": "test"}
         assert response == request
 
     def test_no_activeorg(self):
-        session = {}
         request = RequestFactory().get("/")
-        request.session = session
+        request.session = {}
         response = CustomerDomainMiddleware(lambda request: request)(request)
 
         assert request.session == {}
@@ -71,10 +67,9 @@ class CustomerDomainMiddlewareTest(TestCase):
     def test_ignores_region_subdomains(self):
         regions = {"us", "eu"}
         for region in regions:
-            session = {"activeorg": "test"}
             request = RequestFactory().get("/")
             request.subdomain = region
-            request.session = session
+            request.session = {"activeorg": "test"}
             response = CustomerDomainMiddleware(lambda request: request)(request)
 
             assert request.session == {"activeorg": "test"}
@@ -82,10 +77,9 @@ class CustomerDomainMiddlewareTest(TestCase):
 
     def test_handles_redirects(self):
         self.create_organization(name="sentry")
-        session = {"activeorg": "test"}
         request = RequestFactory().get("/organizations/albertos-apples/issues/")
         request.subdomain = "sentry"
-        request.session = session
+        request.session = {"activeorg": "test"}
         response = CustomerDomainMiddleware(lambda request: request)(request)
 
         assert request.session == {"activeorg": "sentry"}


### PR DESCRIPTION
Branched from https://github.com/getsentry/sentry/pull/37037

-----

This pull request adds the `CustomerDomainMiddleware` middleware that sets the active organization based on `request.subdomain`. In addition, region domains are ignored (e.g. `us.sentry.io`).

For example, if the user is accessing `acme.sentry.io`, then `acme` will be the active organization, regardless of what the previous (if any) active organization was.

Redirects are also handled. For example if `http://acme.sentry.io/organizations/sentry/issues/` was accessed, then a 302 Redirect response will be generated with `http://acme.sentry.io/organizations/acme/issues/`.

The activation of the `CustomerDomainMiddleware` middleware will be in a follow up pull request.