### PR TITLE
ref(perf): Add duplicate detection on group hash

### DIFF
--- a/src/sentry/utils/performance_issues/performance_span_issue.py
+++ b/src/sentry/utils/performance_issues/performance_span_issue.py
@@ -2,12 +2,13 @@ from typing import List
 
 
 class PerformanceSpanIssue:
-    __slots__ = ("span_id", "allowed_op", "spans_involved")
+    __slots__ = ("span_id", "allowed_op", "spans_involved", "fingerprint")
     """
     A class representing a detected performance issue caused by a performance span
     """
 
-    def __init__(self, span_id: str, allowed_op: str, spans_involved: List[str]):
+    def __init__(self, span_id: str, allowed_op: str, spans_involved: List[str], fingerprint=""):
         self.span_id = span_id
         self.allowed_op = allowed_op
         self.spans_involved = spans_involved
+        self.fingerprint = fingerprint

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -24,9 +24,9 @@ def modify_span_start(obj, start):
     return obj
 
 
-def create_span(op, duration=100.0, desc="SELECT count() FROM table WHERE id = %s"):
+def create_span(op, duration=100.0, desc="SELECT count() FROM table WHERE id = %s", hash=""):
     return modify_span_duration(
-        SpanBuilder().with_op(op).with_description(desc).build(),
+        SpanBuilder().with_op(op).with_description(desc).with_hash(hash).build(),
         duration,
     )
 
@@ -76,6 +76,44 @@ class PerformanceDetectionTest(unittest.TestCase):
                 ),
                 call(
                     "_pi_duplicates",
+                    "bbbbbbbbbbbbbbbb",
+                ),
+            ]
+        )
+
+    def test_calls_detect_duplicate_hash(self):
+        no_duplicate_event = create_event(
+            [create_span("http", 100.0, "http://example.com/slow?q=1", "")] * 4
+            + [create_span("http", 100.0, "http://example.com/slow?q=2", "")]
+        )
+        duplicate_event = create_event(
+            [create_span("http", 100.0, "http://example.com/slow?q=1", "abcdef")] * 4
+            + [create_span("http", 100.0, "http://example.com/slow?q=2", "abcdef")]
+        )
+
+        sdk_span_mock = Mock()
+
+        _detect_performance_issue(no_duplicate_event, sdk_span_mock)
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
+
+        _detect_performance_issue(duplicate_event, sdk_span_mock)
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 4
+        sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
+            [
+                call(
+                    "_pi_all_issue_count",
+                    1,
+                ),
+                call(
+                    "_pi_transaction",
+                    "aaaaaaaaaaaaaaaa",
+                ),
+                call(
+                    "_pi_dupes_hash_fp",
+                    "abcdef",
+                ),
+                call(
+                    "_pi_dupes_hash",
                     "bbbbbbbbbbbbbbbb",
                 ),
             ]
@@ -152,64 +190,15 @@ class PerformanceDetectionTest(unittest.TestCase):
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 3
 
     def test_calls_detect_sequential(self):
-        no_sequential_event = {
-            "event_id": "a" * 16,
-            "spans": [
-                modify_span_duration(
-                    SpanBuilder()
-                    .with_op("db")
-                    .with_description("SELECT count() FROM table WHERE id = %s")
-                    .build(),
-                    999.0,
-                )
-            ]
-            * 4,
-        }
-        sequential_event = {
-            "event_id": "a" * 16,
-            "spans": [
-                modify_span_duration(
-                    SpanBuilder()
-                    .with_op("db")
-                    .with_description("SELECT count() FROM table WHERE id = %s")
-                    .build(),
-                    999.0,
-                ),
-            ]
-            * 2
+        no_sequential_event = create_event([create_span("db", 999.0)] * 4)
+        sequential_event = create_event(
+            [create_span("db", 999.0)] * 2
             + [
-                modify_span_start(
-                    modify_span_duration(
-                        SpanBuilder()
-                        .with_op("db")
-                        .with_description("SELECT count() FROM table WHERE id = %s")
-                        .build(),
-                        999.0,
-                    ),
-                    1000.0,
-                ),
-                modify_span_start(
-                    modify_span_duration(
-                        SpanBuilder()
-                        .with_op("db")
-                        .with_description("SELECT count() FROM table WHERE id = %s")
-                        .build(),
-                        999.0,
-                    ),
-                    2000.0,
-                ),
-                modify_span_start(
-                    modify_span_duration(
-                        SpanBuilder()
-                        .with_op("db")
-                        .with_description("SELECT count() FROM table WHERE id = %s")
-                        .build(),
-                        999.0,
-                    ),
-                    3000.0,
-                ),
-            ],
-        }
+                modify_span_start(create_span("db", 999.0), 1000.0),
+                modify_span_start(create_span("db", 999.0), 2000.0),
+                modify_span_start(create_span("db", 999.0), 3000.0),
+            ]
+        )
 
         sdk_span_mock = Mock()
 
@@ -240,37 +229,15 @@ class PerformanceDetectionTest(unittest.TestCase):
         )
 
     def test_calls_detect_long_task(self):
-        tolerable_long_task_spans_event = {
-            "event_id": "a" * 16,
-            "spans": [
-                modify_span_duration(
-                    SpanBuilder().with_op("ui.long-task").with_description("Long Task").build(),
-                    50.0,
-                )
-            ]
-            * 3,
-        }
-
-        long_task_span_event = {
-            "event_id": "a" * 16,
-            "spans": [
-                modify_span_duration(
-                    SpanBuilder().with_op("ui.long-task").with_description("Long Task").build(),
-                    550.0,
-                )
-            ],
-        }
-
-        multiple_long_task_span_event = {
-            "event_id": "c" * 16,
-            "spans": [
-                modify_span_duration(
-                    SpanBuilder().with_op("ui.long-task").with_description("Long Task").build(),
-                    50.0,
-                )
-            ]
-            * 11,
-        }
+        tolerable_long_task_spans_event = create_event(
+            [create_span("ui.long-task", 50.0, "Long Task")] * 3, "a" * 16
+        )
+        long_task_span_event = create_event(
+            [create_span("ui.long-task", 550.0, "Long Task")], "a" * 16
+        )
+        multiple_long_task_span_event = create_event(
+            [create_span("ui.long-task", 50.0, "Long Task")] * 11, "c" * 16
+        )
 
         sdk_span_mock = Mock()
 


### PR DESCRIPTION
### Summary
This uses the existing grouping strategy hash already on the spans for http spans, since we have more refined rules around auto-parameterizing the description etc. If this works, it's also a better fingerprint to use since it allows us to directly query span.groups etc. on a transaction (eg. suspect spans).

The one issue with this approach is that it only works after `manager.save` is called ([here](https://github.com/getsentry/sentry/blob/master/src/sentry/event_manager.py#L1916)), which is where span groups gets calculated, so if we need to propagate data into the transaction based on detection we'll have to figure something else out (or move this to 'save')

#### Other
- Finished cleaning up test setup for other tests which shaved off a few lines.

