### PR TITLE
fix(eventGroup): Un-crop descenders

### DIFF
--- a/static/app/components/eventOrGroupTitle.tsx
+++ b/static/app/components/eventOrGroupTitle.tsx
@@ -106,8 +106,7 @@ const Wrapper = styled('span')<{hasGroupingTreeUI: boolean}>`
     css`
       display: inline-grid;
       grid-template-columns: auto max-content 1fr max-content;
-      align-items: flex-end;
-      line-height: 100%;
+      align-items: baseline;
 
       ${Subtitle} {
         ${p.theme.overflowEllipsis};

--- a/static/less/group-detail.less
+++ b/static/less/group-detail.less
@@ -13,7 +13,6 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    line-height: 1.1;
 
     em {
       font-style: normal;


### PR DESCRIPTION
Fix an issue in which the text descenders (lower hanging part of the letters g, j, p, and q) are cropped off due to our use of `overflowEllipsis`. The solution is to just remove l `line-height: 1` in a couple places.

**Before:**
<img width="619" alt="Screen Shot 2022-08-11 at 2 57 08 PM" src="https://user-images.githubusercontent.com/44172267/184249469-f316f6b4-b862-425f-913d-ed2b95417f72.png">

**After:**
<img width="620" alt="Screen Shot 2022-08-11 at 2 52 07 PM" src="https://user-images.githubusercontent.com/44172267/184248771-28e14d94-04c6-479d-864d-2b4536451d6c.png">

**Note: this also alters the alignment in the issues list.** From what I see though (in MacOS Firefox, Chrome, and Safari), the change seems to be for the better. Here's the before & after:

<img width="817" alt="Screen Shot 2022-08-11 at 2 54 40 PM" src="https://user-images.githubusercontent.com/44172267/184249146-cea966dc-94ce-4901-9d1b-ede2eb8c2e8d.png">
<img width="817" alt="Screen Shot 2022-08-11 at 2 54 51 PM" src="https://user-images.githubusercontent.com/44172267/184249175-63e5500b-ebf5-4b0d-bd53-54565e2f346c.png">

