### PR TITLE
feat(eventstore): Add method to retrieve transactions

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -283,7 +283,7 @@ class EventStorage(Service):
     ):
         """
         Same as get_unfetched_events but returns transactions.
-        Only the event ID, projectID, groupID and timestamp field will be present without
+        Only the event ID, projectID and timestamp field will be present without
         an additional fetch to nodestore.
 
         Used for fetching large volumes of transactions that do not need data

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -272,3 +272,30 @@ class EventStorage(Service):
             for item, node in object_node_list:
                 data = node_results.get(node.id) or {}
                 node.bind_data(data, ref=node.get_ref(item))
+
+    def get_unfetched_transactions(
+        self,
+        snuba_filter,
+        orderby=None,
+        limit=100,
+        offset=0,
+        referrer="eventstore.get_unfetched_transactions",
+    ):
+        """
+        Same as get_unfetched_events but returns transactions.
+        Only the event ID, projectID, groupID and timestamp field will be present without
+        an additional fetch to nodestore.
+
+        Used for fetching large volumes of transactions that do not need data
+        loaded from nodestore. Currently this is just used for transaction
+        data deletions where we just need the transactions IDs in order to
+        process the deletions.
+
+        Arguments:
+        snuba_filter (Filter): Filter
+        orderby (Sequence[str]): List of fields to order by - default ['-time', '-event_id']
+        limit (int): Query limit - default 100
+        offset (int): Query offset - default 0
+        referrer (string): Referrer - default "eventstore.get_unfetched_transactions"
+        """
+        raise NotImplementedError


### PR DESCRIPTION
This PR adds a method `get_unfetched_transactions` for retrieving
transactions. This is similar to `get_unfetched_events` but applicable
for transactions.

Added a new API rather than modifying existing API's to reduce clutter
and keep things simple. This also ensures that nothing would breaks
with this change.
