### PR TITLE
ref(package-data): Replace getMeta (proxy) with _meta object - [TET-144]

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -19,7 +19,7 @@ import EventExtraData from 'sentry/components/events/eventExtraData/eventExtraDa
 import EventSdk from 'sentry/components/events/eventSdk';
 import {EventTags} from 'sentry/components/events/eventTags';
 import EventGroupingInfo from 'sentry/components/events/groupingInfo';
-import EventPackageData from 'sentry/components/events/packageData';
+import {EventPackageData} from 'sentry/components/events/packageData';
 import RRWebIntegration from 'sentry/components/events/rrwebIntegration';
 import EventSdkUpdates from 'sentry/components/events/sdkUpdates';
 import EventUserFeedback from 'sentry/components/events/userFeedback';

--- a/static/app/components/events/packageData.tsx
+++ b/static/app/components/events/packageData.tsx
@@ -1,10 +1,7 @@
-import {Component} from 'react';
-
 import ClippedBox from 'sentry/components/clippedBox';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import EventDataSection from 'sentry/components/events/eventDataSection';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import {getMeta} from 'sentry/components/events/meta/metaProxy';
 import {t} from 'sentry/locale';
 import {Event} from 'sentry/types/event';
 
@@ -12,41 +9,33 @@ type Props = {
   event: Event;
 };
 
-class EventPackageData extends Component<Props> {
-  shouldComponentUpdate(nextProps: Props) {
-    return this.props.event.id !== nextProps.event.id;
+export function EventPackageData({event}: Props) {
+  let longKeys: boolean, title: string;
+
+  const packages = Object.entries(event.packages || {}).map(([key, value]) => ({
+    key,
+    value,
+    subject: key,
+    meta: event._meta?.packages?.[key]?.[''],
+  }));
+
+  switch (event.platform) {
+    case 'csharp':
+      longKeys = true;
+      title = t('Assemblies');
+      break;
+    default:
+      longKeys = false;
+      title = t('Packages');
   }
 
-  render() {
-    const {event} = this.props;
-    let longKeys: boolean, title: string;
-    const packages = Object.entries(event.packages || {}).map(([key, value]) => ({
-      key,
-      value,
-      subject: key,
-      meta: getMeta(event.packages, key),
-    }));
-
-    switch (event.platform) {
-      case 'csharp':
-        longKeys = true;
-        title = t('Assemblies');
-        break;
-      default:
-        longKeys = false;
-        title = t('Packages');
-    }
-
-    return (
-      <EventDataSection type="packages" title={title}>
-        <ClippedBox>
-          <ErrorBoundary mini>
-            <KeyValueList data={packages} longKeys={longKeys} />
-          </ErrorBoundary>
-        </ClippedBox>
-      </EventDataSection>
-    );
-  }
+  return (
+    <EventDataSection type="packages" title={title}>
+      <ClippedBox>
+        <ErrorBoundary mini>
+          <KeyValueList data={packages} longKeys={longKeys} />
+        </ErrorBoundary>
+      </ClippedBox>
+    </EventDataSection>
+  );
 }
-
-export default EventPackageData;

--- a/tests/js/spec/components/events/packageData.spec.tsx
+++ b/tests/js/spec/components/events/packageData.spec.tsx
@@ -1,0 +1,35 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {EventPackageData} from 'sentry/components/events/packageData';
+
+describe('EventPackageData', function () {
+  it('display redacted data', async function () {
+    const event = {
+      ...TestStubs.Event(),
+      packages: {
+        certifi: '',
+        pip: '18.0',
+        python: '2.7.15',
+        'sentry-sdk': '0.3.1',
+        setuptools: '40.0.0',
+        urllib3: '1.23',
+        wheel: '0.31.1',
+        wsgiref: '0.1.2',
+      },
+      _meta: {
+        packages: {
+          certifi: {'': {rem: [['project:1', 'x']]}},
+        },
+      },
+    };
+    render(<EventPackageData event={event} />);
+
+    expect(screen.getByText(/redacted/)).toBeInTheDocument();
+
+    userEvent.hover(screen.getByText(/redacted/));
+
+    expect(
+      await screen.findByText('Removed because of PII rule "project:1"')
+    ).toBeInTheDocument(); // tooltip description
+  });
+});


### PR DESCRIPTION
Tried to redact the data but didn't manage it.

No package rule is suggested in the data scrubber modal at all and the usage of `*` was not possible as the server refused the rule.

**What this PR does:**

- Replace getMeta in the packageData interface with event._meta object
- Add test