### PR TITLE
ref(active-release): update copy to reflect Release Issue Activity intent

### DIFF
--- a/static/app/views/releases/detail/activity/releaseActivityItems.tsx
+++ b/static/app/views/releases/detail/activity/releaseActivityItems.tsx
@@ -43,7 +43,9 @@ export function ReleaseActivityWaiting() {
       iconColor="gray500"
       hideConnector
     >
-      <WaitingContainer>{t('Waiting for issues in this release...')}</WaitingContainer>
+      <WaitingContainer>
+        {t('Waiting for new issues in this release to notify release participants ...')}
+      </WaitingContainer>
     </ReleaseActivityRow>
   );
 }

--- a/tests/js/spec/views/releases/detail/activity/releaseActivity.spec.jsx
+++ b/tests/js/spec/views/releases/detail/activity/releaseActivity.spec.jsx
@@ -70,6 +70,10 @@ describe('ReleaseActivity', () => {
     expect(await screen.findByText('Release Created')).toBeInTheDocument();
     expect(screen.getByText('Deployed to production')).toBeInTheDocument();
     expect(screen.getByText(group.culprit)).toBeInTheDocument();
-    expect(screen.getByText('Waiting for issues in this release...')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Waiting for new issues in this release to notify release participants ...'
+      )
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Not totally sure if this is applicable.

BE fires these activity events when someone is notified about an issue occurring in an active release. 

Inferring on the FE copy, it looks like the issue activity for a release might be to show an new issue happened as part of a release? 
![Screen Shot 2022-08-10 at 12 44 50 PM](https://user-images.githubusercontent.com/101606877/184007851-e3211e8c-900d-4097-99ae-210311216dae.png)
 
We should probably lean one way or the other as this is already confusing me when looking at the release activity page.