### PR TITLE
refactor(replays): useCrumbHandlers utility

### DIFF
--- a/static/app/utils/replays/hooks/useCrumbHandlers.tsx
+++ b/static/app/utils/replays/hooks/useCrumbHandlers.tsx
@@ -1,0 +1,59 @@
+import {useCallback} from 'react';
+
+import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {relativeTimeInMs} from 'sentry/components/replays/utils';
+import {Crumb} from 'sentry/types/breadcrumbs';
+
+function useCrumbHandlers(startTimestampMs: number = 0) {
+  const {
+    clearAllHighlights,
+    highlight,
+    removeHighlight,
+    setCurrentHoverTime,
+    setCurrentTime,
+  } = useReplayContext();
+
+  const handleMouseEnter = useCallback(
+    (item: Crumb) => {
+      if (startTimestampMs) {
+        setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestampMs));
+      }
+
+      if (item.data && 'nodeId' in item.data) {
+        // XXX: Kind of hacky, but mouseLeave does not fire if you move from a
+        // crumb to a tooltip
+        clearAllHighlights();
+        highlight({nodeId: item.data.nodeId, annotation: item.data.label});
+      }
+    },
+    [setCurrentHoverTime, startTimestampMs, highlight, clearAllHighlights]
+  );
+
+  const handleMouseLeave = useCallback(
+    (item: Crumb) => {
+      setCurrentHoverTime(undefined);
+
+      if (item.data && 'nodeId' in item.data) {
+        removeHighlight({nodeId: item.data.nodeId});
+      }
+    },
+    [setCurrentHoverTime, removeHighlight]
+  );
+
+  const handleClick = useCallback(
+    (crumb: Crumb) => {
+      crumb.timestamp !== undefined && startTimestampMs !== undefined
+        ? setCurrentTime(relativeTimeInMs(crumb.timestamp, startTimestampMs))
+        : null;
+    },
+    [setCurrentTime, startTimestampMs]
+  );
+
+  return {
+    handleMouseEnter,
+    handleMouseLeave,
+    handleClick,
+  };
+}
+
+export default useCrumbHandlers;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useRef} from 'react';
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {
@@ -7,10 +7,8 @@ import {
 } from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Crumb} from 'sentry/types/breadcrumbs';
 import {getPrevBreadcrumb} from 'sentry/utils/replays/getBreadcrumb';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import {useCurrentItemScroller} from 'sentry/utils/replays/hooks/useCurrentItemScroller';

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -12,6 +12,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Crumb} from 'sentry/types/breadcrumbs';
 import {getPrevBreadcrumb} from 'sentry/utils/replays/getBreadcrumb';
+import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import {useCurrentItemScroller} from 'sentry/utils/replays/hooks/useCurrentItemScroller';
 import BreadcrumbItem from 'sentry/views/replays/detail/breadcrumbs/breadcrumbItem';
 import FluidPanel from 'sentry/views/replays/detail/layout/fluidPanel';
@@ -29,16 +30,7 @@ function CrumbPlaceholder({number}: {number: number}) {
 type Props = {};
 
 function Breadcrumbs({}: Props) {
-  const {
-    clearAllHighlights,
-    currentHoverTime,
-    currentTime,
-    highlight,
-    removeHighlight,
-    replay,
-    setCurrentHoverTime,
-    setCurrentTime,
-  } = useReplayContext();
+  const {currentHoverTime, currentTime, replay} = useReplayContext();
 
   const replayRecord = replay?.getReplay();
   const allCrumbs = replay?.getRawCrumbs();
@@ -47,6 +39,8 @@ function Breadcrumbs({}: Props) {
   useCurrentItemScroller(crumbListContainerRef);
 
   const startTimestampMs = replayRecord?.started_at.getTime() || 0;
+  const {handleMouseEnter, handleMouseLeave, handleClick} =
+    useCrumbHandlers(startTimestampMs);
 
   const isLoaded = Boolean(replayRecord);
 
@@ -67,42 +61,6 @@ function Breadcrumbs({}: Props) {
           allowExact: true,
         })
       : undefined;
-
-  const handleMouseEnter = useCallback(
-    (item: Crumb) => {
-      if (startTimestampMs) {
-        setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestampMs));
-      }
-
-      if (item.data && 'nodeId' in item.data) {
-        // XXX: Kind of hacky, but mouseLeave does not fire if you move from a
-        // crumb to a tooltip
-        clearAllHighlights();
-        highlight({nodeId: item.data.nodeId, annotation: item.data.label});
-      }
-    },
-    [setCurrentHoverTime, startTimestampMs, highlight, clearAllHighlights]
-  );
-
-  const handleMouseLeave = useCallback(
-    (item: Crumb) => {
-      setCurrentHoverTime(undefined);
-
-      if (item.data && 'nodeId' in item.data) {
-        removeHighlight({nodeId: item.data.nodeId});
-      }
-    },
-    [setCurrentHoverTime, removeHighlight]
-  );
-
-  const handleClick = useCallback(
-    (crumb: Crumb) => {
-      crumb.timestamp !== undefined
-        ? setCurrentTime(relativeTimeInMs(crumb.timestamp, startTimestampMs))
-        : null;
-    },
-    [setCurrentTime, startTimestampMs]
-  );
 
   const content = isLoaded ? (
     <BreadcrumbContainer>

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -1,16 +1,14 @@
-import {useCallback} from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 
 import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
 import HTMLCode from 'sentry/components/htmlCode';
 import {getDetails} from 'sentry/components/replays/breadcrumbs/utils';
 import PlayerRelativeTime from 'sentry/components/replays/playerRelativeTime';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import Truncate from 'sentry/components/truncate';
 import {SVGIconProps} from 'sentry/icons/svgIcon';
 import space from 'sentry/styles/space';
-import {Crumb} from 'sentry/types/breadcrumbs';
+import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import useExtractedCrumbHtml from 'sentry/utils/replays/hooks/useExtractedCrumbHtml';
 import type ReplayReader from 'sentry/utils/replays/replayReader';
 
@@ -20,31 +18,10 @@ type Props = {
 
 function DomMutations({replay}: Props) {
   const {isLoading, actions} = useExtractedCrumbHtml({replay});
-  const {setCurrentTime, setCurrentHoverTime} = useReplayContext();
-
   const startTimestampMs = replay.getReplay().started_at.getTime();
 
-  const handleMouseEnter = useCallback(
-    (item: Crumb) => {
-      if (startTimestampMs) {
-        setCurrentHoverTime(relativeTimeInMs(item.timestamp ?? '', startTimestampMs));
-      }
-    },
-    [setCurrentHoverTime, startTimestampMs]
-  );
-
-  const handleMouseLeave = useCallback(() => {
-    setCurrentHoverTime(undefined);
-  }, [setCurrentHoverTime]);
-
-  const handleTimestampClick = useCallback(
-    (crumb: Crumb) => {
-      crumb.timestamp !== undefined
-        ? setCurrentTime(relativeTimeInMs(crumb.timestamp, startTimestampMs))
-        : null;
-    },
-    [setCurrentTime, startTimestampMs]
-  );
+  const {handleMouseEnter, handleMouseLeave, handleClick} =
+    useCrumbHandlers(startTimestampMs);
 
   if (isLoading) {
     return null;
@@ -56,7 +33,7 @@ function DomMutations({replay}: Props) {
         <MutationListItem
           key={i}
           onMouseEnter={() => handleMouseEnter(mutation.crumb)}
-          onMouseLeave={handleMouseLeave}
+          onMouseLeave={() => handleMouseLeave(mutation.crumb)}
         >
           <StepConnector />
           <MutationItemContainer>
@@ -65,7 +42,7 @@ function DomMutations({replay}: Props) {
                 <IconWrapper color={mutation.crumb.color}>
                   <BreadcrumbIcon type={mutation.crumb.type} />
                 </IconWrapper>
-                <UnstyledButton onClick={() => handleTimestampClick(mutation.crumb)}>
+                <UnstyledButton onClick={() => handleClick(mutation.crumb)}>
                   <PlayerRelativeTime
                     relativeTimeMs={startTimestampMs}
                     timestamp={mutation.crumb.timestamp}


### PR DESCRIPTION
### Changes
- Abstracts the crumb event handlers into a hook so we can use it in the DOM Events view as well
- Introduces the highlighting back into the DOM Events tab

![Screen Shot 2022-08-03 at 1 49 57 PM](https://user-images.githubusercontent.com/3721977/182675493-0a5ab4bd-0ff6-4c10-834f-b3675ad899c8.png)
