### PR TITLE
[WIP] feat(metrics): PoC of running metrics indexer migrations against spanner

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -102,4 +102,4 @@ phabricator>=0.7.0
 # test dependencies, but unable to move to requirements-test until
 # sentry.utils.pytest and sentry.testutils are moved to tests/
 selenium>=4.1.5
-sqlparse>=0.2.4
+sqlparse>=0.3.0

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -151,7 +151,7 @@ sniffio==1.2.0
 snuba-sdk==1.0.0
 sortedcontainers==2.4.0
 soupsieve==2.3.2.post1
-sqlparse==0.2.4
+sqlparse==0.4.2
 statsd==3.3
 structlog==21.1.0
 symbolic==8.7.1

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -104,7 +104,7 @@ sniffio==1.2.0
 snuba-sdk==1.0.0
 sortedcontainers==2.4.0
 soupsieve==2.3.2.post1
-sqlparse==0.2.4
+sqlparse==0.4.2
 statsd==3.3
 structlog==21.1.0
 symbolic==8.7.1

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -149,8 +149,8 @@ DATABASES = {
     "metrics-spanner": {
         "ENGINE": "django_spanner",
         "PROJECT": "search-and-storage",
-        "INSTANCE": "markus-test-spanner",
-        "NAME": "markus-test-spanner-db",
+        "INSTANCE": "markus-test-spanner-pg",
+        "NAME": "markus-test-spanner-db-std",
     },
 }
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -145,8 +145,16 @@ DATABASES = {
         "PORT": "",
         "AUTOCOMMIT": True,
         "ATOMIC_REQUESTS": False,
-    }
+    },
+    "metrics-spanner": {
+        "ENGINE": "django_spanner",
+        "PROJECT": "search-and-storage",
+        "INSTANCE": "markus-test-spanner",
+        "NAME": "markus-test-spanner-db",
+    },
 }
+
+DATABASE_ROUTERS = ("sentry.db.router.MultiDatabaseRouter",)
 
 if "DATABASE_URL" in os.environ:
     url = urlparse(os.environ["DATABASE_URL"])
@@ -321,6 +329,7 @@ TEMPLATES = [
 ]
 
 INSTALLED_APPS = (
+    "django_spanner",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -150,7 +150,7 @@ DATABASES = {
         "ENGINE": "django_spanner",
         "PROJECT": "search-and-storage",
         "INSTANCE": "markus-test-spanner-pg",
-        "NAME": "markus-test-spanner-db-std",
+        "NAME": "metrics-spanner",
     },
 }
 

--- a/src/sentry/db/models/fields/bounded.py
+++ b/src/sentry/db/models/fields/bounded.py
@@ -2,7 +2,6 @@ from typing import cast
 
 from django.conf import settings
 from django.db import models
-from django.db.backends.base.base import BaseDatabaseWrapper
 from django.utils.translation import ugettext_lazy as _
 
 __all__ = (
@@ -60,19 +59,13 @@ if settings.SENTRY_USE_BIG_INTS:
                 assert value <= self.MAX_VALUE
             return cast(int, super().get_prep_value(value))
 
-    class BoundedBigAutoField(models.AutoField):  # type: ignore
+    class BoundedBigAutoField(models.BigAutoField):  # type: ignore
         description = _("Big Integer")
 
         MAX_VALUE = 9223372036854775807
 
-        def db_type(self, connection: BaseDatabaseWrapper) -> str:
-            return "int64"
-
-        def get_related_db_type(self, connection: BaseDatabaseWrapper) -> str:
-            return cast(str, BoundedBigIntegerField().db_type(connection))
-
         def get_internal_type(self) -> str:
-            return "BigIntegerField"
+            return "BigAutoField"
 
         def get_prep_value(self, value: int) -> int:
             if value:

--- a/src/sentry/db/models/fields/bounded.py
+++ b/src/sentry/db/models/fields/bounded.py
@@ -66,7 +66,7 @@ if settings.SENTRY_USE_BIG_INTS:
         MAX_VALUE = 9223372036854775807
 
         def db_type(self, connection: BaseDatabaseWrapper) -> str:
-            return "bigserial"
+            return "int64"
 
         def get_related_db_type(self, connection: BaseDatabaseWrapper) -> str:
             return cast(str, BoundedBigIntegerField().db_type(connection))

--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -1,5 +1,6 @@
 _db_table_to_db = {
     "sentry_stringindexer": "metrics-spanner",  # will replace ^ table above
+    "sentry_perfstringindexer": "metrics-spanner",  # will replace ^ table above
 }
 
 

--- a/src/sentry/db/router.py
+++ b/src/sentry/db/router.py
@@ -1,0 +1,60 @@
+_db_table_to_db = {
+    "sentry_stringindexer": "metrics-spanner",  # will replace ^ table above
+}
+
+
+def db_for_model(model):
+    return db_for_table(model._meta.db_table)
+
+
+def db_for_table(table):
+    return _db_table_to_db.get(table, "default")
+
+
+class MultiDatabaseRouter:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._setup_replicas()
+
+    def _setup_replicas(self):
+        from django.conf import settings
+
+        self._replicas = {}
+        for db, db_conf in settings.DATABASES.items():
+            primary = db_conf.get("REPLICA_OF")
+            if primary:
+                self._replicas[primary] = db
+
+    def db_for_read(self, model, **hints):
+        db = db_for_model(model)
+        if hints.get("replica", False):
+            db = self._replicas.get(db, db)
+        return db
+
+    def db_for_write(self, model, **hints):
+        return db_for_model(model)
+
+    def allow_relation(self, obj1, obj2, **hints):
+        return db_for_model(obj1) == db_for_model(obj2)
+
+    def allow_syncdb(self, db, model):
+        if db_for_model(model) == db:
+            return True
+        return False
+
+    def allow_migrate(self, db, app_label, model=None, **hints):
+        if model:
+            return db_for_model(model) == db
+
+        # We use this hint in our RunSql/RunPython migrations to help resolve databases.
+        if "tables" in hints:
+            dbs = {db_for_table(table) for table in hints["tables"]}
+            if len(dbs) > 1:
+                raise RuntimeError(
+                    "Migration tables resolve to multiple databases. "
+                    f"Got {dbs} when only one database should be used."
+                )
+            return dbs.pop() == db
+        # Assume migrations with no model routing or hints need to run on
+        # the default database.
+        return db == "default"

--- a/src/sentry/migrations/0284_metrics_indexer_alter_seq.py
+++ b/src/sentry/migrations/0284_metrics_indexer_alter_seq.py
@@ -27,16 +27,4 @@ class Migration(CheckedMigration):
         ("sentry", "0283_extend_externalissue_key"),
     ]
 
-    operations = [
-        migrations.RunSQL(
-            """
-            ALTER SEQUENCE sentry_stringindexer_id_seq START WITH 65536;
-            ALTER SEQUENCE sentry_stringindexer_id_seq RESTART;
-            """,
-            hints={"tables": ["sentry_stringindexer"]},
-            reverse_sql="""
-            ALTER SEQUENCE sentry_stringindexer_id_seq START WITH 1;
-            ALTER SEQUENCE sentry_stringindexer_id_seq RESTART;
-            """,
-        )
-    ]
+    operations = []

--- a/src/sentry/migrations/0291_add_new_perf_indexer.py
+++ b/src/sentry/migrations/0291_add_new_perf_indexer.py
@@ -58,15 +58,4 @@ class Migration(CheckedMigration):
                 fields=("string", "organization_id"), name="perf_unique_org_string"
             ),
         ),
-        migrations.RunSQL(
-            """
-            ALTER SEQUENCE sentry_perfstringindexer_id_seq START WITH 65536;
-            ALTER SEQUENCE sentry_perfstringindexer_id_seq RESTART;
-            """,
-            hints={"tables": ["sentry_perfstringindexer"]},
-            reverse_sql="""
-            ALTER SEQUENCE sentry_perfstringindexer_id_seq START WITH 1;
-            ALTER SEQUENCE sentry_perfstringindexer_id_seq RESTART;
-             """,
-        ),
     ]

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -122,6 +122,3 @@ def create_counter_function(app_config, using, **kwargs):
         )
     finally:
         cursor.close()
-
-
-post_migrate.connect(create_counter_function, dispatch_uid="create_counter_function", weak=False)


### PR DESCRIPTION
Quick test as to whether the Django ORM can be used with spanner. The answer is yes, I think. We will have to get rid of sequences, otherwise it Just Works.

As is tradition with Google products, there are two solutions to using Django with Cloud Spanner. When creating a database, one has to specify whether the database is supposed to run in postgres or "google standard sql" mode. This setting cannot be changed after, at least not through the web UI.

I suppose with PostgreSQL mode, one could use psycopg2 and psql and queries are translated serverside, but this PR is actually using the django-google-spanner Django app which constructs "standard sql" queries clientside. So there is no actual postgres dialect involved.

I followed https://cloud.google.com/blog/topics/developers-practitioners/introducing-django-cloud-spanner-database to set this up. In order to try this PR:

0. `make install-py-dev` and `pip install git+https://github.com/googleapis/python-spanner-django`
1. create database in cloud console, do _not_ set the dialect type to postgres.
2. follow https://cloud.google.com/docs/authentication/production to get a JSON file that contains your credentials
3. set the following environment variables in your shell:

      GOOGLE_CLOUD_PROJECT=search-and-storage
      GOOGLE_APPLICATION_CREDENTIALS=/Users/untitaker/Downloads/search-and-storage-XXXX.json

4. run `sentry django migrate --database metrics-spanner` and `sentry django migrate`
5. get and set some strings

## todo

* decide what to do with sequences. the `django_spanner` driver just rolls a random ID for any Django AutoField, through monkeypatching Django.
  * if we want this behavior of `django_spanner`, we need to have https://github.com/googleapis/python-spanner-django/pull/780 released
  * and we need to do something about static strings, either move them into negative int range or find some way to influence which range `django_spanner` takes IDs from
* fix existing metrics-indexer migrations
* I am not sure if the django_migrations table is supposed to exist on the spanner db? isn't one in postgres enough?
* fix projectcounter migration so it actually works with multiple dbs at all (not sure how we manage to deal with this in prod)
* investigate the actual postgresql mode of spanner. Apparently the compat layer is a separate Java app? not sure https://cloud.google.com/spanner/docs/psql-connect
* all backend tests are broken because something in pytest-django doesn't work correctly on test setup