### PR TITLE
fix(suspect-resolutions): Fix get_files_changed() to take a group_id

### DIFF
--- a/src/sentry/utils/suspect_resolutions/commit_correlation.py
+++ b/src/sentry/utils/suspect_resolutions/commit_correlation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Set
 
-from sentry.models import CommitFileChange, Group, GroupRelease, Project, ReleaseCommit
+from sentry.models import CommitFileChange, GroupRelease, Project, ReleaseCommit
 
 
 def is_issue_commit_correlated(resolved_issue: int, candidate_issue: int, project: int) -> bool:
@@ -19,8 +19,8 @@ def is_issue_commit_correlated(resolved_issue: int, candidate_issue: int, projec
     )
 
 
-def get_files_changed(issue: Group, project: Project) -> Set:
-    releases = GroupRelease.objects.filter(group_id=issue.id, project_id=project.id).values_list(
+def get_files_changed(issue_id: int, project: Project) -> Set:
+    releases = GroupRelease.objects.filter(group_id=issue_id, project_id=project.id).values_list(
         "release_id", flat=True
     )
 

--- a/src/sentry/utils/suspect_resolutions/get_suspect_resolutions.py
+++ b/src/sentry/utils/suspect_resolutions/get_suspect_resolutions.py
@@ -36,14 +36,13 @@ def get_suspect_resolutions(resolved_issue_id: int) -> Sequence[int]:
     )
 
     correlated_issue_ids = []
-    (
-        metric_correlation_results,
-        resolution_time,
-        start_time,
-        end_time,
-    ) = is_issue_error_rate_correlated(resolved_issue, all_project_issues)
 
-    for metric_correlation_result in metric_correlation_results:
+    result = is_issue_error_rate_correlated(resolved_issue, all_project_issues)
+
+    if result is None:
+        return correlated_issue_ids
+
+    for metric_correlation_result in result[0]:
         (
             is_commit_correlated,
             resolved_issue_release_ids,
@@ -61,9 +60,9 @@ def get_suspect_resolutions(resolved_issue_id: int) -> Sequence[int]:
             candidate_group_id=metric_correlation_result.candidate_suspect_resolution_id,
             resolved_group_resolution_type=resolution_type,
             pearson_r_coefficient=metric_correlation_result.coefficient,
-            pearson_r_start_time=start_time,
-            pearson_r_end_time=end_time,
-            pearson_r_resolution_time=resolution_time,
+            pearson_r_start_time=result[2],
+            pearson_r_end_time=result[3],
+            pearson_r_resolution_time=result[1],
             is_commit_correlated=is_commit_correlated,
             resolved_issue_release_ids=resolved_issue_release_ids,
             candidate_issue_release_ids=candidate_issue_release_ids,

--- a/src/sentry/utils/suspect_resolutions/metric_correlation.py
+++ b/src/sentry/utils/suspect_resolutions/metric_correlation.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from sentry import tsdb
 from sentry.models import Group
@@ -15,13 +15,13 @@ class MetricCorrelationResult:
 
 def is_issue_error_rate_correlated(
     resolved_issue: Group, candidate_suspect_resolutions: List[Group]
-) -> Tuple[List[MetricCorrelationResult], datetime, datetime, datetime]:
+) -> Optional[Tuple[List[MetricCorrelationResult], datetime, datetime, datetime]]:
     if (
-        resolved_issue is None
-        or resolved_issue.resolved_at is None
+        not resolved_issue
+        or not resolved_issue.resolved_at
         or len(candidate_suspect_resolutions) == 0
     ):
-        return []
+        return None
 
     resolution_time = resolved_issue.resolved_at
 

--- a/tests/sentry/utils/suspect_resolutions/test_commit_correlation.py
+++ b/tests/sentry/utils/suspect_resolutions/test_commit_correlation.py
@@ -42,9 +42,9 @@ class CommitCorrelationTest(TestCase):
         Activity.objects.create(
             project=project, group=issue, type=ActivityType.SET_RESOLVED_IN_RELEASE.value
         )
-        release_ids, files_changed = get_files_changed(issue, project)
+        release_ids, files_changed = get_files_changed(issue.id, project)
 
-        assert len(get_files_changed(issue, project)) == 2
+        assert len(get_files_changed(issue.id, project)) == 2
         assert files_changed == {".random", ".random2"}
         assert release_ids == [release.id]
 
@@ -53,7 +53,7 @@ class CommitCorrelationTest(TestCase):
         Activity.objects.create(
             project=project, group=issue, type=ActivityType.SET_RESOLVED_IN_COMMIT.value
         )
-        release_ids, files_changed = get_files_changed(issue, project)
+        release_ids, files_changed = get_files_changed(issue.id, project)
 
         assert files_changed == {".random", ".random2"}
         assert release_ids == [release.id]
@@ -63,23 +63,23 @@ class CommitCorrelationTest(TestCase):
         Activity.objects.create(
             project=project, group=issue, type=ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value
         )
-        release_ids, files_changed = get_files_changed(issue, project)
+        release_ids, files_changed = get_files_changed(issue.id, project)
 
-        assert len(get_files_changed(issue, project)) == 2
+        assert len(get_files_changed(issue.id, project)) == 2
         assert files_changed == {".random", ".random2"}
         assert release_ids == [release.id]
 
     def test_get_files_changed_unresolved_issue(self):
         (project, issue, release, repo) = setup(self, status=GroupStatus.UNRESOLVED)
-        release_ids, files_changed = get_files_changed(issue, project)
+        release_ids, files_changed = get_files_changed(issue.id, project)
 
-        assert len(get_files_changed(issue, project)) == 2
+        assert len(get_files_changed(issue.id, project)) == 2
         assert files_changed == {".random", ".random2"}
         assert release_ids == [release.id]
 
     def test_get_files_changed_manually_resolved(self):
         (project, issue, release, repo) = setup(self, status=GroupStatus.RESOLVED)
-        release_ids, files_changed = get_files_changed(issue, project)
+        release_ids, files_changed = get_files_changed(issue.id, project)
 
         assert files_changed == {".random", ".random2"}
         assert release_ids == [release.id]
@@ -106,14 +106,14 @@ class CommitCorrelationTest(TestCase):
         GroupRelease.objects.create(
             project_id=project.id, group_id=group2.id, release_id=release2.id
         )
-        group1_release_ids, group1_files_changed = get_files_changed(group1, project)
-        group2_release_ids, group2_files_changed = get_files_changed(group2, project)
+        group1_release_ids, group1_files_changed = get_files_changed(group1.id, project)
+        group2_release_ids, group2_files_changed = get_files_changed(group2.id, project)
 
         assert group1_files_changed == set()
         assert group2_files_changed == set()
         assert group1_release_ids == [release.id]
         assert group2_release_ids == [release2.id]
-        assert not is_issue_commit_correlated(group1, group2, project)
+        assert not is_issue_commit_correlated(group1.id, group2.id, project)
 
     def test_files_changed_unreleased_commits(self):
         project = self.create_project()
@@ -131,7 +131,7 @@ class CommitCorrelationTest(TestCase):
         )
         GroupRelease.objects.create(project_id=project.id, group_id=group.id, release_id=release.id)
 
-        release_ids, files_changed = get_files_changed(group, project)
+        release_ids, files_changed = get_files_changed(group.id, project)
 
         assert files_changed == set()
         assert release_ids == [release.id]
@@ -156,11 +156,11 @@ class CommitCorrelationTest(TestCase):
             project_id=project.id, group_id=issue2.id, release_id=release2.id
         )
 
-        assert get_files_changed(issue, project) == {".random", ".random2"}
-        assert get_files_changed(issue2, project) == {".random"}
-        assert len(get_files_changed(issue, project)) == 2
-        assert len(get_files_changed(issue2, project)) == 1
-        assert is_issue_commit_correlated(issue, issue2, project)
+        assert get_files_changed(issue.id, project) == {".random", ".random2"}
+        assert get_files_changed(issue2.id, project) == {".random"}
+        assert len(get_files_changed(issue.id, project)) == 2
+        assert len(get_files_changed(issue2.id, project)) == 1
+        assert is_issue_commit_correlated(issue.id, issue2.id, project)
 
     def get_files_changed_no_shared_files(self):
         (project, issue, release, repo) = setup(self, status=GroupStatus.RESOLVED)
@@ -182,11 +182,11 @@ class CommitCorrelationTest(TestCase):
             project_id=project.id, group_id=issue2.id, release_id=release2.id
         )
 
-        group1_release_ids, group1_files_changed = get_files_changed(issue, project)
-        group2_release_ids, group2_files_changed = get_files_changed(issue2, project)
+        group1_release_ids, group1_files_changed = get_files_changed(issue.id, project)
+        group2_release_ids, group2_files_changed = get_files_changed(issue2.id, project)
 
         assert group1_files_changed == set()
         assert group2_files_changed == set()
         assert group1_release_ids == [release.id]
         assert group2_release_ids == [release2.id]
-        assert not is_issue_commit_correlated(issue, issue2, project)
+        assert not is_issue_commit_correlated(issue.id, issue2.id, project)


### PR DESCRIPTION
- Pass `group_id` instead of `Group` into `get_files_changed` 
- Changed return type of `is_issue_error_rate_correlated()`

Fixes [SENTRY-VQ9](https://sentry.io/organizations/sentry/issues/3493971383/?project=1&query=suspect_resolutions&statsPeriod=14d) and [SENTRY-VTP](https://sentry.io/organizations/sentry/issues/3494570560/?project=1&query=get_suspect&statsPeriod=14d)