### PR TITLE
test(ui): Fix incorrect console mocks

### DIFF
--- a/tests/js/spec/components/deprecatedforms/jsonForm.spec.tsx
+++ b/tests/js/spec/components/deprecatedforms/jsonForm.spec.tsx
@@ -17,7 +17,7 @@ describe('JsonForm', function () {
 
     it('missing additionalFieldProps required in "valid" prop', function () {
       // eslint-disable-next-line no-console
-      console.error = jest.fn();
+      jest.spyOn(console, 'error').mockImplementation(jest.fn());
       try {
         mountWithTheme(<JsonForm forms={accountDetailsFields} />);
       } catch (error) {
@@ -113,7 +113,7 @@ describe('JsonForm', function () {
 
     it('missing additionalFieldProps required in "valid" prop', function () {
       // eslint-disable-next-line no-console
-      console.error = jest.fn();
+      jest.spyOn(console, 'error').mockImplementation(jest.fn());
       try {
         mountWithTheme(
           <JsonForm

--- a/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
@@ -138,7 +138,7 @@ describe('TraceView', () => {
 
     it('should expand grouped siblings when clicked, and then regroup when clicked again', async () => {
       // eslint-disable-next-line no-console
-      console.error = jest.fn();
+      jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
       const data = initializeData({
         features: ['performance-autogroup-sibling-spans'],

--- a/tests/js/spec/components/lazyLoad.spec.tsx
+++ b/tests/js/spec/components/lazyLoad.spec.tsx
@@ -45,7 +45,7 @@ describe('LazyLoad', function () {
 
   it('renders with error message when promise is rejected', async function () {
     // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
     const getComponent = jest.fn(
       () =>
         new Promise<ResolvedComponent>((_resolve, reject) =>

--- a/tests/js/spec/views/issueList/overview.polling.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.polling.spec.jsx
@@ -82,7 +82,7 @@ describe('IssueList -> Polling', function () {
     // The tests fail because we have a "component update was not wrapped in act" error.
     // It should be safe to ignore this error, but we should remove the mock once we move to react testing library
     // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     MockApiClient.clearMockResponses();
 

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -48,7 +48,7 @@ describe('IssueList', function () {
     // The tests fail because we have a "component update was not wrapped in act" error.
     // It should be safe to ignore this error, but we should remove the mock once we move to react testing library
     // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     MockApiClient.clearMockResponses();
     project = TestStubs.ProjectDetails({

--- a/tests/js/spec/views/organizationContextContainer.spec.jsx
+++ b/tests/js/spec/views/organizationContextContainer.spec.jsx
@@ -146,7 +146,7 @@ describe('OrganizationContextContainer', function () {
       url: '/organizations/org-slug/',
       statusCode: 403,
     });
-    console.error = jest.fn(); // eslint-disable-line no-console
+    jest.spyOn(console, 'error').mockImplementation(jest.fn()); // eslint-disable-line no-console
     wrapper = createWrapper();
 
     // await dispatching action

--- a/tests/js/spec/views/performance/landing/index.spec.tsx
+++ b/tests/js/spec/views/performance/landing/index.spec.tsx
@@ -45,7 +45,7 @@ describe('Performance > Landing > Index', function () {
   beforeEach(function () {
     // @ts-ignore no-console
     // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sdk-updates/',

--- a/tests/js/spec/views/performance/landing/metricsDataSwitcher.spec.tsx
+++ b/tests/js/spec/views/performance/landing/metricsDataSwitcher.spec.tsx
@@ -68,7 +68,7 @@ describe('Performance > Landing > MetricsDataSwitcher', function () {
   beforeEach(function () {
     // @ts-ignore no-console
     // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sdk-updates/',

--- a/tests/js/spec/views/performance/transactionEvents.spec.tsx
+++ b/tests/js/spec/views/performance/transactionEvents.spec.tsx
@@ -61,7 +61,7 @@ describe('Performance > TransactionSummary', function () {
   beforeEach(function () {
     // @ts-ignore no-console
     // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',

--- a/tests/js/spec/views/performance/transactionSummary.spec.tsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.tsx
@@ -58,7 +58,7 @@ describe('Performance > TransactionSummary', function () {
   beforeEach(function () {
     // @ts-ignore no-console
     // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({

--- a/tests/js/spec/views/performance/transactionVitals.spec.jsx
+++ b/tests/js/spec/views/performance/transactionVitals.spec.jsx
@@ -81,7 +81,7 @@ describe('Performance > Web Vitals', function () {
   beforeEach(function () {
     // @ts-ignore no-console
     // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/projects/',

--- a/tests/js/spec/views/projectDetail/index.spec.tsx
+++ b/tests/js/spec/views/projectDetail/index.spec.tsx
@@ -15,7 +15,7 @@ describe('ProjectDetail', function () {
     ProjectsStore.reset();
     // @ts-ignore no-console
     // eslint-disable-next-line no-console
-    console.error = jest.fn();
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/sdk-updates/',


### PR DESCRIPTION
`.mockRestore()` only works on mocks created with `jest.spyOn()`! Also, `jest.spyOn()` doesn't actually _suppress_ `console.log`, so we need to use `.mockImplementation` with a blank function to silence it.

I went with `jest.fn()` over `() => {}` just because it seemed nicer, but you tell me.
