### PR TITLE
bug(ui): Fix TextOverflow when there are special characters at the end of the string

### DIFF
--- a/docs-ui/stories/utilities/textOverflow.stories.js
+++ b/docs-ui/stories/utilities/textOverflow.stories.js
@@ -3,6 +3,8 @@ import TextOverflow from 'sentry/components/textOverflow';
 export default {
   title: 'Utilities/Text/Overflow',
   args: {
+    width: 150,
+    text: 'https://example.com/foo/',
     isParagraph: false,
     ellipsisDirection: 'right',
   },
@@ -16,9 +18,9 @@ export default {
   },
 };
 
-export const _TextOverflow = ({...args}) => (
-  <div style={{width: 50}}>
-    <TextOverflow {...args}>AReallyLongTextString</TextOverflow>
+export const _TextOverflow = ({text, width, ...args}) => (
+  <div style={{width}}>
+    <TextOverflow {...args}>{text}</TextOverflow>
   </div>
 );
 
@@ -30,4 +32,53 @@ _TextOverflow.parameters = {
         'Simple component that adds "text-overflow: ellipsis" and "overflow: hidden", still depends on container styles',
     },
   },
+};
+
+export const TestCases = () => {
+  const examples = [
+    {
+      width: 250,
+      text: 'https://example.com/foo/',
+      isParagraph: false,
+      ellipsisDirection: 'right',
+    },
+    {
+      width: 250,
+      text: 'https://example.com/foo/',
+      isParagraph: false,
+      ellipsisDirection: 'left',
+    },
+    {
+      width: 150,
+      text: 'https://example.com/foo/',
+      isParagraph: false,
+      ellipsisDirection: 'right',
+    },
+    {
+      width: 150,
+      text: 'https://example.com/foo/',
+      isParagraph: false,
+      ellipsisDirection: 'left',
+    },
+    {
+      width: 75,
+      text: 'Hello world',
+      isParagraph: false,
+      ellipsisDirection: 'right',
+    },
+    {
+      width: 75,
+      text: 'Hello world',
+      isParagraph: false,
+      ellipsisDirection: 'left',
+    },
+  ];
+
+  return (
+    <div>
+      {examples.map((props, i) => (
+        <_TextOverflow key={i} {...props} />
+      ))}
+    </div>
+  );
 };

--- a/static/app/components/textOverflow.tsx
+++ b/static/app/components/textOverflow.tsx
@@ -4,13 +4,38 @@ type Props = {
   children: React.ReactNode;
   className?: string;
   ['data-test-id']?: string;
+  /**
+   * Change which side of the text is elided.
+   * Default: 'right'
+   *
+   * BROWSER COMPAT:
+   * When set to `left` the intention is for something like: `...xample.com/foo/`
+   * In Chrome & Firefox this is what happens.
+   *
+   * In Safari (July 2022) you will see this instead: `...https://example.co`.
+   *
+   * See: https://stackoverflow.com/a/24800788
+   */
   ellipsisDirection?: 'left' | 'right';
   isParagraph?: boolean;
 };
 
 const TextOverflow = styled(
-  ({isParagraph, className, children, ['data-test-id']: dataTestId}: Props) => {
+  ({
+    children,
+    className,
+    ellipsisDirection,
+    isParagraph,
+    ['data-test-id']: dataTestId,
+  }: Props) => {
     const Component = isParagraph ? 'p' : 'div';
+    if (ellipsisDirection === 'left') {
+      return (
+        <Component className={className} data-test-id={dataTestId}>
+          <bdi>{children}</bdi>
+        </Component>
+      );
+    }
     return (
       <Component className={className} data-test-id={dataTestId}>
         {children}


### PR DESCRIPTION
Add `<bdi>` to better support special characters with `ellipsisDirection="left"`.

Tested in Firefox, Chrome and Safari. Notes below.

| | Before  | After |
| ------------- | ------------- | ------------- |
| Firefox | <img width="325" alt="Screen Shot 2022-08-01 at 11 46 22 AM" src="https://user-images.githubusercontent.com/187460/182221723-0c72dc45-bfab-4cfc-85df-f8e18c43bc5a.png"> | <img width="325" alt="Screen Shot 2022-08-01 at 11 45 38 AM" src="https://user-images.githubusercontent.com/187460/182221754-6efe79c1-47b1-4964-acb3-54f3b5132780.png"> |
| Chrome | <img width="325" alt="Screen Shot 2022-08-01 at 11 46 27 AM" src="https://user-images.githubusercontent.com/187460/182221799-20e4920c-dab0-4199-a761-c0fba6e02414.png"> | <img width="325" alt="Screen Shot 2022-08-01 at 11 45 45 AM" src="https://user-images.githubusercontent.com/187460/182221824-51512451-195d-42b3-8792-a615c8c45f6b.png"> |
| Safari | <img width="325" alt="Screen Shot 2022-08-01 at 11 46 14 AM" src="https://user-images.githubusercontent.com/187460/182221858-e4dd6af6-05af-4ce3-8283-884bb3525b8e.png"> | <img width="325" alt="Screen Shot 2022-08-01 at 11 45 30 AM" src="https://user-images.githubusercontent.com/187460/182221907-8f549661-fcfa-42fc-8767-b2fdb6199db8.png"> |


**All Browsers** in the 'before' screens would render special characters at the front of the string when `ellipsisDirection === 'left'` is true:

- Before: you'd see `/https://example.com/foo` which is not overflowing, but looks funny
- Before: you'd see `…/example.com/foo` which is missing the trailing slash, it's moved to the front and hidden
- After you'll see `https://example.com/foo/` without the overflow
- After you'll see `…example.com/foo/` with the trailing slash in it's correct spot.


**Safari** before wasn't cutting off the start of the string:

- Before you'd see: `…https://example.co`
- After it's still the same.


To date we're only using `ellipsisDirection="left"` for two purposes:
- Releases: used for eliding the `Package` name (two callsites)
- My new "don't call it a breadcrumb" breadcrumb component that truncates urls
    - https://github.com/getsentry/sentry/pull/37038
    - <img width="967" alt="181337211-b330496b-95fc-474e-8354-66bad35a532c" src="https://user-images.githubusercontent.com/187460/182227905-6a66e399-ebbe-4656-8ed7-2644a3e81a65.png">
 
In-App examples:

Here's a look at a new area inside sentry.io where we're listing the urls that the user visited, truncating on the left side. 

Before this change the trunaction moved those special characters to the left, which makes the urls look funny:
<img width="528" alt="Screen Shot 2022-08-04 at 10 53 23 AM" src="https://user-images.githubusercontent.com/187460/182918317-fc5f347e-127f-4888-a880-ee605f93dd26.png">

The intention is that if the strings are long they will be truncated on the left side, like this:
<img width="504" alt="Screen Shot 2022-08-04 at 10 53 48 AM" src="https://user-images.githubusercontent.com/187460/182918566-c970342b-a481-4561-ad17-62681b0d2d7a.png">

