### PR TITLE
feat(metrics) Lazy load indexer config

### DIFF
--- a/src/sentry/sentry_metrics/configuration.py
+++ b/src/sentry/sentry_metrics/configuration.py
@@ -41,27 +41,27 @@ def _register_ingest_config(config: MetricsIngestConfiguration) -> None:
     _METRICS_INGEST_CONFIG_BY_USE_CASE[config.use_case_id] = config
 
 
-_register_ingest_config(
-    MetricsIngestConfiguration(
-        db_model=DbKey.STRING_INDEXER,
-        input_topic=settings.KAFKA_INGEST_METRICS,
-        output_topic=settings.KAFKA_SNUBA_METRICS,
-        use_case_id=UseCaseKey.RELEASE_HEALTH,
-        internal_metrics_tag="release-health",
-        writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS,
-    )
-)
-_register_ingest_config(
-    MetricsIngestConfiguration(
-        db_model=DbKey.PERF_STRING_INDEXER,
-        input_topic=settings.KAFKA_INGEST_PERFORMANCE_METRICS,
-        output_topic=settings.KAFKA_SNUBA_GENERIC_METRICS,
-        use_case_id=UseCaseKey.PERFORMANCE,
-        internal_metrics_tag="perf",
-        writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE,
-    )
-)
-
-
 def get_ingest_config(use_case_key: UseCaseKey) -> MetricsIngestConfiguration:
+    if len(_METRICS_INGEST_CONFIG_BY_USE_CASE) == 0:
+        _register_ingest_config(
+            MetricsIngestConfiguration(
+                db_model=DbKey.STRING_INDEXER,
+                input_topic=settings.KAFKA_INGEST_METRICS,
+                output_topic=settings.KAFKA_SNUBA_METRICS,
+                use_case_id=UseCaseKey.RELEASE_HEALTH,
+                internal_metrics_tag="release-health",
+                writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS,
+            )
+        )
+        _register_ingest_config(
+            MetricsIngestConfiguration(
+                db_model=DbKey.PERF_STRING_INDEXER,
+                input_topic=settings.KAFKA_INGEST_PERFORMANCE_METRICS,
+                output_topic=settings.KAFKA_SNUBA_GENERIC_METRICS,
+                use_case_id=UseCaseKey.PERFORMANCE,
+                internal_metrics_tag="perf",
+                writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE,
+            )
+        )
+
     return _METRICS_INGEST_CONFIG_BY_USE_CASE[use_case_key]


### PR DESCRIPTION
Currently the indexer configuration is loaded eagerly.
This is a problem for the multi process indexer. 
The multi process pool serializes the module it is created into and sends it to the main process. When the module is loaded the config is not initialized on the new process thus any access to settings would fail before the `configure()` function is invoked.
Though if there is anything that eagerly loads settings would fail.

For the indexer config the issue is easy to fix as we can load it lazily instead.