### PR TITLE
feat(profiling): Remove call tree from profiles payload

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -298,6 +298,16 @@ def _insert_eventstream_call_tree(profile: Profile) -> None:
     except Exception as e:
         sentry_sdk.capture_exception(e)
         return
+    finally:
+        # Assumes that the call tree is inserted into the
+        # event stream before the profile is inserted into
+        # the event stream.
+        #
+        # After inserting the call tree, we no longer need
+        # it, but if we don't delete it here, it will be
+        # inserted in the profile payload making it larger
+        # and slower.
+        del profile["call_trees"]
 
     processed_profiles_publisher.publish(
         "profiles-call-tree",


### PR DESCRIPTION
This is relatively minor but we were writing both the raw profile and the parsed
call tree data in the profiles payload to kafka. This increased time the
insertion took and is writing a lot of extra data unnecessarily.