### PR TITLE
fix(msteams): Handle special characters

### DIFF
--- a/src/sentry/integrations/msteams/card_builder/block.py
+++ b/src/sentry/integrations/msteams/card_builder/block.py
@@ -15,6 +15,7 @@ from sentry.integrations.msteams.card_builder import (
     ItemBlock,
     TextBlock,
 )
+from sentry.integrations.msteams.card_builder.utils import escape_markdown_special_chars
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 
@@ -66,10 +67,10 @@ REQUIRED_ACTION_PARAM = {
 }
 
 
-def create_text_block(text: str, **kwargs: str | bool) -> TextBlock:
+def create_text_block(text: str | None, **kwargs: str | bool) -> TextBlock:
     return {
         "type": "TextBlock",
-        "text": text,
+        "text": escape_markdown_special_chars(text) if text else "",
         "wrap": True,
         **kwargs,
     }

--- a/src/sentry/integrations/msteams/card_builder/utils.py
+++ b/src/sentry/integrations/msteams/card_builder/utils.py
@@ -115,3 +115,14 @@ class IssueConstants:
     ASSIGN_INPUT_ID = "assignInput"
 
     UNASSIGN = "Unassign"
+
+
+translator = str.maketrans({"&": "&amp;", "<": "&lt;", ">": "&gt;", "_": "&#95;"})
+
+
+def escape_markdown_special_chars(text: str) -> str:
+    """
+    Convert markdown special characters to markdown friendly alternatives.
+    docs - https://docs.microsoft.com/en-us/adaptive-cards/authoring-cards/text-features
+    """
+    return text.translate(translator)

--- a/tests/sentry/integrations/msteams/notifications/test_assigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_assigned.py
@@ -39,11 +39,11 @@ class MSTeamsAssignedNotificationTest(MSTeamsActivityNotificationTest):
 
         assert f"Issue assigned to {self.user.get_display_name()} by themselves" == body[0]["text"]
         assert (
-            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-msteams)"
+            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned&#95;activity-msteams)"
             == body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-msteams-user)"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=assigned&#95;activity-msteams-user)"
             == body[3]["columns"][1]["items"][0]["text"]
         )
 
@@ -73,10 +73,10 @@ class MSTeamsAssignedNotificationTest(MSTeamsActivityNotificationTest):
 
         assert f"Issue automatically assigned to {self.user.get_display_name()}" == body[0]["text"]
         assert (
-            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-msteams)"
+            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned&#95;activity-msteams)"
             == body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-msteams-user)"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=assigned&#95;activity-msteams-user)"
             == body[3]["columns"][1]["items"][0]["text"]
         )

--- a/tests/sentry/integrations/msteams/notifications/test_note.py
+++ b/tests/sentry/integrations/msteams/notifications/test_note.py
@@ -39,11 +39,11 @@ class MSTeamsNoteNotificationTest(MSTeamsActivityNotificationTest):
 
         assert f"New comment by {self.user.get_display_name()}" == body[0]["text"]
         assert (
-            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-msteams)"
+            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note&#95;activity-msteams)"
             == body[1]["text"]
         )
         assert notification.activity.data["text"] == body[2]["text"]
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=note_activity-msteams-user)"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=note&#95;activity-msteams-user)"
             == body[3]["columns"][1]["items"][0]["text"]
         )

--- a/tests/sentry/integrations/msteams/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/msteams/notifications/test_unassigned.py
@@ -39,11 +39,11 @@ class MSTeamsUnassignedNotificationTest(MSTeamsActivityNotificationTest):
 
         assert f"Issue unassigned by {self.user.get_display_name()}" == body[0]["text"]
         assert (
-            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-msteams)"
+            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned&#95;activity-msteams)"
             == body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-msteams-user)"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=unassigned&#95;activity-msteams-user)"
             == body[3]["columns"][1]["items"][0]["text"]
         )
 
@@ -73,10 +73,10 @@ class MSTeamsUnassignedNotificationTest(MSTeamsActivityNotificationTest):
 
         assert "Issue unassigned by Sentry" == body[0]["text"]
         assert (
-            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-msteams)"
+            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned&#95;activity-msteams)"
             == body[1]["text"]
         )
         assert (
-            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-msteams-user)"
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=unassigned&#95;activity-msteams-user)"
             == body[3]["columns"][1]["items"][0]["text"]
         )

--- a/tests/sentry/integrations/msteams/test_message_builder.py
+++ b/tests/sentry/integrations/msteams/test_message_builder.py
@@ -94,6 +94,13 @@ class MSTeamsMessageBuilderTest(TestCase):
         assert card["actions"][0]["type"] == ActionType.OPEN_URL
         assert card["actions"][0]["title"] == "button"
 
+    def test_special_chars(self):
+        card = MSTeamsMessageBuilder().build(
+            text="in __init__.py ... return 1 < 2",
+        )
+
+        assert "in &#95;&#95;init&#95;&#95;.py ... return 1 &lt; 2" == card["body"][0]["text"]
+
     def test_missing_action_params(self):
         with pytest.raises(KeyError):
             _ = MSTeamsMessageBuilder().build(
@@ -407,7 +414,7 @@ class MSTeamsNotificationMessageBuilderTest(TestCase):
         assert 4 == len(body)
 
         title = body[0]
-        assert "Notification Title with some_value" == title["text"]
+        assert "Notification Title with some&#95;value" == title["text"]
 
         group_title = body[1]
         assert "[My Title]" in group_title["text"]


### PR DESCRIPTION
Handle special characters in text for MS Teams, especially `_`.