### PR TITLE
fix(notifications): mixed use typing 

### DIFF
--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Iterable, Mapping, MutableMapping, MutableSet, Sequence
+from typing import TYPE_CHECKING, Iterable, Mapping, MutableMapping, MutableSet, Sequence, Union
 
 from django.db import transaction
 from django.db.models import Q, QuerySet
@@ -290,7 +290,7 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
 
     def filter_to_accepting_recipients(
         self,
-        parent: Organization,
+        parent: Union[Organization, Project],
         recipients: Iterable[Team | User],
         type: NotificationSettingTypes = NotificationSettingTypes.ISSUE_ALERTS,
     ) -> Mapping[ExternalProviders, Iterable[Team | User]]:
@@ -306,23 +306,24 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
         # XXX(gilbert): remove this when organizations:active-release-notification-opt-in is removed
         # injects the notification settings since no Notification settings will exist in the db
         from sentry import features
-        from sentry.models import User
+        from sentry.models import Organization, User
 
-        notification_settings_by_recipient = dict(notification_settings_by_recipient)
-        for user_recipient in filter(lambda x: isinstance(x, User), recipients):
-            if type == NotificationSettingTypes.ACTIVE_RELEASE and features.has(
-                "organizations:active-release-notification-opt-in",
-                parent,
-                actor=user_recipient,
-            ):
-                notification_settings_by_recipient[user_recipient] = {
-                    {
-                        NotificationScopeType.USER: {
-                            ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
-                            ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
+        if isinstance(parent, Organization):
+            notification_settings_by_recipient = dict(notification_settings_by_recipient)
+            for user_recipient in filter(lambda x: isinstance(x, User), recipients):
+                if type == NotificationSettingTypes.ACTIVE_RELEASE and features.has(
+                    "organizations:active-release-notification-opt-in",
+                    parent,
+                    actor=user_recipient,
+                ):
+                    notification_settings_by_recipient[user_recipient] = {
+                        {
+                            NotificationScopeType.USER: {
+                                ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
+                                ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
+                            }
                         }
                     }
-                }
 
         mapping = defaultdict(set)
         for recipient in recipients:


### PR DESCRIPTION
Wasn't too careful scanning the usage when I changed the typing here. 

Multiple places calling this function seems to pass in Organizations or Project. This should fix that.

Fixes: SENTRY-VTS