### PR TITLE
fix(mep): Missed a tag resolver

### DIFF
--- a/src/sentry/search/events/datasets/field_aliases.py
+++ b/src/sentry/search/events/datasets/field_aliases.py
@@ -8,8 +8,6 @@ from sentry.models import Project, ProjectTeam
 from sentry.search.events import constants, fields
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.types import SelectType
-from sentry.sentry_metrics.configuration import UseCaseKey
-from sentry.sentry_metrics.utils import resolve_tag_value
 from sentry.utils.numbers import format_grouped_length
 
 
@@ -48,7 +46,7 @@ def resolve_team_key_transaction_alias(
     count = len(team_key_transactions)
     if resolve_metric_index:
         team_key_transactions = [
-            (project, resolve_tag_value(UseCaseKey.PERFORMANCE, org_id, transaction))
+            (project, builder.resolve_tag_value(transaction))
             for project, transaction in team_key_transactions
         ]
 


### PR DESCRIPTION
- This tag resolver is still checking the option which meant that the fix from https://github.com/getsentry/sentry/pull/37709/ wasn't as effective as expected
