### PR TITLE
ref(indexer): Move string indexer cache version out of configuration

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2741,7 +2741,6 @@ ORGANIZATION_VITALS_OVERVIEW_PROJECT_LIMIT = 300
 
 # Default string indexer cache options
 SENTRY_STRING_INDEXER_CACHE_OPTIONS = {
-    "version": 1,
     "cache_name": "default",
 }
 

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -24,8 +24,8 @@ _INDEXER_CACHE_FETCH_METRIC = "sentry_metrics.indexer.memcache.fetch"
 
 
 class StringIndexerCache:
-    def __init__(self, version: int, cache_name: str, partition_key: str):
-        self.version = version
+    def __init__(self, cache_name: str, partition_key: str):
+        self.version = 1
         self.cache = caches[cache_name]
         self.partition_key = partition_key
 

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -39,7 +39,6 @@ def indexer(indexer_cls):
 @pytest.fixture
 def indexer_cache():
     indexer_cache = StringIndexerCache(
-        version=1,
         cache_name="default",
         partition_key="test",
     )


### PR DESCRIPTION
It seems to me that the cache version number should be hardcoded
in the codebase rather than provided as options via configuration.
There seems to be no valid use case for this value to be overridden
by users operating Sentry.