### PR TITLE
feat(replays): Choose default Replay Details layout depending on window aspect ratio

### DIFF
--- a/static/app/views/replays/detail/layout/chooseLayout.tsx
+++ b/static/app/views/replays/detail/layout/chooseLayout.tsx
@@ -1,6 +1,7 @@
 import CompactSelect from 'sentry/components/forms/compactSelect';
 import {IconPanel} from 'sentry/icons';
 import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
+import {handleDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
 
 const LAYOUT_NAMES = ['topbar', 'sidebar_left', 'sidebar_right'];
 const layoutLabels = {
@@ -22,8 +23,7 @@ function getLayoutIcon(layout: string) {
 type Props = {};
 
 function ChooseLayout({}: Props) {
-  const {getParamValue, setParamValue} = useUrlParam('l_page', 'topbar');
-
+  const {getParamValue, setParamValue} = useUrlParam('l_page', handleDefaultLayout());
   return (
     <CompactSelect
       triggerProps={{

--- a/static/app/views/replays/detail/layout/chooseLayout.tsx
+++ b/static/app/views/replays/detail/layout/chooseLayout.tsx
@@ -1,5 +1,7 @@
 import CompactSelect from 'sentry/components/forms/compactSelect';
 import {IconPanel} from 'sentry/icons';
+import PreferencesStore from 'sentry/stores/preferencesStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
 import {getDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
 
@@ -23,7 +25,11 @@ function getLayoutIcon(layout: string) {
 type Props = {};
 
 function ChooseLayout({}: Props) {
-  const {getParamValue, setParamValue} = useUrlParam('l_page', getDefaultLayout());
+  const collapsed = !!useLegacyStore(PreferencesStore).collapsed;
+  const {getParamValue, setParamValue} = useUrlParam(
+    'l_page',
+    getDefaultLayout(collapsed)
+  );
   return (
     <CompactSelect
       triggerProps={{

--- a/static/app/views/replays/detail/layout/chooseLayout.tsx
+++ b/static/app/views/replays/detail/layout/chooseLayout.tsx
@@ -1,7 +1,7 @@
 import CompactSelect from 'sentry/components/forms/compactSelect';
 import {IconPanel} from 'sentry/icons';
 import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
-import {handleDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
+import {getDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
 
 const LAYOUT_NAMES = ['topbar', 'sidebar_left', 'sidebar_right'];
 const layoutLabels = {
@@ -23,7 +23,7 @@ function getLayoutIcon(layout: string) {
 type Props = {};
 
 function ChooseLayout({}: Props) {
-  const {getParamValue, setParamValue} = useUrlParam('l_page', handleDefaultLayout());
+  const {getParamValue, setParamValue} = useUrlParam('l_page', getDefaultLayout());
   return (
     <CompactSelect
       triggerProps={{

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -16,7 +16,7 @@ import SplitPanel from 'sentry/views/replays/detail/layout/splitPanel';
 import SideTabs from 'sentry/views/replays/detail/sideTabs';
 import TagPanel from 'sentry/views/replays/detail/tagPanel';
 
-type Layout =
+export type LayoutModes =
   /**
    * ### Sidebar Right
    * ┌───────────────────┐
@@ -64,7 +64,7 @@ const MIN_CONTENT_HEIGHT = {px: 200};
 const MIN_CRUMBS_HEIGHT = {px: 200};
 
 type Props = {
-  layout?: Layout;
+  layout?: LayoutModes;
   showCrumbs?: boolean;
   showTimeline?: boolean;
   showVideo?: boolean;

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -6,7 +6,11 @@ export const getDefaultLayout = (): LayoutModes => {
   const sidebarWidth = parseInt(theme.sidebar.expandedWidth, 10);
   const windowsWidth = innerWidth - sidebarWidth;
 
-  if (windowsWidth < 1024 || innerHeight > 950) {
+  if (innerHeight > 960 && windowsWidth < 1700) {
+    return 'topbar';
+  }
+
+  if (windowsWidth < 1024) {
     return 'topbar';
   }
 

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -1,24 +1,20 @@
 import theme from 'sentry/utils/theme';
 import {LayoutModes} from 'sentry/views/replays/detail/layout';
 
-const RECOMMENDED_WIDTH = 1700;
-const MIN_RECOMMENDED_WIDTH = 1024;
-const MIN_RECOMMENDED_HEIGHT = 960;
-
-export const getDefaultLayout = (): LayoutModes => {
+export const getDefaultLayout = (collapsed: boolean): LayoutModes => {
   const {innerWidth, innerHeight} = window;
-  const sidebarWidth = parseInt(theme.sidebar.expandedWidth, 10);
-  const windowsWidth = innerWidth - sidebarWidth;
+
+  const sidebarWidth = parseInt(
+    collapsed ? theme.sidebar.collapsedWidth : theme.sidebar.expandedWidth,
+    10
+  );
+
+  const mediumScreenWidth = parseInt(theme.breakpoints.medium, 10);
+
+  const windowsWidth =
+    innerWidth <= mediumScreenWidth ? innerWidth : innerWidth - sidebarWidth;
 
   if (windowsWidth < innerHeight) {
-    return 'topbar';
-  }
-
-  if (innerHeight > MIN_RECOMMENDED_HEIGHT && windowsWidth < RECOMMENDED_WIDTH) {
-    return 'topbar';
-  }
-
-  if (windowsWidth < MIN_RECOMMENDED_WIDTH) {
     return 'topbar';
   }
 

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -2,12 +2,11 @@ import theme from 'sentry/utils/theme';
 import {LayoutModes} from 'sentry/views/replays/detail/layout';
 
 export const getDefaultLayout = (): LayoutModes => {
-  const {innerWidth} = window;
+  const {innerWidth, innerHeight} = window;
   const sidebarWidth = parseInt(theme.sidebar.expandedWidth, 10);
-
   const windowsWidth = innerWidth - sidebarWidth;
 
-  if (windowsWidth < 1024) {
+  if (windowsWidth < 1024 || innerHeight > 950) {
     return 'topbar';
   }
 

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -1,7 +1,7 @@
 import theme from 'sentry/utils/theme';
 import {LayoutModes} from 'sentry/views/replays/detail/layout';
 
-export const handleDefaultLayout = (): LayoutModes => {
+export const getDefaultLayout = (): LayoutModes => {
   const {innerWidth} = window;
   const sidebarWidth = parseInt(theme.sidebar.expandedWidth, 10);
 

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -1,0 +1,15 @@
+import theme from 'sentry/utils/theme';
+import {LayoutModes} from 'sentry/views/replays/detail/layout';
+
+export const handleDefaultLayout = (): LayoutModes => {
+  const {innerWidth} = window;
+  const sidebarWidth = parseInt(theme.sidebar.expandedWidth, 10);
+
+  const windowsWidth = innerWidth - sidebarWidth;
+
+  if (windowsWidth < 1024) {
+    return 'topbar';
+  }
+
+  return 'sidebar_left';
+};

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -1,14 +1,13 @@
 import theme from 'sentry/utils/theme';
 import {LayoutModes} from 'sentry/views/replays/detail/layout';
 
-const DECIMAL_RADIX = 10;
 const RECOMMENDED_WIDTH = 1700;
 const MIN_RECOMMENDED_WIDTH = 1024;
 const MIN_RECOMMENDED_HEIGHT = 960;
 
 export const getDefaultLayout = (): LayoutModes => {
   const {innerWidth, innerHeight} = window;
-  const sidebarWidth = parseInt(theme.sidebar.expandedWidth, DECIMAL_RADIX);
+  const sidebarWidth = parseInt(theme.sidebar.expandedWidth, 10);
   const windowsWidth = innerWidth - sidebarWidth;
 
   if (windowsWidth < innerHeight) {

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -1,16 +1,25 @@
 import theme from 'sentry/utils/theme';
 import {LayoutModes} from 'sentry/views/replays/detail/layout';
 
+const DECIMAL_RADIX = 10;
+const RECOMMENDED_WIDTH = 1700;
+const MIN_RECOMMENDED_WIDTH = 1024;
+const MIN_RECOMMENDED_HEIGHT = 960;
+
 export const getDefaultLayout = (): LayoutModes => {
   const {innerWidth, innerHeight} = window;
-  const sidebarWidth = parseInt(theme.sidebar.expandedWidth, 10);
+  const sidebarWidth = parseInt(theme.sidebar.expandedWidth, DECIMAL_RADIX);
   const windowsWidth = innerWidth - sidebarWidth;
 
-  if (innerHeight > 960 && windowsWidth < 1700) {
+  if (windowsWidth < innerHeight) {
     return 'topbar';
   }
 
-  if (windowsWidth < 1024) {
+  if (innerHeight > MIN_RECOMMENDED_HEIGHT && windowsWidth < RECOMMENDED_WIDTH) {
+    return 'topbar';
+  }
+
+  if (windowsWidth < MIN_RECOMMENDED_WIDTH) {
     return 'topbar';
   }
 

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -7,6 +7,8 @@ import {
   useReplayContext,
 } from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
+import PreferencesStore from 'sentry/stores/preferencesStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {PageContent} from 'sentry/styles/organization';
 import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
 import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
@@ -72,7 +74,8 @@ function ReplayDetails() {
 }
 
 function LoadedDetails({orgId}: {orgId: string}) {
-  const {getParamValue} = useUrlParam('l_page', getDefaultLayout());
+  const collapsed = !!useLegacyStore(PreferencesStore).collapsed;
+  const {getParamValue} = useUrlParam('l_page', getDefaultLayout(collapsed));
   const {replay} = useReplayContext();
   const durationMs = replay?.getDurationMs();
 

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -11,7 +11,8 @@ import {PageContent} from 'sentry/styles/organization';
 import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
 import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
-import Layout, {LayoutModes} from 'sentry/views/replays/detail/layout';
+import Layout from 'sentry/views/replays/detail/layout';
+import {handleDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
 import Page from 'sentry/views/replays/detail/page';
 
 const LAYOUT_NAMES = ['topbar', 'sidebar_right', 'sidebar_left'];
@@ -70,20 +71,8 @@ function ReplayDetails() {
   );
 }
 
-const handleLayout = (): LayoutModes => {
-  const {
-    screen: {height, width},
-  } = window;
-
-  if (height > width) {
-    return 'topbar';
-  }
-
-  return 'sidebar_left';
-};
-
 function LoadedDetails({orgId}: {orgId: string}) {
-  const {getParamValue} = useUrlParam('l_page', handleLayout());
+  const {getParamValue} = useUrlParam('l_page', handleDefaultLayout());
   const {replay} = useReplayContext();
   const durationMs = replay?.getDurationMs();
 

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -12,7 +12,7 @@ import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
 import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import Layout from 'sentry/views/replays/detail/layout';
-import {handleDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
+import {getDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
 import Page from 'sentry/views/replays/detail/page';
 
 const LAYOUT_NAMES = ['topbar', 'sidebar_right', 'sidebar_left'];
@@ -72,7 +72,7 @@ function ReplayDetails() {
 }
 
 function LoadedDetails({orgId}: {orgId: string}) {
-  const {getParamValue} = useUrlParam('l_page', handleDefaultLayout());
+  const {getParamValue} = useUrlParam('l_page', getDefaultLayout());
   const {replay} = useReplayContext();
   const durationMs = replay?.getDurationMs();
 

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -11,7 +11,7 @@ import {PageContent} from 'sentry/styles/organization';
 import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
 import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
-import Layout from 'sentry/views/replays/detail/layout';
+import Layout, {LayoutModes} from 'sentry/views/replays/detail/layout';
 import Page from 'sentry/views/replays/detail/page';
 
 const LAYOUT_NAMES = ['topbar', 'sidebar_right', 'sidebar_left'];
@@ -70,8 +70,20 @@ function ReplayDetails() {
   );
 }
 
+const handleLayout = (): LayoutModes => {
+  const {
+    screen: {height, width},
+  } = window;
+
+  if (height > width) {
+    return 'topbar';
+  }
+
+  return 'sidebar_left';
+};
+
 function LoadedDetails({orgId}: {orgId: string}) {
-  const {getParamValue} = useUrlParam('l_page', 'topbar');
+  const {getParamValue} = useUrlParam('l_page', handleLayout());
   const {replay} = useReplayContext();
   const durationMs = replay?.getDurationMs();
 


### PR DESCRIPTION


<!-- Describe your PR here. -->
Added a new validation for choosing a default layout depending on screen size. Closes #37237 


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
