### PR TITLE
feat(replays): Remove the prefix 'resource.' from type column in Replay Network table

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -142,7 +142,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
           )}
         </Item>
         <Item {...columnHandlers}>
-          <Text>{network.op}</Text>
+          <Text>{network.op.replace('resource.', '')}</Text>
         </Item>
         <Item {...columnHandlers} numeric>
           {`${(networkEndTimestamp - networkStartTimestamp).toFixed(2)}ms`}


### PR DESCRIPTION


<!-- Describe your PR here. -->
Removed prefix `resource.` from the type column string as this was redundant. Closes #37614 

![image](https://user-images.githubusercontent.com/39612839/183975041-ab99ac9a-b353-4dc7-a002-05492a3fadde.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
