### PR TITLE
fix(discover): Apdex denominator

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -1450,6 +1450,71 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         data = response.data["data"]
         assert abs(data[0]["user_misery(300)"] - 0.0653) < 0.0001
 
+    def test_apdex_denominator_correct(self):
+        """This is to test against a bug where the denominator of apdex(total count) was wrong
+
+        This is because the total_count for a LCP apdex should only count transactions that have lcp, and not count
+        all transactions (ie. count_if(transaction has lcp) not just count())
+        """
+        ProjectTransactionThreshold.objects.create(
+            project=self.project,
+            organization=self.project.organization,
+            threshold=600,
+            metric=TransactionMetric.LCP.value,
+        )
+        lcps = [
+            400,
+            400,
+            300,
+            800,
+            3000,
+            3000,
+            3000,
+        ]
+        for idx, lcp in enumerate(lcps):
+            data = load_data(
+                "transaction",
+                timestamp=before_now(minutes=(10 + idx)),
+            )
+            data["event_id"] = f"{idx}" * 32
+            data["transaction"] = "/apdex/new/"
+            data["user"] = {"email": f"{idx}@example.com"}
+            data["measurements"] = {
+                "lcp": {"value": lcp},
+            }
+            self.store_event(data, project_id=self.project.id)
+
+        # Shouldn't count towards apdex
+        data = load_data(
+            "transaction",
+            timestamp=before_now(minutes=(10)),
+            start_timestamp=before_now(minutes=(10)),
+        )
+        data["transaction"] = "/apdex/new/"
+        data["user"] = {"email": "7@example.com"}
+        data["measurements"] = {}
+        self.store_event(data, project_id=self.project.id)
+
+        query = {
+            "field": [
+                "transaction",
+                "apdex()",
+            ],
+            "query": "event.type:transaction",
+            "project": [self.project.id],
+            "sort": "-apdex",
+        }
+
+        response = self.do_request(
+            query,
+        )
+
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 1
+        data = response.data["data"]
+        # 3 satisfied + 1 tolerated => 3.5/7
+        assert data[0]["apdex()"] == 0.5
+
     def test_apdex_new_alias_field(self):
         ProjectTransactionThreshold.objects.create(
             project=self.project,


### PR DESCRIPTION
- This fixes a bug in Apdex's calculation with custom threshold metrics by moving apdex's definition to Sentry from Snuba and by changing the denominator to `countIf(column>=0)` which implicitly checks that the column exists on each txn
- Apdex's denominator would be incorrect if a custom threshold metric was picked (ie. lcp). This is because the numerator would be something like:
`countIf(lcp<300) + countIf(300<lcp<1200)`
which implicitly only counts transactions with a LCP, while the denominator would be a plain `count()` which includes transactions without LCPs, resulting in an Apdex much lower than they  should be.
