### PR TITLE
ref(indexer): Deprecate DbKey

### DIFF
--- a/src/sentry/sentry_metrics/configuration.py
+++ b/src/sentry/sentry_metrics/configuration.py
@@ -10,14 +10,8 @@ class UseCaseKey(Enum):
     PERFORMANCE = "performance"
 
 
-class DbKey(Enum):
-    STRING_INDEXER = "StringIndexer"
-    PERF_STRING_INDEXER = "PerfStringIndexer"
-
-
 @dataclass(frozen=True)
 class MetricsIngestConfiguration:
-    db_model: DbKey
     input_topic: str
     output_topic: str
     use_case_id: UseCaseKey
@@ -36,7 +30,6 @@ def get_ingest_config(use_case_key: UseCaseKey) -> MetricsIngestConfiguration:
     if len(_METRICS_INGEST_CONFIG_BY_USE_CASE) == 0:
         _register_ingest_config(
             MetricsIngestConfiguration(
-                db_model=DbKey.STRING_INDEXER,
                 input_topic=settings.KAFKA_INGEST_METRICS,
                 output_topic=settings.KAFKA_SNUBA_METRICS,
                 use_case_id=UseCaseKey.RELEASE_HEALTH,
@@ -46,7 +39,6 @@ def get_ingest_config(use_case_key: UseCaseKey) -> MetricsIngestConfiguration:
         )
         _register_ingest_config(
             MetricsIngestConfiguration(
-                db_model=DbKey.PERF_STRING_INDEXER,
                 input_topic=settings.KAFKA_INGEST_PERFORMANCE_METRICS,
                 output_topic=settings.KAFKA_SNUBA_GENERIC_METRICS,
                 use_case_id=UseCaseKey.PERFORMANCE,

--- a/src/sentry/sentry_metrics/consumers/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/consumers/last_seen_updater.py
@@ -125,7 +125,7 @@ def _last_seen_updater_processing_factory(
         process_message=retrieve_db_read_keys,
         prefilter=LastSeenUpdaterMessageFilter(metrics=get_metrics()),
         collector=lambda: LastSeenUpdaterCollector(
-            metrics=get_metrics(), table=TABLE_MAPPING[ingest_config.db_model]
+            metrics=get_metrics(), table=TABLE_MAPPING[ingest_config.use_case_id]
         ),
     )
 

--- a/src/sentry/sentry_metrics/indexer/db.py
+++ b/src/sentry/sentry_metrics/indexer/db.py
@@ -1,11 +1,11 @@
 from typing import Mapping, Type
 
-from sentry.sentry_metrics.configuration import DbKey
+from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.models import BaseIndexer, PerfStringIndexer, StringIndexer
 
 IndexerTable = Type[BaseIndexer]
 
-TABLE_MAPPING: Mapping[DbKey, IndexerTable] = {
-    DbKey.STRING_INDEXER: StringIndexer,
-    DbKey.PERF_STRING_INDEXER: PerfStringIndexer,
+TABLE_MAPPING: Mapping[UseCaseKey, IndexerTable] = {
+    UseCaseKey.RELEASE_HEALTH: StringIndexer,
+    UseCaseKey.PERFORMANCE: PerfStringIndexer,
 }

--- a/src/sentry/sentry_metrics/indexer/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres_v2.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping, Optional, Set
 from django.conf import settings
 from django.db.models import Q
 
-from sentry.sentry_metrics.configuration import UseCaseKey, get_ingest_config
+from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.indexer.base import KeyCollection, KeyResult, KeyResults, StringIndexer
 from sentry.sentry_metrics.indexer.cache import CachingIndexer, StringIndexerCache
 from sentry.sentry_metrics.indexer.db import TABLE_MAPPING, IndexerTable
@@ -148,7 +148,7 @@ class PGStringIndexerV2(StringIndexer):
         return string
 
     def _table(self, use_case_id: UseCaseKey) -> IndexerTable:
-        return TABLE_MAPPING[get_ingest_config(use_case_id).db_model]
+        return TABLE_MAPPING[use_case_id]
 
 
 class PostgresIndexer(StaticStringIndexer):


### PR DESCRIPTION
There's no reason for DbKey to exist on the main indexer configuration.
It's a Postgres specific implementation detail. The mapping between
UseCaseKey -> DbKey -> table name is now just UseCaseKey -> table name
and this is only in the Postgres backend.