### PR TITLE
fix(alerts): Pass correct event types when saving alert

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -565,6 +565,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       comparisonDelta,
       uuid,
       timeWindow,
+      eventTypes,
     } = this.state;
     // Remove empty warning trigger
     const sanitizedTriggers = triggers.filter(
@@ -612,7 +613,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
           aggregate,
           ...(hasMetricDataset ? {queryType: DatasetMEPAlertQueryTypes[dataset]} : {}),
           // Remove eventTypes as it is no longer requred for crash free
-          eventTypes: isCrashFreeAlert(rule.dataset) ? undefined : rule.eventTypes,
+          eventTypes: isCrashFreeAlert(rule.dataset) ? undefined : eventTypes,
           dataset,
         },
         {

--- a/tests/js/spec/views/alerts/metricRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/alerts/metricRules/ruleForm.spec.jsx
@@ -242,6 +242,29 @@ describe('Incident Rules Form', () => {
         })
       );
     });
+
+    it('switches event type from error to default', async () => {
+      createWrapper({
+        ruleId: rule.id,
+        rule: {
+          ...rule,
+          eventTypes: ['error', 'default'],
+        },
+      });
+
+      userEvent.click(screen.getByText('event.type:error OR event.type:default'));
+      userEvent.click(await screen.findByText('event.type:default'));
+      userEvent.click(screen.getByLabelText('Save Rule'));
+
+      expect(editRule).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            eventTypes: ['default'],
+          }),
+        })
+      );
+    });
   });
 
   describe('Slack async lookup', () => {


### PR DESCRIPTION
Fixes an issue where the event types were not being saved correctly after making a change.

fixes https://getsentry.atlassian.net/browse/ISSUE-1568