### PR TITLE
fix(hybrid-cloud): Redirect customer domain to last active org

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -8,8 +8,52 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.base import resolve_region
+from sentry.api.utils import generate_organization_url
 from sentry.models import Organization
 from sentry.utils import auth
+
+
+def _org_exists(slug):
+    if not slug:
+        return False
+    try:
+        Organization.objects.get_from_cache(slug=slug)
+        return True
+    except Organization.DoesNotExist:
+        return False
+
+
+def _resolve_activeorg(request):
+    subdomain = request.subdomain
+    session = getattr(request, "session", None)
+    if _org_exists(subdomain):
+        # Assume subdomain is an org slug being accessed
+        return subdomain
+    elif session and "activeorg" in session and _org_exists(session["activeorg"]):
+        return session["activeorg"]
+    return None
+
+
+def _resolve_redirect_url(request, activeorg):
+    subdomain = request.subdomain
+    redirect_subdomain = subdomain != activeorg
+    redirect_url = ""
+    if redirect_subdomain:
+        redirect_url = generate_organization_url(activeorg)
+    result = resolve(request.path)
+    org_slug_path_mismatch = (
+        result.kwargs
+        and "organization_slug" in result.kwargs
+        and result.kwargs["organization_slug"] != activeorg
+    )
+    if not redirect_subdomain and not org_slug_path_mismatch:
+        return None
+    kwargs = {**result.kwargs}
+    if org_slug_path_mismatch:
+        kwargs["organization_slug"] = activeorg
+    path = reverse(result.url_name, kwargs=kwargs)
+    redirect_url = f"{redirect_url}{path}"
+    return redirect_url
 
 
 class CustomerDomainMiddleware:
@@ -26,22 +70,14 @@ class CustomerDomainMiddleware:
         subdomain = request.subdomain
         if subdomain is None or resolve_region(request) is not None:
             return self.get_response(request)
-        try:
-            # Assume subdomain is an org slug being accessed
-            Organization.objects.get_from_cache(slug=subdomain)
-        except Organization.DoesNotExist:
+        activeorg = _resolve_activeorg(request)
+        if not activeorg:
             session = getattr(request, "session", None)
             if session and "activeorg" in session:
                 del session["activeorg"]
             return self.get_response(request)
-        auth.set_active_org(request, subdomain)
-        result = resolve(request.path)
-        if (
-            result.kwargs
-            and "organization_slug" in result.kwargs
-            and result.kwargs["organization_slug"] != subdomain
-        ):
-            return HttpResponseRedirect(
-                reverse(result.url_name, kwargs={**result.kwargs, "organization_slug": subdomain})
-            )
+        auth.set_active_org(request, activeorg)
+        redirect_url = _resolve_redirect_url(request, activeorg)
+        if redirect_url is not None and len(redirect_url) > 0:
+            return HttpResponseRedirect(redirect_url)
         return self.get_response(request)


### PR DESCRIPTION
Update the customer domain middleware introduced in https://github.com/getsentry/sentry/pull/37098 to fallback to the last active org. 