### PR TITLE
fix(ui): Fix GridEditable from scrolling on y overflow

### DIFF
--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -81,6 +81,7 @@ export const Grid = styled('table')`
 
   z-index: ${Z_INDEX_GRID};
   overflow-x: auto;
+  overflow-y: hidden;
 `;
 
 export const GridRow = styled('tr')`


### PR DESCRIPTION
Some tables (discover, dashboards, etc) have whitespace vertical overflow which is causing a scrollbar. I don't think we have any tables in sentry that rely on this behaviour, so setting `overflow-y: hidden;` should be safe?