### PR TITLE
ref: upgrade flake8 to 5.0.2

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -39,8 +39,8 @@ exam==0.10.6
 execnet==1.9.0
 fido2==0.9.2
 filelock==3.7.0
-flake8==4.0.1
-flake8-bugbear==22.4.25
+flake8==5.0.2
+flake8-bugbear==22.7.1
 freezegun==1.1.0
 google-api-core[grpc]==1.32.0
 google-auth==1.35.0
@@ -70,7 +70,7 @@ lazy-object-proxy==1.7.1
 libcst==0.4.3
 lxml==4.6.5
 maxminddb==2.0.3
-mccabe==0.6.1
+mccabe==0.7.0
 milksnake==0.1.5
 mistune==2.0.2
 mmh3==3.0.0
@@ -107,9 +107,9 @@ psycopg2-binary==2.8.6
 py==1.11.0
 pyasn1==0.4.5
 pyasn1-modules==0.2.4
-pycodestyle==2.8.0
+pycodestyle==2.9.0
 pycparser==2.21
-pyflakes==2.4.0
+pyflakes==2.5.0
 pyjwt==2.4.0
 pyopenssl==22.0.0
 pyparsing==3.0.9

--- a/requirements-dev-only-frozen.txt
+++ b/requirements-dev-only-frozen.txt
@@ -15,8 +15,8 @@ docker-pycreds==0.4.0
 exam==0.10.6
 execnet==1.9.0
 filelock==3.7.1
-flake8==4.0.1
-flake8-bugbear==22.4.25
+flake8==5.0.2
+flake8-bugbear==22.7.1
 freezegun==1.1.0
 honcho==1.0.0
 identify==2.5.1
@@ -27,7 +27,7 @@ isodate==0.6.1
 isort==5.10.1
 jsonschema==4.5.1
 lazy-object-proxy==1.7.1
-mccabe==0.6.1
+mccabe==0.7.0
 mock==4.0.3
 more-itertools==8.13.0
 msgpack-types==0.2.0
@@ -46,8 +46,8 @@ platformdirs==2.5.2
 pluggy==0.13.1
 pre-commit==2.18.1
 py==1.11.0
-pycodestyle==2.8.0
-pyflakes==2.4.0
+pycodestyle==2.9.0
+pyflakes==2.5.0
 pyparsing==3.0.9
 pyrsistent==0.18.1
 pytest==6.1.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,8 +16,8 @@ msgpack-types>=0.2.0
 # pre-commit dependencies
 pre-commit>=2.18.1
 black>=22.3.0
-flake8>=4.0.1
-flake8-bugbear>=22.4.25
+flake8>=5.0.2
+flake8-bugbear>=22.7.1
 pyupgrade>=2.37.2
 isort>=5.10.1
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@
 # Currently, the black formatter doesn't wrap long strings: https://github.com/psf/black/issues/182#issuecomment-385325274
 # We already have a lot of E501's - these are lines black didn't wrap.
 # But rather than append # noqa: E501 to all of them, we just ignore E501 for now.
-extend-ignore = E203,E501,E402,E731,B007,B009,B010,B011,B020
+extend-ignore = E203,E501,E402,E731,B007,B009,B010,B011,B020,B023
 
 per-file-ignores =
     # allow prints in tests


### PR DESCRIPTION
I'm upgrading flake8 and flake8-bugbear, B023 causes some false positives so I'm disabling the rule for now: https://github.com/PyCQA/flake8-bugbear/issues/269

https://github.com/getsentry/getsentry/pull/7963 needs to land first

testing done:

```console
$ pre-commit run flake8 --all-files
flake8...................................................................Passed
```

