### PR TITLE
fix(metrics): Add missing `min` operation on distributions [TET-2]

### DIFF
--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -194,6 +194,7 @@ OPERATIONS = (
     "count_unique",
     "count",
     "max",
+    "min",
     "sum",
     "histogram",
 ) + OPERATIONS_PERCENTILES
@@ -202,6 +203,7 @@ DEFAULT_AGGREGATES: Dict[MetricOperationType, Optional[Union[int, List[Tuple[flo
     "avg": None,
     "count_unique": 0,
     "count": 0,
+    "min": None,
     "max": None,
     "p50": None,
     "p75": None,

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -110,7 +110,7 @@ def test_validate_select():
     with pytest.raises(
         InvalidParams,
         match=(
-            "Invalid operation 'foo'. Must be one of avg, count_unique, count, max, sum, "
+            "Invalid operation 'foo'. Must be one of avg, count_unique, count, max, min, sum, "
             "histogram, p50, p75, p90, p95, p99"
         ),
     ):
@@ -142,7 +142,7 @@ def test_validate_order_by():
     with pytest.raises(
         InvalidParams,
         match=(
-            "Invalid operation 'foo'. Must be one of avg, count_unique, count, max, sum, "
+            "Invalid operation 'foo'. Must be one of avg, count_unique, count, max, min, sum, "
             "histogram, p50, p75, p90, p95, p99"
         ),
     ):


### PR DESCRIPTION
Adds `min` to list of supported operations on
metrics distributions query
