### PR TITLE
ref(mep): Only get the tag-values-are-strings option once

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1609,6 +1609,9 @@ class MetricsQueryBuilder(QueryBuilder):
         self.allow_metric_aggregates = allow_metric_aggregates
         self._indexer_cache: Dict[str, Optional[int]] = {}
         self._custom_measurement_cache: Optional[List[MetricMeta]] = None
+        self.tag_values_are_strings = options.get(
+            "sentry-metrics.performance.tags-values-are-strings"
+        )
         # Don't do any of the actions that would impact performance in anyway
         # Skips all indexer checks, and won't interact with clickhouse
         self.dry_run = dry_run
@@ -1687,9 +1690,7 @@ class MetricsQueryBuilder(QueryBuilder):
         tag_id = self.resolve_metric_index(col)
         if tag_id is None:
             raise InvalidSearchQuery(f"Unknown field: {col}")
-        if self.is_performance and options.get(
-            "sentry-metrics.performance.tags-values-are-strings"
-        ):
+        if self.is_performance and self.tag_values_are_strings:
             return f"tags_raw[{tag_id}]"
         else:
             return f"tags[{tag_id}]"
@@ -1877,9 +1878,7 @@ class MetricsQueryBuilder(QueryBuilder):
         return self._indexer_cache[value]
 
     def _resolve_tag_value(self, value: str) -> Union[int, str]:
-        if self.is_performance and options.get(
-            "sentry-metrics.performance.tags-values-are-strings"
-        ):
+        if self.is_performance and self.tag_values_are_strings:
             return value
         if self.dry_run:
             return -1

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -6,7 +6,6 @@ import sentry_sdk
 from django.utils.functional import cached_property
 from snuba_sdk import AliasedExpression, Column, Function
 
-from sentry import options
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import IncompatibleMetricsQuery, InvalidSearchQuery
 from sentry.models.transaction_threshold import (
@@ -66,9 +65,7 @@ class MetricsDatasetConfig(DatasetConfig):
         return metric_id
 
     def resolve_tag_value(self, value: str) -> Union[str, int]:
-        if self.builder.is_performance and options.get(
-            "sentry-metrics.performance.tags-values-are-strings"
-        ):
+        if self.builder.is_performance and self.builder.tag_values_are_strings:
             return value
         return self.resolve_value(value)
 


### PR DESCRIPTION
- This fixes a performance problem where we're doing this once per tag
  value in a query, which can be very expensive when
  team_key_transactions are involved
eg. 
![image](https://user-images.githubusercontent.com/4205004/184159685-13b3abc6-175b-4d42-b26f-8ede3c0b51e0.png)
