### PR TITLE
fix(perf) add smoothing and min value on p75 chart

### DIFF
--- a/static/app/components/events/interfaces/performance/durationChart.tsx
+++ b/static/app/components/events/interfaces/performance/durationChart.tsx
@@ -1,16 +1,22 @@
 import {useRef} from 'react';
 import {useTheme} from '@emotion/react';
+import {YAXisComponentOption} from 'echarts';
 import {Location} from 'history';
 import moment from 'moment';
 
 import EventsRequest from 'sentry/components/charts/eventsRequest';
-import {LineChart} from 'sentry/components/charts/lineChart';
+import {LineChart, LineChartSeries} from 'sentry/components/charts/lineChart';
 import LoadingPanel from 'sentry/components/charts/loadingPanel';
 import {getInterval} from 'sentry/components/charts/utils';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DateString, EventError, Group, Organization} from 'sentry/types';
-import {getDurationUnit, tooltipFormatter} from 'sentry/utils/discover/charts';
+import {Series} from 'sentry/types/echarts';
+import {
+  findRangeOfMultiSeries,
+  getDurationUnit,
+  tooltipFormatter,
+} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import useApi from 'sentry/utils/useApi';
 import {ErrorPanel} from 'sentry/views/performance/styles';
@@ -87,7 +93,7 @@ export function DurationChart({issue, event, organization}: Props) {
             errored: affectedEventsErrored,
           }) => (
             <Content
-              allEvents={allEvents}
+              allEvents={allEvents ?? []}
               affectedEvents={data}
               loading={allEventsLoading || affectedEventsLoading}
               errored={allEventsErrored || affectedEventsErrored}
@@ -99,7 +105,14 @@ export function DurationChart({issue, event, organization}: Props) {
   );
 }
 
-function Content({allEvents, affectedEvents, loading, errored}) {
+interface ContentProps {
+  affectedEvents: LineChartSeries[] | undefined;
+  allEvents: Series[] | undefined;
+  errored: boolean;
+  loading: boolean;
+}
+
+function Content({affectedEvents, allEvents, errored, loading}: ContentProps) {
   const theme = useTheme();
 
   if (!affectedEvents || affectedEvents.length === 0) {
@@ -111,10 +124,16 @@ function Content({allEvents, affectedEvents, loading, errored}) {
   }
 
   const durationUnit = getDurationUnit(affectedEvents);
+  const range = findRangeOfMultiSeries([...affectedEvents, ...(allEvents || [])]);
+  let min = 0;
+  if (range) {
+    min = range.min - (range.max - range.min) * 0.2;
+  }
 
-  const yAxis = {
+  const yAxis: YAXisComponentOption = {
     show: false,
     minInterval: durationUnit,
+    min,
     axisLabel: {
       color: theme.chartLabel,
       formatter() {
@@ -132,8 +151,9 @@ function Content({allEvents, affectedEvents, loading, errored}) {
       grid={{left: '0', right: '0', top: '0', bottom: '0'}}
       height={200}
       series={affectedEvents}
+      seriesOptions={{smooth: true}}
       previousPeriod={allEvents}
-      xAxis={{type: 'time' as const}}
+      xAxis={{type: 'time' as const, axisLine: {onZero: false}}}
       yAxis={yAxis}
       isGroupedByDate
       showTimeInTooltip

--- a/static/app/components/events/interfaces/performance/durationChart.tsx
+++ b/static/app/components/events/interfaces/performance/durationChart.tsx
@@ -51,7 +51,7 @@ export function DurationChart({issue, event, organization}: Props) {
   const issueStart = issue.firstSeen;
   const timeFromFirstSeen = moment(nowRef.current).diff(issueStart);
   const start = moment(issueStart).subtract(timeFromFirstSeen).format();
-  const interval = getInterval({start, end: nowRef.current, utc: true});
+  const interval = getInterval({start, end: nowRef.current, utc: true}, 'low');
 
   return (
     <EventsRequest


### PR DESCRIPTION
Add smoothing and set allEvents line should be 20% higher (arbitrary) then the xAxis line.

I could look into additional smoothing if needed, it would look nicer but not as accurate, lmk!

Before
<img width="461" alt="image" src="https://user-images.githubusercontent.com/44422760/184440047-f019d2fd-0270-45ba-9482-7ec34ba7df5d.png">

After
<img width="467" alt="image" src="https://user-images.githubusercontent.com/44422760/184439933-74c0ff59-c75e-4545-94bd-25401ea1288b.png">
