### PR TITLE
ref(issues): Revert padding changes to DataSection

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -22,6 +22,7 @@ import EventGroupingInfo from 'sentry/components/events/groupingInfo';
 import EventPackageData from 'sentry/components/events/packageData';
 import RRWebIntegration from 'sentry/components/events/rrwebIntegration';
 import EventSdkUpdates from 'sentry/components/events/sdkUpdates';
+import {DataSection} from 'sentry/components/events/styles';
 import EventUserFeedback from 'sentry/components/events/userFeedback';
 import LazyLoad from 'sentry/components/lazyLoad';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -352,7 +353,7 @@ const EventEntries = memo(
     const hasErrors = !objectIsEmpty(event.errors) || !!proGuardErrors.length;
 
     return (
-      <Wrap className={className} data-test-id={`event-entries-loading-${isLoading}`}>
+      <div className={className} data-test-id={`event-entries-loading-${isLoading}`}>
         {hasErrors && !isLoading && (
           <EventErrors
             event={event}
@@ -452,19 +453,10 @@ const EventEntries = memo(
             projectSlug={projectSlug}
           />
         )}
-      </Wrap>
+      </div>
     );
   }
 );
-
-const Wrap = styled('div')`
-  /* Padding aligns with Layout.Body */
-  padding: 0 ${space(4)};
-
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    padding: 0 ${space(2)};
-  }
-`;
 
 const StyledEventDataSection = styled(EventDataSection)`
   /* Hiding the top border because of the event section appears at this breakpoint */
@@ -479,16 +471,28 @@ const LatestEventNotAvailable = styled('div')`
   padding: ${space(2)} ${space(4)};
 `;
 
-const BorderlessEventEntries = styled(EventEntries)`
-  padding: 0;
-
-  & > div:first-child {
-    padding-top: 0;
+const ErrorContainer = styled('div')`
+  /*
+  Remove border on adjacent context summary box.
+  Once that component uses emotion this will be harder.
+  */
+  & + .context-summary {
     border-top: none;
   }
+`;
 
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    padding: 0;
+const BorderlessEventEntries = styled(EventEntries)`
+  & ${/* sc-selector */ DataSection} {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    padding: ${space(3)} 0 0 0;
+  }
+  & ${/* sc-selector */ DataSection}:first-child {
+    padding-top: 0;
+    border-top: 0;
+  }
+  & ${/* sc-selector */ ErrorContainer} {
+    margin-bottom: ${space(2)};
   }
 `;
 

--- a/static/app/components/events/styles.tsx
+++ b/static/app/components/events/styles.tsx
@@ -6,15 +6,14 @@ import {Theme} from 'sentry/utils/theme';
 export const DataSection = styled('div')`
   display: flex;
   flex-direction: column;
-  margin: 0;
   border-top: 1px solid ${p => p.theme.innerBorder};
+  margin: 0;
 
   /* Padding aligns with Layout.Body */
-  padding-top: ${space(3)};
-  padding-bottom: ${space(2)};
+  padding: ${space(3)} ${space(2)} ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    padding-bottom: ${space(3)};
+    padding: ${space(3)} ${space(4)} ${space(3)};
   }
 `;
 

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -182,16 +182,7 @@ const StyledDataSection = styled(DataSection)`
   /* Fixes tooltips in toolbar having lower z-index than .btn-group .btn.active */
   z-index: 3;
 
-  /* Padding aligns with Layout.Body */
-  padding-left: ${space(4)};
-  padding-right: ${space(4)};
-
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    padding-left: ${space(2)};
-    padding-right: ${space(2)};
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
+  @media (max-width: 767px) {
     display: none;
   }
 `;


### PR DESCRIPTION
Revert https://github.com/getsentry/sentry/pull/36934. I'll find a different way to fix the original alert padding issue without changing `DataSection`'s paddings.