### PR TITLE
ref(contexts):remove \n escape

### DIFF
--- a/static/app/components/events/meta/annotatedText/valueElement.tsx
+++ b/static/app/components/events/meta/annotatedText/valueElement.tsx
@@ -34,10 +34,6 @@ const ValueElement = ({value, meta}: Props) => {
     );
   }
 
-  if (typeof value === 'string') {
-    return <Fragment>{value.replace(/\n/g, '\\n')}</Fragment>;
-  }
-
   if (isValidElement(value)) {
     return value;
   }

--- a/tests/js/spec/components/events/eventExtraData.spec.tsx
+++ b/tests/js/spec/components/events/eventExtraData.spec.tsx
@@ -178,7 +178,7 @@ describe('EventExtraData', function () {
       await screen.findByText('Replaced because of PII rule "project:3"')
     ).toBeInTheDocument(); // tooltip description
 
-    // expect(screen.getByText('isNewer')).toBeInTheDocument(); // key
-    // expect(screen.getByText('\\n')).toBeInTheDocument(); // value
+    expect(screen.getByText('isNewer')).toBeInTheDocument(); // key
+    expect(screen.queryByText('\\n')).not.toBeInTheDocument(); // value
   });
 });


### PR DESCRIPTION
It made some sense but it broke some other stuff, so removing it 