### PR TITLE
ref(forms): Delete controls/input.tsx

### DIFF
--- a/static/app/components/forms/controls/input.tsx
+++ b/static/app/components/forms/controls/input.tsx
@@ -1,5 +1,0 @@
-import Input from 'sentry/components/input';
-
-// Temporary re-export to fix a gcloud build issue. Do not use this file. Import
-// Input directly from 'sentry/components/input' instead.
-export default Input;


### PR DESCRIPTION
Both https://github.com/getsentry/sentry/pull/37399 and https://github.com/getsentry/getsentry/pull/7979 have been merged, so now it is safe to delete `forms/controls/input.tsx`