### PR TITLE
feat(sampling): Change how we display alerts

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
@@ -26,9 +26,11 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import {formatPercentage} from 'sentry/utils/formatters';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
+import {SamplingProjectIncompatibleAlert} from '../samplingProjectIncompatibleAlert';
 import {isValidSampleRate, SERVER_SIDE_SAMPLING_DOC_LINK} from '../utils';
 import {projectStatsToSampleRates} from '../utils/projectStatsToSampleRates';
 import useProjectStats from '../utils/useProjectStats';
+import {useRecommendedSdkUpgrades} from '../utils/useRecommendedSdkUpgrades';
 
 import {FooterActions, Stepper} from './uniformRateModal';
 
@@ -63,6 +65,10 @@ export function RecommendedStepsModal({
   recommendedSampleRate,
   onSetRules,
 }: RecommendedStepsModalProps) {
+  const {isProjectIncompatible} = useRecommendedSdkUpgrades({
+    orgSlug: organization.slug,
+    projectId,
+  });
   const [saving, setSaving] = useState(false);
   const {projectStats} = useProjectStats({
     orgSlug: organization.slug,
@@ -209,6 +215,11 @@ export function RecommendedStepsModal({
                 </code>
               </pre>
             </div>
+            <SamplingProjectIncompatibleAlert
+              organization={organization}
+              projectId={projectId}
+              isProjectIncompatible={isProjectIncompatible}
+            />
           </ListItem>
         </List>
       </Body>
@@ -228,7 +239,7 @@ export function RecommendedStepsModal({
             <Button
               priority="primary"
               onClick={handleDone}
-              disabled={onSubmit ? saving || !isValid : false} // do not disable the button if there's on onSubmit handler (modal was opened from the sdk alert)
+              disabled={onSubmit ? saving || !isValid || isProjectIncompatible : false} // do not disable the button if there's on onSubmit handler (modal was opened from the sdk alert)
               title={
                 onSubmit
                   ? !isValid

--- a/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.tsx
@@ -9,11 +9,13 @@ import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 
+import {SamplingProjectIncompatibleAlert} from '../samplingProjectIncompatibleAlert';
 import {isValidSampleRate, SERVER_SIDE_SAMPLING_DOC_LINK} from '../utils';
+import {useRecommendedSdkUpgrades} from '../utils/useRecommendedSdkUpgrades';
 
 import {FooterActions, Stepper, StyledNumberField} from './uniformRateModal';
 
-export type RecommendedStepsModalProps = ModalRenderProps & {
+type SpecifyClientRateModalProps = ModalRenderProps & {
   onChange: (value: number | undefined) => void;
   onGoNext: () => void;
   onReadDocs: () => void;
@@ -33,7 +35,12 @@ export function SpecifyClientRateModal({
   projectId,
   value,
   onChange,
-}: RecommendedStepsModalProps) {
+}: SpecifyClientRateModalProps) {
+  const {isProjectIncompatible} = useRecommendedSdkUpgrades({
+    orgSlug: organization.slug,
+    projectId,
+  });
+
   function handleReadDocs() {
     trackAdvancedAnalyticsEvent('sampling.settings.modal.specify.client.rate_read_docs', {
       organization,
@@ -83,6 +90,11 @@ export function SpecifyClientRateModal({
           flexibleControlStateSize
           inline={false}
         />
+        <SamplingProjectIncompatibleAlert
+          organization={organization}
+          projectId={projectId}
+          isProjectIncompatible={isProjectIncompatible}
+        />
       </Body>
       <Footer>
         <FooterActions>
@@ -95,7 +107,7 @@ export function SpecifyClientRateModal({
             <Button
               priority="primary"
               onClick={handleGoNext}
-              disabled={!isValid}
+              disabled={!isValid || isProjectIncompatible}
               title={!isValid ? t('Sample rate is not valid') : undefined}
             >
               {t('Next')}

--- a/static/app/views/settings/project/server-side-sampling/samplingProjectIncompatibleAlert.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingProjectIncompatibleAlert.tsx
@@ -1,0 +1,54 @@
+import {useEffect} from 'react';
+
+import Alert from 'sentry/components/alert';
+import Button from 'sentry/components/button';
+import {t} from 'sentry/locale';
+import {Organization, Project} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+
+import {SERVER_SIDE_SAMPLING_DOC_LINK} from './utils';
+
+type Props = {
+  isProjectIncompatible: boolean;
+  organization: Organization;
+  projectId: Project['id'];
+};
+
+export function SamplingProjectIncompatibleAlert({
+  isProjectIncompatible,
+  organization,
+  projectId,
+}: Props) {
+  useEffect(() => {
+    if (isProjectIncompatible) {
+      trackAdvancedAnalyticsEvent('sampling.sdk.incompatible.alert', {
+        organization,
+        project_id: projectId,
+      });
+    }
+  }, [isProjectIncompatible, organization, projectId]);
+
+  if (!isProjectIncompatible) {
+    return null;
+  }
+
+  return (
+    <Alert
+      data-test-id="incompatible-project-alert"
+      type="warning"
+      showIcon
+      trailingItems={
+        <Button
+          href={`${SERVER_SIDE_SAMPLING_DOC_LINK}getting-started/#current-limitations`}
+          priority="link"
+          borderless
+          external
+        >
+          {t('Learn More')}
+        </Button>
+      }
+    >
+      {t('Your project is currently incompatible with Server-Side Sampling.')}
+    </Alert>
+  );
+}

--- a/static/app/views/settings/project/server-side-sampling/samplingPromo.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingPromo.tsx
@@ -11,11 +11,17 @@ import {SERVER_SIDE_SAMPLING_DOC_LINK} from './utils';
 
 type Props = {
   hasAccess: boolean;
+  isProjectIncompatible: boolean;
   onGetStarted: () => void;
   onReadDocs: () => void;
 };
 
-export function SamplingPromo({onGetStarted, onReadDocs, hasAccess}: Props) {
+export function SamplingPromo({
+  onGetStarted,
+  onReadDocs,
+  hasAccess,
+  isProjectIncompatible,
+}: Props) {
   return (
     <OnboardingPanel image={<img src={onboardingServerSideSampling} />}>
       <h3>{t('Sample for relevancy')}</h3>
@@ -28,7 +34,7 @@ export function SamplingPromo({onGetStarted, onReadDocs, hasAccess}: Props) {
         <Button
           priority="primary"
           onClick={onGetStarted}
-          disabled={!hasAccess}
+          disabled={!hasAccess || isProjectIncompatible}
           title={hasAccess ? undefined : t('You do not have permission to set up rules')}
         >
           {t('Start Setup')}

--- a/static/app/views/settings/project/server-side-sampling/samplingSDKUpgradesAlert.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingSDKUpgradesAlert.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {openModal} from 'sentry/actionCreators/modal';
@@ -7,32 +7,25 @@ import Button from 'sentry/components/button';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Organization, Project} from 'sentry/types';
-import {RecommendedSdkUpgrade, SamplingRule} from 'sentry/types/sampling';
+import {Organization} from 'sentry/types';
+import {RecommendedSdkUpgrade} from 'sentry/types/sampling';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 
 import {
   RecommendedStepsModal,
   RecommendedStepsModalProps,
 } from './modals/recommendedStepsModal';
-import {isUniformRule, SERVER_SIDE_SAMPLING_DOC_LINK} from './utils';
 
 type Props = Pick<RecommendedStepsModalProps, 'projectId' | 'onReadDocs'> & {
-  incompatibleProjects: Project[];
   organization: Organization;
   recommendedSdkUpgrades: RecommendedSdkUpgrade[];
-  rules: SamplingRule[];
-  showLinkToTheModal?: boolean;
 };
 
 export function SamplingSDKUpgradesAlert({
   organization,
   projectId,
   recommendedSdkUpgrades,
-  incompatibleProjects,
-  rules,
   onReadDocs,
-  showLinkToTheModal = true,
 }: Props) {
   useEffect(() => {
     if (recommendedSdkUpgrades.length > 0) {
@@ -42,15 +35,6 @@ export function SamplingSDKUpgradesAlert({
       });
     }
   }, [recommendedSdkUpgrades.length, organization, projectId]);
-
-  useEffect(() => {
-    if (incompatibleProjects.length > 0) {
-      trackAdvancedAnalyticsEvent('sampling.sdk.incompatible.alert', {
-        organization,
-        project_id: projectId,
-      });
-    }
-  }, [incompatibleProjects.length, organization, projectId]);
 
   function handleOpenRecommendedSteps() {
     openModal(modalProps => (
@@ -64,70 +48,34 @@ export function SamplingSDKUpgradesAlert({
     ));
   }
 
-  const uniformRule = rules.find(isUniformRule);
+  if (recommendedSdkUpgrades.length === 0) {
+    return null;
+  }
 
   return (
-    <Fragment>
-      {rules.length > 0 && recommendedSdkUpgrades.length > 0 && (
-        <Alert
-          data-test-id="recommended-sdk-upgrades-alert"
-          type="info"
-          showIcon
-          trailingItems={
-            showLinkToTheModal && uniformRule ? (
-              <Button onClick={handleOpenRecommendedSteps} priority="link" borderless>
-                {t('Learn More')}
-              </Button>
-            ) : undefined
-          }
-        >
-          {t(
-            'To activate server-side sampling rules, it’s a requirement to update the following project SDK(s):'
-          )}
-          <Projects>
-            {recommendedSdkUpgrades.map(recommendedSdkUpgrade => (
-              <ProjectBadge
-                key={recommendedSdkUpgrade.project.id}
-                project={recommendedSdkUpgrade.project}
-                avatarSize={16}
-              />
-            ))}
-          </Projects>
-        </Alert>
+    <Alert
+      data-test-id="recommended-sdk-upgrades-alert"
+      type="info"
+      showIcon
+      trailingItems={
+        <Button onClick={handleOpenRecommendedSteps} priority="link" borderless>
+          {t('Learn More')}
+        </Button>
+      }
+    >
+      {t(
+        'To activate server-side sampling rules, it’s a requirement to update the following project SDK(s):'
       )}
-      {incompatibleProjects.length > 0 && (
-        <Alert
-          data-test-id="incompatible-projects-alert"
-          type="warning"
-          showIcon
-          trailingItems={
-            showLinkToTheModal ? (
-              <Button
-                href={`${SERVER_SIDE_SAMPLING_DOC_LINK}getting-started/#current-limitations`}
-                priority="link"
-                borderless
-                external
-              >
-                {t('Learn More')}
-              </Button>
-            ) : undefined
-          }
-        >
-          {t(
-            'The following projects are currently incompatible with Server-Side Sampling:'
-          )}
-          <Projects>
-            {incompatibleProjects.map(incompatibleProject => (
-              <ProjectBadge
-                key={incompatibleProject.id}
-                project={incompatibleProject}
-                avatarSize={16}
-              />
-            ))}
-          </Projects>
-        </Alert>
-      )}
-    </Fragment>
+      <Projects>
+        {recommendedSdkUpgrades.map(recommendedSdkUpgrade => (
+          <ProjectBadge
+            key={recommendedSdkUpgrade.project.id}
+            project={recommendedSdkUpgrade.project}
+            avatarSize={16}
+          />
+        ))}
+      </Projects>
+    </Alert>
   );
 }
 

--- a/static/app/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.tsx
@@ -1,14 +1,15 @@
 import {ServerSideSamplingStore} from 'sentry/stores/serverSideSamplingStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import {Organization} from 'sentry/types';
+import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import useProjects from 'sentry/utils/useProjects';
 
 type Props = {
   orgSlug: Organization['slug'];
+  projectId: Project['id'];
 };
 
-export function useRecommendedSdkUpgrades({orgSlug}: Props) {
+export function useRecommendedSdkUpgrades({orgSlug, projectId}: Props) {
   const {samplingSdkVersions, fetching} = useLegacyStore(ServerSideSamplingStore);
 
   const sdksToUpdate = samplingSdkVersions.filter(
@@ -48,5 +49,20 @@ export function useRecommendedSdkUpgrades({orgSlug}: Props) {
     incompatibleSDKs.find(incompatibleSDK => incompatibleSDK.project === project.slug)
   );
 
-  return {recommendedSdkUpgrades, incompatibleProjects, fetching};
+  const isProjectIncompatible = incompatibleProjects.some(
+    incompatibleProject => incompatibleProject.id === projectId
+  );
+
+  const affectedProjects = [
+    ...recommendedSdkUpgrades.map(({project}) => project),
+    ...incompatibleProjects,
+  ];
+
+  return {
+    recommendedSdkUpgrades,
+    incompatibleProjects,
+    affectedProjects,
+    fetching,
+    isProjectIncompatible,
+  };
 }

--- a/tests/js/spec/views/settings/project/server-side-sampling/samplingSDKUpgradesAlert.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/samplingSDKUpgradesAlert.spec.tsx
@@ -5,7 +5,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import GlobalModal from 'sentry/components/globalModal';
 import {SamplingSDKUpgradesAlert} from 'sentry/views/settings/project/server-side-sampling/samplingSDKUpgradesAlert';
 
-import {getMockData, mockedProjects, recommendedSdkUpgrades, uniformRule} from './utils';
+import {getMockData, mockedProjects, recommendedSdkUpgrades} from './utils';
 
 describe('Server-Side Sampling - Sdk Upgrades Alert', function () {
   it('does not render content', function () {
@@ -16,10 +16,7 @@ describe('Server-Side Sampling - Sdk Upgrades Alert', function () {
         organization={organization}
         projectId={project.id}
         onReadDocs={jest.fn()}
-        rules={[uniformRule]}
         recommendedSdkUpgrades={[]}
-        incompatibleProjects={[]}
-        showLinkToTheModal
       />
     );
 
@@ -38,10 +35,7 @@ describe('Server-Side Sampling - Sdk Upgrades Alert', function () {
           organization={organization}
           projectId={project.id}
           onReadDocs={jest.fn()}
-          rules={[uniformRule]}
           recommendedSdkUpgrades={recommendedSdkUpgrades}
-          showLinkToTheModal
-          incompatibleProjects={[]}
         />
       </Fragment>
     );
@@ -72,30 +66,5 @@ describe('Server-Side Sampling - Sdk Upgrades Alert', function () {
         name: 'Update the following SDK versions',
       })
     ).toBeInTheDocument();
-  });
-
-  it('renders incompatible sdks', function () {
-    const {organization, project} = getMockData();
-
-    render(
-      <SamplingSDKUpgradesAlert
-        organization={organization}
-        projectId={project.id}
-        onReadDocs={jest.fn()}
-        rules={[uniformRule]}
-        recommendedSdkUpgrades={recommendedSdkUpgrades}
-        showLinkToTheModal
-        incompatibleProjects={[TestStubs.Project({slug: 'angular', platform: 'angular'})]}
-      />
-    );
-
-    expect(screen.getByTestId('recommended-sdk-upgrades-alert')).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'The following projects are currently incompatible with Server-Side Sampling:'
-      )
-    ).toBeInTheDocument();
-
-    expect(screen.getByTestId('platform-icon-angular')).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
@@ -183,6 +183,8 @@ useRecommendedSdkUpgrades.mockImplementation(() => ({
     },
   ],
   incompatibleProjects: [],
+  isProjectIncompatible: true,
+  affectedProjects: [mockedProjects[1]],
   fetching: false,
 }));
 

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.spec.tsx
@@ -9,14 +9,14 @@ import {mockedSamplingSdkVersions} from '../utils';
 describe('useRecommendedSdkUpgrades', function () {
   it('works', function () {
     ProjectsStore.loadInitialData([
-      TestStubs.Project({id: 1, slug: 'sentry'}),
-      TestStubs.Project({id: 2, slug: 'java'}),
-      TestStubs.Project({id: 3, slug: 'angular'}),
+      TestStubs.Project({id: '1', slug: 'sentry'}),
+      TestStubs.Project({id: '2', slug: 'java'}),
+      TestStubs.Project({id: '3', slug: 'angular'}),
     ]);
     ServerSideSamplingStore.loadSamplingSdkVersionsSuccess(mockedSamplingSdkVersions);
 
     const {result} = reactHooks.renderHook(() =>
-      useRecommendedSdkUpgrades({orgSlug: 'org-slug'})
+      useRecommendedSdkUpgrades({orgSlug: 'org-slug', projectId: '3'})
     );
 
     expect(result.current.recommendedSdkUpgrades.length).toBe(2);
@@ -45,5 +45,7 @@ describe('useRecommendedSdkUpgrades', function () {
         slug: 'angular',
       }),
     ]);
+    expect(result.current.isProjectIncompatible).toBe(true);
+    expect(result.current.affectedProjects.length).toBe(3);
   });
 });


### PR DESCRIPTION
We now block users from creating a DS rule if they are on an incompatible project.
We display this alert to let them know.
![image](https://user-images.githubusercontent.com/9060071/183673794-84bd9a74-a4aa-4cf2-a5cb-a2e233700d1c.png)
If they are on a compatible project with incompatible projects in the trace, we don't block anything - we just let them know that those project will be affected.