### PR TITLE
feat(sampling): Allow to activate rule only if sdks are updated [TET-241][TET-277]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/rule.tsx
+++ b/static/app/views/settings/project/server-side-sampling/rule.tsx
@@ -56,7 +56,7 @@ export function Rule({
 }: Props) {
   const isUniform = isUniformRule(rule);
   const canDelete = !noPermission && !isUniform;
-  const canActivate = true; // TODO(sampling): Enabling this for demo purposes, change this back to `!upgradeSdkForProjects.length;` for LA
+  const canActivate = !noPermission && !upgradeSdkForProjects.length;
   const canDrag = !isUniform && !noPermission;
 
   return (

--- a/tests/js/spec/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
@@ -297,8 +297,7 @@ describe('Server-Side Sampling', function () {
     expect(sdkVersionsMock).not.toHaveBeenCalled();
   });
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('does not let the user activate a rule if sdk updates exists', async function () {
+  it('does not let the user activate a rule if sdk updates exists', async function () {
     const {organization, router, project} = getMockData({
       projects: [
         TestStubs.Project({


### PR DESCRIPTION
Adding back the condition that lets you activate the rule only if you have permissions and all the SDKs are updated.
We had this turned off while we were testing stuff.

Relates to https://github.com/getsentry/sentry/pull/36510