### PR TITLE
fix(metrics): Actually write back rate limits [INGEST-1380]

### DIFF
--- a/src/sentry/ratelimits/sliding_windows.py
+++ b/src/sentry/ratelimits/sliding_windows.py
@@ -393,8 +393,8 @@ class RedisSlidingWindowRateLimiter(SlidingWindowRateLimiter):
     ) -> None:
         assert len(requests) == len(grants)
 
-        keys_to_incr = {}
-        keys_ttl = {}
+        keys_to_incr: MutableMapping[str, int] = {}
+        keys_ttl: MutableMapping[str, int] = {}
 
         for request, grant in zip(requests, grants):
             assert request.prefix == grant.prefix

--- a/src/sentry/sentry_metrics/indexer/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres_v2.py
@@ -143,6 +143,11 @@ class PGStringIndexerV2(StringIndexer):
             # shouldn't consume quota.
             filtered_db_write_keys = writes_limiter_state.accepted_keys
             del db_write_keys
+
+            if filtered_db_write_keys.size == 0:
+                indexer_cache.set_many(new_results_to_cache, use_case_id.value)
+                return cache_key_results.merge(db_read_key_results)
+
             rate_limited_write_results = writes_limiter_state.dropped_strings
 
             new_records = []

--- a/src/sentry/sentry_metrics/indexer/ratelimiters.py
+++ b/src/sentry/sentry_metrics/indexer/ratelimiters.py
@@ -106,7 +106,7 @@ class RateLimitState:
         """
         Consumes the rate limits returned by `check_write_limits`.
         """
-        if exc_type is not None:
+        if exc_type is None:
             self._writes_limiter._get_rate_limiter(self._use_case_id).use_quotas(
                 self._requests, self._grants, self._timestamp
             )

--- a/tests/sentry/ratelimits/test_sliding_windows.py
+++ b/tests/sentry/ratelimits/test_sliding_windows.py
@@ -102,3 +102,22 @@ def test_multiple_windows(limiter):
     )
 
     assert resp == [GrantedQuota(prefix="foo", granted=5, reached_quotas=quotas[:1])]
+
+
+def test_conflicting_quotas(limiter):
+    quotas = [
+        Quota(window_seconds=10, granularity_seconds=1, limit=10, prefix_override="hello"),
+    ]
+
+    resp = limiter.check_and_use_quotas(
+        [
+            RequestedQuota(prefix="foo", requested=6, quotas=quotas),
+            RequestedQuota(prefix="bar", requested=6, quotas=quotas),
+        ],
+        timestamp=TIMESTAMP_OFFSET,
+    )
+
+    assert resp == [
+        GrantedQuota(prefix="foo", granted=6, reached_quotas=[]),
+        GrantedQuota(prefix="bar", granted=4, reached_quotas=quotas),
+    ]


### PR DESCRIPTION
In a recent PR I refactored the rate limiter to a context manager, and I
accidentally flipped the condition under which we write back. Right now
the rate limiter only writes back keys if the DB write crashed.

While adding the missing tests, it turns out that the postgres indexer
crashes if after rate limiting, there are 0 strings to write. So I fixed
that as well.
