### PR TITLE
fix(profiling): Add profiling summary into flamechart breadcrumbs

### DIFF
--- a/static/app/components/profiling/breadcrumb.tsx
+++ b/static/app/components/profiling/breadcrumb.tsx
@@ -6,6 +6,7 @@ import Breadcrumbs, {Crumb} from 'sentry/components/breadcrumbs';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {
+  generateProfileDetailsRouteWithQuery,
   generateProfileFlamechartRouteWithQuery,
   generateProfileSummaryRouteWithQuery,
   generateProfilingRouteWithQuery,
@@ -59,8 +60,12 @@ function trailToCrumb(
       };
     }
     case 'flamechart': {
+      const generateRouteWithQuery =
+        trail.payload.tab === 'flamechart'
+          ? generateProfileFlamechartRouteWithQuery
+          : generateProfileDetailsRouteWithQuery;
       return {
-        to: generateProfileFlamechartRouteWithQuery({
+        to: generateRouteWithQuery({
           location,
           orgSlug: organization.slug,
           projectSlug: trail.payload.projectSlug,
@@ -91,6 +96,7 @@ type FlamegraphTrail = {
   payload: {
     profileId: string;
     projectSlug: string;
+    tab: 'flamechart' | 'details';
     transaction: string;
   };
   type: 'flamechart';

--- a/static/app/components/profiling/profileHeader.tsx
+++ b/static/app/components/profiling/profileHeader.tsx
@@ -18,6 +18,10 @@ function ProfileHeader() {
   const organization = useOrganization();
   const [profileGroup] = useProfileGroup();
 
+  const transaction = profileGroup.type === 'resolved' ? profileGroup.data.name : '';
+  const profileId = params.eventId ?? '';
+  const projectSlug = params.projectId ?? '';
+
   return (
     <Layout.Header style={{gridTemplateColumns: 'minmax(0, 1fr)'}}>
       <Layout.HeaderContent style={{marginBottom: 0}}>
@@ -27,40 +31,47 @@ function ProfileHeader() {
           trails={[
             {type: 'landing'},
             {
+              type: 'profile summary',
+              payload: {
+                projectSlug,
+                transaction,
+              },
+            },
+            {
               type: 'flamechart',
               payload: {
-                transaction:
-                  profileGroup.type === 'resolved' ? profileGroup.data.name : '',
-                profileId: params.eventId ?? '',
-                projectSlug: params.projectId ?? '',
+                transaction,
+                profileId,
+                projectSlug,
+                tab: location.pathname.endsWith('details/') ? 'details' : 'flamechart',
               },
             },
           ]}
         />
       </Layout.HeaderContent>
       <Layout.HeaderNavTabs underlined>
-        <li className={location.pathname.endsWith('details/') ? 'active' : undefined}>
-          <Link
-            to={generateProfileDetailsRouteWithQuery({
-              orgSlug: organization.slug,
-              projectSlug: params.projectId,
-              profileId: params.eventId,
-              location,
-            })}
-          >
-            {t('Details')}
-          </Link>
-        </li>
         <li className={location.pathname.endsWith('flamechart/') ? 'active' : undefined}>
           <Link
             to={generateProfileFlamechartRouteWithQuery({
               orgSlug: organization.slug,
-              projectSlug: params.projectId,
-              profileId: params.eventId,
+              projectSlug,
+              profileId,
               location,
             })}
           >
             {t('Flamechart')}
+          </Link>
+        </li>
+        <li className={location.pathname.endsWith('details/') ? 'active' : undefined}>
+          <Link
+            to={generateProfileDetailsRouteWithQuery({
+              orgSlug: organization.slug,
+              projectSlug,
+              profileId,
+              location,
+            })}
+          >
+            {t('Details')}
           </Link>
         </li>
       </Layout.HeaderNavTabs>

--- a/tests/js/spec/components/profiling/breadcrumb.spec.tsx
+++ b/tests/js/spec/components/profiling/breadcrumb.spec.tsx
@@ -25,6 +25,7 @@ describe('Breadcrumb', function () {
               transaction: 'foo',
               profileId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
               projectSlug: 'bar',
+              tab: 'flamechart',
             },
           },
         ]}


### PR DESCRIPTION
When navigating from the profiling summary to the flamechart, the summary page
should be reachable via breadcrumbs.