### PR TITLE
fix(replays): network table styles

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -123,6 +123,7 @@ const Item = styled('div')<{color?: string; numeric?: boolean}>`
   padding: ${space(0.75)} ${space(1.5)};
   background-color: ${p => p.theme.background};
   min-width: 0;
+  line-height: 16px;
 
   ${p => p.numeric && 'font-variant-numeric: tabular-nums;'}
 `;
@@ -130,7 +131,6 @@ const Item = styled('div')<{color?: string; numeric?: boolean}>`
 const StyledPanelTable = styled(PanelTable)<{columns: number}>`
   grid-template-columns: max-content minmax(200px, 1fr) repeat(3, max-content);
   font-size: ${p => p.theme.fontSizeSmall};
-  line-height: 16px;
   margin-bottom: 0;
   max-height: 100%;
   overflow: auto;
@@ -146,13 +146,13 @@ const StyledPanelTable = styled(PanelTable)<{columns: number}>`
     &:nth-child(${p => p.columns}n) {
       border-right: 0;
       text-align: right;
-      justify-content: end;
+      align-items: end;
     }
 
     /* 2nd last column */
     &:nth-child(${p => p.columns}n - 1) {
       text-align: right;
-      justify-content: end;
+      align-items: end;
     }
   }
 
@@ -161,6 +161,7 @@ const StyledPanelTable = styled(PanelTable)<{columns: number}>`
     padding: ${space(0.5)} ${space(1.5)};
     border-radius: 0;
     color: ${p => p.theme.subText};
+    line-height: 16px;
   }
 `;
 
@@ -176,14 +177,13 @@ const Text = styled('p')`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  line-height: 16px;
 `;
 
 const SortItem = styled('span')`
   cursor: pointer;
 
   svg {
-    vertical-align: top;
+    vertical-align: middle;
   }
 `;
 

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -48,13 +48,15 @@ function NetworkList({event, networkSpans}: Props) {
     [networkSpans, sortConfig]
   );
 
-  const sortArrow = (sortedBy: string) => (
-    <IconArrow
-      color={sortConfig.by === sortedBy ? 'gray300' : 'gray200'}
-      size="xs"
-      direction={sortConfig.by === sortedBy && !sortConfig.asc ? 'up' : 'down'}
-    />
-  );
+  const sortArrow = (sortedBy: string) => {
+    return sortConfig.by === sortedBy ? (
+      <IconArrow
+        color="gray300"
+        size="xs"
+        direction={sortConfig.by === sortedBy && !sortConfig.asc ? 'up' : 'down'}
+      />
+    ) : null;
+  };
 
   const columns = [
     t('Status'),
@@ -146,13 +148,13 @@ const StyledPanelTable = styled(PanelTable)<{columns: number}>`
     &:nth-child(${p => p.columns}n) {
       border-right: 0;
       text-align: right;
-      align-items: end;
+      justify-content: end;
     }
 
     /* 2nd last column */
     &:nth-child(${p => p.columns}n - 1) {
       text-align: right;
-      align-items: end;
+      justify-content: end;
     }
   }
 
@@ -162,6 +164,13 @@ const StyledPanelTable = styled(PanelTable)<{columns: number}>`
     border-radius: 0;
     color: ${p => p.theme.subText};
     line-height: 16px;
+
+    /* Last and 2nd last header columns. As this are flex direction column we have to treat them separately */
+    &:nth-child(${p => p.columns}n),
+    &:nth-child(${p => p.columns}n - 1) {
+      justify-content: center;
+      align-items: end;
+    }
   }
 `;
 

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -132,17 +132,15 @@ const Item = styled('div')<{color?: string; numeric?: boolean}>`
 
 const StyledPanelTable = styled(PanelTable)<{columns: number}>`
   grid-template-columns: max-content minmax(200px, 1fr) repeat(3, max-content);
+  grid-template-rows: 24px repeat(auto-fit, 28px);
   font-size: ${p => p.theme.fontSizeSmall};
   margin-bottom: 0;
-  max-height: 100%;
+  height: 100%;
   overflow: auto;
 
   > * {
     border-right: 1px solid ${p => p.theme.innerBorder};
-
-    &:nth-last-child(n + ${p => p.columns + 1}) {
-      border-bottom: 1px solid ${p => p.theme.innerBorder};
-    }
+    border-bottom: 1px solid ${p => p.theme.innerBorder};
 
     /* Last column */
     &:nth-child(${p => p.columns}n) {
@@ -165,7 +163,7 @@ const StyledPanelTable = styled(PanelTable)<{columns: number}>`
     color: ${p => p.theme.subText};
     line-height: 16px;
 
-    /* Last and 2nd last header columns. As this are flex direction column we have to treat them separately */
+    /* Last and 2nd last header columns. As these are flex direction columns we have to treat them separately */
     &:nth-child(${p => p.columns}n),
     &:nth-child(${p => p.columns}n - 1) {
       justify-content: center;
@@ -192,7 +190,7 @@ const SortItem = styled('span')`
   cursor: pointer;
 
   svg {
-    vertical-align: middle;
+    vertical-align: text-top;
   }
 `;
 

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -107,6 +107,7 @@ function NetworkList({event, networkSpans}: Props) {
       emptyMessage={t('No related network requests found.')}
       headers={columns}
       disablePadding
+      stickyHeaders
     >
       {networkData.map(renderTableRow) || null}
     </StyledPanelTable>
@@ -131,14 +132,8 @@ const StyledPanelTable = styled(PanelTable)<{columns: number}>`
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 16px;
   margin-bottom: 0;
-  height: 100%;
+  max-height: 100%;
   overflow: auto;
-  /* Make the header row sticky */
-  > :nth-child(-n + ${p => p.columns}) {
-    justify-content: center; /* because justify-content:end is applied to some columns, the content, but the flex-direction is different for content and headers, so we need to remove that. */
-    position: sticky;
-    top: 0;
-  }
 
   > * {
     border-right: 1px solid ${p => p.theme.innerBorder};


### PR DESCRIPTION


<!-- Describe your PR here. -->
Fixed the styles of the network table fixing the header cells and height of the table. Closes #37072 

![image](https://user-images.githubusercontent.com/39612839/181275575-fe0bfe24-946f-4593-b071-3740dc15df91.png)

![image](https://user-images.githubusercontent.com/39612839/181275670-2f557c42-7f09-47de-a2b6-5f67fb83c653.png)

![image](https://user-images.githubusercontent.com/39612839/181275810-3ae25409-d8bb-4f58-af2a-0e37157cd279.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
