### PR TITLE
fix(widget-builder): Use onBlur to trigger query change

### DIFF
--- a/static/app/views/dashboardsV2/datasetConfig/base.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/base.tsx
@@ -20,11 +20,12 @@ import {IssuesConfig} from './issues';
 import {ReleasesConfig} from './releases';
 
 export type WidgetBuilderSearchBarProps = {
-  onBlur: SearchBarProps['onBlur'];
   onSearch: SearchBarProps['onSearch'];
   organization: Organization;
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
+  onBlur?: SearchBarProps['onBlur'];
+  onClose?: SearchBarProps['onClose'];
 };
 
 export interface DatasetConfig<SeriesResponse, TableResponse> {

--- a/static/app/views/dashboardsV2/datasetConfig/base.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/base.tsx
@@ -20,7 +20,7 @@ import {IssuesConfig} from './issues';
 import {ReleasesConfig} from './releases';
 
 export type WidgetBuilderSearchBarProps = {
-  onClose: SearchBarProps['onClose'];
+  onBlur: SearchBarProps['onBlur'];
   onSearch: SearchBarProps['onSearch'];
   organization: Organization;
   pageFilters: PageFilters;

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -10,18 +10,13 @@ import {
 } from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 
 interface Props {
-  onClose: SearchBarProps['onClose'];
+  onBlur: SearchBarProps['onBlur'];
   organization: Organization;
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
 }
 
-export function EventsSearchBar({
-  organization,
-  pageFilters,
-  onClose,
-  widgetQuery,
-}: Props) {
+export function EventsSearchBar({organization, pageFilters, onBlur, widgetQuery}: Props) {
   const projectIds = pageFilters.projects;
 
   return (
@@ -31,7 +26,7 @@ export function EventsSearchBar({
       projectIds={projectIds}
       query={widgetQuery.conditions}
       fields={[]}
-      onClose={onClose}
+      onBlur={onBlur}
       useFormWrapper={false}
       maxQueryLength={MAX_QUERY_LENGTH}
       maxSearchItems={MAX_SEARCH_ITEMS}

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/eventsSearchBar.tsx
@@ -10,13 +10,20 @@ import {
 } from 'sentry/views/dashboardsV2/widgetBuilder/utils';
 
 interface Props {
-  onBlur: SearchBarProps['onBlur'];
   organization: Organization;
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
+  onBlur?: SearchBarProps['onBlur'];
+  onClose?: SearchBarProps['onClose'];
 }
 
-export function EventsSearchBar({organization, pageFilters, onBlur, widgetQuery}: Props) {
+export function EventsSearchBar({
+  organization,
+  pageFilters,
+  onBlur,
+  onClose,
+  widgetQuery,
+}: Props) {
   const projectIds = pageFilters.projects;
 
   return (
@@ -27,6 +34,7 @@ export function EventsSearchBar({organization, pageFilters, onBlur, widgetQuery}
       query={widgetQuery.conditions}
       fields={[]}
       onBlur={onBlur}
+      onClose={onClose}
       useFormWrapper={false}
       maxQueryLength={MAX_QUERY_LENGTH}
       maxSearchItems={MAX_SEARCH_ITEMS}

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -63,7 +63,7 @@ export function FilterResultsStep({
     [onQueryChange, queries]
   );
 
-  const handleClose = useCallback(
+  const handleBlur = useCallback(
     (queryIndex: number) => {
       return (field: string) => {
         const newQuery: WidgetQuery = {
@@ -119,7 +119,7 @@ export function FilterResultsStep({
                 <datasetConfig.SearchBar
                   organization={organization}
                   pageFilters={selection}
-                  onClose={handleClose(queryIndex)}
+                  onBlur={handleBlur(queryIndex)}
                   onSearch={handleSearch(queryIndex)}
                   widgetQuery={query}
                 />

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
@@ -16,15 +16,17 @@ import {
 import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 
 interface Props {
-  onClose: SearchBarProps['onClose'];
   organization: Organization;
   pageFilters: PageFilters;
   tags: TagCollection;
   widgetQuery: WidgetQuery;
+  onBlur?: SearchBarProps['onBlur'];
+  onClose?: SearchBarProps['onClose'];
 }
 
 function IssuesSearchBarContainer({
   tags,
+  onBlur,
   onClose,
   widgetQuery,
   organization,
@@ -50,6 +52,7 @@ function IssuesSearchBarContainer({
           searchSource="widget_builder"
           query={widgetQuery.conditions || ''}
           sort=""
+          onBlur={onBlur}
           onClose={onClose}
           excludeEnvironment
           supportedTags={tags}

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -22,16 +22,18 @@ const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   'g'
 );
 interface Props {
-  onClose: SearchBarProps['onClose'];
   organization: Organization;
   pageFilters: PageFilters;
   widgetQuery: WidgetQuery;
+  onBlur?: SearchBarProps['onBlur'];
+  onClose?: SearchBarProps['onClose'];
 }
 
 export function ReleaseSearchBar({
   organization,
   pageFilters,
   widgetQuery,
+  onBlur,
   onClose,
 }: Props) {
   const orgSlug = organization.slug;
@@ -87,6 +89,7 @@ export function ReleaseSearchBar({
             max-height: ${MAX_MENU_HEIGHT ?? 300}px;
             overflow-y: auto;
           `}
+          onBlur={onBlur}
           onClose={onClose}
           maxQueryLength={MAX_QUERY_LENGTH}
           maxSearchItems={MAX_SEARCH_ITEMS}


### PR DESCRIPTION
Fixes a bug where onClose was triggering too often and use onBlur to
only change the queries when the user unfocuses the search field

The current behaviour is incorrect since clicking anywhere on the page
triggers `handleQueryChange`, which ends up wiping out unselected
y-axis aggregates. 

Steps to reproduce:
1. Go to Widget Builder
2. Add a new widget
3. Change to a Line/Area/Bar chart
4. Click "Add Overlay"
5. Click anywhere else on the page without making a selection, the field will be removed

Found that this behaviour had changed in #37135, will ping core-ui to get feedback on this change.