### PR TITLE
feat(profiling): stop thrashing layout in tooltip

### DIFF
--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 
@@ -9,26 +9,24 @@ import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 import theme from 'sentry/utils/theme';
 
-function computeBestTooltipPlacement(cursor: vec2, container: Rect) {
+function computeBestTooltipPlacement(
+  cursor: vec2,
+  container: Rect,
+  tooltip: DOMRect
+): string {
   // This is because the cursor's origin is in the top left corner of the arrow, so we want
   // to offset it just enough so that the tooltip does not overlap with the arrow's tail.
   // When the tooltip placed to the left of the cursor, we do not have that issue and hence
   // no offset is applied.
   const OFFSET_PX = 6;
-
-  const style: Record<string, number | undefined> = {
-    left: cursor[0] + OFFSET_PX,
-    right: undefined,
-    top: cursor[1] + OFFSET_PX,
-    bottom: undefined,
-  };
+  let left = cursor[0] + OFFSET_PX;
+  const top = cursor[1] + OFFSET_PX;
 
   if (cursor[0] > container.width / 2) {
-    style.left = undefined;
-    style.right = container.width - cursor[0]; // No offset is applied here as tooltip is placed to the left
+    left = cursor[0] - tooltip.width; // No offset is applied here as tooltip is placed to the left
   }
 
-  return style;
+  return `translate(${left || 0}px, ${top || 0}px)`;
 }
 
 interface BoundTooltipProps {
@@ -46,7 +44,6 @@ function BoundTooltip({
   flamegraphView,
   children,
 }: BoundTooltipProps): React.ReactElement | null {
-  const tooltipRef = useRef<HTMLDivElement>(null);
   const flamegraphTheme = useFlamegraphTheme();
 
   const physicalSpaceCursor = vec2.transformMat3(
@@ -61,13 +58,34 @@ function BoundTooltip({
     flamegraphCanvas.physicalToLogicalSpace
   );
 
-  const placement = computeBestTooltipPlacement(logicalSpaceCursor, bounds);
+  const rafIdRef = useRef<number | undefined>();
+  const onRef = useCallback(
+    node => {
+      if (node === null) {
+        return;
+      }
+
+      if (rafIdRef.current) {
+        window.cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = undefined;
+      }
+
+      rafIdRef.current = window.requestAnimationFrame(() => {
+        node.style.transform = computeBestTooltipPlacement(
+          logicalSpaceCursor,
+          bounds,
+          node.getBoundingClientRect()
+        );
+      });
+    },
+    [bounds, logicalSpaceCursor]
+  );
 
   return (
     <Tooltip
-      ref={tooltipRef}
+      ref={onRef}
       style={{
-        ...placement,
+        willChange: 'transform',
         fontSize: flamegraphTheme.SIZES.TOOLTIP_FONT_SIZE,
         fontFamily: flamegraphTheme.FONTS.FONT,
         zIndex: theme.zIndex.tooltip,


### PR DESCRIPTION
Use raf + transform style calculation to only trigger composite operation.

Before:
<img width="1091" alt="CleanShot 2022-08-01 at 10 27 21@2x" src="https://user-images.githubusercontent.com/9317857/182174230-81d02a93-a6f5-44ba-87e5-0facf3e41fce.png">
After:
<img width="702" alt="CleanShot 2022-08-01 at 10 35 03@2x" src="https://user-images.githubusercontent.com/9317857/182174275-a8a31b44-2629-45e3-9a3e-290dcbc196ae.png">

Tooltip feels much faster now and since we have the DomRect we can also make some improvements to it
 