### PR TITLE
feat(mep): Add transaction source to discover

### DIFF
--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -462,6 +462,14 @@ class Columns(Enum):
         discover_name="transaction_status",
         alias="transaction.status",
     )
+    TRANSACTION_SOURCE = Column(
+        group_name=None,
+        event_name=None,
+        transaction_name="transaction_source",
+        # Only available in transactions, pretend like its a tag so we dont error and just null instead
+        discover_name="tags[transaction_source]",
+        alias="transaction.source",
+    )
     MEASUREMENTS_KEYS = Column(
         group_name=None,
         event_name=None,


### PR DESCRIPTION
- This adds transaction source to the columns in discover so we can query it via `transaction.source`