### PR TITLE
fix(replays): Adjust Replay list table columns in Issue Summary and Transaction Summary

### DIFF
--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
@@ -107,6 +107,7 @@ const GroupReplays = ({group}: Props) => {
                     </SortLink>,
                     t('Duration'),
                     t('Errors'),
+                    t('Interest'),
                   ]}
                 >
                   {data.tableData ? (
@@ -127,7 +128,7 @@ const GroupReplays = ({group}: Props) => {
 };
 
 const StyledPanelTable = styled(PanelTable)`
-  grid-template-columns: minmax(0, 1fr) max-content max-content max-content;
+  grid-template-columns: minmax(0, 1fr) max-content max-content max-content max-content;
 `;
 
 const StyledPageContent = styled(PageContent)`

--- a/static/app/views/performance/transactionSummary/transactionReplays/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/content.tsx
@@ -112,6 +112,7 @@ function ReplaysContent(props: Props) {
           </SortLink>,
           t('Duration'),
           t('Errors'),
+          t('Interest'),
         ]}
       >
         <ReplayTable
@@ -125,7 +126,7 @@ function ReplaysContent(props: Props) {
 }
 
 const StyledPanelTable = styled(PanelTable)`
-  grid-template-columns: minmax(0, 1fr) max-content max-content max-content;
+  grid-template-columns: minmax(0, 1fr) max-content max-content max-content max-content;
 `;
 
 const SortLink = styled(Link)`


### PR DESCRIPTION
Replay tables were broken due to new "Interest" bar which was added in #37305

Now the table/grid definitions of the other callsites are adjusted to account for that new column.

![image](https://user-images.githubusercontent.com/39612839/182452759-dd8c67bf-7f19-4d65-88cc-0c9f690ff86a.png)
