### PR TITLE
fix(workflow): Move first seen graph dot

### DIFF
--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -16,6 +16,10 @@ type Marker = {
   name: string;
   value: string | number | Date;
   symbolSize?: number;
+  /**
+   * Use "value" to control the marker position, but tooltip value for the real value
+   */
+  tooltipValue?: string | number | Date;
 };
 
 type ChartProps = React.ComponentProps<typeof BaseChart>;
@@ -133,9 +137,14 @@ function MiniBarChart({
       show: true,
       trigger: 'item',
       formatter: ({data}) => {
-        const time = getFormattedDate(data.coord[0], 'MMM D, YYYY LT', {
-          local: !props.utc,
-        });
+        const time = getFormattedDate(
+          // To be safe fallback to the coordinates
+          data.tooltipValue ?? data.coord[0],
+          'MMM D, YYYY LT',
+          {
+            local: !props.utc,
+          }
+        );
         const name = truncationFormatter(data.name, props?.xAxis?.truncate);
         return [
           '<div class="tooltip-series">',
@@ -155,6 +164,7 @@ function MiniBarChart({
         name: marker.name,
         coord: [marker.value, 0],
         tooltip: markerTooltip,
+        tooltipValue: marker.tooltipValue ?? marker.value,
         symbol: 'circle',
         symbolSize: marker.symbolSize ?? 8,
         itemStyle: {

--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -2,33 +2,26 @@
 import './components/markPoint';
 
 import {useTheme} from '@emotion/react';
+import type {GridComponentOption} from 'echarts';
 import set from 'lodash/set';
 
-import {getFormattedDate} from 'sentry/utils/dates';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 
 import {BarChart, BarChartProps, BarChartSeries} from './barChart';
 import type BaseChart from './baseChart';
-import {truncationFormatter} from './utils';
-
-type Marker = {
-  color: string;
-  name: string;
-  value: string | number | Date;
-  symbolSize?: number;
-  /**
-   * Override the value with a different datetime to display
-   */
-  tooltipValue?: string | number | Date;
-};
 
 type ChartProps = React.ComponentProps<typeof BaseChart>;
 
 interface Props extends Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'> {
   /**
+   * Override the default grid padding
+   */
+  grid: GridComponentOption;
+  /**
    * Chart height
    */
   height: number;
+
   /**
    * Colors to use on the chart.
    */
@@ -50,12 +43,6 @@ interface Props extends Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'>
    * Show max/min values on yAxis
    */
   labelYAxisExtents?: boolean;
-
-  /**
-   * A list of series to be rendered as markLine components on the chart
-   * This is often used to indicate start/end markers on the xAxis
-   */
-  markers?: Marker[];
 
   series?: BarChartProps['series'];
 
@@ -85,7 +72,6 @@ interface Props extends Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'>
 }
 
 function MiniBarChart({
-  markers,
   emphasisColors,
   series,
   hideDelay,
@@ -95,6 +81,7 @@ function MiniBarChart({
   labelYAxisExtents = false,
   showMarkLineLabel = false,
   height,
+  grid,
   ...props
 }: Props) {
   const {ref: _ref, ...barChartProps} = props;
@@ -130,50 +117,6 @@ function MiniBarChart({
 
       return updated;
     });
-  }
-
-  if (markers) {
-    const markerTooltip = {
-      show: true,
-      trigger: 'item',
-      formatter: ({data}) => {
-        const time = getFormattedDate(
-          // To be safe fallback to the coordinates
-          data.tooltipValue ?? data.coord[0],
-          'MMM D, YYYY LT',
-          {
-            local: !props.utc,
-          }
-        );
-        const name = truncationFormatter(data.name, props?.xAxis?.truncate);
-        return [
-          '<div class="tooltip-series">',
-          `<div><span class="tooltip-label"><strong>${name}</strong></span></div>`,
-          '</div>',
-          '<div class="tooltip-date">',
-          time,
-          '</div>',
-          '</div>',
-          '<div class="tooltip-arrow"></div>',
-        ].join('');
-      },
-    };
-
-    const markPoint = {
-      data: markers.map((marker: Marker) => ({
-        name: marker.name,
-        coord: [marker.value, 0],
-        tooltip: markerTooltip,
-        tooltipValue: marker.tooltipValue ?? marker.value,
-        symbol: 'circle',
-        symbolSize: marker.symbolSize ?? 8,
-        itemStyle: {
-          color: marker.color,
-          borderColor: theme.background,
-        },
-      })),
-    };
-    chartSeries[0].markPoint = markPoint;
   }
 
   const yAxisOptions = labelYAxisExtents
@@ -220,13 +163,13 @@ function MiniBarChart({
       },
       ...yAxisOptions,
     },
-    grid: {
+    grid: grid ?? {
       // Offset to ensure there is room for the marker symbols at the
       // default size.
       top: labelYAxisExtents || showMarkLineLabel ? 6 : 0,
-      bottom: markers || labelYAxisExtents || showMarkLineLabel ? 4 : 0,
-      left: markers ? 8 : showMarkLineLabel ? 35 : 4,
-      right: markers ? 4 : 0,
+      bottom: labelYAxisExtents || showMarkLineLabel ? 4 : 0,
+      left: showMarkLineLabel ? 35 : 4,
+      right: 0,
     },
     xAxis: {
       axisLine: {

--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -17,7 +17,7 @@ type Marker = {
   value: string | number | Date;
   symbolSize?: number;
   /**
-   * Use "value" to control the marker position, but tooltip value for the real value
+   * Override the value with a different datetime to display
    */
   tooltipValue?: string | number | Date;
 };

--- a/static/app/components/charts/miniBarChart.tsx
+++ b/static/app/components/charts/miniBarChart.tsx
@@ -14,14 +14,9 @@ type ChartProps = React.ComponentProps<typeof BaseChart>;
 
 interface Props extends Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'> {
   /**
-   * Override the default grid padding
-   */
-  grid: GridComponentOption;
-  /**
    * Chart height
    */
   height: number;
-
   /**
    * Colors to use on the chart.
    */
@@ -33,6 +28,11 @@ interface Props extends Omit<ChartProps, 'css' | 'colors' | 'series' | 'height'>
    * You can use this prop to also shift colors on hover.
    */
   emphasisColors?: string[];
+
+  /**
+   * Override the default grid padding
+   */
+  grid?: GridComponentOption;
 
   /**
    * Delay time for hiding tooltip, in ms.

--- a/static/app/components/group/releaseChart.tsx
+++ b/static/app/components/group/releaseChart.tsx
@@ -69,7 +69,7 @@ function GroupReleaseChart(props: Props) {
   });
 
   // Get the timestamp of the first point.
-  const firstTime = series[0].data[0].value;
+  const firstGraphTime = series[0].data[0].name;
 
   if (release && releaseStats) {
     series.push({
@@ -82,26 +82,35 @@ function GroupReleaseChart(props: Props) {
   }
 
   const markers: Markers = [];
-  if (firstSeen) {
-    const firstSeenX = new Date(firstSeen).getTime();
-    if (firstSeenX >= firstTime) {
-      markers.push({
-        name: t('First seen'),
-        value: firstSeenX,
-        color: theme.pink300,
-      });
+  const firstSeenX = new Date(firstSeen ?? 0).getTime();
+  const lastSeenX = new Date(lastSeen ?? 0).getTime();
+
+  if (firstSeen && stats.length > 2 && firstSeenX >= firstGraphTime) {
+    // Find the first bucket that would contain our first seen event
+    const firstBucket = stats.findIndex(([time]) => time * 1000 > firstSeenX);
+
+    let bucketStart: number | undefined;
+    if (firstBucket > 0) {
+      // The size of the data interval in ms
+      const halfBucketSize = ((stats[1][0] - stats[0][0]) * 1000) / 2;
+      // Display the marker closer to the front of the bucket
+      bucketStart = stats[firstBucket - 1][0] * 1000 - halfBucketSize;
     }
+
+    markers.push({
+      name: t('First seen'),
+      value: bucketStart ?? firstSeenX,
+      tooltipValue: firstSeenX,
+      color: theme.pink300,
+    });
   }
 
-  if (lastSeen) {
-    const lastSeenX = new Date(lastSeen).getTime();
-    if (lastSeenX >= firstTime) {
-      markers.push({
-        name: t('Last seen'),
-        value: lastSeenX,
-        color: theme.green300,
-      });
-    }
+  if (lastSeen && lastSeenX >= firstGraphTime) {
+    markers.push({
+      name: t('Last seen'),
+      value: lastSeenX,
+      color: theme.green300,
+    });
   }
 
   const totalSeries =

--- a/tests/js/spec/components/group/minibarChart.spec.tsx
+++ b/tests/js/spec/components/group/minibarChart.spec.tsx
@@ -1,0 +1,30 @@
+import {getGroupReleaseChartMarkers} from 'sentry/components/group/releaseChart';
+import type {TimeseriesValue} from 'sentry/types';
+
+it('should set marker before first bucket', () => {
+  const data: TimeseriesValue[] = [
+    [1659524400, 0],
+    [1659528000, 0],
+    [1659531600, 0],
+    [1659535200, 2],
+    [1659538800, 10],
+    [1659542400, 6],
+    [1659546000, 8],
+    [1659549600, 0],
+    [1659553200, 0],
+  ];
+  const firstSeen = '2022-08-03T14:48:04Z';
+  const markers = getGroupReleaseChartMarkers(data, firstSeen, '2022-08-03T20:23:05Z');
+  expect(markers[0].tooltipValue).toBe(new Date(firstSeen).getTime());
+  expect(markers[0]).toEqual({
+    color: '#F91A8A',
+    name: 'First seen',
+    tooltipValue: 1659538084000,
+    value: 1659533400000,
+  });
+  expect(markers[1]).toEqual({
+    color: '#2BA185',
+    name: 'Last seen',
+    value: 1659558185000,
+  });
+});

--- a/tests/js/spec/components/group/minibarChart.spec.tsx
+++ b/tests/js/spec/components/group/minibarChart.spec.tsx
@@ -1,5 +1,6 @@
 import {getGroupReleaseChartMarkers} from 'sentry/components/group/releaseChart';
 import type {TimeseriesValue} from 'sentry/types';
+import theme from 'sentry/utils/theme';
 
 it('should set marker before first bucket', () => {
   const data: TimeseriesValue[] = [
@@ -14,17 +15,11 @@ it('should set marker before first bucket', () => {
     [1659553200, 0],
   ];
   const firstSeen = '2022-08-03T14:48:04Z';
-  const markers = getGroupReleaseChartMarkers(data, firstSeen, '2022-08-03T20:23:05Z');
-  expect(markers[0].tooltipValue).toBe(new Date(firstSeen).getTime());
-  expect(markers[0]).toEqual({
-    color: '#F91A8A',
-    name: 'First seen',
-    tooltipValue: 1659538084000,
-    value: 1659533400000,
-  });
-  expect(markers[1]).toEqual({
-    color: '#2BA185',
-    name: 'Last seen',
-    value: 1659558185000,
-  });
+  const lastSeen = '2022-08-03T20:23:05Z';
+  const markers = getGroupReleaseChartMarkers(theme as any, data, firstSeen, lastSeen)!
+    .data!;
+
+  expect((markers[0] as any).displayValue).toBe(new Date(firstSeen).getTime());
+  expect(markers[0].coord![0]).toBe(1659533400000);
+  expect(markers[1].coord![0]).toBe(new Date(lastSeen).getTime());
 });


### PR DESCRIPTION
Moves the pink "first seen" dot to where we expect it to be represented. The bar graph uses buckets that can be up to 24 hours, the dot placement feels off because the dot is displayed accurately on the xAxis.

before
<img width="315" alt="image" src="https://user-images.githubusercontent.com/1400464/182731439-470850c9-3c08-418d-b90a-023d2e31b820.png">

after
<img width="312" alt="image" src="https://user-images.githubusercontent.com/1400464/182731458-56b6b49d-de7c-42d4-ba94-fab124abccdf.png">
