### PR TITLE
feat(perf-issues): Show Trace Navigator in Span Tree section for Performance Issues

### DIFF
--- a/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
+++ b/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
@@ -1,13 +1,15 @@
-import React from 'react';
+import React, {useContext} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
+import QuickTrace from 'sentry/components/quickTrace';
 import space from 'sentry/styles/space';
 import {Event, EventTransaction, Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import GenericDiscoverQuery from 'sentry/utils/discover/genericDiscoverQuery';
+import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -28,6 +30,7 @@ export function EmbeddedSpanTree(props: Props) {
   const {event, organization, projectSlug, focusedSpanIds} = props;
   const api = useApi();
   const location = useLocation();
+  const quickTrace = useContext(QuickTraceContext);
 
   const eventView = EventView.fromNewQueryWithLocation(
     {
@@ -78,7 +81,19 @@ export function EmbeddedSpanTree(props: Props) {
 
                   return (
                     <Wrapper>
-                      <h3>Span Tree</h3>
+                      <Header>
+                        <h3>Span Tree</h3>
+                        <QuickTrace
+                          event={event}
+                          quickTrace={quickTrace!}
+                          location={location}
+                          organization={organization}
+                          anchor="left"
+                          errorDest="issue"
+                          transactionDest="performance"
+                        />
+                      </Header>
+
                       <Section>
                         <TraceView
                           organization={organization}
@@ -126,6 +141,11 @@ export const Wrapper = styled('div')`
     margin-bottom: ${space(2)};
     text-transform: uppercase;
   }
+`;
+
+const Header = styled('div')`
+  display: flex;
+  justify-content: space-between;
 `;
 
 const Section = styled('div')`

--- a/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
+++ b/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
@@ -5,12 +5,12 @@ import ErrorBoundary from 'sentry/components/errorBoundary';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import QuickTrace from 'sentry/components/quickTrace';
+import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Event, EventTransaction, Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import GenericDiscoverQuery from 'sentry/utils/discover/genericDiscoverQuery';
 import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
-import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 
@@ -45,74 +45,84 @@ export function EmbeddedSpanTree(props: Props) {
     location
   );
 
+  function getContent() {
+    if (!quickTrace) {
+      return null;
+    }
+
+    if (quickTrace.isLoading) {
+      return <LoadingIndicator />;
+    }
+
+    if (!quickTrace.currentEvent) {
+      return (
+        <LoadingError
+          message={t(
+            'Error loading the span tree because the root transaction is missing'
+          )}
+        />
+      );
+    }
+
+    return (
+      <GenericDiscoverQuery
+        eventView={eventView}
+        orgSlug={organization.slug}
+        route={`events/${projectSlug}:${quickTrace.currentEvent.event_id}`}
+        api={api}
+        location={location}
+      >
+        {_results => {
+          if (_results.isLoading) {
+            return <LoadingIndicator />;
+          }
+
+          if (!_results.tableData) {
+            return (
+              <LoadingError
+                message={t(
+                  'Error loading the span tree because the root transaction is missing'
+                )}
+              />
+            );
+          }
+
+          return (
+            <Wrapper>
+              <Header>
+                <h3>{t('Span Tree')}</h3>
+                <QuickTrace
+                  event={event}
+                  quickTrace={quickTrace!}
+                  location={location}
+                  organization={organization}
+                  anchor="left"
+                  errorDest="issue"
+                  transactionDest="performance"
+                />
+              </Header>
+
+              <Section>
+                <TraceView
+                  organization={organization}
+                  waterfallModel={
+                    new WaterfallModel(
+                      _results.tableData as EventTransaction,
+                      focusedSpanIds
+                    )
+                  }
+                />
+              </Section>
+            </Wrapper>
+          );
+        }}
+      </GenericDiscoverQuery>
+    );
+  }
+
   return (
     <React.Fragment>
-      <ErrorBoundary mini>
-        <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
-          {results => {
-            if (results.isLoading) {
-              return <LoadingIndicator />;
-            }
-
-            if (!results.currentEvent) {
-              return (
-                <LoadingError message="Error loading the span tree because the root transaction is missing." />
-              );
-            }
-
-            return (
-              <GenericDiscoverQuery
-                eventView={eventView}
-                orgSlug={organization.slug}
-                route={`events/${projectSlug}:${results.currentEvent?.event_id}`}
-                api={api}
-                location={location}
-              >
-                {_results => {
-                  if (_results.isLoading) {
-                    return <LoadingIndicator />;
-                  }
-
-                  if (!_results.tableData) {
-                    return (
-                      <LoadingError message="Error loading the span tree because the root transaction is missing." />
-                    );
-                  }
-
-                  return (
-                    <Wrapper>
-                      <Header>
-                        <h3>Span Tree</h3>
-                        <QuickTrace
-                          event={event}
-                          quickTrace={quickTrace!}
-                          location={location}
-                          organization={organization}
-                          anchor="left"
-                          errorDest="issue"
-                          transactionDest="performance"
-                        />
-                      </Header>
-
-                      <Section>
-                        <TraceView
-                          organization={organization}
-                          waterfallModel={
-                            new WaterfallModel(
-                              _results.tableData as EventTransaction,
-                              focusedSpanIds
-                            )
-                          }
-                        />
-                      </Section>
-                    </Wrapper>
-                  );
-                }}
-              </GenericDiscoverQuery>
-            );
-          }}
-        </QuickTraceQuery>
-      </ErrorBoundary>
+      <ErrorBoundary mini>{getContent()}</ErrorBoundary>
     </React.Fragment>
   );
 }

--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -14,7 +14,7 @@ import {Organization} from 'sentry/types';
 import {EventTransaction} from 'sentry/types/event';
 import {objectIsEmpty} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
-import * as QuickTraceContext from 'sentry/utils/performance/quickTrace/quickTraceContext';
+import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import {TraceError} from 'sentry/utils/performance/quickTrace/types';
 import withOrganization from 'sentry/utils/withOrganization';
 

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -46,8 +46,10 @@ import {EventTransaction} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
-import * as QuickTraceContext from 'sentry/utils/performance/quickTrace/quickTraceContext';
-import {QuickTraceContextChildrenProps} from 'sentry/utils/performance/quickTrace/quickTraceContext';
+import {
+  QuickTraceContext,
+  QuickTraceContextChildrenProps,
+} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import {QuickTraceEvent, TraceError} from 'sentry/utils/performance/quickTrace/types';
 import {isTraceFull} from 'sentry/utils/performance/quickTrace/utils';
 

--- a/static/app/utils/performance/quickTrace/quickTraceContext.tsx
+++ b/static/app/utils/performance/quickTrace/quickTraceContext.tsx
@@ -4,8 +4,4 @@ import {QuickTraceQueryChildrenProps} from 'sentry/utils/performance/quickTrace/
 
 export type QuickTraceContextChildrenProps = QuickTraceQueryChildrenProps | undefined;
 
-const QuickTraceContext = createContext<QuickTraceContextChildrenProps>(undefined);
-
-export const Provider = QuickTraceContext.Provider;
-
-export const Consumer = QuickTraceContext.Consumer;
+export const QuickTraceContext = createContext<QuickTraceContextChildrenProps>(undefined);

--- a/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -13,24 +13,30 @@ import {
 
 type QueryProps = Omit<DiscoverQueryProps, 'api' | 'eventView'> & {
   children: (props: QuickTraceQueryChildrenProps) => React.ReactNode;
-  event: Event;
+  event: Event | undefined;
 };
 
 export default function QuickTraceQuery({children, event, ...props}: QueryProps) {
+  const renderEmpty = () => (
+    <Fragment>
+      {children({
+        isLoading: false,
+        error: null,
+        trace: [],
+        type: 'empty',
+        currentEvent: null,
+      })}
+    </Fragment>
+  );
+
+  if (!event) {
+    return renderEmpty();
+  }
+
   const traceId = event.contexts?.trace?.trace_id;
 
   if (!traceId) {
-    return (
-      <Fragment>
-        {children({
-          isLoading: false,
-          error: null,
-          trace: [],
-          type: 'empty',
-          currentEvent: null,
-        })}
-      </Fragment>
-    );
+    return renderEmpty();
   }
 
   const {start, end} = getTraceTimeRangeFromEvent(event);

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -30,7 +30,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {formatTagKey} from 'sentry/utils/discover/fields';
 import {eventDetailsRoute} from 'sentry/utils/discover/urls';
 import {getMessage} from 'sentry/utils/events';
-import * as QuickTraceContext from 'sentry/utils/performance/quickTrace/quickTraceContext';
+import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 import TraceMetaQuery, {
   TraceMetaQueryChildrenProps,

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -115,8 +115,6 @@ class GroupEventToolbar extends Component<Props> {
       evt.dateReceived &&
       Math.abs(+moment(evt.dateReceived) - +moment(evt.dateCreated)) > latencyThreshold;
 
-    const isPerformanceIssue = !!evt.contexts?.performance_issue;
-
     return (
       <StyledDataSection>
         <StyledNavigationButtonGroup
@@ -170,7 +168,6 @@ class GroupEventToolbar extends Component<Props> {
           group={group}
           organization={organization}
           location={location}
-          isPerformanceIssue={isPerformanceIssue}
         />
       </StyledDataSection>
     );

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -115,6 +115,8 @@ class GroupEventToolbar extends Component<Props> {
       evt.dateReceived &&
       Math.abs(+moment(evt.dateReceived) - +moment(evt.dateCreated)) > latencyThreshold;
 
+    const isPerformanceIssue = !!evt.contexts?.performance_issue;
+
     return (
       <StyledDataSection>
         <StyledNavigationButtonGroup
@@ -163,12 +165,15 @@ class GroupEventToolbar extends Component<Props> {
           project={project}
           organization={organization}
         />
-        <QuickTrace
-          event={evt}
-          group={group}
-          organization={organization}
-          location={location}
-        />
+        {/* If this is a Performance issue, the QuickTrace will be rendered along with the embedded span tree instead */}
+        {!isPerformanceIssue && (
+          <QuickTrace
+            event={evt}
+            group={group}
+            organization={organization}
+            location={location}
+          />
+        )}
       </StyledDataSection>
     );
   }

--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -221,7 +221,7 @@ class GroupEventDetails extends Component<GroupEventDetailsProps, State> {
       groupReprocessingStatus,
     } = this.props;
 
-    const eventWithMeta = withMeta(event) as Event;
+    const eventWithMeta = withMeta(event);
 
     // Reprocessing
     const hasReprocessingV2Feature = organization.features?.includes('reprocessing-v2');
@@ -242,48 +242,46 @@ class GroupEventDetails extends Component<GroupEventDetailsProps, State> {
             />
           ) : (
             <Fragment>
-              {eventWithMeta && (
-                <QuickTraceQuery
-                  event={eventWithMeta}
-                  location={location}
-                  orgSlug={organization.slug}
-                >
-                  {results => {
-                    return (
-                      <StyledLayoutMain>
-                        {results && (
-                          <QuickTraceContext.Provider value={results}>
-                            <GroupEventToolbar
-                              group={group}
-                              event={eventWithMeta}
-                              organization={organization}
-                              location={location}
-                              project={project}
-                            />
-                            <Wrapper>
-                              {group.status === 'ignored' && (
-                                <MutedBox statusDetails={group.statusDetails} />
-                              )}
-                              {group.status === 'resolved' && (
-                                <ResolutionBox
-                                  statusDetails={group.statusDetails}
-                                  activities={activities}
-                                  projectId={project.id}
-                                />
-                              )}
-                              {this.renderReprocessedBox(
-                                groupReprocessingStatus,
-                                mostRecentActivity as GroupActivityReprocess
-                              )}
-                            </Wrapper>
-                            {this.renderContent(eventWithMeta)}
-                          </QuickTraceContext.Provider>
+              <QuickTraceQuery
+                event={eventWithMeta}
+                location={location}
+                orgSlug={organization.slug}
+              >
+                {results => {
+                  return (
+                    <StyledLayoutMain>
+                      <QuickTraceContext.Provider value={results}>
+                        {eventWithMeta && (
+                          <GroupEventToolbar
+                            group={group}
+                            event={eventWithMeta}
+                            organization={organization}
+                            location={location}
+                            project={project}
+                          />
                         )}
-                      </StyledLayoutMain>
-                    );
-                  }}
-                </QuickTraceQuery>
-              )}
+                        <Wrapper>
+                          {group.status === 'ignored' && (
+                            <MutedBox statusDetails={group.statusDetails} />
+                          )}
+                          {group.status === 'resolved' && (
+                            <ResolutionBox
+                              statusDetails={group.statusDetails}
+                              activities={activities}
+                              projectId={project.id}
+                            />
+                          )}
+                          {this.renderReprocessedBox(
+                            groupReprocessingStatus,
+                            mostRecentActivity as GroupActivityReprocess
+                          )}
+                        </Wrapper>
+                        {this.renderContent(eventWithMeta)}
+                      </QuickTraceContext.Provider>
+                    </StyledLayoutMain>
+                  );
+                }}
+              </QuickTraceQuery>
 
               <StyledLayoutSide>
                 <GroupSidebar

--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -26,6 +26,8 @@ import {
 } from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import fetchSentryAppInstallations from 'sentry/utils/fetchSentryAppInstallations';
+import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
+import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 
 import GroupEventToolbar from '../eventToolbar';
 import ReprocessingProgress from '../reprocessingProgress';
@@ -240,34 +242,49 @@ class GroupEventDetails extends Component<GroupEventDetailsProps, State> {
             />
           ) : (
             <Fragment>
-              <StyledLayoutMain>
-                {eventWithMeta && (
-                  <GroupEventToolbar
-                    group={group}
-                    event={eventWithMeta}
-                    organization={organization}
-                    location={location}
-                    project={project}
-                  />
-                )}
-                <Wrapper>
-                  {group.status === 'ignored' && (
-                    <MutedBox statusDetails={group.statusDetails} />
-                  )}
-                  {group.status === 'resolved' && (
-                    <ResolutionBox
-                      statusDetails={group.statusDetails}
-                      activities={activities}
-                      projectId={project.id}
-                    />
-                  )}
-                  {this.renderReprocessedBox(
-                    groupReprocessingStatus,
-                    mostRecentActivity as GroupActivityReprocess
-                  )}
-                </Wrapper>
-                {this.renderContent(eventWithMeta)}
-              </StyledLayoutMain>
+              {eventWithMeta && (
+                <QuickTraceQuery
+                  event={eventWithMeta}
+                  location={location}
+                  orgSlug={organization.slug}
+                >
+                  {results => {
+                    return (
+                      <StyledLayoutMain>
+                        {results && (
+                          <QuickTraceContext.Provider value={results}>
+                            <GroupEventToolbar
+                              group={group}
+                              event={eventWithMeta}
+                              organization={organization}
+                              location={location}
+                              project={project}
+                            />
+                            <Wrapper>
+                              {group.status === 'ignored' && (
+                                <MutedBox statusDetails={group.statusDetails} />
+                              )}
+                              {group.status === 'resolved' && (
+                                <ResolutionBox
+                                  statusDetails={group.statusDetails}
+                                  activities={activities}
+                                  projectId={project.id}
+                                />
+                              )}
+                              {this.renderReprocessedBox(
+                                groupReprocessingStatus,
+                                mostRecentActivity as GroupActivityReprocess
+                              )}
+                            </Wrapper>
+                            {this.renderContent(eventWithMeta)}
+                          </QuickTraceContext.Provider>
+                        )}
+                      </StyledLayoutMain>
+                    );
+                  }}
+                </QuickTraceQuery>
+              )}
+
               <StyledLayoutSide>
                 <GroupSidebar
                   organization={organization}

--- a/static/app/views/organizationGroupDetails/quickTrace/index.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/index.tsx
@@ -1,8 +1,9 @@
-import {Fragment} from 'react';
+import {Fragment, useContext} from 'react';
 import {Location} from 'history';
 
 import {Group, Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
+import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 
 import DistributedTracingPrompt from './configureDistributedTracing';
 import IssueQuickTrace from './issueQuickTrace';
@@ -18,6 +19,7 @@ type Props = {
 function QuickTrace({event, group, organization, location, isPerformanceIssue}: Props) {
   const hasPerformanceView = organization.features.includes('performance-view');
   const hasTraceContext = Boolean(event.contexts?.trace?.trace_id);
+  const quickTrace = useContext(QuickTraceContext);
 
   return (
     <Fragment>
@@ -34,6 +36,7 @@ function QuickTrace({event, group, organization, location, isPerformanceIssue}: 
           event={event}
           location={location}
           isPerformanceIssue={isPerformanceIssue}
+          quickTrace={quickTrace!}
         />
       )}
     </Fragment>

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -22,7 +22,7 @@ import {Organization, Project} from 'sentry/types';
 import {Event, EventTag} from 'sentry/types/event';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import {formatTagKey} from 'sentry/utils/discover/fields';
-import * as QuickTraceContext from 'sentry/utils/performance/quickTrace/quickTraceContext';
+import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 import TraceMetaQuery from 'sentry/utils/performance/quickTrace/traceMetaQuery';
 import {getTraceTimeRangeFromEvent} from 'sentry/utils/performance/quickTrace/utils';

--- a/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
@@ -14,7 +14,7 @@ import {spanTargetHash} from 'sentry/components/events/interfaces/spans/utils';
 import WaterfallModel from 'sentry/components/events/interfaces/spans/waterfallModel';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {EntryType, EventTransaction} from 'sentry/types';
-import * as QuickTraceContext from 'sentry/utils/performance/quickTrace/quickTraceContext';
+import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
 
 function initializeData(settings) {


### PR DESCRIPTION
For Performance Issues, moves the Trace Navigator from the top of the page to the Span Tree section in order to be consistent with the design mocks. Also includes some refactors so that we don't have to perform an additional query within the embedded span tree to get the quick trace, and fetches this data from the context provider instead.

### Before
![image](https://user-images.githubusercontent.com/16740047/182668891-3d65ba2a-8e17-4284-a210-24ceece0811f.png)

### After
![image](https://user-images.githubusercontent.com/16740047/182668953-80d94180-5cba-4c6e-8600-9d98189f74bb.png)


Addresses PERF-1597