### PR TITLE
fix(discover): topN transaction status

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import sentry_sdk
 from dateutil.parser import parse as parse_datetime
+from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.function import Function
 from typing_extensions import TypedDict
@@ -398,6 +399,8 @@ def create_result_key(result_row, fields, issues) -> str:
             if issue_id is None:
                 issue_id = "unknown"
             values.append(issue_id)
+        elif field == "transaction.status":
+            values.append(SPAN_STATUS_CODE_TO_NAME.get(result_row[field], "unknown"))
         else:
             value = result_row.get(field)
             if isinstance(value, list):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1180,6 +1180,28 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         assert other["order"] == 5
         assert [{"count": 1}] in [attrs for _, attrs in other["data"]]
 
+    def test_top_events_with_transaction_status(self):
+        with self.feature(self.enabled_features):
+            response = self.client.get(
+                self.url,
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "interval": "1h",
+                    "yAxis": "count()",
+                    "orderby": ["-count()"],
+                    "field": ["count()", "transaction.status"],
+                    "topEvents": 5,
+                },
+                format="json",
+            )
+
+        data = response.data
+
+        assert response.status_code == 200, response.content
+        assert len(data) == 1
+        assert "ok" in data
+
     @mock.patch("sentry.models.GroupManager.get_issues_mapping")
     def test_top_events_with_unknown_issue(self, mock_issues_mapping):
         event = self.events[0]


### PR DESCRIPTION
- This fixes topN graphs to show the transaction status names instead of their codes