### PR TITLE
feat(sampling): Add incompatible SDKs alert [TET-304]

### DIFF
--- a/static/app/actionCreators/serverSideSampling.tsx
+++ b/static/app/actionCreators/serverSideSampling.tsx
@@ -8,15 +8,20 @@ import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 export function fetchSamplingSdkVersions({
   api,
   orgSlug,
+  projectID,
 }: {
   api: Client;
   orgSlug: Organization['slug'];
+  projectID: Project['id'];
 }): Promise<SamplingSdkVersion[]> {
   const {samplingDistribution} = ServerSideSamplingStore.getState();
 
-  const projectIds = samplingDistribution.project_breakdown?.map(
-    projectBreakdown => projectBreakdown.project_id
-  );
+  const projectIds = [
+    projectID,
+    ...(samplingDistribution.project_breakdown?.map(
+      projectBreakdown => projectBreakdown.project_id
+    ) ?? []),
+  ];
 
   const promise = api.requestPromise(
     `/organizations/${orgSlug}/dynamic-sampling/sdk-versions/`,

--- a/static/app/types/sampling.tsx
+++ b/static/app/types/sampling.tsx
@@ -124,6 +124,7 @@ export type SamplingDistribution = {
 export type SamplingSdkVersion = {
   isSendingSampleRate: boolean;
   isSendingSource: boolean;
+  isSupportedPlatform: boolean;
   latestSDKName: string;
   latestSDKVersion: string;
   project: string;

--- a/static/app/utils/analytics/samplingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/samplingAnalyticsEvents.tsx
@@ -8,6 +8,9 @@ type Rule = {
 };
 
 export type SamplingEventParameters = {
+  'sampling.sdk.incompatible.alert': {
+    project_id: string;
+  };
   'sampling.sdk.updgrades.alert': {
     project_id: string;
   };
@@ -100,6 +103,7 @@ type SamplingAnalyticsKey = keyof SamplingEventParameters;
 
 export const samplingEventMap: Record<SamplingAnalyticsKey, string> = {
   'sampling.sdk.updgrades.alert': 'Recommended sdk upgrades alert',
+  'sampling.sdk.incompatible.alert': 'Incompatible sdk upgrades alert',
   'sampling.settings.modal.recommended.next.steps_back': 'Go back to uniform rate step',
   'sampling.settings.modal.recommended.next.steps_cancel':
     'Cancel at recommended next steps step ',

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -102,7 +102,7 @@ export function UniformRateModal({
     groupBy: useMemo(() => ['outcome', 'reason'], []),
   });
 
-  const {recommendedSdkUpgrades} = useRecommendedSdkUpgrades({
+  const {recommendedSdkUpgrades, incompatibleProjects} = useRecommendedSdkUpgrades({
     orgSlug: organization.slug,
   });
 
@@ -510,6 +510,7 @@ export function UniformRateModal({
             projectId={project.id}
             rules={rules}
             recommendedSdkUpgrades={recommendedSdkUpgrades}
+            incompatibleProjects={incompatibleProjects}
             showLinkToTheModal={false}
             onReadDocs={onReadDocs}
           />

--- a/static/app/views/settings/project/server-side-sampling/samplingSDKAlert.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingSDKAlert.tsx
@@ -105,14 +105,16 @@ export function SamplingSDKAlert({
           type="warning"
           showIcon
           trailingItems={
-            <Button
-              href={`${SERVER_SIDE_SAMPLING_DOC_LINK}getting-started/#current-limitations`}
-              priority="link"
-              borderless
-              external
-            >
-              {t('Learn More')}
-            </Button>
+            showLinkToTheModal ? (
+              <Button
+                href={`${SERVER_SIDE_SAMPLING_DOC_LINK}getting-started/#current-limitations`}
+                priority="link"
+                borderless
+                external
+              >
+                {t('Learn More')}
+              </Button>
+            ) : undefined
           }
         >
           {t(

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -103,11 +103,12 @@ export function ServerSideSampling({project}: Props) {
       await fetchSamplingSdkVersions({
         orgSlug: organization.slug,
         api,
+        projectID: project.id,
       });
     }
 
     fetchRecommendedSdkUpgrades();
-  }, [api, organization.slug, project.slug, hasAccess]);
+  }, [api, organization.slug, project.slug, project.id, hasAccess]);
 
   const {projectStats} = useProjectStats({
     orgSlug: organization.slug,
@@ -117,10 +118,9 @@ export function ServerSideSampling({project}: Props) {
     groupBy: 'outcome',
   });
 
-  const {recommendedSdkUpgrades, fetching: fetchingRecommendedSdkUpgrades} =
-    useRecommendedSdkUpgrades({
-      orgSlug: organization.slug,
-    });
+  const {recommendedSdkUpgrades, incompatibleProjects} = useRecommendedSdkUpgrades({
+    orgSlug: organization.slug,
+  });
 
   async function handleActivateToggle(rule: SamplingRule) {
     const newRules = rules.map(r => {
@@ -425,12 +425,13 @@ export function ServerSideSampling({project}: Props) {
             'These settings can only be edited by users with the organization owner, manager, or admin role.'
           )}
         />
-        {!!rules.length && !fetchingRecommendedSdkUpgrades && (
+        {!!rules.length && (
           <SamplingSDKAlert
             organization={organization}
             projectId={project.id}
             rules={rules}
             recommendedSdkUpgrades={recommendedSdkUpgrades}
+            incompatibleProjects={incompatibleProjects}
             onReadDocs={handleReadDocs}
           />
         )}

--- a/tests/js/spec/views/settings/project/server-side-sampling/samplingSDKAlert.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/samplingSDKAlert.spec.tsx
@@ -18,6 +18,7 @@ describe('Server-Side Sampling - Sampling SDK Alert', function () {
         onReadDocs={jest.fn()}
         rules={[uniformRule]}
         recommendedSdkUpgrades={[]}
+        incompatibleProjects={[]}
         showLinkToTheModal
       />
     );
@@ -40,6 +41,7 @@ describe('Server-Side Sampling - Sampling SDK Alert', function () {
           rules={[uniformRule]}
           recommendedSdkUpgrades={recommendedSdkUpgrades}
           showLinkToTheModal
+          incompatibleProjects={[]}
         />
       </Fragment>
     );
@@ -70,5 +72,30 @@ describe('Server-Side Sampling - Sampling SDK Alert', function () {
         name: 'Update the following SDK versions',
       })
     ).toBeInTheDocument();
+  });
+
+  it('renders incompatible sdks', function () {
+    const {organization, project} = getMockData();
+
+    render(
+      <SamplingSDKAlert
+        organization={organization}
+        projectId={project.id}
+        onReadDocs={jest.fn()}
+        rules={[uniformRule]}
+        recommendedSdkUpgrades={recommendedSdkUpgrades}
+        showLinkToTheModal
+        incompatibleProjects={[TestStubs.Project({slug: 'angular', platform: 'angular'})]}
+      />
+    );
+
+    expect(screen.getByTestId('recommended-sdk-upgrades-alert')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The following projects are currently incompatible with Server-Side Sampling:'
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId('platform-icon-angular')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
@@ -94,6 +94,7 @@ export const mockedSamplingSdkVersions: SamplingSdkVersion[] = [
     latestSDKName: 'sentry.javascript.react',
     isSendingSampleRate: true,
     isSendingSource: true,
+    isSupportedPlatform: true,
   },
   {
     project: mockedProjects[1].slug,
@@ -101,6 +102,7 @@ export const mockedSamplingSdkVersions: SamplingSdkVersion[] = [
     latestSDKName: 'sentry.python',
     isSendingSampleRate: false,
     isSendingSource: false,
+    isSupportedPlatform: true,
   },
   {
     project: 'java',
@@ -108,6 +110,15 @@ export const mockedSamplingSdkVersions: SamplingSdkVersion[] = [
     latestSDKName: 'sentry.java',
     isSendingSampleRate: true,
     isSendingSource: false,
+    isSupportedPlatform: true,
+  },
+  {
+    project: 'angular',
+    latestSDKVersion: '1.0.2',
+    latestSDKName: 'sentry.javascript.angular',
+    isSendingSampleRate: false,
+    isSendingSource: false,
+    isSupportedPlatform: false,
   },
 ];
 
@@ -171,6 +182,7 @@ useRecommendedSdkUpgrades.mockImplementation(() => ({
       latestSDKVersion: mockedSamplingSdkVersions[1].latestSDKVersion,
     },
   ],
+  incompatibleProjects: [],
   fetching: false,
 }));
 

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.spec.tsx
@@ -11,6 +11,7 @@ describe('useRecommendedSdkUpgrades', function () {
     ProjectsStore.loadInitialData([
       TestStubs.Project({id: 1, slug: 'sentry'}),
       TestStubs.Project({id: 2, slug: 'java'}),
+      TestStubs.Project({id: 3, slug: 'angular'}),
     ]);
     ServerSideSamplingStore.loadSamplingSdkVersionsSuccess(mockedSamplingSdkVersions);
 
@@ -36,6 +37,13 @@ describe('useRecommendedSdkUpgrades', function () {
           slug: 'sentry',
         }),
       },
+    ]);
+    expect(result.current.incompatibleProjects.length).toBe(1);
+    expect(result.current.incompatibleProjects).toEqual([
+      expect.objectContaining({
+        features: [],
+        slug: 'angular',
+      }),
     ]);
   });
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9060071/183428613-13369205-7757-45cf-8bdd-900cda929e49.png)

During the Limited Availability of dynamic sampling, we'll support only some platforms. We'll show the warning on the unsupported ones.

Requires: https://github.com/getsentry/sentry/pull/37459