### PR TITLE
fix(metrics): Introduce sample rate to error logs [INGEST-1380]

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1467,10 +1467,17 @@ SENTRY_METRICS_SKIP_INTERNAL_PREFIXES = []  # Order this by most frequent prefix
 SENTRY_METRICS_INDEXER = "sentry.sentry_metrics.indexer.postgres_v2.StaticStringsIndexerDecorator"
 SENTRY_METRICS_INDEXER_OPTIONS = {}
 SENTRY_METRICS_INDEXER_CACHE_TTL = 3600 * 2
+
+# Rate limits during string indexing for our metrics product.
+# Which cluster to use. Example: {"cluster": "default"}
 SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS = {}
 SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE = (
     SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS
 )
+
+# Controls the sample rate with which we report errors to Sentry for metric messages
+# dropped due to rate limits.
+SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 0.01
 
 # Release Health
 SENTRY_RELEASE_HEALTH = "sentry.release_health.sessions.SessionsReleaseHealthBackend"

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -39,7 +39,7 @@ def valid_metric_name(name: Optional[str]) -> bool:
 
 def _should_sample_debug_log() -> bool:
     rate = settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE
-    return rate and random.random() <= rate
+    return (rate > 0) and random.random() <= rate
 
 
 def invalid_metric_tags(tags: Mapping[str, str]) -> Sequence[str]:

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -37,7 +37,7 @@ def valid_metric_name(name: Optional[str]) -> bool:
     return True
 
 
-def _should_sample_debug_log():
+def _should_sample_debug_log() -> bool:
     rate = settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE
     return rate and random.random() <= rate
 

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -38,7 +38,7 @@ def valid_metric_name(name: Optional[str]) -> bool:
 
 
 def _should_sample_debug_log() -> bool:
-    rate = settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE
+    rate: float = settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE
     return (rate > 0) and random.random() <= rate
 
 

--- a/src/sentry/sentry_metrics/consumers/indexer/batch.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/batch.py
@@ -1,4 +1,5 @@
 import logging
+import random
 from collections import defaultdict
 from typing import List, Mapping, MutableMapping, NamedTuple, Optional, Sequence, Set
 
@@ -6,6 +7,7 @@ import rapidjson
 import sentry_sdk
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import Message
+from django.conf import settings
 
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.consumers.indexer.common import MessageBatch
@@ -33,6 +35,11 @@ def valid_metric_name(name: Optional[str]) -> bool:
         return False
 
     return True
+
+
+def _should_sample_debug_log():
+    rate = settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE
+    return rate and random.random() <= rate
 
 
 def invalid_metric_tags(tags: Mapping[str, str]) -> Sequence[str]:
@@ -203,15 +210,16 @@ class IndexerBatch:
                         "string_type": "tags",
                     },
                 )
-                logger.error(
-                    "process_messages.dropped_message",
-                    extra={
-                        "string_type": "tags",
-                        "num_global_quotas": exceeded_global_quotas,
-                        "num_org_quotas": exceeded_org_quotas,
-                        "org_batch_size": len(mapping[org_id]),
-                    },
-                )
+                if _should_sample_debug_log():
+                    logger.error(
+                        "process_messages.dropped_message",
+                        extra={
+                            "string_type": "tags",
+                            "num_global_quotas": exceeded_global_quotas,
+                            "num_org_quotas": exceeded_org_quotas,
+                            "org_batch_size": len(mapping[org_id]),
+                        },
+                    )
                 continue
 
             fetch_types_encountered = set()
@@ -234,18 +242,20 @@ class IndexerBatch:
                         "string_type": "metric_id",
                     },
                 )
-                logger.error(
-                    "process_messages.dropped_message",
-                    extra={
-                        "string_type": "metric_id",
-                        "is_global_quota": bool(
-                            metadata
-                            and metadata.fetch_type_ext
-                            and metadata.fetch_type_ext.is_global
-                        ),
-                        "org_batch_size": len(mapping[org_id]),
-                    },
-                )
+
+                if _should_sample_debug_log():
+                    logger.error(
+                        "process_messages.dropped_message",
+                        extra={
+                            "string_type": "metric_id",
+                            "is_global_quota": bool(
+                                metadata
+                                and metadata.fetch_type_ext
+                                and metadata.fetch_type_ext.is_global
+                            ),
+                            "org_batch_size": len(mapping[org_id]),
+                        },
+                    )
                 continue
 
             new_payload_value["retention_days"] = 90

--- a/tests/sentry/sentry_metrics/test_batch.py
+++ b/tests/sentry/sentry_metrics/test_batch.py
@@ -122,7 +122,8 @@ def _get_string_indexer_log_records(caplog):
     ]
 
 
-def test_all_resolved(caplog):
+def test_all_resolved(caplog, settings):
+    settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
         [
             (counter_payload, []),
@@ -253,7 +254,8 @@ def test_all_resolved(caplog):
     ]
 
 
-def test_metric_id_rate_limited(caplog):
+def test_metric_id_rate_limited(caplog, settings):
+    settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
         [
             (counter_payload, []),
@@ -348,7 +350,8 @@ def test_metric_id_rate_limited(caplog):
     ]
 
 
-def test_tag_key_rate_limited(caplog):
+def test_tag_key_rate_limited(caplog, settings):
+    settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
         [
             (counter_payload, []),
@@ -425,7 +428,8 @@ def test_tag_key_rate_limited(caplog):
     assert _deconstruct_messages(snuba_payloads) == []
 
 
-def test_tag_value_rate_limited(caplog):
+def test_tag_value_rate_limited(caplog, settings):
+    settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
         [
             (counter_payload, []),
@@ -542,7 +546,8 @@ def test_tag_value_rate_limited(caplog):
     ]
 
 
-def test_one_org_limited(caplog):
+def test_one_org_limited(caplog, settings):
+    settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     outer_message = _construct_outer_message(
         [
             (counter_payload, []),

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -437,11 +437,12 @@ def test_process_messages_invalid_messages(
     assert error_text in caplog.text
 
 
-def test_process_messages_rate_limited(caplog) -> None:
+def test_process_messages_rate_limited(caplog, settings) -> None:
     """
     Test handling of `None`-values coming from the indexer service, which
     happens when postgres writes are being rate-limited.
     """
+    settings.SENTRY_METRICS_INDEXER_DEBUG_LOG_SAMPLE_RATE = 1.0
     rate_limited_payload = deepcopy(distribution_payload)
     rate_limited_payload["tags"]["custom_tag"] = "rate_limited_test"
 


### PR DESCRIPTION
We found that there is a significant increase in time spent (1-2 ms IIRC) in
reconstruct_messages everytime there is heavy rate limiting going on. Add a
sample rate around what we think is the most likely culprit: The Sentry SDK

I think we could change this error log to only be emitted once per batch too,
i.e. move the `logger.error` statement out of the for-loop and have some aux
datastructure (set of org ids). However this would make it harder to get number
of messages dropped out of Sentry. A uniform sample rate makes that math
simpler.
