### PR TITLE
feat(release-notifications): create a hard-coded FeatureHandler for hot path feature

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -192,7 +192,7 @@ default_manager.add("organizations:sso-saml2", OrganizationFeature)
 default_manager.add("organizations:team-insights", OrganizationFeature)
 
 # Project scoped features
-default_manager.add("projects:active-release-monitor-default-on", ProjectFeature, True)
+default_manager.add("projects:active-release-monitor-default-on", ProjectFeature)
 default_manager.add("projects:alert-filters", ProjectFeature)
 default_manager.add("projects:custom-inbound-filters", ProjectFeature)
 default_manager.add("projects:data-forwarding", ProjectFeature)
@@ -214,6 +214,9 @@ default_manager.add("users:notification-slack-automatic", UserFeature)
 
 # Workflow 2.0 Project features
 default_manager.add("projects:auto-associate-commits-to-release", ProjectFeature)
+
+# register the hard-coded handler
+default_manager.add_handler(ActiveReleaseDefaultOnHardcodeFeatureHandler())  # NOQA
 
 
 # This is a gross hardcoded list, but there's no

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -6,7 +6,7 @@ import abc
 from typing import TYPE_CHECKING, Mapping, MutableSet, Optional, Sequence
 
 if TYPE_CHECKING:
-    from sentry.features.base import Feature
+    from sentry.features.base import Feature, ProjectFeature
     from sentry.features.manager import FeatureCheckBatch
     from sentry.models import Organization, Project, User
 
@@ -69,8 +69,6 @@ class ActiveReleaseDefaultOnHardcodeFeatureHandler(FeatureHandler):
     features = {"projects:active-release-monitor-default-on"}
 
     def has(self, feature: Feature, actor: User, skip_entity: Optional[bool] = False) -> bool:
-        from sentry.features import ProjectFeature
-
         return (
             isinstance(feature, ProjectFeature)
             and feature.name in self.features

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -6,7 +6,7 @@ import abc
 from typing import TYPE_CHECKING, Mapping, MutableSet, Optional, Sequence
 
 if TYPE_CHECKING:
-    from sentry.features.base import Feature, ProjectFeature
+    from sentry.features.base import Feature
     from sentry.features.manager import FeatureCheckBatch
     from sentry.models import Organization, Project, User
 
@@ -69,6 +69,8 @@ class ActiveReleaseDefaultOnHardcodeFeatureHandler(FeatureHandler):
     features = {"projects:active-release-monitor-default-on"}
 
     def has(self, feature: Feature, actor: User, skip_entity: Optional[bool] = False) -> bool:
+        from sentry.features.base import ProjectFeature
+
         return (
             isinstance(feature, ProjectFeature)
             and feature.name in self.features
@@ -83,4 +85,4 @@ class ActiveReleaseDefaultOnHardcodeFeatureHandler(FeatureHandler):
         organization: Optional[Organization] = None,
         batch: bool = True,
     ) -> Optional[Mapping[str, Mapping[str, bool]]]:
-        return None
+        raise NotImplementedError


### PR DESCRIPTION
We discovered the feature flag ('projects:active-release-monitor-default-on') exposed through flagr may be causing a bunch of flagr timeouts.

To reduce the impact on flagr, we can introduce a 'hard-coded' feature flag here to bypass calling flagr altogether. 