### PR TITLE
fix(discover): fixes editable title padding in discover and dashboards

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -194,6 +194,7 @@ const InputWrapper = styled('div')<{isEmpty: boolean}>`
   background: ${p => p.theme.gray100};
   border-radius: ${p => p.theme.borderRadius};
   margin: -${space(0.5)} -${space(1)};
+  padding: ${space(0.5)} ${space(1)};
   max-width: calc(100% + ${space(2)});
 `;
 
@@ -202,7 +203,7 @@ const StyledInput = styled(Input)`
   background: transparent;
   height: auto;
   min-height: 34px;
-  padding: ${space(0.5)} ${space(1)};
+  padding: 0;
   &,
   &:focus,
   &:active,


### PR DESCRIPTION
before 
<img width="376" alt="image" src="https://user-images.githubusercontent.com/83961295/182714958-ea9822af-fee1-47e8-8ac6-c6ea38eae0ac.png">
after
<img width="359" alt="image" src="https://user-images.githubusercontent.com/83961295/182715005-826f1cdc-83c6-4eb9-a4ba-f57b2d72546a.png">
