### PR TITLE
feat(metrics): Add static string for transaction name placeholder [INGEST-1515]

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -98,6 +98,7 @@ SHARED_TAG_STRINGS = {
     "inlier": PREFIX + 229,
     # added after the initial definition
     "sdk": PREFIX + 230,  # release health
+    "<< unparameterized >>": PREFIX + 231,  # placeholder for high-cardinality transaction names
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }


### PR DESCRIPTION
Add string to the indexer for transaction name `<< unparameterized >>`, which is set by Relay for high-cardinality transaction names.

See https://github.com/getsentry/relay/pull/1359.