### PR TITLE
fix(ui): integrations text alignment

### DIFF
--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -141,7 +141,6 @@ export const IssueSyncListElementContainer = styled('div')`
 
 export const IntegrationLink = styled('a')<{disabled?: boolean}>`
   text-decoration: none;
-  padding-bottom: ${space(0.25)};
   margin-left: ${space(1)};
   color: ${p => p.theme.textColor};
   cursor: pointer;


### PR DESCRIPTION
Integrations on the issue details page were misaligned with their icon.


## Before
<img width="642" alt="CleanShot 2022-08-12 at 11 20 49@2x" src="https://user-images.githubusercontent.com/1900676/184420692-b8365ece-213f-4822-853b-391340e11951.png">

## After
<img width="649" alt="CleanShot 2022-08-12 at 11 21 06@2x" src="https://user-images.githubusercontent.com/1900676/184420710-8324c7a9-6e93-42c8-bedc-ec524eac6432.png">

