### PR TITLE
ref(metrics): Split rate limiter into separate indexer decorator [sns-1606]

### DIFF
--- a/src/sentry/sentry_metrics/indexer/base.py
+++ b/src/sentry/sentry_metrics/indexer/base.py
@@ -198,11 +198,24 @@ class StringIndexer(Service):
     Check `sentry.snuba.metrics` for convenience functions.
     """
 
-    __all__ = ("record", "resolve", "reverse_resolve", "bulk_record")
+    __all__ = ("record", "resolve", "reverse_resolve", "bulk_record", "bulk_resolve")
 
     def bulk_record(
         self, use_case_id: UseCaseKey, org_strings: Mapping[int, Set[str]]
     ) -> KeyResults:
+        """
+        Store a set of strings and return corresponding integer IDs.
+        """
+        raise NotImplementedError()
+
+    def bulk_resolve(
+        self, use_case_id: UseCaseKey, org_strings: Mapping[int, Set[str]]
+    ) -> KeyResults:
+        """
+        Lookup the integer IDs for a set of strings.
+
+        Returns a partial key collection if entries cannot be found.
+        """
         raise NotImplementedError()
 
     def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
@@ -217,9 +230,6 @@ class StringIndexer(Service):
         """Lookup the integer ID for a string.
 
         Does not affect the lifetime of the entry.
-
-        Callers should not rely on the default use_case_id -- it exists only
-        as a temporary workaround.
 
         Returns None if the entry cannot be found.
         """

--- a/src/sentry/sentry_metrics/indexer/ratelimiters.py
+++ b/src/sentry/sentry_metrics/indexer/ratelimiters.py
@@ -234,7 +234,7 @@ class WritesLimitingStringIndexerDecorator(StringIndexer):
             if filtered_db_write_keys.size == 0:
                 return db_read_key_results.merge(rate_limited_key_results)
 
-            filtered_org_strings = {}
+            filtered_org_strings: MutableMapping[int, Set[str]] = {}
             for org_id, string in filtered_db_write_keys.as_tuples():
                 filtered_org_strings.setdefault(org_id, set()).add(string)
 


### PR DESCRIPTION
In order to prepare for alternative indexer backends, move the writes
limiter into a wrapping string indexer instead of having it sit within
the postgres indexer service.

This PR also adds a new `bulk_resolve` method on the indexer interface
that allows us to implement the wrapping interface. Prior to this PR,
this sequence of operations happened in `bulk_record` of postgres:

1. look up strings in cache
2. look up strings in db, compute missing strings (strings not in db)
3. rate limit missing strings
4. write missing strings
5. return merged results

the end state that I want to arrive at is:

1. there are four string indexers nested into each other: `StaticStringIndexer -> RateLimitingStringIndexer -> CachingStringIndexer -> PostgresStringIndexer`
2. there is a new `bulk_resolve` method. It is defined with the same signature as `bulk_record`, except it does not write missing strings (the returned keyresult is partially unmapped)
3. `bulk_record` in postgres just does insert if not exists, without any caching or upfront read
4. `bulk_resolve` in postgres is also just a single select stmt
5. `CachingStringIndexer::bulk_record` can be uncached passthrough or not, it won't matter
6. `RateLimitingStringIndexer::bulk_record` calls out to `CachingStringIndexer::bulk_resolve`, then applies rate limits, then calls `CachingStringIndexer::bulk_record`

the final flow for the outermost `bulk_record` changes to:

1. `RateLimitingStringIndexer::bulk_record -> CachingStringIndexer::bulk_resolve`
2. cache lookup in caching string indexer
3. `CachingStringIndexer::bulk_resolve -> PostgresStringIndexer::bulk_resolve`
4. postgres SELECT
5. rate limits are applied in `RateLimitingStringIndexer::bulk_record`
6. `RateLimitingStringIndexer::bulk_record -> CachingStringIndexer::bulk_record`
7. `CachingStringIndexer::bulk_record` does NOT have to look up caches again, it can just forward to postgres
8. postgres INSERT
9. return from all methods

Right now `CachingStringIndexer` is not split out from the postgres
string indexer. It also doesn't matter if it ends up as a
wrapper/decorator string indexer or merged together with
`WritesLimitingStringIndexerDecorator`.
