### PR TITLE
fix(perf): Fix perf issue tag names

### DIFF
--- a/src/sentry/tasks/performance_detection.py
+++ b/src/sentry/tasks/performance_detection.py
@@ -74,27 +74,21 @@ def _detect_performance_issue(data: Event, sdk_span: Any):
     all_fingerprints = [i for _, d in detectors.items() for i in d.stored_issues]
 
     if all_fingerprints:
-        sdk_span.containing_transaction.set_measurement(
-            "_performance_issue_count", len(all_fingerprints)
-        )
+        sdk_span.containing_transaction.set_tag("_pi_all_issue_count", len(all_fingerprints))
         if event_id:
-            sdk_span.containing_transaction.set_tag("_performance_issue_transaction_id", event_id)
+            sdk_span.containing_transaction.set_tag("_pi_transaction", event_id)
 
     duplicate_performance_issues = detectors[DetectorType.DUPLICATE_SPANS].stored_issues
     duplicate_performance_fingerprints = list(duplicate_performance_issues.keys())
     if duplicate_performance_fingerprints:
         first_duplicate = duplicate_performance_issues[duplicate_performance_fingerprints[0]]
-        sdk_span.containing_transaction.set_tag(
-            "_performance_issue_duplicate_spans", first_duplicate["span_id"]
-        )
+        sdk_span.containing_transaction.set_tag("_pi_duplicates", first_duplicate["span_id"])
 
     slow_span_performance_issues = detectors[DetectorType.SLOW_SPAN].stored_issues
     slow_performance_fingerprints = list(slow_span_performance_issues.keys())
     if slow_performance_fingerprints:
         first_slow_span = slow_span_performance_issues[slow_performance_fingerprints[0]]
-        sdk_span.containing_transaction.set_tag(
-            "_performance_issue_slow_span", first_slow_span["span_id"]
-        )
+        sdk_span.containing_transaction.set_tag("_pi_slow_span", first_slow_span["span_id"])
 
     sequential_span_performance_issues = detectors[DetectorType.SEQUENTIAL_SLOW_SPANS].stored_issues
     sequential_performance_fingerprints = list(sequential_span_performance_issues.keys())
@@ -102,9 +96,7 @@ def _detect_performance_issue(data: Event, sdk_span: Any):
         first_sequential_span = sequential_span_performance_issues[
             sequential_performance_fingerprints[0]
         ]
-        sdk_span.containing_transaction.set_tag(
-            "_performance_issue_sequential_span", first_sequential_span["span_id"]
-        )
+        sdk_span.containing_transaction.set_tag("_pi_sequential", first_sequential_span["span_id"])
 
 
 # Creates a stable fingerprint given the same span details using sha1.

--- a/tests/sentry/tasks/test_performance_detection.py
+++ b/tests/sentry/tasks/test_performance_detection.py
@@ -76,27 +76,28 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         _detect_performance_issue(no_duplicate_event, sdk_span_mock)
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
-        assert sdk_span_mock.containing_transaction.set_measurement.call_count == 0
 
         _detect_performance_issue(duplicate_not_allowed_op_event, sdk_span_mock)
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
-        assert sdk_span_mock.containing_transaction.set_measurement.call_count == 0
 
         _detect_performance_issue(duplicate_event, sdk_span_mock)
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 2
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 3
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
-                    "_performance_issue_transaction_id",
+                    "_pi_all_issue_count",
+                    1,
+                ),
+                call(
+                    "_pi_transaction",
                     "aaaaaaaaaaaaaaaa",
                 ),
                 call(
-                    "_performance_issue_duplicate_spans",
+                    "_pi_duplicates",
                     "bbbbbbbbbbbbbbbb",
                 ),
             ]
         )
-        assert sdk_span_mock.containing_transaction.set_measurement.call_count == 1
 
     def test_calls_detect_slow_span(self):
         no_slow_span_event = {
@@ -140,27 +141,28 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         _detect_performance_issue(no_slow_span_event, sdk_span_mock)
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
-        assert sdk_span_mock.containing_transaction.set_measurement.call_count == 0
 
         _detect_performance_issue(slow_not_allowed_op_span_event, sdk_span_mock)
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
-        assert sdk_span_mock.containing_transaction.set_measurement.call_count == 0
 
         _detect_performance_issue(slow_span_event, sdk_span_mock)
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 2
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 3
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
-                    "_performance_issue_transaction_id",
+                    "_pi_all_issue_count",
+                    1,
+                ),
+                call(
+                    "_pi_transaction",
                     "aaaaaaaaaaaaaaaa",
                 ),
                 call(
-                    "_performance_issue_slow_span",
+                    "_pi_slow_span",
                     "bbbbbbbbbbbbbbbb",
                 ),
             ]
         )
-        assert sdk_span_mock.containing_transaction.set_measurement.call_count == 1
 
     def test_calls_detect_sequential(self):
         no_sequential_event = {
@@ -226,24 +228,26 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         _detect_performance_issue(no_sequential_event, sdk_span_mock)
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
-        assert sdk_span_mock.containing_transaction.set_measurement.call_count == 0
 
         _detect_performance_issue(sequential_event, sdk_span_mock)
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 3
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 4
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
-                    "_performance_issue_transaction_id",
+                    "_pi_all_issue_count",
+                    2,
+                ),
+                call(
+                    "_pi_transaction",
                     "aaaaaaaaaaaaaaaa",
                 ),
                 call(
-                    "_performance_issue_duplicate_spans",
+                    "_pi_duplicates",
                     "bbbbbbbbbbbbbbbb",
                 ),
                 call(
-                    "_performance_issue_sequential_span",
+                    "_pi_sequential",
                     "bbbbbbbbbbbbbbbb",
                 ),
             ]
         )
-        assert sdk_span_mock.containing_transaction.set_measurement.call_count == 1


### PR DESCRIPTION
### Summary
In my haste I forgot we had a limit of tag key character length of 32 characters, which some of the tags were failing to register on, making looking up these transactions impossible in discover. Since this is only changing strings, it likely low risk enough that turning the option first isn't required (also there is a try/catch around this so worst case is an alert going off).