### PR TITLE
ref(metrics): Split caching out of indexers, random test refactoring [sns-1606]

### DIFF
--- a/src/sentry/sentry_metrics/indexer/base.py
+++ b/src/sentry/sentry_metrics/indexer/base.py
@@ -203,6 +203,38 @@ class StringIndexer(Service):
     def bulk_record(
         self, use_case_id: UseCaseKey, org_strings: Mapping[int, Set[str]]
     ) -> KeyResults:
+        """
+        Takes in a mapping with org_ids to sets of strings.
+
+        Ultimately returns a mapping of those org_ids to a
+        string -> id mapping, for each string in the set.
+
+        There are three steps to getting the ids for strings:
+            0. ids from static strings (StaticStringIndexer)
+            1. ids from cache (CachingIndexer)
+            2. ids from existing db records (postgres/spanner)
+            3. ids that have been rate limited (postgres/spanner)
+            4. ids from newly created db records (postgres/spanner)
+
+        Each step will start off with a KeyCollection and KeyResults:
+            keys = KeyCollection(mapping)
+            key_results = KeyResults()
+
+        Then the work to get the ids (either from cache, db, etc)
+            .... # work to add results to KeyResults()
+
+        Those results will be added to `mapped_results` which can
+        be retrieved
+            key_results.get_mapped_results()
+
+        Remaining unmapped keys get turned into a new
+        KeyCollection for the next step:
+            new_keys = key_results.get_unmapped_keys(mapping)
+
+        When the last step is reached or a step resolves all the remaining
+        unmapped keys the key_results objects are merged and returned:
+            e.g. return cache_key_results.merge(db_read_key_results)
+        """
         raise NotImplementedError()
 
     def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -1,13 +1,26 @@
 import logging
 import random
-from typing import Mapping, MutableMapping, Optional, Sequence
+from typing import Mapping, MutableMapping, Optional, Sequence, Set
 
 from django.conf import settings
 from django.core.cache import caches
 
+from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.sentry_metrics.indexer.base import (
+    FetchType,
+    KeyCollection,
+    KeyResult,
+    KeyResults,
+    StringIndexer,
+)
+from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
 
 logger = logging.getLogger(__name__)
+
+_INDEXER_CACHE_METRIC = "sentry_metrics.indexer.memcache"
+# only used to compare to the older version of the PGIndexer
+_INDEXER_CACHE_FETCH_METRIC = "sentry_metrics.indexer.memcache.fetch"
 
 
 class StringIndexerCache:
@@ -82,3 +95,77 @@ class StringIndexerCache:
     def delete_many(self, keys: Sequence[str], cache_namespace: str) -> None:
         cache_keys = [self.make_cache_key(key, cache_namespace) for key in keys]
         self.cache.delete_many(cache_keys, version=self.version)
+
+
+class CachingIndexer(StringIndexer):
+    def __init__(self, cache: StringIndexerCache, indexer: StringIndexer) -> None:
+        self.cache = cache
+        self.indexer = indexer
+
+    def bulk_record(
+        self, use_case_id: UseCaseKey, org_strings: Mapping[int, Set[str]]
+    ) -> KeyResults:
+        cache_keys = KeyCollection(org_strings)
+        metrics.gauge("sentry_metrics.indexer.lookups_per_batch", value=cache_keys.size)
+        cache_key_strs = cache_keys.as_strings()
+        cache_results = self.cache.get_many(cache_key_strs, use_case_id.value)
+
+        hits = [k for k, v in cache_results.items() if v is not None]
+        metrics.incr(
+            _INDEXER_CACHE_METRIC,
+            tags={"cache_hit": "true", "caller": "get_many_ids"},
+            amount=len(hits),
+        )
+        metrics.incr(
+            _INDEXER_CACHE_METRIC,
+            tags={"cache_hit": "false", "caller": "get_many_ids"},
+            amount=len(cache_results) - len(hits),
+        )
+
+        # used to compare to pre org_id indexer cache fetch metric
+        metrics.incr(
+            _INDEXER_CACHE_FETCH_METRIC,
+            amount=cache_keys.size,
+        )
+
+        cache_key_results = KeyResults()
+        cache_key_results.add_key_results(
+            [KeyResult.from_string(k, v) for k, v in cache_results.items() if v is not None],
+            FetchType.CACHE_HIT,
+        )
+
+        db_record_keys = cache_key_results.get_unmapped_keys(cache_keys)
+
+        if db_record_keys.size == 0:
+            return cache_key_results
+
+        db_record_key_results = self.indexer.bulk_record(use_case_id, db_record_keys.mapping)
+        self.cache.set_many(
+            db_record_key_results.get_mapped_key_strings_to_ints(), use_case_id.value
+        )
+        return cache_key_results.merge(db_record_key_results)
+
+    def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
+        result = self.bulk_record(use_case_id=use_case_id, org_strings={org_id: {string}})
+        return result[org_id][string]
+
+    def resolve(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
+        key = f"{org_id}:{string}"
+        result = self.cache.get(key, use_case_id.value)
+
+        if result and isinstance(result, int):
+            metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "true", "caller": "resolve"})
+            return result
+
+        metrics.incr(_INDEXER_CACHE_METRIC, tags={"cache_hit": "false", "caller": "resolve"})
+        id = self.indexer.resolve(use_case_id, org_id, string)
+
+        if id is not None:
+            self.cache.set(key, id, use_case_id.value)
+
+        return id
+
+    def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
+        # XXX: We don't cache here at all -- never did in the original
+        # implementation either.
+        return self.indexer.reverse_resolve(use_case_id, id)

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -166,6 +166,4 @@ class CachingIndexer(StringIndexer):
         return id
 
     def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
-        # XXX: We don't cache here at all -- never did in the original
-        # implementation either.
         return self.indexer.reverse_resolve(use_case_id, id)

--- a/src/sentry/sentry_metrics/indexer/cloudspanner.py
+++ b/src/sentry/sentry_metrics/indexer/cloudspanner.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Set
+from typing import Any, Mapping, Optional, Set
 
 from django.conf import settings
 from google.cloud import spanner
@@ -83,5 +83,5 @@ class RawCloudSpannerIndexer(StringIndexer):
 
 
 class CloudSpannerIndexer(StaticStringIndexer):
-    def __init__(self, **kwargs) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(CachingIndexer(indexer_cache, RawCloudSpannerIndexer(**kwargs)))

--- a/src/sentry/sentry_metrics/indexer/mock.py
+++ b/src/sentry/sentry_metrics/indexer/mock.py
@@ -3,12 +3,18 @@ from collections import defaultdict
 from typing import DefaultDict, Dict, Mapping, Optional, Set
 
 from sentry.sentry_metrics.configuration import UseCaseKey
-from sentry.sentry_metrics.indexer.strings import REVERSE_SHARED_STRINGS, SHARED_STRINGS
+from sentry.sentry_metrics.indexer.base import (
+    FetchType,
+    KeyCollection,
+    KeyResult,
+    KeyResults,
+    StringIndexer,
+)
+from sentry.sentry_metrics.indexer.ratelimiters import writes_limiter
+from sentry.sentry_metrics.indexer.strings import StaticStringsIndexer
 
-from .base import KeyResult, KeyResults, StringIndexer
 
-
-class SimpleIndexer(StringIndexer):
+class RawSimpleIndexer(StringIndexer):
 
     """Simple indexer with in-memory store. Do not use in production."""
 
@@ -22,33 +28,56 @@ class SimpleIndexer(StringIndexer):
     def bulk_record(
         self, use_case_id: UseCaseKey, org_strings: Mapping[int, Set[str]]
     ) -> KeyResults:
-        acc = KeyResults()
+        db_read_keys = KeyCollection(org_strings)
+        db_read_key_results = KeyResults()
         for org_id, strs in org_strings.items():
-            strings_to_ints: Dict[str, Optional[int]] = {}
             for string in strs:
-                if string in SHARED_STRINGS:
-                    strings_to_ints[string] = SHARED_STRINGS[string]
-                else:
-                    strings_to_ints[string] = self._record(org_id, string)
-                acc.add_key_result(KeyResult(org_id, string, strings_to_ints[string]))
+                id = self.resolve(use_case_id, org_id, string)
+                if id is not None:
+                    db_read_key_results.add_key_result(
+                        KeyResult(org_id=org_id, string=string, id=id), fetch_type=FetchType.DB_READ
+                    )
 
-        return acc
+        db_write_keys = db_read_key_results.get_unmapped_keys(db_read_keys)
+
+        if db_write_keys.size == 0:
+            return db_read_key_results
+
+        with writes_limiter.check_write_limits(use_case_id, db_write_keys) as writes_limiter_state:
+            # After the DB has successfully committed writes, we exit this
+            # context manager and consume quotas. If the DB crashes we
+            # shouldn't consume quota.
+            filtered_db_write_keys = writes_limiter_state.accepted_keys
+            del db_write_keys
+
+            rate_limited_key_results = KeyResults()
+            for dropped_string in writes_limiter_state.dropped_strings:
+                rate_limited_key_results.add_key_result(
+                    dropped_string.key_result,
+                    fetch_type=dropped_string.fetch_type,
+                    fetch_type_ext=dropped_string.fetch_type_ext,
+                )
+
+            if filtered_db_write_keys.size == 0:
+                return db_read_key_results.merge(rate_limited_key_results)
+
+            db_write_key_results = KeyResults()
+            for org_id, string in filtered_db_write_keys.as_tuples():
+                db_write_key_results.add_key_result(
+                    KeyResult(org_id=org_id, string=string, id=self._record(org_id, string)),
+                    fetch_type=FetchType.FIRST_SEEN,
+                )
+
+        return db_read_key_results.merge(db_write_key_results).merge(rate_limited_key_results)
 
     def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
-        if string in SHARED_STRINGS:
-            return SHARED_STRINGS[string]
         return self._record(org_id, string)
 
     def resolve(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
-        if string in SHARED_STRINGS:
-            return SHARED_STRINGS[string]
-
         strs = self._strings[org_id]
         return strs.get(string)
 
     def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
-        if id in REVERSE_SHARED_STRINGS:
-            return REVERSE_SHARED_STRINGS[id]
         return self._reverse.get(id)
 
     def _record(self, org_id: int, string: str) -> Optional[int]:
@@ -56,6 +85,11 @@ class SimpleIndexer(StringIndexer):
         if index is not None:
             self._reverse[index] = string
         return index
+
+
+class SimpleIndexer(StaticStringsIndexer):
+    def __init__(self) -> None:
+        super().__init__(RawSimpleIndexer())
 
 
 class MockIndexer(SimpleIndexer):

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -1,3 +1,14 @@
+from typing import Mapping, Optional, Set
+
+from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.sentry_metrics.indexer.base import (
+    FetchType,
+    KeyCollection,
+    KeyResult,
+    KeyResults,
+    StringIndexer,
+)
+
 # !!! DO NOT CHANGE THESE VALUES !!!
 #
 # These are hardcoded ids for the metrics indexer and if
@@ -112,3 +123,50 @@ REVERSE_SHARED_STRINGS = {v: k for k, v in SHARED_STRINGS.items()}
 
 # Make sure there are no accidental duplicates
 assert len(SHARED_STRINGS) == len(REVERSE_SHARED_STRINGS)
+
+
+class StaticStringsIndexer(StringIndexer):
+    """
+    Wrapper for static strings
+    """
+
+    def __init__(self, indexer: StringIndexer) -> None:
+        self.indexer = indexer
+
+    def bulk_record(
+        self, use_case_id: UseCaseKey, org_strings: Mapping[int, Set[str]]
+    ) -> KeyResults:
+        static_keys = KeyCollection(org_strings)
+        static_key_results = KeyResults()
+        for org_id, string in static_keys.as_tuples():
+            if string in SHARED_STRINGS:
+                id = SHARED_STRINGS[string]
+                static_key_results.add_key_result(
+                    KeyResult(org_id, string, id), FetchType.HARDCODED
+                )
+
+        org_strings_left = static_key_results.get_unmapped_keys(static_keys)
+
+        if org_strings_left.size == 0:
+            return static_key_results
+
+        indexer_results = self.indexer.bulk_record(
+            use_case_id=use_case_id, org_strings=org_strings_left.mapping
+        )
+
+        return static_key_results.merge(indexer_results)
+
+    def record(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
+        if string in SHARED_STRINGS:
+            return SHARED_STRINGS[string]
+        return self.indexer.record(use_case_id=use_case_id, org_id=org_id, string=string)
+
+    def resolve(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
+        if string in SHARED_STRINGS:
+            return SHARED_STRINGS[string]
+        return self.indexer.resolve(use_case_id=use_case_id, org_id=org_id, string=string)
+
+    def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
+        if id in REVERSE_SHARED_STRINGS:
+            return REVERSE_SHARED_STRINGS[id]
+        return self.indexer.reverse_resolve(use_case_id=use_case_id, id=id)

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -253,6 +253,9 @@ def test_rate_limited(indexer):
     control over which string gets rate-limited. That makes assertions
     quite awkward and imprecise.
     """
+    if isinstance(indexer, RawSimpleIndexer):
+        pytest.skip("mock indexer does not support rate limiting")
+
     org_strings = {1: {"a", "b", "c"}, 2: {"e", "f"}, 3: {"g"}}
 
     with override_options(

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -1,0 +1,327 @@
+"""
+Generic testsuite that runs against all productionized indexer backends.
+
+Tests static string indexer, caching string indexer in combination, plugs in
+various backends to see if their external behavior makes sense, and that e.g.
+the mock indexer actually behaves the same as the postgres indexer.
+"""
+
+from typing import Mapping, Set
+
+import pytest
+
+from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.sentry_metrics.indexer.base import FetchType, FetchTypeExt, Metadata
+from sentry.sentry_metrics.indexer.cache import CachingIndexer, StringIndexerCache
+from sentry.sentry_metrics.indexer.mock import RawSimpleIndexer
+from sentry.sentry_metrics.indexer.postgres_v2 import PGStringIndexerV2
+from sentry.sentry_metrics.indexer.static_strings import StaticStringIndexer
+from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS
+from sentry.testutils.helpers.options import override_options
+
+BACKENDS = [
+    # TODO: add cloud spanner here
+    RawSimpleIndexer,
+    pytest.param(PGStringIndexerV2, marks=pytest.mark.django_db),
+]
+
+
+@pytest.fixture(params=BACKENDS)
+def indexer_cls(request):
+    return request.param
+
+
+@pytest.fixture
+def indexer(indexer_cls):
+    return indexer_cls()
+
+
+@pytest.fixture
+def indexer_cache():
+    indexer_cache = StringIndexerCache(
+        version=1,
+        cache_name="default",
+        partition_key="test",
+    )
+
+    yield indexer_cache
+
+    indexer_cache.cache.clear()
+
+
+use_case_id = UseCaseKey("release-health")
+
+
+def assert_fetch_type_for_tag_string_set(
+    meta: Mapping[str, Metadata], fetch_type: FetchType, str_set: Set[str]
+):
+    assert all([meta[string].fetch_type == fetch_type for string in str_set])
+
+
+def test_static_and_non_static_strings(indexer):
+    static_indexer = StaticStringIndexer(indexer)
+    org_strings = {
+        2: {"release", "1.0.0"},
+        3: {"production", "environment", "release", "2.0.0"},
+    }
+    results = static_indexer.bulk_record(use_case_id=use_case_id, org_strings=org_strings)
+
+    v1 = indexer.resolve(use_case_id, 2, "1.0.0")
+    v2 = indexer.resolve(use_case_id, 3, "2.0.0")
+
+    assert results[2]["release"] == SHARED_STRINGS["release"]
+    assert results[3]["production"] == SHARED_STRINGS["production"]
+    assert results[3]["environment"] == SHARED_STRINGS["environment"]
+    assert results[3]["release"] == SHARED_STRINGS["release"]
+
+    assert results[2]["1.0.0"] == v1
+    assert results[3]["2.0.0"] == v2
+
+    meta = results.get_fetch_metadata()
+    assert_fetch_type_for_tag_string_set(meta[2], FetchType.HARDCODED, {"release"})
+    assert_fetch_type_for_tag_string_set(
+        meta[3], FetchType.HARDCODED, {"release", "production", "environment"}
+    )
+    assert_fetch_type_for_tag_string_set(meta[2], FetchType.FIRST_SEEN, {"1.0.0"})
+    assert_fetch_type_for_tag_string_set(meta[3], FetchType.FIRST_SEEN, {"2.0.0"})
+
+
+def test_indexer(indexer, indexer_cache):
+    org1_id = 1
+    org2_id = 2
+    strings = {"hello", "hey", "hi"}
+
+    raw_indexer = indexer
+    indexer = CachingIndexer(indexer_cache, indexer)
+
+    org_strings = {org1_id: strings, org2_id: {"sup"}}
+
+    # create a record with diff org_id but same string that we test against
+    indexer.record(use_case_id, 999, "hey")
+
+    assert list(
+        indexer_cache.get_many(
+            [f"{org1_id}:{string}" for string in strings],
+            cache_namespace=use_case_id.value,
+        ).values()
+    ) == [None, None, None]
+
+    results = indexer.bulk_record(use_case_id=use_case_id, org_strings=org_strings).results
+
+    org1_string_ids = {
+        raw_indexer.resolve(use_case_id, org1_id, "hello"),
+        raw_indexer.resolve(use_case_id, org1_id, "hey"),
+        raw_indexer.resolve(use_case_id, org1_id, "hi"),
+    }
+
+    assert None not in org1_string_ids
+    assert len(org1_string_ids) == 3  # no overlapping ids
+
+    org2_string_id = raw_indexer.resolve(use_case_id, org2_id, "sup")
+    assert org2_string_id not in org1_string_ids
+
+    # verify org1 results and cache values
+    for value in results[org1_id].values():
+        assert value in org1_string_ids
+
+    for cache_value in indexer_cache.get_many(
+        [f"{org1_id}:{string}" for string in strings],
+        cache_namespace=use_case_id.value,
+    ).values():
+        assert cache_value in org1_string_ids
+
+    # verify org2 results and cache values
+    assert results[org2_id]["sup"] == org2_string_id
+    assert indexer_cache.get(f"{org2_id}:sup", cache_namespace=use_case_id.value) == org2_string_id
+
+    # we should have no results for org_id 999
+    assert not results.get(999)
+
+
+def test_resolve_and_reverse_resolve(indexer, indexer_cache):
+    """
+    Test `resolve` and `reverse_resolve` methods
+    """
+
+    org1_id = 1
+    strings = {"hello", "hey", "hi"}
+
+    indexer = CachingIndexer(indexer_cache, indexer)
+
+    org_strings = {org1_id: strings}
+    indexer.bulk_record(use_case_id=use_case_id, org_strings=org_strings)
+
+    # test resolve and reverse_resolve
+    id = indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="hello")
+    assert id is not None
+    assert indexer.reverse_resolve(use_case_id=use_case_id, id=id) == "hello"
+
+    # test record on a string that already exists
+    indexer.record(use_case_id=use_case_id, org_id=org1_id, string="hello")
+    assert indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="hello") == id
+
+    # test invalid values
+    assert indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="beep") is None
+    assert indexer.reverse_resolve(use_case_id=use_case_id, id=1234) is None
+
+
+def test_already_created_plus_written_results(indexer, indexer_cache) -> None:
+    """
+    Test that we correctly combine db read results with db write results
+    for the same organization.
+    """
+    org_id = 1234
+
+    raw_indexer = indexer
+    indexer = CachingIndexer(indexer_cache, indexer)
+
+    v0 = raw_indexer.record(use_case_id, org_id, "v1.2.0")
+    v1 = raw_indexer.record(use_case_id, org_id, "v1.2.1")
+    v2 = raw_indexer.record(use_case_id, org_id, "v1.2.2")
+
+    expected_mapping = {"v1.2.0": v0, "v1.2.1": v1, "v1.2.2": v2}
+
+    results = indexer.bulk_record(
+        use_case_id=use_case_id, org_strings={org_id: {"v1.2.0", "v1.2.1", "v1.2.2"}}
+    )
+    assert len(results[org_id]) == len(expected_mapping) == 3
+
+    for string, id in results[org_id].items():
+        assert expected_mapping[string] == id
+
+    results = indexer.bulk_record(
+        use_case_id=use_case_id,
+        org_strings={org_id: {"v1.2.0", "v1.2.1", "v1.2.2", "v1.2.3"}},
+    )
+    v3 = raw_indexer.resolve(use_case_id, org_id, "v1.2.3")
+    expected_mapping["v1.2.3"] = v3
+
+    assert len(results[org_id]) == len(expected_mapping) == 4
+
+    for string, id in results[org_id].items():
+        assert expected_mapping[string] == id
+
+    fetch_meta = results.get_fetch_metadata()
+    assert_fetch_type_for_tag_string_set(
+        fetch_meta[org_id], FetchType.CACHE_HIT, {"v1.2.0", "v1.2.1", "v1.2.2"}
+    )
+    assert_fetch_type_for_tag_string_set(fetch_meta[org_id], FetchType.FIRST_SEEN, {"v1.2.3"})
+
+
+def test_already_cached_plus_read_results(indexer, indexer_cache) -> None:
+    """
+    Test that we correctly combine cached results with read results
+    for the same organization.
+    """
+    org_id = 8
+    cached = {f"{org_id}:beep": 10, f"{org_id}:boop": 11}
+    indexer_cache.set_many(cached, use_case_id.value)
+
+    raw_indexer = indexer
+    indexer = CachingIndexer(indexer_cache, indexer)
+
+    results = indexer.bulk_record(use_case_id=use_case_id, org_strings={org_id: {"beep", "boop"}})
+    assert len(results[org_id]) == 2
+    assert results[org_id]["beep"] == 10
+    assert results[org_id]["boop"] == 11
+
+    # confirm we did not write to the db if results were already cached
+    assert not raw_indexer.resolve(use_case_id, org_id, "beep")
+    assert not raw_indexer.resolve(use_case_id, org_id, "boop")
+
+    bam = raw_indexer.record(use_case_id, org_id, "bam")
+    assert bam is not None
+
+    results = indexer.bulk_record(
+        use_case_id=use_case_id, org_strings={org_id: {"beep", "boop", "bam"}}
+    )
+    assert len(results[org_id]) == 3
+    assert results[org_id]["beep"] == 10
+    assert results[org_id]["boop"] == 11
+    assert results[org_id]["bam"] == bam
+
+    fetch_meta = results.get_fetch_metadata()
+    assert_fetch_type_for_tag_string_set(fetch_meta[org_id], FetchType.CACHE_HIT, {"beep", "boop"})
+    assert_fetch_type_for_tag_string_set(fetch_meta[org_id], FetchType.DB_READ, {"bam"})
+
+
+def test_rate_limited(indexer):
+    """
+    Assert that rate limits per-org and globally are applied at all.
+
+    Since we don't have control over ordering in sets/dicts, we have no
+    control over which string gets rate-limited. That makes assertions
+    quite awkward and imprecise.
+    """
+    org_strings = {1: {"a", "b", "c"}, 2: {"e", "f"}, 3: {"g"}}
+
+    with override_options(
+        {
+            "sentry-metrics.writes-limiter.limits.releasehealth.per-org": [
+                {"window_seconds": 10, "granularity_seconds": 10, "limit": 1}
+            ],
+        }
+    ):
+        results = indexer.bulk_record(use_case_id=use_case_id, org_strings=org_strings)
+
+    assert len(results[1]) == 3
+    assert len(results[2]) == 2
+    assert len(results[3]) == 1
+    assert results[3]["g"] is not None
+
+    rate_limited_strings = set()
+
+    for org_id in 1, 2, 3:
+        for k, v in results[org_id].items():
+            if v is None:
+                rate_limited_strings.add((org_id, k))
+
+    assert len(rate_limited_strings) == 3
+    assert (3, "g") not in rate_limited_strings
+
+    for org_id, string in rate_limited_strings:
+        assert results.get_fetch_metadata()[org_id][string] == Metadata(
+            id=None,
+            fetch_type=FetchType.RATE_LIMITED,
+            fetch_type_ext=FetchTypeExt(is_global=False),
+        )
+
+    org_strings = {1: {"x", "y", "z"}}
+
+    # attempt to index even more strings, and assert that we can't get any indexed
+    with override_options(
+        {
+            "sentry-metrics.writes-limiter.limits.releasehealth.per-org": [
+                {"window_seconds": 10, "granularity_seconds": 10, "limit": 1}
+            ],
+        }
+    ):
+        results = indexer.bulk_record(use_case_id=use_case_id, org_strings=org_strings)
+
+    assert results[1] == {"x": None, "y": None, "z": None}
+    for letter in "xyz":
+        assert results.get_fetch_metadata()[1][letter] == Metadata(
+            id=None,
+            fetch_type=FetchType.RATE_LIMITED,
+            fetch_type_ext=FetchTypeExt(is_global=False),
+        )
+
+    org_strings = {1: rate_limited_strings}
+
+    # assert that if we reconfigure limits, the quota resets
+    with override_options(
+        {
+            "sentry-metrics.writes-limiter.limits.releasehealth.global": [
+                {"window_seconds": 10, "granularity_seconds": 10, "limit": 2}
+            ],
+        }
+    ):
+        results = indexer.bulk_record(use_case_id=use_case_id, org_strings=org_strings)
+
+    rate_limited_strings2 = set()
+    for k, v in results[1].items():
+        if v is None:
+            rate_limited_strings2.add(k)
+
+    assert len(rate_limited_strings2) == 1
+    assert len(rate_limited_strings - rate_limited_strings2) == 2

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -476,7 +476,7 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
     from sentry.sentry_metrics.indexer import backend
 
     # Insert a None-value into the mock-indexer to simulate a rate-limit.
-    backend._strings[1]["rate_limited_test"] = None
+    backend.indexer._strings[1]["rate_limited_test"] = None
 
     with caplog.at_level(logging.ERROR):
         new_batch = process_messages(

--- a/tests/sentry/sentry_metrics/test_postgres_indexer.py
+++ b/tests/sentry/sentry_metrics/test_postgres_indexer.py
@@ -1,18 +1,11 @@
 from typing import Mapping, Set
 
-import pytest
-
 from sentry.sentry_metrics.configuration import UseCaseKey
-from sentry.sentry_metrics.indexer.base import FetchType, FetchTypeExt, KeyCollection, Metadata
+from sentry.sentry_metrics.indexer.base import FetchType, KeyCollection, Metadata
+from sentry.sentry_metrics.indexer.cache import CachingIndexer
 from sentry.sentry_metrics.indexer.models import StringIndexer
-from sentry.sentry_metrics.indexer.postgres_v2 import (
-    PGStringIndexerV2,
-    PostgresIndexer,
-    indexer_cache,
-)
-from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS
+from sentry.sentry_metrics.indexer.postgres_v2 import PGStringIndexerV2, indexer_cache
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.utils.cache import cache
 
 
@@ -22,209 +15,16 @@ def assert_fetch_type_for_tag_string_set(
     assert all([meta[string].fetch_type == fetch_type for string in str_set])
 
 
-pytestmark = pytest.mark.sentry_metrics
-
-
-class StaticStringsIndexerTest(TestCase):
-    def setUp(self) -> None:
-        self.indexer = PostgresIndexer()
-        self.use_case_id = UseCaseKey("release-health")
-
-    def test_static_strings_only(self) -> None:
-        org_strings = {2: {"release"}, 3: {"production", "environment", "release"}}
-        results = self.indexer.bulk_record(use_case_id=self.use_case_id, org_strings=org_strings)
-
-        assert results[2]["release"] == SHARED_STRINGS["release"]
-        assert results[3]["production"] == SHARED_STRINGS["production"]
-        assert results[3]["environment"] == SHARED_STRINGS["environment"]
-        assert results[3]["release"] == SHARED_STRINGS["release"]
-
-    def test_static_and_non_static_strings(self):
-        org_strings = {
-            2: {"release", "1.0.0"},
-            3: {"production", "environment", "release", "2.0.0"},
-        }
-        results = self.indexer.bulk_record(use_case_id=self.use_case_id, org_strings=org_strings)
-
-        v1 = StringIndexer.objects.get(organization_id=2, string="1.0.0")
-        v2 = StringIndexer.objects.get(organization_id=3, string="2.0.0")
-
-        assert results[2]["release"] == SHARED_STRINGS["release"]
-        assert results[3]["production"] == SHARED_STRINGS["production"]
-        assert results[3]["environment"] == SHARED_STRINGS["environment"]
-        assert results[3]["release"] == SHARED_STRINGS["release"]
-
-        assert results[2]["1.0.0"] == v1.id
-        assert results[3]["2.0.0"] == v2.id
-
-        meta = results.get_fetch_metadata()
-        assert_fetch_type_for_tag_string_set(meta[2], FetchType.HARDCODED, {"release"})
-        assert_fetch_type_for_tag_string_set(
-            meta[3], FetchType.HARDCODED, {"release", "production", "environment"}
-        )
-        assert_fetch_type_for_tag_string_set(meta[2], FetchType.FIRST_SEEN, {"1.0.0"})
-        assert_fetch_type_for_tag_string_set(meta[3], FetchType.FIRST_SEEN, {"2.0.0"})
-
-
 class PostgresIndexerV2Test(TestCase):
     def setUp(self) -> None:
         self.strings = {"hello", "hey", "hi"}
-        self.indexer = PGStringIndexerV2()
+        self.indexer = CachingIndexer(indexer_cache, PGStringIndexerV2())
         self.org2 = self.create_organization()
         self.use_case_id = UseCaseKey("release-health")
         self.cache_namespace = self.use_case_id.value
 
     def tearDown(self) -> None:
         cache.clear()
-
-    def test_indexer(self):
-        org1_id = self.organization.id
-        org2_id = self.org2.id
-        org_strings = {org1_id: self.strings, org2_id: {"sup"}}
-
-        # create a record with diff org_id but same string that we test against
-        StringIndexer.objects.create(organization_id=999, string="hey")
-
-        assert list(
-            indexer_cache.get_many(
-                [f"{org1_id}:{string}" for string in self.strings],
-                cache_namespace=self.cache_namespace,
-            ).values()
-        ) == [None, None, None]
-
-        results = self.indexer.bulk_record(
-            use_case_id=self.use_case_id, org_strings=org_strings
-        ).results
-
-        org1_string_ids = list(
-            StringIndexer.objects.filter(
-                organization_id=org1_id, string__in=["hello", "hey", "hi"]
-            ).values_list("id", flat=True)
-        )
-        org2_string_id = StringIndexer.objects.get(organization_id=org2_id, string="sup").id
-
-        # verify org1 results and cache values
-        for value in results[org1_id].values():
-            assert value in org1_string_ids
-
-        for cache_value in indexer_cache.get_many(
-            [f"{org1_id}:{string}" for string in self.strings], cache_namespace=self.cache_namespace
-        ).values():
-            assert cache_value in org1_string_ids
-
-        # verify org2 results and cache values
-        assert results[org2_id]["sup"] == org2_string_id
-        assert (
-            indexer_cache.get(f"{org2_id}:sup", cache_namespace=self.cache_namespace)
-            == org2_string_id
-        )
-
-        # we should have no results for org_id 999
-        assert not results.get(999)
-
-    def test_resolve_and_reverse_resolve(self) -> None:
-        """
-        Test `resolve` and `reverse_resolve` methods
-        """
-
-        org1_id = self.organization.id
-        org_strings = {org1_id: self.strings}
-        self.indexer.bulk_record(use_case_id=self.use_case_id, org_strings=org_strings)
-
-        # test resolve and reverse_resolve
-        obj = StringIndexer.objects.get(string="hello")
-        assert (
-            self.indexer.resolve(use_case_id=self.use_case_id, org_id=org1_id, string="hello")
-            == obj.id
-        )
-        assert self.indexer.reverse_resolve(use_case_id=self.use_case_id, id=obj.id) == obj.string
-
-        # test record on a string that already exists
-        self.indexer.record(use_case_id=self.use_case_id, org_id=org1_id, string="hello")
-        assert (
-            self.indexer.resolve(use_case_id=self.use_case_id, org_id=org1_id, string="hello")
-            == obj.id
-        )
-
-        # test invalid values
-        assert (
-            self.indexer.resolve(use_case_id=self.use_case_id, org_id=org1_id, string="beep")
-            is None
-        )
-        assert self.indexer.reverse_resolve(use_case_id=self.use_case_id, id=1234) is None
-
-    def test_already_created_plus_written_results(self) -> None:
-        """
-        Test that we correctly combine db read results with db write results
-        for the same organization.
-        """
-        org_id = 1234
-        v0 = StringIndexer.objects.create(organization_id=org_id, string="v1.2.0")
-        v1 = StringIndexer.objects.create(organization_id=org_id, string="v1.2.1")
-        v2 = StringIndexer.objects.create(organization_id=org_id, string="v1.2.2")
-
-        expected_mapping = {"v1.2.0": v0.id, "v1.2.1": v1.id, "v1.2.2": v2.id}
-
-        results = self.indexer.bulk_record(
-            use_case_id=self.use_case_id, org_strings={org_id: {"v1.2.0", "v1.2.1", "v1.2.2"}}
-        )
-        assert len(results[org_id]) == len(expected_mapping) == 3
-
-        for string, id in results[org_id].items():
-            assert expected_mapping[string] == id
-
-        results = self.indexer.bulk_record(
-            use_case_id=self.use_case_id,
-            org_strings={org_id: {"v1.2.0", "v1.2.1", "v1.2.2", "v1.2.3"}},
-        )
-
-        v3 = StringIndexer.objects.get(organization_id=org_id, string="v1.2.3")
-        expected_mapping["v1.2.3"] = v3.id
-
-        assert len(results[org_id]) == len(expected_mapping) == 4
-
-        for string, id in results[org_id].items():
-            assert expected_mapping[string] == id
-
-        fetch_meta = results.get_fetch_metadata()
-        assert_fetch_type_for_tag_string_set(
-            fetch_meta[org_id], FetchType.CACHE_HIT, {"v1.2.0", "v1.2.1", "v1.2.2"}
-        )
-        assert_fetch_type_for_tag_string_set(fetch_meta[org_id], FetchType.FIRST_SEEN, {"v1.2.3"})
-
-    def test_already_cached_plus_read_results(self) -> None:
-        """
-        Test that we correctly combine cached results with read results
-        for the same organization.
-        """
-        org_id = 8
-        cached = {f"{org_id}:beep": 10, f"{org_id}:boop": 11}
-        indexer_cache.set_many(cached, self.cache_namespace)
-
-        results = self.indexer.bulk_record(
-            use_case_id=self.use_case_id, org_strings={org_id: {"beep", "boop"}}
-        )
-        assert len(results[org_id]) == 2
-        assert results[org_id]["beep"] == 10
-        assert results[org_id]["boop"] == 11
-
-        # confirm we did not write to the db if results were already cached
-        assert not StringIndexer.objects.filter(organization_id=org_id, string__in=["beep", "boop"])
-
-        bam = StringIndexer.objects.create(organization_id=org_id, string="bam")
-        results = self.indexer.bulk_record(
-            use_case_id=self.use_case_id, org_strings={org_id: {"beep", "boop", "bam"}}
-        )
-        assert len(results[org_id]) == 3
-        assert results[org_id]["beep"] == 10
-        assert results[org_id]["boop"] == 11
-        assert results[org_id]["bam"] == bam.id
-
-        fetch_meta = results.get_fetch_metadata()
-        assert_fetch_type_for_tag_string_set(
-            fetch_meta[org_id], FetchType.CACHE_HIT, {"beep", "boop"}
-        )
-        assert_fetch_type_for_tag_string_set(fetch_meta[org_id], FetchType.DB_READ, {"bam"})
 
     def test_get_db_records(self):
         """
@@ -237,94 +37,7 @@ class PostgresIndexerV2Test(TestCase):
         assert indexer_cache.get(key, self.cache_namespace) is None
         assert indexer_cache.get(string.id, self.cache_namespace) is None
 
-        self.indexer._get_db_records(self.use_case_id, collection)
+        self.indexer.indexer._get_db_records(self.use_case_id, collection)
 
         assert indexer_cache.get(string.id, self.cache_namespace) is None
         assert indexer_cache.get(key, self.cache_namespace) is None
-
-    def test_rate_limited(self):
-        """
-        Assert that rate limits per-org and globally are applied at all.
-
-        Since we don't have control over ordering in sets/dicts, we have no
-        control over which string gets rate-limited. That makes assertions
-        quite awkward and imprecise.
-        """
-        org_strings = {1: {"a", "b", "c"}, 2: {"e", "f"}, 3: {"g"}}
-
-        with override_options(
-            {
-                "sentry-metrics.writes-limiter.limits.releasehealth.per-org": [
-                    {"window_seconds": 10, "granularity_seconds": 10, "limit": 1}
-                ],
-            }
-        ):
-            results = self.indexer.bulk_record(
-                use_case_id=self.use_case_id, org_strings=org_strings
-            )
-
-        assert len(results[1]) == 3
-        assert len(results[2]) == 2
-        assert len(results[3]) == 1
-        assert results[3]["g"] is not None
-
-        rate_limited_strings = set()
-
-        for org_id in 1, 2, 3:
-            for k, v in results[org_id].items():
-                if v is None:
-                    rate_limited_strings.add((org_id, k))
-
-        assert len(rate_limited_strings) == 3
-        assert (3, "g") not in rate_limited_strings
-
-        for org_id, string in rate_limited_strings:
-            assert results.get_fetch_metadata()[org_id][string] == Metadata(
-                id=None,
-                fetch_type=FetchType.RATE_LIMITED,
-                fetch_type_ext=FetchTypeExt(is_global=False),
-            )
-
-        org_strings = {1: {"x", "y", "z"}}
-
-        # attempt to index even more strings, and assert that we can't get any indexed
-        with override_options(
-            {
-                "sentry-metrics.writes-limiter.limits.releasehealth.per-org": [
-                    {"window_seconds": 10, "granularity_seconds": 10, "limit": 1}
-                ],
-            }
-        ):
-            results = self.indexer.bulk_record(
-                use_case_id=self.use_case_id, org_strings=org_strings
-            )
-
-        assert results[1] == {"x": None, "y": None, "z": None}
-        for letter in "xyz":
-            assert results.get_fetch_metadata()[1][letter] == Metadata(
-                id=None,
-                fetch_type=FetchType.RATE_LIMITED,
-                fetch_type_ext=FetchTypeExt(is_global=False),
-            )
-
-        org_strings = {1: rate_limited_strings}
-
-        # assert that if we reconfigure limits, the quota resets
-        with override_options(
-            {
-                "sentry-metrics.writes-limiter.limits.releasehealth.global": [
-                    {"window_seconds": 10, "granularity_seconds": 10, "limit": 2}
-                ],
-            }
-        ):
-            results = self.indexer.bulk_record(
-                use_case_id=self.use_case_id, org_strings=org_strings
-            )
-
-        rate_limited_strings2 = set()
-        for k, v in results[1].items():
-            if v is None:
-                rate_limited_strings2.add(k)
-
-        assert len(rate_limited_strings2) == 1
-        assert len(rate_limited_strings - rate_limited_strings2) == 2

--- a/tests/sentry/sentry_metrics/test_strings.py
+++ b/tests/sentry/sentry_metrics/test_strings.py
@@ -1,0 +1,16 @@
+from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.sentry_metrics.indexer.mock import MockIndexer
+from sentry.sentry_metrics.indexer.strings import SHARED_STRINGS, StaticStringsIndexer
+
+use_case_id = UseCaseKey("release-health")
+
+
+def test_static_strings_only() -> None:
+    indexer = StaticStringsIndexer(MockIndexer())
+    org_strings = {2: {"release"}, 3: {"production", "environment", "release"}}
+    results = indexer.bulk_record(use_case_id=use_case_id, org_strings=org_strings)
+
+    assert results[2]["release"] == SHARED_STRINGS["release"]
+    assert results[3]["production"] == SHARED_STRINGS["production"]
+    assert results[3]["environment"] == SHARED_STRINGS["environment"]
+    assert results[3]["release"] == SHARED_STRINGS["release"]


### PR DESCRIPTION
* Move static string indexer out of postgres module
* Create another wrapper class for the cloud spanner indexer similar to
  the one we added for postgres
* Remove static string lookup from mock indexer, we already have a
  perfectly good indexer/decorator for that
* Create _another_ indexer that does caching, move all the caching logic
  out of postgres
* Move all the tests from test_postgres_indexer into a new file, remove
  unittest-dependency of those tests, parametrize the tests over indexer
  backends (starting with postgres and mock indexer)
* Fix mock indexer to return FetchType and other metadata like that. So
  the mock indexer is more trustworthy to use in tests.
* Implement rate limits in the mock indexer just so the tests pass,
  there isn't any real purpose to that.
* I guess one could now use the mock indexer in combination with caching
  (but i'm not going to add that because it's just wasted time in tests)

**About cloud spanner testing**

I suppose we won't have a big opportunity to let cloud spanner tests run
in CI. But somehow it would make sense to test it. What we can do is to
add an entry like:

    pytest.param(CloudSpannerIndexer, marks=pytest.mark.needs_cloud_spanner)

Then have an pytest autouse fixture that checks the `request` fixture
for whether that marker is active.

...or we just use subclassing. I just strongly prefer class-less tests,
personally.

