### PR TITLE
feat(replays): Add feature flag for enabling Replay SDK

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -139,6 +139,7 @@ default_manager.add("organizations:required-email-verification", OrganizationFea
 default_manager.add("organizations:rule-page", OrganizationFeature)
 default_manager.add("organizations:sentry-functions", OrganizationFeature, True)
 default_manager.add("organizations:session-replay", OrganizationFeature, True)
+default_manager.add("organizations:session-replay-sdk", OrganizationFeature, True)
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, True)
 default_manager.add("organizations:symbol-sources", OrganizationFeature)


### PR DESCRIPTION
This will be used to put the initialization of the Replay integration behind a feature flag as we move to enable Replay recording for internal Sentry employees.

(Missed this in #37673)
