### PR TITLE
feat(profiling): Update profiling landing charts

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -244,6 +244,19 @@ export type MultiSeriesEventsStats = {
   [seriesName: string]: EventsStats;
 };
 
+export type EventsStatsSeries = {
+  data: {
+    axis: string;
+    values: number[];
+  }[];
+  meta: {
+    dataset: string;
+    end: number;
+    start: number;
+  };
+  timestamps: number[];
+};
+
 /**
  * Session API types.
  */

--- a/static/app/utils/profiling/hooks/useProfileStats.tsx
+++ b/static/app/utils/profiling/hooks/useProfileStats.tsx
@@ -1,0 +1,82 @@
+import {useEffect, useState} from 'react';
+import * as Sentry from '@sentry/react';
+
+import {Client} from 'sentry/api';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {t} from 'sentry/locale';
+import {EventsStatsSeries, Organization, PageFilters, RequestState} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type ProfileStatsResult = EventsStatsSeries;
+
+interface UseProfileStatsOptions {
+  query: string;
+  selection?: PageFilters;
+}
+
+export function useProfileStats({
+  query,
+  selection,
+}: UseProfileStatsOptions): RequestState<ProfileStatsResult> {
+  const api = useApi();
+  const organization = useOrganization();
+
+  const [requestState, setRequestState] = useState<RequestState<ProfileStatsResult>>({
+    type: 'initial',
+  });
+
+  useEffect(() => {
+    if (!defined(selection)) {
+      return undefined;
+    }
+
+    setRequestState({type: 'loading'});
+
+    fetchProfileStats(api, organization, {
+      query,
+      selection,
+    })
+      .then(result => {
+        setRequestState({
+          type: 'resolved',
+          data: result,
+        });
+      })
+      .catch(err => {
+        setRequestState({
+          type: 'errored',
+          error: t('Error: Unable to load profile stats'),
+        });
+        Sentry.captureException(err);
+      });
+
+    return () => api.clear();
+  }, [api, organization, query, selection]);
+
+  return requestState;
+}
+
+function fetchProfileStats(
+  api: Client,
+  organization: Organization,
+  {
+    query,
+    selection,
+  }: {
+    query: string;
+    selection: PageFilters;
+  }
+) {
+  return api.requestPromise(`/organizations/${organization.slug}/profiling/stats/`, {
+    method: 'GET',
+    includeAllArgs: false,
+    query: {
+      query,
+      project: selection.projects,
+      environment: selection.environments,
+      ...normalizeDateTimeParams(selection.datetime),
+    },
+  });
+}

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -1,9 +1,8 @@
 import {useCallback, useEffect} from 'react';
-import {browserHistory} from 'react-router';
+import {browserHistory, InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
@@ -23,26 +22,25 @@ import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {useProfileFilters} from 'sentry/utils/profiling/hooks/useProfileFilters';
-import {useProfiles} from 'sentry/utils/profiling/hooks/useProfiles';
 import {useProfileTransactions} from 'sentry/utils/profiling/hooks/useProfileTransactions';
 import {generateProfilingOnboardingRoute} from 'sentry/utils/profiling/routes';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
-import {ProfilingScatterChart} from './landing/profilingScatterChart';
+import {ProfileCharts} from './landing/profileCharts';
 
 interface ProfilingContentProps {
   location: Location;
+  router: InjectedRouter;
 }
 
-function ProfilingContent({location}: ProfilingContentProps) {
+function ProfilingContent({location, router}: ProfilingContentProps) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const cursor = decodeScalar(location.query.cursor);
   const query = decodeScalar(location.query.query, '');
   const profileFilters = useProfileFilters({query: '', selection});
-  const profiles = useProfiles({cursor, query, selection});
   const transactions = useProfileTransactions({cursor, query, selection});
 
   useEffect(() => {
@@ -98,23 +96,7 @@ function ProfilingContent({location}: ProfilingContentProps) {
                     maxQueryLength={MAX_QUERY_LENGTH}
                   />
                 </ActionBar>
-                {profiles.type === 'errored' && (
-                  <Alert type="error" showIcon>
-                    {t('Unable to load profiles')}
-                  </Alert>
-                )}
-                <ProfilingScatterChart
-                  datetime={
-                    selection?.datetime ?? {
-                      start: null,
-                      end: null,
-                      period: null,
-                      utc: null,
-                    }
-                  }
-                  traces={profiles.type === 'resolved' ? profiles.data.traces : []}
-                  isLoading={profiles.type === 'loading'}
-                />
+                <ProfileCharts router={router} query={query} selection={selection} />
                 <ProfileTransactionsTable
                   error={
                     transactions.type === 'errored' ? t('Unable to load profiles') : null

--- a/static/app/views/profiling/landing/profileCharts.tsx
+++ b/static/app/views/profiling/landing/profileCharts.tsx
@@ -1,0 +1,145 @@
+import {useMemo} from 'react';
+import {InjectedRouter} from 'react-router';
+import {useTheme} from '@emotion/react';
+
+import {AreaChart} from 'sentry/components/charts/areaChart';
+import ChartZoom from 'sentry/components/charts/chartZoom';
+import {Panel} from 'sentry/components/panels';
+import {PageFilters} from 'sentry/types';
+import {Series} from 'sentry/types/echarts';
+import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
+import {useProfileStats} from 'sentry/utils/profiling/hooks/useProfileStats';
+
+interface ProfileChartsProps {
+  query: string;
+  router: InjectedRouter;
+  selection?: PageFilters;
+}
+
+// We want p99 to be before p75 because echarts renders the series in order.
+// So if p75 is before p99, p99 will be rendered on top of p75 which will
+// cover it up.
+const SERIES_ORDER = ['count()', 'p99()', 'p75()'];
+
+export function ProfileCharts({query, router, selection}: ProfileChartsProps) {
+  const theme = useTheme();
+
+  const profileStats = useProfileStats({query, selection});
+  const series: Series[] = useMemo(() => {
+    if (profileStats.type !== 'resolved') {
+      return [];
+    }
+
+    const timestamps = profileStats.data.timestamps;
+
+    const allSeries = profileStats.data.data.map(rawData => {
+      if (timestamps.length !== rawData.values.length) {
+        throw new Error('Invalid stats response');
+      }
+
+      if (rawData.axis === 'count') {
+        return {
+          data: rawData.values.map((value, i) => ({
+            name: timestamps[i] * 1e3,
+            value: value ?? 0,
+          })),
+          seriesName: `${rawData.axis}()`,
+          xAxisIndex: 0,
+          yAxisIndex: 0,
+        };
+      }
+
+      return {
+        data: rawData.values.map((value, i) => ({
+          name: timestamps[i] * 1e3,
+          value: (value ?? 0) / 1e6, // convert ns to ms
+        })),
+        seriesName: `${rawData.axis}()`,
+        xAxisIndex: 1,
+        yAxisIndex: 1,
+      };
+    });
+
+    allSeries.sort((a, b) => {
+      const idxA = SERIES_ORDER.indexOf(a.seriesName);
+      const idxB = SERIES_ORDER.indexOf(b.seriesName);
+
+      return idxA - idxB;
+    });
+
+    return allSeries;
+  }, [profileStats]);
+
+  return (
+    <ChartZoom router={router} {...selection?.datetime}>
+      {zoomRenderProps => (
+        <Panel>
+          <AreaChart
+            height={300}
+            series={series}
+            grid={[
+              {
+                top: '32px',
+                left: '24px',
+                right: '52%',
+                bottom: '16px',
+              },
+              {
+                top: '32px',
+                left: '52%',
+                right: '24px',
+                bottom: '16px',
+              },
+            ]}
+            legend={{
+              right: 16,
+              top: 12,
+              data: ['p75()', 'p99()', 'count()'],
+            }}
+            axisPointer={{
+              link: [{xAxisIndex: [0, 1]}],
+            }}
+            xAxes={[
+              {
+                gridIndex: 0,
+                type: 'time' as const,
+              },
+              {
+                gridIndex: 1,
+                type: 'time' as const,
+              },
+            ]}
+            yAxes={[
+              {
+                gridIndex: 0,
+                scale: true,
+                axisLabel: {
+                  color: theme.chartLabel,
+                  formatter(value: number) {
+                    return axisLabelFormatter(value, 'count()');
+                  },
+                },
+              },
+              {
+                gridIndex: 1,
+                scale: true,
+                axisLabel: {
+                  color: theme.chartLabel,
+                  formatter(value: number) {
+                    return axisLabelFormatter(value, 'p75()');
+                  },
+                },
+              },
+            ]}
+            tooltip={{
+              valueFormatter: tooltipFormatter,
+            }}
+            isGroupedByDate
+            showTimeInTooltip
+            {...zoomRenderProps}
+          />
+        </Panel>
+      )}
+    </ChartZoom>
+  );
+}


### PR DESCRIPTION
This update changes the scatter plot on the profiling landing page to show 2 new
charts. A throughput graph showing the count of profiles over time and the
p75/p99 of the profiles over time.

# Screenshot

![image](https://user-images.githubusercontent.com/10239353/182477249-4ee008d3-0760-45d8-8f5a-2a7c12f27f6a.png)
