### PR TITLE
fix(release-notifications): bring back opt-in flag and inject NotificationSetting for committers

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -944,6 +944,8 @@ SENTRY_FEATURES = {
     "auth:register": True,
     # Workflow 2.0 Alpha Functionality for sentry users only
     "organizations:active-release-monitor-alpha": False,
+    # Workflow 2.0 Experimental ReleaseMembers who opt-in to get notified as a release committer
+    "organizations:active-release-notification-opt-in": False,
     # Enable advanced search features, like negation and wildcard matching.
     "organizations:advanced-search": True,
     # Use metrics as the dataset for crash free metric alerts

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -58,6 +58,7 @@ default_manager.add("organizations:create")
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:active-release-monitor-alpha", OrganizationFeature, True)
+default_manager.add("organizations:active-release-notification-opt-in", OrganizationFeature, True)
 default_manager.add("organizations:alert-filters", OrganizationFeature)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, True)
 default_manager.add("organizations:api-keys", OrganizationFeature)

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -306,9 +306,9 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
         # XXX(gilbert): remove this when organizations:active-release-notification-opt-in is removed
         # injects the notification settings since no Notification settings will exist in the db
         from sentry import features
-        from sentry.models import User
+        from sentry.models import Project, User
 
-        if parent.organization:
+        if isinstance(parent, Project) and parent.organization:
             notification_settings_by_recipient = dict(notification_settings_by_recipient)
             for user_recipient in filter(lambda x: isinstance(x, User), recipients):
                 if type == NotificationSettingTypes.ACTIVE_RELEASE and features.has(

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -303,6 +303,28 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
         notification_settings_by_recipient = transform_to_notification_settings_by_recipient(
             notification_settings, recipients
         )
+        # XXX(gilbert): remove this when organizations:active-release-notification-opt-in is removed
+        # injects the notification settings since no Notification settings will exist in the db
+        from sentry import features
+        from sentry.models import User
+
+        if parent.organization:
+            notification_settings_by_recipient = dict(notification_settings_by_recipient)
+            for user_recipient in filter(lambda x: isinstance(x, User), recipients):
+                if type == NotificationSettingTypes.ACTIVE_RELEASE and features.has(
+                    "organizations:active-release-notification-opt-in",
+                    parent.organization,
+                    actor=user_recipient,
+                ):
+                    notification_settings_by_recipient[user_recipient] = {
+                        {
+                            NotificationScopeType.USER: {
+                                ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                                ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
+                            }
+                        }
+                    }
+
         mapping = defaultdict(set)
         for recipient in recipients:
             providers = where_should_recipient_be_notified(

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -274,8 +274,20 @@ def _get_release_committers(release: Release) -> Sequence[User]:
     # commit_author_id : Author
     author_users: Mapping[str, Author] = get_users_for_commits(commits)
 
+    # XXX(gilbert): this is inefficient since this evaluates flagr once per user
+    # it should be ok since this method should only be called for projects within sentry
+    # do not copy this unless you know the risk; you've been warned!
     return list(
-        User.objects.filter(id__in={au["id"] for au in author_users.values() if au.get("id")})
+        filter(
+            lambda u: features.has(
+                "organizations:active-release-notification-opt-in", release.organization, actor=u
+            ),
+            list(
+                User.objects.filter(
+                    id__in={au["id"] for au in author_users.values() if au.get("id")}
+                )
+            ),
+        )
     )
 
 

--- a/src/sentry/tasks/release_summary.py
+++ b/src/sentry/tasks/release_summary.py
@@ -7,6 +7,7 @@ from sentry.models import Activity, Release, ReleaseActivity, ReleaseCommit
 from sentry.notifications.notifications.activity.release_summary import (
     ReleaseSummaryActivityNotification,
 )
+from sentry.notifications.utils.participants import _get_release_committers
 from sentry.tasks.base import instrumented_task
 from sentry.types.activity import ActivityType
 from sentry.types.releaseactivity import ReleaseActivityType
@@ -31,6 +32,12 @@ def prepare_release_summary():
             organization_id=release.organization_id, release=release
         ).exists()
         if not release_has_commits:
+            continue
+
+        # Check if any participants are members of the feature flag
+        # TODO(workflow): can remove with active-release-notification-opt-in
+        participants = _get_release_committers(release)
+        if not participants:
             continue
 
         # Find the activity created in Deploy.notify_if_ready

--- a/tests/sentry/mail/activity/test_release_summary.py
+++ b/tests/sentry/mail/activity/test_release_summary.py
@@ -43,14 +43,15 @@ class ReleaseSummaryTestCase(ActivityTestCase):
         self.commit2 = self.another_commit(1, "b", self.user2, repository)
 
     def test_simple(self):
-        release_summary = ReleaseSummaryActivityNotification(
-            Activity(
-                project=self.project,
-                user=self.user1,
-                type=ActivityType.DEPLOY.value,
-                data={"version": self.release.version, "deploy_id": self.deploy.id},
+        with self.feature("organizations:active-release-notification-opt-in"):
+            release_summary = ReleaseSummaryActivityNotification(
+                Activity(
+                    project=self.project,
+                    user=self.user1,
+                    type=ActivityType.DEPLOY.value,
+                    data={"version": self.release.version, "deploy_id": self.deploy.id},
+                )
             )
-        )
 
         # user1 is included because they committed
         participants = release_summary.get_participants_with_group_subscription_reason()[

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -165,7 +165,18 @@ class GetSentToReleaseMembersTest(TestCase):
     def test_default_committer(self, spy_get_release_committers):
         event = self.store_event("empty.lol")
         event.group = self.group
-        assert self.get_send_to_release_members(event) == {ExternalProviders.EMAIL: {self.user}}
+        with self.feature("organizations:active-release-notification-opt-in"):
+            assert self.get_send_to_release_members(event) == {ExternalProviders.EMAIL: {self.user}}
+            assert spy_get_release_committers.call_count == 1
+
+    @mock.patch(
+        "sentry.notifications.utils.participants.get_release_committers",
+        wraps=get_release_committers,
+    )
+    def test_flag_off_should_no_release_members(self, spy_get_release_committers):
+        event = self.store_event("empty.lol")
+        event.group = self.group
+        assert not self.get_send_to_release_members(event)
         assert spy_get_release_committers.call_count == 1
 
 

--- a/tests/sentry/tasks/test_release_summary.py
+++ b/tests/sentry/tasks/test_release_summary.py
@@ -48,6 +48,15 @@ class SendReleaseSummaryTest(ActivityTestCase):
         "sentry.notifications.notifications.activity.release_summary.ReleaseSummaryActivityNotification.send"
     )
     def test_simple(self, mock_release_summary_send):
-        prepare_release_summary()
+        with self.feature("organizations:active-release-notification-opt-in"):
+            prepare_release_summary()
 
         assert len(mock_release_summary_send.mock_calls) == 1
+
+    @patch(
+        "sentry.notifications.notifications.activity.release_summary.ReleaseSummaryActivityNotification.send"
+    )
+    def test_without_feature_flag(self, mock_release_summary_send):
+        prepare_release_summary()
+
+        assert not mock_release_summary_send.mock_calls


### PR DESCRIPTION
This PR does two things:
1. Reverts the commit that removed the `organizations:active-release-notification-opt-in` feature flag. We still need this since we wanna disable `organizations:active-release-monitor-alpha`.
2. Injects the appropriate NotificationSetting when the user is apart of `organizations:active-release-notification-opt-in` 

We have a mess of overlapping feature flagging going on in release notifications which was causing release notifications to not be sent out when this [PR](https://github.com/getsentry/sentry/pull/36993) hit master (the PR introduced NotificationSettings which will be off by default for release notifications).