### PR TITLE
feat(replays): new replays table column

### DIFF
--- a/static/app/components/replays/replayHighlight.tsx
+++ b/static/app/components/replays/replayHighlight.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
+import ScoreBar from 'sentry/components/scoreBar';
 import CHART_PALETTE from 'sentry/constants/chartPalette';
 import {ReplayDurationAndErrors} from 'sentry/views/replays/types';
-
-import ScoreBar from '../scoreBar';
 
 interface Props {
   data: ReplayDurationAndErrors | undefined;

--- a/static/app/components/replays/replayHighlight.tsx
+++ b/static/app/components/replays/replayHighlight.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import CHART_PALETTE from 'sentry/constants/chartPalette';
+import {ReplayDurationAndErrors} from 'sentry/views/replays/types';
+
+import ScoreBar from '../scoreBar';
+
+interface Props {
+  data: ReplayDurationAndErrors | undefined;
+}
+
+function replayHighlight({data}: Props) {
+  let score = 1;
+
+  if (data) {
+    // Mocked data 👇 - this will change with the new backend
+    const pagesVisited = 1;
+    const {count_if_event_type_equals_error: errors, 'equation[0]': durationInSeconds} =
+      data;
+
+    const pagesVisitedOverTime = pagesVisited / (durationInSeconds || 1);
+
+    score = (errors * 25 + pagesVisited * 5 + pagesVisitedOverTime) / 10;
+    score = Math.floor(Math.min(10, Math.max(1, score)));
+  }
+
+  const palette = new Array(10).fill([CHART_PALETTE[0][0]]);
+  return <ScoreBar size={20} score={score} palette={palette} radius={0} />;
+}
+
+export default replayHighlight;

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -6,6 +6,7 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import UserBadge from 'sentry/components/idBadge/userBadge';
 import Link from 'sentry/components/links/link';
 import Placeholder from 'sentry/components/placeholder';
+import ReplayHighlight from 'sentry/components/replays/replayHighlight';
 import {StringWalker} from 'sentry/components/replays/walker/urlWalker';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCalendar} from 'sentry/icons';
@@ -16,21 +17,15 @@ import theme from 'sentry/utils/theme';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {ReplayDiscoveryListItem} from 'sentry/views/replays/types';
+import {
+  ReplayDiscoveryListItem,
+  ReplayDurationAndErrors,
+} from 'sentry/views/replays/types';
 
 type Props = {
   idKey: string;
   replayList: ReplayDiscoveryListItem[];
   showProjectColumn?: boolean;
-};
-
-type ReplayDurationAndErrors = {
-  count_if_event_type_equals_error: number;
-  'equation[0]': number;
-  id: string;
-  max_timestamp: string;
-  min_timestamp: string;
-  replayId: string;
 };
 
 function ReplayTable({replayList, idKey, showProjectColumn}: Props) {
@@ -125,9 +120,15 @@ function ReplayTable({replayList, idKey, showProjectColumn}: Props) {
                   ? dataEntries[replay[idKey]]?.count_if_event_type_equals_error
                   : 0}
               </Item>
+              <Item>
+                <ReplayHighlight data={dataEntries[replay[idKey]]} />
+              </Item>
             </React.Fragment>
           ) : (
             <React.Fragment>
+              <Item>
+                <Placeholder height="24px" />
+              </Item>
               <Item>
                 <Placeholder height="24px" />
               </Item>

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -151,6 +151,7 @@ function Replays() {
                       </SortLink>,
                       t('Duration'),
                       t('Errors'),
+                      t('Interest'),
                     ]}
                   >
                     {data.tableData ? (
@@ -184,10 +185,10 @@ const StyledPageContent = styled(PageContent)`
 `;
 
 const StyledPanelTable = styled(PanelTable)`
-  grid-template-columns: minmax(0, 1fr) max-content max-content max-content max-content;
+  grid-template-columns: minmax(0, 1fr) max-content max-content max-content max-content max-content;
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: minmax(0, 1fr) max-content max-content max-content;
+    grid-template-columns: minmax(0, 1fr) max-content max-content max-content max-content;
   }
 `;
 

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -92,3 +92,15 @@ export interface ReplayError {
   ['project.name']: string;
   timestamp: string;
 }
+
+/**
+ * Replay custom discover query
+ */
+export type ReplayDurationAndErrors = {
+  count_if_event_type_equals_error: number;
+  'equation[0]': number;
+  id: string;
+  max_timestamp: string;
+  min_timestamp: string;
+  replayId: string;
+};


### PR DESCRIPTION

<!-- Describe your PR here. -->
Added a new column for the replays table at the index page, showing an icon of interest. Closes #37070 

![image](https://user-images.githubusercontent.com/39612839/182244849-76a35d07-cd8e-4904-ae35-2a9246af414c.png)



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
