### PR TITLE
ref(profiling): flamegraph -> flamechart

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
+++ b/static/app/components/profiling/FrameStack/frameStackContextMenu.tsx
@@ -29,7 +29,7 @@ export function FrameStackContextMenu(props: FrameStackContextMenuProps) {
         }}
       >
         <ProfilingContextMenuGroup>
-          <ProfilingContextMenuHeading>{t('Flamegraph')}</ProfilingContextMenuHeading>
+          <ProfilingContextMenuHeading>{t('Actions')}</ProfilingContextMenuHeading>
           <ProfilingContextMenuItem
             {...props.contextMenu.getMenuItemProps()}
             onClick={props.onZoomIntoFrameClick}

--- a/static/app/components/profiling/breadcrumb.tsx
+++ b/static/app/components/profiling/breadcrumb.tsx
@@ -6,7 +6,7 @@ import Breadcrumbs, {Crumb} from 'sentry/components/breadcrumbs';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {
-  generateProfileFlamegraphRouteWithQuery,
+  generateProfileFlamechartRouteWithQuery,
   generateProfileSummaryRouteWithQuery,
   generateProfilingRouteWithQuery,
 } from 'sentry/utils/profiling/routes';
@@ -58,9 +58,9 @@ function trailToCrumb(
         preservePageFilters: true,
       };
     }
-    case 'flamegraph': {
+    case 'flamechart': {
       return {
-        to: generateProfileFlamegraphRouteWithQuery({
+        to: generateProfileFlamechartRouteWithQuery({
           location,
           orgSlug: organization.slug,
           projectSlug: trail.payload.projectSlug,
@@ -93,7 +93,7 @@ type FlamegraphTrail = {
     projectSlug: string;
     transaction: string;
   };
-  type: 'flamegraph';
+  type: 'flamechart';
 };
 
 type Trail = ProfilingTrail | ProfileSummaryTrail | FlamegraphTrail;

--- a/static/app/components/profiling/functionsTable.tsx
+++ b/static/app/components/profiling/functionsTable.tsx
@@ -13,7 +13,7 @@ import {Project} from 'sentry/types';
 import {SuspectFunction} from 'sentry/types/profiling/core';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {getShortEventId} from 'sentry/utils/events';
-import {generateProfileFlamegraphRouteWithQuery} from 'sentry/utils/profiling/routes';
+import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
 import {renderTableHead} from 'sentry/utils/profiling/tableRenderer';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -62,7 +62,7 @@ function FunctionsTable(props: FunctionsTableProps) {
           const profileId = example.replaceAll('-', '');
           return {
             value: getShortEventId(profileId),
-            target: generateProfileFlamegraphRouteWithQuery({
+            target: generateProfileFlamechartRouteWithQuery({
               orgSlug: organization.slug,
               projectSlug: props.project.slug,
               profileId,

--- a/static/app/components/profiling/legacyFunctionsTable.tsx
+++ b/static/app/components/profiling/legacyFunctionsTable.tsx
@@ -19,7 +19,7 @@ import {FunctionCall} from 'sentry/types/profiling/core';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {getShortEventId} from 'sentry/utils/events';
 import {formatPercentage} from 'sentry/utils/formatters';
-import {generateProfileFlamegraphRouteWithQuery} from 'sentry/utils/profiling/routes';
+import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
 import {renderTableHead} from 'sentry/utils/profiling/tableRenderer';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -58,7 +58,7 @@ function LegacyFunctionsTable(props: LegacyFunctionsTableProps) {
         ([profileId, threadId]) => {
           return {
             value: getShortEventId(profileId),
-            target: generateProfileFlamegraphRouteWithQuery({
+            target: generateProfileFlamechartRouteWithQuery({
               orgSlug: organization.slug,
               projectSlug: props.project.slug,
               profileId,

--- a/static/app/components/profiling/profileHeader.tsx
+++ b/static/app/components/profiling/profileHeader.tsx
@@ -5,7 +5,7 @@ import {Breadcrumb} from 'sentry/components/profiling/breadcrumb';
 import {t} from 'sentry/locale';
 import {
   generateProfileDetailsRouteWithQuery,
-  generateProfileFlamegraphRouteWithQuery,
+  generateProfileFlamechartRouteWithQuery,
 } from 'sentry/utils/profiling/routes';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -27,7 +27,7 @@ function ProfileHeader() {
           trails={[
             {type: 'landing'},
             {
-              type: 'flamegraph',
+              type: 'flamechart',
               payload: {
                 transaction:
                   profileGroup.type === 'resolved' ? profileGroup.data.name : '',
@@ -51,16 +51,16 @@ function ProfileHeader() {
             {t('Details')}
           </Link>
         </li>
-        <li className={location.pathname.endsWith('flamegraph/') ? 'active' : undefined}>
+        <li className={location.pathname.endsWith('flamechart/') ? 'active' : undefined}>
           <Link
-            to={generateProfileFlamegraphRouteWithQuery({
+            to={generateProfileFlamechartRouteWithQuery({
               orgSlug: organization.slug,
               projectSlug: params.projectId,
               profileId: params.eventId,
               location,
             })}
           >
-            {t('Flamegraph')}
+            {t('Flamechart')}
           </Link>
         </li>
       </Layout.HeaderNavTabs>

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1719,8 +1719,8 @@ function buildRoutes() {
           component={make(() => import('sentry/views/profiling/profileDetails'))}
         />
         <Route
-          path="flamegraph/"
-          component={make(() => import('sentry/views/profiling/profileFlamegraph'))}
+          path="flamechart/"
+          component={make(() => import('sentry/views/profiling/profileFlamechart'))}
         />
       </Route>
     </Route>

--- a/static/app/utils/profiling/routes.tsx
+++ b/static/app/utils/profiling/routes.tsx
@@ -25,7 +25,7 @@ export function generateProfileSummaryRoute({
   return `/organizations/${orgSlug}/profiling/summary/${projectSlug}/`;
 }
 
-export function generateProfileFlamegraphRoute({
+export function generateProfileFlamechartRoute({
   orgSlug,
   projectSlug,
   profileId,
@@ -34,7 +34,7 @@ export function generateProfileFlamegraphRoute({
   profileId: Trace['id'];
   projectSlug: Project['slug'];
 }): string {
-  return `/organizations/${orgSlug}/profiling/profile/${projectSlug}/${profileId}/flamegraph/`;
+  return `/organizations/${orgSlug}/profiling/profile/${projectSlug}/${profileId}/flamechart/`;
 }
 
 export function generateProfileDetailsRoute({
@@ -92,7 +92,7 @@ export function generateProfileSummaryRouteWithQuery({
   };
 }
 
-export function generateProfileFlamegraphRouteWithQuery({
+export function generateProfileFlamechartRouteWithQuery({
   location,
   orgSlug,
   projectSlug,
@@ -105,7 +105,11 @@ export function generateProfileFlamegraphRouteWithQuery({
   location?: Location;
   query?: Location['query'];
 }): LocationDescriptor {
-  const pathname = generateProfileFlamegraphRoute({orgSlug, projectSlug, profileId});
+  const pathname = generateProfileFlamechartRoute({
+    orgSlug,
+    projectSlug,
+    profileId,
+  });
   return {
     pathname,
     query: {

--- a/static/app/views/performance/transactionDetails/transactionToProfileButton.tsx
+++ b/static/app/views/performance/transactionDetails/transactionToProfileButton.tsx
@@ -6,7 +6,7 @@ import Button from 'sentry/components/button';
 import {t} from 'sentry/locale';
 import {RequestState} from 'sentry/types/core';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
-import {generateProfileFlamegraphRoute} from 'sentry/utils/profiling/routes';
+import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -49,7 +49,7 @@ function TransactionToProfileButton({transactionId, orgId, projectId}: Props) {
     });
   }
 
-  const target = generateProfileFlamegraphRoute({
+  const target = generateProfileFlamechartRoute({
     orgSlug: orgId,
     projectSlug: projectId,
     profileId: profileIdState.data,

--- a/static/app/views/profiling/landing/profilingScatterChart.tsx
+++ b/static/app/views/profiling/landing/profilingScatterChart.tsx
@@ -27,7 +27,7 @@ import {Trace} from 'sentry/types/profiling/core';
 import {defined} from 'sentry/utils';
 import {axisLabelFormatter} from 'sentry/utils/discover/charts';
 import {getDuration} from 'sentry/utils/formatters';
-import {generateProfileDetailsRoute} from 'sentry/utils/profiling/routes';
+import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {Theme} from 'sentry/utils/theme';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -250,7 +250,7 @@ function makeScatterChartOptions({
         return;
       }
       browserHistory.push(
-        generateProfileDetailsRoute({
+        generateProfileFlamechartRoute({
           orgSlug: organization.slug,
           projectSlug: project.slug,
           profileId: dataPoint.id,

--- a/static/app/views/profiling/profileDetails.tsx
+++ b/static/app/views/profiling/profileDetails.tsx
@@ -18,7 +18,7 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
-import {generateProfileFlamegraphRouteWithQuery} from 'sentry/utils/profiling/routes';
+import {generateProfileFlamechartRouteWithQuery} from 'sentry/utils/profiling/routes';
 import {makeFormatter} from 'sentry/utils/profiling/units/units';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
@@ -231,7 +231,7 @@ function ProfilingFunctionsTableCell({
       return (
         <Container>
           <Link
-            to={generateProfileFlamegraphRouteWithQuery({
+            to={generateProfileFlamechartRouteWithQuery({
               orgSlug: orgId,
               projectSlug: projectId,
               profileId: eventId,

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -76,7 +76,7 @@ function ProfileFlamegraph(): React.ReactElement {
 
   return (
     <SentryDocumentTitle
-      title={t('Profiling \u2014 Flamegraph')}
+      title={t('Profiling \u2014 Flamechart')}
       orgSlug={organization.slug}
     >
       <FlamegraphStateProvider initialState={initialFlamegraphPreferencesState}>

--- a/tests/js/spec/components/profiling/breadcrumb.spec.tsx
+++ b/tests/js/spec/components/profiling/breadcrumb.spec.tsx
@@ -20,7 +20,7 @@ describe('Breadcrumb', function () {
         trails={[
           {type: 'landing'},
           {
-            type: 'flamegraph',
+            type: 'flamechart',
             payload: {
               transaction: 'foo',
               profileId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',


### PR DESCRIPTION
This has been incorrect for a while. I haven't renamed the rendering components because they can render both a flamegraph and a chart, just depends what we feed it. As part of this PR, I also made the flamechart the default view after clicking on a scatter chart.