### PR TITLE
feat(mep): Split the metrics compatibility endpoint in two

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -39,6 +39,8 @@ class OrganizationEventsMetricsCompatiblity(OrganizationEventsEndpointBase):
 
     This endpoint will return projects that have perfect data along with the overall counts of projects so the
     frontend can make decisions about which projects to show and related info
+
+    DEPRECATED, replaced by 2 endpoints in organization_metrics_meta
     """
 
     private = True
@@ -102,19 +104,16 @@ class OrganizationEventsMetricsCompatiblity(OrganizationEventsEndpointBase):
                 functions_acl=["count_unparameterized_transactions", "count_null_transactions"],
                 use_aggregate_conditions=True,
             )
-            data["sum"]["metrics"] = (
-                sum_metrics["data"][0].get("count") if len(sum_metrics["data"]) > 0 else 0
-            )
-            data["sum"]["metrics_null"] = (
-                sum_metrics["data"][0].get(get_function_alias(count_null))
-                if len(sum_metrics["data"]) > 0
-                else 0
-            )
-            data["sum"]["metrics_unparam"] = (
-                sum_metrics["data"][0].get(get_function_alias(count_unparam))
-                if len(sum_metrics["data"]) > 0
-                else 0
-            )
+            if len(sum_metrics["data"]) > 0:
+                data["sum"].update(
+                    {
+                        "metrics": sum_metrics["data"][0].get("count"),
+                        "metrics_null": sum_metrics["data"][0].get(get_function_alias(count_null)),
+                        "metrics_unparam": sum_metrics["data"][0].get(
+                            get_function_alias(count_unparam)
+                        ),
+                    }
+                )
 
         return Response(data)
 

--- a/src/sentry/api/endpoints/organization_metrics_meta.py
+++ b/src/sentry/api/endpoints/organization_metrics_meta.py
@@ -1,0 +1,113 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
+from sentry.search.events.fields import get_function_alias
+from sentry.snuba import metrics_performance
+
+COUNT_UNPARAM = "count_unparameterized_transactions()"
+COUNT_HAS_TXN = "count_has_transaction_name()"
+COUNT_NULL = "count_null_transactions()"
+
+
+class OrganizationMetricsCompatibility(OrganizationEventsEndpointBase):
+    """Metrics data can contain less than great data like null or unparameterized transactions
+
+    This endpoint will return projects that have dynamic sampling turned on, and another list of "compatible projects"
+    which are the projects which don't have null transactions and have at least 1 transaction with a valid name
+    """
+
+    private = True
+
+    def get(self, request: Request, organization) -> Response:
+        data = {
+            "compatible_projects": [],
+            "dynamic_sampling_projects": [],
+        }
+        try:
+            # This will be used on the perf homepage and contains preset queries, allow global views
+            params = self.get_snuba_params(request, organization, check_global_views=False)
+        except NoProjects:
+            return Response(data)
+        data["compatible_projects"] = params["project_id"]
+        for project in params["project_objects"]:
+            dynamic_sampling = project.get_option("sentry:dynamic_sampling")
+            if dynamic_sampling is not None:
+                data["dynamic_sampling_projects"].append(project.id)
+                if len(data["dynamic_sampling_projects"]) > 50:
+                    break
+
+        # None of the projects had DS rules, nothing is compat the sum & compat projects list is useless
+        if len(data["dynamic_sampling_projects"]) == 0:
+            return Response(data)
+        data["dynamic_sampling_projects"].sort()
+
+        # Save ourselves some work, only query the projects that have DS rules
+        params["project_id"] = data["dynamic_sampling_projects"]
+
+        with self.handle_query_errors():
+            count_has_txn = "count_has_transaction_name()"
+            count_null = "count_null_transactions()"
+            compatible_results = metrics_performance.query(
+                selected_columns=[
+                    "project.id",
+                    count_null,
+                    count_has_txn,
+                ],
+                params=params,
+                query=f"{count_null}:0 AND {count_has_txn}:>0",
+                referrer="api.organization-events-metrics-compatibility.compatible",
+                functions_acl=["count_null_transactions", "count_has_transaction_name"],
+                use_aggregate_conditions=True,
+            )
+            data["compatible_projects"] = sorted(
+                row["project.id"] for row in compatible_results["data"]
+            )
+
+        return Response(data)
+
+
+class OrganizationMetricsCompatibilitySums(OrganizationEventsEndpointBase):
+    """Return the total sum of metrics data, the null transactions and unparameterized transactions
+
+    This is so the frontend can have an idea given its current selection of projects how good/bad the display would
+    be
+    """
+
+    private = True
+
+    def get(self, request: Request, organization) -> Response:
+        data = {
+            "sum": {
+                "metrics": None,
+                "metrics_null": None,
+                "metrics_unparam": None,
+            },
+        }
+        try:
+            # This will be used on the perf homepage and contains preset queries, allow global views
+            params = self.get_snuba_params(request, organization, check_global_views=False)
+        except NoProjects:
+            return Response(data)
+
+        with self.handle_query_errors():
+            sum_metrics = metrics_performance.query(
+                selected_columns=[COUNT_UNPARAM, COUNT_NULL, "count()"],
+                params=params,
+                query="",
+                referrer="api.organization-events-metrics-compatibility.sum_metrics",
+                functions_acl=["count_unparameterized_transactions", "count_null_transactions"],
+                use_aggregate_conditions=True,
+            )
+            if len(sum_metrics["data"]) > 0:
+                data["sum"].update(
+                    {
+                        "metrics": sum_metrics["data"][0].get("count"),
+                        "metrics_null": sum_metrics["data"][0].get(get_function_alias(COUNT_NULL)),
+                        "metrics_unparam": sum_metrics["data"][0].get(
+                            get_function_alias(COUNT_UNPARAM)
+                        ),
+                    }
+                )
+
+        return Response(data)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -314,6 +314,10 @@ from .endpoints.organization_metrics import (
     OrganizationMetricsTagDetailsEndpoint,
     OrganizationMetricsTagsEndpoint,
 )
+from .endpoints.organization_metrics_meta import (
+    OrganizationMetricsCompatibility,
+    OrganizationMetricsCompatibilitySums,
+)
 from .endpoints.organization_monitors import OrganizationMonitorsEndpoint
 from .endpoints.organization_onboarding_continuation_email import (
     OrganizationOnboardingContinuationEmail,
@@ -1177,6 +1181,16 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/events-metrics-compatibility/$",
                     OrganizationEventsMetricsCompatiblity.as_view(),
                     name="sentry-api-0-organization-events-metrics-compatibility",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/metrics-compatibility/$",
+                    OrganizationMetricsCompatibility.as_view(),
+                    name="sentry-api-0-organization-metrics-compatibility",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/metrics-compatibility-sums/$",
+                    OrganizationMetricsCompatibilitySums.as_view(),
+                    name="sentry-api-0-organization-metrics-compatibility-sums",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/events-histogram/$",

--- a/tests/snuba/api/endpoints/test_organization_metrics_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_metrics_meta.py
@@ -1,0 +1,231 @@
+import pytest
+from django.urls import reverse
+
+from sentry.testutils import MetricsEnhancedPerformanceTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
+
+pytestmark = pytest.mark.sentry_metrics
+
+
+class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
+    def setUp(self):
+        super().setUp()
+        self.min_ago = before_now(minutes=1)
+        self.two_min_ago = before_now(minutes=2)
+        self.features = {
+            "organizations:performance-use-metrics": True,
+        }
+        self.login_as(user=self.user)
+        self.project.update_option("sentry:dynamic_sampling", "something-it-doesn't-matter")
+        # Don't create any txn on this, don't set its DS rules, it shouldn't show up anywhere
+        self.create_project()
+
+    def test_unparameterized_transactions(self):
+        # Make current project incompatible
+        self.store_transaction_metric(
+            1, tags={"transaction": "<< unparameterized >>"}, timestamp=self.min_ago
+        )
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["compatible_projects"] == []
+        assert response.data["dynamic_sampling_projects"] == [self.project.id]
+
+    def test_null_transaction(self):
+        # Make current project incompatible
+        self.store_transaction_metric(1, tags={}, timestamp=self.min_ago)
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["compatible_projects"] == []
+        assert response.data["dynamic_sampling_projects"] == [self.project.id]
+
+    def test_no_transaction(self):
+        # Make current project incompatible by having nothing
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["compatible_projects"] == []
+        assert response.data["dynamic_sampling_projects"] == [self.project.id]
+
+    def test_has_transaction(self):
+        self.store_transaction_metric(
+            1, tags={"transaction": "foo_transaction"}, timestamp=self.min_ago
+        )
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["compatible_projects"] == [self.project.id]
+        assert response.data["dynamic_sampling_projects"] == [self.project.id]
+
+    def test_multiple_projects(self):
+        project2 = self.create_project()
+        project2.update_option("sentry:dynamic_sampling", "something-it-doesn't-matter")
+        project3 = self.create_project()
+        project3.update_option("sentry:dynamic_sampling", "something-it-doesn't-matter")
+        # Not setting DS, it shouldn't show up
+        project4 = self.create_project()
+        self.store_transaction_metric(
+            1, tags={"transaction": "foo_transaction"}, timestamp=self.min_ago
+        )
+        self.store_transaction_metric(
+            1, tags={"transaction": "foo_transaction"}, timestamp=self.min_ago, project=project4.id
+        )
+        self.store_transaction_metric(
+            1,
+            tags={"transaction": "<< unparameterized >>"},
+            timestamp=self.min_ago,
+            project=project2.id,
+        )
+        self.store_transaction_metric(
+            1,
+            tags={},
+            timestamp=self.min_ago,
+            project=project3.id,
+        )
+        self.store_event(
+            data={"timestamp": iso_format(self.min_ago), "transaction": "foo_transaction"},
+            project_id=self.project.id,
+        )
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["compatible_projects"] == [self.project.id]
+        assert response.data["dynamic_sampling_projects"] == [
+            self.project.id,
+            project2.id,
+            project3.id,
+        ]
+
+
+class OrganizationEventsMetricsSums(MetricsEnhancedPerformanceTestCase):
+    def setUp(self):
+        super().setUp()
+        self.min_ago = before_now(minutes=1)
+        self.two_min_ago = before_now(minutes=2)
+        self.features = {
+            "organizations:performance-use-metrics": True,
+        }
+        self.login_as(user=self.user)
+        self.project.update_option("sentry:dynamic_sampling", "something-it-doesn't-matter")
+        # Don't create any txn on this, don't set its DS rules, it shouldn't show up anywhere
+        self.create_project()
+
+    def test_unparameterized_transactions(self):
+        # Make current project incompatible
+        self.store_transaction_metric(
+            1, tags={"transaction": "<< unparameterized >>"}, timestamp=self.min_ago
+        )
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility-sums",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["sum"]["metrics"] == 1
+        assert response.data["sum"]["metrics_unparam"] == 1
+        assert response.data["sum"]["metrics_null"] == 0
+
+    def test_null_transaction(self):
+        # Make current project incompatible
+        self.store_transaction_metric(1, tags={}, timestamp=self.min_ago)
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility-sums",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["sum"]["metrics"] == 1
+        assert response.data["sum"]["metrics_unparam"] == 0
+        assert response.data["sum"]["metrics_null"] == 1
+
+    def test_no_transaction(self):
+        # Make current project incompatible by having nothing
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility-sums",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["sum"]["metrics"] == 0
+        assert response.data["sum"]["metrics_unparam"] == 0
+        assert response.data["sum"]["metrics_null"] == 0
+
+    def test_has_transaction(self):
+        self.store_transaction_metric(
+            1, tags={"transaction": "foo_transaction"}, timestamp=self.min_ago
+        )
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility-sums",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["sum"]["metrics"] == 1
+        assert response.data["sum"]["metrics_unparam"] == 0
+        assert response.data["sum"]["metrics_null"] == 0
+
+    def test_multiple_projects(self):
+        project2 = self.create_project()
+        project2.update_option("sentry:dynamic_sampling", "something-it-doesn't-matter")
+        project3 = self.create_project()
+        project3.update_option("sentry:dynamic_sampling", "something-it-doesn't-matter")
+        # Not setting DS, it shouldn't show up
+        project4 = self.create_project()
+        self.store_transaction_metric(
+            1, tags={"transaction": "foo_transaction"}, timestamp=self.min_ago
+        )
+        self.store_transaction_metric(
+            1, tags={"transaction": "foo_transaction"}, timestamp=self.min_ago, project=project4.id
+        )
+        self.store_transaction_metric(
+            1,
+            tags={"transaction": "<< unparameterized >>"},
+            timestamp=self.min_ago,
+            project=project2.id,
+        )
+        self.store_transaction_metric(
+            1,
+            tags={},
+            timestamp=self.min_ago,
+            project=project3.id,
+        )
+        self.store_event(
+            data={"timestamp": iso_format(self.min_ago), "transaction": "foo_transaction"},
+            project_id=self.project.id,
+        )
+        url = reverse(
+            "sentry-api-0-organization-events-metrics-compatibility",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        # project 4 shouldn't show up in these sums
+        assert response.data["sum"]["metrics"] == 3
+        assert response.data["sum"]["metrics_unparam"] == 1
+        assert response.data["sum"]["metrics_null"] == 1

--- a/tests/snuba/api/endpoints/test_organization_metrics_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_metrics_meta.py
@@ -18,7 +18,7 @@ class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
         self.login_as(user=self.user)
         self.project.update_option("sentry:dynamic_sampling", "something-it-doesn't-matter")
         # Don't create any txn on this, don't set its DS rules, it shouldn't show up anywhere
-        self.create_project()
+        self.bad_project = self.create_project()
 
     def test_unparameterized_transactions(self):
         # Make current project incompatible
@@ -32,6 +32,7 @@ class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
+        assert response.data["incompatible_projects"] == [self.project.id, self.bad_project.id]
         assert response.data["compatible_projects"] == []
         assert response.data["dynamic_sampling_projects"] == [self.project.id]
 
@@ -45,6 +46,7 @@ class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
+        assert response.data["incompatible_projects"] == [self.project.id, self.bad_project.id]
         assert response.data["compatible_projects"] == []
         assert response.data["dynamic_sampling_projects"] == [self.project.id]
 
@@ -57,6 +59,7 @@ class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
+        assert response.data["incompatible_projects"] == [self.project.id, self.bad_project.id]
         assert response.data["compatible_projects"] == []
         assert response.data["dynamic_sampling_projects"] == [self.project.id]
 
@@ -71,6 +74,7 @@ class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
+        assert response.data["incompatible_projects"] == [self.bad_project.id]
         assert response.data["compatible_projects"] == [self.project.id]
         assert response.data["dynamic_sampling_projects"] == [self.project.id]
 
@@ -110,6 +114,9 @@ class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
+        assert response.data["incompatible_projects"] == sorted(
+            [project2.id, project3.id, project4.id, self.bad_project.id]
+        )
         assert response.data["compatible_projects"] == [self.project.id]
         assert response.data["dynamic_sampling_projects"] == [
             self.project.id,


### PR DESCRIPTION
- This moves the sums and compatible project checks in two so the
  frontend can either run them in parallel if needed or conditionally
  run one based on the other
- This deprecates the old endpoint, it will be deleted once the frontend
  no longer uses it