### PR TITLE
fix(metrics): Add missing common strings uncovered by integration test

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -59,6 +59,7 @@ TRANSACTION_METRICS_NAMES = {
     "d:transactions/breakdowns.span_ops.ops.db@millisecond": PREFIX + 121,
     "d:transactions/breakdowns.span_ops.ops.browser@millisecond": PREFIX + 122,
     "d:transactions/breakdowns.span_ops.ops.resource@millisecond": PREFIX + 123,
+    "d:transactions/breakdowns.span_ops.ops.ui@millisecond": PREFIX + 124,
 }
 
 # 200 - 299
@@ -99,8 +100,15 @@ SHARED_TAG_STRINGS = {
     # added after the initial definition
     "sdk": PREFIX + 230,  # release health
     "<< unparameterized >>": PREFIX + 231,  # placeholder for high-cardinality transaction names
+    "measurement_rating": PREFIX + 232,
+    "good": PREFIX + 233,
+    "bad": PREFIX + 234,
+    "meh": PREFIX + 235,
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }
 SHARED_STRINGS = {**SESSION_METRIC_NAMES, **TRANSACTION_METRICS_NAMES, **SHARED_TAG_STRINGS}
 REVERSE_SHARED_STRINGS = {v: k for k, v in SHARED_STRINGS.items()}
+
+# Make sure there are no accidental duplicates
+assert len(SHARED_STRINGS) == len(REVERSE_SHARED_STRINGS)


### PR DESCRIPTION
Add a `relay_integration` test that checks if all the standard strings emitted in metrics kafka messages by Relay are part of the list of common strings used by the string indexer.

Also add the strings uncovered by this integration test to the list of common strings where possible (i.e. if they do not yet exist in the release health dataset).