### PR TITLE
Add errors bool to serializer

### DIFF
--- a/src/sentry/api/endpoints/integrations/sentry_apps/components.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/components.py
@@ -23,7 +23,7 @@ class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
             request=request,
             queryset=sentry_app.components.all(),
             paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: serialize(x, request.user, errors=[]),
         )
 
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/components.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/components.py
@@ -40,6 +40,7 @@ class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
             return Response([], status=404)
 
         components = []
+        errors = []
 
         for install in SentryAppInstallation.objects.get_installed_for_organization(
             organization.id
@@ -54,13 +55,14 @@ class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
                     sentry_app_components.Preparer.run(
                         component=component, install=install, project=project
                     )
-                    components.append(component)
                 except APIError:
-                    continue
+                    errors.append(str(component.uuid))
+
+                components.append(component)
 
         return self.paginate(
             request=request,
             queryset=components,
             paginator_cls=OffsetPaginator,
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: serialize(x, request.user, errors=errors),
         )

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -5,11 +5,12 @@ from sentry.models import SentryAppComponent
 
 @register(SentryAppComponent)
 class SentryAppComponentSerializer(Serializer):
-    def serialize(self, obj, attrs, user):
+    def serialize(self, obj, attrs, user, errors):
         return {
             "uuid": str(obj.uuid),
             "type": obj.type,
             "schema": obj.schema,
+            "error": True if str(obj.uuid) in errors else False,
             "sentryApp": {
                 "uuid": obj.sentry_app.uuid,
                 "slug": obj.sentry_app.slug,

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -37,6 +37,7 @@ class SentryAppComponentsTest(APITestCase):
             "uuid": str(self.component.uuid),
             "type": "issue-link",
             "schema": self.component.schema,
+            "error": False,
             "sentryApp": {
                 "uuid": self.sentry_app.uuid,
                 "slug": self.sentry_app.slug,
@@ -99,6 +100,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
             "uuid": str(self.component1.uuid),
             "type": "issue-link",
             "schema": self.component1.schema,
+            "error": False,
             "sentryApp": {
                 "uuid": self.sentry_app1.uuid,
                 "slug": self.sentry_app1.slug,
@@ -111,6 +113,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
             "uuid": str(self.component2.uuid),
             "type": "issue-link",
             "schema": self.component2.schema,
+            "error": False,
             "sentryApp": {
                 "uuid": self.sentry_app2.uuid,
                 "slug": self.sentry_app2.slug,
@@ -153,6 +156,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
                 "uuid": str(component.uuid),
                 "type": "alert-rule",
                 "schema": component.schema,
+                "error": False,
                 "sentryApp": {
                     "uuid": sentry_app.uuid,
                     "slug": sentry_app.slug,
@@ -181,18 +185,31 @@ class OrganizationSentryAppComponentsTest(APITestCase):
             self.org.slug, qs_params={"projectId": self.project.id}
         )
 
-        # Does not include self.component1 data, because it raised an exception
+        # self.component1 data contains an error, because it raised an exception
         # during preparation.
         assert response.data == [
+            {
+                "uuid": str(self.component1.uuid),
+                "type": self.component1.type,
+                "schema": self.component1.schema,
+                "error": True,
+                "sentryApp": {
+                    "uuid": self.sentry_app1.uuid,
+                    "slug": self.sentry_app1.slug,
+                    "name": self.sentry_app1.name,
+                    "avatars": get_sentry_app_avatars(self.sentry_app1),
+                },
+            },
             {
                 "uuid": str(self.component2.uuid),
                 "type": self.component2.type,
                 "schema": self.component2.schema,
+                "error": False,
                 "sentryApp": {
                     "uuid": self.sentry_app2.uuid,
                     "slug": self.sentry_app2.slug,
                     "name": self.sentry_app2.name,
                     "avatars": get_sentry_app_avatars(self.sentry_app2),
                 },
-            }
+            },
         ]


### PR DESCRIPTION
Add a boolean to the `SentryAppComponentSerializer` showing whether or not there was an error with the 3rd party service. Once this is merged the front end can use this information to conditionally disable the issue link in the sidebar. See https://getsentry.atlassian.net/browse/API-2776