### PR TITLE
fix(active-release): Return list releases from suspect-releases

### DIFF
--- a/src/sentry/api/endpoints/group_suspect_releases.py
+++ b/src/sentry/api/endpoints/group_suspect_releases.py
@@ -76,9 +76,5 @@ class GroupSuspectReleasesEndpoint(GroupEndpoint, EnvironmentMixin):
         suspect_releases.update(releases)
 
         suspect_releases = serialize(suspect_releases, request.user)
-        data = {
-            "suspectReleases": list(
-                sorted(suspect_releases, key=lambda x: x["dateCreated"], reverse=True)
-            )
-        }
+        data = list(sorted(suspect_releases, key=lambda x: x["dateCreated"], reverse=True))
         return Response(data)

--- a/tests/sentry/api/endpoints/test_group_suspect_releases.py
+++ b/tests/sentry/api/endpoints/test_group_suspect_releases.py
@@ -16,7 +16,7 @@ class GroupSuspectReleasesTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert response.data["suspectReleases"] == []
+        assert response.data == []
 
         release = self.create_release(
             project=group.project,
@@ -34,7 +34,7 @@ class GroupSuspectReleasesTest(APITestCase, SnubaTestCase):
         )
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
-        assert response.data["suspectReleases"] == []
+        assert response.data == []
 
     def test_with_suspect_release(self):
         self.login_as(user=self.user)
@@ -59,7 +59,7 @@ class GroupSuspectReleasesTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert response.data["suspectReleases"] == [serialize(release)]
+        assert response.data == [serialize(release)]
 
     def test_with_regression(self):
         self.login_as(user=self.user)
@@ -82,7 +82,7 @@ class GroupSuspectReleasesTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert response.data["suspectReleases"] == [serialize(release)]
+        assert response.data == [serialize(release)]
 
     def test_multiple_suspect_releases(self):
         self.login_as(user=self.user)
@@ -120,7 +120,7 @@ class GroupSuspectReleasesTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert response.data["suspectReleases"] == [
+        assert response.data == [
             serialize(release),
             serialize(regression_release),
         ]
@@ -155,4 +155,4 @@ class GroupSuspectReleasesTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
-        assert response.data["suspectReleases"] == [serialize(release)]
+        assert response.data == [serialize(release)]


### PR DESCRIPTION
Removes the object with `{suspectReleases: []}` and returns the array of releases directly
