### PR TITLE
fix(replays): DOM Events item breakpoint

### DIFF
--- a/static/app/utils/replays/hooks/useWidth.tsx
+++ b/static/app/utils/replays/hooks/useWidth.tsx
@@ -1,0 +1,20 @@
+import {useState} from 'react';
+import {useResizeObserver} from '@react-aria/utils';
+import debounce from 'lodash/debounce';
+
+const debounced = (cb: () => void) => debounce(cb, 100);
+
+function useWidth(ref: React.RefObject<HTMLDivElement>) {
+  const [width, setWidth] = useState(0);
+  useResizeObserver({
+    ref,
+    onResize: debounced(() => {
+      if (ref.current) {
+        setWidth(ref.current.offsetWidth);
+      }
+    }),
+  });
+  return width;
+}
+
+export default useWidth;

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
 import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
@@ -92,7 +91,11 @@ const MutationListItem = styled('li')`
 
 const MutationItemContainer = styled('div')`
   display: grid;
-  grid-template-columns: 280px 1fr;
+  grid-template-columns: 1fr;
+
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    grid-template-columns: 280px 1fr;
+  }
 `;
 
 const MutationMetadata = styled('div')`
@@ -148,13 +151,14 @@ const CodeContainer = styled('div')`
   overflow: auto;
   max-height: 400px;
   max-width: 100%;
+  z-index: 1;
 `;
 
 const StepConnector = styled('div')`
   position: absolute;
   height: 100%;
   top: 28px;
-  left: 31px;
+  left: 28px;
   border-right: 1px ${p => p.theme.border} dashed;
 `;
 

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -13,11 +13,13 @@ import type ReplayReader from 'sentry/utils/replays/replayReader';
 
 type Props = {
   replay: ReplayReader;
+  width: number;
 };
 
-function DomMutations({replay}: Props) {
+function DomMutations({replay, width}: Props) {
   const {isLoading, actions} = useExtractedCrumbHtml({replay});
   const startTimestampMs = replay.getReplay().startedAt.getTime();
+  const isWideView = width > 768;
 
   const {handleMouseEnter, handleMouseLeave, handleClick} =
     useCrumbHandlers(startTimestampMs);
@@ -35,7 +37,7 @@ function DomMutations({replay}: Props) {
           onMouseLeave={() => handleMouseLeave(mutation.crumb)}
         >
           <StepConnector />
-          <MutationItemContainer>
+          <MutationItemContainer isWideView={isWideView}>
             <div>
               <MutationMetadata>
                 <IconWrapper color={mutation.crumb.color}>
@@ -89,13 +91,9 @@ const MutationListItem = styled('li')`
   }
 `;
 
-const MutationItemContainer = styled('div')`
+const MutationItemContainer = styled('div')<{isWideView: boolean}>`
   display: grid;
-  grid-template-columns: 1fr;
-
-  @media (min-width: ${p => p.theme.breakpoints.large}) {
-    grid-template-columns: 280px 1fr;
-  }
+  grid-template-columns: ${p => (p.isWideView ? '280px 1fr' : '1fr')};
 `;
 
 const MutationMetadata = styled('div')`

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -156,7 +156,7 @@ const StepConnector = styled('div')`
   position: absolute;
   height: 100%;
   top: 28px;
-  left: 28px;
+  left: 27px;
   border-right: 1px ${p => p.theme.border} dashed;
 `;
 

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -26,7 +26,7 @@ function getBreadcrumbsByCategory(breadcrumbs: Crumb[], categories: string[]) {
     .filter(breadcrumb => categories.includes(breadcrumb.category || ''));
 }
 
-function FocusArea({width = 0}: Props) {
+function FocusArea({width}: Props) {
   const {getActiveTab} = useActiveReplayTab();
   const {currentTime, currentHoverTime, replay, setCurrentTime, setCurrentHoverTime} =
     useReplayContext();

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -16,7 +16,9 @@ import MemoryChart from 'sentry/views/replays/detail/memoryChart';
 import NetworkList from 'sentry/views/replays/detail/network';
 import Trace from 'sentry/views/replays/detail/trace';
 
-type Props = {};
+type Props = {
+  width: number;
+};
 
 function getBreadcrumbsByCategory(breadcrumbs: Crumb[], categories: string[]) {
   return breadcrumbs
@@ -24,7 +26,7 @@ function getBreadcrumbsByCategory(breadcrumbs: Crumb[], categories: string[]) {
     .filter(breadcrumb => categories.includes(breadcrumb.category || ''));
 }
 
-function FocusArea({}: Props) {
+function FocusArea({width = 0}: Props) {
   const {getActiveTab} = useActiveReplayTab();
   const {currentTime, currentHoverTime, replay, setCurrentTime, setCurrentHoverTime} =
     useReplayContext();
@@ -87,7 +89,7 @@ function FocusArea({}: Props) {
         <IssueList replayId={replayRecord.replayId} projectId={replayRecord.projectId} />
       );
     case 'dom':
-      return <DomMutations replay={replay} />;
+      return <DomMutations width={width} replay={replay} />;
     case 'memory':
       return (
         <MemoryChart

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import ErrorBoundary from 'sentry/components/errorBoundary';
@@ -8,6 +8,7 @@ import space from 'sentry/styles/space';
 import useFullscreen from 'sentry/utils/replays/hooks/useFullscreen';
 import {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
 import useUrlParams from 'sentry/utils/replays/hooks/useUrlParams';
+import useWidth from 'sentry/utils/replays/hooks/useWidth';
 import Breadcrumbs from 'sentry/views/replays/detail/breadcrumbs';
 import FocusArea from 'sentry/views/replays/detail/focusArea';
 import FocusTabs from 'sentry/views/replays/detail/focusTabs';
@@ -37,6 +38,8 @@ function ReplayLayout({
   showVideo = true,
 }: Props) {
   const {ref: fullscreenRef, toggle: toggleFullscreen} = useFullscreen();
+  const focusAreaRef = useRef<HTMLDivElement>(null);
+  const focusAreaWidth = useWidth(focusAreaRef);
 
   const timeline = showTimeline ? (
     <ErrorBoundary mini>
@@ -60,8 +63,8 @@ function ReplayLayout({
 
   const content = (
     <ErrorBoundary mini>
-      <FluidPanel title={<FocusTabs />}>
-        <FocusArea />
+      <FluidPanel title={<FocusTabs />} bodyRef={focusAreaRef}>
+        <FocusArea width={focusAreaWidth} />
       </FluidPanel>
     </ErrorBoundary>
   );


### PR DESCRIPTION
### Changes
- Adds breakpoint so that code collapses below meta data on dom event list items

### Notes
I was adding a conditional breakpoint based on the layout. We have more space in the tab if the layout is topbar for instance. I had some issue with style linting when I tried to implement it so I just removed it for now. Let me know if you think that's for sure worth adding.

Closes #37550 

![Screen Shot 2022-08-09 at 3 46 45 PM](https://user-images.githubusercontent.com/3721977/183747881-9ef9b395-d39c-4407-9ec1-6dfe8f9f2e9c.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
