### PR TITLE
feat(dashboard): Add Latest Releases as an option to dropdown

### DIFF
--- a/static/app/views/dashboardsV2/releasesSelectControl.tsx
+++ b/static/app/views/dashboardsV2/releasesSelectControl.tsx
@@ -21,6 +21,13 @@ type Props = {
   isDisabled?: boolean;
 };
 
+const ALIASED_RELEASES = [
+  {
+    label: 'Latest Release(s)',
+    value: 'latest',
+  },
+];
+
 function ReleasesSelectControl({
   handleChangeFilter,
   selectedReleases,
@@ -66,12 +73,15 @@ function ReleasesSelectControl({
           value: '_releases',
           label: t('Sorted by date created'),
           options: releases.length
-            ? releases.map(release => {
-                return {
-                  label: release.shortVersion ?? release.version,
-                  value: release.version,
-                };
-              })
+            ? [
+                ...ALIASED_RELEASES,
+                ...releases.map(release => {
+                  return {
+                    label: release.shortVersion ?? release.version,
+                    value: release.version,
+                  };
+                }),
+              ]
             : [],
         },
       ]}

--- a/static/app/views/dashboardsV2/releasesSelectControl.tsx
+++ b/static/app/views/dashboardsV2/releasesSelectControl.tsx
@@ -23,7 +23,7 @@ type Props = {
 
 const ALIASED_RELEASES = [
   {
-    label: 'Latest Release(s)',
+    label: t('Latest Release(s)'),
     value: 'latest',
   },
 ];

--- a/tests/js/spec/views/dashboardsV2/releasesSelectControl.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/releasesSelectControl.spec.tsx
@@ -37,6 +37,7 @@ describe('Dashboards > ReleasesSelectControl', function () {
     expect(screen.getByText('All Releases')).toBeInTheDocument();
 
     userEvent.click(screen.getByText('All Releases'));
+    expect(screen.getByText('Latest Release(s)')).toBeInTheDocument();
     userEvent.click(screen.getByText('sentry-android-shop@1.2.0'));
 
     userEvent.click(document.body);


### PR DESCRIPTION
This adds allows user to query by latest release. Works even
if it is a part of an "IN" query. Works for Events and Issues
dataset for now. Setting it as Do Not Merge till we get it
working for releases as well.