### PR TITLE
feat(discover): Discover unparameterized banner

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -194,6 +194,7 @@ const InputWrapper = styled('div')<{isEmpty: boolean}>`
   background: ${p => p.theme.gray100};
   border-radius: ${p => p.theme.borderRadius};
   margin: -${space(0.5)} -${space(1)};
+  padding: ${space(0.5)} ${space(1)};
   max-width: calc(100% + ${space(2)});
 `;
 
@@ -202,7 +203,7 @@ const StyledInput = styled(Input)`
   background: transparent;
   height: auto;
   min-height: 34px;
-  padding: ${space(0.5)} ${space(1)};
+  padding: 0;
   &,
   &:focus,
   &:active,

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -474,7 +474,7 @@ class Results extends Component<Props, State> {
       return (
         <Alert type="info" showIcon>
           {tct(
-            'These are unparameterized transactions. To better organize your transactions, [link: set transaction names manually].',
+            'These are unparameterized transactions. To better organize your transactions, [link:set transaction names manually].',
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/#parameterized-transaction-names" />

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -18,6 +18,7 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
+import ExternalLink from 'sentry/components/links/externalLink';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -72,6 +73,7 @@ type State = {
   totalValues: null | number;
   savedQuery?: SavedQuery;
   showMetricsAlert?: boolean;
+  showUnparameterizedBanner?: boolean;
 };
 const SHOW_TAGS_STORAGE_KEY = 'discover2:show-tags';
 
@@ -124,6 +126,13 @@ class Results extends Component<Props, State> {
       browserHistory.replace({
         ...location,
         query: {...location.query, fromMetric: undefined},
+      });
+    }
+    if (location.query.showUnparameterizedBanner) {
+      this.setState({showUnparameterizedBanner: true});
+      browserHistory.replace({
+        ...location,
+        query: {...location.query, showUnparameterizedBanner: undefined},
       });
     }
     loadOrganizationTags(this.tagsApi, organization.slug, selection);
@@ -457,6 +466,20 @@ class Results extends Component<Props, State> {
         <Alert type="info" showIcon>
           {t(
             "You've navigated to this page from a performance metric widget generated from processed events. The results here only show sampled events."
+          )}
+        </Alert>
+      );
+    }
+    if (this.state.showUnparameterizedBanner) {
+      return (
+        <Alert type="info" showIcon>
+          {tct(
+            'These are unparameterized transactions. To better organize your transactions, [link: set transaction names manually].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/#parameterized-transaction-names" />
+              ),
+            }
           )}
         </Alert>
       );

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -1672,4 +1672,35 @@ describe('Results', function () {
       "You've navigated to this page from a performance metric widget generated from processed events. The results here only show sampled events."
     );
   });
+
+  it('renders unparameterized data banner', async function () {
+    const organization = TestStubs.Organization({
+      features: ['discover-basic'],
+    });
+
+    const initialData = initializeOrg({
+      organization,
+      router: {
+        location: {query: {showUnparameterizedBanner: true}},
+      },
+    });
+
+    ProjectsStore.loadInitialData([TestStubs.Project()]);
+
+    const wrapper = mountWithThemeAndOrg(
+      <Results
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+      />,
+      initialData.routerContext,
+      organization
+    );
+
+    await tick();
+    wrapper.update();
+    expect(wrapper.find('Alert').find('Message').text()).toEqual(
+      'These are unparameterized transactions. To better organize your transactions,  set transaction names manually.'
+    );
+  });
 });

--- a/tests/js/spec/views/eventsV2/results.spec.jsx
+++ b/tests/js/spec/views/eventsV2/results.spec.jsx
@@ -1700,7 +1700,7 @@ describe('Results', function () {
     await tick();
     wrapper.update();
     expect(wrapper.find('Alert').find('Message').text()).toEqual(
-      'These are unparameterized transactions. To better organize your transactions,  set transaction names manually.'
+      'These are unparameterized transactions. To better organize your transactions, set transaction names manually.'
     );
   });
 });


### PR DESCRIPTION
Allows showing banner when navigating to Discover from a unparameterized transaction name link
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/83961295/182718432-57e66ded-ad2e-4b52-b8de-08527f60c292.png">