### PR TITLE
fix(replays): Use Tooltip in Network Table "Path" column

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 import {PanelTable, PanelTableHeader} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {showPlayerTime} from 'sentry/components/replays/utils';
+import Tooltip from 'sentry/components/tooltip';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import theme from 'sentry/utils/theme';
 import {
   ISortConfig,
   NetworkSpan,
@@ -91,8 +91,16 @@ function NetworkList({replayRecord, networkSpans}: Props) {
     return (
       <Fragment key={index}>
         <Item>{<StatusPlaceHolder height="20px" />}</Item>
-        <Item color={theme.gray400}>
-          <Text>{network.description || <Placeholder height="24px" />}</Text>
+        <Item color="gray400">
+          <Tooltip
+            title={network.description}
+            isHoverable
+            overlayStyle={{
+              maxWidth: '500px !important',
+            }}
+          >
+            <Text>{network.description || <Placeholder height="24px" />}</Text>
+          </Tooltip>
         </Item>
         <Item>
           <Text>{network.op}</Text>
@@ -123,7 +131,7 @@ const Item = styled('div')<{color?: string; numeric?: boolean}>`
   display: flex;
   align-items: center;
   max-height: 28px;
-  color: ${p => p.color || p.theme.subText};
+  color: ${({theme, color}) => (color ? theme[color] || theme.subText : theme.subText)};
   border-radius: 0;
   padding: ${space(0.75)} ${space(1.5)};
   background-color: ${p => p.theme.background};

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -103,7 +103,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
               <Text>{network.description}</Text>
             </Tooltip>
           ) : (
-            <Text italic>{t('No description')}</Text>
+            <Text italic>({t('No description')})</Text>
           )}
         </Item>
         <Item>

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -103,7 +103,9 @@ function NetworkList({replayRecord, networkSpans}: Props) {
               <Text>{network.description}</Text>
             </Tooltip>
           ) : (
-            <Text italic>({t('No description')})</Text>
+            <Text italic dimmed>
+              ({t('No description')})
+            </Text>
           )}
         </Item>
         <Item>
@@ -194,13 +196,14 @@ const StatusPlaceHolder = styled(Placeholder)`
   max-width: 40px;
 `;
 
-const Text = styled('p')<{italic?: boolean}>`
+const Text = styled('p')<{dimmed?: boolean; italic?: boolean}>`
   padding: 0;
   margin: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
   ${p => p.italic && 'font-style: italic;'}
+  ${p => p.dimmed && `color: ${p.theme.subText};`}
 `;
 
 const SortItem = styled('span')`

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -92,15 +92,19 @@ function NetworkList({replayRecord, networkSpans}: Props) {
       <Fragment key={index}>
         <Item>{<StatusPlaceHolder height="20px" />}</Item>
         <Item color="gray400">
-          <Tooltip
-            title={network.description}
-            isHoverable
-            overlayStyle={{
-              maxWidth: '500px !important',
-            }}
-          >
-            <Text>{network.description || <Placeholder height="24px" />}</Text>
-          </Tooltip>
+          {network.description ? (
+            <Tooltip
+              title={network.description}
+              isHoverable
+              overlayStyle={{
+                maxWidth: '500px !important',
+              }}
+            >
+              <Text>{network.description}</Text>
+            </Tooltip>
+          ) : (
+            <Placeholder height="24px" />
+          )}
         </Item>
         <Item>
           <Text>{network.op}</Text>

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -103,9 +103,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
               <Text>{network.description}</Text>
             </Tooltip>
           ) : (
-            <Text italic dimmed>
-              ({t('No description')})
-            </Text>
+            <EmptyText>({t('No description')})</EmptyText>
           )}
         </Item>
         <Item>
@@ -196,14 +194,17 @@ const StatusPlaceHolder = styled(Placeholder)`
   max-width: 40px;
 `;
 
-const Text = styled('p')<{dimmed?: boolean; italic?: boolean}>`
+const Text = styled('p')`
   padding: 0;
   margin: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
-  ${p => p.italic && 'font-style: italic;'}
-  ${p => p.dimmed && `color: ${p.theme.subText};`}
+`;
+
+const EmptyText = styled(Text)`
+  font-style: italic;
+  color: ${p => p.theme.subText};
 `;
 
 const SortItem = styled('span')`

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -8,6 +8,7 @@ import Tooltip from 'sentry/components/tooltip';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import {ColorOrAlias} from 'sentry/utils/theme';
 import {
   ISortConfig,
   NetworkSpan,
@@ -90,7 +91,9 @@ function NetworkList({replayRecord, networkSpans}: Props) {
 
     return (
       <Fragment key={index}>
-        <Item center>{<StatusPlaceHolder height="20px" />}</Item>
+        <Item center>
+          <StatusPlaceHolder height="20px" />
+        </Item>
         <Item color="gray400">
           {network.description ? (
             <Tooltip
@@ -103,7 +106,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
               <Text>{network.description}</Text>
             </Tooltip>
           ) : (
-            <EmptyText>({t('No description')})</EmptyText>
+            <EmptyText>({t('Missing path')})</EmptyText>
           )}
         </Item>
         <Item>
@@ -131,17 +134,14 @@ function NetworkList({replayRecord, networkSpans}: Props) {
   );
 }
 
-const Item = styled('div')<{center?: boolean; color?: string; numeric?: boolean}>`
+const Item = styled('div')<{center?: boolean; color?: ColorOrAlias; numeric?: boolean}>`
   display: flex;
   align-items: center;
   ${p => p.center && 'justify-content: center;'}
   max-height: 28px;
-  color: ${({theme, color}) => theme[color || ''] ?? theme.subText};
-  border-radius: 0;
+  color: ${p => p.theme[p.color || 'subText']};
   padding: ${space(0.75)} ${space(1.5)};
   background-color: ${p => p.theme.background};
-  min-width: 0;
-  line-height: 16px;
 
   ${p => p.numeric && 'font-variant-numeric: tabular-nums;'}
 `;

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -90,7 +90,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
 
     return (
       <Fragment key={index}>
-        <Item>{<StatusPlaceHolder height="20px" />}</Item>
+        <Item center>{<StatusPlaceHolder height="20px" />}</Item>
         <Item color="gray400">
           {network.description ? (
             <Tooltip
@@ -103,7 +103,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
               <Text>{network.description}</Text>
             </Tooltip>
           ) : (
-            <Placeholder height="24px" />
+            <Text italic>{t('No description')}</Text>
           )}
         </Item>
         <Item>
@@ -131,11 +131,12 @@ function NetworkList({replayRecord, networkSpans}: Props) {
   );
 }
 
-const Item = styled('div')<{color?: string; numeric?: boolean}>`
+const Item = styled('div')<{center?: boolean; color?: string; numeric?: boolean}>`
   display: flex;
   align-items: center;
+  ${p => p.center && 'justify-content: center;'}
   max-height: 28px;
-  color: ${({theme, color}) => (color ? theme[color] || theme.subText : theme.subText)};
+  color: ${({theme, color}) => theme[color || ''] ?? theme.subText};
   border-radius: 0;
   padding: ${space(0.75)} ${space(1.5)};
   background-color: ${p => p.theme.background};
@@ -193,12 +194,13 @@ const StatusPlaceHolder = styled(Placeholder)`
   max-width: 40px;
 `;
 
-const Text = styled('p')`
+const Text = styled('p')<{italic?: boolean}>`
   padding: 0;
   margin: 0;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  ${p => p.italic && 'font-style: italic;'}
 `;
 
 const SortItem = styled('span')`


### PR DESCRIPTION
<!-- Describe your PR here. -->
### Changes
- Added tooltip for the column "Path" in the network table in order to show text that is too long. 
- Fixed colors for dark theme

Closes #37192
Closes #37239


![image](https://user-images.githubusercontent.com/39612839/182405110-959a6113-a241-4b7f-ba9e-b4dfc6570237.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
