### PR TITLE
fix(eventstore): Expose get_unfetched_transactions

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -127,6 +127,7 @@ class EventStorage(Service):
         "get_earliest_event_id",
         "get_latest_event_id",
         "bind_nodes",
+        "get_unfetched_transactions",
     )
 
     # The minimal list of columns we need to get from snuba to bootstrap an


### PR DESCRIPTION
Need `get_unfetched_transactions` in getsentry repository. Forgot to do it in https://github.com/getsentry/sentry/pull/37386
