### PR TITLE
chore(auth): Add hasAuthProvider to OrganizationSummary

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -172,9 +172,15 @@ class OrganizationSerializer(Serializer):  # type: ignore
             a.organization_id: a
             for a in OrganizationAvatar.objects.filter(organization__in=item_list)
         }
+        auth_providers = {
+            a.organization_id: a for a in AuthProvider.objects.filter(organization__in=item_list)
+        }
         data: MutableMapping[Organization, MutableMapping[str, Any]] = {}
         for item in item_list:
-            data[item] = {"avatar": avatars.get(item.id)}
+            data[item] = {
+                "avatar": avatars.get(item.id),
+                "auth_provider": auth_providers.get(item.id, None),
+            }
         return data
 
     def serialize(
@@ -244,7 +250,7 @@ class OrganizationSerializer(Serializer):  # type: ignore
         if "server-side-sampling" not in feature_list and "mep-rollout-flag" in feature_list:
             feature_list.remove("mep-rollout-flag")
 
-        has_auth_provider = AuthProvider.objects.filter(organization=obj).exists()
+        has_auth_provider = attrs.get("auth_provider", None) is not None
 
         return {
             "id": str(obj.id),

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -41,6 +41,7 @@ from sentry.constants import (
 from sentry.lang.native.utils import convert_crashreport_count
 from sentry.models import (
     ApiKey,
+    AuthProvider,
     Organization,
     OrganizationAccessRequest,
     OrganizationAvatar,
@@ -159,6 +160,7 @@ class OrganizationSerializerResponse(TypedDict):
     avatar: Any  # TODO replace with Avatar
     features: Any  # TODO
     links: _Links
+    hasAuthProvider: bool
 
 
 @register(Organization)
@@ -242,6 +244,8 @@ class OrganizationSerializer(Serializer):  # type: ignore
         if "server-side-sampling" not in feature_list and "mep-rollout-flag" in feature_list:
             feature_list.remove("mep-rollout-flag")
 
+        has_auth_provider = AuthProvider.objects.filter(organization=obj).exists()
+
         return {
             "id": str(obj.id),
             "slug": obj.slug,
@@ -260,6 +264,7 @@ class OrganizationSerializer(Serializer):  # type: ignore
                 "organizationUrl": generate_organization_url(obj.slug),
                 "regionUrl": generate_region_url(),
             },
+            "hasAuthProvider": has_auth_provider,
         }
 
 

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -120,7 +120,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         )
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 35
+        expected_queries = 36
 
         # TODO(mgaeta): Extra query while we're "dual reading" from UserOptions and NotificationSettings.
         expected_queries += 1
@@ -215,6 +215,15 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             # check that created is in the correct range
             created = parse_date(response_data[i]["created"])
             assert start_time < created < end_time
+
+    def test_has_auth_provider(self):
+        response = self.get_success_response(self.organization.slug)
+        assert response.data["hasAuthProvider"] is False
+
+        AuthProvider.objects.create(organization=self.organization, provider="dummy")
+
+        response = self.get_success_response(self.organization.slug)
+        assert response.data["hasAuthProvider"] is True
 
 
 class OrganizationUpdateTest(OrganizationDetailsTestBase):


### PR DESCRIPTION
I'm adding `hasAuthProvider` here so that I can remove this hack in the future: https://github.com/getsentry/sentry/blob/2fa5658c1c15de6ccde3c7e5b461f46aaad96fc2/static/app/views/settings/organizationAuth/index.tsx#L31-L34

The routing hack above doesn't work reliably, and in Chrome, pressing the back button doesn't lead back to the React app.

I aim to link the "Auth" navigation link on the org settings page directly to `/organizations/orgslug/auth/configure/` whenever `hasAuthProvider` is `true`.