### PR TITLE
fix(perf) Fix duration unit set to week if all values are 0

### DIFF
--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -152,7 +152,9 @@ export function findRangeOfMultiSeries(series: Series[], legend?: LegendComponen
       }
     });
     if (maxSeries?.data) {
-      const max = Math.max(...maxSeries.data.map(({value}) => value));
+      const max = Math.max(
+        ...maxSeries.data.map(({value}) => value).filter(value => !!value)
+      );
       const min = Math.min(
         ...minSeries.data.map(({value}) => value).filter(value => !!value)
       );

--- a/tests/js/spec/utils/discover/charts.spec.tsx
+++ b/tests/js/spec/utils/discover/charts.spec.tsx
@@ -248,4 +248,10 @@ describe('getDurationUnit()', () => {
     expect(numOfDigits).toBeLessThan(6);
     expect(durationUnit).not.toBe(MILLISECOND);
   });
+
+  it('Should return ms if all values are 0', () => {
+    const series = generateSeries([0, 0, 0]);
+    const durationUnit = getDurationUnit(series);
+    expect(durationUnit).toBe(1);
+  });
 });

--- a/tests/js/spec/utils/discover/charts.spec.tsx
+++ b/tests/js/spec/utils/discover/charts.spec.tsx
@@ -252,6 +252,6 @@ describe('getDurationUnit()', () => {
   it('Should return ms if all values are 0', () => {
     const series = generateSeries([0, 0, 0]);
     const durationUnit = getDurationUnit(series);
-    expect(durationUnit).toBe(1);
+    expect(durationUnit).toBe(MILLISECOND);
   });
 });


### PR DESCRIPTION
Fixes PERF-1654

Small bug where the charts would display a week if all data in the series contain a value of 0
Before
<img width="1253" alt="image" src="https://user-images.githubusercontent.com/44422760/183157204-58b57140-7d94-4a7d-b5bf-ca37659bf82d.png">

After
<img width="900" alt="image" src="https://user-images.githubusercontent.com/44422760/183157142-f2f3d94a-6d1a-4da3-b4eb-a78f74efa4ca.png">
