### PR TITLE
feat(dashboard-filters): Expose id in release endpoint

### DIFF
--- a/api-docs/paths/releases/organization-release.json
+++ b/api-docs/paths/releases/organization-release.json
@@ -32,6 +32,7 @@
               "$ref": "../../components/schemas/releases/organization-release.json#/OrganizationRelease"
             },
             "example": {
+              "id": 2,
               "authors": [],
               "commitCount": 0,
               "data": {},
@@ -146,6 +147,7 @@
               "$ref": "../../components/schemas/releases/organization-release.json#/OrganizationRelease"
             },
             "example": {
+              "id": 2,
               "authors": [],
               "commitCount": 0,
               "data": {},

--- a/api-docs/paths/releases/organization-releases.json
+++ b/api-docs/paths/releases/organization-releases.json
@@ -35,6 +35,7 @@
             },
             "example": [
               {
+                "id": 2,
                 "authors": [],
                 "commitCount": 0,
                 "data": {},
@@ -59,6 +60,7 @@
                 "version": "2.0rc2"
               },
               {
+                "id": 1,
                 "authors": [],
                 "commitCount": 0,
                 "data": {},
@@ -241,6 +243,7 @@
               "$ref": "../../components/schemas/releases/organization-release.json#/OrganizationRelease"
             },
             "example": {
+              "id": 2,
               "authors": [],
               "commitCount": 0,
               "data": {},

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -511,6 +511,7 @@ class ReleaseSerializer(Serializer):
             return rv
 
         d = {
+            "id": obj.id,
             "version": obj.version,
             "status": ReleaseStatus.to_string(obj.status),
             "shortVersion": obj.version,


### PR DESCRIPTION
Adds `id` to the organization release endpoint response so the new
release filter can start selecting on `id` as well