### PR TITLE
fix(workflow): Hide release firstseen if too close to last seen

### DIFF
--- a/static/app/components/group/releaseChart.tsx
+++ b/static/app/components/group/releaseChart.tsx
@@ -49,8 +49,16 @@ export function getGroupReleaseChartMarkers(
 
   const firstSeenX = new Date(firstSeen ?? 0).getTime();
   const lastSeenX = new Date(lastSeen ?? 0).getTime();
+  const difference = lastSeenX - firstSeenX;
+  const oneHourMs = 1000 * 60 * 60;
 
-  if (firstSeen && stats.length > 2 && firstSeenX >= firstGraphTime) {
+  if (
+    firstSeen &&
+    stats.length > 2 &&
+    firstSeenX >= firstGraphTime &&
+    // Don't show first seen if the markers are too close together
+    difference > oneHourMs
+  ) {
     // Find the first bucket that would contain our first seen event
     const firstBucket = stats.findIndex(([time]) => time * 1000 > firstSeenX);
 
@@ -83,7 +91,9 @@ export function getGroupReleaseChartMarkers(
     show: true,
     trigger: 'item',
     formatter: ({data}) => {
-      const time = getFormattedDate(data.displayValue, 'MMM D, YYYY LT');
+      const time = getFormattedDate(data.displayValue, 'MMM D, YYYY LT', {
+        local: true,
+      });
       return [
         '<div class="tooltip-series">',
         `<div><span class="tooltip-label"><strong>${data.name}</strong></span></div>`,
@@ -182,7 +192,7 @@ function GroupReleaseChart(props: Props) {
           top: 6,
           bottom: 4,
           left: 4,
-          right: 0,
+          right: 4,
         }}
       />
     </SidebarSection>


### PR DESCRIPTION
Also fix the tooltip date format

Example of the dots hiding the graph data. This usually happens on issues with one event.
![Screen Shot 2022-08-04 at 3 35 39 PM](https://user-images.githubusercontent.com/1400464/182964284-1daca10e-3ed8-4597-809c-52ee49666059.png)

