### PR TITLE
ref(replays): Stop calling transformCrumbs on already transformed crumbs

### DIFF
--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -4,7 +4,6 @@ import {useResizeObserver} from '@react-aria/utils';
 
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
-import {transformCrumbs} from 'sentry/components/events/interfaces/breadcrumbs/utils';
 import CompositeSelect from 'sentry/components/forms/compositeSelect';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {formatTime, relativeTimeInMs} from 'sentry/components/replays/utils';
@@ -89,7 +88,7 @@ function ReplayPlayPauseBar({isCompact}: {isCompact: boolean}) {
             if (!startTimestampMs) {
               return;
             }
-            const transformedCrumbs = transformCrumbs(replay?.getRawCrumbs() || []);
+            const transformedCrumbs = replay?.getRawCrumbs() || [];
             const next = getNextBreadcrumb({
               crumbs: transformedCrumbs.filter(crumb =>
                 USER_ACTIONS.includes(crumb.type)


### PR DESCRIPTION
`getRawCrumbs()` will internally call `transformCrumbs()`, so no need to do it twice.

Here's where the internal call happens: https://github.com/getsentry/sentry/blob/master/static/app/utils/replays/replayDataUtils.tsx#L118