### PR TITLE
feat(msteams): Add regression notification

### DIFF
--- a/src/sentry/integrations/msteams/notifications.py
+++ b/src/sentry/integrations/msteams/notifications.py
@@ -12,6 +12,7 @@ from sentry.models import Team, User
 from sentry.notifications.notifications.activity import (
     AssignedActivityNotification,
     NoteActivityNotification,
+    RegressionActivityNotification,
     ReleaseActivityNotification,
     ResolvedActivityNotification,
     ResolvedInReleaseActivityNotification,
@@ -39,6 +40,7 @@ SUPPORTED_NOTIFICATION_TYPES = [
     ResolvedActivityNotification,
     ResolvedInReleaseActivityNotification,
     ReleaseActivityNotification,
+    RegressionActivityNotification,
 ]
 MESSAGE_BUILDERS = {
     "SlackNotificationsMessageBuilder": MSTeamsNotificationsMessageBuilder,

--- a/tests/sentry/integrations/msteams/notifications/test_regression.py
+++ b/tests/sentry/integrations/msteams/notifications/test_regression.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock, Mock, patch
+
+from sentry.models import Activity
+from sentry.notifications.notifications.activity import RegressionActivityNotification
+from sentry.testutils.cases import MSTeamsActivityNotificationTest
+from sentry.types.activity import ActivityType
+
+
+@patch(
+    "sentry.integrations.msteams.MsTeamsAbstractClient.get_user_conversation_id",
+    Mock(return_value="some_conversation_id"),
+)
+@patch("sentry.integrations.msteams.MsTeamsAbstractClient.send_card")
+class MSTeamsRegressionNotificationTest(MSTeamsActivityNotificationTest):
+    def test_regression(self, mock_send_card: MagicMock):
+        """
+        Test that the card for MS Teams notification is generated correctly when an issue regresses.
+        """
+        notification = RegressionActivityNotification(
+            Activity(
+                project=self.project,
+                group=self.group,
+                user=self.user,
+                type=ActivityType.SET_REGRESSION,
+                data={},
+            )
+        )
+        with self.tasks():
+            notification.send()
+
+        mock_send_card.assert_called_once()
+
+        args, kwargs = mock_send_card.call_args
+
+        assert args[0] == "some_conversation_id"
+
+        body = args[1]["body"]
+        assert 4 == len(body)
+
+        assert "Issue marked as regression" == body[0]["text"]
+        assert (
+            f"[{self.group.title}](http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression\\_activity-msteams)"
+            == body[1]["text"]
+        )
+        assert (
+            f"{self.project.slug} | [Notification Settings](http://testserver/settings/account/notifications/workflow/?referrer=regression\\_activity-msteams-user)"
+            == body[3]["columns"][1]["items"][0]["text"]
+        )


### PR DESCRIPTION
Add regression notification, and we are done with notifications enabled by these three options!

<img width="405" alt="image" src="https://user-images.githubusercontent.com/19944378/184237926-01f4ee86-2b49-436c-a734-62898a7982c6.png">

<img width="424" alt="image" src="https://user-images.githubusercontent.com/19944378/184237976-65e70f2f-44da-4454-8441-32960782d996.png">

Screenshot

<img width="631" alt="image" src="https://user-images.githubusercontent.com/19944378/184284814-06ab92c4-dc08-4ab6-b1ac-11337ae3f5cc.png">

