### PR TITLE
fix(suspect-resolutions): Check for division by zero in Pearson correlation calculation

### DIFF
--- a/src/sentry/utils/suspect_resolutions/metric_correlation.py
+++ b/src/sentry/utils/suspect_resolutions/metric_correlation.py
@@ -55,7 +55,7 @@ def is_issue_error_rate_correlated(
 
 def calculate_pearson_correlation_coefficient(x: List[int], y: List[int]) -> int:
     # source: https://inside-machinelearning.com/en/pearson-formula-in-python-linear-correlation-coefficient/
-    if len(x) and len(y) == 0:
+    if len(x) == 0 or len(y) == 0:
         return 0
 
     mean_x = sum(x) / len(x)
@@ -71,4 +71,4 @@ def calculate_pearson_correlation_coefficient(x: List[int], y: List[int]) -> int
     if st_dev_x_y == 0:
         return 0
 
-    return cov / (st_dev_x * st_dev_y)
+    return cov / st_dev_x_y

--- a/src/sentry/utils/suspect_resolutions/metric_correlation.py
+++ b/src/sentry/utils/suspect_resolutions/metric_correlation.py
@@ -66,6 +66,9 @@ def calculate_pearson_correlation_coefficient(x: List[int], y: List[int]) -> int
     st_dev_x = (sum((a - mean_x) ** 2 for a in x) / len(x)) ** 0.5
     st_dev_y = (sum((b - mean_y) ** 2 for b in y) / len(y)) ** 0.5
 
-    result = cov / (st_dev_x * st_dev_y)
+    st_dev_x_y = st_dev_x * st_dev_y
 
-    return result
+    if st_dev_x_y == 0:
+        return 0
+
+    return cov / (st_dev_x * st_dev_y)

--- a/src/sentry/utils/suspect_resolutions/metric_correlation.py
+++ b/src/sentry/utils/suspect_resolutions/metric_correlation.py
@@ -53,10 +53,10 @@ def is_issue_error_rate_correlated(
     return results, resolution_time, start_time, end_time
 
 
-def calculate_pearson_correlation_coefficient(x: List[int], y: List[int]) -> int:
+def calculate_pearson_correlation_coefficient(x: List[int], y: List[int]) -> float:
     # source: https://inside-machinelearning.com/en/pearson-formula-in-python-linear-correlation-coefficient/
     if len(x) == 0 or len(y) == 0:
-        return 0
+        return 0.0
 
     mean_x = sum(x) / len(x)
     mean_y = sum(y) / len(y)
@@ -68,7 +68,7 @@ def calculate_pearson_correlation_coefficient(x: List[int], y: List[int]) -> int
 
     st_dev_x_y = st_dev_x * st_dev_y
 
-    if st_dev_x_y == 0:
-        return 0
+    if st_dev_x_y == 0 or st_dev_x_y == 0.0:
+        return 0.0
 
     return cov / st_dev_x_y


### PR DESCRIPTION
- Fix check for empty lists from `and` to `or`
- Check if the standard deviation is 0 and return early to avoid division by 0 

Fixes SENTRY-VTN