### PR TITLE
test(widget-builder): Decrease steps in flaky debounce test

### DIFF
--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -98,11 +98,9 @@ describe('VisualizationStep', function () {
       }
     );
 
-    await screen.findByText('Table');
-
     await waitFor(() => expect(eventsv2Mock).toHaveBeenCalledTimes(1));
 
-    userEvent.type(screen.getByPlaceholderText('Alias'), 'First Alias{enter}');
+    userEvent.type(await screen.findByPlaceholderText('Alias'), 'abc');
     act(() => {
       jest.advanceTimersByTime(DEFAULT_DEBOUNCE_DURATION + 1);
     });


### PR DESCRIPTION
The test relies on typing so we can't completely replace that operation
with a paste. Instead we can decrease the number of characters that it
types as well as remove an await to avoid unnecessary work
