### PR TITLE
fix(dashboard-filters): Remove filter reset code

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -48,7 +48,6 @@ import {
 } from './layoutUtils';
 import SortableWidget from './sortableWidget';
 import {DashboardDetails, DashboardWidgetSource, Widget, WidgetType} from './types';
-import {getSavedPageFilters} from './utils';
 
 export const DRAG_HANDLE_CLASS = 'widget-drag';
 const DRAG_RESIZE_CLASS = 'widget-resize';
@@ -346,9 +345,6 @@ class Dashboard extends Component<Props, State> {
           pathname: `/organizations/${organization.slug}/dashboard/${paramDashboardId}/widget/${index}/edit/`,
           query: {
             ...location.query,
-            ...(organization.features.includes('dashboards-top-level-filter')
-              ? getSavedPageFilters(dashboard)
-              : {}),
             source: DashboardWidgetSource.DASHBOARDS,
           },
         });


### PR DESCRIPTION
Now that dashboard actions are disabled when there are unsaved filters,
the code for resetting the filters can be removed. Also fixes a maximum depth
issue since it removes a setState that's being triggered when there are unsaved
changes, but new dashboards always have unsaved changes.

Fixes JAVASCRIPT-28M0