### PR TITLE
feat(profiling): Allow selection of function types

### DIFF
--- a/static/app/utils/profiling/hooks/useFunctions.tsx
+++ b/static/app/utils/profiling/hooks/useFunctions.tsx
@@ -36,12 +36,12 @@ export function isFunctionsResultV2(
 }
 
 interface UseFunctionsOptions {
-  functionType: 'application' | 'system' | 'all';
   project: Project;
   query: string;
   sort: string;
   transaction: string;
   cursor?: string;
+  functionType?: 'application' | 'system' | 'all';
   selection?: PageFilters;
 }
 
@@ -133,7 +133,7 @@ function fetchFunctions(
     transaction,
   }: {
     cursor: string | undefined;
-    functionType: 'application' | 'system' | 'all';
+    functionType: 'application' | 'system' | 'all' | undefined;
     projectSlug: Project['slug'];
     query: string;
     selection: PageFilters;

--- a/static/app/utils/profiling/hooks/useFunctions.tsx
+++ b/static/app/utils/profiling/hooks/useFunctions.tsx
@@ -36,6 +36,7 @@ export function isFunctionsResultV2(
 }
 
 interface UseFunctionsOptions {
+  functionType: 'application' | 'system' | 'all';
   project: Project;
   query: string;
   sort: string;
@@ -45,6 +46,7 @@ interface UseFunctionsOptions {
 }
 
 function useFunctions({
+  functionType,
   project,
   query,
   transaction,
@@ -67,6 +69,7 @@ function useFunctions({
     setRequestState({type: 'loading'});
 
     fetchFunctions(api, organization, {
+      functionType,
       projectSlug: project.slug,
       query,
       selection,
@@ -102,7 +105,17 @@ function useFunctions({
       });
 
     return () => api.clear();
-  }, [api, cursor, organization, project.slug, query, selection, sort, transaction]);
+  }, [
+    api,
+    cursor,
+    functionType,
+    organization,
+    project.slug,
+    query,
+    selection,
+    sort,
+    transaction,
+  ]);
 
   return requestState;
 }
@@ -112,6 +125,7 @@ function fetchFunctions(
   organization: Organization,
   {
     cursor,
+    functionType,
     projectSlug,
     query,
     selection,
@@ -119,6 +133,7 @@ function fetchFunctions(
     transaction,
   }: {
     cursor: string | undefined;
+    functionType: 'application' | 'system' | 'all';
     projectSlug: Project['slug'];
     query: string;
     selection: PageFilters;
@@ -140,6 +155,12 @@ function fetchFunctions(
         ...normalizeDateTimeParams(selection.datetime),
         query: conditions.formatString(),
         sort,
+        is_application:
+          functionType === 'application'
+            ? '1'
+            : functionType === 'system'
+            ? '0'
+            : undefined,
       },
     }
   );

--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -1,9 +1,10 @@
-import {Fragment, useCallback, useMemo} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
+import CompactSelect from 'sentry/components/forms/compactSelect';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Pagination from 'sentry/components/pagination';
 import {FunctionsTable} from 'sentry/components/profiling/functionsTable';
@@ -63,6 +64,10 @@ function ProfileSummaryContent(props: ProfileSummaryContentProps) {
     selection: props.selection,
   });
 
+  const [functionType, setFunctionType] = useState<'application' | 'system' | 'all'>(
+    'application'
+  );
+
   const functions = useFunctions({
     cursor: functionsCursor,
     project: props.project,
@@ -70,6 +75,7 @@ function ProfileSummaryContent(props: ProfileSummaryContentProps) {
     selection: props.selection,
     transaction: props.transaction,
     sort: functionsSort,
+    functionType,
   });
 
   const handleFunctionsCursor = useCallback((cursor, pathname, query) => {
@@ -106,7 +112,25 @@ function ProfileSummaryContent(props: ProfileSummaryContentProps) {
       ) : (
         <Fragment>
           <TableHeader>
-            <SectionHeading>{t('Suspect Functions')}</SectionHeading>
+            <CompactSelect
+              triggerProps={{prefix: t('Suspect Functions'), size: 'xs'}}
+              value={functionType}
+              options={[
+                {
+                  label: t('All'),
+                  value: 'all',
+                },
+                {
+                  label: t('Application'),
+                  value: 'application',
+                },
+                {
+                  label: t('System'),
+                  value: 'system',
+                },
+              ]}
+              onChange={({value}) => setFunctionType(value)}
+            />
             <StyledPagination
               pageLinks={
                 functions.type === 'resolved' && isFunctionsResultV2(functions.data)

--- a/tests/js/spec/utils/profiling/hooks/useFunctions.spec.tsx
+++ b/tests/js/spec/utils/profiling/hooks/useFunctions.spec.tsx
@@ -105,4 +105,103 @@ describe('useFunctions', function () {
       },
     });
   });
+
+  it('fetches application functions', async function () {
+    const mock = MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/profiling/functions/`,
+      body: {functions: []},
+      match: [MockApiClient.matchQuery({is_application: '1'})],
+    });
+
+    const hook = reactHooks.renderHook(
+      () =>
+        useFunctions({
+          functionType: 'application',
+          project,
+          query: '',
+          transaction: '',
+          selection,
+          sort: '-p99',
+        }),
+      {wrapper: TestContext}
+    );
+    expect(hook.result.current).toEqual({type: 'loading'});
+    await hook.waitForNextUpdate();
+    expect(hook.result.current).toEqual({
+      type: 'resolved',
+      data: {
+        functions: [],
+        pageLinks: null,
+        version: 2,
+      },
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches system functions', async function () {
+    const mock = MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/profiling/functions/`,
+      body: {functions: []},
+      match: [MockApiClient.matchQuery({is_application: '0'})],
+    });
+
+    const hook = reactHooks.renderHook(
+      () =>
+        useFunctions({
+          functionType: 'system',
+          project,
+          query: '',
+          transaction: '',
+          selection,
+          sort: '-p99',
+        }),
+      {wrapper: TestContext}
+    );
+    expect(hook.result.current).toEqual({type: 'loading'});
+    await hook.waitForNextUpdate();
+    expect(hook.result.current).toEqual({
+      type: 'resolved',
+      data: {
+        functions: [],
+        pageLinks: null,
+        version: 2,
+      },
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetches all functions', async function () {
+    const mock = MockApiClient.addMockResponse({
+      url: `/projects/org-slug/${project.slug}/profiling/functions/`,
+      body: {functions: []},
+      match: [MockApiClient.matchQuery({is_application: undefined})],
+    });
+
+    const hook = reactHooks.renderHook(
+      () =>
+        useFunctions({
+          functionType: 'all',
+          project,
+          query: '',
+          transaction: '',
+          selection,
+          sort: '-p99',
+        }),
+      {wrapper: TestContext}
+    );
+    expect(hook.result.current).toEqual({type: 'loading'});
+    await hook.waitForNextUpdate();
+    expect(hook.result.current).toEqual({
+      type: 'resolved',
+      data: {
+        functions: [],
+        pageLinks: null,
+        version: 2,
+      },
+    });
+
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
There are 2 classes of functions: application and system. This introduces a
dropdown to allow the user to select the type of functions they want to see so
they can view just application or just system or both.

# Screenshot

![image](https://user-images.githubusercontent.com/10239353/181629765-08e3619c-5e3a-4a84-8e15-94adc46075b3.png)
