### PR TITLE
fix(replays): Limit the replays listed in Issues to only those where there is really a replay associated

### DIFF
--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
@@ -50,7 +50,7 @@ const GroupReplays = ({group}: Props) => {
       ],
       projects: [+project.id],
       orderby: getQueryParamAsString(query.sort) || '-timestamp',
-      query: `issue.id:${groupId}`,
+      query: `issue.id:${groupId} has:replayId`,
     };
 
     return EventView.fromNewQueryWithLocation(eventQueryParams, location);


### PR DESCRIPTION
We've got two places in the app where we integrate a list of related replays:
1) Issue/Event Summary
2) Performance Summary

They're both delivering the same type of output, a list of replays related to the Issue or Transaction that's being looked at. The Perf page is already [filtering with `has:replayId`](https://github.com/getsentry/sentry/blob/8c21016af27c752e1b16504e98c187a4f0c1d85d/static/app/views/performance/transactionSummary/transactionReplays/index.tsx#L130), this query missed the param. 
