### PR TITLE
feat(mep): Rename sampled to indexed

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -246,9 +246,9 @@ function WidgetCardContextMenu({
           <Feature organization={organization} features={['dashboards-mep']}>
             {isMetricsData === false && (
               <SampledTag
-                tooltipText={t('This widget is only applicable to sampled events.')}
+                tooltipText={t('This widget is only applicable to indexed events.')}
               >
-                {t('Sampled')}
+                {t('Indexed')}
               </SampledTag>
             )}
           </Feature>

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -646,7 +646,7 @@ describe('Dashboards > WidgetCard', function () {
 
     await waitFor(() => {
       // Badge in the widget header
-      expect(screen.getByText('Sampled')).toBeInTheDocument();
+      expect(screen.getByText('Indexed')).toBeInTheDocument();
     });
 
     await waitFor(() => {
@@ -812,7 +812,7 @@ describe('Dashboards > WidgetCard', function () {
 
       await waitFor(() => {
         // Badge in the widget header
-        expect(screen.getByText('Sampled')).toBeInTheDocument();
+        expect(screen.getByText('Indexed')).toBeInTheDocument();
       });
 
       await waitFor(() => {


### PR DESCRIPTION
- This renames sampled to indexed in the dashboards since we're no longer going with "sampled" for users