### PR TITLE
meta(labels): Remove javascript/python

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -342,12 +342,6 @@
 - name: invalid
   color: 'F6F6F8'
   description: ''
-- name: javascript
-  color: 'F6F6F8'
-  description: Pull requests that update Javascript code
-- name: python
-  color: 'F6F6F8'
-  description: Pull requests that update Python code
 - name: wcgw
   color: 'F6F6F8'
   description: ''


### PR DESCRIPTION
These were for dependabot and are no longer beng being used after
3609b9f978fb91319f45397459b9f85d72b234d6.