### PR TITLE
ref(replays): Remove some duplicate code related to Details Page Layout

### DIFF
--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -1,21 +1,18 @@
 import {useCallback} from 'react';
 
-import {t} from 'sentry/locale';
 import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
 
-export const ReplayTabs = {
-  console: t('Console'),
-  dom: t('DOM Events'),
-  network: t('Network'),
-  trace: t('Trace'),
-  issues: t('Issues'),
-  memory: t('Memory'),
-};
+export enum TabKey {
+  console = 'console',
+  dom = 'dom',
+  network = 'network',
+  trace = 'trace',
+  issues = 'issues',
+  memory = 'memory',
+}
 
-type TabKey = keyof typeof ReplayTabs;
-
-export function isReplayTab(tab: string): tab is TabKey {
-  return tab in ReplayTabs;
+function isReplayTab(tab: string): tab is TabKey {
+  return tab in TabKey;
 }
 
 const DEFAULT_TAB = 'console';

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -30,8 +30,11 @@ function useActiveReplayTab() {
       () => (isReplayTab(paramValue || '') ? (paramValue as TabKey) : DEFAULT_TAB),
       [paramValue]
     ),
-    setActiveTab: (value: string) =>
-      isReplayTab(value) ? setParamValue(value) : setParamValue(DEFAULT_TAB),
+    setActiveTab: useCallback(
+      (value: string) =>
+        isReplayTab(value) ? setParamValue(value) : setParamValue(DEFAULT_TAB),
+      [setParamValue]
+    ),
   };
 }
 

--- a/static/app/utils/replays/hooks/useActiveReplayTab.tsx
+++ b/static/app/utils/replays/hooks/useActiveReplayTab.tsx
@@ -15,7 +15,7 @@ function isReplayTab(tab: string): tab is TabKey {
   return tab in TabKey;
 }
 
-const DEFAULT_TAB = 'console';
+const DEFAULT_TAB = TabKey.console;
 
 function useActiveReplayTab() {
   const {getParamValue, setParamValue} = useUrlParams('t_main', DEFAULT_TAB);

--- a/static/app/utils/replays/hooks/useReplayLayout.tsx
+++ b/static/app/utils/replays/hooks/useReplayLayout.tsx
@@ -1,0 +1,79 @@
+import {useCallback} from 'react';
+
+import {t} from 'sentry/locale';
+import PreferencesStore from 'sentry/stores/preferencesStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
+import {getDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
+
+export const layoutLabels = {
+  /**
+   * ### Topbar
+   *┌────────────────────┐
+   *│ Timeline           │
+   *├───────────┬────────┤
+   *│ Video     │ Crumbs │
+   *│           │        │
+   *├^^^^^^^^^^^^^^^^^^^^┤
+   *│ Details            │
+   *│                    │
+   *└────────────────────┘
+   */
+  topbar: t('Player Top'),
+  /**
+   * ### Sidebar Left
+   * ┌───────────────────┐
+   * │ Timeline          │
+   * ├────────┬──────────┤
+   * │ Video  > Details  │
+   * │        >          │
+   * │^^^^^^^ >          |
+   * │ Crumbs >          │
+   * │        >          │
+   * └────────┴──────────┘
+   */
+  sidebar_left: t('Player Left'),
+  /**
+   * ### Sidebar Right
+   * ┌───────────────────┐
+   * │ Timeline          │
+   * ├──────────┬────────┤
+   * │ Details  > Video  │
+   * │          >        │
+   * │          >^^^^^^^^┤
+   * │          > Crumbs │
+   * │          >        │
+   * └──────────┴────────┘
+   */
+  sidebar_right: t('Player Right'),
+};
+
+type LayoutKey = keyof typeof layoutLabels;
+
+export function isLayout(val: string): val is LayoutKey {
+  return val in layoutLabels;
+}
+
+function useActiveReplayTab() {
+  const collapsed = !!useLegacyStore(PreferencesStore).collapsed;
+  const defaultLayout = getDefaultLayout(collapsed);
+
+  const {getParamValue, setParamValue} = useUrlParams('l_page', defaultLayout);
+
+  const paramValue = getParamValue();
+
+  return {
+    getLayout: useCallback(
+      (): LayoutKey =>
+        isLayout(paramValue || '') ? (paramValue as LayoutKey) : defaultLayout,
+      [defaultLayout, paramValue]
+    ),
+    setLayout: useCallback(
+      (value: string) =>
+        isLayout(value) ? setParamValue(value) : setParamValue(defaultLayout),
+      [defaultLayout, setParamValue]
+    ),
+  };
+}
+
+export default useActiveReplayTab;

--- a/static/app/utils/replays/hooks/useReplayLayout.tsx
+++ b/static/app/utils/replays/hooks/useReplayLayout.tsx
@@ -1,12 +1,11 @@
 import {useCallback} from 'react';
 
-import {t} from 'sentry/locale';
 import PreferencesStore from 'sentry/stores/preferencesStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
 import {getDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
 
-export const layoutLabels = {
+export enum LayoutKey {
   /**
    * ### Topbar
    *┌────────────────────┐
@@ -19,7 +18,7 @@ export const layoutLabels = {
    *│                    │
    *└────────────────────┘
    */
-  topbar: t('Player Top'),
+  topbar = 'topbar',
   /**
    * ### Sidebar Left
    * ┌───────────────────┐
@@ -32,7 +31,7 @@ export const layoutLabels = {
    * │        >          │
    * └────────┴──────────┘
    */
-  sidebar_left: t('Player Left'),
+  sidebar_left = 'sidebar_left',
   /**
    * ### Sidebar Right
    * ┌───────────────────┐
@@ -45,13 +44,11 @@ export const layoutLabels = {
    * │          >        │
    * └──────────┴────────┘
    */
-  sidebar_right: t('Player Right'),
-};
+  sidebar_right = 'sidebar_right',
+}
 
-type LayoutKey = keyof typeof layoutLabels;
-
-export function isLayout(val: string): val is LayoutKey {
-  return val in layoutLabels;
+function isLayout(val: string): val is LayoutKey {
+  return val in LayoutKey;
 }
 
 function useActiveReplayTab() {

--- a/static/app/views/replays/detail/focusTabs.tsx
+++ b/static/app/views/replays/detail/focusTabs.tsx
@@ -1,9 +1,17 @@
 import {MouseEvent} from 'react';
 
 import NavTabs from 'sentry/components/navTabs';
-import useActiveReplayTab, {
-  ReplayTabs,
-} from 'sentry/utils/replays/hooks/useActiveReplayTab';
+import {t} from 'sentry/locale';
+import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
+
+const ReplayTabs: Record<TabKey, string> = {
+  console: t('Console'),
+  dom: t('DOM Events'),
+  network: t('Network'),
+  trace: t('Trace'),
+  issues: t('Issues'),
+  memory: t('Memory'),
+};
 
 type Props = {};
 

--- a/static/app/views/replays/detail/layout/chooseLayout.tsx
+++ b/static/app/views/replays/detail/layout/chooseLayout.tsx
@@ -1,16 +1,6 @@
 import CompactSelect from 'sentry/components/forms/compactSelect';
 import {IconPanel} from 'sentry/icons';
-import PreferencesStore from 'sentry/stores/preferencesStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
-import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
-import {getDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
-
-const LAYOUT_NAMES = ['topbar', 'sidebar_left', 'sidebar_right'];
-const layoutLabels = {
-  sidebar_right: 'Player Right',
-  sidebar_left: 'Player Left',
-  topbar: 'Player Top',
-};
+import useReplayLayout, {layoutLabels} from 'sentry/utils/replays/hooks/useReplayLayout';
 
 function getLayoutIcon(layout: string) {
   const layoutToDir = {
@@ -25,25 +15,22 @@ function getLayoutIcon(layout: string) {
 type Props = {};
 
 function ChooseLayout({}: Props) {
-  const collapsed = !!useLegacyStore(PreferencesStore).collapsed;
-  const {getParamValue, setParamValue} = useUrlParam(
-    'l_page',
-    getDefaultLayout(collapsed)
-  );
+  const {getLayout, setLayout} = useReplayLayout();
+
   return (
     <CompactSelect
       triggerProps={{
         size: 'xs',
-        icon: getLayoutIcon(getParamValue()),
+        icon: getLayoutIcon(getLayout()),
       }}
       triggerLabel=""
-      value={getParamValue()}
+      value={getLayout()}
       placement="bottom right"
-      onChange={opt => setParamValue(opt?.value)}
-      options={LAYOUT_NAMES.map(key => ({
-        value: key,
-        label: layoutLabels[key],
-        leadingItems: getLayoutIcon(key),
+      onChange={opt => setLayout(opt?.value)}
+      options={Object.entries(layoutLabels).map(([value, label]) => ({
+        value,
+        label,
+        leadingItems: getLayoutIcon(value),
       }))}
     />
   );

--- a/static/app/views/replays/detail/layout/chooseLayout.tsx
+++ b/static/app/views/replays/detail/layout/chooseLayout.tsx
@@ -1,13 +1,21 @@
 import CompactSelect from 'sentry/components/forms/compactSelect';
 import {IconPanel} from 'sentry/icons';
-import useReplayLayout, {layoutLabels} from 'sentry/utils/replays/hooks/useReplayLayout';
+import {t} from 'sentry/locale';
+import useReplayLayout, {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
+
+const layoutToLabel: Record<LayoutKey, string> = {
+  topbar: t('Player Top'),
+  sidebar_left: t('Player Left'),
+  sidebar_right: t('Player Right'),
+};
+
+const layoutToDir: Record<LayoutKey, string> = {
+  topbar: 'up',
+  sidebar_left: 'left',
+  sidebar_right: 'right',
+};
 
 function getLayoutIcon(layout: string) {
-  const layoutToDir = {
-    sidebar_right: 'right',
-    sidebar_left: 'left',
-    topbar: 'up',
-  };
   const dir = layout in layoutToDir ? layoutToDir[layout] : 'up';
   return <IconPanel size="sm" direction={dir} />;
 }
@@ -27,7 +35,7 @@ function ChooseLayout({}: Props) {
       value={getLayout()}
       placement="bottom right"
       onChange={opt => setLayout(opt?.value)}
-      options={Object.entries(layoutLabels).map(([value, label]) => ({
+      options={Object.entries(layoutToLabel).map(([value, label]) => ({
         value,
         label,
         leadingItems: getLayoutIcon(value),

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -6,7 +6,7 @@ import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline
 import ReplayView from 'sentry/components/replays/replayView';
 import space from 'sentry/styles/space';
 import useFullscreen from 'sentry/utils/replays/hooks/useFullscreen';
-import {layoutLabels} from 'sentry/utils/replays/hooks/useReplayLayout';
+import {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
 import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import FocusArea from 'sentry/views/replays/detail/focusArea';
@@ -17,8 +17,6 @@ import SplitPanel from 'sentry/views/replays/detail/layout/splitPanel';
 import SideTabs from 'sentry/views/replays/detail/sideTabs';
 import TagPanel from 'sentry/views/replays/detail/tagPanel';
 
-type LayoutModes = keyof typeof layoutLabels;
-
 const MIN_VIDEO_WIDTH = {px: 325};
 const MIN_CONTENT_WIDTH = {px: 325};
 const MIN_VIDEO_HEIGHT = {px: 200};
@@ -26,14 +24,14 @@ const MIN_CONTENT_HEIGHT = {px: 200};
 const MIN_CRUMBS_HEIGHT = {px: 200};
 
 type Props = {
-  layout?: LayoutModes;
+  layout?: LayoutKey;
   showCrumbs?: boolean;
   showTimeline?: boolean;
   showVideo?: boolean;
 };
 
 function ReplayLayout({
-  layout = 'topbar',
+  layout = LayoutKey.topbar,
   showCrumbs = true,
   showTimeline = true,
   showVideo = true,

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -6,6 +6,7 @@ import ReplayTimeline from 'sentry/components/replays/breadcrumbs/replayTimeline
 import ReplayView from 'sentry/components/replays/replayView';
 import space from 'sentry/styles/space';
 import useFullscreen from 'sentry/utils/replays/hooks/useFullscreen';
+import {layoutLabels} from 'sentry/utils/replays/hooks/useReplayLayout';
 import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import FocusArea from 'sentry/views/replays/detail/focusArea';
@@ -16,46 +17,7 @@ import SplitPanel from 'sentry/views/replays/detail/layout/splitPanel';
 import SideTabs from 'sentry/views/replays/detail/sideTabs';
 import TagPanel from 'sentry/views/replays/detail/tagPanel';
 
-export type LayoutModes =
-  /**
-   * ### Sidebar Right
-   * ┌───────────────────┐
-   * │ Timeline          │
-   * ├──────────┬────────┤
-   * │ Details  > Video  │
-   * │          >        │
-   * │          >^^^^^^^^┤
-   * │          > Crumbs │
-   * │          >        │
-   * └──────────┴────────┘
-   */
-  | 'sidebar_right'
-  /**
-   * ### Sidebar Left
-   * ┌───────────────────┐
-   * │ Timeline          │
-   * ├────────┬──────────┤
-   * │ Video  > Details  │
-   * │        >          │
-   * │^^^^^^^ >          |
-   * │ Crumbs >          │
-   * │        >          │
-   * └────────┴──────────┘
-   */
-  | 'sidebar_left'
-  /**
-   * ### Topbar
-   *┌────────────────────┐
-   *│ Timeline           │
-   *├───────────┬────────┤
-   *│ Video     │ Crumbs │
-   *│           │        │
-   *├^^^^^^^^^^^^^^^^^^^^┤
-   *│ Details            │
-   *│                    │
-   *└────────────────────┘
-   */
-  | 'topbar';
+type LayoutModes = keyof typeof layoutLabels;
 
 const MIN_VIDEO_WIDTH = {px: 325};
 const MIN_CONTENT_WIDTH = {px: 325};

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -1,9 +1,7 @@
-import {layoutLabels} from 'sentry/utils/replays/hooks/useReplayLayout';
+import {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
 import theme from 'sentry/utils/theme';
 
-type LayoutModes = keyof typeof layoutLabels;
-
-export const getDefaultLayout = (collapsed: boolean): LayoutModes => {
+export const getDefaultLayout = (collapsed: boolean): LayoutKey => {
   const {innerWidth, innerHeight} = window;
 
   const sidebarWidth = parseInt(
@@ -17,8 +15,8 @@ export const getDefaultLayout = (collapsed: boolean): LayoutModes => {
     innerWidth <= mediumScreenWidth ? innerWidth : innerWidth - sidebarWidth;
 
   if (windowsWidth < innerHeight) {
-    return 'topbar';
+    return LayoutKey.topbar;
   }
 
-  return 'sidebar_left';
+  return LayoutKey.sidebar_left;
 };

--- a/static/app/views/replays/detail/layout/utils.tsx
+++ b/static/app/views/replays/detail/layout/utils.tsx
@@ -1,5 +1,7 @@
+import {layoutLabels} from 'sentry/utils/replays/hooks/useReplayLayout';
 import theme from 'sentry/utils/theme';
-import {LayoutModes} from 'sentry/views/replays/detail/layout';
+
+type LayoutModes = keyof typeof layoutLabels;
 
 export const getDefaultLayout = (collapsed: boolean): LayoutModes => {
   const {innerWidth, innerHeight} = window;

--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -7,17 +7,12 @@ import {
   useReplayContext,
 } from 'sentry/components/replays/replayContext';
 import {t} from 'sentry/locale';
-import PreferencesStore from 'sentry/stores/preferencesStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {PageContent} from 'sentry/styles/organization';
 import useReplayData from 'sentry/utils/replays/hooks/useReplayData';
-import useUrlParam from 'sentry/utils/replays/hooks/useUrlParams';
+import useReplayLayout from 'sentry/utils/replays/hooks/useReplayLayout';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import Layout from 'sentry/views/replays/detail/layout';
-import {getDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
 import Page from 'sentry/views/replays/detail/page';
-
-const LAYOUT_NAMES = ['topbar', 'sidebar_right', 'sidebar_left'];
 
 function ReplayDetails() {
   const {
@@ -74,8 +69,7 @@ function ReplayDetails() {
 }
 
 function LoadedDetails({orgId}: {orgId: string}) {
-  const collapsed = !!useLegacyStore(PreferencesStore).collapsed;
-  const {getParamValue} = useUrlParam('l_page', getDefaultLayout(collapsed));
+  const {getLayout} = useReplayLayout();
   const {replay} = useReplayContext();
   const durationMs = replay?.getDurationMs();
 
@@ -86,12 +80,7 @@ function LoadedDetails({orgId}: {orgId: string}) {
       durationMs={durationMs}
       replayRecord={replay?.getReplay()}
     >
-      <Layout
-        layout={
-          // TODO(replay): If we end up keeping this, we'll fix up the typing
-          LAYOUT_NAMES.includes(getParamValue()) ? (getParamValue() as any) : 'topbar'
-        }
-      />
+      <Layout layout={getLayout()} />
     </Page>
   );
 }


### PR DESCRIPTION
Previously there were a few places where we listed out `const LAYOUT_NAMES = [...];`. So I put a lot of the logic into `static/app/utils/replays/hooks/useReplayLayout.tsx` which is modeled after `useActiveReplayTab.tsx` to make things slightly more typesafe, and less duplication all around.