### PR TITLE
ref(ui): Show disabled save search button in searcbar

### DIFF
--- a/static/app/components/smartSearchBar/actions.tsx
+++ b/static/app/components/smartSearchBar/actions.tsx
@@ -144,19 +144,32 @@ export function makeSaveSearchAction({sort}: SaveSearchActionOpts) {
 
     return (
       <Access organization={organization} access={['org:write']}>
-        {menuItemVariant ? (
-          <MenuItem withBorder icon={<IconAdd size="xs" />} onClick={onClick}>
-            {t('Create Saved Search')}
-          </MenuItem>
-        ) : (
-          <ActionButton
-            onClick={onClick}
-            data-test-id="save-current-search"
-            icon={<IconAdd size="xs" />}
-            title={t('Add to organization saved searches')}
-            aria-label={t('Add to organization saved searches')}
-          />
-        )}
+        {({hasAccess}) => {
+          const title = hasAccess
+            ? t('Add to organization saved searches')
+            : t('You do not have permission to create a saved search');
+
+          return menuItemVariant ? (
+            <MenuItem
+              onClick={onClick}
+              disabled={!hasAccess}
+              icon={<IconAdd size="xs" />}
+              title={!hasAccess ? title : undefined}
+              withBorder
+            >
+              {t('Create Saved Search')}
+            </MenuItem>
+          ) : (
+            <ActionButton
+              onClick={onClick}
+              disabled={!hasAccess}
+              icon={<IconAdd size="xs" />}
+              title={title}
+              aria-label={title}
+              data-test-id="save-current-search"
+            />
+          );
+        }}
       </Access>
     );
   };


### PR DESCRIPTION
I was trying to figure out how to save a search. Should help users

Before 
![image](https://user-images.githubusercontent.com/1421724/184023420-fc83604c-a0fb-4a13-a4a9-313089c0bc0c.png)

After
<img width="800" alt="image" src="https://user-images.githubusercontent.com/1421724/184024815-b26293b9-7a51-452f-b270-c80723670124.png">
