### PR TITLE
feat(sampling): Increase max hour events [TET-238]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.tsx
@@ -6,7 +6,7 @@ import {Outcome} from 'sentry/views/organizationStats/types';
 
 import {quantityField} from '.';
 
-const MAX_PER_HOUR = 100 * 60 * 60;
+const MAX_PER_HOUR = 300 * 60 * 60;
 const COMMON_SAMPLE_RATES = [
   0.01, 0.015, 0.02, 0.025, 0.03, 0.035, 0.04, 0.045, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1,
   0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9,

--- a/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
@@ -64,8 +64,8 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     expect(screen.getByRole('radio', {name: 'Suggested'})).not.toBeChecked();
     expect(screen.getByText('100%')).toBeInTheDocument(); // Current client-side sample rate
     expect(screen.getByText('N/A')).toBeInTheDocument(); // Current server-side sample rate
-    expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(30); // Suggested client-side sample rate
-    expect(screen.getAllByRole('spinbutton')[1]).toHaveValue(30); // Suggested server-side sample rate
+    expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(95); // Suggested client-side sample rate
+    expect(screen.getAllByRole('spinbutton')[1]).toHaveValue(95); // Suggested server-side sample rate
     expect(screen.queryByLabelText('Reset to suggested values')).not.toBeInTheDocument();
 
     // Enter invalid client-side sample rate
@@ -86,7 +86,7 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     // Reset client-side sample rate to suggested value
     userEvent.click(screen.getByLabelText('Reset to suggested values'));
     expect(screen.getByText('Suggested')).toBeInTheDocument();
-    expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(30); // Suggested client-side sample rate
+    expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(95); // Suggested client-side sample rate
 
     // Footer
     expect(screen.getByRole('button', {name: 'Read Docs'})).toHaveAttribute(

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.spec.tsx
@@ -3,8 +3,8 @@ import {projectStatsToSampleRates} from 'sentry/views/settings/project/server-si
 describe('projectStatsToSampleRates', function () {
   it('returns correct sample rates', function () {
     expect(projectStatsToSampleRates(TestStubs.Outcomes())).toEqual({
-      hoursOverLimit: 18,
-      maxSafeSampleRate: 0.3,
+      hoursOverLimit: 1,
+      maxSafeSampleRate: 0.95,
       trueSampleRate: 1,
     });
   });


### PR DESCRIPTION
During testing, we went with a conservative number of 100 events per second.

Now we are increasing it to 300 to match the actual rate limit.

This affects the suggested client rate recommendation.