### PR TITLE
feat(auditlog): Remove version from query payload

### DIFF
--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -57,7 +57,7 @@ type Props = {
   eventTypes: string[] | null;
   isLoading: boolean;
   onCursor: CursorHandler | undefined;
-  onEventSelect: (value: string) => void;
+  onEventSelect: (value: string, location: Location) => void;
   pageLinks: string | null;
 };
 
@@ -86,7 +86,7 @@ const AuditLogList = ({
       placeholder={t('Select Action: ')}
       options={eventOptions}
       onChange={options => {
-        onEventSelect(options?.value);
+        onEventSelect(options?.value, location);
       }}
     />
   );

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -57,7 +57,7 @@ type Props = {
   eventTypes: string[] | null;
   isLoading: boolean;
   onCursor: CursorHandler | undefined;
-  onEventSelect: (value: string, location: Location) => void;
+  onEventSelect: (value: string) => void;
   pageLinks: string | null;
 };
 
@@ -88,7 +88,7 @@ const AuditLogList = ({
       placeholder={t('Select Action: ')}
       options={eventOptions}
       onChange={options => {
-        onEventSelect(options?.value, location);
+        onEventSelect(options?.value);
       }}
     />
   );

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -65,6 +65,7 @@ const AuditLogList = ({
   isLoading,
   pageLinks,
   entries,
+  eventType,
   eventTypes,
   onCursor,
   onEventSelect,
@@ -83,6 +84,7 @@ const AuditLogList = ({
       clearable
       isDisabled={isLoading}
       name="eventFilter"
+      value={eventType}
       placeholder={t('Select Action: ')}
       options={eventOptions}
       onChange={options => {

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
 import {browserHistory} from 'react-router';
 import * as Sentry from '@sentry/react';
+import {Location} from 'history';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {CursorHandler} from 'sentry/components/pagination';
@@ -11,26 +12,27 @@ import withOrganization from 'sentry/utils/withOrganization';
 import AuditLogList from './auditLogList';
 
 type Props = {
+  location: Location;
   organization: Organization;
 };
 
 type State = {
   entryList: AuditLog[] | null;
   entryListPageLinks: string | null;
+  eventType: string | undefined;
   eventTypes: string[] | null;
   isLoading: boolean;
   currentCursor?: string;
-  eventType?: string;
 };
 
-function OrganizationAuditLog({organization}: Props) {
+function OrganizationAuditLog({location, organization}: Props) {
   const [state, setState] = useState<State>({
     entryList: [],
     entryListPageLinks: null,
+    eventType: undefined,
     eventTypes: [],
     isLoading: true,
   });
-
   const api = useApi();
 
   const handleCursor: CursorHandler = resultsCursor => {
@@ -80,14 +82,14 @@ function OrganizationAuditLog({organization}: Props) {
     fetchAuditLogData();
   }, [fetchAuditLogData]);
 
-  const handleEventSelect = (value: string | undefined) => {
+  const handleEventSelect = (value: string) => {
     setState(prevState => ({
       ...prevState,
       eventType: value,
     }));
     browserHistory.push({
       pathname: location.pathname,
-      search: `?event=${value}`,
+      query: {...location.query, event: value},
     });
   };
 

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -6,6 +6,7 @@ import {Location} from 'history';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {CursorHandler} from 'sentry/components/pagination';
 import {AuditLog, Organization} from 'sentry/types';
+import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -29,7 +30,7 @@ function OrganizationAuditLog({location, organization}: Props) {
   const [state, setState] = useState<State>({
     entryList: [],
     entryListPageLinks: null,
-    eventType: undefined,
+    eventType: decodeScalar(location.query.event),
     eventTypes: [],
     isLoading: true,
   });
@@ -42,7 +43,15 @@ function OrganizationAuditLog({location, organization}: Props) {
     }));
   };
 
+  useEffect(() => {
+    // Watch the location for changes so we can re-fetch data.
+    const eventType = decodeScalar(location.query.event);
+    setState(prevState => ({...prevState, eventType}));
+  }, [location.query]);
+
   const fetchAuditLogData = useCallback(async () => {
+    setState(prevState => ({...prevState, isLoading: true}));
+
     try {
       const payload = {cursor: state.currentCursor, event: state.eventType};
       if (!payload.cursor) {

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -60,6 +60,7 @@ function OrganizationAuditLog({location, organization}: Props) {
       if (!payload.event) {
         delete payload.event;
       }
+      setState(prevState => ({...prevState, isLoading: true}));
       const [data, _, response] = await api.requestPromise(
         `/organizations/${organization.slug}/audit-logs/`,
         {

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -41,7 +41,7 @@ function OrganizationAuditLog({organization}: Props) {
 
   const fetchAuditLogData = useCallback(async () => {
     try {
-      const payload = {cursor: state.currentCursor, event: state.eventType, version: '2'};
+      const payload = {cursor: state.currentCursor, event: state.eventType};
       if (!payload.cursor) {
         delete payload.cursor;
       }

--- a/static/app/views/settings/organizationAuditLog/index.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.tsx
@@ -1,4 +1,5 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
+import {browserHistory} from 'react-router';
 import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -84,6 +85,10 @@ function OrganizationAuditLog({organization}: Props) {
       ...prevState,
       eventType: value,
     }));
+    browserHistory.push({
+      pathname: location.pathname,
+      search: `?event=${value}`,
+    });
   };
 
   return (

--- a/tests/js/spec/views/settings/auditLogView.spec.jsx
+++ b/tests/js/spec/views/settings/auditLogView.spec.jsx
@@ -8,7 +8,6 @@ describe('OrganizationAuditLog', () => {
   const {routerContext, org} = initializeOrg({
     projects: [],
     router: {
-      location: {query: {version: '2'}},
       params: {orgId: 'org-slug'},
     },
   });
@@ -23,15 +22,9 @@ describe('OrganizationAuditLog', () => {
   });
 
   it('renders', async () => {
-    render(
-      <OrganizationAuditLog
-        location={{query: {version: '2'}}}
-        params={{orgId: org.slug}}
-      />,
-      {
-        context: routerContext,
-      }
-    );
+    render(<OrganizationAuditLog params={{orgId: org.slug}} />, {
+      context: routerContext,
+    });
 
     expect(await screen.findByRole('heading')).toHaveTextContent('Audit Log');
     expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -50,29 +43,17 @@ describe('OrganizationAuditLog', () => {
       body: {rows: [], options: TestStubs.AuditLogsApiEventNames()},
     });
 
-    render(
-      <OrganizationAuditLog
-        location={{query: {version: '2'}}}
-        params={{orgId: org.slug}}
-      />,
-      {
-        context: routerContext,
-      }
-    );
+    render(<OrganizationAuditLog params={{orgId: org.slug}} />, {
+      context: routerContext,
+    });
 
     expect(await screen.findByText('No audit entries available')).toBeInTheDocument();
   });
 
   it('displays whether an action was done by a superuser', async () => {
-    render(
-      <OrganizationAuditLog
-        location={{query: {version: '2'}}}
-        params={{orgId: org.slug}}
-      />,
-      {
-        context: routerContext,
-      }
-    );
+    render(<OrganizationAuditLog params={{orgId: org.slug}} />, {
+      context: routerContext,
+    });
 
     expect(await screen.findByText('Sentry Staff')).toBeInTheDocument();
     expect(screen.getAllByText('Foo Bar')).toHaveLength(2);

--- a/tests/js/spec/views/settings/auditLogView.spec.jsx
+++ b/tests/js/spec/views/settings/auditLogView.spec.jsx
@@ -12,6 +12,7 @@ describe('OrganizationAuditLog', () => {
     },
   });
   const ENDPOINT = `/organizations/${org.slug}/audit-logs/`;
+  const mockLocation = {query: {}};
 
   beforeEach(function () {
     Client.clearMockResponses();
@@ -22,9 +23,16 @@ describe('OrganizationAuditLog', () => {
   });
 
   it('renders', async () => {
-    render(<OrganizationAuditLog params={{orgId: org.slug}} />, {
-      context: routerContext,
-    });
+    render(
+      <OrganizationAuditLog
+        location={mockLocation}
+        organization={org}
+        params={{orgId: org.slug}}
+      />,
+      {
+        context: routerContext,
+      }
+    );
 
     expect(await screen.findByRole('heading')).toHaveTextContent('Audit Log');
     expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -43,17 +51,31 @@ describe('OrganizationAuditLog', () => {
       body: {rows: [], options: TestStubs.AuditLogsApiEventNames()},
     });
 
-    render(<OrganizationAuditLog params={{orgId: org.slug}} />, {
-      context: routerContext,
-    });
+    render(
+      <OrganizationAuditLog
+        location={mockLocation}
+        organization={org}
+        params={{orgId: org.slug}}
+      />,
+      {
+        context: routerContext,
+      }
+    );
 
     expect(await screen.findByText('No audit entries available')).toBeInTheDocument();
   });
 
   it('displays whether an action was done by a superuser', async () => {
-    render(<OrganizationAuditLog params={{orgId: org.slug}} />, {
-      context: routerContext,
-    });
+    render(
+      <OrganizationAuditLog
+        location={mockLocation}
+        organization={org}
+        params={{orgId: org.slug}}
+      />,
+      {
+        context: routerContext,
+      }
+    );
 
     expect(await screen.findByText('Sentry Staff')).toBeInTheDocument();
     expect(screen.getAllByText('Foo Bar')).toHaveLength(2);

--- a/tests/js/spec/views/settings/organizationAuditLog.spec.jsx
+++ b/tests/js/spec/views/settings/organizationAuditLog.spec.jsx
@@ -50,17 +50,18 @@ describe('OrganizationAuditLog', () => {
       },
     });
 
-    const {router, routerContext, organization} = initializeOrg({
+    const {routerContext, organization} = initializeOrg({
       projects: [],
       router: {
         params: {orgId: 'org-slug'},
       },
     });
+    const mockLocation = {query: {}};
     render(
       <OrganizationAuditLog
         organization={organization}
         params={{orgId: organization.slug}}
-        location={router.location}
+        location={mockLocation}
       />,
       {
         context: routerContext,

--- a/tests/js/spec/views/settings/organizationAuditLog.spec.jsx
+++ b/tests/js/spec/views/settings/organizationAuditLog.spec.jsx
@@ -53,7 +53,6 @@ describe('OrganizationAuditLog', () => {
     const {router, routerContext, organization} = initializeOrg({
       projects: [],
       router: {
-        location: {query: {version: '2'}},
         params: {orgId: 'org-slug'},
       },
     });


### PR DESCRIPTION
Requires [sentry#37301](https://github.com/getsentry/sentry/pull/37301)

Removes the `version:2` query from the request payload. The versioning was a temporary update to allow the audit log endpoint to add the audit log api names list to be included in the api response. 

Also adds `browserHistory` when filtering by an audit log event type to aid in sharing URL links to a filtered view of the audit log event entries.