### PR TITLE
feat(hybrid-cloud): Update org switcher to make use of customer domains

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -52,10 +52,24 @@ const SwitchOrganization = ({organizations, canCreateOrganization}: Props) => (
           >
             <OrganizationList role="list">
               {sortBy(organizations, ['status.id']).map(organization => {
-                const url = `/organizations/${organization.slug}/`;
+                const {slug, organizationUrl} = organization;
+
+                const shouldUseLegacyRoute =
+                  !organizationUrl || !organization.features.includes('customer-domains');
+
+                const menuItemProps: Partial<
+                  React.ComponentProps<typeof SidebarMenuItem>
+                > = {};
+
+                if (shouldUseLegacyRoute) {
+                  menuItemProps.to = `/organizations/${slug}/`;
+                } else {
+                  menuItemProps.href = organizationUrl;
+                  menuItemProps.openInNewTab = false;
+                }
 
                 return (
-                  <SidebarMenuItem key={organization.slug} to={url}>
+                  <SidebarMenuItem key={slug} href={organizationUrl} {...menuItemProps}>
                     <SidebarOrgSummary organization={organization} />
                   </SidebarMenuItem>
                 );


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/37232

-----

This pull request updates the org switcher to make use of `organizationUrl` (e.g. `danny.sentry.io`) if an organization has the customer domain feature. Otherwise the legacy behaviour is retained.