### PR TITLE
feat(js): Add React ErrorBoundary componentStack to errors

### DIFF
--- a/static/app/components/errorBoundary.tsx
+++ b/static/app/components/errorBoundary.tsx
@@ -62,6 +62,13 @@ class ErrorBoundary extends Component<Props, State> {
         Object.keys(errorTag).forEach(tag => scope.setTag(tag, errorTag[tag]));
       }
 
+      // Based on https://github.com/getsentry/sentry-javascript/blob/6f4ad562c469f546f1098136b65583309d03487b/packages/react/src/errorboundary.tsx#L75-L85
+      const errorBoundaryError = new Error(error.message);
+      errorBoundaryError.name = `React ErrorBoundary ${errorBoundaryError.name}`;
+      errorBoundaryError.stack = errorInfo.componentStack;
+
+      error.cause = errorBoundaryError;
+
       scope.setExtra('errorInfo', errorInfo);
       Sentry.captureException(error);
     });


### PR DESCRIPTION
Make use of React 17+ Native Component Stack errors and attach them to errors being captured by Sentry. This should provide a more useful stacktrace when trying to debug these issues.

https://reactjs.org/blog/2020/08/10/react-v17-rc.html#native-component-stacks

ref: https://github.com/getsentry/sentry-javascript/issues/5504
ref: https://github.com/getsentry/sentry/pull/37262
ref: https://github.com/getsentry/sentry-javascript/pull/4005