### PR TITLE
ref(tasks): Fix collect project platforms for snowflake ids

### DIFF
--- a/src/sentry/tasks/collect_project_platforms.py
+++ b/src/sentry/tasks/collect_project_platforms.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.db.models import Max, Min
+from django.core.paginator import Paginator
 from django.utils import timezone
 
 from sentry.constants import VALID_PLATFORMS
@@ -8,14 +8,21 @@ from sentry.models import Group, Project, ProjectPlatform
 from sentry.tasks.base import instrumented_task
 
 
-def _collect_project_platforms(min_project_id, max_project_id, now, step):
-    while min_project_id <= max_project_id:
+@instrumented_task(name="sentry.tasks.collect_project_platforms", queue="stats")
+def collect_project_platforms(**kwargs):
+    now = timezone.now()
+
+    all_project_query = [p.id for p in Project.objects.using_replica().all()]
+    paginator = Paginator(all_project_query, 1000)
+
+    for i in paginator.page_range:
+        page_of_projects = paginator.get_page(i)
+
         queryset = (
             Group.objects.using_replica()
             .filter(
                 last_seen__gte=now - timedelta(days=1),
-                project__gte=min_project_id,
-                project__lt=min_project_id + step,
+                project_id__in=page_of_projects,
                 platform__isnull=False,
             )
             .values_list("platform", "project_id")
@@ -29,34 +36,6 @@ def _collect_project_platforms(min_project_id, max_project_id, now, step):
             ProjectPlatform.objects.create_or_update(
                 project_id=project_id, platform=platform, values={"last_seen": now}
             )
-        min_project_id += step
-
-
-@instrumented_task(name="sentry.tasks.collect_project_platforms", queue="stats")
-def collect_project_platforms(**kwargs):
-    now = timezone.now()
-
-    pre_snowflake_max_value = 2147483647
-
-    min_project_id = 0
-    max_project_id_before_snowflake = Project.objects.filter(
-        id__lt=pre_snowflake_max_value
-    ).aggregate(x=Max("id"))["x"]
-    step = 1000
-
-    _collect_project_platforms(min_project_id, max_project_id_before_snowflake, now, step)
-
-    min_project_id_after_snowflake = Project.objects.filter(
-        id__gt=pre_snowflake_max_value
-    ).aggregate(x=Min("id"))["x"]
-    max_project_id_after_snowflake = Project.objects.filter(
-        id__gt=pre_snowflake_max_value
-    ).aggregate(x=Max("id"))["x"]
-    step = max((max_project_id_after_snowflake - min_project_id_after_snowflake) / 1000, 1)
-
-    _collect_project_platforms(
-        min_project_id_after_snowflake, max_project_id_after_snowflake, now, step
-    )
 
     # remove (likely) unused platform associations
     ProjectPlatform.objects.filter(last_seen__lte=now - timedelta(days=90)).delete()

--- a/src/sentry/tasks/collect_project_platforms.py
+++ b/src/sentry/tasks/collect_project_platforms.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.db.models import Max
+from django.db.models import Max, Min
 from django.utils import timezone
 
 from sentry.constants import VALID_PLATFORMS
@@ -8,13 +8,7 @@ from sentry.models import Group, Project, ProjectPlatform
 from sentry.tasks.base import instrumented_task
 
 
-@instrumented_task(name="sentry.tasks.collect_project_platforms", queue="stats")
-def collect_project_platforms(**kwargs):
-    now = timezone.now()
-
-    min_project_id = 0
-    max_project_id = Project.objects.using_replica().aggregate(x=Max("id"))["x"] or 0
-    step = 1000
+def _collect_project_platforms(min_project_id, max_project_id, now, step):
     while min_project_id <= max_project_id:
         queryset = (
             Group.objects.using_replica()
@@ -36,6 +30,33 @@ def collect_project_platforms(**kwargs):
                 project_id=project_id, platform=platform, values={"last_seen": now}
             )
         min_project_id += step
+
+
+@instrumented_task(name="sentry.tasks.collect_project_platforms", queue="stats")
+def collect_project_platforms(**kwargs):
+    now = timezone.now()
+
+    pre_snowflake_max_value = 2147483647
+
+    min_project_id = 0
+    max_project_id_before_snowflake = Project.objects.filter(
+        id__lt=pre_snowflake_max_value
+    ).aggregate(x=Max("id"))["x"]
+    step = 1000
+
+    _collect_project_platforms(min_project_id, max_project_id_before_snowflake, now, step)
+
+    min_project_id_after_snowflake = Project.objects.filter(
+        id__gt=pre_snowflake_max_value
+    ).aggregate(x=Min("id"))["x"]
+    max_project_id_after_snowflake = Project.objects.filter(
+        id__gt=pre_snowflake_max_value
+    ).aggregate(x=Max("id"))["x"]
+    step = max((max_project_id_after_snowflake - min_project_id_after_snowflake) / 1000, 1)
+
+    _collect_project_platforms(
+        min_project_id_after_snowflake, max_project_id_after_snowflake, now, step
+    )
 
     # remove (likely) unused platform associations
     ProjectPlatform.objects.filter(last_seen__lte=now - timedelta(days=90)).delete()

--- a/tests/sentry/tasks/test_collect_project_platforms.py
+++ b/tests/sentry/tasks/test_collect_project_platforms.py
@@ -16,7 +16,7 @@ class CollectProjectPlatformsTest(TestCase):
         self.create_group(project=project2, last_seen=now, platform="python")
 
         with self.tasks():
-            collect_project_platforms()
+            collect_project_platforms(1)
 
         assert ProjectPlatform.objects.filter(project_id=project1.id, platform="php").exists()
         assert ProjectPlatform.objects.filter(project_id=project1.id, platform="perl").exists()


### PR DESCRIPTION
*edit Abandoned the approach of manually slicing the Project table up by ID ranges. Now we'll paginate queries over the Project table and fetch 1000 IDs at a time

Snowflake_id currently destroys the loop in `collect_project_platforms` in `src/sentry/tasks/collect_project_platforms.py` . With snowflake ids a trouble rises due to while `min_project_id <= max_project_id` with our `max_project_id  now becoming massive`. 
We can divide this into 2 parts, the projects created before and after snowflake ids. with the ones before,  filtering like the following makes sense since 1 step is equivalent to 1 project
```step=1000
project__gte=min_project_id,
project__lt=min_project_id + step,
```
but with snowflake ids, the current filtering method wouldn't make sense since 1000 would just now represent 1000 seconds and there could be 0 projects in that timeframe.

The changes added will maintain the current method for pre_snowflake id projects. For the projects created after snowflake id implementation, we will change the steps to be 1/1000th of the time from the first to last snowflake id