### PR TITLE
feat(projectconfig): Entry for transaction name strategy [INGEST-1524]

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -408,6 +408,11 @@ register("relay.drop-transaction-metrics", default=[])
 #       given fraction of orgs even if the corresponding feature flag is disabled.
 register("relay.transaction-metrics-org-sample-rate", default=0.0)
 
+# Sample rate for opting in orgs into the new transaction name handling.
+# old behavior: Treat transactions from old SDKs as high-cardinality.
+# new behavior: Treat transactions from old SDKs as low-cardinality, except for browser JS.
+register("relay.transaction-names-client-based", default=0.0)
+
 # Write new kafka headers in eventstream
 register("eventstream:kafka-headers", default=True)
 

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2022-07-22T12:59:33.487327Z'
+created: '2022-07-27T10:44:43.700505Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -861,6 +861,7 @@ metricConditionalTagging:
   - d:transactions/duration@millisecond
   targetTag: histogram_outlier
 transactionMetrics:
+  acceptTransactionNames: strict
   customMeasurements:
     limit: 5
   extractCustomTags: []


### PR DESCRIPTION
Relay has two modes for handling transaction names with source `unknown` (see https://github.com/getsentry/relay/pull/1352):

1. In `strict` mode, treat all transaction names with source `unknown` as high-cardinality, and drop the name in the extracted metrics.
2. In `clientBased` mode, treat `unknown` as low-cardinality, except for browser JS SDKs.

This PR adds the corresponding project config, such that a percentage of orgs can be consistently sampled into `clientBased` behavior.