### PR TITLE
feat(dashboard): Display selected custom performance metric even if no longer valid in selected time range

### DIFF
--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -271,7 +271,10 @@ class QueryField extends Component<Props> {
     this.props.onChange(fieldValue);
   }
 
-  getFieldOrTagOrMeasurementValue(name: string | undefined): FieldValue | null {
+  getFieldOrTagOrMeasurementValue(
+    name: string | undefined,
+    functions: string[] = []
+  ): FieldValue | null {
     const {fieldOptions} = this.props;
     if (name === undefined) {
       return null;
@@ -306,9 +309,21 @@ class QueryField extends Component<Props> {
       return fieldOptions[tagName].value;
     }
 
-    // Likely a tag that was deleted but left behind in a saved query
-    // Cook up a tag option so select control works.
     if (name.length > 0) {
+      // Custom Measurement. Probably not appearing in field options because
+      // no metrics found within selected time range
+      if (name.startsWith('measurements.')) {
+        return {
+          kind: FieldValueKind.CUSTOM_MEASUREMENT,
+          meta: {
+            name,
+            dataType: 'number',
+            functions,
+          },
+        };
+      }
+      // Likely a tag that was deleted but left behind in a saved query
+      // Cook up a tag option so select control works.
       return {
         kind: FieldValueKind.TAG,
         meta: {
@@ -351,7 +366,8 @@ class QueryField extends Component<Props> {
         (param, index: number): ParameterDescription => {
           if (param.kind === 'column') {
             const fieldParameter = this.getFieldOrTagOrMeasurementValue(
-              fieldValue.function[1]
+              fieldValue.function[1],
+              [fieldValue.function[0]]
             );
             fieldOptions = this.appendFieldIfUnknown(fieldOptions, fieldParameter);
             return {
@@ -411,6 +427,12 @@ class QueryField extends Component<Props> {
       // Clone the options so we don't mutate other rows.
       fieldOptions = Object.assign({}, fieldOptions);
       fieldOptions[field.meta.name] = {label: field.meta.name, value: field};
+    } else if (field && field.kind === FieldValueKind.CUSTOM_MEASUREMENT) {
+      fieldOptions = Object.assign({}, fieldOptions);
+      fieldOptions[`measurement:${field.meta.name}`] = {
+        label: field.meta.name,
+        value: field,
+      };
     }
 
     return fieldOptions;

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -3720,6 +3720,39 @@ describe('WidgetBuilder', function () {
 
         await screen.findByText('12.0 KiB');
       });
+
+      it('displays custom performance metric in column select', async function () {
+        renderTestComponent({
+          query: {source: DashboardWidgetSource.DISCOVERV2},
+          dashboard: {
+            ...testDashboard,
+            widgets: [
+              {
+                title: 'Custom Measurement Widget',
+                interval: '1d',
+                id: '1',
+                widgetType: WidgetType.DISCOVER,
+                displayType: DisplayType.TABLE,
+                queries: [
+                  {
+                    conditions: '',
+                    name: '',
+                    fields: ['p99(measurements.custom.measurement)'],
+                    columns: [],
+                    aggregates: ['p99(measurements.custom.measurement)'],
+                    orderby: '-p99(measurements.custom.measurement)',
+                  },
+                ],
+              },
+            ],
+          },
+          params: {
+            widgetIndex: '0',
+          },
+          orgFeatures: [...defaultOrgFeatures, 'discover-frontend-use-events-endpoint'],
+        });
+        await screen.findByText('measurements.custom.measurement');
+      });
     });
   });
 });


### PR DESCRIPTION
When editing a dashboard widget with a custom performance metric selected, the custom performance metric may no longer be valid because there might not be any metrics recorded within the selected time range. This causes the custom performance metric to disappear from the yAxis/column select (since the `measurements-meta` endpoint no longer contains that value).

Updates the yaxis/column select to always display the selected custom performance metric value, until manually deselected.