### PR TITLE
fix(counter): Fix minor linting violation

### DIFF
--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -69,8 +69,7 @@ def increment_project_counter(project, delta=1, using="default"):
 
             project_counter = cur.fetchone()[0]
 
-            if settings.SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT:
-                assert statement_timeout is not None
+            if statement_timeout is not None:
                 cur.execute(
                     "set local statement_timeout = %s",
                     [statement_timeout],

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -40,6 +40,7 @@ def increment_project_counter(project, delta=1, using="default"):
     with transaction.atomic(using=using):
         cur = connections[using].cursor()
         try:
+            statement_timeout = None
             if settings.SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT:
                 # WARNING: This is not a proper fix and should be removed once
                 #          we have better way of generating next_short_id.
@@ -69,6 +70,7 @@ def increment_project_counter(project, delta=1, using="default"):
             project_counter = cur.fetchone()[0]
 
             if settings.SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT:
+                assert statement_timeout is not None
                 cur.execute(
                     "set local statement_timeout = %s",
                     [statement_timeout],


### PR DESCRIPTION
Resolves

      /home/runner/work/sentry/sentry/src/sentry/models/counter.py:81:22 - error: "statement_timeout" is possibly unbound (reportUnboundVariable)

which was uncovered in passing while working on #36426.