### PR TITLE
feat(profiling): Toggle has_profiles flag when receiving profiles

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -15,6 +15,7 @@ from sentry.constants import DataCategory
 from sentry.lang.native.symbolicator import Symbolicator
 from sentry.models import Organization, Project, ProjectDebugFile
 from sentry.profiles.device import classify_device
+from sentry.signals import first_profile_received
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.symbolication import RetrySymbolication
 from sentry.utils import json, kafka_config, metrics
@@ -244,6 +245,9 @@ def _track_outcome(
     key_id: Optional[int],
     reason: Optional[str] = None,
 ) -> None:
+    if not project.flags.has_profiles:
+        first_profile_received.send_robust(project=project, sender=Project)
+
     track_outcome(
         org_id=project.organization_id,
         project_id=project.id,

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -19,6 +19,7 @@ from sentry.signals import (
     event_processed,
     first_event_pending,
     first_event_received,
+    first_profile_received,
     first_transaction_received,
     integration_added,
     issue_tracker_used,
@@ -203,6 +204,11 @@ def record_first_transaction(project, event, **kwargs):
         project_id=project.id,
         platform=project.platform,
     )
+
+
+@first_profile_received.connect(weak=False)
+def record_first_profile(project, **kwargs):
+    project.update(flags=F("flags").bitor(Project.flags.has_profiles))
 
 
 @member_invited.connect(weak=False)

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -67,6 +67,7 @@ first_event_pending = BetterSignal(providing_args=["project", "user"])
 
 first_event_received = BetterSignal(providing_args=["project", "event"])
 first_transaction_received = BetterSignal(providing_args=["project", "event"])
+first_profile_received = BetterSignal(providing_args=["project"])
 member_invited = BetterSignal(providing_args=["member", "user"])
 member_joined = BetterSignal(providing_args=["member", "organization"])
 issue_tracker_used = BetterSignal(providing_args=["plugin", "project", "user"])


### PR DESCRIPTION
When a profile is received on a project, make sure to toggle has_profiles to
indicate the project has previously received a profile.