### PR TITLE
feat(sampling): Clamp server recommendation to the client recommendation [TET-278]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -132,7 +132,7 @@ function UniformRateModal({
       : undefined;
   const recommendedServerSampling = shouldUseConservativeSampleRate
     ? CONSERVATIVE_SAMPLE_RATE
-    : currentClientSampling;
+    : Math.min(currentClientSampling ?? 1, recommendedClientSampling ?? 1);
 
   const [selectedStrategy, setSelectedStrategy] = useState<Strategy>(Strategy.CURRENT);
   const [clientInput, setClientInput] = useState(

--- a/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
@@ -65,7 +65,7 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     expect(screen.getByText('100%')).toBeInTheDocument(); // Current client-side sample rate
     expect(screen.getByText('N/A')).toBeInTheDocument(); // Current server-side sample rate
     expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(30); // Suggested client-side sample rate
-    expect(screen.getAllByRole('spinbutton')[1]).toHaveValue(100); // Suggested server-side sample rate
+    expect(screen.getAllByRole('spinbutton')[1]).toHaveValue(30); // Suggested server-side sample rate
     expect(screen.queryByLabelText('Reset to suggested values')).not.toBeInTheDocument();
 
     // Enter invalid client-side sample rate


### PR DESCRIPTION
Clamping recommended server rate to the recommended client rate.
Having a higher sample rate on the server does not make sense otherwise this would happen:
![image](https://user-images.githubusercontent.com/9060071/181742546-71fe57ce-4147-4cd5-9f33-3efed23d0368.png)
