### PR TITLE
ref(sampling): Remove unused typescript types [TET-277]

### DIFF
--- a/static/app/types/sampling.tsx
+++ b/static/app/types/sampling.tsx
@@ -5,10 +5,6 @@ export enum SamplingRuleType {
    * The rule applies to traces (transaction events considered in the context of a trace)
    */
   TRACE = 'trace',
-  /**
-   *  The rule applies to transaction events considered independently
-   */
-  TRANSACTION = 'transaction',
 }
 
 export enum SamplingConditionOperator {
@@ -42,10 +38,6 @@ export enum SamplingInnerOperator {
    * It uses simple equality for checking
    */
   EQUAL = 'eq',
-  /**
-   * Custom Operation
-   */
-  CUSTOM = 'custom',
 }
 
 /**
@@ -56,62 +48,17 @@ export enum SamplingInnerOperator {
 export enum SamplingInnerName {
   TRACE_RELEASE = 'trace.release',
   TRACE_ENVIRONMENT = 'trace.environment',
-  TRACE_USER_ID = 'trace.user.id',
-  TRACE_USER_SEGMENT = 'trace.user.segment',
-  TRACE_TRANSACTION = 'trace.transaction',
-  EVENT_RELEASE = 'event.release',
-  EVENT_ENVIRONMENT = 'event.environment',
-  EVENT_USER_ID = 'event.user.id',
-  EVENT_USER_SEGMENT = 'event.user.segment',
-  EVENT_LOCALHOST = 'event.is_local_ip',
-  EVENT_WEB_CRAWLERS = 'event.web_crawlers',
-  EVENT_TRANSACTION = 'event.transaction',
-  EVENT_OS_NAME = 'event.contexts.os.name',
-  EVENT_OS_VERSION = 'event.contexts.os.version',
-  EVENT_DEVICE_NAME = 'event.contexts.device.name',
-  EVENT_DEVICE_FAMILY = 'event.contexts.device.family',
-  // Custom operators
-  EVENT_IP_ADDRESSES = 'event.client_ip',
-  EVENT_LEGACY_BROWSER = 'event.legacy_browser',
-  EVENT_CSP = 'event.csp',
-  EVENT_CUSTOM_TAG = 'event.custom_tag', // used for the fresh new custom tag condition (gets replaced once you choose tag key)
-}
-
-export enum LegacyBrowser {
-  IE_PRE_9 = 'ie_pre_9',
-  IE9 = 'ie9',
-  IE10 = 'ie10',
-  IE11 = 'ie11',
-  SAFARI_PRE_6 = 'safari_pre_6',
-  OPERA_PRE_15 = 'opera_pre_15',
-  OPERA_MINI_PRE_8 = 'opera_mini_pre_8',
-  ANDROID_PRE_4 = 'android_pre_4',
 }
 
 type SamplingConditionLogicalInnerGlob = {
-  name:
-    | SamplingInnerName.EVENT_RELEASE
-    | SamplingInnerName.TRACE_RELEASE
-    | SamplingInnerName.EVENT_TRANSACTION
-    | SamplingInnerName.TRACE_TRANSACTION
-    | SamplingInnerName.EVENT_OS_NAME
-    | SamplingInnerName.EVENT_OS_VERSION
-    | SamplingInnerName.EVENT_DEVICE_FAMILY
-    | SamplingInnerName.EVENT_DEVICE_NAME
-    | SamplingInnerName.EVENT_CUSTOM_TAG
-    | string; // for custom tags
+  name: SamplingInnerName.TRACE_RELEASE;
   op: SamplingInnerOperator.GLOB_MATCH;
   value: Array<string>;
 };
 
 type SamplingConditionLogicalInnerEq = {
-  name:
-    | SamplingInnerName.EVENT_ENVIRONMENT
-    | SamplingInnerName.TRACE_ENVIRONMENT
-    | SamplingInnerName.EVENT_USER_ID
-    | SamplingInnerName.TRACE_USER_ID
-    | SamplingInnerName.EVENT_USER_SEGMENT
-    | SamplingInnerName.TRACE_USER_SEGMENT;
+  name: SamplingInnerName.TRACE_ENVIRONMENT;
+
   op: SamplingInnerOperator.EQUAL;
   options: {
     ignoreCase: boolean;
@@ -119,30 +66,9 @@ type SamplingConditionLogicalInnerEq = {
   value: Array<string>;
 };
 
-type SamplingConditionLogicalInnerEqBoolean = {
-  name: SamplingInnerName.EVENT_LOCALHOST | SamplingInnerName.EVENT_WEB_CRAWLERS;
-  op: SamplingInnerOperator.EQUAL;
-  value: boolean;
-};
-
-type SamplingConditionLogicalInnerCustom = {
-  name: SamplingInnerName.EVENT_CSP | SamplingInnerName.EVENT_IP_ADDRESSES;
-  op: SamplingInnerOperator.CUSTOM;
-  value: Array<string>;
-};
-
-type SamplingConditionLogicalInnerCustomLegacyBrowser = {
-  name: SamplingInnerName.EVENT_LEGACY_BROWSER;
-  op: SamplingInnerOperator.CUSTOM;
-  value: Array<LegacyBrowser>;
-};
-
 export type SamplingConditionLogicalInner =
   | SamplingConditionLogicalInnerGlob
-  | SamplingConditionLogicalInnerEq
-  | SamplingConditionLogicalInnerEqBoolean
-  | SamplingConditionLogicalInnerCustom
-  | SamplingConditionLogicalInnerCustomLegacyBrowser;
+  | SamplingConditionLogicalInnerEq;
 
 export type SamplingCondition = {
   inner: Array<SamplingConditionLogicalInner>;

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/conditions.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/conditions.tsx
@@ -15,7 +15,7 @@ import {TagValueAutocomplete, TagValueAutocompleteProps} from './tagValueAutocom
 import {getMatchFieldPlaceholder, getTagKey} from './utils';
 
 export type Condition = {
-  category: SamplingInnerName | string; // string is used for custom tags
+  category: SamplingInnerName;
   match?: string;
 };
 

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.tsx
@@ -19,10 +19,7 @@ type TagValue = Pick<
 >;
 
 export interface TagValueAutocompleteProps {
-  category:
-    | SamplingInnerName.TRACE_ENVIRONMENT
-    | SamplingInnerName.TRACE_RELEASE
-    | string;
+  category: SamplingInnerName.TRACE_ENVIRONMENT | SamplingInnerName.TRACE_RELEASE;
   onChange: (value: string) => void;
   orgSlug: Organization['slug'];
   projectId: Project['id'];

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/utils.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/utils.tsx
@@ -13,7 +13,7 @@ import {TruncatedLabel} from './truncatedLabel';
 
 type Condition = React.ComponentProps<typeof Conditions>['conditions'][0];
 
-export function getMatchFieldPlaceholder(category: SamplingInnerName | string) {
+export function getMatchFieldPlaceholder(category: SamplingInnerName) {
   switch (category) {
     case SamplingInnerName.TRACE_ENVIRONMENT:
       return t('ex. prod, dev');
@@ -40,8 +40,7 @@ export function getNewCondition(condition: Condition): SamplingConditionLogicalI
 
   return {
     op: SamplingInnerOperator.EQUAL,
-    // TODO(sampling): remove the cast
-    name: condition.category as SamplingInnerName.TRACE_ENVIRONMENT,
+    name: condition.category,
     value: newValue,
     options: {
       ignoreCase: true,

--- a/static/app/views/settings/project/server-side-sampling/utils/index.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/index.tsx
@@ -8,7 +8,7 @@ import {defined} from 'sentry/utils';
 export const SERVER_SIDE_SAMPLING_DOC_LINK =
   'https://docs.sentry.io/product/data-management-settings/filtering/';
 
-export function getInnerNameLabel(name: SamplingInnerName | string) {
+export function getInnerNameLabel(name: SamplingInnerName) {
   switch (name) {
     case SamplingInnerName.TRACE_ENVIRONMENT:
       return t('Environment');

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
@@ -8,6 +8,7 @@ import {
   RecommendedSdkUpgrade,
   SamplingConditionOperator,
   SamplingDistribution,
+  SamplingInnerName,
   SamplingInnerOperator,
   SamplingRule,
   SamplingRuleType,
@@ -47,7 +48,7 @@ export const specificRule: SamplingRule = {
     inner: [
       {
         op: SamplingInnerOperator.GLOB_MATCH,
-        name: 'trace.release',
+        name: SamplingInnerName.TRACE_RELEASE,
         value: ['1.2.2'],
       },
     ],


### PR DESCRIPTION
We can put these back if we decide to bring some of these conditions back after LA.

A follow-up to the discussion here: https://github.com/getsentry/sentry/pull/37169