### PR TITLE
fix(replays): Make sure minimum Timeline Event position is >=1 for visual alignment

### DIFF
--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -124,7 +124,8 @@ export function getCrumbsByColumn(
       : timestampMilliSeconds - startMilliSeconds;
     const column = Math.floor((sinceStart / safeDuration) * (totalColumns - 1)) + 1;
 
-    return [column, breadcrumb] as [number, Crumb];
+    // Should start at minimum in the first column
+    return [column || 1, breadcrumb] as [number, Crumb];
   });
 
   const crumbsByColumn = columnCrumbPairs.reduce((map, [column, breadcrumb]) => {

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -127,7 +127,7 @@ export function getCrumbsByColumn(
       Math.floor((sinceStart / safeDuration) * (totalColumns - 1)) + 1;
 
     // Should start at minimum in the first column
-    const column = columnPositionCalc <= 0 ? 1 : columnPositionCalc;
+    const column = Math.max(1, columnPositionCalc);
 
     return [column, breadcrumb] as [number, Crumb];
   });

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -122,10 +122,14 @@ export function getCrumbsByColumn(
     const sinceStart = isNaN(timestampMilliSeconds)
       ? 0
       : timestampMilliSeconds - startMilliSeconds;
-    const column = Math.floor((sinceStart / safeDuration) * (totalColumns - 1)) + 1;
+
+    const columnPositionCalc =
+      Math.floor((sinceStart / safeDuration) * (totalColumns - 1)) + 1;
 
     // Should start at minimum in the first column
-    return [column || 1, breadcrumb] as [number, Crumb];
+    const column = columnPositionCalc <= 0 ? 1 : columnPositionCalc;
+
+    return [column, breadcrumb] as [number, Crumb];
   });
 
   const crumbsByColumn = columnCrumbPairs.reduce((map, [column, breadcrumb]) => {


### PR DESCRIPTION

<!-- Describe your PR here. -->
Added new condition to make sure the minimum crumb position in the timeline would be the first column.

before (This happened because the first element was being positioned at column 0): 


![image](https://user-images.githubusercontent.com/39612839/181378144-236f7038-f510-438d-9bd2-fc126203a0e1.png)

After: 
![image](https://user-images.githubusercontent.com/39612839/181378062-e2edfff5-3e71-498c-9ce3-d5386308cae7.png)

Fixes https://github.com/getsentry/sentry-replay/issues/116


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
