### PR TITLE
feat(sampling): Render sampling modals asap [TET-302]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -95,12 +95,11 @@ function UniformRateModal({
     statsPeriod: '30d',
   });
 
-  const {recommendedSdkUpgrades, fetching: fetchingRecommendedSdkUpgrades} =
-    useRecommendedSdkUpgrades({
-      orgSlug: organization.slug,
-    });
+  const {recommendedSdkUpgrades} = useRecommendedSdkUpgrades({
+    orgSlug: organization.slug,
+  });
 
-  const loading = loading30d || !projectStats || fetchingRecommendedSdkUpgrades;
+  const loading = loading30d || !projectStats;
 
   useEffect(() => {
     if (loading) {


### PR DESCRIPTION
We do not need to block the render of the modal while SDK updates are fetching.
We added this as an attempt to fix flaky acceptance tests but the problem is somewhere else.