### PR TITLE
fix(discover-metrics): Update sort on multiple env filters

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1934,6 +1934,13 @@ class MetricsQueryBuilder(QueryBuilder):
 
         return Condition(lhs, Op(search_filter.operator), value)
 
+    def _resolve_environment_filter_value(self, value):
+        value_id = self.config.resolve_value(f"{value}")
+        if value_id is None:
+            raise IncompatibleMetricsQuery("Environment: {value} was not found")
+
+        return value_id
+
     def _environment_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
         """All of this is copied from the parent class except for the addition of `resolve_value`
 
@@ -1945,8 +1952,7 @@ class MetricsQueryBuilder(QueryBuilder):
         values_set = set(value if isinstance(value, (list, tuple)) else [value])
         # sorted for consistency
         values = sorted(
-            self.config.resolve_value(f"{value}") if self.config.resolve_value(f"{value}") else 0
-            for value in values_set
+            self._resolve_environment_filter_value(value) if value else 0 for value in values_set
         )
         environment = self.column("environment")
         if len(values) == 1:

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1934,7 +1934,7 @@ class MetricsQueryBuilder(QueryBuilder):
 
         return Condition(lhs, Op(search_filter.operator), value)
 
-    def _resolve_environment_filter_value(self, value):
+    def _resolve_environment_filter_value(self, value: str) -> Optional[int]:
         value_id = self.config.resolve_value(f"{value}")
         if value_id is None:
             raise IncompatibleMetricsQuery("Environment: {value} was not found")

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1945,7 +1945,8 @@ class MetricsQueryBuilder(QueryBuilder):
         values_set = set(value if isinstance(value, (list, tuple)) else [value])
         # sorted for consistency
         values = sorted(
-            self.config.resolve_value(f"{value}") if value else 0 for value in values_set
+            self.config.resolve_value(f"{value}") if self.config.resolve_value(f"{value}") else 0
+            for value in values_set
         )
         environment = self.column("environment")
         if len(values) == 1:

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1934,8 +1934,8 @@ class MetricsQueryBuilder(QueryBuilder):
 
         return Condition(lhs, Op(search_filter.operator), value)
 
-    def _resolve_environment_filter_value(self, value: str) -> Optional[int]:
-        value_id = self.config.resolve_value(f"{value}")
+    def _resolve_environment_filter_value(self, value: str) -> int:
+        value_id: Optional[int] = self.config.resolve_value(f"{value}")
         if value_id is None:
             raise IncompatibleMetricsQuery("Environment: {value} was not found")
 

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1937,7 +1937,7 @@ class MetricsQueryBuilder(QueryBuilder):
     def _resolve_environment_filter_value(self, value: str) -> int:
         value_id: Optional[int] = self.config.resolve_value(f"{value}")
         if value_id is None:
-            raise IncompatibleMetricsQuery("Environment: {value} was not found")
+            raise IncompatibleMetricsQuery(f"Environment: {value} was not found")
 
         return value_id
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -503,7 +503,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             [{"count": 0}],
         ]
 
-    def test_multiple_environments_filter(self):
+    def test_search_query_if_environment_does_not_exist_on_indexer(self):
         self.create_environment(self.project, name="prod")
         self.create_environment(self.project, name="dev")
         self.store_transaction_metric(
@@ -529,3 +529,4 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             [{"count": 0}],
             [{"count": 0}],
         ]
+        assert not response.data["isMetricsData"]


### PR DESCRIPTION
Metrics enhanced dashboard widgets break when environment
filter is used and environment value does not exist
on metrics indexer. Raise IncompatibleMetricsQuery
in this case to fallback to transaction.

Fixes SENTRY-VKW