### PR TITLE
fix(stack-trace-header): Full stack trace toggle not enabled

### DIFF
--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -89,7 +89,7 @@ export function TraceEventDataSection({
 
   const [state, setState] = useState<State>({
     sortBy: recentFirst ? 'recent-first' : 'recent-last',
-    fullStackTrace,
+    fullStackTrace: !hasAppOnlyFrames ? true : fullStackTrace,
     display: [],
   });
 
@@ -215,6 +215,7 @@ export function TraceEventDataSection({
                     name="full-stack-trace-toggler"
                     label={t('Full stack trace')}
                     hideControlState
+                    disabled={!hasAppOnlyFrames}
                     value={state.fullStackTrace}
                     onChange={() =>
                       setState({


### PR DESCRIPTION
**What this PR does:**

- Enable the full stack trace when there are no app frames available 

**Before:**

![image](https://user-images.githubusercontent.com/29228205/182354138-9a2ddbf0-4c14-46e8-8ee6-658592cf78e0.png)

**After:**

![image](https://user-images.githubusercontent.com/29228205/182354177-25643bee-a7ee-47cc-87c9-4890e0dc071c.png)
