### PR TITLE
ref(builds): Check backend increased parallelization

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -64,12 +64,12 @@ jobs:
       fail-fast: false
       matrix:
         # XXX: When updating this, make sure you also update MATRIX_INSTANCE_TOTAL.
-        instance: [0, 1, 2]
+        instance: [0, 1, 2, 3, 4]
         pg-version: ['9.6']
 
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
-      MATRIX_INSTANCE_TOTAL: 3
+      MATRIX_INSTANCE_TOTAL: 5
       MIGRATIONS_TEST_MIGRATE: 1
 
     steps:


### PR DESCRIPTION
### Summary
Just checking what bumping the instance count for our 15+ minute backend tests would do for their time, considering their overhead is around 2.5 mins it should speed things up a bit.

**Not planning on merging this, just checking the times for now with a real PR.**

