### PR TITLE
feat(notifications): correct team fallback settings

### DIFF
--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -107,6 +107,19 @@ class GetSendToTeamTest(TestCase):
             NotificationSettingOptionValues.ALWAYS,
             team=self.team,
         )
+        integration = self.create_integration(
+            self.organization,
+            self.team.id,
+            name="Github Installation",
+            provider="github",
+        )
+        ExternalActor.objects.create(
+            actor=self.team.actor,
+            organization=self.team.organization,
+            integration=integration,
+            provider=ExternalProviders.GITHUB.value,
+            external_name="my-name",
+        )
 
         assert self.get_send_to_team() == {ExternalProviders.EMAIL: {self.user}}
 


### PR DESCRIPTION
This PR changes the fallback logic if we can't send a notification to a team. This is needed because we are going to change the default settings for slack alerts to be on whereas previously it was off by default. Since we actually make a notification setting when you link a team (https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/slack/views/link_team.py#L127-L136) it was never an issue before. If you had the notification setting for a team enabled, it meant there was an external actor row. But when we change the default that won't be the case anymore. As a result, we should check the `ExternalActor` row in addition to notification settings to see if we want to fallback to sending to the members. If there is no `ExternalActor` row for that provider, we will just fall back to sending to members individually as usual.