### PR TITLE
fix: Remove unused metric [INGEST-1380]

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import List, Mapping, MutableMapping, MutableSet, NamedTuple, Optional, Sequence, Set
+from typing import List, Mapping, MutableMapping, NamedTuple, Optional, Sequence, Set
 
 import rapidjson
 import sentry_sdk
@@ -54,7 +54,6 @@ class IndexerBatch:
     @metrics.wraps("process_messages.parse_outer_message")
     def extract_strings(self) -> Mapping[int, Set[str]]:
         org_strings = defaultdict(set)
-        strings: MutableSet[str] = set()
 
         self.skipped_offsets: Set[PartitionIdxOffset] = set()
         self.parsed_payloads_by_offset: MutableMapping[PartitionIdxOffset, json.JSONData] = {}
@@ -130,7 +129,6 @@ class IndexerBatch:
         for org_set in org_strings:
             string_count += len(org_strings[org_set])
         metrics.gauge("process_messages.lookups_per_batch", value=string_count)
-        metrics.incr("process_messages.total_strings_indexer_lookup", amount=len(strings))
 
         return org_strings
 


### PR DESCRIPTION
In #37170 i accidentally removed a line and made this metric a constant
zero. I accidentally removed this because I thought the metric didn't
make any sense but failed to properly follow up on it.

I propose we remove this metric because strings are per-organization,
and so counting the total number of unique strings across the entire
batch doesn't make sense. On the previous line we already emit a metric
for the number of total string lookups.