### PR TITLE
feat: Add option to send all transaction events to random partitions

### DIFF
--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -26,6 +26,9 @@ class KafkaEventStream(SnubaProtocolEventStream):
     def __init__(self, **options):
         self.topic = settings.KAFKA_EVENTS
         self.transactions_topic = settings.KAFKA_TRANSACTIONS
+        self.assign_transaction_partitions_randomly = options.get(
+            "kafka.partition-transactions-randomly"
+        )
 
     @cached_property
     def producer(self):
@@ -116,8 +119,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
     ):
         message_type = "transaction" if self._is_transaction_event(event) else "error"
 
-        # Check if transaction
-        if message_type == "transaction" and options.get("kafka.partition-transactions-randomly"):
+        if message_type == "transaction" and self.assign_transaction_partitions_randomly:
             assign_partitions_randomly = True
         else:
             assign_partitions_randomly = killswitch_matches_context(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -443,6 +443,12 @@ register("store.save-transactions-ingest-consumer-rate", default=0.0)
 # Drop delete_old_primary_hash messages for a particular project.
 register("reprocessing2.drop-delete-old-primary-hash", default=[])
 
+
+# Send transaction events to random Kafka partitions. Currently
+# this defaults to false as transaction events are partitioned the same
+# as errors (by project ID). Eventually we will flip the default.
+register("kafka.partition-transactions-randomly", default=False)
+
 # Send event messages for specific project IDs to random partitions in Kafka
 # contents are a list of project IDs to message types to be randomly assigned
 # e.g. [{"project_id": 2, "message_type": "error"}, {"project_id": 3, "message_type": "transaction"}]


### PR DESCRIPTION
This adds an option to send all transactions to random partitions if flipped
to true. The default is false, which leaves behavior unchanged.

The goal is to eventually fully split the errors and transactions pipelines and
drop semantic partitioning of transactions everywhere, as this can lead to very
unevenly sized partitions. Unlike errors there is no requirement by subscriptions
or post process for a project's transactions to be monotonically ordered.

We will be testing this change in single tenant first which this option
will allow us to do.