### PR TITLE
fix(releases): filter out releases with projects by project membership instead of access

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -379,7 +379,9 @@ class OrganizationEndpoint(Endpoint):
 class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationReleasePermission,)
 
-    def get_projects(self, request: Request, organization, project_ids=None):
+    def get_projects(
+        self, request: Request, organization, project_ids=None, include_all_accessible=True
+    ):
         """
         Get all projects the current user or API token has access to. More
         detail in the parent class's method of the same name.
@@ -401,7 +403,7 @@ class OrganizationReleasesBaseEndpoint(OrganizationEndpoint):
             request,
             organization,
             force_global_perms=has_valid_api_key,
-            include_all_accessible=True,
+            include_all_accessible=include_all_accessible,
             project_ids=project_ids,
         )
 

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -222,7 +222,7 @@ class OrganizationReleasesEndpoint(
             request,
             organization,
             project_ids=project_ids,
-            include_all_accessible=False if "GET" == request.method else True,
+            include_all_accessible="GET" != request.method,
         )
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -217,6 +217,14 @@ class OrganizationReleasesEndpoint(
         ]
     )
 
+    def get_projects(self, request: Request, organization, project_ids=None):
+        return super().get_projects(
+            request,
+            organization,
+            project_ids=project_ids,
+            include_all_accessible=False if "GET" == request.method else True,
+        )
+
     def get(self, request: Request, organization) -> Response:
         """
         List an Organization's Releases

--- a/tests/apidocs/endpoints/releases/test_organization_releases.py
+++ b/tests/apidocs/endpoints/releases/test_organization_releases.py
@@ -15,6 +15,8 @@ class OrganizationReleasesDocsTest(APIDocsTestCase):
 
         team1 = self.create_team(organization=org)
         team2 = self.create_team(organization=org)
+        self.create_team_membership(team1, user=user)
+        self.create_team_membership(team2, user=user)
 
         self.project1 = self.create_project(teams=[team1], organization=org)
         self.project2 = self.create_project(teams=[team2], organization=org2)

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -1,6 +1,7 @@
 from exam import fixture
 from rest_framework import status
 
+from sentry.auth import access
 from sentry.models import (
     Organization,
     OrganizationAccessRequest,
@@ -441,6 +442,51 @@ class DeleteOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         assert not OrganizationMemberTeam.objects.filter(
             team=self.team, organizationmember=self.owner_on_team
         ).exists()
+
+    def test_access_revoked_after_leaving_team(self):
+        user = self.create_user()
+        organization = self.create_organization(flags=0)
+        team = self.create_team(organization=organization)
+        project = self.create_project(organization=organization, teams=[team])
+        member = self.create_member(organization=organization, user=user, teams=[team])
+
+        ax = access.from_user(user, organization)
+
+        # user a member of the team that is a part of the project should have the following access and scopes
+        assert ax.scopes == member.get_scopes()
+        assert ax.has_team_access(team)
+        assert ax.has_team_scope(team, "project:read")
+        assert ax.has_project_access(project)
+        assert ax.has_projects_access([project])
+        assert ax.has_project_scope(project, "project:read")
+        assert not ax.has_project_scope(project, "project:write")
+        assert ax.has_any_project_scope(project, ["project:read", "project:write"])
+        assert not ax.has_any_project_scope(project, ["project:write", "project:admin"])
+        assert ax.has_project_membership(project)
+
+        self.login_as(user)
+        self.get_success_response(
+            organization.slug, member.id, team.slug, status_code=status.HTTP_200_OK
+        )
+
+        assert OrganizationMember.objects.filter(id=member.id).exists()
+        assert not OrganizationMemberTeam.objects.filter(organizationmember=member.id).exists()
+
+        ax_after_leaving = access.from_user(user, organization)
+        assert ax_after_leaving.scopes == member.get_scopes()
+        assert not ax_after_leaving.has_team_access(team)
+        assert not ax_after_leaving.has_team_scope(team, "project:read")
+        assert not ax_after_leaving.has_project_access(project)
+        assert not ax_after_leaving.has_projects_access([project])
+        assert not ax_after_leaving.has_project_scope(project, "project:read")
+        assert not ax_after_leaving.has_project_scope(project, "project:write")
+        assert not ax_after_leaving.has_any_project_scope(
+            project, ["project:read", "project:write"]
+        )
+        assert not ax_after_leaving.has_any_project_scope(
+            project, ["project:write", "project:admin"]
+        )
+        assert not ax_after_leaving.has_project_membership(project)
 
 
 class ReadOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):

--- a/tests/sentry/api/endpoints/test_organization_member_team_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_team_details.py
@@ -453,15 +453,8 @@ class DeleteOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         ax = access.from_user(user, organization)
 
         # user a member of the team that is a part of the project should have the following access and scopes
-        assert ax.scopes == member.get_scopes()
         assert ax.has_team_access(team)
-        assert ax.has_team_scope(team, "project:read")
         assert ax.has_project_access(project)
-        assert ax.has_projects_access([project])
-        assert ax.has_project_scope(project, "project:read")
-        assert not ax.has_project_scope(project, "project:write")
-        assert ax.has_any_project_scope(project, ["project:read", "project:write"])
-        assert not ax.has_any_project_scope(project, ["project:write", "project:admin"])
         assert ax.has_project_membership(project)
 
         self.login_as(user)
@@ -473,19 +466,8 @@ class DeleteOrganizationMemberTeamTest(OrganizationMemberTeamTestBase):
         assert not OrganizationMemberTeam.objects.filter(organizationmember=member.id).exists()
 
         ax_after_leaving = access.from_user(user, organization)
-        assert ax_after_leaving.scopes == member.get_scopes()
         assert not ax_after_leaving.has_team_access(team)
-        assert not ax_after_leaving.has_team_scope(team, "project:read")
         assert not ax_after_leaving.has_project_access(project)
-        assert not ax_after_leaving.has_projects_access([project])
-        assert not ax_after_leaving.has_project_scope(project, "project:read")
-        assert not ax_after_leaving.has_project_scope(project, "project:write")
-        assert not ax_after_leaving.has_any_project_scope(
-            project, ["project:read", "project:write"]
-        )
-        assert not ax_after_leaving.has_any_project_scope(
-            project, ["project:write", "project:admin"]
-        )
         assert not ax_after_leaving.has_project_membership(project)
 
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1841,7 +1841,7 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
     def setUp(self):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user)
-        team = self.create_team(organization=org)
+        team = self.create_team(organization=org, members=[self.user])
         project1 = self.create_project(organization=org, teams=[team], name="foo")
         project2 = self.create_project(organization=org, teams=[team], name="bar")
 

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -13,6 +13,7 @@ from sentry.api.endpoints.organization_releases import (
     ReleaseSerializerWithProjects,
 )
 from sentry.app import locks
+from sentry.auth import access
 from sentry.constants import BAD_RELEASE_CHARS, MAX_COMMIT_LENGTH, MAX_VERSION_LENGTH
 from sentry.models import (
     Activity,
@@ -627,6 +628,52 @@ class OrganizationReleaseListTest(APITestCase, SnubaTestCase):
             date_released=datetime(2013, 8, 15, 3, 8, 24, 880386),
         )
         release3.add_project(project1)
+
+        ax = access.from_user(user, org)
+        assert ax.has_projects_access([project1])
+        assert ax.has_project_membership(project1)
+        assert not ax.has_project_membership(project2)
+
+        response = self.get_success_response(org.slug)
+        self.assert_expected_versions(response, [release1, release3])
+
+    def test_project_permissions_open_access(self):
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.create_organization()
+        org.flags.allow_joinleave = True
+        org.save()
+
+        team1 = self.create_team(organization=org)
+        team2 = self.create_team(organization=org)
+
+        project1 = self.create_project(teams=[team1], organization=org)
+        project2 = self.create_project(teams=[team2], organization=org)
+
+        self.create_member(teams=[team1], user=user, organization=org)
+        self.login_as(user=user)
+
+        release1 = Release.objects.create(
+            organization_id=org.id, version="1", date_added=datetime(2013, 8, 13, 3, 8, 24, 880386)
+        )
+        release1.add_project(project1)
+
+        release2 = Release.objects.create(
+            organization_id=org.id, version="2", date_added=datetime(2013, 8, 14, 3, 8, 24, 880386)
+        )
+        release2.add_project(project2)
+
+        release3 = Release.objects.create(
+            organization_id=org.id,
+            version="3",
+            date_added=datetime(2013, 8, 12, 3, 8, 24, 880386),
+            date_released=datetime(2013, 8, 15, 3, 8, 24, 880386),
+        )
+        release3.add_project(project1)
+
+        ax = access.from_user(user, org)
+        assert ax.has_projects_access([project1, project2])
+        assert ax.has_project_membership(project1)
+        assert not ax.has_project_membership(project2)
 
         response = self.get_success_response(org.slug)
         self.assert_expected_versions(response, [release1, release3])


### PR DESCRIPTION
Related [PR](https://github.com/getsentry/sentry/pull/22703), which got [reverted](https://github.com/getsentry/sentry/pull/25293).

The current endpoint returns all releases filtered by projects a user has access to.

This leads to the release lists page showing many different releases that are irrelevant to users (especially when `Open Membership` is enabled). 
<img width="679" alt="Screen Shot 2022-08-04 at 4 20 15 PM" src="https://user-images.githubusercontent.com/101606877/182971252-fe2c88e8-88d6-4093-9ef8-6b27f0b8bed7.png">

With this change, we will only return releases with projects a user is a member of. 

This PR only affects the default landing Release lists page when you initially click `Releases`   in the navbar, a user will still be able to see releases for all projects he/she has access to by clicking the `Show All Projects` button:
<img width="408" alt="Screen Shot 2022-08-04 at 4 21 42 PM" src="https://user-images.githubusercontent.com/101606877/182971382-1ed0a648-36fe-41bd-b51f-b61683677cbd.png">

Fixes WOR-1665