### PR TITLE
ref(replays): Update Details page to use the replay specific api endpoints

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -2,15 +2,15 @@ import {useCallback, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import {inflate} from 'pako';
 
-import {IssueAttachment} from 'sentry/types';
-import {EventTransaction} from 'sentry/types/event';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
 import type {
   RecordingEvent,
+  Replay,
   ReplayCrumb,
   ReplayError,
+  ReplaySegment,
   ReplaySpan,
 } from 'sentry/views/replays/types';
 
@@ -27,11 +27,6 @@ type State = {
   errors: undefined | ReplayError[];
 
   /**
-   * The root replay event
-   */
-  event: undefined | EventTransaction;
-
-  /**
    * If any request returned an error then nothing is being returned
    */
   fetchError: undefined | RequestError;
@@ -46,6 +41,11 @@ type State = {
    * Are errors currently being fetched
    */
   isErrorsFetching: boolean;
+
+  /**
+   * The root replay event
+   */
+  replay: undefined | Replay;
 
   /**
    * The flattened list of rrweb events. These are stored as multiple attachments on the root replay object: the `event` prop.
@@ -80,11 +80,6 @@ interface Result extends Pick<State, 'fetchError' | 'fetching'> {
   replay: ReplayReader | null;
 }
 
-const IS_RRWEB_ATTACHMENT_FILENAME = /rrweb-[0-9]{13}.json/;
-
-function isRRWebEventAttachment(attachment: IssueAttachment) {
-  return IS_RRWEB_ATTACHMENT_FILENAME.test(attachment.name);
-}
 export function mapRRWebAttachments(unsortedReplayAttachments): ReplayAttachment {
   const replayAttachments: ReplayAttachment = {
     breadcrumbs: [],
@@ -106,14 +101,14 @@ export function mapRRWebAttachments(unsortedReplayAttachments): ReplayAttachment
 }
 
 const INITIAL_STATE: State = Object.freeze({
+  breadcrumbs: undefined,
   errors: undefined,
-  event: undefined,
   fetchError: undefined,
   fetching: true,
   isErrorsFetching: true,
+  replay: undefined,
   rrwebEvents: undefined,
   spans: undefined,
-  breadcrumbs: undefined,
 });
 
 /**
@@ -143,19 +138,19 @@ function useReplayData({eventSlug, orgId}: Options): Result {
   const fetchEvent = useCallback(() => {
     return api.requestPromise(
       `/organizations/${orgId}/replays/${eventSlug}/`
-    ) as Promise<EventTransaction>;
+    ) as Promise<{data: Replay}>;
   }, [api, orgId, eventSlug]);
 
   const fetchRRWebEvents = useCallback(async () => {
     // can we use 'count_sequences' instead of making another (N) calls to list the segments available
-    const attachmentIds = (await api.requestPromise(
+    const segments = (await api.requestPromise(
       `/projects/${orgId}/${projectId}/replays/${eventId}/recording-segments/`
-    )) as IssueAttachment[];
-    const rrwebAttachmentIds = attachmentIds.filter(isRRWebEventAttachment);
+    )) as ReplaySegment[];
+
     const attachments = await Promise.all(
-      rrwebAttachmentIds.map(async attachment => {
+      segments.map(async segment => {
         const response = await api.requestPromise(
-          `/api/0/projects/${orgId}/${projectId}/events/${eventId}/recording-segments/${attachment.id}/?download`,
+          `/api/0/projects/${orgId}/${projectId}/events/${eventId}/recording-segments/${segment.segment_id}/?download`,
           {
             includeAllArgs: true,
           }
@@ -208,7 +203,7 @@ function useReplayData({eventSlug, orgId}: Options): Result {
 
       setState(prev => ({
         ...prev,
-        event,
+        event: event.data,
         fetchError: undefined,
         fetching: prev.isErrorsFetching || false,
         rrwebEvents: attachments.recording,
@@ -231,13 +226,13 @@ function useReplayData({eventSlug, orgId}: Options): Result {
 
   const replay = useMemo(() => {
     return ReplayReader.factory({
-      event: state.event,
+      replay: state.replay,
       errors: state.errors,
       rrwebEvents: state.rrwebEvents,
       breadcrumbs: state.breadcrumbs,
       spans: state.spans,
     });
-  }, [state.event, state.rrwebEvents, state.breadcrumbs, state.spans, state.errors]);
+  }, [state.replay, state.rrwebEvents, state.breadcrumbs, state.spans, state.errors]);
 
   return {
     fetchError: state.fetchError,

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -142,19 +142,20 @@ function useReplayData({eventSlug, orgId}: Options): Result {
 
   const fetchEvent = useCallback(() => {
     return api.requestPromise(
-      `/organizations/${orgId}/events/${eventSlug}/`
+      `/organizations/${orgId}/replays/${eventSlug}/`
     ) as Promise<EventTransaction>;
   }, [api, orgId, eventSlug]);
 
   const fetchRRWebEvents = useCallback(async () => {
+    // can we use 'count_sequences' instead of making another (N) calls to list the segments available
     const attachmentIds = (await api.requestPromise(
-      `/projects/${orgId}/${projectId}/events/${eventId}/attachments/`
+      `/projects/${orgId}/${projectId}/replays/${eventId}/recording-segments/`
     )) as IssueAttachment[];
     const rrwebAttachmentIds = attachmentIds.filter(isRRWebEventAttachment);
     const attachments = await Promise.all(
       rrwebAttachmentIds.map(async attachment => {
         const response = await api.requestPromise(
-          `/api/0/projects/${orgId}/${projectId}/events/${eventId}/attachments/${attachment.id}/?download`,
+          `/api/0/projects/${orgId}/${projectId}/events/${eventId}/recording-segments/${attachment.id}/?download`,
           {
             includeAllArgs: true,
           }

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -9,9 +9,9 @@ import type {
   RawCrumb,
 } from 'sentry/types/breadcrumbs';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
-import {Event} from 'sentry/types/event';
 import type {
   RecordingEvent,
+  Replay,
   ReplayCrumb,
   ReplayError,
   ReplaySpan,
@@ -41,12 +41,12 @@ export function rrwebEventListFactory(
 
 export function breadcrumbFactory(
   startTimestamp: number,
-  rootEvent: Event,
+  replay: Replay,
   errors: ReplayError[],
   rawCrumbs: ReplayCrumb[],
   spans: ReplaySpan[]
 ): Crumb[] {
-  const {tags} = rootEvent;
+  const {tags} = replay;
   const initialUrl = tags.find(tag => tag.key === 'url')?.value;
   const initBreadcrumb = {
     type: BreadcrumbType.INIT,

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -17,11 +17,11 @@ import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
 
-import {Replay} from './types';
+import {DiscoReplayListItem} from './types';
 
 type Props = {
   idKey: string;
-  replayList: Replay[];
+  replayList: DiscoReplayListItem[];
   showProjectColumn?: boolean;
 };
 

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -24,7 +24,7 @@ import usePageFilters from 'sentry/utils/usePageFilters';
 
 import ReplaysFilters from './filters';
 import ReplayTable from './replayTable';
-import {Replay} from './types';
+import {DiscoReplayListItem} from './types';
 
 const columns = [t('Session'), t('Project')];
 
@@ -158,7 +158,7 @@ function Replays() {
                       <ReplayTable
                         idKey="id"
                         showProjectColumn
-                        replayList={data.tableData.data as Replay[]}
+                        replayList={data.tableData.data as DiscoReplayListItem[]}
                       />
                     ) : null}
                   </StyledPanelTable>

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -3,6 +3,43 @@ import type {eventWithTime} from 'rrweb/typings/types';
 import type {RawCrumb} from 'sentry/types/breadcrumbs';
 
 export type Replay = {
+  count_errors: number;
+  count_sequences: number;
+  count_urls: number;
+  dist: null | string;
+  duration: number;
+  environment: string;
+  finished_at: Date;
+  ip_address_v4: string;
+  ip_address_v6: null | string;
+  longest_transaction: number;
+  platform: string;
+  project_id: string;
+  release: string;
+  replay_id: string;
+  sdk_name: string;
+  sdk_version: string;
+  started_at: Date;
+  tags: Record<string, any>;
+  title: string;
+  trace_ids: string[];
+  urls: string[];
+  user: string;
+  user_email: string;
+  user_hash: string;
+  user_id: string;
+  user_name: string;
+};
+
+export type ReplaySegment = {
+  date_added: Date;
+  id: string;
+  project_id: number;
+  replay_id: string;
+  segment_id: number;
+};
+
+export type DiscoReplayListItem = {
   eventID: string;
   id: string;
   project: string;


### PR DESCRIPTION
I was pulling type info from the blueprint docs here: https://github.com/getsentry/replay-backend/pull/15/files