### PR TITLE
fix(profiling): fix margin on toolbar

### DIFF
--- a/static/app/components/profiling/flamegraphToolbar.tsx
+++ b/static/app/components/profiling/flamegraphToolbar.tsx
@@ -10,6 +10,6 @@ export const FlamegraphToolbar = styled('div')<FlamegraphToolbarProps>`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: ${space(1)} ${space(4)};
+  margin: ${space(1)};
   gap: ${space(1)};
 `;


### PR DESCRIPTION
Smaller margin on toolbar gives us a bit more space and it aligns well when table is set left/right. It is slightly wider than the title above, but given that content below it is spanning full width, I think it works as a nice progressive step towards that

<img width="657" alt="CleanShot 2022-08-11 at 08 58 53@2x" src="https://user-images.githubusercontent.com/9317857/184139205-dbb36abc-71bb-4533-93bb-42a87e12b9d9.png">
