### PR TITLE
feat(hybrid-cloud): Add regionUrl to organizationSummary

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -19,7 +19,7 @@ from sentry.api.serializers.models.role import (
     TeamRoleSerializer,
 )
 from sentry.api.serializers.models.team import TeamSerializerResponse
-from sentry.api.utils import generate_organization_url
+from sentry.api.utils import generate_organization_url, generate_region_url
 from sentry.app import quotas
 from sentry.auth.access import Access
 from sentry.constants import (
@@ -151,6 +151,7 @@ class OrganizationSerializerResponse(TypedDict):
     dateCreated: datetime
     isEarlyAdopter: bool
     organizationUrl: str
+    regionUrl: str
     require2FA: bool
     requireEmailVerification: bool
     avatar: Any  # TODO replace with Avatar
@@ -246,6 +247,7 @@ class OrganizationSerializer(Serializer):  # type: ignore
             "dateCreated": obj.date_added,
             "isEarlyAdopter": bool(obj.flags.early_adopter),
             "organizationUrl": generate_organization_url(obj.slug),
+            "regionUrl": generate_region_url(),
             "require2FA": bool(obj.flags.require_2fa),
             "requireEmailVerification": bool(
                 features.has("organizations:required-email-verification", obj)

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -143,6 +143,11 @@ class _Status(TypedDict):
     name: str
 
 
+class _Links(TypedDict):
+    organizationUrl: str
+    regionUrl: str
+
+
 class OrganizationSerializerResponse(TypedDict):
     id: str
     slug: str
@@ -150,12 +155,11 @@ class OrganizationSerializerResponse(TypedDict):
     name: str
     dateCreated: datetime
     isEarlyAdopter: bool
-    organizationUrl: str
-    regionUrl: str
     require2FA: bool
     requireEmailVerification: bool
     avatar: Any  # TODO replace with Avatar
     features: Any  # TODO
+    links: _Links
 
 
 @register(Organization)
@@ -246,8 +250,6 @@ class OrganizationSerializer(Serializer):  # type: ignore
             "name": obj.name or obj.slug,
             "dateCreated": obj.date_added,
             "isEarlyAdopter": bool(obj.flags.early_adopter),
-            "organizationUrl": generate_organization_url(obj.slug),
-            "regionUrl": generate_region_url(),
             "require2FA": bool(obj.flags.require_2fa),
             "requireEmailVerification": bool(
                 features.has("organizations:required-email-verification", obj)
@@ -255,6 +257,10 @@ class OrganizationSerializer(Serializer):  # type: ignore
             ),
             "avatar": avatar,
             "features": feature_list,
+            "links": {
+                "organizationUrl": generate_organization_url(obj.slug),
+                "regionUrl": generate_region_url(),
+            },
         }
 
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -58,7 +58,10 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         response = self.get_success_response(self.organization.slug)
 
         assert response.data["slug"] == self.organization.slug
-        assert response.data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
+        assert response.data["links"] == {
+            "organizationUrl": f"http://{self.organization.slug}.us.testserver",
+            "regionUrl": "http://us.testserver",
+        }
         assert response.data["onboardingTasks"] == []
         assert response.data["id"] == str(self.organization.id)
         assert response.data["role"] == "owner"
@@ -73,7 +76,10 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         )
 
         assert response.data["slug"] == self.organization.slug
-        assert response.data["organizationUrl"] == f"http://{self.organization.slug}.us.testserver"
+        assert response.data["links"] == {
+            "organizationUrl": f"http://{self.organization.slug}.us.testserver",
+            "regionUrl": "http://us.testserver",
+        }
         assert response.data["onboardingTasks"] == []
         assert response.data["id"] == str(self.organization.id)
         assert response.data["role"] == "owner"


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/37690

-----

This pull request adds `regionUrl` to the `organizationSummary`. 

Organizations that are opted into the customer domain feature will consume `regionUrl` for API endpoint fetches on the frontend app.

In addition, I've collected `organizationUrl` and `regionUrl` together as a `links` dictionary.