### PR TITLE
ref: upgrade sentry-arroyo (to get confluent-kafka upgrade)

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -55,7 +55,7 @@ requests>=2.25.1
 rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
-sentry-arroyo>=1.0.0
+sentry-arroyo>=1.0.1
 sentry-relay>=0.8.13
 sentry-sdk>=1.7.2
 snuba-sdk>=1.0.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -17,7 +17,7 @@ cffi==1.15.1
 cfgv==3.3.1
 chardet==4.0.0
 click==8.0.4
-confluent-kafka==1.7.0
+confluent-kafka==1.8.2
 coverage[toml]==6.3.3
 croniter==0.3.37
 cryptography==37.0.2
@@ -142,7 +142,7 @@ rfc3986-validator==0.1.1
 rsa==4.8
 s3transfer==0.5.2
 selenium==4.3.0
-sentry-arroyo==1.0.0
+sentry-arroyo==1.0.1
 sentry-relay==0.8.13
 sentry-sdk==1.7.2
 simplejson==3.17.6

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -14,7 +14,7 @@ certifi==2022.5.18.1
 cffi==1.15.1
 chardet==4.0.0
 click==8.0.4
-confluent-kafka==1.7.0
+confluent-kafka==1.8.2
 croniter==0.3.37
 cryptography==37.0.2
 cssselect==1.0.3
@@ -95,7 +95,7 @@ rfc3986-validator==0.1.1
 rsa==4.8
 s3transfer==0.5.2
 selenium==4.3.0
-sentry-arroyo==1.0.0
+sentry-arroyo==1.0.1
 sentry-relay==0.8.13
 sentry-sdk==1.7.2
 simplejson==3.17.6

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -62,11 +62,8 @@ class KafkaEventStream(SnubaProtocolEventStream):
                 value = False
             return str(int(value))
 
-        # WARNING: We must remove all None headers. There is a bug in confluent-kafka-python
-        # (used by both Sentry and Snuba) that incorrectly decrements the reference count of
-        # Python's None on any attempt to read header values containing null values, leading
-        # None to eventually get deallocated and crash the interpreter. The bug exists in the
-        # version we are using (1.5) as well as in the latest (at the time of writing) 1.7 version.
+        # we stripe `None` values here so later in the pipeline they can be
+        # cleanly encoded without nullability checks
         def strip_none_values(value: Mapping[str, Optional[str]]) -> Mapping[str, str]:
             return {key: value for key, value in value.items() if value is not None}
 

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -62,7 +62,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
                 value = False
             return str(int(value))
 
-        # we stripe `None` values here so later in the pipeline they can be
+        # we strip `None` values here so later in the pipeline they can be
         # cleanly encoded without nullability checks
         def strip_none_values(value: Mapping[str, Optional[str]]) -> Mapping[str, str]:
             return {key: value for key, value in value.items() if value is not None}


### PR DESCRIPTION
my eventual goal is to get to 1.9.x but would like to validate 1.8.2 first!

- [arroyo 1.0.1..1.0.2](https://github.com/getsentry/arroyo/compare/1.0.0..1.0.1)
- changelog for confluent-kafka: https://github.com/confluentinc/confluent-kafka-python/blob/master/CHANGELOG.md#v182

looks like there may be some considerations for the deprecated format -- I don't know if we're affected by that though :thinking: 