### PR TITLE
feat(discover): Metrics Query Builder always query 90 days for metrics when constructing custom_measurement_map

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Set, Tuple, Union, cast
 
 import sentry_sdk
@@ -1635,8 +1635,8 @@ class MetricsQueryBuilder(QueryBuilder):
             self._custom_measurement_cache = get_custom_measurements(
                 project_ids=self.params["project_id"],
                 organization_id=self.organization_id,
-                start=self.start,
-                end=self.end,
+                start=datetime.today() - timedelta(days=90),
+                end=datetime.today(),
             )
         return self._custom_measurement_cache
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -385,6 +385,29 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         assert meta["fields"] == {"time": "date", "sum_measurements_datacenter_memory": "size"}
         assert meta["units"] == {"time": None, "sum_measurements_datacenter_memory": "pebibyte"}
 
+    def test_does_not_fallback_if_custom_metric_is_out_of_request_time_range(self):
+        self.store_transaction_metric(
+            123,
+            timestamp=self.day_ago + timedelta(hours=1),
+            internal_metric="d:transactions/measurements.custom@kibibyte",
+            entity="metrics_distributions",
+        )
+        response = self.do_request(
+            data={
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=2)),
+                "interval": "1h",
+                "yAxis": "p99(measurements.custom)",
+                "dataset": "metricsEnhanced",
+            },
+        )
+        meta = response.data["meta"]
+        assert response.status_code == 200, response.content
+        assert response.data["isMetricsData"]
+        assert meta["isMetricsData"]
+        assert meta["fields"] == {"time": "date", "p99_measurements_custom": "size"}
+        assert meta["units"] == {"time": None, "p99_measurements_custom": "kibibyte"}
+
     def test_multi_yaxis_custom_measurement(self):
         self.store_transaction_metric(
             123,


### PR DESCRIPTION
Updates the Metrics Query Builder to always query for full 90 days when constructing the `custom_measurement_map`.

This is because a user may make an events request (ie `events`, `events-stats`, etc) containing a custom performance metric, but that custom performance metric might not have any recent records within selected time range, like 24h. 