### PR TITLE
feat(profiling): persist layout preferences in storage

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -80,15 +80,15 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
   }, []);
 
   const onTableLeftClick = useCallback(() => {
-    dispatchFlamegraphPreferences({type: 'set layout', payload: 'table_left'});
+    dispatchFlamegraphPreferences({type: 'set layout', payload: 'table left'});
   }, [dispatchFlamegraphPreferences]);
 
   const onTableBottomClick = useCallback(() => {
-    dispatchFlamegraphPreferences({type: 'set layout', payload: 'table_bottom'});
+    dispatchFlamegraphPreferences({type: 'set layout', payload: 'table bottom'});
   }, [dispatchFlamegraphPreferences]);
 
   const onTableRightClick = useCallback(() => {
-    dispatchFlamegraphPreferences({type: 'set layout', payload: 'table_right'});
+    dispatchFlamegraphPreferences({type: 'set layout', payload: 'table right'});
   }, [dispatchFlamegraphPreferences]);
 
   return (
@@ -160,16 +160,16 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
           style={{
             flex: '1 1 100%',
             cursor:
-              flamegraphPreferences.layout === 'table_bottom' ? 'ns-resize' : undefined,
+              flamegraphPreferences.layout === 'table bottom' ? 'ns-resize' : undefined,
           }}
           onMouseDown={
-            flamegraphPreferences.layout === 'table_bottom' ? props.onResize : undefined
+            flamegraphPreferences.layout === 'table bottom' ? props.onResize : undefined
           }
         />
         <li>
           <LayoutSelectionContainer>
             <StyledButton
-              active={flamegraphPreferences.layout === 'table_left'}
+              active={flamegraphPreferences.layout === 'table left'}
               onClick={onTableLeftClick}
               size="xs"
               title={t('Table left')}
@@ -177,7 +177,7 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
               <IconPanel size="xs" direction="right" />
             </StyledButton>
             <StyledButton
-              active={flamegraphPreferences.layout === 'table_bottom'}
+              active={flamegraphPreferences.layout === 'table bottom'}
               onClick={onTableBottomClick}
               size="xs"
               title={t('Table bottom')}
@@ -185,7 +185,7 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
               <IconPanel size="xs" direction="down" />
             </StyledButton>
             <StyledButton
-              active={flamegraphPreferences.layout === 'table_right'}
+              active={flamegraphPreferences.layout === 'table right'}
               onClick={onTableRightClick}
               size="xs"
               title={t('Table right')}
@@ -202,8 +202,8 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
         tree={maybeFilteredOrInvertedTree ?? []}
         canvasPoolManager={props.canvasPoolManager}
       />
-      {flamegraphPreferences.layout === 'table_left' ||
-      flamegraphPreferences.layout === 'table_right' ? (
+      {flamegraphPreferences.layout === 'table left' ||
+      flamegraphPreferences.layout === 'table right' ? (
         <ResizableVerticalDrawer>
           {/* The border should be 1px, but we want the actual handler to be wider
           to improve the user experience and not have users have to click on the exact pixel */}
@@ -250,17 +250,17 @@ const FrameDrawer = styled('div')<{layout: FlamegraphPreferences['layout']}>`
   display: grid;
   grid-template-rows: auto 1fr;
   grid-template-columns: ${({layout}) =>
-    layout === 'table_left' ? '1fr auto' : layout === 'table_right' ? 'auto 1fr' : '1fr'};
+    layout === 'table left' ? '1fr auto' : layout === 'table right' ? 'auto 1fr' : '1fr'};
   /* false positive for grid layout */
   /* stylelint-disable */
   grid-template-areas: ${({layout}) =>
-    layout === 'table_bottom'
+    layout === 'table bottom'
       ? `
     'tabs'
     'table'
     'drawer'
     `
-      : layout === 'table_left'
+      : layout === 'table left'
       ? `
       'tabs drawer'
       'table drawer'

--- a/static/app/components/profiling/profilingFlamechartLayout.tsx
+++ b/static/app/components/profiling/profilingFlamechartLayout.tsx
@@ -38,7 +38,7 @@ export function ProfilingFlamechartLayout(props: ProfilingFlamechartLayoutProps)
         return;
       }
 
-      if (layout === 'table_left' || layout === 'table_right') {
+      if (layout === 'table left' || layout === 'table right') {
         frameStackRef.current.style.width = `${newDimensions[0]}px`;
         frameStackRef.current.style.height = `100%`;
       } else {
@@ -51,9 +51,9 @@ export function ProfilingFlamechartLayout(props: ProfilingFlamechartLayoutProps)
       initialDimensions,
       onResize,
       direction:
-        layout === 'table_left'
+        layout === 'table left'
           ? 'horizontal-ltr'
-          : layout === 'table_right'
+          : layout === 'table right'
           ? 'horizontal-rtl'
           : 'vertical',
       min,
@@ -92,33 +92,33 @@ const ProfilingFlamechartGrid = styled('div')<{
   display: grid;
   width: 100%;
   grid-template-rows: ${({layout}) =>
-    layout === 'table_bottom'
+    layout === 'table bottom'
       ? 'auto 1fr'
-      : layout === 'table_right'
+      : layout === 'table right'
       ? '100px auto'
       : '100px auto'};
   grid-template-columns: ${({layout}) =>
-    layout === 'table_bottom'
+    layout === 'table bottom'
       ? '100%'
-      : layout === 'table_left'
+      : layout === 'table left'
       ? `min-content auto`
       : `auto min-content`};
 
   /* false positive for grid layout */
   /* stylelint-disable */
   grid-template-areas: ${({layout}) =>
-    layout === 'table_bottom'
+    layout === 'table bottom'
       ? `
         'minimap'
         'flamegraph'
         'frame-stack'
         `
-      : layout === 'table_right'
+      : layout === 'table right'
       ? `
         'minimap    frame-stack'
         'flamegraph frame-stack'
       `
-      : layout === 'table_left'
+      : layout === 'table left'
       ? `
         'frame-stack minimap'
         'frame-stack flamegraph'

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
@@ -11,7 +11,7 @@ export type FlamegraphAxisOptions = ['standalone', 'transaction'];
 
 export interface FlamegraphPreferences {
   colorCoding: FlamegraphColorCodings[number];
-  layout: 'table_right' | 'table_bottom' | 'table_left';
+  layout: 'table right' | 'table bottom' | 'table left';
   sorting: FlamegraphSorting[number];
   view: FlamegraphViewOptions[number];
   xAxis: FlamegraphAxisOptions[number];


### PR DESCRIPTION
Store some "user" preferences in localstorage state. The layout will be initialized from localstorage or default value. We dont currently sync the qs with query params so that the user preferences are respected when sharing links. Layout value will always be initialized from localStorage, but I added the decoding from qs code so that we can modify this in the future and initialize from qs if value is present - I have no very strong opinion on that behavior, I think we should try respect user preferences if possible, but there may be a case where it makes sense to have the exact same layout as the person who shared the link.

I also modified the state value to be consistent with the rest and removed the snake case