### PR TITLE
feat(metrics): Adds mqb query transform to MetricsQuery [TET-163]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -485,6 +485,13 @@ class DerivedOp(DerivedOpDefinition, MetricOperation):
 
 class MetricExpressionBase(ABC):
     @abstractmethod
+    def validate_can_orderby(self) -> None:
+        """
+        Validate that the expression can be used to order a query
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def get_entity(
         self, projects: Sequence[Project], use_case_id: UseCaseKey
     ) -> Union[MetricEntity, Dict[MetricEntity, Sequence[str]]]:
@@ -655,6 +662,9 @@ class MetricExpression(MetricExpressionDefinition, MetricExpressionBase):
 
     def __str__(self) -> str:
         return f"{self.metric_operation.op}({self.metric_object.metric_mri})"
+
+    def validate_can_orderby(self) -> None:
+        self.metric_operation.validate_can_orderby()
 
     def get_entity(self, projects: Sequence[Project], use_case_id: UseCaseKey) -> MetricEntity:
         return _get_entity_of_metric_mri(projects, self.metric_object.metric_mri, use_case_id).value
@@ -836,6 +846,9 @@ class SingularEntityDerivedMetric(DerivedMetricExpression):
                 raise DerivedMetricParseException(
                     "SnQL cannot be None for instances of SingularEntityDerivedMetric"
                 )
+
+    def validate_can_orderby(self) -> None:
+        return
 
     @classmethod
     def __recursively_get_all_entities_in_derived_metric_dependency_tree(
@@ -1035,6 +1048,9 @@ class CompositeEntityDerivedMetric(DerivedMetricExpression):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.result_type = "numeric"
+
+    def validate_can_orderby(self) -> None:
+        raise NotSupportedOverCompositeEntityException()
 
     def generate_metric_ids(self, projects: Sequence[Project], use_case_id: UseCaseKey) -> Set[Any]:
         raise NotSupportedOverCompositeEntityException()

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -311,9 +311,9 @@ def session_duration_filters(org_id):
 
 def histogram_snql_factory(
     aggregate_filter,
-    histogram_buckets: int = 100,
     histogram_from: Optional[float] = None,
     histogram_to: Optional[float] = None,
+    histogram_buckets: int = 100,
     alias=None,
 ):
     zoom_conditions = zoom_histogram(

--- a/src/sentry/snuba/metrics/mqb_query_transformer.py
+++ b/src/sentry/snuba/metrics/mqb_query_transformer.py
@@ -1,0 +1,7 @@
+from snuba_sdk.query import Query
+
+from sentry.snuba.metrics.query import MetricsQuery
+
+
+def tranform_mqb_query_to_metrics_query(query: Query) -> MetricsQuery:
+    return query

--- a/src/sentry/snuba/metrics/mqb_query_transformer.py
+++ b/src/sentry/snuba/metrics/mqb_query_transformer.py
@@ -208,6 +208,7 @@ def _transform_orderby(query_orderby):
 
 
 def tranform_mqb_query_to_metrics_query(query: Query) -> MetricsQuery:
+    # ToDo(having): Validate against
     # Handles select statements
     select, extra_groupby = _transform_select(query.select)
     # Handle groupby

--- a/src/sentry/snuba/metrics/mqb_query_transformer.py
+++ b/src/sentry/snuba/metrics/mqb_query_transformer.py
@@ -159,7 +159,7 @@ def _transform_groupby(query_groupby):
             )
         else:
             raise MQBQueryTransformationException(f"Unsupported groupby field {groupby_field}")
-    return mq_groupby, include_series
+    return mq_groupby if len(mq_groupby) > 0 else None, include_series
 
 
 def _get_mq_dict_params_from_where(query_where):
@@ -190,7 +190,7 @@ def _get_mq_dict_params_from_where(query_where):
             )
         else:
             where.append(condition)
-    mq_dict["where"] = where
+    mq_dict["where"] = where if len(where) > 0 else None
     return mq_dict
 
 
@@ -204,7 +204,7 @@ def _transform_orderby(query_orderby):
         #     op=transformed_field.op, metric_mri=transformed_field.metric_mri
         # )
         mq_orderby.append(MetricOrderBy(field=transformed_field, direction=orderby_field.direction))
-    return mq_orderby
+    return mq_orderby if len(mq_orderby) > 0 else None
 
 
 def tranform_mqb_query_to_metrics_query(query: Query) -> MetricsQuery:

--- a/src/sentry/snuba/metrics/mqb_query_transformer.py
+++ b/src/sentry/snuba/metrics/mqb_query_transformer.py
@@ -1,7 +1,209 @@
+import inspect
+
+from snuba_sdk import AliasedExpression, Column, Function, Granularity, Op
 from snuba_sdk.query import Query
 
-from sentry.snuba.metrics.query import MetricsQuery
+from sentry.snuba.metrics.fields.base import DERIVED_OPS
+from sentry.snuba.metrics.query import (
+    MetricConditionField,
+    MetricField,
+    MetricGroupByField,
+    MetricsQuery,
+)
+from sentry.snuba.metrics.query import OrderBy as MetricOrderBy
+
+
+class MQBQueryTransformationException(Exception):
+    ...
+
+
+def _get_derived_op_metric_field_from_snuba_function(function: Function):
+    if len(function.parameters) == 0 or not isinstance(function.parameters[0], Column):
+        raise MQBQueryTransformationException(
+            "The first parameter of a function should be a column of the metric MRI"
+        )
+
+    metric_field_params = {}
+    function_params = function.parameters[1:]
+    snql_func_args = inspect.signature(DERIVED_OPS[function.function].snql_func).parameters.keys()
+    for arg in snql_func_args:
+        if arg in {"aggregate_filer", "org_id"}:
+            continue
+        try:
+            metric_field_params[arg] = function_params.pop(0)
+        except IndexError:
+            raise MQBQueryTransformationException(
+                f"Too few function parameters are provided. The arguments provided for function "
+                f"{function.function} are "
+                f"{[arg for arg in snql_func_args if arg not in {'org_id', 'aggregate_filter'}]}"
+            )
+
+    return MetricField(
+        op=function.function,
+        metric_mri=function.parameters[0].name,
+        params=metric_field_params,
+        alias=function.alias,
+    )
+
+
+def _transform_select(query_select):
+    select = []
+    groupby = []
+    for select_field in query_select:
+        if isinstance(select_field, Column):
+            if select_field.name.startswith("tags["):
+                groupby.append(select_field)
+
+            select.append(
+                MetricField(
+                    op=None,
+                    metric_mri=select_field.name,
+                )
+            )
+        elif isinstance(select_field, AliasedExpression):
+            if select_field.exp.name.startswith("tags["):
+                groupby.append(select_field)
+
+            select.append(
+                MetricField(
+                    op=None,
+                    metric_mri=select_field.exp.name,
+                    alias=select_field.alias,
+                )
+            )
+        elif isinstance(select_field, Function):
+            if select_field.function in DERIVED_OPS:
+                select.append(_get_derived_op_metric_field_from_snuba_function(select_field))
+            else:
+                if len(select_field.parameters) == 0 or not isinstance(
+                    select_field.parameters[0], Column
+                ):
+                    raise MQBQueryTransformationException(
+                        "The first parameter of a function should be a column of the metric MRI"
+                    )
+                select.append(
+                    MetricField(
+                        op=select_field.function,
+                        metric_mri=select_field.parameters[0].name,
+                        alias=select_field.alias,
+                    )
+                )
+        else:
+            raise MQBQueryTransformationException(f"Unsupported select field {select_field}")
+    return select, groupby
+
+
+def _transform_groupby(query_groupby):
+    mq_groupby = []
+    include_series = False
+    for groupby_field in query_groupby:
+        if isinstance(groupby_field, Column):
+            if groupby_field.name == "bucketed_time":
+                include_series = True
+                continue
+            if not groupby_field.name.startswith("tags["):
+                raise MQBQueryTransformationException(f"Unsupported groupby field {groupby_field}")
+            mq_groupby.append(
+                MetricGroupByField(
+                    field=groupby_field.name.split("tags[")[1].split("]")[0],
+                )
+            )
+        elif isinstance(groupby_field, AliasedExpression):
+            if groupby_field.exp.name == "bucketed_time":
+                include_series = True
+                continue
+            if not groupby_field.name.exp.startswith("tags["):
+                raise MQBQueryTransformationException(f"Unsupported groupby field {groupby_field}")
+            mq_groupby.append(
+                MetricGroupByField(
+                    field=groupby_field.name.split("tags[")[1].split("]")[0],
+                    alias=groupby_field.alias,
+                )
+            )
+        elif isinstance(groupby_field, Function):
+            if groupby_field.function not in DERIVED_OPS:
+                raise MQBQueryTransformationException(
+                    f"Unsupported function {groupby_field.function}"
+                )
+
+            if not DERIVED_OPS[groupby_field.function].can_groupby:
+                raise MQBQueryTransformationException(
+                    f"Cannot group by function {groupby_field.function}"
+                )
+
+            mq_groupby.append(
+                MetricGroupByField(
+                    field=_get_derived_op_metric_field_from_snuba_function(groupby_field),
+                    alias=groupby_field.alias,
+                )
+            )
+        else:
+            raise MQBQueryTransformationException(f"Unsupported groupby field {groupby_field}")
+    return mq_groupby, include_series
+
+
+def _get_mq_dict_params_from_where(query_where):
+    mq_dict = {}
+    where = []
+    for condition in query_where:
+        if isinstance(condition.lhs, Column):
+            if condition.lhs.name == "project_id":
+                mq_dict["project_ids"] = condition.rhs
+            elif condition.lhs.name == "org_id":
+                mq_dict["org_id"] = condition.rhs
+            elif condition.lhs.name == "timestamp":
+                if condition.op == Op.GTE:
+                    mq_dict["start"] = condition.rhs
+                elif condition.op == Op.LT:
+                    mq_dict["end"] = condition.rhs
+        elif isinstance(condition.lhs, Function):
+            if condition.lhs.function not in DERIVED_OPS:
+                raise MQBQueryTransformationException(
+                    f"Unsupported function {condition.lhs.function}"
+                )
+            if not DERIVED_OPS[condition.lhs.function].can_filter:
+                raise MQBQueryTransformationException(
+                    f"Cannot filter by function {condition.lhs.function}"
+                )
+            where.append(
+                MetricConditionField(
+                    lhs=_get_derived_op_metric_field_from_snuba_function(condition.lhs),
+                    op=condition.op,
+                    rhs=condition.rhs,
+                )
+            )
+        else:
+            where.append(condition)
+        mq_dict["where"] = where
+        return mq_dict
+
+
+def _transform_orderby(query_orderby):
+    mq_orderby = []
+    for orderby_field in query_orderby:
+        transformed_field_lst, _ = _transform_select([orderby_field.exp])
+        transformed_field = transformed_field_lst.pop()
+        mq_orderby.append(MetricOrderBy(field=transformed_field, direction=orderby_field.direction))
+    return mq_orderby
 
 
 def tranform_mqb_query_to_metrics_query(query: Query) -> MetricsQuery:
-    return query
+    # Handles select statements
+    select, extra_groupby = _transform_select(query.select)
+    # Handle groupby
+    groupby, include_series = _transform_groupby(query.groupby + extra_groupby)
+    # Handle orderby
+    orderby = _transform_orderby(query.orderby)
+
+    mq_dict = {
+        "select": select,
+        "groupby": groupby,
+        "limit": query.limit,
+        "offset": query.offset,
+        "include_totals": True,
+        "include_series": include_series,
+        "granularity": query.granularity if query.granularity is not None else Granularity(3600),
+        "orderby": orderby,
+        **_get_mq_dict_params_from_where(query.where),
+    }
+    return MetricsQuery(**mq_dict)

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -231,8 +231,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             totals=None,
         ),
         MetricsQuery(
-            org_id=21,
-            project_ids=[20],
+            org_id=14,
+            project_ids=[13],
             select=[
                 MetricField(
                     op="p95",

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -1,0 +1,707 @@
+import datetime
+
+import pytest
+import pytz
+from snuba_sdk.aliased_expression import AliasedExpression
+from snuba_sdk.column import Column
+from snuba_sdk.conditions import Condition, Op
+from snuba_sdk.entity import Entity
+from snuba_sdk.expressions import Granularity, Limit, Offset
+from snuba_sdk.function import Function
+from snuba_sdk.orderby import Direction, OrderBy
+from snuba_sdk.query import Query
+
+from sentry.snuba.metrics import MetricField, MetricsQuery
+from sentry.snuba.metrics.mqb_query_transformer import tranform_mqb_query_to_metrics_query
+
+
+class MetricGroupByField:
+    ...
+
+
+# ToDo Test Invalid queries:= Transform Function, Tags in the select, Ordering by bucketed_time
+
+VALID_QUERIES_INTEGRATION_TEST_CASES = [
+    # Totals Query
+    pytest.param(
+        Query(
+            match=Entity("metrics_distributions"),
+            select=[
+                Function(
+                    function="count_web_vitals_measurements",
+                    initializers=None,
+                    parameters=[Column("d:transactions/measurements.cls@millisecond"), "good"],
+                    alias="count_web_vitals_measurements_cls_good",
+                ),
+                Function(
+                    function="count_web_vitals_measurements",
+                    initializers=None,
+                    parameters=[Column("d:transactions/measurements.fid@millisecond"), "meh"],
+                    alias="count_web_vitals_measurements_fid_meh",
+                ),
+                Function(
+                    function="count_web_vitals_measurements",
+                    initializers=None,
+                    parameters=[Column("d:transactions/measurements.fp@millisecond"), "good"],
+                    alias="count_web_vitals_measurements_fp_good",
+                ),
+                Function(
+                    function="count_web_vitals_measurements",
+                    initializers=None,
+                    parameters=[Column("d:transactions/measurements.lcp@millisecond"), "good"],
+                    alias="count_web_vitals_measurements_lcp_good",
+                ),
+                Function(
+                    function="count_web_vitals_measurements",
+                    initializers=None,
+                    parameters=[Column("d:transactions/measurements.fcp@millisecond"), "meh"],
+                    alias="count_web_vitals_measurements_fcp_meh",
+                ),
+            ],
+            groupby=[
+                AliasedExpression(
+                    exp=Column(
+                        name="tags[transaction]",
+                        entity=None,
+                        subscriptable="tags",
+                        key="transaction",
+                    ),
+                    alias="transaction",
+                )
+            ],
+            array_join=None,
+            where=[
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.GTE,
+                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 35, 447729, tzinfo=pytz.utc),
+                ),
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.LT,
+                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 35, 447729, tzinfo=pytz.utc),
+                ),
+                Condition(
+                    lhs=Column(name="project_id", entity=None, subscriptable=None, key=None),
+                    op=Op.IN,
+                    rhs=[11],
+                ),
+                Condition(
+                    lhs=Column(name="org_id", entity=None, subscriptable=None, key=None),
+                    op=Op.EQ,
+                    rhs=11,
+                ),
+            ],
+            having=[],
+            orderby=[],
+            limitby=None,
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            granularity=None,
+            totals=None,
+        ),
+        MetricsQuery(
+            org_id=11,
+            project_ids=[11],
+            select=[
+                MetricField(
+                    op="count_web_vitals_measurements",
+                    metric_name="d:transactions/measurements.cls@millisecond",
+                    args=["good"],
+                    alias="count_web_vitals_measurements_cls_good",
+                ),
+                MetricField(
+                    op="count_web_vitals_measurements",
+                    metric_name="d:transactions/measurements.fid@millisecond",
+                    args=["meh"],
+                    alias="count_web_vitals_measurements_fid_meh",
+                ),
+                MetricField(
+                    op="count_web_vitals_measurements",
+                    metric_name="d:transactions/measurements.fp@millisecond",
+                    args=["good"],
+                    alias="count_web_vitals_measurements_fp_good",
+                ),
+                MetricField(
+                    op="count_web_vitals_measurements",
+                    metric_name="d:transactions/measurements.lcp@millisecond",
+                    args=["good"],
+                    alias="count_web_vitals_measurements_lcp_good",
+                ),
+                MetricField(
+                    op="count_web_vitals_measurements",
+                    metric_name="d:transactions/measurements.fcp@millisecond",
+                    args=["meh"],
+                    alias="count_web_vitals_measurements_fcp_meh",
+                ),
+            ],
+            start=datetime.datetime(2022, 3, 24, 11, 11, 35, 447729, tzinfo=pytz.utc),
+            end=datetime.datetime(2022, 6, 22, 11, 11, 35, 447729, tzinfo=pytz.utc),
+            granularity=Granularity(granularity=3600),
+            where=None,
+            groupby=[MetricGroupByField("transaction", alias=None)],
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            include_series=False,
+        ),
+        id="count_web_vitals test case",
+    ),
+    pytest.param(
+        Query(
+            match=Entity("metrics_distributions"),
+            select=[
+                Function(
+                    function="p95",
+                    initializers=None,
+                    parameters=[Column("d:transactions/duration@millisecond")],
+                    alias="p95",
+                ),
+                Function(
+                    function="rate",
+                    initializers=None,
+                    parameters=[
+                        Column("d:transactions/duration@millisecond"),
+                        60,
+                        7776000.0,
+                    ],
+                    alias="epm",
+                ),
+                Function(
+                    function="e:transaction/failure_rate@ratio",
+                    initializers=None,
+                    parameters=[],
+                    alias="failure_rate",
+                ),
+            ],
+            groupby=[
+                AliasedExpression(
+                    exp=Column("transaction.status"),
+                    alias="transaction.status",
+                ),
+                Function(
+                    function="e:transactions/team_key_transactions@none",
+                    initializers=None,
+                    parameters=[
+                        [(13, "foo_transaction")],
+                    ],
+                    alias="team_key_transaction",
+                ),
+                AliasedExpression(exp=Column("transaction"), alias="title"),
+                Column("project_id"),
+            ],
+            array_join=None,
+            where=[
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.GTE,
+                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 36, 75132, tzinfo=pytz.utc),
+                ),
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.LT,
+                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 36, 75132, tzinfo=pytz.utc),
+                ),
+                Condition(
+                    lhs=Column(name="project_id", entity=None, subscriptable=None, key=None),
+                    op=Op.IN,
+                    rhs=[13],
+                ),
+                Condition(
+                    lhs=Column(name="org_id", entity=None, subscriptable=None, key=None),
+                    op=Op.EQ,
+                    rhs=14,
+                ),
+            ],
+            having=[],
+            orderby=[
+                OrderBy(
+                    exp=Function(
+                        function="p95",
+                        initializers=None,
+                        parameters=[Column("d:transactions/duration@millisecond")],
+                        alias="p95",
+                    ),
+                    direction=Direction.ASC,
+                )
+            ],
+            limitby=None,
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            granularity=None,
+            totals=None,
+        ),
+        MetricsQuery(
+            org_id=21,
+            project_ids=[20],
+            select=[
+                MetricField(
+                    op="p95",
+                    metric_name="d:transactions/duration@millisecond",
+                    alias="p95",
+                ),
+                MetricField(
+                    op="rate",
+                    metric_name="d:transactions/duration@millisecond",
+                    args=[60, 7776000.0],
+                    alias="epm",
+                ),
+                MetricField(
+                    op=None,
+                    metric_name="e:transaction/failure_rate@ratio",
+                    alias="failure_rate",
+                ),
+                MetricField(
+                    op=None,
+                    metric_name="e:transactions/team_key_transactions@none",
+                    args=[[(20, "foo_transaction")]],
+                    alias="team_key_transaction",
+                ),
+            ],
+            start=datetime.datetime(2022, 3, 24, 11, 11, 38, 32475, tzinfo=pytz.utc),
+            end=datetime.datetime(2022, 6, 22, 11, 11, 38, 32475, tzinfo=pytz.utc),
+            granularity=Granularity(granularity=3600),
+            where=None,
+            groupby=[
+                MetricGroupByField("transaction.status"),
+                MetricGroupByField(
+                    MetricField(
+                        op=None,
+                        metric_name="e:transactions/team_key_transactions@none",
+                        args=[[(20, "foo_transaction")]],
+                        alias="e:transactions/team_key_transactions@none",
+                    ),
+                ),
+                MetricGroupByField("project_id"),
+                MetricGroupByField("transaction", alias="title"),
+            ],
+            orderby=[
+                OrderBy(
+                    field=MetricField(
+                        op=None,
+                        metric_name="e:transactions/team_key_transactions@none",
+                        args=[[(20, "foo_transaction")]],
+                        alias="e:transactions/team_key_transactions@none",
+                    ),
+                    direction=Direction.ASC,
+                ),
+                OrderBy(
+                    field=MetricField(
+                        op="p95",
+                        metric_name="d:transactions/duration@millisecond",
+                        alias="p95",
+                    ),
+                    direction=Direction.ASC,
+                ),
+            ],
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            include_series=False,
+        ),
+        id="team_key_transaction + groupby & select aliasing test case",
+    ),
+    pytest.param(
+        Query(
+            match=Entity("metrics_distributions"),
+            select=[
+                Function(
+                    function="e:transactions/apdex@ratio",
+                    initializers=None,
+                    parameters=[],
+                    alias="apdex",
+                ),
+                Function(
+                    function="p75",
+                    initializers=None,
+                    parameters=[
+                        Column("d:transactions/measurements.cls@millisecond"),
+                    ],
+                    alias="p75_measurements_cls",
+                ),
+                Function(
+                    function="rate",
+                    initializers=None,
+                    parameters=[
+                        Column("d:transactions/duration@millisecond"),
+                        60,
+                        7776000.0,
+                    ],
+                    alias="tpm",
+                ),
+                Function(
+                    function="p75",
+                    initializers=None,
+                    parameters=[Column("d:transactions/measurements.fid@millisecond")],
+                    alias="p75_measurements_fid",
+                ),
+                Function(
+                    function="p75",
+                    initializers=None,
+                    parameters=[Column("d:transactions/measurements.fcp@millisecond")],
+                    alias="p75_measurements_fcp",
+                ),
+                Function(
+                    function="p75",
+                    initializers=None,
+                    parameters=[Column("d:transactions/measurements.lcp@millisecond")],
+                    alias="p75_measurements_lcp",
+                ),
+            ],
+            groupby=[
+                AliasedExpression(
+                    exp=Column("transaction"),
+                    alias="transaction",
+                ),
+                Column("project_id"),
+            ],
+            array_join=None,
+            where=[
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.GTE,
+                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 37, 278535, tzinfo=pytz.utc),
+                ),
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.LT,
+                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 37, 278535, tzinfo=pytz.utc),
+                ),
+                Condition(
+                    lhs=Column(name="project_id", entity=None, subscriptable=None, key=None),
+                    op=Op.IN,
+                    rhs=[18],
+                ),
+                Condition(
+                    lhs=Column(name="org_id", entity=None, subscriptable=None, key=None),
+                    op=Op.EQ,
+                    rhs=19,
+                ),
+            ],
+            having=[],
+            orderby=[],
+            limitby=None,
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            granularity=None,
+            totals=None,
+        ),
+        MetricsQuery(
+            org_id=19,
+            project_ids=[18],
+            select=[
+                MetricField(
+                    op=None,
+                    metric_name="e:transactions/apdex@ratio",
+                    alias="apdex",
+                ),
+                MetricField(
+                    op="p75",
+                    metric_name="d:transactions/measurements.cls@millisecond",
+                    alias="p75_measurement_cls",
+                ),
+                MetricField(
+                    op="rate",
+                    metric_name="d:transactions/duration@millisecond",
+                    args=[60, 7776000.0],
+                    alias="tpm",
+                ),
+                MetricField(
+                    op="p75",
+                    metric_name="d:transactions/measurements.fid@millisecond",
+                    alias="p75_measurement_fid",
+                ),
+                MetricField(
+                    op="p75",
+                    metric_name="d:transactions/measurements.fcp@millisecond",
+                    alias="p75_measurement_fcp",
+                ),
+                MetricField(
+                    op="p75",
+                    metric_name="d:transactions/measurements.lcp@millisecond",
+                    alias="p75_measurement_lcp",
+                ),
+            ],
+            start=datetime.datetime(2022, 3, 24, 11, 11, 37, 278535, tzinfo=pytz.utc),
+            end=datetime.datetime(2022, 6, 22, 11, 11, 37, 278535, tzinfo=pytz.utc),
+            granularity=Granularity(granularity=3600),
+            where=None,
+            groupby=[
+                MetricGroupByField("project_id", alias=None),
+                MetricGroupByField("transaction", alias=None),
+            ],
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            include_series=False,
+        ),
+        id="apdex + percentiles test cases",
+    ),
+    pytest.param(
+        Query(
+            match=Entity("metrics_sets"),
+            select=[
+                Function(
+                    function="count_unique",
+                    initializers=None,
+                    parameters=[
+                        Column("s:transactions/user@none"),
+                    ],
+                    alias="count_unique_user",
+                ),
+            ],
+            groupby=[
+                AliasedExpression(
+                    exp=Column(
+                        name="tags[transaction]",
+                        entity=None,
+                        subscriptable="tags",
+                        key="transaction",
+                    ),
+                    alias="transaction",
+                )
+            ],
+            array_join=None,
+            where=[
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.GTE,
+                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 33, 21219, tzinfo=pytz.utc),
+                ),
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.LT,
+                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 33, 21219, tzinfo=pytz.utc),
+                ),
+                Condition(
+                    lhs=Column(name="project_id", entity=None, subscriptable=None, key=None),
+                    op=Op.IN,
+                    rhs=[2],
+                ),
+                Condition(
+                    lhs=Column(name="org_id", entity=None, subscriptable=None, key=None),
+                    op=Op.EQ,
+                    rhs=2,
+                ),
+                Condition(
+                    lhs=Function(
+                        function="tuple",
+                        initializers=None,
+                        parameters=[
+                            Column(
+                                name="tags[transaction]",
+                                entity=None,
+                                subscriptable="tags",
+                                key="transaction",
+                            )
+                        ],
+                        alias=None,
+                    ),
+                    op=Op.IN,
+                    rhs=Function(
+                        function="tuple",
+                        initializers=None,
+                        parameters=[("foo_transaction",), ("bar_transaction",)],
+                        alias=None,
+                    ),
+                ),
+            ],
+            having=[],
+            orderby=[],
+            limitby=None,
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            granularity=None,
+            totals=None,
+        ),
+        MetricsQuery(
+            org_id=2,
+            project_ids=[2],
+            select=[
+                MetricField(
+                    op="count_unique",
+                    metric_name="d:transactions/duration@millisecond",
+                    alias="count_unique_user",
+                )
+            ],
+            start=datetime.datetime(2022, 3, 24, 11, 11, 33, 21219, tzinfo=pytz.utc),
+            end=datetime.datetime(2022, 6, 22, 11, 11, 33, 21219, tzinfo=pytz.utc),
+            granularity=Granularity(granularity=3600),
+            where=[
+                Condition(
+                    lhs=Function(
+                        function="tuple",
+                        initializers=None,
+                        parameters=[
+                            Column(
+                                name="tags[transaction]",
+                                entity=None,
+                                subscriptable="tags",
+                                key="transaction",
+                            )
+                        ],
+                        alias=None,
+                    ),
+                    op=Op.IN,
+                    rhs=Function(
+                        function="tuple",
+                        initializers=None,
+                        parameters=[("foo_transaction",), ("bar_transaction",)],
+                        alias=None,
+                    ),
+                ),
+            ],
+            groupby=[
+                MetricGroupByField("project_id", alias=None),
+                MetricGroupByField("transaction", alias=None),
+            ],
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            include_series=False,
+        ),
+        id="tuple condition + metrics sets test case",
+    ),
+    pytest.param(
+        Query(
+            match=Entity("metrics_sets"),
+            select=[
+                Function(
+                    function="count_unique",
+                    initializers=None,
+                    parameters=[
+                        Column("s:transactions/user@none"),
+                    ],
+                    alias="count_unique_user",
+                )
+            ],
+            groupby=[AliasedExpression(Column("bucketed_time"), "time")],
+            array_join=None,
+            where=[
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.GTE,
+                    rhs=datetime.datetime(2022, 6, 21, 10, 0, tzinfo=None),
+                ),
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.LT,
+                    rhs=datetime.datetime(2022, 6, 21, 12, 0, tzinfo=None),
+                ),
+                Condition(
+                    lhs=Column(name="project_id", entity=None, subscriptable=None, key=None),
+                    op=Op.IN,
+                    rhs=[2],
+                ),
+                Condition(
+                    lhs=Column(name="org_id", entity=None, subscriptable=None, key=None),
+                    op=Op.EQ,
+                    rhs=2,
+                ),
+            ],
+            having=[],
+            orderby=[],
+            limitby=None,
+            limit=Limit(limit=50),
+            offset=None,
+            granularity=Granularity(granularity=60),
+            totals=None,
+        ),
+        MetricsQuery(
+            org_id=2,
+            project_ids=[2],
+            select=[
+                MetricField(
+                    op="count_unique",
+                    metric_name="s:transactions/user@none",
+                    alias="count_unique_user",
+                )
+            ],
+            start=datetime.datetime(2022, 6, 21, 10, 0, tzinfo=None),
+            end=datetime.datetime(2022, 6, 21, 12, 0, tzinfo=None),
+            granularity=Granularity(granularity=60),
+            where=None,
+            groupby=None,
+            include_series=True,
+            include_totals=True,
+            limit=Limit(limit=50),
+            offset=Offset(offset=0),
+        ),
+        id="series query test case",
+    ),
+    # Histogram Query
+    pytest.param(
+        Query(
+            match=Entity("metrics_distributions"),
+            select=[
+                Function(
+                    function="histogram",
+                    parameters=[
+                        Column("d:transactions/duration@millisecond"),
+                        0,  # min
+                        5,  # max
+                        5,  # num_buckets
+                    ],
+                    alias="histogram_transaction_duration",
+                ),
+            ],
+            groupby=[],
+            array_join=None,
+            where=[
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.GTE,
+                    rhs=datetime.datetime(2022, 3, 24, 14, 52, 59, 179755),
+                ),
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.LT,
+                    rhs=datetime.datetime(2022, 6, 22, 14, 52, 59, 179755),
+                ),
+                Condition(
+                    lhs=Column(name="project_id", entity=None, subscriptable=None, key=None),
+                    op=Op.IN,
+                    rhs=[3],
+                ),
+                Condition(
+                    lhs=Column(name="org_id", entity=None, subscriptable=None, key=None),
+                    op=Op.EQ,
+                    rhs=3,
+                ),
+            ],
+            having=[],
+            orderby=[],
+            limitby=None,
+            limit=Limit(limit=50),
+            offset=Offset(offset=0),
+            granularity=None,
+            totals=None,
+        ),
+        MetricsQuery(
+            org_id=3,
+            project_ids=[3],
+            select=[
+                MetricField(
+                    op="histogram",
+                    metric_name="d:transactions/duration@millisecond",
+                    args=[0, 5, 5],  # min  # max  # num_buckets
+                    alias="histogram_transaction_duration",
+                )
+            ],
+            start=datetime.datetime(2022, 3, 24, 14, 52, 59, 179755, tzinfo=pytz.utc),
+            end=datetime.datetime(2022, 6, 22, 14, 52, 59, 179755, tzinfo=pytz.utc),
+            granularity=None,
+            where=None,
+            groupby=None,
+            include_series=True,
+            include_totals=True,
+            limit=Limit(limit=50),
+            offset=Offset(offset=0),
+        ),
+        id="histogram query test case",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input, output",
+    VALID_QUERIES_INTEGRATION_TEST_CASES,
+)
+def test_mqb_to_metrics_query_tranformer(input, output):
+    assert tranform_mqb_query_to_metrics_query(input) == output

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -25,7 +25,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
     # Totals Query
     pytest.param(
         Query(
-            match=Entity("metrics_distributions"),
+            match=Entity("generic_metrics_distributions"),
             select=[
                 Function(
                     function="count_web_vitals_measurements",
@@ -148,7 +148,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
     ),
     pytest.param(
         Query(
-            match=Entity("metrics_distributions"),
+            match=Entity("generic_metrics_distributions"),
             select=[
                 Function(
                     function="p95",
@@ -301,7 +301,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
     ),
     pytest.param(
         Query(
-            match=Entity("metrics_distributions"),
+            match=Entity("generic_metrics_distributions"),
             select=[
                 Function(
                     function="e:transactions/apdex@ratio",
@@ -436,7 +436,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
     ),
     pytest.param(
         Query(
-            match=Entity("metrics_sets"),
+            match=Entity("generic_metrics_sets"),
             select=[
                 Function(
                     function="count_unique",
@@ -560,7 +560,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
     ),
     pytest.param(
         Query(
-            match=Entity("metrics_sets"),
+            match=Entity("generic_metrics_sets"),
             select=[
                 Function(
                     function="count_unique",
@@ -628,7 +628,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
     # Histogram Query
     pytest.param(
         Query(
-            match=Entity("metrics_distributions"),
+            match=Entity("generic_metrics_distributions"),
             select=[
                 Function(
                     function="histogram",

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -700,12 +700,103 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             granularity=None,
             where=None,
             groupby=None,
-            include_series=True,
+            include_series=False,
             include_totals=True,
             limit=Limit(limit=50),
             offset=Offset(offset=0),
         ),
         id="histogram query test case",
+    ),
+    # Count transaction name
+    pytest.param(
+        Query(
+            match=Entity("generic_metrics_distributions"),
+            select=[
+                Function(
+                    function="count_transaction_name",
+                    parameters=[Column("d:transactions/duration@millisecond"), "is_null"],
+                    alias="null_transaction_count",
+                ),
+                Function(
+                    function="count_transaction_name",
+                    parameters=[
+                        Column("d:transactions/duration@millisecond"),
+                        "is_unparameterized",
+                    ],
+                    alias="unparameterized_transaction_count",
+                ),
+                Function(
+                    function="count_transaction_name",
+                    parameters=[Column("d:transactions/duration@millisecond"), "has_value"],
+                    alias="has_value_transaction_count",
+                ),
+            ],
+            groupby=[],
+            array_join=None,
+            where=[
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.GTE,
+                    rhs=datetime.datetime(2022, 3, 24, 14, 52, 59, 179755),
+                ),
+                Condition(
+                    lhs=Column(name="timestamp", entity=None, subscriptable=None, key=None),
+                    op=Op.LT,
+                    rhs=datetime.datetime(2022, 6, 22, 14, 52, 59, 179755),
+                ),
+                Condition(
+                    lhs=Column(name="project_id", entity=None, subscriptable=None, key=None),
+                    op=Op.IN,
+                    rhs=[3],
+                ),
+                Condition(
+                    lhs=Column(name="org_id", entity=None, subscriptable=None, key=None),
+                    op=Op.EQ,
+                    rhs=3,
+                ),
+            ],
+            having=[],
+            orderby=[],
+            limitby=None,
+            limit=Limit(limit=50),
+            offset=Offset(offset=0),
+            granularity=None,
+            totals=None,
+        ),
+        MetricsQuery(
+            org_id=3,
+            project_ids=[3],
+            select=[
+                MetricField(
+                    op="count_transaction_name",
+                    metric_mri="d:transactions/duration@millisecond",
+                    params={"transaction_name": "null_transaction_count"},
+                    alias="null_transaction_count",
+                ),
+                MetricField(
+                    op="count_transaction_name",
+                    metric_mri="d:transactions/duration@millisecond",
+                    params={"transaction_name": "is_unparameterized"},
+                    alias="unparameterized_transaction_count",
+                ),
+                MetricField(
+                    op="count_transaction_name",
+                    metric_mri="d:transactions/duration@millisecond",
+                    params={"transaction_name": "has_value"},
+                    alias="has_value_transaction_count",
+                ),
+            ],
+            start=datetime.datetime(2022, 3, 24, 14, 52, 59, 179755, tzinfo=pytz.utc),
+            end=datetime.datetime(2022, 6, 22, 14, 52, 59, 179755, tzinfo=pytz.utc),
+            granularity=None,
+            where=None,
+            groupby=None,
+            include_series=False,
+            include_totals=True,
+            limit=Limit(limit=50),
+            offset=Offset(offset=0),
+        ),
+        id="count_transaction_name query test case",
     ),
 ]
 

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -1,7 +1,6 @@
 import datetime
 
 import pytest
-import pytz
 from snuba_sdk.aliased_expression import AliasedExpression
 from snuba_sdk.column import Column
 from snuba_sdk.conditions import Condition, Op
@@ -102,14 +101,14 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                         name="timestamp",
                     ),
                     op=Op.GTE,
-                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 35, 447729, tzinfo=pytz.utc),
+                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 35, 447729),
                 ),
                 Condition(
                     lhs=Column(
                         name="timestamp",
                     ),
                     op=Op.LT,
-                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 35, 447729, tzinfo=pytz.utc),
+                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 35, 447729),
                 ),
                 Condition(
                     lhs=Column(
@@ -169,8 +168,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="count_web_vitals_measurements_fcp_meh",
                 ),
             ],
-            start=datetime.datetime(2022, 3, 24, 11, 11, 35, 447729, tzinfo=pytz.utc),
-            end=datetime.datetime(2022, 6, 22, 11, 11, 35, 447729, tzinfo=pytz.utc),
+            start=datetime.datetime(2022, 3, 24, 11, 11, 35, 447729),
+            end=datetime.datetime(2022, 6, 22, 11, 11, 35, 447729),
             granularity=Granularity(granularity=86400),
             where=None,
             groupby=[MetricGroupByField("transaction")],
@@ -193,8 +192,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     function="rate",
                     parameters=[
                         Column("d:transactions/duration@millisecond"),
-                        60,
                         7776000.0,
+                        60,
                     ],
                     alias="epm",
                 ),
@@ -226,14 +225,14 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                         name="timestamp",
                     ),
                     op=Op.GTE,
-                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 36, 75132, tzinfo=pytz.utc),
+                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 36, 75132),
                 ),
                 Condition(
                     lhs=Column(
                         name="timestamp",
                     ),
                     op=Op.LT,
-                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 36, 75132, tzinfo=pytz.utc),
+                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 36, 75132),
                 ),
                 Condition(
                     lhs=Column(
@@ -306,8 +305,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="team_key_transaction",
                 ),
             ],
-            start=datetime.datetime(2022, 3, 24, 11, 11, 38, 32475, tzinfo=pytz.utc),
-            end=datetime.datetime(2022, 6, 22, 11, 11, 38, 32475, tzinfo=pytz.utc),
+            start=datetime.datetime(2022, 3, 24, 11, 11, 38, 32475),
+            end=datetime.datetime(2022, 6, 22, 11, 11, 38, 32475),
             granularity=Granularity(granularity=86400),
             where=[
                 MetricConditionField(
@@ -378,8 +377,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     function="rate",
                     parameters=[
                         Column("d:transactions/duration@millisecond"),
-                        60,
                         7776000.0,
+                        60,
                     ],
                     alias="tpm",
                 ),
@@ -413,14 +412,14 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                         name="timestamp",
                     ),
                     op=Op.GTE,
-                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 37, 278535, tzinfo=pytz.utc),
+                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 37, 278535),
                 ),
                 Condition(
                     lhs=Column(
                         name="timestamp",
                     ),
                     op=Op.LT,
-                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 37, 278535, tzinfo=pytz.utc),
+                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 37, 278535),
                 ),
                 Condition(
                     lhs=Column(
@@ -481,8 +480,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="p75_measurement_lcp",
                 ),
             ],
-            start=datetime.datetime(2022, 3, 24, 11, 11, 37, 278535, tzinfo=pytz.utc),
-            end=datetime.datetime(2022, 6, 22, 11, 11, 37, 278535, tzinfo=pytz.utc),
+            start=datetime.datetime(2022, 3, 24, 11, 11, 37, 278535),
+            end=datetime.datetime(2022, 6, 22, 11, 11, 37, 278535),
             granularity=Granularity(granularity=86400),
             where=None,
             groupby=[
@@ -522,14 +521,14 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                         name="timestamp",
                     ),
                     op=Op.GTE,
-                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 33, 21219, tzinfo=pytz.utc),
+                    rhs=datetime.datetime(2022, 3, 24, 11, 11, 33, 21219),
                 ),
                 Condition(
                     lhs=Column(
                         name="timestamp",
                     ),
                     op=Op.LT,
-                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 33, 21219, tzinfo=pytz.utc),
+                    rhs=datetime.datetime(2022, 6, 22, 11, 11, 33, 21219),
                 ),
                 Condition(
                     lhs=Column(
@@ -579,8 +578,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="count_unique_user",
                 )
             ],
-            start=datetime.datetime(2022, 3, 24, 11, 11, 33, 21219, tzinfo=pytz.utc),
-            end=datetime.datetime(2022, 6, 22, 11, 11, 33, 21219, tzinfo=pytz.utc),
+            start=datetime.datetime(2022, 3, 24, 11, 11, 33, 21219),
+            end=datetime.datetime(2022, 6, 22, 11, 11, 33, 21219),
             granularity=Granularity(granularity=3600),
             where=[
                 Condition(
@@ -659,7 +658,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             orderby=[],
             limitby=None,
             limit=Limit(limit=50),
-            offset=None,
+            offset=Offset(offset=0),
             granularity=Granularity(granularity=60),
             totals=None,
         ),
@@ -752,8 +751,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="histogram_transaction_duration",
                 )
             ],
-            start=datetime.datetime(2022, 3, 24, 14, 52, 59, 179755, tzinfo=pytz.utc),
-            end=datetime.datetime(2022, 6, 22, 14, 52, 59, 179755, tzinfo=pytz.utc),
+            start=datetime.datetime(2022, 3, 24, 14, 52, 59, 179755),
+            end=datetime.datetime(2022, 6, 22, 14, 52, 59, 179755),
             granularity=Granularity(3600),
             where=None,
             groupby=None,
@@ -835,7 +834,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                 MetricField(
                     op="count_transaction_name",
                     metric_mri="d:transactions/duration@millisecond",
-                    params={"transaction_name": "null_transaction_count"},
+                    params={"transaction_name": "is_null"},
                     alias="null_transaction_count",
                 ),
                 MetricField(
@@ -851,8 +850,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="has_value_transaction_count",
                 ),
             ],
-            start=datetime.datetime(2022, 3, 24, 14, 52, 59, 179755, tzinfo=pytz.utc),
-            end=datetime.datetime(2022, 6, 22, 14, 52, 59, 179755, tzinfo=pytz.utc),
+            start=datetime.datetime(2022, 3, 24, 14, 52, 59, 179755),
+            end=datetime.datetime(2022, 6, 22, 14, 52, 59, 179755),
             granularity=Granularity(3600),
             where=None,
             groupby=None,

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -898,15 +898,13 @@ def test_mqb_to_metrics_query_tranformer(input, output):
 
 
 def _construct_snuba_sdk_query(
-    select=None,
+    select,
     groupby=None,
     orderby=None,
     where=None,
     having=None,
     entity="generic_metrics_distributions",
 ):
-    if select is None:
-        select = []
     if groupby is None:
         groupby = []
     if orderby is None:
@@ -1130,7 +1128,7 @@ INVALID_QUERIES_INTEGRATION_TEST_CASES = [
                 ),
             ],
         ),
-        "Unsupported function 'transform' in groupby",
+        "Cannot group by function transform",
         id="Unsupported function in groupby statement",
     ),
     pytest.param(

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -131,7 +131,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             limitby=None,
             limit=Limit(limit=51),
             offset=Offset(offset=0),
-            granularity=None,
+            granularity=Granularity(granularity=86400),
             totals=None,
         ),
         MetricsQuery(
@@ -171,7 +171,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             ],
             start=datetime.datetime(2022, 3, 24, 11, 11, 35, 447729, tzinfo=pytz.utc),
             end=datetime.datetime(2022, 6, 22, 11, 11, 35, 447729, tzinfo=pytz.utc),
-            granularity=Granularity(granularity=3600),
+            granularity=Granularity(granularity=86400),
             where=None,
             groupby=[MetricGroupByField("transaction")],
             limit=Limit(limit=51),
@@ -274,7 +274,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             limitby=None,
             limit=Limit(limit=51),
             offset=Offset(offset=0),
-            granularity=None,
+            granularity=Granularity(granularity=86400),
             totals=None,
         ),
         MetricsQuery(
@@ -306,7 +306,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             ],
             start=datetime.datetime(2022, 3, 24, 11, 11, 38, 32475, tzinfo=pytz.utc),
             end=datetime.datetime(2022, 6, 22, 11, 11, 38, 32475, tzinfo=pytz.utc),
-            granularity=Granularity(granularity=3600),
+            granularity=Granularity(granularity=86400),
             where=[
                 MetricConditionField(
                     lhs=MetricField(
@@ -440,7 +440,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             limitby=None,
             limit=Limit(limit=51),
             offset=Offset(offset=0),
-            granularity=None,
+            granularity=Granularity(granularity=86400),
             totals=None,
         ),
         MetricsQuery(
@@ -481,7 +481,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             ],
             start=datetime.datetime(2022, 3, 24, 11, 11, 37, 278535, tzinfo=pytz.utc),
             end=datetime.datetime(2022, 6, 22, 11, 11, 37, 278535, tzinfo=pytz.utc),
-            granularity=Granularity(granularity=3600),
+            granularity=Granularity(granularity=86400),
             where=None,
             groupby=[
                 MetricGroupByField("project_id", alias=None),
@@ -564,7 +564,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             limitby=None,
             limit=Limit(limit=51),
             offset=Offset(offset=0),
-            granularity=None,
+            granularity=Granularity(granularity=3600),
             totals=None,
         ),
         MetricsQuery(
@@ -736,7 +736,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             limitby=None,
             limit=Limit(limit=50),
             offset=Offset(offset=0),
-            granularity=None,
+            granularity=Granularity(granularity=3600),
             totals=None,
         ),
         MetricsQuery(
@@ -823,7 +823,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             limitby=None,
             limit=Limit(limit=50),
             offset=Offset(offset=0),
-            granularity=None,
+            granularity=Granularity(granularity=3600),
             totals=None,
         ),
         MetricsQuery(

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -201,6 +201,14 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     exp=Column("e:transactions/failure_rate@ratio"),
                     alias="failure_rate",
                 ),
+                Function(
+                    function="team_key_transaction",
+                    parameters=[
+                        Column("d:transactions/duration@millisecond"),
+                        [(13, "foo_transaction")],
+                    ],
+                    alias="team_key_transaction",
+                ),
             ],
             groupby=[
                 AliasedExpression(
@@ -270,7 +278,18 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                         alias="p95",
                     ),
                     direction=Direction.ASC,
-                )
+                ),
+                OrderBy(
+                    exp=Function(
+                        function="team_key_transaction",
+                        parameters=[
+                            Column("d:transactions/duration@millisecond"),
+                            [(13, "foo_transaction")],
+                        ],
+                        alias="team_key_transaction",
+                    ),
+                    direction=Direction.ASC,
+                ),
             ],
             limitby=None,
             limit=Limit(limit=51),
@@ -301,19 +320,19 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                 MetricField(
                     op="team_key_transaction",
                     metric_mri="d:transactions/duration@millisecond",
-                    params={"team_key_condition_rhs": [(20, "foo_transaction")]},
+                    params={"team_key_condition_rhs": [(13, "foo_transaction")]},
                     alias="team_key_transaction",
                 ),
             ],
-            start=datetime.datetime(2022, 3, 24, 11, 11, 38, 32475),
-            end=datetime.datetime(2022, 6, 22, 11, 11, 38, 32475),
+            start=datetime.datetime(2022, 3, 24, 11, 11, 36, 75132),
+            end=datetime.datetime(2022, 6, 22, 11, 11, 36, 75132),
             granularity=Granularity(granularity=86400),
             where=[
                 MetricConditionField(
                     lhs=MetricField(
                         op="team_key_transaction",
                         metric_mri="d:transactions/duration@millisecond",
-                        params={"team_key_condition_rhs": [(20, "foo_transaction")]},
+                        params={"team_key_condition_rhs": [(13, "foo_transaction")]},
                         alias="team_key_transaction",
                     ),
                     op=Op.EQ,
@@ -326,28 +345,28 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     MetricField(
                         op="team_key_transaction",
                         metric_mri="d:transactions/duration@millisecond",
-                        params={"team_key_condition_rhs": [(20, "foo_transaction")]},
+                        params={"team_key_condition_rhs": [(13, "foo_transaction")]},
                         alias="team_key_transaction",
                     ),
                 ),
-                MetricGroupByField("project_id"),
                 MetricGroupByField("transaction", alias="title"),
+                MetricGroupByField("project_id"),
             ],
             orderby=[
-                MetricsOrderBy(
-                    field=MetricField(
-                        op="team_key_transaction",
-                        metric_mri="d:transactions/duration@millisecond",
-                        params={"team_key_condition_rhs": [(20, "foo_transaction")]},
-                        alias="team_key_transaction",
-                    ),
-                    direction=Direction.ASC,
-                ),
                 MetricsOrderBy(
                     field=MetricField(
                         op="p95",
                         metric_mri="d:transactions/duration@millisecond",
                         alias="p95",
+                    ),
+                    direction=Direction.ASC,
+                ),
+                MetricsOrderBy(
+                    field=MetricField(
+                        op="team_key_transaction",
+                        metric_mri="d:transactions/duration@millisecond",
+                        params={"team_key_condition_rhs": [(13, "foo_transaction")]},
+                        alias="team_key_transaction",
                     ),
                     direction=Direction.ASC,
                 ),
@@ -456,28 +475,28 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                 MetricField(
                     op="p75",
                     metric_mri="d:transactions/measurements.cls@millisecond",
-                    alias="p75_measurement_cls",
+                    alias="p75_measurements_cls",
                 ),
                 MetricField(
                     op="rate",
                     metric_mri="d:transactions/duration@millisecond",
-                    params={"denominator": 60, "numerator": 7776000.0},
+                    params={"numerator": 7776000.0, "denominator": 60},
                     alias="tpm",
                 ),
                 MetricField(
                     op="p75",
                     metric_mri="d:transactions/measurements.fid@millisecond",
-                    alias="p75_measurement_fid",
+                    alias="p75_measurements_fid",
                 ),
                 MetricField(
                     op="p75",
                     metric_mri="d:transactions/measurements.fcp@millisecond",
-                    alias="p75_measurement_fcp",
+                    alias="p75_measurements_fcp",
                 ),
                 MetricField(
                     op="p75",
                     metric_mri="d:transactions/measurements.lcp@millisecond",
-                    alias="p75_measurement_lcp",
+                    alias="p75_measurements_lcp",
                 ),
             ],
             start=datetime.datetime(2022, 3, 24, 11, 11, 37, 278535),
@@ -485,8 +504,8 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             granularity=Granularity(granularity=86400),
             where=None,
             groupby=[
-                MetricGroupByField("project_id", alias=None),
                 MetricGroupByField("transaction", alias=None),
+                MetricGroupByField("project_id", alias=None),
             ],
             limit=Limit(limit=51),
             offset=Offset(offset=0),
@@ -507,12 +526,13 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                 ),
             ],
             groupby=[
+                Column("project_id"),
                 AliasedExpression(
                     exp=Column(
                         name="tags[transaction]",
                     ),
                     alias="transaction",
-                )
+                ),
             ],
             array_join=None,
             where=[
@@ -574,7 +594,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             select=[
                 MetricField(
                     op="count_unique",
-                    metric_mri="d:transactions/duration@millisecond",
+                    metric_mri="s:transactions/user@none",
                     alias="count_unique_user",
                 )
             ],

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -40,6 +40,9 @@ These SnQL function generators can be found in `sentry/src/sentry/snuba/metrics/
 defined for all derived operations i.e. operations not supported by clickhouse like rate, count_web_vitals,
 histogram (as it requires extra logic over the clickhouse function supported by datasketch), team_key_transaction,
 and count_transaction_name (for unparameterized and None)
+
+All non clickhouse functions (derived functions) are listed here
+https://github.com/getsentry/sentry/blob/0eb312411989c2dbde3cf0b5094d47829d01c854/src/sentry/snuba/metrics/fields/base.py#L1505-L1540
 - Originally, it was agreed that all derived metrics such as failure_rate, user_misery and the other ones listed here
 https://github.com/getsentry/sentry/blob/4d3efb171ac2fc3ac77a846ec3d96f0da829ed12/src/sentry/snuba/metrics/naming_layer/mri.py#L98-L106
 would be passed as SnQL functions. However, this won't work without expanding the snuba-sdk Function regex to accept MRI

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -211,6 +211,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                 Function(
                     function="team_key_transaction",
                     parameters=[
+                        Column("d:transactions/duration@millisecond"),
                         [(13, "foo_transaction")],
                     ],
                     alias="team_key_transaction",
@@ -252,6 +253,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     lhs=Function(
                         function="team_key_transaction",
                         parameters=[
+                            Column("d:transactions/duration@millisecond"),
                             [(13, "foo_transaction")],
                         ],
                         alias="team_key_transaction",


### PR DESCRIPTION
So far this PR has only test cases that shows expected output from MQB (input to metrics abstraction layer) and the final output that would be passed to metrics abstraction layer 

I have printed out queries spit out by MQB and coalesced them into the test cases in this PR, and so should cover all queries made by performance to metrics:
- I have only listed a variation or two of the same functions for example `p75(transaction.duration)` but I did not add `p50(transaction.duration)` because the logic would be the same so need to add this to these tests 
- Only thing missing is the recent `countIf` functions added for performance which I will add later on listed here -> https://github.com/getsentry/sentry/blob/master/src/sentry/search/events/datasets/metrics.py#L179-L276

### Changes to MQB output:-
- Removed tags from select statement, as if they are listed in the `groupBy`, they will be returned by metrics abstraction layer
- Having clauses are not supported 
- Transform functions are not supported
- Removed ordering by `bucketed_time` as this behavior is handled post query by metrics abstraction layer
- Replaced metric ids/names with MRI as this is the naming contract we can guarantee
- Replaced tag values with their tag names because metrics abstraction layer will handle the indexer resolving and reverse resolving
- Replaced SnQL function definition with their corresponding derived metrics so for example failure_rate, apdex, user_misery, team_key_transactions, count_web_vitals and histogram functions


### ToDo from me to get this test to pass

- [x] `snuba-sdk` needs to support MRI as a column name in `Column` [TET-323]
- [x] `MetricField` needs to support `args` and `alias` [TET-320, TET-322]
- [x] Add `MetricGroupByField` for `groupBy` columns that accept an `alias` [TET-320]
- [x] Aliasing functionality needs to be supported [TET-320]
- [x] Add derived metric for `team_key_transaction` [TET-325]
- [x] Add derived metric for `count_web_vital_measurements` [TET-161]
- [x] Add derived metric for `rate` [TET-129]
- [x] `MetricsQuery` accepts MRI rather than public facing names [TET-321]
- [x] Support for tuples conditions [TET-319]
- [x] Add derived metrics for the 3 `countIf` functions [TET-326]
- [x] Transform MQB `Query` object to `MetricsQuery` (This PR)
- [x] Figure out addition of Granularity processor [TET-327]
- [x] Add Invalid test cases (This PR)
- [ ] Discuss granularity differences/query bounds (Will be handled in subsequent PR [TET-452])



[TET-323]: https://getsentry.atlassian.net/browse/TET-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ