### PR TITLE
fix(email): Fix debug email view for incident trigger

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -188,7 +188,9 @@ def generate_incident_trigger_email_context(
     project, incident, alert_rule_trigger, trigger_status, incident_status
 ):
     trigger = alert_rule_trigger
-    incident_trigger = IncidentTrigger.objects.get(incident=incident, alert_rule_trigger=trigger)
+    incident_trigger = IncidentTrigger.objects.filter(
+        incident=incident, alert_rule_trigger=trigger
+    ).first()
 
     alert_rule = trigger.alert_rule
     snuba_query = alert_rule.snuba_query
@@ -249,7 +251,7 @@ def generate_incident_trigger_email_context(
         "incident_name": incident.title,
         "environment": environment_string,
         "time_window": format_duration(snuba_query.time_window / 60),
-        "triggered_at": incident_trigger.date_added,
+        "triggered_at": incident_trigger.date_added if incident_trigger else None,
         "aggregate": aggregate,
         "query": snuba_query.query,
         "threshold": threshold,


### PR DESCRIPTION
http://localhost:8000/debug/mail/incident-trigger

![image](https://user-images.githubusercontent.com/8980455/181359252-963a28ba-5518-4321-a356-3cf531d394bc.png)

Currently `generate_incident_trigger_email_context` fails when called from the debug email view because `IncidentTrigger.objects.get(incident=incident, alert_rule_trigger=trigger)` throws an error. The `IncidentTrigger` is only used for the `date_added` attribute, so this PR makes it optional.