### PR TITLE
ref: strip extras so they can be used as constraints files

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -18,7 +18,7 @@ cfgv==3.3.1
 chardet==4.0.0
 click==8.0.4
 confluent-kafka==1.8.2
-coverage[toml]==6.3.3
+coverage==6.3.3
 croniter==0.3.37
 cryptography==37.0.2
 cssselect==1.0.3
@@ -42,7 +42,7 @@ filelock==3.7.0
 flake8==5.0.2
 flake8-bugbear==22.7.1
 freezegun==1.1.0
-google-api-core[grpc]==1.32.0
+google-api-core==1.32.0
 google-auth==1.35.0
 google-cloud-bigtable==1.6.1
 google-cloud-core==1.5.0
@@ -51,7 +51,7 @@ google-cloud-pubsub==2.2.0
 google-cloud-storage==1.35.0
 google-crc32c==1.1.2
 google-resumable-media==1.3.3
-googleapis-common-protos[grpc]==1.56.2
+googleapis-common-protos==1.56.2
 grpc-google-iam-v1==0.12.4
 grpcio==1.47.0
 h11==0.13.0
@@ -167,7 +167,7 @@ typing-inspect==0.7.1
 ua-parser==0.10.0
 unidiff==0.7.4
 uritemplate==4.1.1
-urllib3[brotli,secure,socks]==1.26.9
+urllib3==1.26.9
 uwsgi==2.0.20.0
 vine==1.3.0
 virtualenv==20.14.1

--- a/requirements-dev-only-frozen.txt
+++ b/requirements-dev-only-frozen.txt
@@ -7,7 +7,7 @@ certifi==2022.5.18.1
 cfgv==3.3.1
 charset-normalizer==2.0.12
 click==8.1.3
-coverage[toml]==6.4.1
+coverage==6.4.1
 dictpath==0.1.3
 distlib==0.3.4
 docker==3.7.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -28,7 +28,7 @@ djangorestframework==3.12.4
 drf-spectacular==0.22.1
 email-reply-parser==0.5.12
 fido2==0.9.2
-google-api-core[grpc]==1.32.0
+google-api-core==1.32.0
 google-auth==1.35.0
 google-cloud-bigtable==1.6.1
 google-cloud-core==1.5.0
@@ -37,7 +37,7 @@ google-cloud-pubsub==2.2.0
 google-cloud-storage==1.35.0
 google-crc32c==1.1.2
 google-resumable-media==1.3.3
-googleapis-common-protos[grpc]==1.56.2
+googleapis-common-protos==1.56.2
 grpc-google-iam-v1==0.12.4
 grpcio==1.47.0
 h11==0.13.0
@@ -116,7 +116,7 @@ typing-inspect==0.7.1
 ua-parser==0.10.0
 unidiff==0.7.4
 uritemplate==4.1.1
-urllib3[brotli,secure,socks]==1.26.9
+urllib3==1.26.9
 uwsgi==2.0.20.0
 vine==1.3.0
 wsproto==1.1.0

--- a/tools/freeze_requirements.py
+++ b/tools/freeze_requirements.py
@@ -61,10 +61,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     base_cmd = (
         "pip-compile",
-        "--no-header",
-        "--no-annotate",
         "--allow-unsafe",
-        "-q",
+        "--no-annotate",
+        "--no-header",
+        "--quiet",
+        "--strip-extras",
     )
 
     executor = ThreadPoolExecutor(max_workers=3)


### PR DESCRIPTION
without this, `--constraint` can't be used with these files (for example to create a derived subset of the requirements)

extras in this file don't impact the final installed packages since we freeze everything