### PR TITLE
Adjust warning message in 2FA modal

### DIFF
--- a/static/app/components/modals/recoveryOptionsModal.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.tsx
@@ -44,7 +44,8 @@ class RecoveryOptionsModal extends AsyncComponent<Props, State> {
       {}
     );
     const recoveryEnrolled = recovery && recovery.isEnrolled;
-    const displaySmsPrompt = sms && !sms.isEnrolled && !skipSms;
+    const displaySmsPrompt =
+      sms && !sms.isEnrolled && !skipSms && !sms.disallowNewEnrollment;
 
     return (
       <Fragment>


### PR DESCRIPTION
If new enrollments of 2FA are disabled, we should not show a recommendation to setup SMS as a backup method.

If new SMS 2FA enrollments are still allowed, nothing changes:
![image](https://user-images.githubusercontent.com/20070360/181794214-751ffc5f-52c4-416f-a80e-b8220dbf6d31.png)

If they are disabled:
![image](https://user-images.githubusercontent.com/20070360/181794261-cd5e4943-fcd7-4171-b06c-082bcd80e7f8.png)

Related PRs:

- https://github.com/getsentry/sentry/pull/36345
- https://github.com/getsentry/sentry/pull/36344