### PR TITLE
fix(sampling): Do not display project breakdown without access

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -469,7 +469,7 @@ export function ServerSideSampling({project}: Props) {
           />
         )}
 
-        <SamplingBreakdown orgSlug={organization.slug} />
+        {hasAccess && <SamplingBreakdown orgSlug={organization.slug} />}
         {!rules.length ? (
           <SamplingPromo
             onGetStarted={handleGetStarted}


### PR DESCRIPTION
API will bounce the request so the chart would always appear empty.