### PR TITLE
refs: Make sure `owners-migrations` is notified about all migration changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 
 # Migrations
 /src/sentry/migrations/  @getsentry/owners-migrations
+/src/sentry/*/migrations/  @getsentry/owners-migrations
 
 # API Owners for unowned endpoints / serializers
 /src/**/endpoints/              @getsentry/owners-api


### PR DESCRIPTION
A team added migrations in a new module. Adding a rule so that owners-migrations is notified about
changes to all migrations