### PR TITLE
test-config: Add static/ to jest test match config

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -174,7 +174,10 @@ const config: Config.InitialOptions = {
     '<rootDir>/tests/js/setupFramework.ts',
     '@testing-library/jest-dom/extend-expect',
   ],
-  testMatch: testMatch || ['<rootDir>/tests/js/**/*(*.)@(spec|test).(js|ts)?(x)'],
+  testMatch: testMatch || [
+    '<rootDir>/static/**/?(*.)+(spec|test).[jt]s?(x)',
+    '<rootDir>/tests/js/**/*(*.)@(spec|test).(js|ts)?(x)',
+  ],
   testPathIgnorePatterns: ['<rootDir>/tests/sentry/lang/javascript/'],
 
   unmockedModulePathPatterns: [


### PR DESCRIPTION
An attempt to break frontend test colocation into
smaller steps.