### PR TITLE
feat(hybrid-cloud): Revise organizationUrl to omit region segment

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -162,15 +162,10 @@ def generate_organization_hostname(org_slug: str) -> str:
     org_base_hostname_template = options.get("system.organization-base-hostname")
     if not org_base_hostname_template:
         return url_prefix_hostname
-    has_region_placeholder = "{region}" in org_base_hostname_template
     has_org_slug_placeholder = "{slug}" in org_base_hostname_template
-    if not has_region_placeholder and not has_org_slug_placeholder:
+    if not has_org_slug_placeholder:
         return url_prefix_hostname
     org_hostname = org_base_hostname_template.replace("{slug}", org_slug)
-    region = options.get("system.region") or None
-    if region is None:
-        return url_prefix_hostname
-    org_hostname = org_hostname.replace("{region}", region)
     return org_hostname
 
 

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -162,7 +162,9 @@ def generate_organization_hostname(org_slug: str) -> str:
     org_base_hostname_template = options.get("system.organization-base-hostname")
     if not org_base_hostname_template:
         return url_prefix_hostname
-    if "{slug}" not in org_base_hostname_template or "{region}" not in org_base_hostname_template:
+    has_region_placeholder = "{region}" in org_base_hostname_template
+    has_org_slug_placeholder = "{slug}" in org_base_hostname_template
+    if not has_region_placeholder and not has_org_slug_placeholder:
         return url_prefix_hostname
     org_hostname = org_base_hostname_template.replace("{slug}", org_slug)
     region = options.get("system.region") or None

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -148,7 +148,7 @@ def pytest_configure(config):
             "mail.backend": "django.core.mail.backends.locmem.EmailBackend",
             "system.url-prefix": "http://testserver",
             "system.base-hostname": "testserver",
-            "system.organization-base-hostname": "{slug}.{region}.testserver",
+            "system.organization-base-hostname": "{slug}.testserver",
             "system.organization-url-template": "http://{hostname}",
             "system.region-api-url-template": "http://{region}.testserver",
             "system.region": "us",

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -59,7 +59,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
 
         assert response.data["slug"] == self.organization.slug
         assert response.data["links"] == {
-            "organizationUrl": f"http://{self.organization.slug}.us.testserver",
+            "organizationUrl": f"http://{self.organization.slug}.testserver",
             "regionUrl": "http://us.testserver",
         }
         assert response.data["onboardingTasks"] == []
@@ -77,7 +77,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
 
         assert response.data["slug"] == self.organization.slug
         assert response.data["links"] == {
-            "organizationUrl": f"http://{self.organization.slug}.us.testserver",
+            "organizationUrl": f"http://{self.organization.slug}.testserver",
             "regionUrl": "http://us.testserver",
         }
         assert response.data["onboardingTasks"] == []

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -167,7 +167,7 @@ class ClientConfigViewTest(TestCase):
         assert data["isAuthenticated"] is True
         assert data["lastOrganization"] == self.organization.slug
         assert data["links"] == {
-            "organizationUrl": f"http://{self.organization.slug}.us.testserver",
+            "organizationUrl": f"http://{self.organization.slug}.testserver",
             "regionUrl": "http://us.testserver",
             "sentryUrl": "http://testserver",
         }
@@ -192,7 +192,7 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
-                "organizationUrl": f"http://{self.organization.slug}.eu.testserver",
+                "organizationUrl": f"http://{self.organization.slug}.testserver",
                 "regionUrl": "http://eu.testserver",
                 "sentryUrl": "http://testserver",
             }
@@ -222,7 +222,7 @@ class ClientConfigViewTest(TestCase):
                 "sentryUrl": "http://testserver",
             }
 
-        with self.options({"system.organization-base-hostname": "{region}.{slug}.testserver"}):
+        with self.options({"system.organization-base-hostname": "{region}.testserver"}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200
             assert resp["Content-Type"] == "application/json"
@@ -232,7 +232,22 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
-                "organizationUrl": f"http://us.{self.organization.slug}.testserver",
+                "organizationUrl": "http://us.testserver",
+                "regionUrl": "http://us.testserver",
+                "sentryUrl": "http://testserver",
+            }
+
+        with self.options({"system.organization-base-hostname": "{slug}.testserver"}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+
+            data = json.loads(resp.content)
+
+            assert data["isAuthenticated"] is True
+            assert data["lastOrganization"] == self.organization.slug
+            assert data["links"] == {
+                "organizationUrl": f"http://{self.organization.slug}.testserver",
                 "regionUrl": "http://us.testserver",
                 "sentryUrl": "http://testserver",
             }
@@ -287,7 +302,7 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
-                "organizationUrl": f"ftp://{self.organization.slug}.us.testserver",
+                "organizationUrl": f"ftp://{self.organization.slug}.testserver",
                 "regionUrl": "http://us.testserver",
                 "sentryUrl": "http://testserver",
             }
@@ -449,7 +464,7 @@ class ClientConfigViewTest(TestCase):
             assert data["isAuthenticated"] is True
             assert data["lastOrganization"] == self.organization.slug
             assert data["links"] == {
-                "organizationUrl": f"http://{self.organization.slug}.us.testserver",
+                "organizationUrl": f"http://{self.organization.slug}.testserver",
                 "regionUrl": "http://foobar.us.testserver",
                 "sentryUrl": "http://testserver",
             }

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -222,21 +222,6 @@ class ClientConfigViewTest(TestCase):
                 "sentryUrl": "http://testserver",
             }
 
-        with self.options({"system.organization-base-hostname": "{region}.testserver"}):
-            resp = self.client.get(self.path)
-            assert resp.status_code == 200
-            assert resp["Content-Type"] == "application/json"
-
-            data = json.loads(resp.content)
-
-            assert data["isAuthenticated"] is True
-            assert data["lastOrganization"] == self.organization.slug
-            assert data["links"] == {
-                "organizationUrl": "http://us.testserver",
-                "regionUrl": "http://us.testserver",
-                "sentryUrl": "http://testserver",
-            }
-
         with self.options({"system.organization-base-hostname": "{slug}.testserver"}):
             resp = self.client.get(self.path)
             assert resp.status_code == 200


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/37691

This pull request updates the `organizationUrl` to omit the region segment in light of the introduction of the `regionUrl` concept.