### PR TITLE
Add Starlette and FastAPI to supported modules.

### DIFF
--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -164,6 +164,24 @@ SDK_SUPPORTED_MODULES = [
     },
     {
         "sdk_name": "sentry.python",
+        "sdk_version_added": "1.8.0",
+        "module_name": "starlette",
+        "module_version_min": "0.19.1",
+        "suggestion": EnableIntegrationSuggestion(
+            "starlette", "https://docs.sentry.io/platforms/python/starlette/"
+        ),
+    },
+    {
+        "sdk_name": "sentry.python",
+        "sdk_version_added": "1.8.0",
+        "module_name": "fastapi",
+        "module_version_min": "0.79.0",
+        "suggestion": EnableIntegrationSuggestion(
+            "fastapi", "https://docs.sentry.io/platforms/python/fastapi/"
+        ),
+    },
+    {
+        "sdk_name": "sentry.python",
         "sdk_version_added": "0.7.9",
         "module_name": "bottle",
         "module_version_min": "0.12.0",


### PR DESCRIPTION
Starlette and FastAPI are two new Python web framework we support.

Related frontend part: https://github.com/getsentry/sentry/pull/37100