### PR TITLE
feat(profiling): Make flamegraph view the default

### DIFF
--- a/static/app/components/profiling/profilesTable.tsx
+++ b/static/app/components/profiling/profilesTable.tsx
@@ -16,7 +16,7 @@ import {defined} from 'sentry/utils';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {getShortEventId} from 'sentry/utils/events';
 import {
-  generateProfileDetailsRoute,
+  generateProfileFlamechartRoute,
   generateProfileSummaryRouteWithQuery,
 } from 'sentry/utils/profiling/routes';
 import {renderTableHead} from 'sentry/utils/profiling/tableRenderer';
@@ -113,7 +113,7 @@ function ProfilesTableCell({column, dataRow}: ProfilesTableCellProps) {
         return <Container>{getShortEventId(dataRow.id)}</Container>;
       }
 
-      const flamegraphTarget = generateProfileDetailsRoute({
+      const flamegraphTarget = generateProfileFlamechartRoute({
         orgSlug: organization.slug,
         projectSlug: project.slug,
         profileId: dataRow.id,


### PR DESCRIPTION
Currently the profile ids in the recent profiles table on the profiling summary
page links to the profile details view. This is the last direct entry point to
the details view. Changing this to the profile flamegraph view will make the
flamegraph the default view.