### PR TITLE
chore(active-release): remove flag references to organizations:active-release-notification-opt-in

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -943,8 +943,6 @@ SENTRY_FEATURES = {
     "auth:register": True,
     # Workflow 2.0 Alpha Functionality for sentry users only
     "organizations:active-release-monitor-alpha": False,
-    # Workflow 2.0 Experimental ReleaseMembers who opt-in to get notified as a release committer
-    "organizations:active-release-notification-opt-in": False,
     # Enable advanced search features, like negation and wildcard matching.
     "organizations:advanced-search": True,
     # Use metrics as the dataset for crash free metric alerts

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -58,7 +58,6 @@ default_manager.add("organizations:create")
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:active-release-monitor-alpha", OrganizationFeature, True)
-default_manager.add("organizations:active-release-notification-opt-in", OrganizationFeature, True)
 default_manager.add("organizations:alert-filters", OrganizationFeature)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, True)
 default_manager.add("organizations:api-keys", OrganizationFeature)

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -274,20 +274,8 @@ def _get_release_committers(release: Release) -> Sequence[User]:
     # commit_author_id : Author
     author_users: Mapping[str, Author] = get_users_for_commits(commits)
 
-    # XXX(gilbert): this is inefficient since this evaluates flagr once per user
-    # it should be ok since this method should only be called for projects within sentry
-    # do not copy this unless you know the risk; you've been warned!
     return list(
-        filter(
-            lambda u: features.has(
-                "organizations:active-release-notification-opt-in", release.organization, actor=u
-            ),
-            list(
-                User.objects.filter(
-                    id__in={au["id"] for au in author_users.values() if au.get("id")}
-                )
-            ),
-        )
+        User.objects.filter(id__in={au["id"] for au in author_users.values() if au.get("id")})
     )
 
 

--- a/src/sentry/tasks/release_summary.py
+++ b/src/sentry/tasks/release_summary.py
@@ -7,7 +7,6 @@ from sentry.models import Activity, Release, ReleaseActivity, ReleaseCommit
 from sentry.notifications.notifications.activity.release_summary import (
     ReleaseSummaryActivityNotification,
 )
-from sentry.notifications.utils.participants import _get_release_committers
 from sentry.tasks.base import instrumented_task
 from sentry.types.activity import ActivityType
 from sentry.types.releaseactivity import ReleaseActivityType
@@ -32,12 +31,6 @@ def prepare_release_summary():
             organization_id=release.organization_id, release=release
         ).exists()
         if not release_has_commits:
-            continue
-
-        # Check if any participants are members of the feature flag
-        # TODO(workflow): can remove with active-release-notification-opt-in
-        participants = _get_release_committers(release)
-        if not participants:
             continue
 
         # Find the activity created in Deploy.notify_if_ready

--- a/tests/sentry/mail/activity/test_release_summary.py
+++ b/tests/sentry/mail/activity/test_release_summary.py
@@ -43,15 +43,14 @@ class ReleaseSummaryTestCase(ActivityTestCase):
         self.commit2 = self.another_commit(1, "b", self.user2, repository)
 
     def test_simple(self):
-        with self.feature("organizations:active-release-notification-opt-in"):
-            release_summary = ReleaseSummaryActivityNotification(
-                Activity(
-                    project=self.project,
-                    user=self.user1,
-                    type=ActivityType.DEPLOY.value,
-                    data={"version": self.release.version, "deploy_id": self.deploy.id},
-                )
+        release_summary = ReleaseSummaryActivityNotification(
+            Activity(
+                project=self.project,
+                user=self.user1,
+                type=ActivityType.DEPLOY.value,
+                data={"version": self.release.version, "deploy_id": self.deploy.id},
             )
+        )
 
         # user1 is included because they committed
         participants = release_summary.get_participants_with_group_subscription_reason()[

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -165,18 +165,7 @@ class GetSentToReleaseMembersTest(TestCase):
     def test_default_committer(self, spy_get_release_committers):
         event = self.store_event("empty.lol")
         event.group = self.group
-        with self.feature("organizations:active-release-notification-opt-in"):
-            assert self.get_send_to_release_members(event) == {ExternalProviders.EMAIL: {self.user}}
-            assert spy_get_release_committers.call_count == 1
-
-    @mock.patch(
-        "sentry.notifications.utils.participants.get_release_committers",
-        wraps=get_release_committers,
-    )
-    def test_flag_off_should_no_release_members(self, spy_get_release_committers):
-        event = self.store_event("empty.lol")
-        event.group = self.group
-        assert not self.get_send_to_release_members(event)
+        assert self.get_send_to_release_members(event) == {ExternalProviders.EMAIL: {self.user}}
         assert spy_get_release_committers.call_count == 1
 
 

--- a/tests/sentry/tasks/test_release_summary.py
+++ b/tests/sentry/tasks/test_release_summary.py
@@ -48,15 +48,6 @@ class SendReleaseSummaryTest(ActivityTestCase):
         "sentry.notifications.notifications.activity.release_summary.ReleaseSummaryActivityNotification.send"
     )
     def test_simple(self, mock_release_summary_send):
-        with self.feature("organizations:active-release-notification-opt-in"):
-            prepare_release_summary()
-
-        assert len(mock_release_summary_send.mock_calls) == 1
-
-    @patch(
-        "sentry.notifications.notifications.activity.release_summary.ReleaseSummaryActivityNotification.send"
-    )
-    def test_without_feature_flag(self, mock_release_summary_send):
         prepare_release_summary()
 
-        assert not mock_release_summary_send.mock_calls
+        assert len(mock_release_summary_send.mock_calls) == 1


### PR DESCRIPTION
No longer needed since we introduced NotificationSettings to toggle on/off these types of notifications. 

Users within sentry can personally opt-in if they choose instead of relying on this flag to 'opt' them in. 