### PR TITLE
fix: Make mandatory argument mandatory [INGEST-1380]

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -558,7 +558,7 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
 @click.option("--input-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--output-block-size", type=int, default=DEFAULT_BLOCK_SIZE)
 @click.option("--factory-name", default="default")
-@click.option("--ingest-profile")
+@click.option("--ingest-profile", required=True)
 @click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=25000)
 @click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=10000)
 def metrics_streaming_consumer(**options):


### PR DESCRIPTION
split out from #36531 

Without this, you get a rather ugly error msg:

```
  File "/Users/untitaker/projects/sentry/.venv/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/untitaker/projects/sentry/src/sentry/runner/decorators.py", line 69, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/Users/untitaker/projects/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/untitaker/projects/sentry/.venv/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/untitaker/projects/sentry/src/sentry/runner/decorators.py", line 29, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/Users/untitaker/projects/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/untitaker/projects/sentry/src/sentry/runner/commands/run.py", line 570, in metrics_streaming_consumer
    ingest_config = get_ingest_config(UseCaseKey(options["ingest_profile"]))
  File "/Users/untitaker/.pyenv/versions/3.8.13/lib/python3.8/enum.py", line 339, in __call__
    return cls.__new__(cls, value)
  File "/Users/untitaker/.pyenv/versions/3.8.13/lib/python3.8/enum.py", line 663, in __new__
    raise ve_exc
ValueError: None is not a valid UseCaseKey
```

