### PR TITLE
ref(message-interface): Replace getMeta (proxy) with _meta object - [TET-144]

### DIFF
--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -4,7 +4,7 @@ import DebugMeta from 'sentry/components/events/interfaces/debugMeta';
 import Exception from 'sentry/components/events/interfaces/exception';
 import ExceptionV2 from 'sentry/components/events/interfaces/exceptionV2';
 import {Generic} from 'sentry/components/events/interfaces/generic';
-import Message from 'sentry/components/events/interfaces/message';
+import {Message} from 'sentry/components/events/interfaces/message';
 import Request from 'sentry/components/events/interfaces/request';
 import Spans from 'sentry/components/events/interfaces/spans';
 import StackTrace from 'sentry/components/events/interfaces/stackTrace';
@@ -70,7 +70,7 @@ function EventEntry({
     }
     case EntryType.MESSAGE: {
       const {data} = entry;
-      return <Message data={data} />;
+      return <Message data={data} meta={event._meta?.message ?? {}} />;
     }
     case EntryType.REQUEST: {
       const {data, type} = entry;

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -70,7 +70,7 @@ function EventEntry({
     }
     case EntryType.MESSAGE: {
       const {data} = entry;
-      return <Message data={data} meta={event._meta?.message ?? {}} />;
+      return <Message data={data} event={event} />;
     }
     case EntryType.REQUEST: {
       const {data, type} = entry;

--- a/static/app/components/events/interfaces/message.tsx
+++ b/static/app/components/events/interfaces/message.tsx
@@ -2,6 +2,7 @@ import EventDataSection from 'sentry/components/events/eventDataSection';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
 import AnnotatedText from 'sentry/components/events/meta/annotatedText';
 import {t} from 'sentry/locale';
+import {EntryType, Event} from 'sentry/types';
 import {objectIsEmpty} from 'sentry/utils';
 
 type Props = {
@@ -9,10 +10,15 @@ type Props = {
     formatted: string | null;
     params?: Record<string, any> | any[] | null;
   };
-  meta?: Record<any, any>;
+  event: Event;
 };
 
-export function Message({data, meta}: Props) {
+export function Message({data, event}: Props) {
+  const messageEntryIndex = event.entries.findIndex(
+    entry => entry.type === EntryType.MESSAGE
+  );
+  const meta = event?._meta?.entries?.[messageEntryIndex] ?? {};
+
   function renderParams() {
     const params = data?.params;
 

--- a/static/app/components/events/interfaces/message.tsx
+++ b/static/app/components/events/interfaces/message.tsx
@@ -6,8 +6,8 @@ import {objectIsEmpty} from 'sentry/utils';
 
 type Props = {
   data: {
-    formatted: string;
-    params?: Record<string, any> | any[];
+    formatted: string | null;
+    params?: Record<string, any> | any[] | null;
   };
   meta?: Record<any, any>;
 };

--- a/static/app/components/events/interfaces/message.tsx
+++ b/static/app/components/events/interfaces/message.tsx
@@ -1,7 +1,6 @@
 import EventDataSection from 'sentry/components/events/eventDataSection';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import Annotated from 'sentry/components/events/meta/annotated';
-import {getMeta} from 'sentry/components/events/meta/metaProxy';
+import AnnotatedText from 'sentry/components/events/meta/annotatedText';
 import {t} from 'sentry/locale';
 import {objectIsEmpty} from 'sentry/utils';
 
@@ -10,10 +9,11 @@ type Props = {
     formatted: string;
     params?: Record<string, any> | any[];
   };
+  meta?: Record<any, any>;
 };
 
-const Message = ({data}: Props) => {
-  const renderParams = () => {
+export function Message({data, meta}: Props) {
+  function renderParams() {
     const params = data?.params;
 
     if (!params || objectIsEmpty(params)) {
@@ -32,6 +32,7 @@ const Message = ({data}: Props) => {
           key,
           value,
           subject: key,
+          meta: meta?.data?.params?.[i]?.[''],
         };
       });
 
@@ -42,20 +43,20 @@ const Message = ({data}: Props) => {
       key,
       value,
       subject: key,
-      meta: getMeta(params, key),
+      meta: meta?.data?.params?.[key]?.[''],
     }));
 
     return <KeyValueList data={objectData} isSorted={false} isContextData />;
-  };
+  }
 
   return (
     <EventDataSection type="message" title={t('Message')}>
-      <Annotated object={data} objectKey="formatted">
-        {value => <pre className="plain">{value}</pre>}
-      </Annotated>
+      {meta?.data?.formatted?.[''] ? (
+        <AnnotatedText value={data.formatted} meta={meta?.data?.formatted?.['']} />
+      ) : (
+        <pre className="plain">{data.formatted}</pre>
+      )}
       {renderParams()}
     </EventDataSection>
   );
-};
-
-export default Message;
+}

--- a/tests/js/spec/components/events/interfaces/message.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/message.spec.tsx
@@ -1,0 +1,27 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {Message} from 'sentry/components/events/interfaces/message';
+
+describe('Message entry', function () {
+  it('display redacted data', async function () {
+    const event = {
+      ...TestStubs.Event(),
+      _meta: {
+        message: {
+          data: {
+            formatted: {'': {rem: [['project:1', 'x']]}},
+          },
+        },
+      },
+    };
+    render(<Message data={{formatted: null}} meta={event._meta.message} />);
+
+    expect(screen.getByText(/redacted/)).toBeInTheDocument();
+
+    userEvent.hover(screen.getByText(/redacted/));
+
+    expect(
+      await screen.findByText('Removed because of PII rule "project:1"')
+    ).toBeInTheDocument(); // tooltip description
+  });
+});

--- a/tests/js/spec/components/events/interfaces/message.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/message.spec.tsx
@@ -6,15 +6,25 @@ describe('Message entry', function () {
   it('display redacted data', async function () {
     const event = {
       ...TestStubs.Event(),
-      _meta: {
-        message: {
+      entries: [
+        {
+          type: 'message',
           data: {
-            formatted: {'': {rem: [['project:1', 'x']]}},
+            formatted: null,
+          },
+        },
+      ],
+      _meta: {
+        entries: {
+          0: {
+            data: {
+              formatted: {'': {rem: [['project:1', 'x']]}},
+            },
           },
         },
       },
     };
-    render(<Message data={{formatted: null}} meta={event._meta.message} />);
+    render(<Message data={{formatted: null}} event={event} />);
 
     expect(screen.getByText(/redacted/)).toBeInTheDocument();
 


### PR DESCRIPTION
**What this PR does:**

- Replace getMeta in the message interface with event._meta object
- Add test

**Preview:**

![image](https://user-images.githubusercontent.com/29228205/182380369-c7e2ef78-c72d-4fca-a932-8cf005378692.png)
