### PR TITLE
feat(profiling): Add option to not draw focus frames

### DIFF
--- a/static/app/components/profiling/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsMenu.tsx
@@ -7,6 +7,7 @@ import {t} from 'sentry/locale';
 import {CanvasPoolManager} from 'sentry/utils/profiling/canvasScheduler';
 import {FlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences';
 import {useFlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/useFlamegraphPreferences';
+import {useFlamegraphProfilesValue} from 'sentry/utils/profiling/flamegraph/useFlamegraphProfiles';
 
 interface FlamegraphOptionsMenuProps {
   canvasPoolManager: CanvasPoolManager;
@@ -15,39 +16,58 @@ interface FlamegraphOptionsMenuProps {
 function FlamegraphOptionsMenu({
   canvasPoolManager,
 }: FlamegraphOptionsMenuProps): React.ReactElement {
-  const [{colorCoding, xAxis}, dispatch] = useFlamegraphPreferences();
+  const [{colorCoding, focus, xAxis}, dispatch] = useFlamegraphPreferences();
+  const {focusFrame} = useFlamegraphProfilesValue();
 
   const options = useMemo(() => {
-    return [
-      {
-        label: t('X Axis'),
-        value: 'x axis',
-        defaultValue: xAxis,
-        options: Object.entries(X_AXIS).map(([value, label]) => ({
-          label,
-          value,
-        })),
-        onChange: value =>
-          dispatch({
-            type: 'set xAxis',
-            payload: value,
-          }),
-      },
-      {
-        label: t('Color Coding'),
-        value: 'by symbol name',
-        defaultValue: colorCoding,
-        options: Object.entries(COLOR_CODINGS).map(([value, label]) => ({
-          label,
-          value,
-        })),
-        onChange: value =>
-          dispatch({
-            type: 'set color coding',
-            payload: value,
-          }),
-      },
-    ];
+    const xAxisOptions = {
+      label: t('X Axis'),
+      value: 'x axis',
+      defaultValue: xAxis,
+      options: Object.entries(X_AXIS).map(([value, label]) => ({
+        label,
+        value,
+      })),
+      onChange: value =>
+        dispatch({
+          type: 'set xAxis',
+          payload: value,
+        }),
+    };
+
+    const colorCodingOptions = {
+      label: t('Color Coding'),
+      value: 'by symbol name',
+      defaultValue: colorCoding,
+      options: Object.entries(COLOR_CODINGS).map(([value, label]) => ({
+        label,
+        value,
+      })),
+      onChange: value =>
+        dispatch({
+          type: 'set color coding',
+          payload: value,
+        }),
+    };
+
+    const focusOptions = {
+      label: t('Focus Frame'),
+      value: 'focus',
+      defaultValue: focus,
+      options: Object.entries(FOCUS).map(([value, label]) => ({
+        label,
+        value,
+      })),
+      onChange: value =>
+        dispatch({
+          type: 'set focus',
+          payload: value,
+        }),
+    };
+
+    return focusFrame
+      ? [xAxisOptions, colorCodingOptions, focusOptions]
+      : [xAxisOptions, colorCodingOptions];
     // If we add color and xAxis it updates the memo and the component is re-rendered (losing hovered state)
     // Not ideal, but since we are only passing default value I guess we can live with it
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -81,6 +101,11 @@ const COLOR_CODINGS: Record<FlamegraphPreferences['colorCoding'], string> = {
   'by library': t('By Library'),
   'by system / application': t('By System / Application'),
   'by recursion': t('By Recursion'),
+};
+
+const FOCUS: Record<FlamegraphPreferences['focus'], string> = {
+  focus: t('Focus'),
+  hide: t('Hide'),
 };
 
 export {FlamegraphOptionsMenu};

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -134,7 +134,7 @@ function FlamegraphZoomView({
   }, [configSpaceCursor, flamegraphRenderer]);
 
   const focusedRects: Rect[] = useMemo(() => {
-    if (!flamegraphProfile.focusFrame) {
+    if (!flamegraphProfile.focusFrame || flamegraphState.preferences.focus === 'hide') {
       return [];
     }
 
@@ -156,7 +156,7 @@ function FlamegraphZoomView({
     }
 
     return rects;
-  }, [flamegraph, flamegraphProfile.focusFrame]);
+  }, [flamegraph, flamegraphProfile.focusFrame, flamegraphState.preferences.focus]);
 
   useEffect(() => {
     const onKeyDown = (evt: KeyboardEvent) => {
@@ -338,6 +338,13 @@ function FlamegraphZoomView({
       return undefined;
     }
 
+    // if we're hiding the focus, then no need to setup the draw callbacks
+    // also dispatch a draw call to remove the existing focus
+    if (flamegraphState.preferences.focus === 'hide') {
+      scheduler.draw();
+      return undefined;
+    }
+
     const drawFocusedFrameBorder = () => {
       selectedFrameRenderer.draw(
         focusedRects,
@@ -360,6 +367,7 @@ function FlamegraphZoomView({
     flamegraphView,
     flamegraphTheme,
     focusedRects,
+    flamegraphState.preferences.focus,
     scheduler,
     selectedFrameRenderer,
   ]);

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
@@ -4,14 +4,16 @@ export type FlamegraphColorCodings = [
   'by library',
   'by recursion'
 ];
-
+export type FlamegraphFocus = ['focus', 'hide'];
+export type FlamegraphLayout = ['table right', 'table bottom', 'table left'];
 export type FlamegraphSorting = ['left heavy', 'call order'];
 export type FlamegraphViewOptions = ['top down', 'bottom up'];
 export type FlamegraphAxisOptions = ['standalone', 'transaction'];
 
 export interface FlamegraphPreferences {
   colorCoding: FlamegraphColorCodings[number];
-  layout: 'table right' | 'table bottom' | 'table left';
+  focus: FlamegraphFocus[number];
+  layout: FlamegraphLayout[number];
   sorting: FlamegraphSorting[number];
   view: FlamegraphViewOptions[number];
   xAxis: FlamegraphAxisOptions[number];
@@ -19,6 +21,7 @@ export interface FlamegraphPreferences {
 
 type FlamegraphPreferencesAction =
   | {payload: FlamegraphPreferences['colorCoding']; type: 'set color coding'}
+  | {payload: FlamegraphPreferences['focus']; type: 'set focus'}
   | {payload: FlamegraphPreferences['sorting']; type: 'set sorting'}
   | {payload: FlamegraphPreferences['view']; type: 'set view'}
   | {payload: FlamegraphPreferences['layout']; type: 'set layout'}
@@ -42,6 +45,12 @@ export function flamegraphPreferencesReducer(
       return {
         ...state,
         colorCoding: action.payload,
+      };
+    }
+    case 'set focus': {
+      return {
+        ...state,
+        focus: action.payload,
       };
     }
     case 'set sorting': {

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -22,6 +22,7 @@ import {useFlamegraphStateValue} from '../useFlamegraphState';
 import {
   FlamegraphAxisOptions,
   FlamegraphColorCodings,
+  FlamegraphFocus,
   flamegraphPreferencesReducer,
   FlamegraphSorting,
   FlamegraphViewOptions,
@@ -33,7 +34,10 @@ import {flamegraphZoomPositionReducer} from './flamegraphZoomPosition';
 // Intersect the types so we can properly guard
 type PossibleQuery =
   | Query
-  | (Pick<FlamegraphState['preferences'], 'colorCoding' | 'sorting' | 'view' | 'xAxis'> &
+  | (Pick<
+      FlamegraphState['preferences'],
+      'colorCoding' | 'focus' | 'sorting' | 'view' | 'xAxis'
+    > &
       Pick<FlamegraphState['search'], 'query'>);
 
 function isColorCoding(
@@ -45,6 +49,14 @@ function isColorCoding(
     'by library',
     'by recursion',
   ];
+
+  return values.includes(value as any);
+}
+
+function isFocus(
+  value: PossibleQuery['focus'] | FlamegraphState['preferences']['focus']
+): value is FlamegraphState['preferences']['focus'] {
+  const values: FlamegraphFocus = ['focus', 'hide'];
 
   return values.includes(value as any);
 }
@@ -101,6 +113,9 @@ export function decodeFlamegraphStateFromQueryParams(
       colorCoding: isColorCoding(query.colorCoding)
         ? query.colorCoding
         : DEFAULT_FLAMEGRAPH_STATE.preferences.colorCoding,
+      focus: isFocus(query.focus)
+        ? query.focus
+        : DEFAULT_FLAMEGRAPH_STATE.preferences.focus,
       sorting: isSorting(query.sorting)
         ? query.sorting
         : DEFAULT_FLAMEGRAPH_STATE.preferences.sorting,
@@ -217,6 +232,7 @@ export const DEFAULT_FLAMEGRAPH_STATE: FlamegraphState = {
   },
   preferences: {
     colorCoding: 'by symbol name',
+    focus: 'focus',
     sorting: 'call order',
     view: 'top down',
     xAxis: 'standalone',
@@ -260,6 +276,9 @@ export function FlamegraphStateProvider(
       colorCoding:
         props.initialState?.preferences?.colorCoding ??
         DEFAULT_FLAMEGRAPH_STATE.preferences.colorCoding,
+      focus:
+        props.initialState?.preferences?.focus ??
+        DEFAULT_FLAMEGRAPH_STATE.preferences.focus,
       sorting:
         props.initialState?.preferences?.sorting ??
         DEFAULT_FLAMEGRAPH_STATE.preferences.sorting,


### PR DESCRIPTION
This adds a new option to the menu that hides the focus frames. For now, this
option only exists when there is a focus frame selected.