### PR TITLE
ref(replays): Use camelCase field names for api responses

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -32,7 +32,7 @@ function ReplayTimeline({}: Props) {
   }
 
   const durationMs = replay.getDurationMs();
-  const startTimestampMs = replay.getReplay().started_at.getTime();
+  const startTimestampMs = replay.getReplay().startedAt.getTime();
   const crumbs = replay.getRawCrumbs() || [];
   const spans = replay.getRawSpans() || [];
   const userCrumbs = crumbs.filter(crumb => USER_ACTIONS.includes(crumb.type));

--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -16,7 +16,7 @@ function DetailsPageBreadcrumbs({orgId, replayRecord}: Props) {
   const labelTitle =
     replayRecord?.user.name ||
     replayRecord?.user.email ||
-    replayRecord?.user.ip ||
+    replayRecord?.user.ipAddress ||
     replayRecord?.user.id;
 
   return (

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -85,7 +85,7 @@ function ReplayPlayPauseBar({isCompact}: {isCompact: boolean}) {
           title={t('Next breadcrumb')}
           icon={<IconNext size="sm" />}
           onClick={() => {
-            const startTimestampMs = replay?.getReplay().started_at?.getTime();
+            const startTimestampMs = replay?.getReplay().startedAt?.getTime();
             if (!startTimestampMs) {
               return;
             }

--- a/static/app/components/replays/walker/urlWalker.tsx
+++ b/static/app/components/replays/walker/urlWalker.tsx
@@ -24,7 +24,7 @@ type StringProps = {
 export const CrumbWalker = memo(function CrumbWalker({crumbs, replayRecord}: CrumbProps) {
   const {setCurrentTime} = useReplayContext();
 
-  const startTimestampMs = replayRecord.started_at.getTime();
+  const startTimestampMs = replayRecord.startedAt.getTime();
 
   const handleClick = useCallback(
     (crumb: Crumb) => {

--- a/static/app/utils/replays/getCurrentUrl.tsx
+++ b/static/app/utils/replays/getCurrentUrl.tsx
@@ -9,7 +9,7 @@ function getCurrentUrl(
   crumbs: Crumb[],
   currentOffsetMS: number
 ) {
-  const startTimestampMs = replayRecord.started_at.getTime();
+  const startTimestampMs = replayRecord.startedAt.getTime();
   const currentTimeMs = startTimestampMs + Math.floor(currentOffsetMS);
 
   const navigationCrumbs = crumbs.filter(

--- a/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
@@ -87,7 +87,7 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
 
     try {
       // Run the replay to the end, we will capture data as it streams into the plugin
-      replayerRef.pause(replay.getReplay().finished_at.getTime());
+      replayerRef.pause(replay.getReplay().finishedAt.getTime());
     } catch (error) {
       Sentry.captureException(error);
     }

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -90,37 +90,35 @@ export default class ReplayReader {
       .filter(Boolean) as string[];
 
     this.replayRecord = {
-      count_errors: this.getRawCrumbs().filter(
+      countErrors: this.getRawCrumbs().filter(
         crumb => crumb.category === BreadcrumbType.ERROR
       ).length,
-      count_segments: 0,
-      count_urls: urls.length,
+      countSegments: 0,
+      countUrls: urls.length,
       dist: this.event.dist,
       duration: endTimestampMs - startTimestampMs,
       environment: null,
-      finished_at: new Date(endTimestampMs),
-      ip_address_v4: this.event.user?.ip_address,
-      ip_address_v6: null,
-      longest_transaction: 0,
+      finishedAt: new Date(endTimestampMs),
+      longestTransaction: 0,
       platform: this.event.platform,
-      project_id: this.event.projectID,
-      project_slug: '',
+      projectId: this.event.projectID,
+      projectSlug: '', // TODO(replay)
       release: null, // event.release is not a string, expected to be `version@1.4`
-      replay_id: this.event.id,
-      sdk_name: this.event.sdk?.name,
-      sdk_version: this.event.sdk?.version,
-      started_at: new Date(startTimestampMs),
+      replayId: this.event.id,
+      sdkName: this.event.sdk?.name,
+      sdkVersion: this.event.sdk?.version,
+      startedAt: new Date(startTimestampMs),
       tags: this.event.tags.reduce((tags, {key, value}) => {
         tags[key] = value;
         return tags;
       }, {} as ReplayRecord['tags']),
       title: this.event.title,
-      trace_ids: [],
+      traceIds: [],
       urls,
       user: {
         email: this.event.user?.email,
         id: this.event.user?.id,
-        ip: this.event.user?.ip_address,
+        ipAddress: this.event.user?.ip_address,
         name: this.event.user?.name,
       },
     } as ReplayRecord;

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -95,6 +95,7 @@ export default class ReplayReader {
       ).length,
       countSegments: 0,
       countUrls: urls.length,
+      errorIds: [],
       dist: this.event.dist,
       duration: endTimestampMs - startTimestampMs,
       environment: null,
@@ -115,6 +116,7 @@ export default class ReplayReader {
       title: this.event.title,
       traceIds: [],
       urls,
+      userAgent: '',
       user: {
         email: this.event.user?.email,
         id: this.event.user?.id,

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -99,16 +99,16 @@ export default class ReplayReader {
       dist: this.event.dist,
       duration: endTimestampMs - startTimestampMs,
       environment: null,
-      finishedAt: new Date(endTimestampMs),
+      finishedAt: new Date(endTimestampMs), // TODO(replay): Convert from string to Date when reading API
       longestTransaction: 0,
       platform: this.event.platform,
       projectId: this.event.projectID,
-      projectSlug: '', // TODO(replay)
+      projectSlug: '', // TODO(replay): Read from useProject to fill this in
       release: null, // event.release is not a string, expected to be `version@1.4`
       replayId: this.event.id,
       sdkName: this.event.sdk?.name,
       sdkVersion: this.event.sdk?.version,
-      startedAt: new Date(startTimestampMs),
+      startedAt: new Date(startTimestampMs), // TODO(replay): Convert from string to Date when reading API
       tags: this.event.tags.reduce((tags, {key, value}) => {
         tags[key] = value;
         return tags;

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -36,7 +36,7 @@ function Breadcrumbs({}: Props) {
   const crumbListContainerRef = useRef<HTMLDivElement>(null);
   useCurrentItemScroller(crumbListContainerRef);
 
-  const startTimestampMs = replayRecord?.started_at.getTime() || 0;
+  const startTimestampMs = replayRecord?.startedAt.getTime() || 0;
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
 

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -18,7 +18,7 @@ type Props = {
 
 function DomMutations({replay}: Props) {
   const {isLoading, actions} = useExtractedCrumbHtml({replay});
-  const startTimestampMs = replay.getReplay().started_at.getTime();
+  const startTimestampMs = replay.getReplay().startedAt.getTime();
 
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);

--- a/static/app/views/replays/detail/eventMetaData.tsx
+++ b/static/app/views/replays/detail/eventMetaData.tsx
@@ -27,8 +27,8 @@ function EventMetaData({crumbs, durationMs, replayRecord}: Props) {
       {replayRecord ? (
         <ProjectBadge
           project={
-            projects.find(p => p.id === replayRecord.project_id) || {
-              slug: replayRecord.project_slug || '',
+            projects.find(p => p.id === replayRecord.projectId) || {
+              slug: replayRecord.projectSlug || '',
             }
           }
           avatarSize={16}
@@ -41,7 +41,7 @@ function EventMetaData({crumbs, durationMs, replayRecord}: Props) {
         {replayRecord ? (
           <React.Fragment>
             <IconCalendar color="gray300" />
-            <TimeSince date={replayRecord.started_at} shorten />
+            <TimeSince date={replayRecord.startedAt} shorten />
           </React.Fragment>
         ) : (
           <HeaderPlaceholder />

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -41,7 +41,7 @@ function FocusArea({}: Props) {
   }
 
   const replayRecord = replay.getReplay();
-  const startTimestampMs = replayRecord.started_at.getTime();
+  const startTimestampMs = replayRecord.startedAt.getTime();
 
   const getNetworkSpans = () => {
     return replay.getRawSpans().filter(replay.isNotMemorySpan);
@@ -56,7 +56,7 @@ function FocusArea({}: Props) {
       return (
         <Console
           breadcrumbs={consoleMessages ?? []}
-          startTimestampMs={replayRecord.started_at.getTime()}
+          startTimestampMs={replayRecord.startedAt.getTime()}
         />
       );
     case 'network':
@@ -84,10 +84,7 @@ function FocusArea({}: Props) {
       );
     case 'issues':
       return (
-        <IssueList
-          replayId={replayRecord.replay_id}
-          projectId={replayRecord.project_id}
-        />
+        <IssueList replayId={replayRecord.replayId} projectId={replayRecord.projectId} />
       );
     case 'dom':
       return <DomMutations replay={replay} />;

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -23,7 +23,7 @@ type Props = {
 };
 
 function NetworkList({replayRecord, networkSpans}: Props) {
-  const startTimestampMs = replayRecord.started_at.getTime();
+  const startTimestampMs = replayRecord.startedAt.getTime();
   const {setCurrentHoverTime, setCurrentTime} = useReplayContext();
   const [sortConfig, setSortConfig] = useState<ISortConfig>({
     by: 'startTimestamp',

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 function Page({children, crumbs, durationMs, orgId, replayRecord}: Props) {
   const title = replayRecord
-    ? `${replayRecord.replay_id} - Replays - ${orgId}`
+    ? `${replayRecord.replayId} - Replays - ${orgId}`
     : `Replays - ${orgId}`;
 
   const header = (

--- a/static/app/views/replays/detail/trace.tsx
+++ b/static/app/views/replays/detail/trace.tsx
@@ -67,8 +67,8 @@ export default function Trace({replayRecord, organization}: Props) {
   } = useRouteContext();
   const [, eventId] = eventSlug.split(':');
 
-  const start = getUtcDateString(replayRecord.started_at.getTime());
-  const end = getUtcDateString(replayRecord.finished_at.getTime());
+  const start = getUtcDateString(replayRecord.startedAt.getTime());
+  const end = getUtcDateString(replayRecord.finishedAt.getTime());
 
   useEffect(() => {
     async function loadTraces() {

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -11,6 +11,7 @@ export type ReplayRecord = {
   dist: null | string;
   duration: number;
   environment: null | string;
+  errorIds: string[];
   finishedAt: Date; // API will send a string, needs to be hydrated
   longestTransaction: number;
   platform: string;
@@ -31,6 +32,7 @@ export type ReplayRecord = {
     ipAddress: null | string;
     name: null | string;
   };
+  userAgent: string;
 };
 
 export type ReplayDiscoveryListItem = {

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -5,30 +5,30 @@ import type {RawCrumb} from 'sentry/types/breadcrumbs';
 // Keep this in sync with the backend blueprint
 // "ReplayRecord" is distinct from the common: "replay = new ReplayReader()"
 export type ReplayRecord = {
-  count_errors: number;
-  count_segments: number;
-  count_urls: number;
+  countErrors: number;
+  countSegments: number;
+  countUrls: number;
   dist: null | string;
   duration: number;
   environment: null | string;
-  finished_at: Date; // API will send a string, needs to be hydrated
-  longest_transaction: number;
+  finishedAt: Date; // API will send a string, needs to be hydrated
+  longestTransaction: number;
   platform: string;
-  project_id: string;
-  project_slug: string;
+  projectId: string;
+  projectSlug: string;
   release: null | string;
-  replay_id: string;
-  sdk_name: string;
-  sdk_version: string;
-  started_at: Date; // API will send a string, needs to be hydrated
+  replayId: string;
+  sdkName: string;
+  sdkVersion: string;
+  startedAt: Date; // API will send a string, needs to be hydrated
   tags: Record<string, string>;
   title: string;
-  trace_ids: string[];
+  traceIds: string[];
   urls: string[];
   user: {
     email: null | string;
     id: null | string;
-    ip: null | string;
+    ipAddress: null | string;
     name: null | string;
   };
 };

--- a/tests/js/spec/utils/replays/getCurrentUrl.spec.tsx
+++ b/tests/js/spec/utils/replays/getCurrentUrl.spec.tsx
@@ -56,8 +56,8 @@ describe('getCurrentUrl', () => {
     tags: {
       url: 'https://sourcemaps.io/#initial',
     },
-    started_at: START_DATE,
-    finished_at: END_DATE,
+    startedAt: START_DATE,
+    finishedAt: END_DATE,
   }) as ReplayRecord;
 
   it('should return the url from tags when the offset is early', () => {


### PR DESCRIPTION
Updated to match the latest here: https://github.com/getsentry/replay-backend/pull/15/files#diff-3bc37663e99c0db745c2c39afae6b8814015ea3ee4066c495f97598fe6b154efR47-R74