### PR TITLE
feat(hybrid-cloud): Introduce system.region-api-url-template

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -177,3 +177,11 @@ def generate_organization_url(org_slug: str) -> str:
     if not org_url_template:
         return options.get("system.url-prefix")
     return org_url_template.replace("{hostname}", generate_organization_hostname(org_slug))
+
+
+def generate_region_url() -> str:
+    region_url_template = options.get("system.region-api-url-template")
+    region = options.get("system.region") or None
+    if not region_url_template or not region:
+        return options.get("system.url-prefix")
+    return region_url_template.replace("{region}", region)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -33,6 +33,9 @@ register(
 register(
     "system.organization-url-template", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE
 )
+register(
+    "system.region-api-url-template", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE
+)
 register("system.region", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_NOSTORE)
 register("system.root-api-key", flags=FLAG_PRIORITIZE_DISK)
 register("system.logging-format", default=LoggingFormat.HUMAN, flags=FLAG_NOSTORE)

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -150,6 +150,7 @@ def pytest_configure(config):
             "system.base-hostname": "testserver",
             "system.organization-base-hostname": "{slug}.{region}.testserver",
             "system.organization-url-template": "http://{hostname}",
+            "system.region-api-url-template": "http://{region}.testserver",
             "system.region": "us",
             "system.secret-key": "a" * 52,
             "slack.client-id": "slack-client-id",

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -212,8 +212,11 @@ def get_client_config(request=None):
         "enableAnalytics": settings.ENABLE_ANALYTICS,
         "validateSUForm": getattr(settings, "VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON", False),
         "sentryUrl": options.get("system.url-prefix"),
-        "organizationUrl": generate_organization_url(last_org_slug) if last_org_slug else None,
-        "regionUrl": generate_region_url() if last_org_slug else None,
+        "links": {
+            "organizationUrl": generate_organization_url(last_org_slug) if last_org_slug else None,
+            "regionUrl": generate_region_url() if last_org_slug else None,
+            "sentryUrl": options.get("system.url-prefix"),
+        },
     }
     if user and user.is_authenticated:
         context.update(

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -211,7 +211,6 @@ def get_client_config(request=None):
         "demoMode": settings.DEMO_MODE,
         "enableAnalytics": settings.ENABLE_ANALYTICS,
         "validateSUForm": getattr(settings, "VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON", False),
-        "sentryUrl": options.get("system.url-prefix"),
         "links": {
             "organizationUrl": generate_organization_url(last_org_slug) if last_org_slug else None,
             "regionUrl": generate_region_url() if last_org_slug else None,

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -9,7 +9,7 @@ import sentry
 from sentry import features, options
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
-from sentry.api.utils import generate_organization_url
+from sentry.api.utils import generate_organization_url, generate_region_url
 from sentry.auth.access import get_cached_organization_member
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import Organization, OrganizationMember, ProjectKey
@@ -213,6 +213,7 @@ def get_client_config(request=None):
         "validateSUForm": getattr(settings, "VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON", False),
         "sentryUrl": options.get("system.url-prefix"),
         "organizationUrl": generate_organization_url(last_org_slug) if last_org_slug else None,
+        "regionUrl": generate_region_url() if last_org_slug else None,
     }
     if user and user.is_authenticated:
         context.update(

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -142,7 +142,6 @@ class ClientConfigViewTest(TestCase):
         assert not data["isAuthenticated"]
         assert data["user"] is None
         assert data["lastOrganization"] is None
-        assert data["sentryUrl"] == "http://testserver"
         assert data["links"] == {
             "organizationUrl": None,
             "regionUrl": None,
@@ -167,7 +166,6 @@ class ClientConfigViewTest(TestCase):
 
         assert data["isAuthenticated"] is True
         assert data["lastOrganization"] == self.organization.slug
-        assert data["sentryUrl"] == "http://testserver"
         assert data["links"] == {
             "organizationUrl": f"http://{self.organization.slug}.us.testserver",
             "regionUrl": "http://us.testserver",
@@ -193,7 +191,6 @@ class ClientConfigViewTest(TestCase):
 
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
-            assert data["sentryUrl"] == "http://testserver"
             assert data["links"] == {
                 "organizationUrl": f"http://{self.organization.slug}.eu.testserver",
                 "regionUrl": "http://eu.testserver",
@@ -219,7 +216,6 @@ class ClientConfigViewTest(TestCase):
 
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
-            assert data["sentryUrl"] == "http://testserver"
             assert data["links"] == {
                 "organizationUrl": "http://testserver",
                 "regionUrl": "http://us.testserver",
@@ -235,7 +231,6 @@ class ClientConfigViewTest(TestCase):
 
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
-            assert data["sentryUrl"] == "http://testserver"
             assert data["links"] == {
                 "organizationUrl": f"http://us.{self.organization.slug}.testserver",
                 "regionUrl": "http://us.testserver",
@@ -261,7 +256,6 @@ class ClientConfigViewTest(TestCase):
 
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
-            assert data["sentryUrl"] == "http://testserver"
             assert data["links"] == {
                 "organizationUrl": "invalid",
                 "regionUrl": "http://us.testserver",
@@ -277,7 +271,6 @@ class ClientConfigViewTest(TestCase):
 
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
-            assert data["sentryUrl"] == "http://testserver"
             assert data["links"] == {
                 "organizationUrl": "http://testserver",
                 "regionUrl": "http://us.testserver",
@@ -293,7 +286,6 @@ class ClientConfigViewTest(TestCase):
 
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
-            assert data["sentryUrl"] == "http://testserver"
             assert data["links"] == {
                 "organizationUrl": f"ftp://{self.organization.slug}.us.testserver",
                 "regionUrl": "http://us.testserver",
@@ -431,7 +423,6 @@ class ClientConfigViewTest(TestCase):
 
         assert data["isAuthenticated"] is True
         assert data["lastOrganization"] is None
-        assert data["sentryUrl"] == "http://testserver"
         assert data["links"] == {
             "organizationUrl": None,
             "regionUrl": None,
@@ -457,7 +448,6 @@ class ClientConfigViewTest(TestCase):
 
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
-            assert data["sentryUrl"] == "http://testserver"
             assert data["links"] == {
                 "organizationUrl": f"http://{self.organization.slug}.us.testserver",
                 "regionUrl": "http://foobar.us.testserver",

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -143,8 +143,11 @@ class ClientConfigViewTest(TestCase):
         assert data["user"] is None
         assert data["lastOrganization"] is None
         assert data["sentryUrl"] == "http://testserver"
-        assert data["organizationUrl"] is None
-        assert data["regionUrl"] is None
+        assert data["links"] == {
+            "organizationUrl": None,
+            "regionUrl": None,
+            "sentryUrl": "http://testserver",
+        }
 
     def test_links_authenticated(self):
         self.login_as(self.user)
@@ -165,8 +168,11 @@ class ClientConfigViewTest(TestCase):
         assert data["isAuthenticated"] is True
         assert data["lastOrganization"] == self.organization.slug
         assert data["sentryUrl"] == "http://testserver"
-        assert data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
-        assert data["regionUrl"] == "http://us.testserver"
+        assert data["links"] == {
+            "organizationUrl": f"http://{self.organization.slug}.us.testserver",
+            "regionUrl": "http://us.testserver",
+            "sentryUrl": "http://testserver",
+        }
 
     def test_organization_url_region(self):
         self.login_as(self.user)
@@ -188,8 +194,11 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == f"http://{self.organization.slug}.eu.testserver"
-            assert data["regionUrl"] == "http://eu.testserver"
+            assert data["links"] == {
+                "organizationUrl": f"http://{self.organization.slug}.eu.testserver",
+                "regionUrl": "http://eu.testserver",
+                "sentryUrl": "http://testserver",
+            }
 
     def test_organization_url_organization_base_hostname(self):
         self.login_as(self.user)
@@ -211,7 +220,11 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == "http://testserver"
+            assert data["links"] == {
+                "organizationUrl": "http://testserver",
+                "regionUrl": "http://us.testserver",
+                "sentryUrl": "http://testserver",
+            }
 
         with self.options({"system.organization-base-hostname": "{region}.{slug}.testserver"}):
             resp = self.client.get(self.path)
@@ -223,8 +236,11 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == f"http://us.{self.organization.slug}.testserver"
-            assert data["regionUrl"] == "http://us.testserver"
+            assert data["links"] == {
+                "organizationUrl": f"http://us.{self.organization.slug}.testserver",
+                "regionUrl": "http://us.testserver",
+                "sentryUrl": "http://testserver",
+            }
 
     def test_organization_url_organization_url_template(self):
         self.login_as(self.user)
@@ -246,7 +262,11 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == "invalid"
+            assert data["links"] == {
+                "organizationUrl": "invalid",
+                "regionUrl": "http://us.testserver",
+                "sentryUrl": "http://testserver",
+            }
 
         with self.options({"system.organization-url-template": None}):
             resp = self.client.get(self.path)
@@ -258,7 +278,11 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == "http://testserver"
+            assert data["links"] == {
+                "organizationUrl": "http://testserver",
+                "regionUrl": "http://us.testserver",
+                "sentryUrl": "http://testserver",
+            }
 
         with self.options({"system.organization-url-template": "ftp://{hostname}"}):
             resp = self.client.get(self.path)
@@ -270,7 +294,11 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == f"ftp://{self.organization.slug}.us.testserver"
+            assert data["links"] == {
+                "organizationUrl": f"ftp://{self.organization.slug}.us.testserver",
+                "regionUrl": "http://us.testserver",
+                "sentryUrl": "http://testserver",
+            }
 
     def test_deleted_last_organization(self):
         self.login_as(self.user)
@@ -404,7 +432,11 @@ class ClientConfigViewTest(TestCase):
         assert data["isAuthenticated"] is True
         assert data["lastOrganization"] is None
         assert data["sentryUrl"] == "http://testserver"
-        assert data["organizationUrl"] is None
+        assert data["links"] == {
+            "organizationUrl": None,
+            "regionUrl": None,
+            "sentryUrl": "http://testserver",
+        }
 
     def test_region_api_url_template(self):
         self.login_as(self.user)
@@ -426,5 +458,8 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["sentryUrl"] == "http://testserver"
-            assert data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
-            assert data["regionUrl"] == "http://foobar.us.testserver"
+            assert data["links"] == {
+                "organizationUrl": f"http://{self.organization.slug}.us.testserver",
+                "regionUrl": "http://foobar.us.testserver",
+                "sentryUrl": "http://testserver",
+            }


### PR DESCRIPTION
This pull request introduces the `regionUrl` concept:

- Introduce `system.region-api-url-template` option. Potential value for this is `"http://{region}.dev.getsentry.net:8000"` or `"https://{region}.sentry.io"`
- Introduce `generate_region_url()` that will generate `regionUrl` such as `us.sentry.io`.
- Propagate `regionUrl` to the client config if an active org exists for a given request instance.