### PR TITLE
feat(perf): Detect "Uncompressed Asset" performance issues

### DIFF
--- a/src/sentry/tasks/performance_detection.py
+++ b/src/sentry/tasks/performance_detection.py
@@ -122,16 +122,6 @@ def _detect_performance_issue(data: Event, sdk_span: Any):
             len(sequential_performance_fingerprints),
         )
 
-    metrics.incr(
-        "performance.performance_issue.detected",
-        instance=str(bool(all_fingerprints)),
-        tags={
-            "duplicates": bool(len(duplicate_performance_fingerprints)),
-            "slow_span": bool(len(slow_performance_fingerprints)),
-            "sequential": bool(len(sequential_performance_fingerprints)),
-        },
-    )
-
     uncompressed_asset_performance_issues = detectors[
         DetectorType.UNCOMPRESSED_ASSET_SPAN
     ].stored_issues
@@ -143,6 +133,17 @@ def _detect_performance_issue(data: Event, sdk_span: Any):
         sdk_span.containing_transaction.set_tag(
             "_pi_uncompressed_asset", first_uncompressed_asset_span["span_id"]
         )
+
+    metrics.incr(
+        "performance.performance_issue.detected",
+        instance=str(bool(all_fingerprints)),
+        tags={
+            "duplicates": bool(len(duplicate_performance_fingerprints)),
+            "slow_span": bool(len(slow_performance_fingerprints)),
+            "sequential": bool(len(sequential_performance_fingerprints)),
+            "uncompressed_asset": bool(len(uncompressed_asset_fingerprints)),
+        },
+    )
 
 
 # Creates a stable fingerprint given the same span details using sha1.

--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -60,6 +60,10 @@ class SpanBuilder:
         self.hash = hash
         return self
 
+    def with_data(self, data: Any) -> "SpanBuilder":
+        self.data = data
+        return self
+
     def build(self) -> Span:
         span = {
             "trace_id": self.trace_id,


### PR DESCRIPTION
Large assets can affect First Contentful Paint (FCP) and overall page load time. One easy way to make text assets smaller is to apply HTTP compression to them. Mark transactions containing uncompressed script or CSS resource loads (over a configurable minimum size, currently 500 KiB) as having an Uncompressed Asset performance issue.