### PR TITLE
ref(error-item): Replace getMeta (proxy) with _meta object - [TET-144] 

### DIFF
--- a/static/app/components/events/errorItem.tsx
+++ b/static/app/components/events/errorItem.tsx
@@ -5,7 +5,7 @@ import moment from 'moment';
 
 import Button from 'sentry/components/button';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import {getMeta} from 'sentry/components/events/meta/metaProxy';
+import AnnotatedText from 'sentry/components/events/meta/annotatedText';
 import ListItem from 'sentry/components/list/listItem';
 import {JavascriptProcessingErrors} from 'sentry/constants/eventErrors';
 import {t, tct} from 'sentry/locale';
@@ -35,9 +35,10 @@ const keyMapping = {
 
 export type ErrorItemProps = {
   error: Error;
+  meta?: Record<any, any>;
 };
 
-export function ErrorItem({error}: ErrorItemProps) {
+export function ErrorItem({error, meta}: ErrorItemProps) {
   const [expanded, setExpanded] = useState(false);
 
   const cleanedData = useMemo(() => {
@@ -69,25 +70,38 @@ export function ErrorItem({error}: ErrorItemProps) {
       );
     }
 
-    return Object.entries(data).map(([key, value]) => ({
-      key,
-      value,
-      subject: keyMapping[key] || startCase(key),
-      meta: getMeta(data, key),
-    }));
-  }, [error.data]);
+    return Object.entries(data)
+      .map(([key, value]) => ({
+        key,
+        value,
+        subject: keyMapping[key] || startCase(key),
+        meta: key === 'image_name' ? meta?.image_path?.[''] : meta?.[key]?.[''],
+      }))
+      .filter(d => {
+        if (!d.value && !!d.meta) {
+          return true;
+        }
+        return !!d.value;
+      });
+  }, [error.data, meta]);
 
   return (
     <StyledListItem>
       <OverallInfo>
         <div>
-          {!error.data?.name || typeof error.data?.name !== 'string' ? null : (
+          {meta?.data?.name?.[''] ? (
+            <AnnotatedText value={error.message} meta={meta?.data?.name?.['']} />
+          ) : !error.data?.name || typeof error.data?.name !== 'string' ? null : (
             <Fragment>
               <strong>{error.data?.name}</strong>
               {': '}
             </Fragment>
           )}
-          {error.message}
+          {meta?.message?.[''] ? (
+            <AnnotatedText value={error.message} meta={meta?.message?.['']} />
+          ) : (
+            error.message
+          )}
           {Object.values(JavascriptProcessingErrors).includes(
             error.type as JavascriptProcessingErrors
           ) && (

--- a/static/app/components/events/errors.tsx
+++ b/static/app/components/events/errors.tsx
@@ -114,7 +114,7 @@ class Errors extends Component<Props, State> {
   render() {
     const {event, proGuardErrors} = this.props;
     const {releaseArtifacts} = this.state;
-    const {dist: eventDistribution, errors: eventErrors = []} = event;
+    const {dist: eventDistribution, errors: eventErrors = [], _meta} = event;
 
     // XXX: uniqWith returns unique errors and is not performant with large datasets
     const otherErrors: Array<Error> =
@@ -136,6 +136,8 @@ class Errors extends Component<Props, State> {
             >
               {errors.map((error, errorIdx) => {
                 const data = error.data ?? {};
+                const meta = _meta?.errors?.[errorIdx];
+
                 if (
                   error.type === JavascriptProcessingErrors.JS_MISSING_SOURCE &&
                   data.url &&
@@ -166,7 +168,7 @@ class Errors extends Component<Props, State> {
                   }
                 }
 
-                return <ErrorItem key={errorIdx} error={{...error, data}} />;
+                return <ErrorItem key={errorIdx} error={{...error, data}} meta={meta} />;
               })}
             </ErrorList>,
           ]}

--- a/tests/js/spec/components/events/interfaces/errorItem.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/errorItem.spec.tsx
@@ -24,4 +24,35 @@ describe('Issue error item', function () {
 
     expect(screen.getByText('Mapping Uuid')).toBeInTheDocument();
   });
+
+  it('display redacted data', async function () {
+    render(
+      <ErrorItem
+        error={{
+          data: {
+            image_path: '',
+            image_uuid: '6b77ffb6-5aba-3b5f-9171-434f9660f738',
+            message: '',
+          },
+          message: 'A required debug information file was missing.',
+          type: 'native_missing_dsym',
+        }}
+        meta={{
+          image_path: {'': {rem: [['project:2', 's', 0, 0]], len: 117}},
+        }}
+      />
+    );
+
+    userEvent.click(screen.getByLabelText('Expand'));
+
+    expect(screen.getByText('File Name')).toBeInTheDocument();
+    expect(screen.getByText('File Path')).toBeInTheDocument();
+    expect(screen.getAllByText(/redacted/)).toHaveLength(2);
+
+    userEvent.hover(screen.getAllByText(/redacted/)[0]);
+
+    expect(
+      await screen.findByText('Replaced because of PII rule "project:2"')
+    ).toBeInTheDocument(); // tooltip description
+  });
 });


### PR DESCRIPTION
**What this PR does:**

- Replace `getMeta` in the `errorItem` with `event._meta `object
- Add test


**Before:**
![image](https://user-images.githubusercontent.com/29228205/181253222-d179be10-9f77-4c9b-81e2-8cb0e16fec4c.png)


**After:**
![image](https://user-images.githubusercontent.com/29228205/181253402-acdc51d8-6404-4c39-af4a-cc9425c67930.png)


ps: the backend team still has to fix an issue with the _meta -> INGEST-1526