### PR TITLE
feat(notifications): remove notification default logic

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -214,10 +214,7 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
     const {notificationType} = this.props;
     const {notificationSettings} = this.state;
 
-    // NOTE: Update this when we want to enable Slack by default.
-    const provider = !isEverythingDisabled(notificationType, notificationSettings)
-      ? getCurrentProviders(notificationType, notificationSettings)
-      : ['email'];
+    const provider = getCurrentProviders(notificationType, notificationSettings);
 
     const childTypes: string[] = typeMappedChildren[notificationType] || [];
     const childTypesDefaults = Object.fromEntries(


### PR DESCRIPTION
We don't need logic on the fron-end to have a default provider because the backend handles proving defaults. And if no providers are enabled at all, then we just don't even render the form input where we show which providers are available. 