### PR TITLE
feat(sampling): Add empty state to the sampling breakdown [TET-297]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingBreakdown.tsx
@@ -47,10 +47,6 @@ export function SamplingBreakdown({orgSlug}: Props) {
     }))
     .sort((a, z) => z.percentage - a.percentage);
 
-  if (projectsWithPercentages.length === 0 && !fetching) {
-    return null;
-  }
-
   function projectWithPercentage(project: Project, percentage: number) {
     return (
       <ProjectWithPercentage key={project.slug}>
@@ -106,11 +102,15 @@ export function SamplingBreakdown({orgSlug}: Props) {
                 ),
               }))}
             />
-            <Projects>
-              {projectsWithPercentages.map(({project, percentage}) =>
-                projectWithPercentage(project, percentage)
-              )}
-            </Projects>
+            {projectsWithPercentages.length ? (
+              <Projects>
+                {projectsWithPercentages.map(({project, percentage}) =>
+                  projectWithPercentage(project, percentage)
+                )}
+              </Projects>
+            ) : (
+              <EmptyMessage>{t('No transactions in the last 24 hours')}</EmptyMessage>
+            )}
           </Fragment>
         )}
       </PanelBody>
@@ -138,5 +138,12 @@ const ProjectWithPercentage = styled('div')`
   display: flex;
   align-items: center;
   gap: ${space(0.5)};
+  color: ${p => p.theme.subText};
+`;
+
+const EmptyMessage = styled('div')`
+  display: flex;
+  align-items: center;
+  min-height: 25px;
   color: ${p => p.theme.subText};
 `;

--- a/tests/js/spec/views/settings/project/server-side-sampling/samplingBreakdown.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/samplingBreakdown.spec.tsx
@@ -13,12 +13,12 @@ describe('Server-Side Sampling - SamplingBreakdown', function () {
     ServerSideSamplingStore.reset();
   });
 
-  it('does not render content', function () {
+  it('renders empty', function () {
     const {organization} = getMockData();
 
     render(<SamplingBreakdown orgSlug={organization.slug} />);
 
-    expect(screen.queryByText(samplingBreakdownTitle)).not.toBeInTheDocument();
+    expect(screen.getByText('No transactions in the last 24 hours')).toBeInTheDocument();
   });
 
   it('renders project breakdown', function () {


### PR DESCRIPTION
We used to hide it completely when it was empty.

Now we show an empty state to have a bit more consistent UI.

https://user-images.githubusercontent.com/9060071/183878640-2d2b3b57-e4aa-4de7-ad36-8ce89e69843d.mp4

