### PR TITLE
ref(dropdownMenuItem): Fix exhaustive-deps lint warning

### DIFF
--- a/static/app/components/dropdownMenuItemV2.tsx
+++ b/static/app/components/dropdownMenuItemV2.tsx
@@ -108,7 +108,6 @@ const MenuItem = ({
   renderAs = 'li' as React.ElementType,
   ...submenuTriggerProps
 }: Props) => {
-  const [isHovering, setIsHovering] = useState(false);
   const ourRef = useRef(null);
   const isDisabled = state.disabledKeys.has(node.key);
   const isFocused = state.selectionManager.focusedKey === node.key;
@@ -128,16 +127,30 @@ const MenuItem = ({
   };
 
   // Open submenu on hover
+  const [isHovering, setIsHovering] = useState(false);
   const {hoverProps} = useHover({onHoverChange: setIsHovering});
   useEffect(() => {
     if (isHovering && isFocused) {
+      // We need to redeclare `select` & `clearSelection` as new constants. Otherwise
+      // eslint will throw a react-hooks/exhaustive-deps warning requiring that the entire
+      // state (`state.selectionManager`) be listed in the deps array.
+      const select = state.selectionManager.select;
+      const clearSelection = state.selectionManager.clearSelection;
+
       if (isSubmenuTrigger) {
-        state.selectionManager.select(node.key);
+        select(node.key);
         return;
       }
-      state.selectionManager.clearSelection();
+      clearSelection();
     }
-  }, [isHovering, isFocused]);
+  }, [
+    isHovering,
+    isFocused,
+    isSubmenuTrigger,
+    node.key,
+    state.selectionManager.select,
+    state.selectionManager.clearSelection,
+  ]);
 
   // Open submenu on arrow right key press
   const {keyboardProps} = useKeyboard({

--- a/static/app/components/dropdownMenuItemV2.tsx
+++ b/static/app/components/dropdownMenuItemV2.tsx
@@ -12,6 +12,7 @@ import MenuListItem, {
   MenuListItemProps,
 } from 'sentry/components/menuListItem';
 import {IconChevron} from 'sentry/icons';
+import usePrevious from 'sentry/utils/usePrevious';
 
 export type MenuItemProps = MenuListItemProps & {
   /**
@@ -129,27 +130,28 @@ const MenuItem = ({
   // Open submenu on hover
   const [isHovering, setIsHovering] = useState(false);
   const {hoverProps} = useHover({onHoverChange: setIsHovering});
+  const prevIsHovering = usePrevious(isHovering);
+  const prevIsFocused = usePrevious(isFocused);
   useEffect(() => {
-    if (isHovering && isFocused) {
-      // We need to redeclare `select` & `clearSelection` as new constants. Otherwise
-      // eslint will throw a react-hooks/exhaustive-deps warning requiring that the entire
-      // state (`state.selectionManager`) be listed in the deps array.
-      const select = state.selectionManager.select;
-      const clearSelection = state.selectionManager.clearSelection;
+    if (isHovering === prevIsHovering && isFocused === prevIsFocused) {
+      return;
+    }
 
+    if (isHovering && isFocused) {
       if (isSubmenuTrigger) {
-        select(node.key);
+        state.selectionManager.select(node.key);
         return;
       }
-      clearSelection();
+      state.selectionManager.clearSelection();
     }
   }, [
     isHovering,
     isFocused,
+    prevIsHovering,
+    prevIsFocused,
     isSubmenuTrigger,
     node.key,
-    state.selectionManager.select,
-    state.selectionManager.clearSelection,
+    state.selectionManager,
   ]);
 
   // Open submenu on arrow right key press


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/37129, but ensure that the effect only runs when either `isHovering` or `isFocused` changes and not when any other dependency changes. This fixes a loop that is caused by including `state.selectionManager` in the dependency array.