### PR TITLE
feat(analytics): Add analytics event to track quick trace status in issue details

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -15,6 +15,10 @@ export type IssueEventParameters = {
   'inbox_tab.issue_clicked': {
     group_id: string;
   };
+  'issue.quick_trace_status': {
+    is_performance_issue: boolean;
+    status: string;
+  };
   'issue.search_sidebar_clicked': {};
   'issue.shared_publicly': {};
   'issue_error_banner.viewed': {
@@ -61,4 +65,5 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issue.shared_publicly': 'Issue Shared Publicly',
   resolve_issue: 'Resolve Issue',
   'tag.clicked': 'Tag: Clicked',
+  'issue.quick_trace_status': 'Issue Quick Trace Status',
 };

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -115,7 +115,7 @@ class GroupEventToolbar extends Component<Props> {
       evt.dateReceived &&
       Math.abs(+moment(evt.dateReceived) - +moment(evt.dateCreated)) > latencyThreshold;
 
-    const isPerformanceIssue = !!evt.contexts.performance_issue;
+    const isPerformanceIssue = !!evt.contexts?.performance_issue;
 
     return (
       <StyledDataSection>

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -115,6 +115,8 @@ class GroupEventToolbar extends Component<Props> {
       evt.dateReceived &&
       Math.abs(+moment(evt.dateReceived) - +moment(evt.dateCreated)) > latencyThreshold;
 
+    const isPerformanceIssue = !!evt.contexts.performance_issue;
+
     return (
       <StyledDataSection>
         <StyledNavigationButtonGroup
@@ -168,6 +170,7 @@ class GroupEventToolbar extends Component<Props> {
           group={group}
           organization={organization}
           location={location}
+          isPerformanceIssue={isPerformanceIssue}
         />
       </StyledDataSection>
     );

--- a/static/app/views/organizationGroupDetails/quickTrace/index.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/index.tsx
@@ -12,9 +12,10 @@ type Props = {
   group: Group;
   location: Location;
   organization: Organization;
+  isPerformanceIssue?: boolean;
 };
 
-function QuickTrace({event, group, organization, location}: Props) {
+function QuickTrace({event, group, organization, location, isPerformanceIssue}: Props) {
   const hasPerformanceView = organization.features.includes('performance-view');
   const hasTraceContext = Boolean(event.contexts?.trace?.trace_id);
 
@@ -28,7 +29,12 @@ function QuickTrace({event, group, organization, location}: Props) {
         />
       )}
       {hasPerformanceView && hasTraceContext && (
-        <IssueQuickTrace organization={organization} event={event} location={location} />
+        <IssueQuickTrace
+          organization={organization}
+          event={event}
+          location={location}
+          isPerformanceIssue={isPerformanceIssue}
+        />
       )}
     </Fragment>
   );

--- a/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
@@ -18,6 +18,7 @@ import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
 import withApi from 'sentry/utils/withApi';
@@ -27,6 +28,7 @@ type Props = {
   event: Event;
   location: Location;
   organization: Organization;
+  isPerformanceIssue?: boolean;
 };
 
 type State = {
@@ -101,7 +103,7 @@ class IssueQuickTrace extends Component<Props, State> {
   };
 
   renderQuickTrace(results) {
-    const {event, location, organization} = this.props;
+    const {event, location, organization, isPerformanceIssue} = this.props;
     const {shouldShow} = this.state;
     const {isLoading, error, trace, type} = results;
 
@@ -113,6 +115,12 @@ class IssueQuickTrace extends Component<Props, State> {
       if (!shouldShow) {
         return null;
       }
+
+      trackAdvancedAnalyticsEvent('issue.quick_trace_status', {
+        organization,
+        status: type === 'missing' ? 'transaction missing' : 'trace missing',
+        is_performance_issue: isPerformanceIssue ?? false,
+      });
 
       return (
         <StyledAlert
@@ -140,6 +148,12 @@ class IssueQuickTrace extends Component<Props, State> {
         </StyledAlert>
       );
     }
+
+    trackAdvancedAnalyticsEvent('issue.quick_trace_status', {
+      organization,
+      status: 'success',
+      is_performance_issue: isPerformanceIssue ?? false,
+    });
 
     return (
       <QuickTrace


### PR DESCRIPTION
Adds an analytics event to track the status of the quick trace navigator within the issue details page. Will also track whether the issue it resides on is a Performance Issue or not.

I won't add this to Reload since this isn't an interactive event, and we mainly want to use this event to see how frequently people are unable to see associated transactions within issues, since this is an entry point into the Performance product.