### PR TITLE
feat(redis): Allow readonly cluster config and separate projectconfig…

### DIFF
--- a/src/sentry/relay/projectconfig_cache/redis.py
+++ b/src/sentry/relay/projectconfig_cache/redis.py
@@ -17,6 +17,9 @@ class RedisProjectConfigCache(ProjectConfigCache):
         cluster_key = options.get("cluster", "default")
         self.cluster = redis.redis_clusters.get(cluster_key)
 
+        read_cluster_key = options.get("read_cluster", cluster_key)
+        self.cluster_read = redis.redis_clusters.get(read_cluster_key)
+
         super().__init__(**options)
 
     def validate(self):
@@ -52,7 +55,7 @@ class RedisProjectConfigCache(ProjectConfigCache):
         )
 
     def get(self, public_key):
-        rv = self.cluster.get(self.__get_redis_key(public_key))
+        rv = self.cluster_read.get(self.__get_redis_key(public_key))
         if rv is not None:
             try:
                 rv = zstandard.decompress(rv).decode()

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -206,6 +206,10 @@ class _RedisCluster:
         hosts = config.get("hosts")
         hosts = list(hosts.values()) if isinstance(hosts, dict) else hosts
 
+        # support for scaling reads using the readonly mode
+        # https://redis.io/docs/reference/cluster-spec/#scaling-reads-using-replica-nodes
+        readonly_mode = config.get("readonly_mode", False)
+
         # Redis cluster does not wait to attempt to connect. We'd prefer to not
         # make TCP connections on boot. Wrap the client in a lazy proxy object.
         def cluster_factory():
@@ -223,6 +227,7 @@ class _RedisCluster:
                     skip_full_coverage_check=True,
                     max_connections=16,
                     max_connections_per_node=True,
+                    readonly_mode=readonly_mode,
                 )
             else:
                 host = hosts[0].copy()


### PR DESCRIPTION
This PR allows us to configure Redis clusters in read-only mode to scale reads ~ https://redis.io/docs/reference/cluster-spec/#scaling-reads-using-replica-nodes

+ separating project config cache cluster for reads