### PR TITLE
ref(charts): Use size "sm" for OptionSelector

### DIFF
--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -57,13 +57,13 @@ function OptionSelector({
 
   return (
     <CompactSelect
+      size="sm"
       options={mappedOptions}
       value={selected}
       onChange={onValueChange}
       isOptionDisabled={isOptionDisabled}
       multiple={multiple}
       triggerProps={{
-        size: 'sm',
         borderless: true,
         prefix: (
           <Fragment>


### PR DESCRIPTION
Take advantage of `CompactSelect`'s new `size` prop for a smaller, more proportional dropdown menu in `OptionSelector`.
**Before:**
<img width="245" alt="Screen Shot 2022-08-08 at 1 21 18 PM" src="https://user-images.githubusercontent.com/44172267/183507641-244adb60-d4eb-415a-a222-89ad8b25a4db.png">

**After:**
<img width="245" alt="Screen Shot 2022-08-08 at 1 22 03 PM" src="https://user-images.githubusercontent.com/44172267/183507652-99a6ddec-cdd6-49a0-a0cd-f4ef8bf7534f.png">

