### PR TITLE
fix(replays): Fix currentTime setting in player when changing layout

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -313,9 +313,9 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
         unMountedRef.current = false;
       }
 
-      replayerRef.current.pause(getCurrentTime());
+      replayerRef.current.pause(currentPlayerTime);
     },
-    [events, theme.purple200, setReplayFinished, hasNewEvents, getCurrentTime]
+    [events, theme.purple200, setReplayFinished, hasNewEvents, currentPlayerTime]
   );
 
   useEffect(() => {
@@ -420,8 +420,11 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
   }, []);
 
   // Only on pageload: set the initial playback timestamp
-  // Don't include `setCurrentTime` in the hook deps array because it changes
+  // Do not include `setCurrentTime` in the hook deps array because it changes
   // on each play/pause state change.
+  // Do include replayerRef.current in the hook deps. The rule warns that since
+  // it is a ref changing it will not cause a re-render. However, when that
+  // value changes we will get a re-render because other state values have changed.
   useEffect(() => {
     if (initialTimeOffset && events && replayerRef.current) {
       setCurrentTime(initialTimeOffset * 1000);
@@ -430,7 +433,7 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
     return () => {
       unMountedRef.current = true;
     };
-  }, [initialTimeOffset, events]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialTimeOffset, events, replayerRef.current]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [isBuffering, currentTime] =
     buffer.target !== -1 &&


### PR DESCRIPTION
This fixes an issue that was introduced in #37394

The original problem was that: when you change the layout the currentTime was being reset back to `0:00`.
#37394 introduced a new issue that changing the layout failed to re-create the Replayer instance, so there was no iframe in the player area anymore.

This fixes the known problems by:
a) Use (as before) `replayerRef.current` in the useEffect hook dependencies. This is despite the lint rules warnings. What we want is a reliable way to track whether the Replayer instance is mounted or not, and we do get re-renders when that changes, so the lint rule isn't applicable.
b) Just read the `currentPlayerTime` which is a state variable and is already set, instead of pulling the time out again from the function.

Testing notes:
I did test this before with two steps:
1. Click into the timeline to set `currentTime` to be greater than zero
2. Use the dropdown in the top-right corner to change the layout
Expected that the `currentTime` would be unchanged after the layout is updated.

I'm not sure why the tests weren't working when I did #37394, but I made sure to fully restart my dev server and clear caches to know that things are working now.