### PR TITLE
fix(mep): Use project thresholds for apdex calculation

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -7,6 +7,10 @@ from snuba_sdk.conditions import InvalidConditionError
 from sentry.discover.models import TeamKeyTransaction
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.models import ProjectTeam
+from sentry.models.transaction_threshold import (
+    ProjectTransactionThresholdOverride,
+    TransactionMetric,
+)
 from sentry.search.events import constants
 from sentry.testutils import MetricsEnhancedPerformanceTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -1414,6 +1418,67 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         assert data[0]["transaction"] is None
         assert data[0]["p50(transaction.duration)"] == 1
         assert meta["isMetricsData"]
+
+    def test_apdex_transaction_threshold(self):
+        ProjectTransactionThresholdOverride.objects.create(
+            transaction="foo_transaction",
+            project=self.project,
+            organization=self.project.organization,
+            threshold=600,
+            metric=TransactionMetric.LCP.value,
+        )
+        ProjectTransactionThresholdOverride.objects.create(
+            transaction="bar_transaction",
+            project=self.project,
+            organization=self.project.organization,
+            threshold=600,
+            metric=TransactionMetric.LCP.value,
+        )
+        self.store_transaction_metric(
+            1,
+            tags={
+                "transaction": "foo_transaction",
+                constants.METRIC_SATISFACTION_TAG_KEY: constants.METRIC_SATISFIED_TAG_VALUE,
+            },
+            timestamp=self.min_ago,
+        )
+        self.store_transaction_metric(
+            1,
+            "measurements.lcp",
+            tags={
+                "transaction": "bar_transaction",
+                constants.METRIC_SATISFACTION_TAG_KEY: constants.METRIC_SATISFIED_TAG_VALUE,
+            },
+            timestamp=self.min_ago,
+        )
+        response = self.do_request(
+            {
+                "field": [
+                    "transaction",
+                    "apdex()",
+                ],
+                "orderby": ["apdex()"],
+                "query": "event.type:transaction",
+                "dataset": "metrics",
+                "per_page": 50,
+            }
+        )
+
+        assert len(response.data["data"]) == 2
+        data = response.data["data"]
+        meta = response.data["meta"]
+        field_meta = meta["fields"]
+
+        assert data[0]["transaction"] == "bar_transaction"
+        # Threshold is lcp based
+        assert data[0]["apdex()"] == 1
+        assert data[1]["transaction"] == "foo_transaction"
+        # Threshold is lcp based
+        assert data[1]["apdex()"] == 0
+
+        assert meta["isMetricsData"]
+        assert field_meta["transaction"] == "string"
+        assert field_meta["apdex()"] == "number"
 
     def test_apdex_satisfaction_param(self):
         for function in ["apdex(300)", "user_misery(300)", "count_miserable(user, 300)"]:


### PR DESCRIPTION
- Currently apdex is always based on the satisfaction tags in the transaction.duration metrics. This updates the apdex function so we read the threshold config, and use that to determine which metric we should read the satisfaction tags from instead
