### PR TITLE
fix: Fix `reset-db` to create a user before loading mocks

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -236,6 +236,7 @@ reset-db() {
     drop-db
     create-db
     apply-migrations
+    create-user
     # This ensures that your set up as some data inside of it
     bin/load-mocks
 }

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -237,8 +237,7 @@ reset-db() {
     create-db
     apply-migrations
     create-user
-    # This ensures that your set up as some data inside of it
-    bin/load-mocks
+    echo "Finished resetting database. To load mock data, run `./bin/load-mocks`"
 }
 
 prerequisites() {


### PR DESCRIPTION
Currently, `reset-db` will fail to create mocks, since we need a superuser in place. This adds the
call back in place.

Alternatively, we could go back to how this worked before and just run up to migrations, maybe
output a couple of commands explaining how to populate the db with data if desired. `reset-db` used
to be a fairly fast command, so this might make more sense.