### PR TITLE
feat(auditlog): Remove versioning from endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_auditlogs.py
+++ b/src/sentry/api/endpoints/organization_auditlogs.py
@@ -53,7 +53,5 @@ class OrganizationAuditLogsEndpoint(OrganizationEndpoint):
             order_by="-datetime",
             on_results=lambda x: serialize(x, request.user),
         )
-        # TODO: Cleanup after frontend is fully moved to version 2
-        if "version" in request.GET and request.GET.get("version") == "2":
-            response.data = {"rows": response.data, "options": audit_log.get_api_names()}
+        response.data = {"rows": response.data, "options": audit_log.get_api_names()}
         return response

--- a/tests/sentry/api/endpoints/test_organization_auditlogs.py
+++ b/tests/sentry/api/endpoints/test_organization_auditlogs.py
@@ -40,9 +40,9 @@ class OrganizationAuditLogsTest(APITestCase):
         )
 
         response = self.get_success_response(self.organization.slug)
-        assert len(response.data) == 2
-        assert response.data[0]["id"] == str(entry2.id)
-        assert response.data[1]["id"] == str(entry1.id)
+        assert len(response.data["rows"]) == 2
+        assert response.data["rows"][0]["id"] == str(entry2.id)
+        assert response.data["rows"][1]["id"] == str(entry1.id)
 
     def test_filter_by_event(self):
         now = timezone.now()
@@ -63,8 +63,8 @@ class OrganizationAuditLogsTest(APITestCase):
         response = self.get_success_response(
             self.organization.slug, qs_params={"event": "org.edit"}
         )
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(entry1.id)
+        assert len(response.data["rows"]) == 1
+        assert response.data["rows"][0]["id"] == str(entry1.id)
 
     def test_filter_by_user(self):
         now = timezone.now()
@@ -86,8 +86,8 @@ class OrganizationAuditLogsTest(APITestCase):
         )
 
         response = self.get_success_response(org.slug, qs_params={"actor": self.user.id})
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(entry1.id)
+        assert len(response.data["rows"]) == 1
+        assert response.data["rows"][0]["id"] == str(entry1.id)
 
     def test_filter_by_user_and_event(self):
         now = timezone.now()
@@ -117,8 +117,8 @@ class OrganizationAuditLogsTest(APITestCase):
         response = self.get_success_response(
             org.slug, qs_params={"event": "org.edit", "actor": self.user.id}
         )
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(entry1.id)
+        assert len(response.data["rows"]) == 1
+        assert response.data["rows"][0]["id"] == str(entry1.id)
 
     def test_invalid_event(self):
         now = timezone.now()
@@ -131,7 +131,7 @@ class OrganizationAuditLogsTest(APITestCase):
         )
 
         response = self.get_success_response(self.organization.slug, qs_params={"event": "wrong"})
-        assert response.data == []
+        assert response.data["rows"] == []
 
     def test_user_out_of_bounds(self):
         now = timezone.now()
@@ -155,12 +155,10 @@ class OrganizationAuditLogsTest(APITestCase):
             ]
         }
 
-    def test_version_two_response(self):
-        # Test that version two request will send "rows" with audit log entries
-        # and "options" with the audit log api names list.
+    def test_options_data_included(self):
         now = timezone.now()
 
-        entry = AuditLogEntry.objects.create(
+        AuditLogEntry.objects.create(
             organization=self.organization,
             event=audit_log.get_event_id("ORG_EDIT"),
             actor=self.user,
@@ -168,11 +166,6 @@ class OrganizationAuditLogsTest(APITestCase):
         )
         audit_log_api_names = set(audit_log.get_api_names())
 
-        response = self.get_success_response(self.organization.slug, qs_params={"version": "2"})
+        response = self.get_success_response(self.organization.slug)
         assert len(response.data) == 2
-        assert response.data["rows"][0]["id"] == str(entry.id)
         assert set(response.data["options"]) == audit_log_api_names
-
-        response_2 = self.get_success_response(self.organization.slug, qs_params={"version": "3"})
-        assert len(response_2.data) == 1
-        assert response_2.data[0]["id"] == str(entry.id)


### PR DESCRIPTION
In order to supply the list of audit log event api names to the audit log frontend view (to replace hard-coding updates), a version 2 query parameter was temporarily added to the requests. This ensured the endpoint would provide the api names list to only requests that included `"version":"2"` in the query.

Removing this condition so that all requests to the endpoint provide both `rows` of the audit log entries and `options` of the api names. 
Confirmed that requests to the endpoint have included the `"version":"2"` query parameter, and its removal will not impact users. 
