### PR TITLE
feat(discover): Support size type in axis and tooltip formatters

### DIFF
--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -2,7 +2,7 @@ import {LegendComponentOption} from 'echarts';
 
 import {t} from 'sentry/locale';
 import {Series} from 'sentry/types/echarts';
-import {defined} from 'sentry/utils';
+import {defined, formatBytesBase2} from 'sentry/utils';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {
   DAY,
@@ -44,6 +44,8 @@ export function tooltipFormatterUsingAggregateOutputType(
       return formatPercentage(value, 2);
     case 'duration':
       return getDuration(value / 1000, 2, true);
+    case 'size':
+      return formatBytesBase2(value);
     default:
       return value.toString();
   }
@@ -76,7 +78,6 @@ export function axisLabelFormatterUsingAggregateOutputType(
   abbreviation: boolean = false,
   durationUnit?: number
 ): string {
-  // TODO: Add formatter for size type
   switch (type) {
     case 'integer':
     case 'number':
@@ -85,6 +86,8 @@ export function axisLabelFormatterUsingAggregateOutputType(
       return formatPercentage(value, 0);
     case 'duration':
       return axisDuration(value, durationUnit);
+    case 'size':
+      return formatBytesBase2(value, 0);
     default:
       return value.toString();
   }

--- a/tests/js/spec/utils/discover/charts.spec.tsx
+++ b/tests/js/spec/utils/discover/charts.spec.tsx
@@ -38,6 +38,7 @@ describe('tooltipFormatterUsingAggregateOutputType()', () => {
       ['integer', 0.125, '0.125'],
       ['percentage', 0.6612, '66.12%'],
       ['duration', 321, '321.00ms'],
+      ['size', 416 * 1024, '416.0 KiB'],
       ['', 444, '444'],
     ];
     for (const scenario of cases) {
@@ -105,6 +106,7 @@ describe('axisLabelFormatterUsingAggregateOutputType()', () => {
       ['integer', 0.125, '0.125'],
       ['percentage', 0.6612, '66%'],
       ['duration', 321, '321ms'],
+      ['size', 416 * 1024, '416 KiB'],
       ['', 444, '444'],
     ];
     for (const scenario of cases) {


### PR DESCRIPTION
Update to handle size type for discover chart axis and tooltip formatters. This is mostly for custom performance metric widgets
![image](https://user-images.githubusercontent.com/83961295/181379993-33c102f4-498a-4766-b120-5d834ac40584.png)
