### PR TITLE
fix(dashboards): Add padding under page filters in default-overview

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -707,11 +707,11 @@ class DashboardDetail extends Component<Props, State> {
                 widgetLimitReached={widgetLimitReached}
               />
             </StyledPageHeader>
-            <PageFilterBar condensed>
+            <StyledPageFilterBar condensed>
               <ProjectPageFilter />
               <EnvironmentPageFilter />
               <DatePageFilter alignDropdown="left" />
-            </PageFilterBar>
+            </StyledPageFilterBar>
             <HookHeader organization={organization} />
             <Dashboard
               paramDashboardId={dashboardId}
@@ -919,6 +919,10 @@ const StyledTitle = styled(Layout.Title)`
 
 const StyledPageContent = styled(PageContent)`
   padding: 0;
+`;
+
+const StyledPageFilterBar = styled(PageFilterBar)`
+  margin-bottom: ${space(2)};
 `;
 
 export default withApi(withOrganization(DashboardDetail));


### PR DESCRIPTION
Without the dashboard-edit feature flag, we render the page filters differently.
Add 16px of padding to be consistent with normal view dashboards.

Before:
![Screen Shot 2022-07-27 at 2 08 12 PM](https://user-images.githubusercontent.com/22846452/181342431-bceefd0b-723a-46c4-8874-914832f47d28.png)

After:
![Screen Shot 2022-07-27 at 2 08 37 PM](https://user-images.githubusercontent.com/22846452/181342454-b63e5b2c-237c-4a96-a2b7-4ae3fd92561e.png)

