### PR TITLE
feat(profiling): set selected border on zoomed frame

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
@@ -34,7 +34,7 @@ export function FrameStackContextMenu(props: FrameStackContextMenuProps) {
             {...props.contextMenu.getMenuItemProps()}
             onClick={props.onZoomIntoFrameClick}
           >
-            {t('Scope view to this node')}
+            {t('Show in flamegraph')}
           </ProfilingContextMenuItem>
         </ProfilingContextMenuGroup>
       </ProfilingContextMenu>

--- a/static/app/components/profiling/FrameStack/frameStackTable.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackTable.tsx
@@ -116,6 +116,10 @@ export function FrameStackTable({
     }
 
     canvasPoolManager.dispatch('zoom at frame', [clickedContextMenuNode.node, 'exact']);
+    canvasPoolManager.dispatch('highlight frame', [
+      clickedContextMenuNode.node,
+      'selected',
+    ]);
   }, [canvasPoolManager, clickedContextMenuNode]);
 
   const renderRow: UseVirtualizedListProps<FlamegraphFrame>['renderRow'] = useCallback(


### PR DESCRIPTION
When zooming into frame, highlight it so that it gives a fast visual anchor to the user.

https://user-images.githubusercontent.com/9317857/182180492-c85fb07a-1b19-4146-8696-9f85a59744a5.mp4

