### PR TITLE
feat(sampling): Change chart colors [TET-261]

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -28,14 +28,14 @@ import {getTooltipFormatter, getXAxisDates, getXAxisLabelInterval} from './utils
 type ChartProps = React.ComponentProps<typeof BaseChart>;
 
 const COLOR_ERRORS = Color(commonTheme.dataCategory.errors).lighten(0.25).string();
-export const COLOR_TRANSACTIONS = Color(commonTheme.dataCategory.transactions)
+const COLOR_TRANSACTIONS = Color(commonTheme.dataCategory.transactions)
   .lighten(0.35)
   .string();
 const COLOR_ATTACHMENTS = Color(commonTheme.dataCategory.attachments)
   .lighten(0.65)
   .string();
 
-export const COLOR_DROPPED = commonTheme.red300;
+const COLOR_DROPPED = commonTheme.red300;
 const COLOR_FILTERED = commonTheme.pink100;
 
 export type CategoryOption = {

--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.tsx
@@ -6,10 +6,6 @@ import {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import commonTheme from 'sentry/utils/theme';
 import {Outcome} from 'sentry/views/organizationStats/types';
-import {
-  COLOR_DROPPED,
-  COLOR_TRANSACTIONS,
-} from 'sentry/views/organizationStats/usageChart';
 
 import {quantityField} from '.';
 
@@ -88,19 +84,19 @@ export function projectStatsToPredictedSeries(
   return [
     {
       seriesName: t('Indexed and Processed'),
-      color: COLOR_TRANSACTIONS,
+      color: commonTheme.green300,
       ...commonSeriesConfig,
       data: seriesData.accepted,
     },
     {
       seriesName: t('Processed'),
-      color: COLOR_DROPPED,
+      color: commonTheme.yellow300,
       data: seriesData.droppedServer,
       ...commonSeriesConfig,
     },
     {
       seriesName: t('Dropped'),
-      color: commonTheme.yellow300,
+      color: commonTheme.red300,
       data: seriesData.droppedClient,
       ...commonSeriesConfig,
     },

--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSeries.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSeries.tsx
@@ -6,10 +6,6 @@ import {SeriesApi} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import commonTheme from 'sentry/utils/theme';
 import {Outcome} from 'sentry/views/organizationStats/types';
-import {
-  COLOR_DROPPED,
-  COLOR_TRANSACTIONS,
-} from 'sentry/views/organizationStats/usageChart';
 
 import {quantityField} from '.';
 
@@ -59,19 +55,19 @@ export function projectStatsToSeries(projectStats: SeriesApi | undefined): Serie
   return [
     {
       seriesName: t('Indexed and Processed'),
-      color: COLOR_TRANSACTIONS,
+      color: commonTheme.green300,
       ...commonSeriesConfig,
       data: seriesData.accepted,
     },
     {
       seriesName: t('Processed'),
-      color: COLOR_DROPPED,
+      color: commonTheme.yellow300,
       data: seriesData.droppedServer,
       ...commonSeriesConfig,
     },
     {
       seriesName: t('Dropped'),
-      color: commonTheme.yellow300,
+      color: commonTheme.red300,
       data: seriesData.droppedClient,
       ...commonSeriesConfig,
     },

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.spec.tsx
@@ -5,7 +5,7 @@ describe('projectStatsToPredictedSeries', function () {
     expect(projectStatsToPredictedSeries(TestStubs.Outcomes(), 0.3, 0.1)).toEqual([
       {
         seriesName: 'Indexed and Processed',
-        color: 'hsl(340.79999999999995, 61%, 79.4%)',
+        color: '#2BA185',
         barMinHeight: 1,
         type: 'bar',
         stack: 'predictedUsage',
@@ -62,7 +62,7 @@ describe('projectStatsToPredictedSeries', function () {
       },
       {
         seriesName: 'Processed',
-        color: '#F55459',
+        color: '#F5B000',
         data: [
           {name: 1656788400000, value: 58873},
           {name: 1656792000000, value: 56426},
@@ -119,7 +119,7 @@ describe('projectStatsToPredictedSeries', function () {
       },
       {
         seriesName: 'Dropped',
-        color: '#F5B000',
+        color: '#F55459',
         data: [
           {name: 1656788400000, value: 206057},
           {name: 1656792000000, value: 197491},

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils/projectStatsToSeries.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils/projectStatsToSeries.spec.tsx
@@ -5,7 +5,7 @@ describe('projectStatsToSeries', function () {
     expect(projectStatsToSeries(TestStubs.Outcomes())).toEqual([
       {
         seriesName: 'Indexed and Processed',
-        color: 'hsl(340.79999999999995, 61%, 79.4%)',
+        color: '#2BA185',
         barMinHeight: 1,
         type: 'bar',
         stack: 'usage',
@@ -62,7 +62,7 @@ describe('projectStatsToSeries', function () {
       },
       {
         seriesName: 'Processed',
-        color: '#F55459',
+        color: '#F5B000',
         data: [
           {name: 1656788400000, value: 250},
           {name: 1656792000000, value: 279},
@@ -119,7 +119,7 @@ describe('projectStatsToSeries', function () {
       },
       {
         seriesName: 'Dropped',
-        color: '#F5B000',
+        color: '#F55459',
         data: [
           {name: 1656788400000, value: 0},
           {name: 1656792000000, value: 1},


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/9060071/181734290-38b1f2f9-3c5f-49ae-aaa0-bd8532d7c669.png)

## After
![image](https://user-images.githubusercontent.com/9060071/181734164-53e24f7b-7e35-41ed-929d-a1f8a331bb1c.png)

At first, we wanted to be a bit more consistent with org stats but then based on user testing we decided to make the difference more obvious.
