### PR TITLE
feat(sampling): Add alert to the stats [TET-329]

### DIFF
--- a/static/app/utils/analytics/samplingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/samplingAnalyticsEvents.tsx
@@ -100,7 +100,6 @@ export type SamplingEventParameters = {
   'sampling.settings.view_read_docs': {
     project_id: string;
   };
-  'sampling.stats.alert.click': {};
 };
 
 type SamplingAnalyticsKey = keyof SamplingEventParameters;
@@ -144,5 +143,4 @@ export const samplingEventMap: Record<SamplingAnalyticsKey, string> = {
   'sampling.settings.view': 'View sampling settings',
   'sampling.settings.view_get_started': 'Get started with sampling',
   'sampling.settings.view_read_docs': 'Read sampling docs', // fired for all read docs buttons
-  'sampling.stats.alert.click': 'Go to server-side sampling settings from stats',
 };

--- a/static/app/utils/analytics/samplingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/samplingAnalyticsEvents.tsx
@@ -100,6 +100,7 @@ export type SamplingEventParameters = {
   'sampling.settings.view_read_docs': {
     project_id: string;
   };
+  'sampling.stats.alert.click': {};
 };
 
 type SamplingAnalyticsKey = keyof SamplingEventParameters;
@@ -143,4 +144,5 @@ export const samplingEventMap: Record<SamplingAnalyticsKey, string> = {
   'sampling.settings.view': 'View sampling settings',
   'sampling.settings.view_get_started': 'Get started with sampling',
   'sampling.settings.view_read_docs': 'Read sampling docs', // fired for all read docs buttons
+  'sampling.stats.alert.click': 'Go to server-side sampling settings from stats',
 };

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -6,6 +6,9 @@ import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 import moment from 'moment';
 
+import {navigateTo} from 'sentry/actionCreators/navigation';
+import Feature from 'sentry/components/acl/feature';
+import Alert from 'sentry/components/alert';
 import {DateTimeObject} from 'sentry/components/charts/utils';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import CompactSelect from 'sentry/components/forms/compactSelect';
@@ -21,10 +24,11 @@ import {
   DEFAULT_RELATIVE_PERIODS,
   DEFAULT_STATS_PERIOD,
 } from 'sentry/constants';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {DataCategory, DateString, Organization, Project} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import withOrganization from 'sentry/utils/withOrganization';
 import HeaderTabs from 'sentry/views/organizationStats/header';
 
@@ -182,6 +186,21 @@ export class OrganizationStats extends Component<Props> {
     });
   };
 
+  navigateToSamplingSettings = (e: React.MouseEvent) => {
+    e.preventDefault?.();
+
+    const {organization, router} = this.props;
+
+    trackAdvancedAnalyticsEvent('sampling.stats.alert.click', {
+      organization,
+    });
+
+    navigateTo(
+      `/settings/${organization.slug}/projects/:projectId/server-side-sampling/`,
+      router
+    );
+  };
+
   /**
    * TODO: Enable user to set dateStart/dateEnd
    *
@@ -290,6 +309,23 @@ export class OrganizationStats extends Component<Props> {
                   />
                 </ErrorBoundary>
               </PageGrid>
+
+              <Feature
+                features={['server-side-sampling', 'server-side-sampling-ui']}
+                organization={organization}
+              >
+                {this.dataCategory === DataCategory.TRANSACTIONS && (
+                  <Alert type="info" showIcon>
+                    {tct(
+                      'Manage your transaction usage in Server-Side Sampling. Go to [link: Server-Side Sampling Settings].',
+                      {
+                        link: <a href="#" onClick={this.navigateToSamplingSettings} />,
+                      }
+                    )}
+                  </Alert>
+                )}
+              </Feature>
+
               <ErrorBoundary mini>
                 <UsageStatsProjects
                   organization={organization}

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -28,7 +28,6 @@ import {t, tct} from 'sentry/locale';
 import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {DataCategory, DateString, Organization, Project} from 'sentry/types';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import withOrganization from 'sentry/utils/withOrganization';
 import HeaderTabs from 'sentry/views/organizationStats/header';
 
@@ -191,12 +190,8 @@ export class OrganizationStats extends Component<Props> {
 
     const {organization, router} = this.props;
 
-    trackAdvancedAnalyticsEvent('sampling.stats.alert.click', {
-      organization,
-    });
-
     navigateTo(
-      `/settings/${organization.slug}/projects/:projectId/server-side-sampling/`,
+      `/settings/${organization.slug}/projects/:projectId/server-side-sampling/?referrer=org-stats.alert`,
       router
     );
   };

--- a/tests/js/spec/views/organizationStats/index.spec.jsx
+++ b/tests/js/spec/views/organizationStats/index.spec.jsx
@@ -364,6 +364,29 @@ describe('OrganizationStats', function () {
       },
     });
   });
+
+  it('displays sampling alert', function () {
+    const {organization: orgWithSampling} = initializeOrg({
+      organization: {features: ['server-side-sampling', 'server-side-sampling-ui']},
+      router,
+    });
+    const wrapper = mountWithTheme(
+      <OrganizationStats
+        organization={orgWithSampling}
+        location={{
+          query: {
+            dataCategory: DataCategory.TRANSACTIONS,
+          },
+        }}
+        router={router}
+      />,
+      routerContext
+    );
+
+    expect(wrapper.text()).toContain(
+      'Manage your transaction usage in Server-Side Sampling'
+    );
+  });
 });
 
 function getMockResponse() {


### PR DESCRIPTION
https://user-images.githubusercontent.com/9060071/184140846-1d3b0f77-20f2-48f8-8450-bfbb0beb01b9.mp4

The reasoning behind this change: https://getsentry.atlassian.net/browse/TET-329

The alert will be visible only for organizations opted in the Limited Availability program of Dynamic Sampling.