### PR TITLE
feat(replays): Open the network tab when clicking a Network Span

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
@@ -5,6 +5,7 @@ import {divide, flattenSpans} from 'sentry/components/replays/utils';
 import Tooltip from 'sentry/components/tooltip';
 import {tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type {ReplaySpan} from 'sentry/views/replays/types';
 
 type Props = {
@@ -31,6 +32,7 @@ type Props = {
 
 function ReplayTimelineEvents({className, durationMs, spans, startTimestampMs}: Props) {
   const flattenedSpans = flattenSpans(spans);
+  const {setActiveTab} = useActiveReplayTab();
 
   return (
     <Spans className={className}>
@@ -58,7 +60,11 @@ function ReplayTimelineEvents({className, durationMs, spans, startTimestampMs}: 
             disableForVisualTest
             position="bottom"
           >
-            <Span startPct={startPct} widthPct={widthPct} />
+            <Span
+              startPct={startPct}
+              widthPct={widthPct}
+              onClick={() => setActiveTab('network')}
+            />
           </Tooltip>
         );
       })}
@@ -79,6 +85,7 @@ const Spans = styled('ul')`
 `;
 
 const Span = styled('li')<{startPct: number; widthPct: number}>`
+  cursor: pointer;
   display: block;
   position: absolute;
   left: ${p => p.startPct * 100}%;

--- a/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
@@ -5,7 +5,7 @@ import {divide, flattenSpans} from 'sentry/components/replays/utils';
 import Tooltip from 'sentry/components/tooltip';
 import {tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
+import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type {ReplaySpan} from 'sentry/views/replays/types';
 
 type Props = {
@@ -32,7 +32,9 @@ type Props = {
 
 function ReplayTimelineEvents({className, durationMs, spans, startTimestampMs}: Props) {
   const flattenedSpans = flattenSpans(spans);
-  const {setActiveTab} = useActiveReplayTab();
+  const {setActiveTab, getActiveTab} = useActiveReplayTab();
+
+  const activeTab = getActiveTab();
 
   return (
     <Spans className={className}>
@@ -63,6 +65,7 @@ function ReplayTimelineEvents({className, durationMs, spans, startTimestampMs}: 
             <Span
               startPct={startPct}
               widthPct={widthPct}
+              activeTab={activeTab}
               onClick={() => setActiveTab('network')}
             />
           </Tooltip>
@@ -84,8 +87,8 @@ const Spans = styled('ul')`
   pointer-events: none;
 `;
 
-const Span = styled('li')<{startPct: number; widthPct: number}>`
-  cursor: pointer;
+const Span = styled('li')<{activeTab: TabKey; startPct: number; widthPct: number}>`
+  ${p => p.activeTab !== 'network' && 'cursor: pointer;'}
   display: block;
   position: absolute;
   left: ${p => p.startPct * 100}%;

--- a/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
@@ -5,7 +5,7 @@ import {divide, flattenSpans} from 'sentry/components/replays/utils';
 import Tooltip from 'sentry/components/tooltip';
 import {tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
+import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type {ReplaySpan} from 'sentry/views/replays/types';
 
 type Props = {
@@ -32,9 +32,7 @@ type Props = {
 
 function ReplayTimelineEvents({className, durationMs, spans, startTimestampMs}: Props) {
   const flattenedSpans = flattenSpans(spans);
-  const {setActiveTab, getActiveTab} = useActiveReplayTab();
-
-  const activeTab = getActiveTab();
+  const {setActiveTab} = useActiveReplayTab();
 
   return (
     <Spans className={className}>
@@ -65,7 +63,6 @@ function ReplayTimelineEvents({className, durationMs, spans, startTimestampMs}: 
             <Span
               startPct={startPct}
               widthPct={widthPct}
-              activeTab={activeTab}
               onClick={() => setActiveTab('network')}
             />
           </Tooltip>
@@ -87,8 +84,8 @@ const Spans = styled('ul')`
   pointer-events: none;
 `;
 
-const Span = styled('li')<{activeTab: TabKey; startPct: number; widthPct: number}>`
-  ${p => p.activeTab !== 'network' && 'cursor: pointer;'}
+const Span = styled('li')<{startPct: number; widthPct: number}>`
+  cursor: pointer;
   display: block;
   position: absolute;
   left: ${p => p.startPct * 100}%;


### PR DESCRIPTION


<!-- Describe your PR here. -->
Added a click functionality for the Network Span in order to open the network tab in case it is not open yet. Closes #36089 


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
