### PR TITLE
fix(releases): block the creation of Releases with empty version

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -766,7 +766,11 @@ def _get_or_create_release_many(jobs, projects):
         except ValidationError:
             release = None
             logger.exception(
-                "Failed creating Release(project=%s, version=%s)", projects[project_id], version
+                "Failed creating Release due to ValidationError",
+                extra={
+                    "project": projects[project_id],
+                    "version": version,
+                },
             )
 
         if release:

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -529,10 +529,12 @@ class Release(Model):
 
     @staticmethod
     def is_valid_version(value):
+        if any(c in value for c in BAD_RELEASE_CHARS):
+            return False
+
         value_stripped = str(value).strip()
         return not (
             not value_stripped
-            or any(c in value_stripped for c in BAD_RELEASE_CHARS)
             or value_stripped in (".", "..")
             or value_stripped.lower() == "latest"
         )

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -529,11 +529,12 @@ class Release(Model):
 
     @staticmethod
     def is_valid_version(value):
+        value_stripped = str(value).strip()
         return not (
-            not value
-            or any(c in value for c in BAD_RELEASE_CHARS)
-            or value in (".", "..")
-            or value.lower() == "latest"
+            not value_stripped
+            or any(c in value_stripped for c in BAD_RELEASE_CHARS)
+            or value_stripped in (".", "..")
+            or value_stripped.lower() == "latest"
         )
 
     @property

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -36,8 +36,10 @@ from sentry.types.releaseactivity import ReleaseActivityType
 
 
 def validate_release_empty_version(instance: Release, **kwargs):
-    if instance.version == "":
-        raise ValidationError(f"release_id({instance.id}) failed to save because of empty version")
+    if not Release.is_valid_version(instance.version):
+        raise ValidationError(
+            f"release_id({instance.id}) failed to save because of invalid version"
+        )
 
 
 def resolve_group_resolutions(instance, created, **kwargs):

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -1,6 +1,7 @@
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import F
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, pre_save
 from django.utils import timezone
 
 from sentry import analytics, features
@@ -32,6 +33,11 @@ from sentry.signals import buffer_incr_complete, issue_resolved
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
 from sentry.types.activity import ActivityType
 from sentry.types.releaseactivity import ReleaseActivityType
+
+
+def validate_release_empty_version(instance: Release, **kwargs):
+    if instance.version == "":
+        raise ValidationError(f"release_id({instance.id}) failed to save because of empty version")
 
 
 def resolve_group_resolutions(instance, created, **kwargs):
@@ -234,6 +240,13 @@ def save_release_activity(instance: Release, created: bool, **kwargs):
                 date_added=instance.date_added,
             )
 
+
+pre_save.connect(
+    validate_release_empty_version,
+    sender=Release,
+    dispatch_uid="validate_release_empty_version",
+    weak=False,
+)
 
 post_save.connect(
     resolve_group_resolutions, sender=Release, dispatch_uid="resolve_group_resolutions", weak=False

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1039,6 +1039,26 @@ class OrganizationReleasesStatsTest(APITestCase):
 
 
 class OrganizationReleaseCreateTest(APITestCase):
+    def test_empty_release_version(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.create_organization()
+        org.flags.allow_joinleave = False
+        org.save()
+
+        team = self.create_team(organization=org)
+        project = self.create_project(name="foo", organization=org, teams=[team])
+        project2 = self.create_project(name="bar", organization=org, teams=[team])
+
+        self.create_member(teams=[team], user=user, organization=org)
+        self.login_as(user=user)
+
+        url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})
+        response = self.client.post(
+            url, data={"version": "", "projects": [project.slug, project2.slug]}
+        )
+
+        assert response.status_code == 400
+
     def test_minimal(self):
         user = self.create_user(is_staff=False, is_superuser=False)
         org = self.create_organization()

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1043,6 +1043,12 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
         assert event1.transaction == "foobar"
         assert event1.culprit == "baz"
 
+    def test_release_with_empty_version(self):
+        event = self.make_release_event("", self.project.id)
+        assert not event.group.first_release
+        assert Release.objects.filter(projects__in=[self.project.id]).count() == 0
+        assert Release.objects.filter(organization_id=self.project.organization_id).count() == 0
+
     def test_first_release(self):
         project_id = 1
         event = self.make_release_event("1.0", project_id)

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1044,10 +1044,12 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
         assert event1.culprit == "baz"
 
     def test_release_with_empty_version(self):
-        event = self.make_release_event("", self.project.id)
-        assert not event.group.first_release
-        assert Release.objects.filter(projects__in=[self.project.id]).count() == 0
-        assert Release.objects.filter(organization_id=self.project.organization_id).count() == 0
+        cases = ["", " ", "\t", "\n"]
+        for case in cases:
+            event = self.make_release_event(case, self.project.id)
+            assert not event.group.first_release
+            assert Release.objects.filter(projects__in=[self.project.id]).count() == 0
+            assert Release.objects.filter(organization_id=self.project.organization_id).count() == 0
 
     def test_first_release(self):
         project_id = 1

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -66,14 +66,6 @@ def test_version_is_semver_invalid(release_version):
     assert Release.is_semver_version(release_version) is False
 
 
-class ReleasesTest(TestCase):
-    def test_empty_version(self):
-        org = self.create_organization()
-        self.assertRaises(
-            ValidationError, lambda: Release.objects.create(version="", organization=org)
-        )
-
-
 class MergeReleasesTest(TestCase):
     def test_simple(self):
         org = self.create_organization()
@@ -683,8 +675,17 @@ class SetRefsTest(SetRefsTestCase):
         assert len(mock_fetch_commit.method_calls) == 0
 
     def test_invalid_version(self):
-        release = Release.objects.create(organization=self.org)
-        assert not release.is_valid_version(None)
+        cases = ["", "latest", ".", "..", "\t", "\n", "  "]
+
+        for case in cases:
+            self.assertRaises(
+                ValidationError,
+                lambda: Release.objects.create(version=case, organization=self.org),
+            )
+        self.assertRaises(
+            ValidationError,
+            lambda: Release.objects.create(organization=self.org),
+        )
 
     @staticmethod
     def test_invalid_chars_in_version():

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -63,6 +64,14 @@ def test_version_is_semver_valid(release_version):
 )
 def test_version_is_semver_invalid(release_version):
     assert Release.is_semver_version(release_version) is False
+
+
+class ReleasesTest(TestCase):
+    def test_empty_version(self):
+        org = self.create_organization()
+        self.assertRaises(
+            ValidationError, lambda: Release.objects.create(version="", organization=org)
+        )
 
 
 class MergeReleasesTest(TestCase):

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -678,14 +678,11 @@ class SetRefsTest(SetRefsTestCase):
         cases = ["", "latest", ".", "..", "\t", "\n", "  "]
 
         for case in cases:
-            self.assertRaises(
-                ValidationError,
-                lambda: Release.objects.create(version=case, organization=self.org),
-            )
-        self.assertRaises(
-            ValidationError,
-            lambda: Release.objects.create(organization=self.org),
-        )
+            with pytest.raises(ValidationError):
+                Release.objects.create(version=case, organization=self.org)
+
+        with pytest.raises(ValidationError):
+            Release.objects.create(organization=self.org)
 
     @staticmethod
     def test_invalid_chars_in_version():


### PR DESCRIPTION
For one reason or another, Releases are still be created with empty `version`. Throughout the codebase there seems to be reasonable validation to avoid this scenario, but I see recent DB rows with empty version.

The rows with empty version are few (161) and look innocuous and likely aren't being used. Will submit a migration to purge these rows.

