### PR TITLE
ref(dropdownMenu): Forward size prop to submenu

### DIFF
--- a/static/app/components/dropdownMenuControl.tsx
+++ b/static/app/components/dropdownMenuControl.tsx
@@ -197,6 +197,7 @@ function MenuControl({
         {...menuProps}
         triggerRef={ref}
         triggerWidth={triggerWidth}
+        size={size}
         isSubmenu={isSubmenu}
         isDismissable={!isSubmenu && props.isDismissable}
         shouldCloseOnBlur={!isSubmenu && props.shouldCloseOnBlur}

--- a/static/app/components/dropdownMenuV2.tsx
+++ b/static/app/components/dropdownMenuV2.tsx
@@ -48,6 +48,7 @@ type Props = {
    */
   menuTitle?: string;
   onClose?: () => void;
+  size?: MenuItemProps['size'];
   /**
    * Current width of the trigger element. This is used as the menu's minimum
    * width.
@@ -65,6 +66,7 @@ function Menu({
   closeOnSelect = true,
   triggerRef,
   triggerWidth,
+  size,
   isSubmenu,
   menuTitle,
   closeRootMenu,
@@ -191,6 +193,7 @@ function Menu({
         crossOffset={-8}
         closeOnSelect={closeOnSelect}
         isOpen={state.selectionManager.isSelected(node.key)}
+        size={size}
         isSubmenu
         closeRootMenu={closeRootMenu}
         closeCurrentSubmenu={() => state.selectionManager.clearSelection()}


### PR DESCRIPTION
Forward `size` prop from `DropdownMenuControl` to submenus, so that adding a `size` prop to the root menu will also update the submenu sizes.

**Before**, when setting `size="sm"` on the root menu:
<img width="616" alt="Screen Shot 2022-08-08 at 2 14 50 PM" src="https://user-images.githubusercontent.com/44172267/183516227-1ad3038b-6262-4ded-bcb4-8a6837ea080d.png">


**After:**
<img width="616" alt="Screen Shot 2022-08-08 at 2 14 26 PM" src="https://user-images.githubusercontent.com/44172267/183516243-de4f6748-976d-4872-8189-d22391522c3c.png">
