### PR TITLE
ref(metrics-indexer): Add optional partitioning to cache

### DIFF
--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class StringIndexerCache:
-    def __init__(self, version: int, cache_name: str, partition_key: Optional[str] = None):
+    def __init__(self, version: int, cache_name: str, partition_key: str):
         self.version = version
         self.cache = caches[cache_name]
         self.partition_key = partition_key
@@ -26,8 +26,7 @@ class StringIndexerCache:
 
     def make_cache_key(self, key: str, cache_namespace: str) -> str:
         hashed = md5_text(key).hexdigest()
-        formatted_partition_key = f":{self.partition_key}" if self.partition_key else ""
-        return f"indexer{formatted_partition_key}:org:str:{cache_namespace}:{hashed}"
+        return f"indexer:{self.partition_key}:org:str:{cache_namespace}:{hashed}"
 
     def _format_results(
         self, keys: Sequence[str], results: Mapping[str, Optional[int]], cache_namespace: str
@@ -83,6 +82,3 @@ class StringIndexerCache:
     def delete_many(self, keys: Sequence[str], cache_namespace: str) -> None:
         cache_keys = [self.make_cache_key(key, cache_namespace) for key in keys]
         self.cache.delete_many(cache_keys, version=self.version)
-
-
-indexer_cache = StringIndexerCache(**settings.SENTRY_STRING_INDEXER_CACHE_OPTIONS)

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -17,10 +17,10 @@ class PartitionKey(Enum):
 
 
 class StringIndexerCache:
-    def __init__(self, version: int, cache_name: str, partition_key: Optional[str] = None):
+    def __init__(self, version: int, cache_name: str, partition_key: Optional[PartitionKey] = None):
         self.version = version
         self.cache = caches[cache_name]
-        self.partition_key = partition_key or ""
+        self.partition_key = partition_key.value if partition_key else ""
 
     @property
     def randomized_ttl(self) -> int:

--- a/src/sentry/sentry_metrics/indexer/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres_v2.py
@@ -2,11 +2,12 @@ from functools import reduce
 from operator import or_
 from typing import Any, Mapping, Optional, Set
 
+from django.conf import settings
 from django.db.models import Q
 
 from sentry.sentry_metrics.configuration import UseCaseKey, get_ingest_config
 from sentry.sentry_metrics.indexer.base import KeyCollection, KeyResult, KeyResults, StringIndexer
-from sentry.sentry_metrics.indexer.cache import indexer_cache
+from sentry.sentry_metrics.indexer.cache import PartitionKey, StringIndexerCache
 from sentry.sentry_metrics.indexer.db import TABLE_MAPPING, IndexerTable
 from sentry.sentry_metrics.indexer.ratelimiters import writes_limiter
 from sentry.sentry_metrics.indexer.static_strings import StaticStringIndexer
@@ -21,6 +22,10 @@ _INDEXER_CACHE_METRIC = "sentry_metrics.indexer.memcache"
 _INDEXER_DB_METRIC = "sentry_metrics.indexer.postgres"
 # only used to compare to the older version of the PGIndexer
 _INDEXER_CACHE_FETCH_METRIC = "sentry_metrics.indexer.memcache.fetch"
+
+indexer_cache = StringIndexerCache(
+    **settings.SENTRY_STRING_INDEXER_CACHE_OPTIONS, partition_key=PartitionKey.POSTGRES
+)
 
 
 class PostgresIndexer(StaticStringIndexer):

--- a/src/sentry/sentry_metrics/indexer/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres_v2.py
@@ -7,7 +7,7 @@ from django.db.models import Q
 
 from sentry.sentry_metrics.configuration import UseCaseKey, get_ingest_config
 from sentry.sentry_metrics.indexer.base import KeyCollection, KeyResult, KeyResults, StringIndexer
-from sentry.sentry_metrics.indexer.cache import PartitionKey, StringIndexerCache
+from sentry.sentry_metrics.indexer.cache import StringIndexerCache
 from sentry.sentry_metrics.indexer.db import TABLE_MAPPING, IndexerTable
 from sentry.sentry_metrics.indexer.ratelimiters import writes_limiter
 from sentry.sentry_metrics.indexer.static_strings import StaticStringIndexer
@@ -23,8 +23,10 @@ _INDEXER_DB_METRIC = "sentry_metrics.indexer.postgres"
 # only used to compare to the older version of the PGIndexer
 _INDEXER_CACHE_FETCH_METRIC = "sentry_metrics.indexer.memcache.fetch"
 
+_PARTITION_KEY = "pg"
+
 indexer_cache = StringIndexerCache(
-    **settings.SENTRY_STRING_INDEXER_CACHE_OPTIONS, partition_key=PartitionKey.POSTGRES
+    **settings.SENTRY_STRING_INDEXER_CACHE_OPTIONS, partition_key=_PARTITION_KEY
 )
 
 

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -1,11 +1,18 @@
 import pytest
+from django.conf import settings
 
 from sentry.sentry_metrics.configuration import UseCaseKey
-from sentry.sentry_metrics.indexer.cache import indexer_cache
+from sentry.sentry_metrics.indexer.cache import StringIndexerCache
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 
 pytestmark = pytest.mark.sentry_metrics
+
+_PARTITION_KEY = "test"
+
+indexer_cache = StringIndexerCache(
+    **settings.SENTRY_STRING_INDEXER_CACHE_OPTIONS, partition_key=_PARTITION_KEY
+)
 
 
 @pytest.fixture

--- a/tests/sentry/sentry_metrics/test_indexer_cache.py
+++ b/tests/sentry/sentry_metrics/test_indexer_cache.py
@@ -43,7 +43,7 @@ def test_cache_many(use_case_id: str) -> None:
 
 def test_make_cache_key(use_case_id: str) -> None:
     key = indexer_cache.make_cache_key("blah", "release-health")
-    assert key == f"indexer:org:str:{use_case_id}:{md5_text('blah').hexdigest()}"
+    assert key == f"indexer:test:org:str:{use_case_id}:{md5_text('blah').hexdigest()}"
 
 
 def test_formatted_results(use_case_id: str) -> None:

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -4,9 +4,12 @@ import pytest
 
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.base import FetchType, FetchTypeExt, KeyCollection, Metadata
-from sentry.sentry_metrics.indexer.cache import indexer_cache
 from sentry.sentry_metrics.indexer.models import StringIndexer
-from sentry.sentry_metrics.indexer.postgres_v2 import PGStringIndexerV2, PostgresIndexer
+from sentry.sentry_metrics.indexer.postgres_v2 import (
+    PGStringIndexerV2,
+    PostgresIndexer,
+    indexer_cache,
+)
 from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options


### PR DESCRIPTION
**context:**
We're looking into using a different, more scalable option than Postgres for the indexer. One option we are going to test out is Google Cloud Spanner. 

If we want to run multiple indexers backends in parallel in prod, it's probably a good idea to split out the cache namespace per the backends. To do that I've added `partition_key`. ~I made it optional so that tests isolating the cache don't need to be tied to a backend, but also so that if we didn't want to change the current implementation for Postgres we didn't have to.~ **[edit]:** it's required now to keep the format consistent

The first part of the key is the only thing that changes:

```
indexer:pg:org:str...
indexer:cs:org:str...
```

So for the implementation that will be added after https://github.com/getsentry/sentry/pull/37631 could use `cs`for the `partition_key`

