### PR TITLE
ref(active-release): remove feature flag references to configure experimental rule

### DIFF
--- a/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
+++ b/src/sentry/api/endpoints/project_agnostic_rule_conditions.py
@@ -1,7 +1,6 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.rules import rules
 
@@ -20,19 +19,12 @@ class ProjectAgnosticRuleConditionsEndpoint(OrganizationEndpoint):
 
             return context
 
-        has_active_release_condition = features.has(
-            "organizations:alert-release-notification-workflow", organization
-        )
-
         return Response(
             [
                 info_extractor(rule_cls)
                 for rule_type, rule_cls in rules
                 if rule_type.startswith("condition/")
-                and (
-                    has_active_release_condition
-                    or rule_cls.id
-                    != "sentry.rules.conditions.active_release.ActiveReleaseEventCondition"
-                )
+                and rule_cls.id
+                != "sentry.rules.conditions.active_release.ActiveReleaseEventCondition"
             ]
         )

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -21,9 +21,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         can_create_tickets = features.has(
             "organizations:integrations-ticket-rules", project.organization
         )
-        org_release_notifications = features.has(
-            "organizations:alert-release-notification-workflow", project.organization
-        )
 
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
@@ -64,8 +61,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
 
             if rule_type.startswith("condition/"):
                 if (
-                    org_release_notifications
-                    or context["id"]
+                    context["id"]
                     != "sentry.rules.conditions.active_release.ActiveReleaseEventCondition"
                 ):
                     condition_list.append(context)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -949,8 +949,6 @@ SENTRY_FEATURES = {
     "organizations:advanced-search": True,
     # Use metrics as the dataset for crash free metric alerts
     "organizations:alert-crash-free-metrics": False,
-    # Workflow 2.0 notifications following a release
-    "organizations:alert-release-notification-workflow": False,
     # Alert wizard redesign version 3
     "organizations:alert-wizard-v3": True,
     "organizations:api-keys": False,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -61,7 +61,6 @@ default_manager.add("organizations:active-release-monitor-alpha", OrganizationFe
 default_manager.add("organizations:active-release-notification-opt-in", OrganizationFeature, True)
 default_manager.add("organizations:alert-filters", OrganizationFeature)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, True)
-default_manager.add("organizations:alert-release-notification-workflow", OrganizationFeature, True)
 default_manager.add("organizations:alert-wizard-v3", OrganizationFeature, True)
 default_manager.add("organizations:api-keys", OrganizationFeature)
 default_manager.add("organizations:breadcrumb-linked-event", OrganizationFeature, True)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -384,7 +384,7 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
 
         issue_title = build_attachment_title(obj)
         event_id = self.event.event_id if self.event else None
-        # TODO(workflow): Remove referrer experiement with flag "organizations:alert-release-notification-workflow"
+        # TODO(workflow): Remove referrer experiement with flag "organizations:active-release-monitor-alpha"
         title_url = self.group.get_absolute_url(
             params={"referrer": "alert_slack_release"}, event_id=event_id
         )


### PR DESCRIPTION
Undo the experimental feature flag for WF2.0 allowing users to create a custom issue alert rule targetting RELEASE_MEMBERS.

Related to this PR:
https://github.com/getsentry/sentry/pull/35806/files#diff-156f5b2b4da6ecb6afd906f84b345efdc5e28efa42468674cdbd942de2db05e0 