### PR TITLE
feat(issues): Track analytics event for issues stream sorting

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -41,6 +41,9 @@ export type IssueEventParameters = {
   'issues_stream.realtime_clicked': {
     enabled: boolean;
   };
+  'issues_stream.sort_changed': {
+    sort: string;
+  };
   'issues_tab.viewed': {
     num_issues: number;
     tab: string;
@@ -66,6 +69,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issues_stream.realtime_clicked': 'Issues Stream: Realtime Clicked',
   'issues_stream.issue_clicked': 'Clicked Issue from Issues Stream',
   'issues_stream.issue_assigned': 'Assigned Issue from Issues Stream',
+  'issues_stream.sort_changed': 'Changed Sort on Issues Stream',
   'issue.shared_publicly': 'Issue Shared Publicly',
   resolve_issue: 'Resolve Issue',
   'tag.clicked': 'Tag: Clicked',

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -818,6 +818,11 @@ class IssueListOverview extends Component<Props, State> {
   };
 
   onSortChange = (sort: string) => {
+    trackAdvancedAnalyticsEvent('issues_stream.sort_changed', {
+      organization: this.props.organization,
+      sort,
+    });
+
     this.transitionTo({sort});
   };
 


### PR DESCRIPTION
We will want to know more about how users are using the issues stream, especially with regards to sorting since that might have to change a bit when adding performance issues.

Let me know if you think anything else should be added to the payload.