### PR TITLE
fix(config): Ensure user is member of lastOrganization

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -11,7 +11,7 @@ from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
 from sentry.api.utils import generate_organization_url
 from sentry.auth.superuser import is_active_superuser
-from sentry.models import Organization, ProjectKey
+from sentry.models import Organization, OrganizationMember, ProjectKey
 from sentry.utils import auth
 from sentry.utils.assets import get_frontend_app_asset_url
 from sentry.utils.email import is_smtp_enabled
@@ -99,6 +99,11 @@ def _get_public_dsn():
     return result
 
 
+def _delete_activeorg(session):
+    if session and "activeorg" in session:
+        del session["activeorg"]
+
+
 def get_client_config(request=None):
     """
     Provides initial bootstrap data needed to boot the frontend application.
@@ -139,13 +144,22 @@ def get_client_config(request=None):
 
     public_dsn = _get_public_dsn()
 
-    last_organization = session["activeorg"] if session and "activeorg" in session else None
+    last_org_slug = session["activeorg"] if session and "activeorg" in session else None
     try:
-        Organization.objects.get_from_cache(slug=last_organization)
+        last_org = Organization.objects.get_from_cache(slug=last_org_slug)
+        if user is not None and not isinstance(user, AnonymousUser):
+            has_membership = OrganizationMember.objects.filter(
+                user=user, organization=last_org
+            ).exists()
+            if not has_membership:
+                last_org_slug = None
+                _delete_activeorg(session)
+        else:
+            last_org_slug = None
+            _delete_activeorg(session)
     except Organization.DoesNotExist:
-        last_organization = None
-        if session and "activeorg" in session:
-            del session["activeorg"]
+        last_org_slug = None
+        _delete_activeorg(session)
 
     context = {
         "singleOrganization": settings.SENTRY_SINGLE_ORGANIZATION,
@@ -169,7 +183,7 @@ def get_client_config(request=None):
         # Note `lastOrganization` should not be expected to update throughout frontend app lifecycle
         # It should only be used on a fresh browser nav to a path where an
         # organization is not in context
-        "lastOrganization": last_organization,
+        "lastOrganization": last_org_slug,
         "languageCode": language_code,
         "userIdentity": user_identity,
         "csrfCookieName": settings.CSRF_COOKIE_NAME,
@@ -193,9 +207,7 @@ def get_client_config(request=None):
         "enableAnalytics": settings.ENABLE_ANALYTICS,
         "validateSUForm": getattr(settings, "VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON", False),
         "sentryUrl": options.get("system.url-prefix"),
-        "organizationUrl": generate_organization_url(last_organization)
-        if last_organization
-        else None,
+        "organizationUrl": generate_organization_url(last_org_slug) if last_org_slug else None,
     }
     if user and user.is_authenticated:
         context.update(

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -145,21 +145,25 @@ def get_client_config(request=None):
     public_dsn = _get_public_dsn()
 
     last_org_slug = session["activeorg"] if session and "activeorg" in session else None
-    try:
-        last_org = Organization.objects.get_from_cache(slug=last_org_slug)
-        if user is not None and not isinstance(user, AnonymousUser):
-            has_membership = OrganizationMember.objects.filter(
-                user=user, organization=last_org
-            ).exists()
-            if not has_membership:
-                last_org_slug = None
-                _delete_activeorg(session)
-        else:
-            last_org_slug = None
-            _delete_activeorg(session)
-    except Organization.DoesNotExist:
+    if not last_org_slug:
         last_org_slug = None
         _delete_activeorg(session)
+    else:
+        try:
+            last_org = Organization.objects.get_from_cache(slug=last_org_slug)
+            if user is not None and not isinstance(user, AnonymousUser):
+                has_membership = OrganizationMember.objects.filter(
+                    user=user, organization=last_org
+                ).exists()
+                if not has_membership:
+                    last_org_slug = None
+                    _delete_activeorg(session)
+            else:
+                last_org_slug = None
+                _delete_activeorg(session)
+        except Organization.DoesNotExist:
+            last_org_slug = None
+            _delete_activeorg(session)
 
     context = {
         "singleOrganization": settings.SENTRY_SINGLE_ORGANIZATION,

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -3,7 +3,7 @@ from unittest import mock
 from django.urls import reverse
 from exam import fixture
 
-from sentry.models import Organization, OrganizationStatus, ScheduledDeletion
+from sentry.models import Organization, OrganizationMember, OrganizationStatus, ScheduledDeletion
 from sentry.tasks.deletion import run_deletion
 from sentry.testutils import TestCase
 from sentry.utils import json
@@ -306,6 +306,59 @@ class ClientConfigViewTest(TestCase):
             run_deletion(deletion.id)
 
         assert Organization.objects.filter(slug=self.organization.slug).count() == 0
+
+        # Check lastOrganization
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+
+        assert data["isAuthenticated"] is True
+        assert data["lastOrganization"] is None
+        assert "activeorg" not in self.client.session
+
+    def test_not_member_of_last_org(self):
+        self.login_as(self.user)
+        other_org = self.create_organization(
+            name="other_org", owner=self.create_user("bar@example.com")
+        )
+        member_om = self.create_member(user=self.user, organization=other_org, role="owner")
+
+        # Check lastOrganization
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+
+        assert data["isAuthenticated"] is True
+        assert data["lastOrganization"] is None
+        assert "activeorg" not in self.client.session
+
+        # Induce last active organization
+        resp = self.client.get(reverse("sentry-api-0-organization-projects", args=[other_org.slug]))
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        # Check lastOrganization
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+
+        assert data["isAuthenticated"] is True
+        assert data["lastOrganization"] == other_org.slug
+        assert self.client.session["activeorg"] == other_org.slug
+
+        # Delete membership
+        assert OrganizationMember.objects.filter(id=member_om.id).exists()
+        resp = self.client.delete(
+            reverse("sentry-api-0-organization-member-details", args=[other_org.slug, member_om.id])
+        )
+        assert resp.status_code == 204
+        assert not OrganizationMember.objects.filter(id=member_om.id).exists()
 
         # Check lastOrganization
         resp = self.client.get(self.path)


### PR DESCRIPTION
In addition to checking for the existence of `lastOrganization` (https://github.com/getsentry/sentry/pull/37032), we would also need to check if the user is a member of the `lastOrganization`.

I've also included a test case to check that usage of API tokens does not induce setting the `activeorg` key in the user's session.

This is due diligence as part of the customer domain work for hybrid cloud. 