### PR TITLE
chore(hybrid-cloud): Update config store type and stub values

### DIFF
--- a/fixtures/js-stubs/config.js
+++ b/fixtures/js-stubs/config.js
@@ -43,8 +43,11 @@ export function Config(params = {}) {
     apmSampling: 1,
     dsn_requests: '',
     demoMode: false,
-    sentryUrl: 'https://sentry.io',
-    organizationUrl: 'https://foobar.us.sentry.io',
+    links: {
+      sentryUrl: 'https://sentry.io',
+      organizationUrl: 'https://foobar.sentry.io',
+      regionUrl: 'https://us.sentry.io',
+    },
     ...params,
   };
 }

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -126,20 +126,23 @@ export interface Config {
   isSelfHosted: boolean;
   languageCode: string;
   lastOrganization: string | null;
+  links: {
+    organizationUrl: string | undefined;
+    regionUrl: string | undefined;
+    sentryUrl: string;
+  };
   /**
    * This comes from django (django.contrib.messages)
    */
   messages: {level: keyof Theme['alert']; message: string}[];
   needsUpgrade: boolean;
 
-  organizationUrl: string | undefined;
   privacyUrl: string | null;
   sentryConfig: {
     dsn: string;
     release: string;
     whitelistUrls: string[];
   };
-  sentryUrl: string;
   singleOrganization: boolean;
   supportEmail: string;
   termsUrl: string | null;

--- a/tests/js/spec/stores/configStore.spec.tsx
+++ b/tests/js/spec/stores/configStore.spec.tsx
@@ -2,7 +2,11 @@ import ConfigStore from 'sentry/stores/configStore';
 
 describe('ConfigStore', () => {
   it('should have apiUrl and organizationUrl', () => {
-    expect(ConfigStore.get('sentryUrl')).toEqual('https://sentry.io');
-    expect(ConfigStore.get('organizationUrl')).toEqual('https://foobar.us.sentry.io');
+    const links = ConfigStore.get('links');
+    expect(links).toEqual({
+      organizationUrl: 'https://foobar.sentry.io',
+      regionUrl: 'https://us.sentry.io',
+      sentryUrl: 'https://sentry.io',
+    });
   });
 });


### PR DESCRIPTION
Update config store types and stub values in light of changes introduced in https://github.com/getsentry/sentry/pull/37690