### PR TITLE
feat(replay): use `--:--` for loading timestamps instead of `00:00`

### DIFF
--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -114,7 +114,7 @@ function ReplayCurrentTime() {
 
   return (
     <span>
-      {formatTime(currentTime)} / {durationMs ? formatTime(durationMs) : '??:??'}
+      {formatTime(currentTime)} / {durationMs ? formatTime(durationMs) : '--:--'}
     </span>
   );
 }


### PR DESCRIPTION
High amount of polish, but I've had the idea in my head for a while that "00:00" looks like a zero length replay, when really it's still loading. I like "--:--" for loading instead, it feels more like a placeholder instead of a zero-value.

<img width="382" alt="Screen Shot 2022-08-09 at 9 17 37 AM" src="https://user-images.githubusercontent.com/187460/183715574-0a0306cf-6d80-43b0-9fec-98f524a9d556.png">
