### PR TITLE
feat(dashboards): Adds beta badges to widget builder alert banners and event detail page

### DIFF
--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
+import FeatureBadge from 'sentry/components/featureBadge';
 import {Panel} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -37,6 +38,7 @@ export default function EventCustomPerformanceMetrics({
   return (
     <Container>
       <SectionHeading>{t('Custom Performance Metrics')}</SectionHeading>
+      <FeatureBadge type="beta" />
       <Measurements>
         {measurementNames.map(name => {
           return (

--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -86,7 +86,7 @@ export function CustomMeasurementsProvider({
           }
 
           const errorResponse =
-            e?.responseJSON ?? t('Unable to fetch custom measurements');
+            e?.responseJSON ?? t('Unable to fetch custom performance metrics');
           addErrorMessage(errorResponse);
           handleXhrErrorResponse(errorResponse)(e);
         });

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -12,6 +12,7 @@ import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import {HeaderTitle} from 'sentry/components/charts/styles';
 import ErrorBoundary from 'sentry/components/errorBoundary';
+import FeatureBadge from 'sentry/components/featureBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
 import {Panel} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
@@ -330,6 +331,7 @@ class WidgetCard extends Component<Props, State> {
                               ),
                             }
                           )}
+                          <FeatureBadge type="beta" />
                         </StoredDataAlert>
                       );
                     }
@@ -344,6 +346,7 @@ class WidgetCard extends Component<Props, State> {
                               ),
                             }
                           )}
+                          <FeatureBadge type="beta" />
                         </StoredDataAlert>
                       );
                     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/83961295/182908646-2b39a10d-8ef9-4e0e-bd71-c9633878febf.png)
![image](https://user-images.githubusercontent.com/83961295/182908664-0e69dc6e-078b-4093-bf43-2994f6c9e67c.png)
![image](https://user-images.githubusercontent.com/83961295/182908704-61d9c2df-a2eb-4f92-a0b2-46c72ac54ccf.png)
