### PR TITLE
feat(suspect-resolutions): track the suspect resolutions algo changes in analytics events

### DIFF
--- a/src/sentry/utils/suspect_resolutions/__init__.py
+++ b/src/sentry/utils/suspect_resolutions/__init__.py
@@ -1,1 +1,5 @@
 from .analytics import *  # NOQA
+
+# make sure to increment this when making changes to anything within the 'suspect_resolutions' directory
+# keeps track of changes to how we process suspect commits, so we can filter out analytics events by the algo version
+ALGO_VERSION = "0.0.2"

--- a/src/sentry/utils/suspect_resolutions/analytics.py
+++ b/src/sentry/utils/suspect_resolutions/analytics.py
@@ -5,6 +5,7 @@ class SuspectResolutionEvaluation(analytics.Event):
     type = "suspect_resolution.evaluation"
 
     attributes = (
+        analytics.Attribute("algo_version"),
         analytics.Attribute("resolved_group_id"),
         analytics.Attribute("candidate_group_id"),
         analytics.Attribute("resolved_group_resolution_type"),

--- a/src/sentry/utils/suspect_resolutions/get_suspect_resolutions.py
+++ b/src/sentry/utils/suspect_resolutions/get_suspect_resolutions.py
@@ -5,13 +5,9 @@ from sentry import features
 from sentry.models import Activity, Group, GroupStatus
 from sentry.signals import issue_resolved
 from sentry.tasks.base import instrumented_task
-from sentry.utils.suspect_resolutions import analytics
+from sentry.utils.suspect_resolutions import ALGO_VERSION, analytics
 from sentry.utils.suspect_resolutions.commit_correlation import is_issue_commit_correlated
 from sentry.utils.suspect_resolutions.metric_correlation import is_issue_error_rate_correlated
-
-# make sure to increment this when making changes to anything within the 'suspect_resolutions' directory
-# keeps track of changes to how we process suspect commits, so we can filter out analytics events by the algo version
-ALGO_VERSION = "0.0.2"
 
 
 @issue_resolved.connect(weak=False)

--- a/src/sentry/utils/suspect_resolutions/get_suspect_resolutions.py
+++ b/src/sentry/utils/suspect_resolutions/get_suspect_resolutions.py
@@ -9,6 +9,10 @@ from sentry.utils.suspect_resolutions import analytics
 from sentry.utils.suspect_resolutions.commit_correlation import is_issue_commit_correlated
 from sentry.utils.suspect_resolutions.metric_correlation import is_issue_error_rate_correlated
 
+# make sure to increment this when making changes to anything within the 'suspect_resolutions' directory
+# keeps track of changes to how we process suspect commits, so we can filter out analytics events by the algo version
+ALGO_VERSION = "0.0.2"
+
 
 @issue_resolved.connect(weak=False)
 def record_suspect_resolutions(organization_id, project, group, user, resolution_type, **kwargs):
@@ -56,6 +60,7 @@ def get_suspect_resolutions(resolved_issue_id: int) -> Sequence[int]:
             correlated_issue_ids.append(metric_correlation_result.candidate_suspect_resolution_id)
         analytics.record(
             "suspect_resolution.evaluation",
+            algo_version=ALGO_VERSION,
             resolved_group_id=resolved_issue.id,
             candidate_group_id=metric_correlation_result.candidate_suspect_resolution_id,
             resolved_group_resolution_type=resolution_type,

--- a/tests/sentry/utils/suspect_resolutions/test_get_suspect_resolutions.py
+++ b/tests/sentry/utils/suspect_resolutions/test_get_suspect_resolutions.py
@@ -7,7 +7,10 @@ from sentry.models import Activity, Group, GroupStatus
 from sentry.signals import issue_resolved
 from sentry.testutils import TestCase
 from sentry.types.activity import ActivityType
-from sentry.utils.suspect_resolutions.get_suspect_resolutions import get_suspect_resolutions
+from sentry.utils.suspect_resolutions.get_suspect_resolutions import (
+    ALGO_VERSION,
+    get_suspect_resolutions,
+)
 from sentry.utils.suspect_resolutions.metric_correlation import MetricCorrelationResult
 
 
@@ -171,6 +174,7 @@ class GetSuspectResolutionsTest(TestCase):
         assert notification_record == [
             mock.call(
                 "suspect_resolution.evaluation",
+                algo_version=ALGO_VERSION,
                 resolved_group_id=resolved_issue.id,
                 candidate_group_id=0,
                 resolved_group_resolution_type=resolution_type.type,


### PR DESCRIPTION
When we make changes to any of the suspect resolutions code, we probably wanna differentiate the analytics events fired with the version of the code that's producing these events. Otherwise, it'll be hard to see which events are 'valid' from invalid ones.

Make sure to approve this [PR](https://github.com/getsentry/reload/pull/281) before merging this one.