### PR TITLE
feat(profiling): add frequency color encoding option

### DIFF
--- a/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
@@ -23,6 +23,7 @@ const FLAMEGRAPH_COLOR_CODINGS: FlamegraphColorCodings = [
   'by system / application',
   'by library',
   'by recursion',
+  'by frequency',
 ];
 const FLAMEGRAPH_VIEW_OPTIONS: FlamegraphViewOptions = ['top down', 'bottom up'];
 const FLAMEGRAPH_SORTING_OPTIONS: FlamegraphSorting = ['left heavy', 'call order'];

--- a/static/app/components/profiling/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsMenu.tsx
@@ -81,6 +81,7 @@ const COLOR_CODINGS: Record<FlamegraphPreferences['colorCoding'], string> = {
   'by library': t('By Library'),
   'by system / application': t('By System / Application'),
   'by recursion': t('By Recursion'),
+  'by frequency': t('By Frequency'),
 };
 
 export {FlamegraphOptionsMenu};

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -249,3 +249,38 @@ export const makeColorMapBySystemVsApplication = (
 
   return colors;
 };
+
+export const makeColorMapByFrequency = (
+  frames: ReadonlyArray<FlamegraphFrame>,
+  colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
+): Map<FlamegraphFrame['frame']['key'], ColorChannels> => {
+  let max = 0;
+
+  const countMap = new Map<FlamegraphFrame['frame']['key'], number>();
+  const colors = new Map<FlamegraphFrame['key'], ColorChannels>();
+
+  for (let i = 0; i < frames.length; i++) {
+    const frame = frames[i];
+    const key = frame.frame.name + frame.frame.image;
+
+    if (!countMap.has(key)) {
+      countMap.set(key, 0);
+    }
+
+    const previousCount = countMap.get(key)!;
+
+    countMap.set(key, previousCount + 1);
+    max = Math.max(max, previousCount + 1);
+  }
+
+  for (let i = 0; i < frames.length; i++) {
+    const key = frames[i].frame.name + frames[i].frame.image;
+    const count = countMap.get(key)!;
+    const [r, g, b] = colorBucket(0.7, frames[i].frame);
+    const color: ColorChannels = [r, g, b, Math.max(count / max, 0.1)];
+
+    colors.set(frames[i].key, color);
+  }
+
+  return colors;
+};

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphPreferences.tsx
@@ -2,7 +2,8 @@ export type FlamegraphColorCodings = [
   'by symbol name',
   'by system / application',
   'by library',
-  'by recursion'
+  'by recursion',
+  'by frequency'
 ];
 
 export type FlamegraphSorting = ['left heavy', 'call order'];

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/index.tsx
@@ -44,6 +44,7 @@ function isColorCoding(
     'by system / application',
     'by library',
     'by recursion',
+    'by frequency',
   ];
 
   return values.includes(value as any);

--- a/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphThemeProvider.tsx
@@ -4,6 +4,7 @@ import ConfigStore from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 
 import {
+  makeColorMapByFrequency,
   makeColorMapByImage,
   makeColorMapByRecursion,
   makeColorMapBySystemVsApplication,
@@ -45,6 +46,12 @@ function FlamegraphThemeProvider(
         return {
           ...base,
           COLORS: {...base.COLORS, COLOR_MAP: makeColorMapBySystemVsApplication},
+        };
+      }
+      case 'by frequency': {
+        return {
+          ...base,
+          COLORS: {...base.COLORS, COLOR_MAP: makeColorMapByFrequency},
         };
       }
       default: {


### PR DESCRIPTION
Add encoding by frequency to flamechart. Counts all frames and maps the alpha channel from 0-1 depending on max occurrence count