### PR TITLE
fix(integrations): Don't show install tooltip for document integratio…

### DIFF
--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -111,6 +111,12 @@ class AbstractIntegrationDetailedView<
     throw new Error('Not implemented');
   }
 
+  // Checks to see if integration requires admin access to install, doc integrations don't
+  get requiresAccess(): boolean {
+    // default is integration requires access to install
+    return true;
+  }
+
   // Returns an array of RawIntegrationFeatures which is used in feature gating
   // and displaying what the integration does
   get featureData(): IntegrationFeature[] {
@@ -266,7 +272,7 @@ class AbstractIntegrationDetailedView<
                   title={t(
                     'You must be an organization owner, manager or admin to install this.'
                   )}
-                  disabled={hasAccess}
+                  disabled={hasAccess || !this.requiresAccess}
                 >
                   {!hideButtonIfDisabled && disabled ? (
                     <div />

--- a/static/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/docIntegrationDetailedView.tsx
@@ -63,6 +63,10 @@ class DocIntegrationDetailedView extends AbstractIntegrationDetailedView<
     return this.integration.features ?? [];
   }
 
+  get requiresAccess() {
+    return false;
+  }
+
   componentDidMount() {
     super.componentDidMount();
     this.trackIntegrationAnalytics('integrations.integration_viewed', {


### PR DESCRIPTION
…ns (API-1037)


Document integrations always show the install permissions tooltip when they shouldn't show any tooltip at all, as there's no way to install them from Sentry.