### PR TITLE
fix(vercel): add sentry env vars to all default environments in Vercel

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -253,7 +253,7 @@ class VercelIntegration(IntegrationInstallation):
         data = {
             "key": key,
             "value": value,
-            "target": ["production"],
+            "target": ["production", "preview", "development"],
             "type": type,
         }
         try:

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -169,7 +169,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 json={
                     "key": env_var,
                     "value": details["value"],
-                    "target": ["production"],
+                    "target": ["production", "preview", "development"],
                     "type": details["type"],
                 },
             )
@@ -192,30 +192,30 @@ class VercelIntegrationTest(IntegrationTestCase):
         req_params = json.loads(responses.calls[5].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[6].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[7].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[9].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "system"
 
     @responses.activate
@@ -270,7 +270,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 json={
                     "key": env_var,
                     "value": details["value"],
-                    "target": ["production"],
+                    "target": ["production", "preview", "development"],
                     "type": details["type"],
                 },
             )
@@ -292,30 +292,30 @@ class VercelIntegrationTest(IntegrationTestCase):
         req_params = json.loads(responses.calls[5].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == org.slug
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[8].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == self.project.slug
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[11].request.body)
         assert req_params["key"] == "SENTRY_DSN"
         assert req_params["value"] == enabled_dsn
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[14].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "encrypted"
 
         req_params = json.loads(responses.calls[17].request.body)
         assert req_params["key"] == "VERCEL_GIT_COMMIT_SHA"
         assert req_params["value"] == "VERCEL_GIT_COMMIT_SHA"
-        assert req_params["target"] == ["production"]
+        assert req_params["target"] == ["production", "preview", "development"]
         assert req_params["type"] == "system"
 
     @responses.activate


### PR DESCRIPTION
Today, when adding a Sentry integration trough the Vercel marketplace, we set Sentry related env vars only for the production environment.

This is not great because Vercel automatically integrates with Github and once users next.js app (hosted on Vercel) adds Sentry, we break their deployments, like this:

<img width="1201" alt="Screen Shot 2022-08-10 at 12 35 34" src="https://user-images.githubusercontent.com/29886766/183881166-c1799b5a-7bd6-490a-8c00-8e93d7347d59.png">

To fix this, I propose we start storing our env vars in all Vercel environments: `production`, `development` and `preview`

