### PR TITLE
fix(mep): Invalid compatible projects

### DIFF
--- a/src/sentry/api/endpoints/organization_events_meta.py
+++ b/src/sentry/api/endpoints/organization_events_meta.py
@@ -60,7 +60,6 @@ class OrganizationEventsMetricsCompatiblity(OrganizationEventsEndpointBase):
             params = self.get_snuba_params(request, organization, check_global_views=False)
         except NoProjects:
             return Response(data)
-        data["compatible_projects"] = params["project_id"]
         for project in params["project_objects"]:
             dynamic_sampling = project.get_option("sentry:dynamic_sampling")
             if dynamic_sampling is not None:
@@ -74,6 +73,7 @@ class OrganizationEventsMetricsCompatiblity(OrganizationEventsEndpointBase):
         data["dynamic_sampling_projects"].sort()
 
         # Save ourselves some work, only query the projects that have DS rules
+        data["compatible_projects"] = params["project_id"]
         params["project_id"] = data["dynamic_sampling_projects"]
 
         with self.handle_query_errors():

--- a/src/sentry/api/endpoints/organization_metrics_meta.py
+++ b/src/sentry/api/endpoints/organization_metrics_meta.py
@@ -31,7 +31,6 @@ class OrganizationMetricsCompatibility(OrganizationEventsEndpointBase):
         except NoProjects:
             return Response(data)
         original_project_ids = params["project_id"].copy()
-        data["compatible_projects"] = params["project_id"]
         for project in params["project_objects"]:
             dynamic_sampling = project.get_option("sentry:dynamic_sampling")
             if dynamic_sampling is not None:
@@ -45,6 +44,7 @@ class OrganizationMetricsCompatibility(OrganizationEventsEndpointBase):
         data["dynamic_sampling_projects"].sort()
 
         # Save ourselves some work, only query the projects that have DS rules
+        data["compatible_projects"] = params["project_id"]
         params["project_id"] = data["dynamic_sampling_projects"]
 
         with self.handle_query_errors():

--- a/tests/snuba/api/endpoints/test_organization_metrics_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_metrics_meta.py
@@ -124,6 +124,18 @@ class OrganizationMetricsCompatiblity(MetricsEnhancedPerformanceTestCase):
             project3.id,
         ]
 
+    def test_no_ds(self):
+        url = reverse(
+            "sentry-api-0-organization-metrics-compatibility",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+        response = self.client.get(url, data={"project": [self.bad_project.id]}, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["dynamic_sampling_projects"] == []
+        assert response.data["incompatible_projects"] == []
+        assert response.data["compatible_projects"] == []
+
 
 class OrganizationEventsMetricsSums(MetricsEnhancedPerformanceTestCase):
     def setUp(self):


### PR DESCRIPTION
- This fixes a bug where compatible projects was incorrect because it was being set before determining dynamic_sampling_projects
