### PR TITLE
fix(api): add pagination for /users/ endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -4,9 +4,11 @@ from rest_framework.response import Response
 
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import OrganizationMemberWithProjectsSerializer
 from sentry.models import OrganizationMember, OrganizationMemberTeam, ProjectTeam
+from sentry.utils.cursors import Cursor
 
 
 class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
@@ -25,7 +27,7 @@ class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
         projects = self.get_projects(request, organization)
 
         with sentry_sdk.start_span(op="OrganizationUsersEndpoint.get_members") as span:
-            qs = (
+            queryset = (
                 OrganizationMember.objects.filter(
                     user__is_active=True,
                     organization=organization,
@@ -41,17 +43,21 @@ class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 )
                 .order_by("user__email")
             )
-            organization_members = list(qs)
+            organization_members = list(queryset)
 
             span.set_data("Project Count", len(projects))
             span.set_data("Member Count", len(organization_members))
 
-        return Response(
-            serialize(
-                organization_members,
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            paginator_cls=OffsetPaginator,
+            cursor_cls=Cursor,
+            on_results=lambda x: serialize(
+                x,
                 request.user,
                 serializer=OrganizationMemberWithProjectsSerializer(
                     project_ids=[p.id for p in projects]
                 ),
-            )
+            ),
         )

--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -8,7 +8,6 @@ from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import OrganizationMemberWithProjectsSerializer
 from sentry.models import OrganizationMember, OrganizationMemberTeam, ProjectTeam
-from sentry.utils.cursors import Cursor
 
 
 class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
@@ -52,7 +51,6 @@ class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
             request=request,
             queryset=queryset,
             paginator_cls=OffsetPaginator,
-            cursor_cls=Cursor,
             on_results=lambda x: serialize(
                 x,
                 request.user,

--- a/tests/sentry/api/endpoints/test_organization_users.py
+++ b/tests/sentry/api/endpoints/test_organization_users.py
@@ -44,3 +44,26 @@ class OrganizationMemberListTest(APITestCase):
             OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
         )
         assert response.data == expected
+
+    def test_simple_pagination(self):
+        projects_ids = [self.project_1.id, self.project_2.id]
+        response = self.get_success_response(self.org.slug, project=projects_ids, cursor="1:1:0")
+        expected = serialize(
+            list(
+                self.org.member_set.filter(user__in=[self.owner_user, self.user_2]).order_by(
+                    "user__email"
+                )
+            )[1:],
+            self.user_2,
+            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+        )
+        assert response.data == expected
+
+        projects_ids = [self.project_2.id]
+        response = self.get_success_response(self.org.slug, project=projects_ids, cursor="1:1:0")
+        expected = serialize(
+            list(self.org.member_set.filter(user__in=[self.user_2]).order_by("user__email"))[1:],
+            self.user_2,
+            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+        )
+        assert response.data == expected


### PR DESCRIPTION
Adds pagination to the /users/ endpoint of the Sentry API

Fixes ISSUE-1274