### PR TITLE
fix(replays): Issues tab wonky loading

### DIFF
--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -33,6 +33,7 @@ function IssueList(props: Props) {
   const {selection} = usePageFilters();
   const isScreenLarge = useMedia(`(min-width: ${theme.breakpoints.large})`);
 
+  const [loadingIssueData, setLoadingIssueData] = useState(false);
   const [issuesById, setIssuesById] = useState<Record<string, Group>>({});
   const [issueStatsById, setIssuesStatsById] = useState<Record<string, Group>>({});
 
@@ -52,6 +53,7 @@ function IssueList(props: Props) {
 
   const fetchIssueData = useCallback(async () => {
     let issues;
+    setLoadingIssueData(true);
     try {
       issues = await api.requestPromise(`/organizations/${organization.slug}/issues/`, {
         includeAllArgs: true,
@@ -64,6 +66,7 @@ function IssueList(props: Props) {
       setIssuesById(keyBy(issues[0], 'id'));
     } catch (error) {
       setIssuesById({});
+      setLoadingIssueData(false);
       return;
     }
 
@@ -82,6 +85,8 @@ function IssueList(props: Props) {
       setIssuesStatsById(keyBy(issuesResults[0], 'id'));
     } catch (error) {
       setIssuesStatsById({});
+    } finally {
+      setLoadingIssueData(false);
     }
   }, [api, organization.slug, props.replayId, props.projectId]);
 
@@ -159,7 +164,7 @@ function IssueList(props: Props) {
           <StyledPanelTable
             isEmpty={data.tableData?.data.length === 0}
             emptyMessage={t('No related Issues found.')}
-            isLoading={data.isLoading}
+            isLoading={data.isLoading || loadingIssueData}
             headers={
               isScreenLarge ? columns : columns.filter(column => column !== t('Graph'))
             }


### PR DESCRIPTION


<!-- Describe your PR here. -->
Added a loading state when fetching the issue data preventing the weird pause and jumping out of the data. Closes #37353  


https://user-images.githubusercontent.com/39612839/184226205-a5106f1f-b1b4-4782-93a1-d7e97b524c4e.mp4




<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
