### PR TITLE
fix(rh-widgets): Throw an error if RH widget queries are beyond July 12

### DIFF
--- a/static/app/views/dashboardsV2/datasetConfig/releases.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/releases.tsx
@@ -16,6 +16,7 @@ import {
 } from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
+import {statsPeriodToDays} from 'sentry/utils/dates';
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {QueryFieldValue} from 'sentry/utils/discover/fields';
@@ -35,6 +36,7 @@ import {
   SESSIONS_TAGS,
   TAG_SORT_DENY_LIST,
 } from '../widgetBuilder/releaseWidget/fields';
+import {METRICS_BACKED_SESSIONS_START_DATE} from '../widgetCard';
 import {
   derivedMetricsToField,
   requiresCustomReleaseSorting,
@@ -386,6 +388,33 @@ function getReleasesRequest(
 ) {
   const {environments, projects, datetime} = pageFilters;
   const {start, end, period} = datetime;
+
+  let showIncompleteDataAlert: boolean = false;
+
+  if (start) {
+    let startDate: Date | undefined = undefined;
+    if (typeof start === 'string') {
+      startDate = new Date(start);
+    } else {
+      startDate = start;
+    }
+    showIncompleteDataAlert = startDate < METRICS_BACKED_SESSIONS_START_DATE;
+  } else if (period) {
+    const periodInDays = statsPeriodToDays(period);
+    const current = new Date();
+    const prior = new Date(new Date().setDate(current.getDate() - periodInDays));
+    showIncompleteDataAlert = prior < METRICS_BACKED_SESSIONS_START_DATE;
+  }
+
+  if (showIncompleteDataAlert) {
+    return Promise.reject(
+      new Error(
+        t(
+          'Releases data is only available from Jul 12. Please retry your query with a more recent date range.'
+        )
+      )
+    );
+  }
 
   // Only time we need to use sessions API is when session.status is requested
   // as a group by.

--- a/static/app/views/dashboardsV2/datasetConfig/releases.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/releases.tsx
@@ -36,7 +36,6 @@ import {
   SESSIONS_TAGS,
   TAG_SORT_DENY_LIST,
 } from '../widgetBuilder/releaseWidget/fields';
-import {METRICS_BACKED_SESSIONS_START_DATE} from '../widgetCard';
 import {
   derivedMetricsToField,
   requiresCustomReleaseSorting,
@@ -60,6 +59,8 @@ const DEFAULT_WIDGET_QUERY: WidgetQuery = {
   conditions: '',
   orderby: `-crash_free_rate(${SessionField.SESSION})`,
 };
+
+const METRICS_BACKED_SESSIONS_START_DATE = new Date('2022-07-12');
 
 export const ReleasesConfig: DatasetConfig<
   SessionApiResponse | MetricsApiResponse,

--- a/static/app/views/dashboardsV2/sortableWidget.tsx
+++ b/static/app/views/dashboardsV2/sortableWidget.tsx
@@ -2,6 +2,7 @@ import {ComponentProps, useEffect} from 'react';
 import {useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 
+import PanelAlert from 'sentry/components/panels/panelAlert';
 import {Organization} from 'sentry/types';
 import theme from 'sentry/utils/theme';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -87,6 +88,13 @@ function SortableWidget(props: Props) {
     index,
     dashboardFilters,
     hasUnsavedFilters,
+    renderErrorMessage: errorMessage => {
+      return (
+        typeof errorMessage === 'string' && (
+          <PanelAlert type="error">{errorMessage}</PanelAlert>
+        )
+      );
+    },
   };
 
   if (organization.features.includes('dashboard-grid-layout')) {

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -78,8 +78,6 @@ type State = {
 
 type SearchFilterKey = {key?: {value: string}};
 
-export const METRICS_BACKED_SESSIONS_START_DATE = new Date('2022-07-12');
-
 const ERROR_FIELDS = [
   'error.handled',
   'error.unhandled',

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -11,7 +11,6 @@ import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import {HeaderTitle} from 'sentry/components/charts/styles';
-import DateTime from 'sentry/components/dateTime';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Panel} from 'sentry/components/panels';
@@ -23,7 +22,6 @@ import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
-import {statsPeriodToDays} from 'sentry/utils/dates';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {parseFunction} from 'sentry/utils/discover/fields';
 import withApi from 'sentry/utils/withApi';
@@ -80,7 +78,7 @@ type State = {
 
 type SearchFilterKey = {key?: {value: string}};
 
-const METRICS_BACKED_SESSIONS_START_DATE = new Date('2022-07-12');
+export const METRICS_BACKED_SESSIONS_START_DATE = new Date('2022-07-12');
 
 const ERROR_FIELDS = [
   'error.handled',
@@ -233,24 +231,6 @@ class WidgetCard extends Component<Props, State> {
       dashboardFilters,
     } = this.props;
 
-    const {start, period} = selection.datetime;
-    let showIncompleteDataAlert: boolean = false;
-    if (widget.widgetType === WidgetType.RELEASE && showStoredAlert) {
-      if (start) {
-        let startDate: Date | undefined = undefined;
-        if (typeof start === 'string') {
-          startDate = new Date(start);
-        } else {
-          startDate = start;
-        }
-        showIncompleteDataAlert = startDate < METRICS_BACKED_SESSIONS_START_DATE;
-      } else if (period) {
-        const periodInDays = statsPeriodToDays(period);
-        const current = new Date();
-        const prior = new Date(new Date().setDate(current.getDate() - periodInDays));
-        showIncompleteDataAlert = prior < METRICS_BACKED_SESSIONS_START_DATE;
-      }
-    }
     if (widget.displayType === DisplayType.TOP_N) {
       const queries = widget.queries.map(query => ({
         ...query,
@@ -369,20 +349,6 @@ class WidgetCard extends Component<Props, State> {
                   return null;
                 }}
               </DashboardsMEPConsumer>
-            </Feature>
-            <Feature organization={organization} features={['dashboards-releases']}>
-              {showIncompleteDataAlert && (
-                <StoredDataAlert showIcon>
-                  {tct(
-                    'Releases data is only available from [date]. Data may be incomplete as a result.',
-                    {
-                      date: (
-                        <DateTime date={METRICS_BACKED_SESSIONS_START_DATE} dateOnly />
-                      ),
-                    }
-                  )}
-                </StoredDataAlert>
-              )}
             </Feature>
           </React.Fragment>
         )}

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -1375,6 +1375,7 @@ describe('Modals -> WidgetViewerModal', function () {
       });
     });
     it('does a sessions query', async function () {
+      jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
       await renderModal({initialData, widget: mockWidget});
       expect(metricsMock).toHaveBeenCalled();
     });

--- a/tests/js/spec/views/dashboardsV2/releaseWidgetQueries.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/releaseWidgetQueries.spec.tsx
@@ -72,6 +72,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
   });
 
   it('can send chart requests', async function () {
+    jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
       body: TestStubs.MetricsField({
@@ -457,6 +458,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
   });
 
   it('can send table requests', async function () {
+    jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
       body: TestStubs.MetricsSessionUserCountByStatusByRelease(),
@@ -556,6 +558,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
   });
 
   it('can send big number requests', async function () {
+    jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
       body: TestStubs.MetricsField({
@@ -603,6 +606,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
   });
 
   it('can send multiple API requests', function () {
+    jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
     const metricsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
       body: TestStubs.SessionsField({
@@ -699,6 +703,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
   });
 
   it('adjusts interval based on date window', function () {
+    jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/metrics/data/',
       body: TestStubs.SessionsField({
@@ -711,7 +716,7 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
         api={api}
         widget={{...singleQueryWidget, interval: '1m'}}
         organization={organization}
-        selection={{...selection, datetime: {...selection.datetime, period: '90d'}}}
+        selection={{...selection, datetime: {...selection.datetime, period: '14d'}}}
       >
         {() => <div data-test-id="child" />}
       </ReleaseWidgetQueries>
@@ -723,8 +728,8 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
       expect.anything(),
       expect.objectContaining({
         query: expect.objectContaining({
-          interval: '4h',
-          statsPeriod: '90d',
+          interval: '30m',
+          statsPeriod: '14d',
           environment: ['prod'],
           project: [1],
         }),

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2605,6 +2605,7 @@ describe('WidgetBuilder', function () {
       });
 
       it('makes the appropriate sessions call', async function () {
+        jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
         renderTestComponent({
           orgFeatures: releaseHealthFeatureFlags,
         });
@@ -2636,6 +2637,7 @@ describe('WidgetBuilder', function () {
       });
 
       it('calls the session endpoint with the right limit', async function () {
+        jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
         renderTestComponent({
           orgFeatures: releaseHealthFeatureFlags,
         });
@@ -2673,6 +2675,7 @@ describe('WidgetBuilder', function () {
       });
 
       it('calls sessions api when session.status is selected as a groupby', async function () {
+        jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
         renderTestComponent({
           orgFeatures: releaseHealthFeatureFlags,
         });
@@ -2736,6 +2739,7 @@ describe('WidgetBuilder', function () {
       });
 
       it('sets widgetType to release', async function () {
+        jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
         renderTestComponent({
           orgFeatures: releaseHealthFeatureFlags,
         });
@@ -2835,6 +2839,7 @@ describe('WidgetBuilder', function () {
       });
 
       it('adds a function when the only column chosen in a table is a tag', async function () {
+        jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
         renderTestComponent({
           orgFeatures: releaseHealthFeatureFlags,
         });

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -2571,6 +2571,7 @@ describe('WidgetBuilder', function () {
       });
 
       it('does not allow sort on tags except release', async function () {
+        jest.useFakeTimers().setSystemTime(new Date('2022-08-02'));
         renderTestComponent({
           orgFeatures: releaseHealthFeatureFlags,
         });


### PR DESCRIPTION
Error if RH widget queries are beyond Jul 12.
<img width="654" alt="Screen Shot 2022-08-03 at 2 33 01 PM" src="https://user-images.githubusercontent.com/63818634/182683483-21d64739-0a55-4946-ad06-dc11c41f481b.png">
<img width="650" alt="Screen Shot 2022-08-03 at 2 32 52 PM" src="https://user-images.githubusercontent.com/63818634/182683487-8cef0849-b2ed-45cf-9179-cf0b49126f79.png">

