### PR TITLE
ref(replays): Absolute imports in all the replays files

### DIFF
--- a/static/app/components/replays/breadcrumbs/gridlines.tsx
+++ b/static/app/components/replays/breadcrumbs/gridlines.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import * as Timeline from 'sentry/components/replays/breadcrumbs/timeline';
-
-import {countColumns, formatTime} from '../utils';
+import {countColumns, formatTime} from 'sentry/components/replays/utils';
 
 type LineStyle = 'dotted' | 'solid' | 'none';
 

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -3,15 +3,14 @@ import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import * as Timeline from 'sentry/components/replays/breadcrumbs/timeline';
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {getCrumbsByColumn, relativeTimeInMs} from 'sentry/components/replays/utils';
 import Tooltip from 'sentry/components/tooltip';
 import space from 'sentry/styles/space';
 import {Crumb} from 'sentry/types/breadcrumbs';
 import type {Color} from 'sentry/utils/theme';
 import theme from 'sentry/utils/theme';
 import BreadcrumbItem from 'sentry/views/replays/detail/breadcrumbs/breadcrumbItem';
-
-import {useReplayContext} from '../replayContext';
-import {getCrumbsByColumn, relativeTimeInMs} from '../utils';
 
 const EVENT_STICK_MARKER_WIDTH = 4;
 

--- a/static/app/components/replays/playerRelativeTime.tsx
+++ b/static/app/components/replays/playerRelativeTime.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled';
 
 import DateTime from 'sentry/components/dateTime';
+import {showPlayerTime} from 'sentry/components/replays/utils';
 import Tooltip from 'sentry/components/tooltip';
-
-import {showPlayerTime} from './utils';
 
 type Props = {
   relativeTime: number | undefined;

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -3,10 +3,9 @@ import styled from '@emotion/styled';
 import {useResizeObserver} from '@react-aria/utils';
 
 import {Panel as _Panel} from 'sentry/components/panels';
+import BufferingOverlay from 'sentry/components/replays/player/bufferingOverlay';
+import FastForwardBadge from 'sentry/components/replays/player/fastForwardBadge';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-
-import BufferingOverlay from './player/bufferingOverlay';
-import FastForwardBadge from './player/fastForwardBadge';
 
 interface Props {
   className?: string;

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -4,6 +4,8 @@ import {inflate} from 'pako';
 
 import {IssueAttachment} from 'sentry/types';
 import {EventTransaction} from 'sentry/types/event';
+import flattenListOfObjects from 'sentry/utils/replays/flattenListOfObjects';
+import useReplayErrors from 'sentry/utils/replays/hooks/useReplayErrors';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
@@ -13,10 +15,6 @@ import type {
   ReplayError,
   ReplaySpan,
 } from 'sentry/views/replays/types';
-
-import flattenListOfObjects from '../flattenListOfObjects';
-
-import useReplayErrors from './useReplayErrors';
 
 type State = {
   breadcrumbs: undefined | ReplayCrumb[];

--- a/static/app/utils/replays/hooks/useReplayErrors.tsx
+++ b/static/app/utils/replays/hooks/useReplayErrors.tsx
@@ -1,8 +1,7 @@
 import {useMemo} from 'react';
 
+import useDiscoverQuery from 'sentry/utils/replays/hooks/useDiscoveryQuery';
 import {ReplayError} from 'sentry/views/replays/types';
-
-import useDiscoverQuery from './useDiscoveryQuery';
 
 interface Params {
   replayId: string;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -13,9 +13,8 @@ import space from 'sentry/styles/space';
 import {Crumb} from 'sentry/types/breadcrumbs';
 import {getPrevBreadcrumb} from 'sentry/utils/replays/getBreadcrumb';
 import {useCurrentItemScroller} from 'sentry/utils/replays/hooks/useCurrentItemScroller';
+import BreadcrumbItem from 'sentry/views/replays/detail/breadcrumbs/breadcrumbItem';
 import FluidPanel from 'sentry/views/replays/detail/layout/fluidPanel';
-
-import BreadcrumbItem from './breadcrumbItem';
 
 function CrumbPlaceholder({number}: {number: number}) {
   return (

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -10,10 +10,9 @@ import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import type {BreadcrumbLevelType, BreadcrumbTypeDefault} from 'sentry/types/breadcrumbs';
+import ConsoleMessage from 'sentry/views/replays/detail/console/consoleMessage';
+import {filterBreadcrumbs} from 'sentry/views/replays/detail/console/utils';
 import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
-
-import ConsoleMessage from './consoleMessage';
-import {filterBreadcrumbs} from './utils';
 
 interface Props {
   breadcrumbs: BreadcrumbTypeDefault[];

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -9,13 +9,12 @@ import type {RawCrumb} from 'sentry/types/breadcrumbs';
 import {isBreadcrumbTypeDefault} from 'sentry/types/breadcrumbs';
 import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import useOrganization from 'sentry/utils/useOrganization';
-
-import Console from './console';
-import DomMutations from './domMutations';
-import IssueList from './issueList';
-import MemoryChart from './memoryChart';
-import NetworkList from './network';
-import Trace from './trace';
+import Console from 'sentry/views/replays/detail/console';
+import DomMutations from 'sentry/views/replays/detail/domMutations';
+import IssueList from 'sentry/views/replays/detail/issueList';
+import MemoryChart from 'sentry/views/replays/detail/memoryChart';
+import NetworkList from 'sentry/views/replays/detail/network';
+import Trace from 'sentry/views/replays/detail/trace';
 
 type Props = {};
 

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -9,8 +9,11 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {EventTransaction} from 'sentry/types';
 import theme from 'sentry/utils/theme';
-
-import {ISortConfig, NetworkSpan, sortNetwork} from './utils';
+import {
+  ISortConfig,
+  NetworkSpan,
+  sortNetwork,
+} from 'sentry/views/replays/detail/network/utils';
 
 type Props = {
   event: EventTransaction;

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -9,9 +9,10 @@ import space from 'sentry/styles/space';
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import type {EventTransaction} from 'sentry/types/event';
 import getUrlPathname from 'sentry/utils/getUrlPathname';
+import EventMetaData, {
+  HeaderPlaceholder,
+} from 'sentry/views/replays/detail/eventMetaData';
 import ChooseLayout from 'sentry/views/replays/detail/layout/chooseLayout';
-
-import EventMetaData, {HeaderPlaceholder} from './eventMetaData';
 
 type Props = {
   children: ReactNode;

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -16,8 +16,7 @@ import theme from 'sentry/utils/theme';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-
-import {Replay} from './types';
+import {Replay} from 'sentry/views/replays/types';
 
 type Props = {
   idKey: string;

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -21,10 +21,9 @@ import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-
-import ReplaysFilters from './filters';
-import ReplayTable from './replayTable';
-import {Replay} from './types';
+import ReplaysFilters from 'sentry/views/replays/filters';
+import ReplayTable from 'sentry/views/replays/replayTable';
+import {Replay} from 'sentry/views/replays/types';
 
 const columns = [t('Session'), t('Project')];
 


### PR DESCRIPTION
**Motivation:**
I was renaming some stuff:
```
- import {Replay} from './types';
+ import {DiscoReplayListItem} from './types';
```
but it was annoying because, before i jumped into the change, I wanted to find all the places that did the import and only do the rename if it’s a small list.
So how do I find all the places that use `Replay` or `types`, there are a lot of search hits for a naive search. Another approach might've been to rename the thing and see what breaks, but that's noisy too, and the broken lines will not always be the lines that need to be updated.

Basically, i'm asserting that 'relative imports' make this tough.
Sometimes we’ve got `import foo from './foo';` and other times it’s crawling up the tree `import foo from '../foo';` even.

So, at least in this corner of the world, I think some standardization is good. VSCode will auto-update imports when a file is renamed... but sometimes I just want to grep around and figure out the size of a problem before messing up my working copy.