### PR TITLE
Rename statsPeriod to timeframe where appropriate (API-2880)

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -22,7 +22,7 @@ from sentry.api.helpers.group_index import (
 from sentry.api.paginator import DateTimePaginator, Paginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
-from sentry.api.utils import InvalidParams, get_date_range_from_params
+from sentry.api.utils import InvalidParams, get_date_range_from_stats_period
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import (
@@ -220,7 +220,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         """
         stats_period = request.GET.get("groupStatsPeriod")
         try:
-            start, end = get_date_range_from_params(request.GET)
+            start, end = get_date_range_from_stats_period(request.GET)
         except InvalidParams as e:
             raise ParseError(detail=str(e))
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -7,7 +7,7 @@ from sentry.api.endpoints.organization_group_index import ERR_INVALID_STATS_PERI
 from sentry.api.helpers.group_index import build_query_params_from_request, calculate_stats_period
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
-from sentry.api.utils import InvalidParams, get_date_range_from_params
+from sentry.api.utils import InvalidParams, get_date_range_from_stats_period
 from sentry.models import Group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
@@ -55,7 +55,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
 
         stats_period = request.GET.get("groupStatsPeriod")
         try:
-            start, end = get_date_range_from_params(request.GET)
+            start, end = get_date_range_from_stats_period(request.GET)
         except InvalidParams as e:
             raise ParseError(detail=str(e))
 

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -40,6 +40,48 @@ def default_start_end_dates(now=None, default_stats_period=MAX_STATS_PERIOD):
 
 def get_date_range_from_params(params, optional=False, default_stats_period=MAX_STATS_PERIOD):
     """
+    A wrapper function for `get_date_range_from_stats_period` that allows us
+    to alias `statsPeriod` to ensure backward compatibility.
+
+    If `timeframe` is passed then convert to a time delta and make sure it
+    fits within our min/max period length. Values are in the format
+    <number><period_type>, where period type is one of `s` (seconds),
+    `m` (minutes), `h` (hours) or `d` (days).
+
+    Similarly, `timeframeStart` and `timeframeEnd` allow for selecting a
+    relative range, for example: 15 days ago through 8 days ago. This uses the same
+    format as `statsPeriod`
+
+    :param params:
+    If `start` end `end` are passed, validate them, convert to `datetime` and
+    returns them if valid.
+    :param optional: When True, if no params passed then return `(None, None)`.
+    :param default_stats_period: When set, this becomes the interval upon which default start
+    and end dates are defined
+    :return: A length 2 tuple containing start/end or raises an `InvalidParams`
+    exception
+    """
+    timeframe = params.get("timeframe")
+    timeframe_start = params.get("timeframeStart")
+    timeframe_end = params.get("timeframeEnd")
+
+    if timeframe is not None:
+        params["statsPeriod"] = timeframe
+
+    elif timeframe_start or timeframe_end:
+        if not all([timeframe_start, timeframe_end]):
+            raise InvalidParams("timeframeStart and timeframeEnd are both required")
+        else:
+            params["statsPeriodStart"] = timeframe_start
+            params["statsPeriodEnd"] = timeframe_end
+
+    return get_date_range_from_stats_period(
+        params, optional=optional, default_stats_period=default_stats_period
+    )
+
+
+def get_date_range_from_stats_period(params, optional=False, default_stats_period=MAX_STATS_PERIOD):
+    """
     Gets a date range from standard date range params we pass to the api.
 
     If `statsPeriod` is passed then convert to a time delta and make sure it
@@ -55,7 +97,7 @@ def get_date_range_from_params(params, optional=False, default_stats_period=MAX_
     If `start` end `end` are passed, validate them, convert to `datetime` and
     returns them if valid.
     :param optional: When True, if no params passed then return `(None, None)`.
-    :param default_stats_period: When set, this becomes the interval upon which default start and
+    :param default_stats_period: When set, this becomes the interval upon which default start
     and end dates are defined
     :return: A length 2 tuple containing start/end or raises an `InvalidParams`
     exception

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -50,7 +50,7 @@ def get_date_range_from_params(params, optional=False, default_stats_period=MAX_
 
     Similarly, `timeframeStart` and `timeframeEnd` allow for selecting a
     relative range, for example: 15 days ago through 8 days ago. This uses the same
-    format as `statsPeriod`
+    format as `statsPeriod`.
 
     :param params:
     If `start` end `end` are passed, validate them, convert to `datetime` and

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -9,7 +9,22 @@ from sentry.api.utils import MAX_STATS_PERIOD, InvalidParams, get_date_range_fro
 
 
 class GetDateRangeFromParamsTest(unittest.TestCase):
-    def test_stats_period(self):
+    def test_timeframe(self):
+        start, end = get_date_range_from_params({"timeframe": "14h"})
+        assert end - datetime.timedelta(hours=14) == start
+
+        start, end = get_date_range_from_params({"timeframe": "14d"})
+        assert end - datetime.timedelta(days=14) == start
+
+        start, end = get_date_range_from_params({"timeframe": "60m"})
+        assert end - datetime.timedelta(minutes=60) == start
+
+        start, end = get_date_range_from_params({"timeframe": "3600s"})
+        assert end - datetime.timedelta(seconds=3600) == start
+
+        start, end = get_date_range_from_params({"timeframe": "91d"})
+        assert end - datetime.timedelta(days=91) == start
+
         start, end = get_date_range_from_params({"statsPeriod": "14h"})
         assert end - datetime.timedelta(hours=14) == start
 
@@ -19,14 +34,8 @@ class GetDateRangeFromParamsTest(unittest.TestCase):
         start, end = get_date_range_from_params({"statsPeriod": "60m"})
         assert end - datetime.timedelta(minutes=60) == start
 
-        start, end = get_date_range_from_params({"statsPeriod": "3600s"})
-        assert end - datetime.timedelta(seconds=3600) == start
-
-        start, end = get_date_range_from_params({"statsPeriod": "91d"})
-        assert end - datetime.timedelta(days=91) == start
-
         with pytest.raises(InvalidParams):
-            get_date_range_from_params({"statsPeriod": "9000000d"})
+            get_date_range_from_params({"timeframe": "9000000d"})
 
     def test_date_range(self):
         start, end = get_date_range_from_params({"start": "2018-11-01", "end": "2018-11-07"})
@@ -51,6 +60,11 @@ class GetDateRangeFromParamsTest(unittest.TestCase):
 
     @freeze_time("2018-12-11 03:21:34")
     def test_relative_date_range(self):
+        start, end = get_date_range_from_params({"timeframeStart": "14d", "timeframeEnd": "7d"})
+
+        assert start == datetime.datetime(2018, 11, 27, 3, 21, 34, tzinfo=timezone.utc)
+        assert end == datetime.datetime(2018, 12, 4, 3, 21, 34, tzinfo=timezone.utc)
+
         start, end = get_date_range_from_params({"statsPeriodStart": "14d", "statsPeriodEnd": "7d"})
 
         assert start == datetime.datetime(2018, 11, 27, 3, 21, 34, tzinfo=timezone.utc)
@@ -60,4 +74,4 @@ class GetDateRangeFromParamsTest(unittest.TestCase):
     def test_relative_date_range_incomplete(self):
 
         with pytest.raises(InvalidParams):
-            start, end = get_date_range_from_params({"statsPeriodStart": "14d"})
+            start, end = get_date_range_from_params({"timeframeStart": "14d"})


### PR DESCRIPTION
Rename `statsPeriod` to `timeframe` for all API endpoints where appropriate. API calls with the old parameter will continue to function as normal. Also updated tests as necessary.

Fixes https://github.com/getsentry/sentry/issues/36375