### PR TITLE
fix(replays): SplitPanel conditional handlers

### DIFF
--- a/static/app/views/replays/detail/layout/splitPanel.tsx
+++ b/static/app/views/replays/detail/layout/splitPanel.tsx
@@ -197,9 +197,7 @@ function SplitPanel(props: Props) {
     onPositionChange: handlePositionChange,
   });
 
-  const activeTrackingProps = mousedown
-    ? mouseTrackingProps
-    : {ref: mouseTrackingProps.ref};
+  const activeTrackingProps = mousedown ? mouseTrackingProps : {};
 
   if ('left' in props) {
     const {left: a, right: b} = props;

--- a/static/app/views/replays/detail/layout/splitPanel.tsx
+++ b/static/app/views/replays/detail/layout/splitPanel.tsx
@@ -197,11 +197,15 @@ function SplitPanel(props: Props) {
     onPositionChange: handlePositionChange,
   });
 
+  const activeTrackingProps = mousedown
+    ? mouseTrackingProps
+    : {ref: mouseTrackingProps.ref};
+
   if ('left' in props) {
     const {left: a, right: b} = props;
 
     return (
-      <SplitPanelContainer orientation="columns" size={sizeCSS} {...mouseTrackingProps}>
+      <SplitPanelContainer orientation="columns" size={sizeCSS} {...activeTrackingProps}>
         <Panel>{getValFromSide(a, 'content') || a}</Panel>
         <Divider
           slideDirection="leftright"
@@ -214,7 +218,7 @@ function SplitPanel(props: Props) {
   }
   const {top: a, bottom: b} = props;
   return (
-    <SplitPanelContainer orientation="rows" size={sizeCSS} {...mouseTrackingProps}>
+    <SplitPanelContainer orientation="rows" size={sizeCSS} {...activeTrackingProps}>
       <Panel>{getValFromSide(a, 'content') || a}</Panel>
       <Divider
         slideDirection="updown"


### PR DESCRIPTION
### Changes
- Conditionally adds mouse event handlers to split panel if mousedown is engaged

Closes #36816 


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
