### PR TITLE
fix(profiling): Profiling stats response for no projects

### DIFF
--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -139,7 +139,7 @@ def zerofill(data, start, end, rollup, allow_partial_buckets=False, fill_default
     return rv
 
 
-def calculateTimeframe(start, end, rollup):
+def calculate_time_frame(start, end, rollup):
     rollup_start = (int(to_timestamp(start)) // rollup) * rollup
     rollup_end = (int(to_timestamp(end)) // rollup) * rollup
     if rollup_end - rollup_start == rollup:
@@ -349,7 +349,7 @@ class SnubaTSResultSerializer(BaseSnubaSerializer):
         res["isMetricsData"] = result.data.get("isMetricsData", False)
 
         if hasattr(result, "start") and hasattr(result, "end"):
-            timeframe = calculateTimeframe(result.start, result.end, result.rollup)
+            timeframe = calculate_time_frame(result.start, result.end, result.rollup)
             res["start"] = timeframe["start"]
             res["end"] = timeframe["end"]
 

--- a/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
+++ b/tests/sentry/api/endpoints/test_organization_profiling_profiles.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from freezegun import freeze_time
 from rest_framework.exceptions import ErrorDetail
 
 from sentry.testutils import APITestCase
@@ -82,3 +83,38 @@ class OrganizationProfilingTransactionsTest(APITestCase):
             response = self.client.get(self.url)
         assert response.status_code == 200
         assert response.data == []
+
+
+class OrganizationProfilingStatsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-profiling-stats"
+
+    def setUp(self):
+        self.login_as(user=self.user)
+        self.url = reverse(self.endpoint, args=(self.organization.slug,))
+
+    def test_feature_flag_disabled(self):
+        response = self.client.get(self.url)
+        assert response.status_code == 404
+
+    def test_bad_filter(self):
+        with self.feature(PROFILING_FEATURES):
+            response = self.client.get(self.url, {"query": "foo:bar"})
+        assert response.status_code == 400
+        assert response.data == {
+            "detail": ErrorDetail(string="Invalid query: foo is not supported", code="parse_error")
+        }
+
+    @freeze_time("2022-08-12 13:45:11")
+    def test_no_projects(self):
+        with self.feature(PROFILING_FEATURES):
+            response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.data == {
+            "data": [],
+            "meta": {
+                "dataset": "profiles",
+                "start": 1652486400,
+                "end": 1660262400,
+            },
+            "timestamps": [],
+        }, response.data["meta"]


### PR DESCRIPTION
Returning an empty array when there are no projects does not align with the
usual response format. This ensures that the response for no projects has the
same shape as when there are projects.