### PR TITLE
ref(sampling): Display request error message

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateChart.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateChart.tsx
@@ -11,11 +11,10 @@ import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 
 type Props = {
-  isLoading: boolean;
   series: Series[];
 };
 
-function UniformRateChart({series, isLoading}: Props) {
+function UniformRateChart({series}: Props) {
   const legend = {
     right: 10,
     top: 5,
@@ -25,7 +24,7 @@ function UniformRateChart({series, isLoading}: Props) {
   return (
     <ChartPanel>
       <ChartContainer>
-        <TransitionChart loading={isLoading} reloading={false} height="224px">
+        <TransitionChart loading={false} reloading={false} height="224px">
           <HeaderTitle>{t('Transactions (Last 30 days) ')}</HeaderTitle>
 
           {getDynamicText({

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateChart.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateChart.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import {BarChart} from 'sentry/components/charts/barChart';
 import {ChartContainer, HeaderTitle} from 'sentry/components/charts/styles';
-import TransitionChart from 'sentry/components/charts/transitionChart';
 import {Panel} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
@@ -24,35 +23,32 @@ function UniformRateChart({series}: Props) {
   return (
     <ChartPanel>
       <ChartContainer>
-        <TransitionChart loading={false} reloading={false} height="224px">
-          <HeaderTitle>{t('Transactions (Last 30 days) ')}</HeaderTitle>
+        <HeaderTitle>{t('Transactions (Last 30 days) ')}</HeaderTitle>
+        {getDynamicText({
+          value: (
+            <BarChart
+              legend={legend}
+              series={series}
+              grid={{
+                left: '10px',
+                right: '10px',
+                top: '40px',
+                bottom: '0px',
+              }}
+              height={200}
+              isGroupedByDate
+              showTimeInTooltip={false}
+              tooltip={{valueFormatter: value => formatAbbreviatedNumber(value)}}
+              yAxis={{
+                axisLabel: {
+                  formatter: (value: number) => formatAbbreviatedNumber(value),
+                },
+              }}
+            />
+          ),
 
-          {getDynamicText({
-            value: (
-              <BarChart
-                legend={legend}
-                series={series}
-                grid={{
-                  left: '10px',
-                  right: '10px',
-                  top: '40px',
-                  bottom: '0px',
-                }}
-                height={200}
-                isGroupedByDate
-                showTimeInTooltip={false}
-                tooltip={{valueFormatter: value => formatAbbreviatedNumber(value)}}
-                yAxis={{
-                  axisLabel: {
-                    formatter: (value: number) => formatAbbreviatedNumber(value),
-                  },
-                }}
-              />
-            ),
-
-            fixed: <Placeholder height="224px" />,
-          })}
-        </TransitionChart>
+          fixed: <Placeholder height="224px" />,
+        })}
       </ChartContainer>
     </ChartPanel>
   );

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -8,6 +8,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import {NumberField} from 'sentry/components/forms';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {PanelTable} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
@@ -91,9 +92,9 @@ export function UniformRateModal({
   const modalStore = useLegacyStore(ModalStore);
 
   const {
+    onRefetch: onRefetch30d,
     projectStats: projectStats30d,
-    // TODO(sampling): check how to render this error in the UI
-    error: _error30d,
+    error: error30d,
     loading: loading30d,
   } = useProjectStats({
     orgSlug: organization.slug,
@@ -258,14 +259,18 @@ export function UniformRateModal({
     });
   }
 
-  if (activeStep === undefined || loading) {
+  if (activeStep === undefined || loading || error30d) {
     return (
       <Fragment>
         <Header closeButton>
-          <Placeholder height="22px" />
+          {error30d ? (
+            <h4>{t('Set a global sample rate')}</h4>
+          ) : (
+            <Placeholder height="22px" />
+          )}
         </Header>
         <Body>
-          <LoadingIndicator />
+          {error30d ? <LoadingError onRetry={onRefetch30d} /> : <LoadingIndicator />}
         </Body>
         <Footer>
           <FooterActions>
@@ -278,7 +283,17 @@ export function UniformRateModal({
             </Button>
             <ButtonBar gap={1}>
               <Button onClick={closeModal}>{t('Cancel')}</Button>
-              <Placeholder height="40px" width="80px" />
+              {error30d ? (
+                <Button
+                  priority="primary"
+                  title={t('There was an error loading data')}
+                  disabled
+                >
+                  {t('Done')}
+                </Button>
+              ) : (
+                <Placeholder height="40px" width="80px" />
+              )}
             </ButtonBar>
           </FooterActions>
         </Footer>
@@ -345,7 +360,6 @@ export function UniformRateModal({
             }
           )}
         </TextBlock>
-
         <Fragment>
           <UniformRateChart
             series={
@@ -358,7 +372,6 @@ export function UniformRateModal({
                     specifiedClientRate
                   )
             }
-            isLoading={loading30d}
           />
 
           <StyledPanelTable

--- a/static/app/views/settings/project/server-side-sampling/utils/useProjectStats.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/useProjectStats.tsx
@@ -19,11 +19,13 @@ function useProjectStats({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
   const [projectStats, setProjectStats] = useState<SeriesApi | undefined>(undefined);
+  const [refetch, setRefetch] = useState(false);
 
   useEffect(() => {
     async function fetchStats() {
       try {
         setLoading(true);
+        setError(undefined);
         const response = await api.requestPromise(`/organizations/${orgSlug}/stats_v2/`, {
           query: {
             category: 'transaction',
@@ -37,23 +39,27 @@ function useProjectStats({
 
         setProjectStats(response);
         setLoading(false);
+        setRefetch(false);
       } catch (err) {
         const errorMessage = t('Unable to load project stats');
         handleXhrErrorResponse(errorMessage)(err);
         setError(errorMessage);
         setLoading(false);
+        setRefetch(false);
       }
     }
-    if (!disable) {
+
+    if (!disable || refetch) {
       fetchStats();
     }
-  }, [api, projectId, orgSlug, interval, statsPeriod, disable, groupBy]);
+  }, [api, projectId, orgSlug, interval, statsPeriod, disable, groupBy, refetch]);
 
   return {
     loading,
     error,
     projectStats,
     projectStatsSeries: projectStatsToSeries(projectStats),
+    onRefetch: () => setRefetch(true),
   };
 }
 

--- a/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
@@ -337,5 +337,36 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     expect(
       await screen.findByRole('heading', {name: 'Set a global sample rate'})
     ).toBeInTheDocument();
+
+    // Close Modal
+    userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+    await waitForElementToBeRemoved(() => screen.queryByLabelText('Cancel'));
+  });
+
+  it('display request error message', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/stats_v2/',
+      statusCode: 500,
+    });
+
+    const {organization, project} = getMockData();
+
+    render(<GlobalModal />);
+
+    openModal(modalProps => (
+      <UniformRateModal
+        {...modalProps}
+        organization={organization}
+        project={project}
+        projectStats={outcomesWithoutClientDiscarded}
+        rules={[]}
+        onSubmit={jest.fn()}
+        onReadDocs={jest.fn()}
+      />
+    ));
+
+    expect(
+      await screen.findByText(/There was an error loading data/)
+    ).toBeInTheDocument();
   });
 });

--- a/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
+++ b/tests/js/spec/views/settings/project/server-side-sampling/utils.tsx
@@ -165,6 +165,7 @@ useProjectStats.mockImplementation(() => ({
   loading: false,
   error: undefined,
   projectStatsSeries: [],
+  onRefetch: jest.fn(),
 }));
 
 jest.mock(


### PR DESCRIPTION
**What this PR does:**

- Display an error message in the UI when the stats v2 request fails
- Add a new test to validate this behavior 

**Preview:**

![Screenshot 2022-08-10 at 17 07 56](https://user-images.githubusercontent.com/29228205/183940937-c3f3e1f6-3ee4-4b3e-a021-3c700d4efd53.png)
