### PR TITLE
fix(bootstrap): link librdkafka in C_INCLUDE_PATH and LIBRARY_PATH

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -109,8 +109,8 @@ install-py-dev() {
         pip install https://storage.googleapis.com/python-arm64-wheels/psycopg2_binary-2.8.6-cp38-cp38-macosx_11_0_arm64.whl
         # The CPATH is needed for confluent-kakfa --> https://github.com/confluentinc/confluent-kafka-python/issues/1190
         export CPATH="$(brew --prefix librdkafka)/include"
-        export C_INCLUDE_PATH="$(brew info librdkafka | sed -n 4p | cut -d' ' -f1)/include/"
-        export LIBRARY_PATH="$(brew info librdkafka | sed -n 4p | cut -d' ' -f1)/lib"
+        export C_INCLUDE_PATH="$(brew --prefix librdkafka)/include"
+        export LIBRARY_PATH="$(brew --prefex librdkafka)/lib"
         # The LDFLAGS is needed for uWSGI --> https://github.com/unbit/uwsgi/issues/2361
         export LDFLAGS="-L$(brew --prefix gettext)/lib"
     fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -109,6 +109,8 @@ install-py-dev() {
         pip install https://storage.googleapis.com/python-arm64-wheels/psycopg2_binary-2.8.6-cp38-cp38-macosx_11_0_arm64.whl
         # The CPATH is needed for confluent-kakfa --> https://github.com/confluentinc/confluent-kafka-python/issues/1190
         export CPATH="$(brew --prefix librdkafka)/include"
+        export C_INCLUDE_PATH="$(brew info librdkafka | sed -n 4p | cut -d' ' -f1)/include/"
+        export LIBRARY_PATH="$(brew info librdkafka | sed -n 4p | cut -d' ' -f1)/lib"
         # The LDFLAGS is needed for uWSGI --> https://github.com/unbit/uwsgi/issues/2361
         export LDFLAGS="-L$(brew --prefix gettext)/lib"
     fi


### PR DESCRIPTION
I'm not entirely certain if this is the _right_ way to do this, but currently `make bootstrap` runs into issues with installing `confluent-kafka` without these values set. I had to set these environment variables to get things working.

```
fatal error: 'librdkafka/rdkafka.h' file not found
      #include <librdkafka/rdkafka.h>
               ^~~~~~~~~~~~~~~~~~~~~~
      1 error generated.
      error: command 'clang' failed with exit status 1
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  WARNING: No metadata found in ./.venv/lib/python3.8/site-packages
  Rolling back uninstall of confluent-kafka
  ```