### PR TITLE
fix: Fix date-sensitive test by fixing date [INGEST-1522]

### DIFF
--- a/tests/sentry/release_health/test_duplex.py
+++ b/tests/sentry/release_health/test_duplex.py
@@ -535,7 +535,7 @@ def test_get_sessionsv2_schema():
     assert schema["avg(session.duration)"] == FixedList(22 * [Ct.Quantile] + 2 * [Ct.Ignore])
 
 
-@pytest.mark.xfail(reason="date-sensitive test")
+@freeze_time("2022-05-02 15:17")
 def test_sessionsv2_config():
     with Feature("organizations:release-health-return-metrics"):
         backend = DuplexReleaseHealthBackend(datetime(2022, 4, 28, 16, 0, tzinfo=timezone.utc))


### PR DESCRIPTION
this test failed on master, so asottile disabled it using pytest.skip. i'm reenabling it by using freeze_time.