### PR TITLE
ref(calendar): Extract date pickers into reusable components

### DIFF
--- a/docs-ui/stories/components/calendar.stories.js
+++ b/docs-ui/stories/components/calendar.stories.js
@@ -1,0 +1,45 @@
+import {useState} from 'react';
+
+import {DatePicker, DateRangePicker} from 'sentry/components/calendar';
+
+export default {
+  title: 'Components/Calendar',
+};
+
+export const _DateRangePicker = () => {
+  const [range, setRange] = useState({startDate: new Date(), endDate: new Date()});
+
+  return (
+    <DateRangePicker
+      onChange={newRange => {
+        setRange(newRange);
+      }}
+      startDate={range.startDate}
+      endDate={range.endDate}
+    />
+  );
+};
+
+_DateRangePicker.storyName = 'DateRangePicker';
+_DateRangePicker.parameters = {
+  docs: {
+    description: {
+      story: 'Calendar widget for selecting a date range. Uses react-date-range',
+    },
+  },
+};
+
+export const _DatePicker = () => {
+  const [date, setDate] = useState(() => new Date());
+
+  return <DatePicker date={date} onChange={setDate} />;
+};
+
+_DatePicker.storyName = 'DatePicker';
+_DatePicker.parameters = {
+  docs: {
+    description: {
+      story: 'Calendar widget for selecting a single date. Uses react-date-range',
+    },
+  },
+};

--- a/static/app/components/calendar/calendarStylesWrapper.tsx
+++ b/static/app/components/calendar/calendarStylesWrapper.tsx
@@ -8,14 +8,8 @@ import space from 'sentry/styles/space';
 const CalendarStylesWrapper = styled('div')`
   padding: ${space(3)};
 
-  .rdrCalendarWrapper:not(.rdrDateRangeWrapper) {
-    .rdrDayHovered {
-      .rdrDayNumber {
-        &:after {
-          border: 0;
-        }
-      }
-    }
+  .rdrCalendarWrapper:not(.rdrDateRangeWrapper) .rdrDayHovered .rdrDayNumber:after {
+    border: 0;
   }
 
   .rdrSelected,

--- a/static/app/components/calendar/calendarStylesWrapper.tsx
+++ b/static/app/components/calendar/calendarStylesWrapper.tsx
@@ -1,13 +1,22 @@
 import 'react-date-range/dist/styles.css';
 import 'react-date-range/dist/theme/default.css';
 
-import {DateRangePicker as BaseDateRangePicker} from 'react-date-range';
 import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
 
-const DateRangePicker = styled(BaseDateRangePicker)`
-  padding: 21px; /* this is specifically so we can align borders */
+const CalendarStylesWrapper = styled('div')`
+  padding: ${space(3)};
+
+  .rdrCalendarWrapper:not(.rdrDateRangeWrapper) {
+    .rdrDayHovered {
+      .rdrDayNumber {
+        &:after {
+          border: 0;
+        }
+      }
+    }
+  }
 
   .rdrSelected,
   .rdrInRange,
@@ -139,4 +148,4 @@ const DateRangePicker = styled(BaseDateRangePicker)`
   }
 `;
 
-export default DateRangePicker;
+export default CalendarStylesWrapper;

--- a/static/app/components/calendar/datePicker.tsx
+++ b/static/app/components/calendar/datePicker.tsx
@@ -1,0 +1,15 @@
+import {Calendar, CalendarProps} from 'react-date-range';
+
+import CalendarStylesWrapper from './calendarStylesWrapper';
+
+export type DatePickerProps = CalendarProps;
+
+const DateRangePicker = (props: DatePickerProps) => {
+  return (
+    <CalendarStylesWrapper>
+      <Calendar {...props} />
+    </CalendarStylesWrapper>
+  );
+};
+
+export default DateRangePicker;

--- a/static/app/components/calendar/dateRangePicker.tsx
+++ b/static/app/components/calendar/dateRangePicker.tsx
@@ -1,0 +1,45 @@
+import {useCallback, useMemo} from 'react';
+import {DateRange, DateRangeProps, Range, RangeKeyDict} from 'react-date-range';
+
+import {callIfFunction} from 'sentry/utils/callIfFunction';
+
+import CalendarStylesWrapper from './calendarStylesWrapper';
+
+export type DateRangePickerProps = Omit<DateRangeProps, 'ranges' | 'onChange'> & {
+  onChange: (range: Range) => void;
+  endDate?: Date;
+  startDate?: Date;
+};
+
+type RangeSelection = {primary: Range};
+
+const PRIMARY_RANGE_KEY = 'primary';
+
+function isRangeSelection(rangesByKey: RangeKeyDict): rangesByKey is RangeSelection {
+  return rangesByKey?.[PRIMARY_RANGE_KEY] !== undefined;
+}
+
+const DateRangePicker = (props: DateRangePickerProps) => {
+  const onChange = useCallback(
+    (rangesByKey: RangeKeyDict) => {
+      if (!isRangeSelection(rangesByKey)) {
+        return;
+      }
+
+      callIfFunction(props.onChange, rangesByKey[PRIMARY_RANGE_KEY]);
+    },
+    [props.onChange]
+  );
+
+  const ranges: Range[] = useMemo(() => {
+    return [{startDate: props.startDate, endDate: props.endDate, key: PRIMARY_RANGE_KEY}];
+  }, [props.endDate, props.startDate]);
+
+  return (
+    <CalendarStylesWrapper>
+      <DateRange {...props} onChange={onChange} ranges={ranges} />
+    </CalendarStylesWrapper>
+  );
+};
+
+export default DateRangePicker;

--- a/static/app/components/calendar/dateRangePicker.tsx
+++ b/static/app/components/calendar/dateRangePicker.tsx
@@ -1,8 +1,6 @@
 import {useCallback, useMemo} from 'react';
 import {DateRange, DateRangeProps, Range, RangeKeyDict} from 'react-date-range';
 
-import {callIfFunction} from 'sentry/utils/callIfFunction';
-
 import CalendarStylesWrapper from './calendarStylesWrapper';
 
 export type DateRangePickerProps = Omit<DateRangeProps, 'ranges' | 'onChange'> & {
@@ -19,21 +17,26 @@ function isRangeSelection(rangesByKey: RangeKeyDict): rangesByKey is RangeSelect
   return rangesByKey?.[PRIMARY_RANGE_KEY] !== undefined;
 }
 
-const DateRangePicker = (props: DateRangePickerProps) => {
+const DateRangePicker = ({
+  onChange: incomingOnChange,
+  startDate,
+  endDate,
+  ...props
+}: DateRangePickerProps) => {
   const onChange = useCallback(
     (rangesByKey: RangeKeyDict) => {
       if (!isRangeSelection(rangesByKey)) {
         return;
       }
 
-      callIfFunction(props.onChange, rangesByKey[PRIMARY_RANGE_KEY]);
+      incomingOnChange?.(rangesByKey[PRIMARY_RANGE_KEY]);
     },
-    [props.onChange]
+    [incomingOnChange]
   );
 
   const ranges: Range[] = useMemo(() => {
-    return [{startDate: props.startDate, endDate: props.endDate, key: PRIMARY_RANGE_KEY}];
-  }, [props.endDate, props.startDate]);
+    return [{startDate, endDate, key: PRIMARY_RANGE_KEY}];
+  }, [endDate, startDate]);
 
   return (
     <CalendarStylesWrapper>

--- a/static/app/components/calendar/index.tsx
+++ b/static/app/components/calendar/index.tsx
@@ -1,0 +1,40 @@
+import {FunctionComponent, lazy, Suspense} from 'react';
+
+import LoadingIndicator from '../loadingIndicator';
+import Placeholder from '../placeholder';
+
+import type {DatePickerProps} from './datePicker';
+import type {DateRangePickerProps} from './dateRangePicker';
+
+const LazyDatePicker = lazy(() => import('./datePicker'));
+const LazyDateRangePicker = lazy(() => import('./dateRangePicker'));
+
+const CalendarSuspenseWrapper: FunctionComponent = ({children}) => {
+  return (
+    <Suspense
+      fallback={
+        <Placeholder width="342px" height="254px">
+          <LoadingIndicator />
+        </Placeholder>
+      }
+    >
+      {children}
+    </Suspense>
+  );
+};
+
+export const DatePicker = (props: DatePickerProps) => {
+  return (
+    <CalendarSuspenseWrapper>
+      <LazyDatePicker {...props} />
+    </CalendarSuspenseWrapper>
+  );
+};
+
+export const DateRangePicker = (props: DateRangePickerProps) => {
+  return (
+    <CalendarSuspenseWrapper>
+      <LazyDateRangePicker {...props} />
+    </CalendarSuspenseWrapper>
+  );
+};

--- a/static/app/components/calendar/index.tsx
+++ b/static/app/components/calendar/index.tsx
@@ -1,4 +1,4 @@
-import {FunctionComponent, lazy, Suspense} from 'react';
+import React, {lazy, Suspense} from 'react';
 
 import LoadingIndicator from '../loadingIndicator';
 import Placeholder from '../placeholder';
@@ -9,7 +9,7 @@ import type {DateRangePickerProps} from './dateRangePicker';
 const LazyDatePicker = lazy(() => import('./datePicker'));
 const LazyDateRangePicker = lazy(() => import('./dateRangePicker'));
 
-const CalendarSuspenseWrapper: FunctionComponent = ({children}) => {
+const CalendarSuspenseWrapper: React.FC = ({children}) => {
   return (
     <Suspense
       fallback={

--- a/static/app/components/forms/datePickerField.tsx
+++ b/static/app/components/forms/datePickerField.tsx
@@ -1,13 +1,12 @@
-import {lazy, Suspense} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment';
 
 import DropdownMenu from 'sentry/components/dropdownMenu';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
-import Placeholder from 'sentry/components/placeholder';
 import {IconCalendar} from 'sentry/icons';
 import {inputStyles} from 'sentry/styles/input';
 import space from 'sentry/styles/space';
+
+import {DatePicker} from '../calendar';
 
 import InputField, {InputFieldProps, onEvent} from './inputField';
 
@@ -25,8 +24,6 @@ function handleChangeDate(
   // close dropdown menu
   close();
 }
-
-const Calendar = lazy(() => import('./calendarField'));
 
 export default function DatePickerField(props: DatePickerFieldProps) {
   return (
@@ -50,20 +47,12 @@ export default function DatePickerField(props: DatePickerFieldProps) {
 
                 {isOpen && (
                   <CalendarMenu {...getMenuProps()}>
-                    <Suspense
-                      fallback={
-                        <Placeholder width="332px" height="282px">
-                          <LoadingIndicator />
-                        </Placeholder>
+                    <DatePicker
+                      date={inputValue}
+                      onChange={date =>
+                        handleChangeDate(onChange, onBlur, date, actions.close)
                       }
-                    >
-                      <Calendar
-                        date={inputValue}
-                        onChange={date =>
-                          handleChangeDate(onChange, onBlur, date, actions.close)
-                        }
-                      />
-                    </Suspense>
+                    />
                   </CalendarMenu>
                 )}
               </div>

--- a/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
@@ -1,15 +1,14 @@
-import {Component, lazy, Suspense} from 'react';
-import type {Range, RangeKeyDict} from 'react-date-range';
+import {Component} from 'react';
+import type {Range} from 'react-date-range';
 // eslint-disable-next-line no-restricted-imports
 import {withRouter, WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment';
 
+import {DateRangePicker} from 'sentry/components/calendar';
 import Checkbox from 'sentry/components/checkbox';
-import LoadingIndicator from 'sentry/components/loadingIndicator';
 import TimePicker from 'sentry/components/organizations/timeRangeSelector/timePicker';
-import Placeholder from 'sentry/components/placeholder';
 import {MAX_PICKABLE_DAYS} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -24,15 +23,7 @@ import {
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {Theme} from 'sentry/utils/theme';
 
-const DateRangePicker = lazy(() => import('./dateRangeWrapper'));
-
 const getTimeStringFromDate = (date: Date) => moment(date).local().format('HH:mm');
-
-type RangeSelection = {selection: Range};
-
-function isRangeSelection(rangesByKey: RangeKeyDict): rangesByKey is RangeSelection {
-  return rangesByKey?.selection !== undefined;
-}
 
 type ChangeData = {end?: Date; hasDateRangeErrors?: boolean; start?: Date};
 
@@ -98,13 +89,9 @@ class BaseDateRange extends Component<Props, State> {
     hasEndErrors: false,
   };
 
-  handleSelectDateRange = (rangesByKey: RangeKeyDict) => {
-    if (!isRangeSelection(rangesByKey)) {
-      return;
-    }
-    const {selection} = rangesByKey;
+  handleSelectDateRange = (range: Range) => {
     const {onChange} = this.props;
-    const {startDate, endDate} = selection;
+    const {startDate, endDate} = range;
 
     const end = endDate ? getEndOfDay(endDate) : endDate;
 
@@ -178,8 +165,7 @@ class BaseDateRange extends Component<Props, State> {
   };
 
   render() {
-    const {className, maxPickableDays, utc, showTimePicker, onChangeUtc, theme} =
-      this.props;
+    const {className, maxPickableDays, utc, showTimePicker, onChangeUtc} = this.props;
     const start = this.props.start ?? '';
     const end = this.props.end ?? '';
 
@@ -201,27 +187,13 @@ class BaseDateRange extends Component<Props, State> {
 
     return (
       <div className={className} data-test-id="date-range">
-        <Suspense
-          fallback={
-            <Placeholder width="342px" height="254px">
-              <LoadingIndicator />
-            </Placeholder>
-          }
-        >
-          <DateRangePicker
-            rangeColors={[theme.purple300]}
-            ranges={[
-              {
-                startDate: moment(start).local().toDate(),
-                endDate: moment(end).local().toDate(),
-                key: 'selection',
-              },
-            ]}
-            minDate={minDate}
-            maxDate={maxDate}
-            onChange={this.handleSelectDateRange}
-          />
-        </Suspense>
+        <DateRangePicker
+          startDate={moment(start).local().toDate()}
+          endDate={moment(end).local().toDate()}
+          minDate={minDate}
+          maxDate={maxDate}
+          onChange={this.handleSelectDateRange}
+        />
         {showTimePicker && (
           <TimeAndUtcPicker>
             <TimePicker


### PR DESCRIPTION
There are two uses of calendars currently:

1. In `<TimeRangeSelector />`, where it pops out for absolute ranges
2. In `<DatePickerField />`, which doesn't seem to be used anywhere yet and uses react-date-range's default styles

This creates common components `<DatePicker />` and `<DateRangePicker />` which wraps react-date-range, provide custom styling, and handles lazy loading. `<DateRangePicker />` modifies a couple props to make it easier to use for a single range (react-date-range supports multiple but we have no use for that).

Before/after for DatePickerField:

![image](https://user-images.githubusercontent.com/10888943/181642621-b4090c87-e5c7-4d8d-8f53-80a0ce89d4c2.png)

![image](https://user-images.githubusercontent.com/10888943/181642647-7b44bb12-287c-4461-a1a0-8e5fe9770fe6.png)
