### PR TITLE
ref(useApi): add api to hook deps

### DIFF
--- a/static/app/components/charts/eventsGeoRequest.tsx
+++ b/static/app/components/charts/eventsGeoRequest.tsx
@@ -89,7 +89,7 @@ const EventsGeoRequest = ({
       // Prevent setState leaking on unmounted component
       mounted = false;
     };
-  }, [query, yAxis, start, end, period, environments, projects]);
+  }, [query, yAxis, start, end, period, environments, projects, api]);
 
   return children({
     errored,

--- a/static/app/components/globalSdkUpdateAlert.tsx
+++ b/static/app/components/globalSdkUpdateAlert.tsx
@@ -65,7 +65,7 @@ function InnerGlobalSdkUpdateAlert(
     return () => {
       isUnmounted = true;
     };
-  }, []);
+  }, [api]);
 
   if (!showUpdateAlert || !props.sdkUpdates?.length) {
     return null;

--- a/static/app/components/projects/appStoreConnectContext.tsx
+++ b/static/app/components/projects/appStoreConnectContext.tsx
@@ -96,7 +96,7 @@ const Provider = ({children, project, organization}: ProviderProps) => {
     return () => {
       unmounted = true;
     };
-  }, [projectDetails, organization, appStoreConnectSymbolSources]);
+  }, [projectDetails, organization, appStoreConnectSymbolSources, api]);
 
   function getUpdateAlertMessage(
     respository: NonNullable<Parameters<typeof getAppStoreValidationErrorMessage>[1]>,

--- a/static/app/stores/persistedStore.tsx
+++ b/static/app/stores/persistedStore.tsx
@@ -73,7 +73,7 @@ export function PersistedStoreProvider(props: {children: React.ReactNode}) {
     return () => {
       shouldCancelRequest = true;
     };
-  }, [organization]);
+  }, [api, organization]);
 
   return (
     <PersistedStoreContext.Provider value={[state, setState]}>
@@ -109,7 +109,7 @@ export function usePersistedStoreCategory<C extends keyof PersistedStore>(
         data: val,
       });
     },
-    [category, organization]
+    [category, organization, api]
   );
 
   const stableState: UsePersistedCategory<PersistedStore[C]> = useMemo(() => {

--- a/static/app/views/organizationGroupDetails/groupEventDetails/index.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/index.tsx
@@ -40,7 +40,7 @@ export function GroupEventDetailsContainer(props: GroupEventDetailsProps) {
       fetchOrganizationEnvironments(props.api, props.organization.slug);
     }
     // XXX: Missing dependencies, but it reflects the old of componentDidMount
-  }, []);
+  }, [props.api]);
 
   if (state.error) {
     return (


### PR DESCRIPTION
Adds `api` as a hook dependency. I've manually checked and each of these components either consumes the api directly from `useApi` or through `withApi` (which uses `useApi`). Since useApi provides a stable ref to the Api (manually checked implementation) this is safe to update.

Fixes a 2 hook errors and partially fixes a few more