### PR TITLE
fix(dashboard-filters): Patch unsaved filter reset in create dashboard

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -645,9 +645,13 @@ class DashboardDetail extends Component<Props, State> {
 
   renderWidgetBuilder() {
     const {children, dashboard, organization, location} = this.props;
-    const {modifiedDashboard} = this.state;
+    const {dashboardState, modifiedDashboard} = this.state;
 
+    // By definition, a new dashboard has unsaved filter changes
+    // so only attempt to set state when there are actually
+    // saved filters to compare to
     if (
+      dashboardState !== DashboardState.CREATE &&
       organization.features.includes('dashboards-top-level-filter') &&
       modifiedDashboard &&
       hasUnsavedFilterChanges(dashboard, location, modifiedDashboard.filters)


### PR DESCRIPTION
Since new dashboards don't have filters at all, anything that's set
in the filters will be compared against undefined values and trigger a
reset, but this causes an infinite loop and crashes. This reset code
will be removed when the PR for disabled dashboard actions lands
