### PR TITLE
ref(projectconfig): Remove acks_late on celery tasks

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 @instrumented_task(
     name="sentry.tasks.relay.build_project_config",
     queue="relay_config",
-    acks_late=True,
     soft_time_limit=5,
     time_limit=10,  # Extra 5 seconds to remove the debounce key.
     expires=30,  # Relay stops waiting for this anyway.
@@ -191,7 +190,6 @@ def compute_projectkey_config(key):
 @instrumented_task(
     name="sentry.tasks.relay.invalidate_project_config",
     queue="relay_config_bulk",
-    acks_late=True,
     soft_time_limit=25 * 60,  # 25mins
     time_limit=25 * 60 + 5,
 )


### PR DESCRIPTION
This does not help in the slightest with guaranteed at-least-once
processing of this task so only gives a false sense of security.  This
only protects agains bugs is the Celery worker code, which is kind of
a lost cause.  This system instead relies on short TTLs and external
triggers, requests from relay or db triggers to re-schedule the
request if something really did get lost.

INGEST-1461

