### PR TITLE
feat(mep): add ingest-profile to last-seen updater (no-op)

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -614,6 +614,7 @@ def replays_recordings_consumer(**options):
 @click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=25000)
 @click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=10000)
 @click.option("--topic", default="snuba-metrics", help="Topic to read indexer output from.")
+@click.option("--ingest-profile")
 def last_seen_updater(**options):
     from sentry.sentry_metrics.consumers.last_seen_updater import get_last_seen_updater
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -616,7 +616,11 @@ def replays_recordings_consumer(**options):
 @click.option("--topic", default="snuba-metrics", help="Topic to read indexer output from.")
 @click.option("--ingest-profile")
 def last_seen_updater(**options):
+    from sentry.sentry_metrics.configuration import UseCaseKey, get_ingest_config
     from sentry.sentry_metrics.consumers.last_seen_updater import get_last_seen_updater
+
+    if options["ingest_profile"]:
+        get_ingest_config(UseCaseKey(options["ingest_profile"]))
 
     consumer = get_last_seen_updater(**options)
 


### PR DESCRIPTION
This lets us pass the argument which will be required later in our deploys, so once we split by use case we'll never be implicitly using a different type