### PR TITLE
ref: make the default `make` target `make develop`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+.PHONY: all
+all: develop
+
 PIP := python -m pip --disable-pip-version-check
 WEBPACK := yarn build-acceptance
 


### PR DESCRIPTION
make was defaulting to `freeze-requirements` since it was the first target and there was no explicit `all`