### PR TITLE
feat(active-release): Add suspect releases to issue details

### DIFF
--- a/static/app/components/group/seenInfo.tsx
+++ b/static/app/components/group/seenInfo.tsx
@@ -33,13 +33,6 @@ class SeenInfo extends Component<Props> {
     return release?.version !== nextProps.release?.version || date !== nextProps.date;
   }
 
-  getReleaseTrackingUrl() {
-    const {organization, projectSlug} = this.props;
-    const orgSlug = organization.slug;
-
-    return `/settings/${orgSlug}/projects/${projectSlug}/release-tracking/`;
-  }
-
   render() {
     const {date, dateGlobal, environment, release, organization, projectSlug, projectId} =
       this.props;

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -200,7 +200,7 @@ class BaseGroupSidebar extends Component<Props, State> {
         />
 
         <Feature organization={organization} features={['active-release-monitor-alpha']}>
-          <SuspectReleases organization={organization} project={project} group={group} />
+          <SuspectReleases group={group} />
         </Feature>
 
         {event && (

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -6,6 +6,7 @@ import keyBy from 'lodash/keyBy';
 import pickBy from 'lodash/pickBy';
 
 import {Client} from 'sentry/api';
+import Feature from 'sentry/components/acl/feature';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalIssueList from 'sentry/components/group/externalIssuesList';
@@ -29,6 +30,7 @@ import {Event} from 'sentry/types/event';
 import withApi from 'sentry/utils/withApi';
 
 import SidebarSection from './sidebarSection';
+import SuspectReleases from './suspectReleases';
 
 type Props = {
   api: Client;
@@ -196,6 +198,10 @@ class BaseGroupSidebar extends Component<Props, State> {
           group={group}
           currentRelease={currentRelease}
         />
+
+        <Feature organization={organization} features={['active-release-monitor-alpha']}>
+          <SuspectReleases organization={organization} project={project} group={group} />
+        </Feature>
 
         {event && (
           <ErrorBoundary mini>

--- a/static/app/components/group/suspectReleases.tsx
+++ b/static/app/components/group/suspectReleases.tsx
@@ -35,6 +35,10 @@ class SuspectReleases extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
+    if (!this.state.suspectReleases) {
+      return null;
+    }
+
     return (
       <SidebarSection secondary title={t('Suspect Releases')}>
         {this.state.suspectReleases?.map(release => (

--- a/static/app/components/group/suspectReleases.tsx
+++ b/static/app/components/group/suspectReleases.tsx
@@ -17,20 +17,13 @@ type Props = AsyncComponent['props'] & {
 };
 
 type State = AsyncComponent['state'] & {
-  suspectReleases: {suspectReleases: Release[]} | null;
+  suspectReleases: Release[] | null;
 };
 
 class SuspectReleases extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {group} = this.props;
     return [['suspectReleases', `/issues/${group.id}/suspect-releases/`]];
-  }
-
-  getDefaultState(): State {
-    return {
-      ...super.getDefaultState(),
-      suspectReleases: null,
-    };
   }
 
   renderLoading() {
@@ -44,7 +37,7 @@ class SuspectReleases extends AsyncComponent<Props, State> {
   renderBody() {
     return (
       <SidebarSection secondary title={t('Suspect Releases')}>
-        {this.state.suspectReleases?.suspectReleases?.map(release => (
+        {this.state.suspectReleases?.map(release => (
           <SuspectReleaseWrapper key={release.version}>
             <div>
               <StyledVersion version={release.version} />

--- a/static/app/components/group/suspectReleases.tsx
+++ b/static/app/components/group/suspectReleases.tsx
@@ -35,7 +35,7 @@ class SuspectReleases extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    if (!this.state.suspectReleases) {
+    if (!this.state.suspectReleases?.length) {
       return null;
     }
 

--- a/static/app/components/group/suspectReleases.tsx
+++ b/static/app/components/group/suspectReleases.tsx
@@ -1,0 +1,91 @@
+import styled from '@emotion/styled';
+
+import AsyncComponent from 'sentry/components/asyncComponent';
+import Placeholder from 'sentry/components/placeholder';
+import Version from 'sentry/components/version';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import type {Group, Release} from 'sentry/types';
+
+import AvatarList from '../avatar/avatarList';
+import TimeSince from '../timeSince';
+
+import SidebarSection from './sidebarSection';
+
+type Props = AsyncComponent['props'] & {
+  group: Group;
+};
+
+type State = AsyncComponent['state'] & {
+  suspectReleases: {suspectReleases: Release[]} | null;
+};
+
+class SuspectReleases extends AsyncComponent<Props, State> {
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {group} = this.props;
+    return [['suspectReleases', `/issues/${group.id}/suspect-releases/`]];
+  }
+
+  getDefaultState(): State {
+    return {
+      ...super.getDefaultState(),
+      suspectReleases: null,
+    };
+  }
+
+  renderLoading() {
+    return (
+      <SidebarSection data-test-id="linked-issues" title={t('Linked Issues')}>
+        <Placeholder height="60px" />
+      </SidebarSection>
+    );
+  }
+
+  renderBody() {
+    return (
+      <SidebarSection secondary title={t('Suspect Releases')}>
+        {this.state.suspectReleases?.suspectReleases?.map(release => (
+          <SuspectReleaseWrapper key={release.version}>
+            <div>
+              <StyledVersion version={release.version} />
+              {release.lastDeploy && (
+                <ReleaseDeployedDate>
+                  {release.lastDeploy.environment
+                    ? t('Deployed to %s ', release.lastDeploy.environment)
+                    : t('Deployed ')}
+                  <TimeSince date={release.lastDeploy.dateFinished} />
+                </ReleaseDeployedDate>
+              )}
+            </div>
+            <AvatarList
+              users={release.authors}
+              avatarSize={25}
+              tooltipOptions={{container: 'body'} as any}
+              typeMembers="authors"
+            />
+          </SuspectReleaseWrapper>
+        ))}
+      </SidebarSection>
+    );
+  }
+}
+
+const SuspectReleaseWrapper = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  justify-content: space-between;
+  align-items: center;
+  line-height: 1.2;
+  margin: ${space(1.5)} 0;
+`;
+
+const StyledVersion = styled(Version)`
+  margin-bottom: ${space(0.75)};
+`;
+
+const ReleaseDeployedDate = styled('div')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  color: ${p => p.theme.subText};
+`;
+
+export default SuspectReleases;

--- a/tests/js/spec/components/group/suspectReleases.spec.jsx
+++ b/tests/js/spec/components/group/suspectReleases.spec.jsx
@@ -1,15 +1,31 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import SuspectReleases from 'sentry/components/group/suspectReleases';
 
 describe('SuspectReleases', () => {
+  const group = TestStubs.Group();
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
   it('displays a suspect release', async () => {
-    const group = TestStubs.Group();
     MockApiClient.addMockResponse({
       url: `/issues/${group.id}/suspect-releases/`,
       body: [TestStubs.Release({authors: [TestStubs.User()]})],
     });
     render(<SuspectReleases group={group} />);
     expect(await screen.findByText('1.2.0')).toBeInTheDocument();
+  });
+
+  it('hides when there are no suspect-releases', async () => {
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/suspect-releases/`,
+      body: [],
+    });
+    const wrapper = render(<SuspectReleases group={group} />);
+    await waitFor(() => {
+      expect(wrapper.container).toBeEmptyDOMElement();
+    });
   });
 });

--- a/tests/js/spec/components/group/suspectReleases.spec.jsx
+++ b/tests/js/spec/components/group/suspectReleases.spec.jsx
@@ -7,9 +7,7 @@ describe('SuspectReleases', () => {
     const group = TestStubs.Group();
     MockApiClient.addMockResponse({
       url: `/issues/${group.id}/suspect-releases/`,
-      body: {
-        suspectReleases: [TestStubs.Release({authors: [TestStubs.User()]})],
-      },
+      body: [TestStubs.Release({authors: [TestStubs.User()]})],
     });
     render(<SuspectReleases group={group} />);
     expect(await screen.findByText('1.2.0')).toBeInTheDocument();

--- a/tests/js/spec/components/group/suspectReleases.spec.jsx
+++ b/tests/js/spec/components/group/suspectReleases.spec.jsx
@@ -1,0 +1,17 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import SuspectReleases from 'sentry/components/group/suspectReleases';
+
+describe('SuspectReleases', () => {
+  it('displays a suspect release', async () => {
+    const group = TestStubs.Group();
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/suspect-releases/`,
+      body: {
+        suspectReleases: [TestStubs.Release({authors: [TestStubs.User()]})],
+      },
+    });
+    render(<SuspectReleases group={group} />);
+    expect(await screen.findByText('1.2.0')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Behind the `active-release-monitor-alpha` flag. Adds suspect releases to the issue details sidebar as part of active release

<img width="327" alt="Screen Shot 2022-07-29 at 5 21 23 PM" src="https://user-images.githubusercontent.com/1400464/182240765-1a44db39-cdf7-434f-acf3-8f34a8db605b.png">

