### PR TITLE
fix(replays): Remove "paint" type spans

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -37,7 +37,7 @@ function ReplayTimeline({}: Props) {
   const spans = replay.getRawSpans() || [];
   const userCrumbs = crumbs.filter(crumb => USER_ACTIONS.includes(crumb.type));
 
-  const networkSpans = spans.filter(replay.isNotMemoryNorWebVitalSpan);
+  const networkSpans = spans.filter(replay.isNetworkSpan);
 
   return (
     <Panel>

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -37,7 +37,7 @@ function ReplayTimeline({}: Props) {
   const spans = replay.getRawSpans() || [];
   const userCrumbs = crumbs.filter(crumb => USER_ACTIONS.includes(crumb.type));
 
-  const networkSpans = spans.filter(replay.isNotMemorySpan);
+  const networkSpans = spans.filter(replay.isNotMemoryNorWebVitalSpan);
 
   return (
     <Panel>

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -163,7 +163,7 @@ export default class ReplayReader {
     return span.op === 'memory';
   };
 
-  isNotMemorySpan = (span: ReplaySpan) => {
-    return !this.isMemorySpan(span);
+  isNotMemoryNorWebVitalSpan = (span: ReplaySpan) => {
+    return !this.isMemorySpan(span) && !span.op.includes('paint');
   };
 }

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -163,7 +163,7 @@ export default class ReplayReader {
     return span.op === 'memory';
   };
 
-  isNotMemoryNorWebVitalSpan = (span: ReplaySpan) => {
+  isNetworkSpan = (span: ReplaySpan) => {
     return !this.isMemorySpan(span) && !span.op.includes('paint');
   };
 }

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -44,7 +44,7 @@ function FocusArea({}: Props) {
   const startTimestampMs = replayRecord.startedAt.getTime();
 
   const getNetworkSpans = () => {
-    return replay.getRawSpans().filter(replay.isNotMemorySpan);
+    return replay.getRawSpans().filter(replay.isNotMemoryNorWebVitalSpan);
   };
 
   switch (getActiveTab()) {

--- a/static/app/views/replays/detail/focusArea.tsx
+++ b/static/app/views/replays/detail/focusArea.tsx
@@ -44,7 +44,7 @@ function FocusArea({}: Props) {
   const startTimestampMs = replayRecord.startedAt.getTime();
 
   const getNetworkSpans = () => {
-    return replay.getRawSpans().filter(replay.isNotMemoryNorWebVitalSpan);
+    return replay.getRawSpans().filter(replay.isNetworkSpan);
   };
 
   switch (getActiveTab()) {


### PR DESCRIPTION

<!-- Describe your PR here. -->
Removed Spans that have anything to do with "paint", for the timeline and network table. Closes #37122


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
