### PR TITLE
fix(ui): Preserve labels on Sentry App alert rule actions select fields

### DIFF
--- a/static/app/components/forms/selectAsyncField.tsx
+++ b/static/app/components/forms/selectAsyncField.tsx
@@ -10,7 +10,13 @@ import {GeneralSelectValue} from 'sentry/components/forms/selectControl';
 
 export interface SelectAsyncFieldProps
   extends Omit<InputFieldProps, 'highlighted' | 'visible' | 'required' | 'value'>,
-    SelectAsyncControlProps {}
+    SelectAsyncControlProps {
+  /**
+   * Similar to onChange, except it provides the entire option object (including label) when a
+   * change is made to the field. Occurs after onChange.
+   */
+  onChangeOption?: (option: GeneralSelectValue, event: any) => void;
+}
 
 type SelectAsyncFieldState = {
   results: Result[];
@@ -29,6 +35,7 @@ class SelectAsyncField extends Component<SelectAsyncFieldProps, SelectAsyncField
   handleChange = (
     onBlur: SelectAsyncFieldProps['onBlur'],
     onChange: SelectAsyncFieldProps['onChange'],
+    onChangeOption: SelectAsyncFieldProps['onChangeOption'],
     optionObj: GeneralSelectValue,
     event: React.MouseEvent
   ) => {
@@ -43,6 +50,7 @@ class SelectAsyncField extends Component<SelectAsyncFieldProps, SelectAsyncField
     }
     this.setState({latestSelection: optionObj});
     onChange?.(value, event);
+    onChangeOption?.(optionObj, event);
     onBlur?.(value, event);
   };
 
@@ -66,24 +74,19 @@ class SelectAsyncField extends Component<SelectAsyncFieldProps, SelectAsyncField
   }
 
   render() {
-    const {...otherProps} = this.props;
+    const {onChangeOption, ...otherProps} = this.props;
     return (
       <InputField
         {...otherProps}
-        field={({onChange, onBlur, required: _required, onResults, value, ...props}) => (
+        field={({onBlur, onChange, required: _required, onResults, value, ...props}) => (
           <SelectAsyncControl
             {...props}
-            onChange={this.handleChange.bind(this, onBlur, onChange)}
+            onChange={this.handleChange.bind(this, onBlur, onChange, onChangeOption)}
             onResults={data => {
               const results = onResults(data);
               const resultSelection = results.find(result => result.value === value);
               this.setState(
-                resultSelection
-                  ? {
-                      results,
-                      latestSelection: resultSelection,
-                    }
-                  : {results}
+                resultSelection ? {results, latestSelection: resultSelection} : {results}
               );
               return results;
             }}


### PR DESCRIPTION
Currently, we only save the value of select fields when users set up their alert rules. With this PR, we will also be saving the `label` so that if they want to verify the settings later on, we have the associated label to display, and not just the value.

**example**

> User saves an alert rule select field with `Project A` label
> Our backend only saves the value, e.g. `1`
> The next time they go to modify it, it appears blank

This happens because there is no label. If we showed the value `1` it'd have no context to the user who saved it. This can happen if the Select Field has the `skip_load_on_open` property set in the schema.

Also, the branch name ticket is no longer accurate, it's API-2875 now

**TODO**
- [x] Add tests for different Select schema shapes