### PR TITLE
feat(msteams): Make cards wider

### DIFF
--- a/src/sentry/integrations/msteams/card_builder/base.py
+++ b/src/sentry/integrations/msteams/card_builder/base.py
@@ -46,4 +46,5 @@ class MSTeamsMessageBuilder(AbstractMessageBuilder):
             "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
             "version": "1.2",
             "actions": actions or [],
+            "msteams": {"width": "Full"},
         }


### PR DESCRIPTION
- Make cards use more available width.
- Cards look much better with less wrapping and text not being chopped off.
- https://docs.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-format?tabs=adaptive-md%2Cconnector-html#construct-full-width-cards

<img width="997" alt="image" src="https://user-images.githubusercontent.com/19944378/183223219-331c32fa-ecf8-4d5e-ac84-d66bcabc10cb.png">

<img width="1141" alt="image" src="https://user-images.githubusercontent.com/19944378/183223301-216346cc-75bc-4290-a128-8391f028ea16.png">