### PR TITLE
feat(sampling): Add feature badge, link to faq [TET-310]

### DIFF
--- a/static/app/views/settings/components/settingsNavItem.tsx
+++ b/static/app/views/settings/components/settingsNavItem.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, ReactElement} from 'react';
 import {Link as RouterLink} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -12,7 +12,7 @@ import space from 'sentry/styles/space';
 type Props = {
   label: React.ReactNode;
   to: React.ComponentProps<RouterLink>['to'];
-  badge?: string | number | null;
+  badge?: string | number | null | ReactElement;
   id?: string;
   index?: boolean;
   onClick?: (e: React.MouseEvent) => void;
@@ -36,8 +36,10 @@ const SettingsNavItem = ({badge, label, index, id, ...props}: Props) => {
         <StyledBadge text={badge} type="warning" />
       </Tooltip>
     );
-  } else {
+  } else if (typeof badge === 'string' || typeof badge === 'number') {
     renderedBadge = <StyledBadge text={badge} />;
+  } else {
+    renderedBadge = badge;
   }
 
   return (

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -1,3 +1,6 @@
+import styled from '@emotion/styled';
+
+import FeatureBadge from 'sentry/components/featureBadge';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
 import {NavigationSection} from 'sentry/views/settings/types';
@@ -74,6 +77,8 @@ export default function getConfiguration({
           description: t(
             "Per-Project basis solution to configure sampling rules within Sentry's UI"
           ),
+          // hack to make the badge fit next to Server-Side Sampling
+          badge: () => <NarrowFeatureBadge type="beta" />,
         },
         {
           path: `${pathPrefix}/security-and-privacy/`,
@@ -168,3 +173,9 @@ export default function getConfiguration({
     },
   ];
 }
+
+const NarrowFeatureBadge = styled(FeatureBadge)`
+  max-width: 25px;
+  position: relative;
+  top: 1px;
+`;

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -16,6 +16,7 @@ import {
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
+import FeatureBadge from 'sentry/components/featureBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Panel, PanelFooter, PanelHeader} from 'sentry/components/panels';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -401,11 +402,18 @@ export function ServerSideSampling({project}: Props) {
   return (
     <SentryDocumentTitle title={t('Server-Side Sampling')}>
       <Fragment>
-        <SettingsPageHeader title={t('Server-Side Sampling')} />
+        <SettingsPageHeader
+          title={
+            <Fragment>
+              {t('Server-Side Sampling')} <FeatureBadge type="beta" />
+            </Fragment>
+          }
+        />
         <TextBlock>
           {tct(
-            'Enhance the performance monitoring experience by targeting which transactions are most valuable to your organization without the need for re-deployment. To learn more about server-side sampling, [docsLink:read the docs].',
+            'Enhance the Performance monitoring experience by targeting which transactions are most valuable to your organization. To learn more about our beta program, [faqLink: visit our FAQ], for more general information, [docsLink: read our docs].',
             {
+              faqLink: <ExternalLink href="https://help.sentry.io/product-features/" />, // TODO(sampling): replace with better link once we have it
               docsLink: <ExternalLink href={SERVER_SIDE_SAMPLING_DOC_LINK} />,
             }
           )}

--- a/static/app/views/settings/types.tsx
+++ b/static/app/views/settings/types.tsx
@@ -1,3 +1,5 @@
+import {ReactElement} from 'react';
+
 import {Organization, Project, Scope} from 'sentry/types';
 
 export type NavigationProps = {
@@ -23,7 +25,7 @@ export type NavigationItem = {
   /**
    * Returns the text of the badge to render next to the navigation.
    */
-  badge?: (opts: NavigationGroupProps) => string | number | null;
+  badge?: (opts: NavigationGroupProps) => string | number | null | ReactElement;
   /**
    * The description of the settings section. This will be used in search.
    */

--- a/tests/js/spec/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
@@ -59,7 +59,7 @@ describe('Server-Side Sampling', function () {
     );
 
     expect(
-      screen.getByRole('heading', {name: 'Server-Side Sampling'})
+      screen.getByRole('heading', {name: /Server-Side Sampling/})
     ).toBeInTheDocument();
 
     expect(screen.getByText(/enhance the performance monitoring/i)).toBeInTheDocument();


### PR DESCRIPTION
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/9060071/182823702-79312ddc-76e5-4f7f-9ee1-453e97bd4d61.png">


We had to pass a custom FeatureBadge to our `navItem` so that we could adjust the width to fit next to the long `Server-Side Sampling` title. We don’t have our usual space between the end of badge and border of the nav but it’s not that bad.