### PR TITLE
ref(perf): Adjust perf issue thresholds

### DIFF
--- a/src/sentry/tasks/performance_detection.py
+++ b/src/sentry/tasks/performance_detection.py
@@ -39,7 +39,7 @@ def detect_performance_issue(data: Event):
 
 # Gets some of the thresholds to perform performance detection. Can be made configurable later.
 # Thresholds are in milliseconds.
-def get_detection_settings():
+def get_default_detection_settings():
     return {
         DetectorType.DUPLICATE_SPANS: {
             "count": 5,
@@ -48,11 +48,11 @@ def get_detection_settings():
         },
         DetectorType.SEQUENTIAL_SLOW_SPANS: {
             "count": 3,
-            "cumulative_duration": 600.0,  # ms
+            "cumulative_duration": 1200.0,  # ms
             "allowed_span_ops": ["db", "http", "ui"],
         },
         DetectorType.SLOW_SPAN: {
-            "duration_threshold": 500.0,  # ms
+            "duration_threshold": 1000.0,  # ms
             "allowed_span_ops": ["db", "http"],
         },
     }
@@ -62,7 +62,7 @@ def _detect_performance_issue(data: Event, sdk_span: Any):
     event_id = data.get("event_id", None)
     spans: TransactionSpans = data.get("spans", [])
 
-    detection_settings = get_detection_settings()
+    detection_settings = get_default_detection_settings()
     detectors = {
         DetectorType.DUPLICATE_SPANS: DuplicateSpanDetector(detection_settings),
         DetectorType.SLOW_SPAN: SlowSpanDetector(detection_settings),

--- a/tests/sentry/tasks/test_performance_detection.py
+++ b/tests/sentry/tasks/test_performance_detection.py
@@ -175,7 +175,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                     .with_op("http.client")
                     .with_description("http://example.com")
                     .build(),
-                    501.0,
+                    1001.0,
                 )
             ]
             * 1,

--- a/tests/sentry/tasks/test_performance_detection.py
+++ b/tests/sentry/tasks/test_performance_detection.py
@@ -110,7 +110,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                     .with_op("db")
                     .with_description("SELECT count() FROM table WHERE id = %s")
                     .build(),
-                    499.0,
+                    999.0,
                 )
             ]
             * 1,
@@ -123,7 +123,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                     .with_op("db")
                     .with_description("SELECT count() FROM table WHERE id = %s")
                     .build(),
-                    501.0,
+                    1001.0,
                 )
             ]
             * 1,
@@ -133,7 +133,7 @@ class PerformanceDetectionTest(unittest.TestCase):
             "spans": [
                 modify_span_duration(
                     SpanBuilder().with_op("random").with_description("example").build(),
-                    501.0,
+                    1001.0,
                 )
             ]
             * 1,
@@ -211,7 +211,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                     .with_op("db")
                     .with_description("SELECT count() FROM table WHERE id = %s")
                     .build(),
-                    499.0,
+                    999.0,
                 )
             ]
             * 4,
@@ -224,7 +224,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                     .with_op("db")
                     .with_description("SELECT count() FROM table WHERE id = %s")
                     .build(),
-                    499.0,
+                    999.0,
                 ),
             ]
             * 2
@@ -235,7 +235,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                         .with_op("db")
                         .with_description("SELECT count() FROM table WHERE id = %s")
                         .build(),
-                        499.0,
+                        999.0,
                     ),
                     1000.0,
                 ),
@@ -245,7 +245,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                         .with_op("db")
                         .with_description("SELECT count() FROM table WHERE id = %s")
                         .build(),
-                        499.0,
+                        999.0,
                     ),
                     2000.0,
                 ),
@@ -255,7 +255,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                         .with_op("db")
                         .with_description("SELECT count() FROM table WHERE id = %s")
                         .build(),
-                        499.0,
+                        999.0,
                     ),
                     3000.0,
                 ),


### PR DESCRIPTION
### Summary
This tests out the sensitivity on some of the noisiest detected issues, slow spans and sequential spans, to see how they respond to higher thresholds. We may choose to modify these values via options directly later.
