### PR TITLE
ref: temporarily limit setuptools to <64.0.0 to work around PEP 660

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.2.0", "wheel"]
+requires = ["setuptools>=40.2.0,<64.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
I am having a difficult time reproducing but the release of setuptools 64 lines up pretty closely with cloudbuild breaking so I'm going to try this as a first attempt to fix things while I research more

I will revert this if I find it doesn't fix it, and even if I merge this I'll look into the _correct_ way to fixing this (though I assume there's a bug in setuptools)