### PR TITLE
chore(hybrid-cloud): Update organization type and stubs to add regionUrl

### DIFF
--- a/fixtures/js-stubs/organization.js
+++ b/fixtures/js-stubs/organization.js
@@ -4,8 +4,11 @@ export function Organization(params = {}) {
   return {
     id: '3',
     slug: 'org-slug',
-    organizationUrl: 'https://org-slug.us.sentry.io',
     name: 'Organization Name',
+    links: {
+      organizationUrl: 'https://org-slug.sentry.io',
+      regionUrl: 'https://us.sentry.io',
+    },
     access: [
       'org:read',
       'org:write',

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -14,8 +14,11 @@ export interface OrganizationSummary {
   features: string[];
   id: string;
   isEarlyAdopter: boolean;
+  links: {
+    organizationUrl: string;
+    regionUrl: string;
+  };
   name: string;
-  organizationUrl: string;
   require2FA: boolean;
   slug: string;
   status: {


### PR DESCRIPTION
This updates the organization summary type and updates the sub values in light of the changes introduced in https://github.com/getsentry/sentry/pull/37691