### PR TITLE
ref(issues): Turn sort option tooltips into details text

### DIFF
--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -13,20 +13,20 @@ type Props = {
 function getSortTooltip(key: IssueSortOptions) {
   switch (key) {
     case IssueSortOptions.INBOX:
-      return t('When the issue was flagged for review.');
+      return t('When issue was flagged for review.');
     case IssueSortOptions.NEW:
-      return t('When the issue was first seen in the selected time period.');
+      return t('First time the issue occurred.');
     case IssueSortOptions.PRIORITY:
-      return t('Issues trending upward recently.');
+      return t('Recent issues trending upward.');
     case IssueSortOptions.FREQ:
-      return t('Number of events in the time selected.');
+      return t('Number of events.');
     case IssueSortOptions.USER:
-      return t('Number of users affected in the time selected.');
+      return t('Number of users affected.');
     case IssueSortOptions.TREND:
-      return t('% change in event count over the time selected.');
+      return t('% change in event count.');
     case IssueSortOptions.DATE:
     default:
-      return t('When the issue was last seen in the selected time period.');
+      return t('Last time the issue occurred.');
   }
 }
 
@@ -38,7 +38,7 @@ function getSortOptions(sortKeys: IssueSortOptions[], hasTrendSort = false) {
   return combinedSortKeys.map(key => ({
     value: key,
     label: getSortLabel(key),
-    tooltip: getSortTooltip(key),
+    details: getSortTooltip(key),
   }));
 }
 


### PR DESCRIPTION
With shorter descriptions from @doralchan.

**Before:**
<img width="237" alt="Screen Shot 2022-08-10 at 2 39 43 PM" src="https://user-images.githubusercontent.com/44172267/184025282-34058e7e-7cdf-4ad7-9746-1e2d297ea5a6.png">


**After:**
<img width="248" alt="Screen Shot 2022-08-10 at 2 39 58 PM" src="https://user-images.githubusercontent.com/44172267/184025315-3dd5c630-c0de-40f8-8ff8-28617eb74ad4.png">
