### PR TITLE
feat(alerts): remove default action experiment

### DIFF
--- a/static/app/data/experimentConfig.tsx
+++ b/static/app/data/experimentConfig.tsx
@@ -14,12 +14,6 @@ export const unassignedValue = -1;
  */
 export const experimentList = [
   {
-    key: 'DefaultIssueAlertActionExperiment',
-    type: ExperimentType.Organization,
-    parameter: 'exposed',
-    assignments: [0, 1],
-  },
-  {
     key: 'MetricAlertBannerExperiment',
     type: ExperimentType.Organization,
     parameter: 'exposed',

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -82,11 +82,6 @@ type FirstPartyIntegrationAdditionalCTAProps = {
 
 type GuideUpdateCallback = (nextGuide: Guide | null, opts: {dismissed?: boolean}) => void;
 
-type DefaultAlertRuleActionHook = (
-  callback: (showDefaultAction: boolean) => void,
-  organization: Organization
-) => void;
-
 type CodeOwnersCTAProps = {
   organization: Organization;
   project: Project;
@@ -224,7 +219,6 @@ export type SettingsHooks = {
  * and perform some sort of callback logic
  */
 type CallbackHooks = {
-  'callback:default-action-alert-rule': DefaultAlertRuleActionHook;
   'callback:on-guide-update': GuideUpdateCallback;
 };
 

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -35,8 +35,6 @@ import {Panel, PanelBody} from 'sentry/components/panels';
 import {ALL_ENVIRONMENTS_KEY} from 'sentry/constants';
 import {IconChevron} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
-import HookStore from 'sentry/stores/hookStore';
 import space from 'sentry/styles/space';
 import {
   Environment,
@@ -59,7 +57,6 @@ import {getDisplayName} from 'sentry/utils/environment';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import routeTitleGen from 'sentry/utils/routeTitle';
-import withExperiment from 'sentry/utils/withExperiment';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
 import {
@@ -118,9 +115,7 @@ type RuleTaskResponse = {
 type RouteParams = {orgId: string; projectId?: string; ruleId?: string};
 
 type Props = {
-  experimentAssignment: 0 | 1;
   location: Location;
-  logExperiment: () => void;
   organization: Organization;
   project: Project;
   projects: Project[];
@@ -164,44 +159,6 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
   componentWillUnmount() {
     window.clearTimeout(this.pollingTimeout);
-  }
-
-  componentDidMount() {
-    const {params, organization, experimentAssignment, logExperiment} = this.props;
-    // only new rules
-    if (params.ruleId) {
-      return;
-    }
-    // check if there is a callback registered
-    const callback = HookStore.get('callback:default-action-alert-rule')[0];
-    if (!callback) {
-      return;
-    }
-    // let hook decide when we want to select a default alert rule
-    callback((showDefaultAction: boolean) => {
-      if (showDefaultAction) {
-        const user = ConfigStore.get('user');
-        const {rule} = this.state;
-        // always log the experiment if we meet the basic requirements decided by the hook
-        logExperiment();
-        if (experimentAssignment) {
-          // this will add a default alert rule action
-          // to send notifications in
-          this.setState({
-            rule: {
-              ...rule,
-              actions: [
-                {
-                  id: 'sentry.mail.actions.NotifyEmailAction',
-                  targetIdentifier: user.id,
-                  targetType: 'Member',
-                } as any, // Need to fix IssueAlertRuleAction typing
-              ],
-            } as UnsavedIssueAlertRule,
-          });
-        }
-      }
-    }, organization);
   }
 
   componentDidUpdate(_prevProps: Props, prevState: State) {
@@ -1211,10 +1168,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   }
 }
 
-export default withExperiment(withOrganization(withProjects(IssueRuleEditor)), {
-  experiment: 'DefaultIssueAlertActionExperiment',
-  injectLogExperiment: true,
-});
+export default withOrganization(withProjects(IssueRuleEditor));
 
 // TODO(ts): Understand why styled is not correctly inheriting props here
 const StyledForm = styled(Form)<Form['props']>`


### PR DESCRIPTION
This PR removes the experiment where we auto-populated a default action for alerts. This wasn't helping generate higher quality alerts so we can remove the experiment.