### PR TITLE
bug(replays): Revert #37394 & #37442

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -244,13 +244,6 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
     setIsPlaying(false);
   }, []);
 
-  const getCurrentTime = useCallback(
-    () => (replayerRef.current ? Math.max(replayerRef.current.getCurrentTime(), 0) : 0),
-    []
-  );
-
-  const currentPlayerTime = useCurrentTime(getCurrentTime);
-
   const initRoot = useCallback(
     (root: RootElem) => {
       if (events === undefined) {
@@ -312,10 +305,8 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
       if (unMountedRef.current) {
         unMountedRef.current = false;
       }
-
-      replayerRef.current.pause(getCurrentTime());
     },
-    [events, theme.purple200, setReplayFinished, hasNewEvents, getCurrentTime]
+    [events, theme.purple200, setReplayFinished, hasNewEvents]
   );
 
   useEffect(() => {
@@ -334,6 +325,11 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [initRoot, events]);
+
+  const getCurrentTime = useCallback(
+    () => (replayerRef.current ? Math.max(replayerRef.current.getCurrentTime(), 0) : 0),
+    []
+  );
 
   const setCurrentTime = useCallback(
     (requestedTimeMs: number) => {
@@ -420,8 +416,6 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
   }, []);
 
   // Only on pageload: set the initial playback timestamp
-  // Don't include `setCurrentTime` in the hook deps array because it changes
-  // on each play/pause state change.
   useEffect(() => {
     if (initialTimeOffset && events && replayerRef.current) {
       setCurrentTime(initialTimeOffset * 1000);
@@ -430,7 +424,9 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
     return () => {
       unMountedRef.current = true;
     };
-  }, [initialTimeOffset, events]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [events, replayerRef.current]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const currentPlayerTime = useCurrentTime(getCurrentTime);
 
   const [isBuffering, currentTime] =
     buffer.target !== -1 &&

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -313,9 +313,9 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
         unMountedRef.current = false;
       }
 
-      replayerRef.current.pause(currentPlayerTime);
+      replayerRef.current.pause(getCurrentTime());
     },
-    [events, theme.purple200, setReplayFinished, hasNewEvents, currentPlayerTime]
+    [events, theme.purple200, setReplayFinished, hasNewEvents, getCurrentTime]
   );
 
   useEffect(() => {
@@ -420,11 +420,8 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
   }, []);
 
   // Only on pageload: set the initial playback timestamp
-  // Do not include `setCurrentTime` in the hook deps array because it changes
+  // Don't include `setCurrentTime` in the hook deps array because it changes
   // on each play/pause state change.
-  // Do include replayerRef.current in the hook deps. The rule warns that since
-  // it is a ref changing it will not cause a re-render. However, when that
-  // value changes we will get a re-render because other state values have changed.
   useEffect(() => {
     if (initialTimeOffset && events && replayerRef.current) {
       setCurrentTime(initialTimeOffset * 1000);
@@ -433,7 +430,7 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
     return () => {
       unMountedRef.current = true;
     };
-  }, [initialTimeOffset, events, replayerRef.current]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialTimeOffset, events]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [isBuffering, currentTime] =
     buffer.target !== -1 &&


### PR DESCRIPTION
These were trying to maintain player timestamp during layout change, but the root issue is deeper and requires more thought to how we handle mounting and unmounting the `new Replayer` instance.