### PR TITLE
fix: `release:latest` query filter alias on metrics endpoint

### DIFF
--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -193,7 +193,7 @@ def parse_query(query_string: str, projects: Sequence[Project]) -> Sequence[Cond
             Dataset.Sessions,
             params={
                 "project_id": [project.id for project in projects],
-                "organization_id": org_id_from_projects(projects),
+                "organization_id": org_id_from_projects(projects) if projects else None,
             },
         )
         where, _ = query_builder.resolve_conditions(query_string, use_aggregate_conditions=True)

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -193,6 +193,7 @@ def parse_query(query_string: str, projects: Sequence[Project]) -> Sequence[Cond
             Dataset.Sessions,
             params={
                 "project_id": [project.id for project in projects],
+                "organization_id": org_id_from_projects(projects),
             },
         )
         where, _ = query_builder.resolve_conditions(query_string, use_aggregate_conditions=True)

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -58,7 +58,7 @@ from sentry.snuba.metrics.naming_layer.mapping import get_mri
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.metrics.query import MetricField
 from sentry.snuba.metrics.query_builder import QueryDefinition
-from sentry.testutils import BaseMetricsTestCase, TestCase
+from sentry.testutils import TestCase
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -964,7 +964,7 @@ def test_translate_meta_results_with_duplicates():
     )
 
 
-class QueryDefinitionTestCase(TestCase, BaseMetricsTestCase):
+class QueryDefinitionTestCase(TestCase):
     def test_valid_latest_release_alias_filter(self):
         self.create_release(version="foo", project=self.project)
 

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -59,6 +59,7 @@ from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.metrics.query import MetricField
 from sentry.snuba.metrics.query_builder import QueryDefinition
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import before_now
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -966,7 +967,8 @@ def test_translate_meta_results_with_duplicates():
 
 class QueryDefinitionTestCase(TestCase):
     def test_valid_latest_release_alias_filter(self):
-        self.create_release(version="foo", project=self.project)
+        self.create_release(version="foo", project=self.project, date_added=before_now(days=4))
+        self.create_release(version="bar", project=self.project, date_added=before_now(days=2))
 
         query_params = MultiValueDict(
             {
@@ -981,6 +983,6 @@ class QueryDefinitionTestCase(TestCase):
             Condition(
                 Column(name="release"),
                 Op.IN,
-                rhs=["foo"],
+                rhs=["bar"],
             )
         ]

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -58,6 +58,7 @@ from sentry.snuba.metrics.naming_layer.mapping import get_mri
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.snuba.metrics.query import MetricField
 from sentry.snuba.metrics.query_builder import QueryDefinition
+from sentry.testutils import BaseMetricsTestCase, TestCase
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -961,3 +962,25 @@ def test_translate_meta_results_with_duplicates():
         ],
         key=lambda elem: elem["name"],
     )
+
+
+class QueryDefinitionTestCase(TestCase, BaseMetricsTestCase):
+    def test_valid_latest_release_alias_filter(self):
+        self.create_release(version="foo", project=self.project)
+
+        query_params = MultiValueDict(
+            {
+                "query": ["release:latest"],
+                "field": [
+                    "sum(sentry.sessions.session)",
+                ],
+            }
+        )
+        query = QueryDefinition([self.project], query_params)
+        assert query.parsed_query == [
+            Condition(
+                Column(name="release"),
+                Op.IN,
+                rhs=["foo"],
+            )
+        ]

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -968,7 +968,9 @@ def test_translate_meta_results_with_duplicates():
 class QueryDefinitionTestCase(TestCase):
     def test_valid_latest_release_alias_filter(self):
         self.create_release(version="foo", project=self.project, date_added=before_now(days=4))
-        self.create_release(version="bar", project=self.project, date_added=before_now(days=2))
+        self.create_release(
+            version="bar", project=self.project, date_added=before_now(days=2)
+        )  # latest release
 
         query_params = MultiValueDict(
             {


### PR DESCRIPTION
UnresolvedQuery requires organization_id to support the `latest`
filter alias on the release tag. UnresolvedQuery calls
[release_filter_converter](https://github.com/getsentry/sentry/blob/31f606045ce6c1c96df8869f6ae0e890bec8cbcc/src/sentry/search/events/datasets/filter_aliases.py#L33) to resolve the where clause for releases and
only returns latest releases correctly if organization_id
is passed.