### PR TITLE
fix(mep): Fallback on missing tag values

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1883,7 +1883,7 @@ class MetricsQueryBuilder(QueryBuilder):
             return -1
         result = self.resolve_metric_index(value)
         if result is None:
-            raise InvalidSearchQuery("Tag value was not found")
+            raise IncompatibleMetricsQuery("Tag value was not found")
         return result
 
     def _default_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -1116,7 +1116,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             pytest.skip("test does not apply if tag values are in clickhouse")
 
         with pytest.raises(
-            InvalidSearchQuery,
+            IncompatibleMetricsQuery,
             match=re.escape("Tag value was not found"),
         ):
             MetricsQueryBuilder(
@@ -1130,7 +1130,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
         if options.get("sentry-metrics.performance.tags-values-are-strings"):
             pytest.skip("test does not apply if tag values are in clickhouse")
         with pytest.raises(
-            InvalidSearchQuery,
+            IncompatibleMetricsQuery,
             match=re.escape("Tag value was not found"),
         ):
             MetricsQueryBuilder(
@@ -2382,7 +2382,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         if options.get("sentry-metrics.performance.tags-values-are-strings"):
             pytest.skip("test does not apply if tag values are in clickhouse")
         with pytest.raises(
-            InvalidSearchQuery,
+            IncompatibleMetricsQuery,
             match=re.escape("Tag value was not found"),
         ):
             TimeseriesMetricQueryBuilder(
@@ -2397,7 +2397,7 @@ class TimeseriesMetricQueryBuilderTest(MetricBuilderBaseTest):
         if options.get("sentry-metrics.performance.tags-values-are-strings"):
             pytest.skip("test does not apply if tag values are in clickhouse")
         with pytest.raises(
-            InvalidSearchQuery,
+            IncompatibleMetricsQuery,
             match=re.escape("Tag value was not found"),
         ):
             TimeseriesMetricQueryBuilder(


### PR DESCRIPTION
- Currently we're raising invalid search queries if a tag value is missing, but in these cases we should just try again with discover since the query might still be valid