### PR TITLE
feat(replays): Add ms to timestamp column in Replay details Network table

### DIFF
--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -1,15 +1,11 @@
+import padStart from 'lodash/padStart';
+
 import {Crumb} from 'sentry/types/breadcrumbs';
 import type {ReplaySpan} from 'sentry/views/replays/types';
 
 function padZero(num: number, len = 2): string {
-  let str = String(num);
-  const threshold = Math.pow(10, len - 1);
-  if (num < threshold) {
-    while (String(threshold).length > str.length) {
-      str = '0' + num;
-    }
-  }
-  return str;
+  const str = String(num);
+  return padStart(str, len, '0');
 }
 
 const SECOND = 1000;
@@ -30,25 +26,42 @@ export function relativeTimeInMs(
 
 export function showPlayerTime(
   timestamp: ConstructorParameters<typeof Date>[0],
-  relativeTimeMs: number
+  relativeTimeMs: number,
+  showMs: boolean = false
 ): string {
-  return formatTime(relativeTimeInMs(timestamp, relativeTimeMs));
+  return formatTime(relativeTimeInMs(timestamp, relativeTimeMs), showMs);
 }
 
 // TODO: move into 'sentry/utils/formatters'
-export function formatTime(ms: number): string {
+export function formatTime(ms: number, showMs?: boolean): string {
   if (ms <= 0 || isNaN(ms)) {
+    if (showMs) {
+      return '00:00.000';
+    }
+
     return '00:00';
   }
+
   const hour = Math.floor(ms / HOUR);
   ms = ms % HOUR;
   const minute = Math.floor(ms / MINUTE);
   ms = ms % MINUTE;
   const second = Math.floor(ms / SECOND);
+
+  let formattedTime = '00:00';
+
   if (hour) {
-    return `${padZero(hour)}:${padZero(minute)}:${padZero(second)}`;
+    formattedTime = `${padZero(hour)}:${padZero(minute)}:${padZero(second)}`;
+  } else {
+    formattedTime = `${padZero(minute)}:${padZero(second)}`;
   }
-  return `${padZero(minute)}:${padZero(second)}`;
+
+  if (showMs) {
+    const milliSeconds = Math.floor(ms % SECOND);
+    formattedTime = `${formattedTime}.${padZero(milliSeconds, 3)}`;
+  }
+
+  return formattedTime;
 }
 
 /**

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -57,8 +57,8 @@ export function formatTime(ms: number, showMs?: boolean): string {
   }
 
   if (showMs) {
-    const milliSeconds = Math.floor(ms % SECOND);
-    formattedTime = `${formattedTime}.${padZero(milliSeconds, 3)}`;
+    const milliseconds = Math.floor(ms % SECOND);
+    formattedTime = `${formattedTime}.${padZero(milliseconds, 3)}`;
   }
 
   return formattedTime;

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -149,7 +149,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
         </Item>
         <Item {...columnHandlers} numeric>
           <UnstyledButton onClick={() => handleClick(networkStartTimestamp)}>
-            {showPlayerTime(networkStartTimestamp, startTimestampMs)}
+            {showPlayerTime(networkStartTimestamp, startTimestampMs, true)}
           </UnstyledButton>
         </Item>
       </Fragment>


### PR DESCRIPTION


<!-- Describe your PR here. -->
### Changes
- Added milliseconds to the Timestamp column on the network table

Closes #37616.

![image](https://user-images.githubusercontent.com/39612839/183991387-5658b424-f1b8-49cc-b5b1-4b7e44532d61.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
