### PR TITLE
ref(tagStore): Cleanup tagstore and refactor to make more sense

### DIFF
--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -16,9 +16,9 @@ const BUILTIN_TAGS = ISSUE_FIELDS.reduce<TagCollection>((acc, tag) => {
 }, {});
 
 interface TagStoreDefinition extends CommonStoreDefinition<TagCollection> {
-  getAllTags(): TagCollection;
-  getBuiltInTags(): TagCollection;
   getIssueAttributes(): TagCollection;
+  getIssueTags(): TagCollection;
+  getStateTags(): TagCollection;
   loadTagsSuccess(data: Tag[]): void;
   reset(): void;
   state: TagCollection;
@@ -32,10 +32,9 @@ const storeConfig: TagStoreDefinition = {
     this.state = {};
   },
 
-  getBuiltInTags() {
-    return {...BUILTIN_TAGS, ...SEMVER_TAGS};
-  },
-
+  /**
+   * Gets only predefined issue attributes
+   */
   getIssueAttributes() {
     // TODO(mitsuhiko): what do we do with translations here?
     const isSuggestions = [
@@ -121,17 +120,34 @@ const storeConfig: TagStoreDefinition = {
     };
   },
 
-  reset() {
-    this.state = {};
-    this.trigger(this.state);
+  /**
+   * Get all tags including builtin issue tags and issue attributes
+   */
+  getIssueTags() {
+    return {
+      ...BUILTIN_TAGS,
+      ...SEMVER_TAGS,
+      // State tags should overwrite built ins.
+      ...this.state,
+      // We want issue attributes to overwrite any built in and state tags
+      ...this.getIssueAttributes(),
+    };
   },
 
-  getAllTags() {
-    return this.state;
+  /**
+   * Get only tags loaded from the backend
+   */
+  getStateTags() {
+    return this.getState();
   },
 
   getState() {
-    return this.getAllTags();
+    return this.state;
+  },
+
+  reset() {
+    this.state = {};
+    this.trigger(this.state);
   },
 
   loadTagsSuccess(data) {

--- a/static/app/utils/withIssueTags.tsx
+++ b/static/app/utils/withIssueTags.tsx
@@ -1,5 +1,4 @@
 import {useCallback, useEffect, useState} from 'react';
-import assign from 'lodash/assign';
 
 import MemberListStore from 'sentry/stores/memberListStore';
 import TagStore from 'sentry/stores/tagStore';
@@ -90,10 +89,8 @@ function withIssueTags<Props extends WithIssueTagsProps>(
 
     // Listen to tag store updates and cleanup listener on unmount
     useEffect(() => {
-      const unsubscribeTags = TagStore.listen((storeTags: TagCollection) => {
-        const tags = assign({}, TagStore.getIssueTags(), storeTags);
-
-        setAssigned({tags});
+      const unsubscribeTags = TagStore.listen(() => {
+        setAssigned({tags: TagStore.getIssueTags()});
       }, undefined);
 
       return () => unsubscribeTags();

--- a/static/app/utils/withIssueTags.tsx
+++ b/static/app/utils/withIssueTags.tsx
@@ -35,12 +35,7 @@ function withIssueTags<Props extends WithIssueTagsProps>(
 ) {
   function ComponentWithTags(props: Omit<Props, keyof WithIssueTagsProps>) {
     const [state, setState] = useState<WrappedComponentState>({
-      tags: assign(
-        {},
-        TagStore.getAllTags(),
-        TagStore.getIssueAttributes(),
-        TagStore.getBuiltInTags()
-      ),
+      tags: TagStore.getIssueTags(),
       users: MemberListStore.getAll(),
       teams: TeamStore.getAll(),
     });
@@ -96,12 +91,7 @@ function withIssueTags<Props extends WithIssueTagsProps>(
     // Listen to tag store updates and cleanup listener on unmount
     useEffect(() => {
       const unsubscribeTags = TagStore.listen((storeTags: TagCollection) => {
-        const tags = assign(
-          {},
-          storeTags,
-          TagStore.getIssueAttributes(),
-          TagStore.getBuiltInTags()
-        );
+        const tags = assign({}, TagStore.getIssueTags(), storeTags);
 
         setAssigned({tags});
       }, undefined);
@@ -116,7 +106,7 @@ function withIssueTags<Props extends WithIssueTagsProps>(
       }, undefined);
 
       return () => unsubscribeMembers();
-    }, []);
+    }, [setAssigned]);
 
     return <WrappedComponent {...(props as Props)} tags={state.tags} />;
   }

--- a/static/app/utils/withTags.tsx
+++ b/static/app/utils/withTags.tsx
@@ -20,7 +20,7 @@ function withTags<P extends InjectedTagsProps>(WrappedComponent: React.Component
     static displayName = `withTags(${getDisplayName(WrappedComponent)})`;
 
     state: State = {
-      tags: TagStore.getAllTags(),
+      tags: TagStore.getStateTags(),
     };
 
     componentWillUnmount() {

--- a/tests/js/spec/components/smartSearchBar/index.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar/index.spec.jsx
@@ -23,7 +23,7 @@ describe('SmartSearchBar', function () {
     TagStore.reset();
     TagStore.loadTagsSuccess(TestStubs.Tags());
     tagValuesMock.mockClear();
-    supportedTags = TagStore.getAllTags();
+    supportedTags = TagStore.getStateTags();
     supportedTags.firstRelease = {
       key: 'firstRelease',
       name: 'firstRelease',

--- a/tests/js/spec/stores/tagStore.spec.jsx
+++ b/tests/js/spec/stores/tagStore.spec.jsx
@@ -19,7 +19,7 @@ describe('TagStore', function () {
         {key: 'other', name: 'Other'},
       ]);
 
-      const tags = TagStore.getAllTags();
+      const tags = TagStore.getStateTags();
       expect(tags.mytag).toEqual({
         key: 'mytag',
         name: 'My Custom Tag',
@@ -71,14 +71,28 @@ describe('TagStore', function () {
     });
   });
 
-  describe('getBuiltInTags()', function () {
-    it('should be a map of built in properties', () => {
-      const tags = TagStore.getBuiltInTags();
-      expect(tags.location).toEqual({
-        key: 'location',
-        name: 'location',
-      });
-      expect(tags.id).toBeUndefined();
+  describe('getIssueTags()', function () {
+    it('should have built in, state, and issue attribute tags', () => {
+      TagStore.loadTagsSuccess([
+        {
+          key: 'mytag',
+          name: 'My Custom Tag',
+        },
+      ]);
+
+      const tags = TagStore.getIssueTags();
+
+      // state
+      expect(tags.mytag).toBeTruthy();
+      expect(tags.mytag.key).toBe('mytag');
+
+      // attribute
+      expect(tags.has).toBeTruthy();
+      expect(tags.has.key).toBe('has');
+
+      // built in
+      expect(tags['device.family']).toBeTruthy();
+      expect(tags['device.family'].key).toBe('device.family');
     });
   });
 });

--- a/tests/js/spec/views/issueList/searchBar.spec.jsx
+++ b/tests/js/spec/views/issueList/searchBar.spec.jsx
@@ -25,7 +25,7 @@ describe('IssueListSearchBar', function () {
   beforeEach(function () {
     TagStore.reset();
     TagStore.loadTagsSuccess(TestStubs.Tags());
-    supportedTags = TagStore.getAllTags();
+    supportedTags = TagStore.getStateTags();
     // Add a tag that is preseeded with values.
     supportedTags.is = {
       key: 'is',


### PR DESCRIPTION
`getAllTags` never made sense because it was never all the tags, just the state tags, use `getStateTags` instead. `getBuiltInTags` was also removed and functionality moved to `getIssueTags`