### PR TITLE
feat(hybrid-cloud): Introduce system.region-api-url-template

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -135,3 +135,11 @@ def generate_organization_url(org_slug: str) -> str:
     if not org_url_template:
         return options.get("system.url-prefix")
     return org_url_template.replace("{hostname}", generate_organization_hostname(org_slug))
+
+
+def generate_region_url() -> str:
+    region_url_template = options.get("system.region-api-url-template")
+    region = options.get("system.region") or None
+    if not region_url_template or not region:
+        return options.get("system.url-prefix")
+    return region_url_template.replace("{region}", region)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -33,6 +33,9 @@ register(
 register(
     "system.organization-url-template", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE
 )
+register(
+    "system.region-api-url-template", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE
+)
 register("system.region", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE)
 register("system.root-api-key", flags=FLAG_PRIORITIZE_DISK)
 register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -9,7 +9,7 @@ import sentry
 from sentry import features, options
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
-from sentry.api.utils import generate_organization_url
+from sentry.api.utils import generate_organization_url, generate_region_url
 from sentry.auth.access import get_cached_organization_member
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import Organization, OrganizationMember, ProjectKey
@@ -213,6 +213,7 @@ def get_client_config(request=None):
         "validateSUForm": getattr(settings, "VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON", False),
         "sentryUrl": options.get("system.url-prefix"),
         "organizationUrl": generate_organization_url(last_org_slug) if last_org_slug else None,
+        "regionUrl": generate_region_url() if last_org_slug else None,
     }
     if user and user.is_authenticated:
         context.update(


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/37159

This pull request introduces the `regionUrl` concept:

- Introduce `system.region-api-url-template` option. Potential value for this is `"http://{region}.dev.getsentry.net:8000"` or `"https://{region}.sentry.io"`
- Introduce `generate_region_url()` that will generate `regionUrl` such as `us.sentry.io`.
- Propagate `regionUrl` to the client config if an active org exists for a given request instance.