### PR TITLE
fix(dashboard): Remove save/cancel CTAs on Dashboard template

### DIFF
--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -801,6 +801,7 @@ class DashboardDetail extends Component<Props, State> {
                     isEditingDashboard={
                       dashboardState !== DashboardState.CREATE && this.isEditing
                     }
+                    isPreview={this.isPreview}
                     filters={filters}
                     onDashboardFilterChange={this.handleChangeFilter}
                     onCancel={() => {

--- a/static/app/views/dashboardsV2/filtersBar.tsx
+++ b/static/app/views/dashboardsV2/filtersBar.tsx
@@ -21,6 +21,7 @@ type FiltersBarProps = {
   filters: DashboardFilters;
   hasUnsavedChanges: boolean;
   isEditingDashboard: boolean;
+  isPreview: boolean;
   onCancel: () => void;
   onDashboardFilterChange: (activeFilters: DashboardFilters) => void;
   onSave: () => void;
@@ -30,6 +31,7 @@ export default function FiltersBar({
   filters,
   hasUnsavedChanges,
   isEditingDashboard,
+  isPreview,
   onCancel,
   onDashboardFilterChange,
   onSave,
@@ -57,7 +59,7 @@ export default function FiltersBar({
               </ReleasesProvider>
             </FilterButton>
           </FilterButtons>
-          {hasUnsavedChanges && !isEditingDashboard && (
+          {hasUnsavedChanges && !isEditingDashboard && !isPreview && (
             <FilterButtons>
               <Button priority="primary" onClick={onSave}>
                 {t('Save')}

--- a/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
@@ -1032,6 +1032,42 @@ describe('Dashboards > Detail', function () {
       );
     });
 
+    it('does not render save and cancel buttons on templates', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/releases/',
+        body: [
+          TestStubs.Release({
+            shortVersion: 'sentry-android-shop@1.2.0',
+            version: 'sentry-android-shop@1.2.0',
+          }),
+        ],
+      });
+      render(
+        <CreateDashboard
+          organization={{
+            ...initialData.organization,
+            features: [
+              ...initialData.organization.features,
+              'dashboards-top-level-filter',
+            ],
+          }}
+          params={{orgId: 'org-slug', templateId: 'default-template'}}
+          router={initialData.router}
+          location={initialData.router.location}
+        />,
+        {
+          context: initialData.routerContext,
+          organization: initialData.organization,
+        }
+      );
+
+      userEvent.click(await screen.findByText('24H'));
+      userEvent.click(screen.getByText('Last 7 days'));
+
+      expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
+      expect(screen.queryByText('Save')).not.toBeInTheDocument();
+    });
+
     it('can save dashboard filters in existing dashboard', async () => {
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',


### PR DESCRIPTION
Remove save/cancel CTAs on Dashboard template
when updating the dashboard filters.