### PR TITLE
ref(sampling): Add client and server warning/help icons- [TET-298]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -435,7 +435,10 @@ export function UniformRateModal({
               </ClientColumn>
               <ClientHelpOrWarningColumn>
                 {isEdited && !isValidSampleRate(percentageToRate(clientInput)) ? (
-                  <Tooltip title={t('Set a value between 0 and 100')}>
+                  <Tooltip
+                    title={t('Set a value between 0 and 100')}
+                    containerDisplayMode="inline-flex"
+                  >
                     <IconWarning
                       color="red300"
                       size="sm"
@@ -468,7 +471,10 @@ export function UniformRateModal({
               </ServerColumn>
               <ServerWarningColumn>
                 {isEdited && !isValidSampleRate(percentageToRate(serverInput)) && (
-                  <Tooltip title={t('Set a value between 0 and 100')}>
+                  <Tooltip
+                    title={t('Set a value between 0 and 100')}
+                    containerDisplayMode="inline-flex"
+                  >
                     <IconWarning
                       color="red300"
                       size="sm"

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -486,6 +486,7 @@ export function UniformRateModal({
               <RefreshRatesColumn>
                 {isEdited && (
                   <Button
+                    title={t('Reset to suggested values')}
                     icon={<IconRefresh size="sm" />}
                     aria-label={t('Reset to suggested values')}
                     onClick={() => {

--- a/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
@@ -65,12 +65,17 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     expect(screen.getByText('100%')).toBeInTheDocument(); // Current client-side sample rate
     expect(screen.getByText('N/A')).toBeInTheDocument(); // Current server-side sample rate
     expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(95); // Suggested client-side sample rate
+    expect(screen.queryByTestId('invalid-client-rate')).not.toBeInTheDocument(); // Client input warning is not visible
+    expect(screen.getAllByTestId('more-information')).toHaveLength(2); // Client input help is visible
     expect(screen.getAllByRole('spinbutton')[1]).toHaveValue(95); // Suggested server-side sample rate
     expect(screen.queryByLabelText('Reset to suggested values')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invalid-server-rate')).not.toBeInTheDocument(); // Server input warning is not visible
 
     // Enter invalid client-side sample rate
     userEvent.clear(screen.getAllByRole('spinbutton')[0]);
-    expect(screen.getByRole('button', {name: 'Next'})).toBeDisabled();
+    userEvent.hover(screen.getByTestId('invalid-client-rate')); // Client input warning is visible
+    expect(await screen.findByText('Set a value between 0 and 100')).toBeInTheDocument();
+    expect(screen.queryByTestId('more-information')).not.toBeInTheDocument(); // Client input help is not visible
 
     // Hover over next button
     userEvent.hover(screen.getByRole('button', {name: 'Next'}));
@@ -83,10 +88,19 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     expect(screen.getByRole('radio', {name: 'New'})).toBeChecked();
     expect(screen.getByLabelText('Reset to suggested values')).toBeInTheDocument();
 
-    // Reset client-side sample rate to suggested value
+    // Enter invalid server-side sample rate
+    userEvent.clear(screen.getAllByRole('spinbutton')[1]);
+    userEvent.hover(screen.getByTestId('invalid-server-rate')); // Server input warning is visible
+    expect(await screen.findByText('Set a value between 0 and 100')).toBeInTheDocument();
+
+    // Reset sample rates to suggested values
     userEvent.click(screen.getByLabelText('Reset to suggested values'));
     expect(screen.getByText('Suggested')).toBeInTheDocument();
     expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(95); // Suggested client-side sample rate
+    expect(screen.getAllByRole('spinbutton')[1]).toHaveValue(95); // Suggested server-side sample rate
+    expect(screen.queryByTestId('invalid-client-rate')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('more-information')).toHaveLength(2); // Question marks (help components) are visible
+    expect(screen.queryByTestId('invalid-server-rate')).not.toBeInTheDocument();
 
     // Footer
     expect(screen.getByRole('button', {name: 'Read Docs'})).toHaveAttribute(


### PR DESCRIPTION
**What this PR does:**

- Display a warning next to the client sample rate input if the entered value is invalid
- Display a warning next to the server sample rate input if the entered value is invalid
- Display a help question mark component next to the client sample rate input if the entered value is valid 
- Add tests


**Preview:**



https://user-images.githubusercontent.com/29228205/182811138-52f72e96-728a-4705-9fb1-b8f0d6462f93.mov





