### PR TITLE
feat(dashboard): Fetch releases on filter

### DIFF
--- a/static/app/views/dashboardsV2/releasesSelectControl.tsx
+++ b/static/app/views/dashboardsV2/releasesSelectControl.tsx
@@ -1,9 +1,11 @@
 import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import debounce from 'lodash/debounce';
 
 import Badge from 'sentry/components/badge';
 import CompactSelect from 'sentry/components/forms/compactSelect';
 import TextOverflow from 'sentry/components/textOverflow';
+import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconReleases} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useReleases} from 'sentry/utils/releases/releasesProvider';
@@ -23,7 +25,7 @@ function ReleasesSelectControl({
   className,
   isDisabled,
 }: Props) {
-  const {releases, loading} = useReleases();
+  const {releases, loading, onSearch} = useReleases();
   const [activeReleases, setActiveReleases] = useState<string[]>(selectedReleases);
 
   useEffect(() => {
@@ -45,6 +47,9 @@ function ReleasesSelectControl({
       isLoading={loading}
       menuTitle={t('Filter Releases')}
       className={className}
+      onInputChange={debounce(val => {
+        void onSearch(val);
+      }, DEFAULT_DEBOUNCE_DURATION)}
       options={
         releases.length
           ? releases.map(release => {

--- a/static/app/views/dashboardsV2/releasesSelectControl.tsx
+++ b/static/app/views/dashboardsV2/releasesSelectControl.tsx
@@ -48,7 +48,7 @@ function ReleasesSelectControl({
       menuTitle={t('Filter Releases')}
       className={className}
       onInputChange={debounce(val => {
-        void onSearch(val);
+        onSearch(val);
       }, DEFAULT_DEBOUNCE_DURATION)}
       options={
         releases.length

--- a/tests/js/spec/views/dashboardsV2/releasesSelectControl.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/releasesSelectControl.spec.tsx
@@ -1,9 +1,9 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ReleasesContext} from 'sentry/utils/releases/releasesProvider';
 import ReleasesSelectControl from 'sentry/views/dashboardsV2/releasesSelectControl';
 
-function renderReleasesSelect() {
+function renderReleasesSelect(onSearch?: (searchTerm: string) => void) {
   render(
     <ReleasesContext.Provider
       value={{
@@ -22,6 +22,7 @@ function renderReleasesSelect() {
           }),
         ],
         loading: false,
+        onSearch: onSearch ?? jest.fn(),
       }}
     >
       <ReleasesSelectControl selectedReleases={[]} />
@@ -57,5 +58,17 @@ describe('Dashboards > ReleasesSelectControl', function () {
 
     expect(screen.getByText('sentry-android-shop@1.2.0')).toBeInTheDocument();
     expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
+  it('calls onSearch when filtering by releases', async function () {
+    const mockOnSearch = jest.fn();
+    renderReleasesSelect(mockOnSearch);
+
+    expect(screen.getByText('All Releases')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('All Releases'));
+    userEvent.type(screen.getByText('Search\u2026'), 'se');
+
+    await waitFor(() => expect(mockOnSearch).toBeCalled());
   });
 });


### PR DESCRIPTION
Fetch releases again on search input in the
top level query filter.

