### PR TITLE
fix(metrics): Do not crash when limiting all strings in a message [INGEST-1380]

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -562,12 +562,16 @@ def ingest_consumer(consumer_types, all_consumer_types, **options):
 @click.option("commit_max_batch_size", "--commit-max-batch-size", type=int, default=25000)
 @click.option("commit_max_batch_time", "--commit-max-batch-time-ms", type=int, default=10000)
 def metrics_streaming_consumer(**options):
+    import sentry_sdk
+
     from sentry.sentry_metrics.configuration import UseCaseKey, get_ingest_config
     from sentry.sentry_metrics.consumers.indexer.multiprocess import get_streaming_metrics_consumer
     from sentry.sentry_metrics.metrics_wrapper import MetricsWrapper
     from sentry.utils.metrics import backend, global_tags
 
-    ingest_config = get_ingest_config(UseCaseKey(options["ingest_profile"]))
+    use_case = UseCaseKey(options["ingest_profile"])
+    sentry_sdk.set_tag("sentry_metrics.use_case_key", use_case.value)
+    ingest_config = get_ingest_config(use_case)
     metrics_wrapper = MetricsWrapper(backend, "sentry_metrics.indexer")
     configure_metrics(metrics_wrapper)
 

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -154,6 +154,7 @@ class IndexerBatch:
 
             metric_name = new_payload_value["name"]
             org_id = new_payload_value["org_id"]
+            sentry_sdk.set_tag("sentry_metrics.organization_id", org_id)
             tags = new_payload_value.get("tags", {})
             used_tags.add(metric_name)
 

--- a/src/sentry/sentry_metrics/indexer/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres_v2.py
@@ -144,11 +144,9 @@ class PGStringIndexerV2(StringIndexer):
             filtered_db_write_keys = writes_limiter_state.accepted_keys
             del db_write_keys
 
-            rate_limited_write_results = writes_limiter_state.dropped_strings
-
-            db_write_key_results = KeyResults()
-            for dropped_string in rate_limited_write_results:
-                db_write_key_results.add_key_result(
+            rate_limited_key_results = KeyResults()
+            for dropped_string in writes_limiter_state.dropped_strings:
+                rate_limited_key_results.add_key_result(
                     dropped_string.key_result,
                     fetch_type=dropped_string.fetch_type,
                     fetch_type_ext=dropped_string.fetch_type_ext,
@@ -156,7 +154,7 @@ class PGStringIndexerV2(StringIndexer):
 
             if filtered_db_write_keys.size == 0:
                 indexer_cache.set_many(new_results_to_cache, use_case_id.value)
-                return cache_key_results.merge(db_read_key_results).merge(db_write_key_results)
+                return cache_key_results.merge(db_read_key_results).merge(rate_limited_key_results)
 
             new_records = []
             for write_pair in filtered_db_write_keys.as_tuples():
@@ -171,6 +169,7 @@ class PGStringIndexerV2(StringIndexer):
                 # attempt to create the rows down below.
                 self._table(use_case_id).objects.bulk_create(new_records, ignore_conflicts=True)
 
+        db_write_key_results = KeyResults()
         db_write_key_results.add_key_results(
             [
                 KeyResult(org_id=db_obj.organization_id, string=db_obj.string, id=db_obj.id)
@@ -182,7 +181,11 @@ class PGStringIndexerV2(StringIndexer):
         new_results_to_cache.update(db_write_key_results.get_mapped_key_strings_to_ints())
         indexer_cache.set_many(new_results_to_cache, use_case_id.value)
 
-        return cache_key_results.merge(db_read_key_results).merge(db_write_key_results)
+        return (
+            cache_key_results.merge(db_read_key_results)
+            .merge(db_write_key_results)
+            .merge(rate_limited_key_results)
+        )
 
     def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
         """Store a string and return the integer ID generated for it"""

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -327,7 +327,13 @@ class PostgresIndexerV2Test(TestCase):
                 use_case_id=self.use_case_id, org_strings=org_strings
             )
 
-        assert results[1] == {}
+        assert results[1] == {"x": None, "y": None, "z": None}
+        for letter in "xyz":
+            assert results.get_fetch_metadata()[1][letter] == Metadata(
+                id=None,
+                fetch_type=FetchType.RATE_LIMITED,
+                fetch_type_ext=FetchTypeExt(is_global=False),
+            )
 
         org_strings = {1: rate_limited_strings}
 


### PR DESCRIPTION
If the postgres indexer backend determines that there are no strings to
be written to postgres because of rate limits, it returns early, just as
we do when there are no strings to be read from postgres. In that
early-return path, we were accidentally omitting the KeyResults for the
dropped strings + metadata that indicates that they were, causing a
KeyError in StringBatch when attempting to access the result.

We didn't even drop data this way, we just crashed processing a message
that we would've dropped anyway.

Also add a few more tags that are useful to determine impact of errors:
A usecase tag to see if an indexer crash affects releasehealth or
performance, and a tag for the organization id to quickly determine
which organization is the most heavily rate limited.



