### PR TITLE
fix(breadcrumbsFilter): Fix level tag crop issue

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/level.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/level.tsx
@@ -52,6 +52,7 @@ const LevelTag = styled(Tag)`
   display: flex;
   align-items: center;
   ${Background} {
+    /** Same height as menu item labels, to prevent vertical cropping */
     height: calc(${p => p.theme.fontSizeMedium} * 1.4);
     overflow: hidden;
   }

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/level.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/level.tsx
@@ -49,10 +49,10 @@ const Level = memo(function Level({level, searchTerm = ''}: Props) {
 export default Level;
 
 const LevelTag = styled(Tag)`
-  height: 24px;
   display: flex;
   align-items: center;
   ${Background} {
+    height: calc(${p => p.theme.fontSizeMedium} * 1.4);
     overflow: hidden;
   }
 `;


### PR DESCRIPTION
**Before:**
<img width="188" alt="Screen Shot 2022-08-12 at 11 26 12 AM" src="https://user-images.githubusercontent.com/44172267/184421072-ad96e182-927a-4714-8838-664a8b9311a2.png">

**After:**
<img width="188" alt="Screen Shot 2022-08-12 at 11 25 47 AM" src="https://user-images.githubusercontent.com/44172267/184421074-48393f17-1ac0-4249-876f-d436d8887be4.png">
