### PR TITLE
feat(dashboard-filters): Save and expose releaseId in dashboards

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -145,8 +145,10 @@ class DashboardDetailsSerializer(Serializer):
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
+        from sentry.api.serializers.rest_framework.base import camel_to_snake_case
+
         page_filter_keys = ["environment", "period", "utc"]
-        dashboard_filter_keys = ["release"]
+        dashboard_filter_keys = ["release", "releaseId"]
         data = {
             "id": str(obj.id),
             "title": obj.title,
@@ -166,8 +168,8 @@ class DashboardDetailsSerializer(Serializer):
                     data[key] = obj.filters[key]
 
             for key in dashboard_filter_keys:
-                if obj.filters.get(key) is not None:
-                    data["filters"][key] = obj.filters[key]
+                if obj.filters.get(camel_to_snake_case(key)) is not None:
+                    data["filters"][key] = obj.filters[camel_to_snake_case(key)]
 
             start, end = obj.filters.get("start"), obj.filters.get("end")
             if start and end:

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -323,7 +323,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
 
     def update_dashboard_filters(self, instance, validated_data):
         page_filter_keys = ["environment", "period", "start", "end", "utc"]
-        dashboard_filter_keys = ["release"]
+        dashboard_filter_keys = ["release", "release_id"]
 
         filters = {}
 

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -489,7 +489,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                 "projects": [project1.id, project2.id],
                 "environment": ["alpha"],
                 "period": "7d",
-                "filters": {"release": ["v1"]},
+                "filters": {"release": ["v1"], "releaseId": ["1"]},
             },
         )
         assert response.status_code == 201
@@ -497,6 +497,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.data["environment"] == ["alpha"]
         assert response.data["period"] == "7d"
         assert response.data["filters"]["release"] == ["v1"]
+        assert response.data["filters"]["releaseId"] == ["1"]
 
     def test_post_with_start_and_end_filter(self):
         start = iso_format(datetime.now() - timedelta(seconds=10))


### PR DESCRIPTION
Add releaseId to dashboard responses

The serializer converts camel case to snake case for incoming data
so it'll save under `release_id`, but return as `releaseId` in the response.