### PR TITLE
fix(profiling): Retry the request if vroom returns a bad gateway error

### DIFF
--- a/src/sentry/utils/profiling.py
+++ b/src/sentry/utils/profiling.py
@@ -48,6 +48,7 @@ _profiling_pool = connection_from_url(
     settings.SENTRY_PROFILING_SERVICE_URL,
     retries=RetrySkipTimeout(
         total=3,
+        status_forcelist={502},
         allowed_methods={"GET", "POST"},
     ),
     timeout=30,


### PR DESCRIPTION
`vroom` will return a `502 Bad Gateway` status when GCS returns an error with this PR https://github.com/getsentry/vroom/pull/47.

Those are transient errors we should retry.