### PR TITLE
ref(sampling): Do not display specify client rate modal if no groups

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -88,7 +88,12 @@ function UniformRateModal({
 
   const modalStore = useLegacyStore(ModalStore);
 
-  const {projectStats: projectStats30d, loading: loading30d} = useProjectStats({
+  const {
+    projectStats: projectStats30d,
+    // TODO(sampling): check how to render this error in the UI
+    error: _error30d,
+    loading: loading30d,
+  } = useProjectStats({
     orgSlug: organization.slug,
     projectId: project.id,
     interval: '1d',
@@ -103,17 +108,23 @@ function UniformRateModal({
   const loading = loading30d || !projectStats || fetchingRecommendedSdkUpgrades;
 
   useEffect(() => {
-    if (loading) {
+    if (loading || !projectStats30d) {
       return;
     }
-    const clientDiscard = projectStats30d?.groups.some(
+
+    if (!projectStats30d.groups.length) {
+      setActiveStep(Step.SET_UNIFORM_SAMPLE_RATE);
+      return;
+    }
+
+    const clientDiscard = projectStats30d.groups.some(
       g => g.by.outcome === Outcome.CLIENT_DISCARD
     );
 
     setActiveStep(
       clientDiscard ? Step.SET_UNIFORM_SAMPLE_RATE : Step.SET_CURRENT_CLIENT_SAMPLE_RATE
     );
-  }, [loading, projectStats30d?.groups]);
+  }, [loading, projectStats30d]);
 
   const shouldUseConservativeSampleRate =
     recommendedSdkUpgrades.length === 0 &&

--- a/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
@@ -282,5 +282,37 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
 
     // Specified sample rate has to still be there
     expect(screen.getByRole('spinbutton')).toHaveValue(0.2);
+
+    // Close Modal
+    userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+    await waitForElementToBeRemoved(() => screen.queryByLabelText('Cancel'));
+  });
+
+  it('does not display "Specify client rate modal" if no groups', async function () {
+    const outcomesWithoutGroups = {...outcomesWithoutClientDiscarded, groups: []};
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/stats_v2/',
+      body: outcomesWithoutGroups,
+    });
+
+    const {organization, project} = getMockData();
+
+    render(<GlobalModal />);
+
+    openModal(modalProps => (
+      <UniformRateModal
+        {...modalProps}
+        organization={organization}
+        project={project}
+        projectStats={outcomesWithoutGroups}
+        rules={[]}
+        onSubmit={jest.fn()}
+        onReadDocs={jest.fn()}
+      />
+    ));
+
+    expect(
+      await screen.findByRole('heading', {name: 'Set a global sample rate'})
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**What this PR does:**

- Update the logic to display the Specify Client Sample Modal, as we don't want to display it if projectStats has no groups 
- Add test