### PR TITLE
fix: Alpha badges for Replay nav items and rename DOM tab

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -228,6 +228,7 @@ function Sidebar({location, organization}: Props) {
         label={t('Replays')}
         to={`/organizations/${organization.slug}/replays/`}
         id="replays"
+        isAlpha
       />
     </Feature>
   );

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -5,7 +5,7 @@ import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
 
 export const ReplayTabs = {
   console: t('Console'),
-  dom: t('DOM'),
+  dom: t('DOM Events'),
   network: t('Network'),
   trace: t('Trace'),
   issues: t('Issues'),

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -23,6 +23,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import Link from 'sentry/components/links/link';
 import ListLink from 'sentry/components/links/listLink';
 import NavTabs from 'sentry/components/navTabs';
+import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import SeenByList from 'sentry/components/seenByList';
 import ShortId from 'sentry/components/shortId';
 import Tooltip from 'sentry/components/tooltip';
@@ -372,6 +373,7 @@ class GroupHeader extends Component<Props, State> {
                 isActive={() => currentTab === Tab.REPLAYS}
               >
                 {t('Replays')} <Badge text={replaysCount ?? ''} />
+                <ReplaysFeatureBadge />
               </ListLink>
             </Feature>
           </NavTabs>


### PR DESCRIPTION
### Changes
- Adds alpha badge to replays link in sidebar navigation
- Adds alpha badge to replays link in issues detail tabs
- Rename DOM tab on replay details to DOM Events

![Screen Shot 2022-07-28 at 3 23 37 PM](https://user-images.githubusercontent.com/3721977/181620696-94c9e4a2-ac03-4fb9-b0f4-4077e705cbff.png)
![Screen Shot 2022-07-28 at 3 23 40 PM](https://user-images.githubusercontent.com/3721977/181620700-a18e9bfb-7ba8-4639-a830-665218fec350.png)
![Screen Shot 2022-07-28 at 3 23 50 PM](https://user-images.githubusercontent.com/3721977/181620702-ccd1e1c2-ba04-48b3-ae15-d3150d1bccb1.png)


Closes #37124 
Closes #37021 
Closes #37144 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
