### PR TITLE
 feat(hybrid-cloud): Only allow Sentry staff to use customer domains

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Callable
 
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import resolve, reverse
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -86,7 +87,10 @@ class CustomerDomainMiddleware:
             url_prefix = options.get("system.url-prefix")
             qs = _query_string(request)
             redirect_url = f"{url_prefix}{request.path}{qs}"
-            return HttpResponseRedirect(redirect_url)
+            if request.method == "GET":
+                return HttpResponseRedirect(redirect_url)
+            else:
+                return HttpResponse(status=status.HTTP_400_BAD_REQUEST)
 
         activeorg = _resolve_activeorg(request)
         if not activeorg:

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -162,11 +162,14 @@ def provision_middleware():
     SENTRY_SELF_HOSTED=False,
 )
 class End2EndTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.middleware = provision_middleware()
+
     def test_with_middleware_no_customer_domain(self):
         self.create_organization(name="albertos-apples")
 
-        middleware = provision_middleware()
-        with override_settings(MIDDLEWARE=tuple(middleware)):
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
             # Induce activeorg session value of a non-existent org
             assert "activeorg" not in self.client.session
             response = self.client.post(
@@ -210,8 +213,7 @@ class End2EndTest(APITestCase):
     def test_with_middleware_and_customer_domain(self):
         self.create_organization(name="albertos-apples")
 
-        middleware = provision_middleware()
-        with override_settings(MIDDLEWARE=tuple(middleware)):
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
             # Induce activeorg session value of a non-existent org
             assert "activeorg" not in self.client.session
             response = self.client.post(
@@ -281,8 +283,7 @@ class End2EndTest(APITestCase):
         non_staff_user = self.create_user(is_staff=False)
         self.login_as(user=non_staff_user)
 
-        middleware = provision_middleware()
-        with override_settings(MIDDLEWARE=tuple(middleware)):
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
             # GET request
             response = self.client.get(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
@@ -324,8 +325,7 @@ class End2EndTest(APITestCase):
         is_staff_user = self.create_user(is_staff=True)
         self.login_as(user=is_staff_user)
 
-        middleware = provision_middleware()
-        with override_settings(MIDDLEWARE=tuple(middleware)):
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
             response = self.client.get(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
                 HTTP_HOST="albertos-apples.testserver",

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -286,17 +286,15 @@ class End2EndTest(APITestCase):
             response = self.client.get(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
                 data={"querystring": "value"},
-                HTTP_HOST="albertos-apples.testserver",
-            )
-            assert response.status_code == 302
-            assert (
-                response["Location"] == "http://testserver/api/0/albertos-apples/?querystring=value"
-            )
-
-            response = self.client.get(
-                reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
+                # This should preferably be HTTP_HOST.
+                # Using SERVER_NAME until https://code.djangoproject.com/ticket/32106 is fixed.
+                SERVER_NAME="albertos-apples.testserver",
+                follow=True,
             )
             assert response.status_code == 200
+            assert response.redirect_chain == [
+                ("http://testserver/api/0/albertos-apples/?querystring=value", 302)
+            ]
             assert response.data == {
                 "organization_slug": "albertos-apples",
                 "subdomain": None,

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -288,6 +288,17 @@ class End2EndTest(APITestCase):
             assert response.status_code == 302
             assert response["Location"] == "http://testserver/api/0/albertos-apples/"
 
+            response = self.client.get(
+                reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
+            )
+            assert response.status_code == 200
+            assert response.data == {
+                "organization_slug": "albertos-apples",
+                "subdomain": None,
+                "activeorg": None,
+            }
+            assert "activeorg" not in self.client.session
+
     def test_with_middleware_and_is_staff(self):
         self.create_organization(name="albertos-apples")
         is_staff_user = self.create_user(is_staff=True)

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -241,11 +241,12 @@ class End2EndTest(APITestCase):
             # Redirect response for org slug path mismatch
             response = self.client.get(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "some-org"}),
+                data={"querystring": "value"},
                 HTTP_HOST="albertos-apples.testserver",
                 follow=True,
             )
             assert response.status_code == 200
-            assert response.redirect_chain == [("/api/0/albertos-apples/", 302)]
+            assert response.redirect_chain == [("/api/0/albertos-apples/?querystring=value", 302)]
             assert response.data == {
                 "organization_slug": "albertos-apples",
                 "subdomain": "albertos-apples",
@@ -257,6 +258,7 @@ class End2EndTest(APITestCase):
             # Redirect response for subdomain and path mismatch
             response = self.client.get(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "some-org"}),
+                data={"querystring": "value"},
                 # This should preferably be HTTP_HOST.
                 # Using SERVER_NAME until https://code.djangoproject.com/ticket/32106 is fixed.
                 SERVER_NAME="does-not-exist.testserver",
@@ -264,7 +266,7 @@ class End2EndTest(APITestCase):
             )
             assert response.status_code == 200
             assert response.redirect_chain == [
-                ("http://albertos-apples.testserver/api/0/albertos-apples/", 302)
+                ("http://albertos-apples.testserver/api/0/albertos-apples/?querystring=value", 302)
             ]
             assert response.data == {
                 "organization_slug": "albertos-apples",
@@ -283,10 +285,13 @@ class End2EndTest(APITestCase):
         with override_settings(MIDDLEWARE=tuple(middleware)):
             response = self.client.get(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
+                data={"querystring": "value"},
                 HTTP_HOST="albertos-apples.testserver",
             )
             assert response.status_code == 302
-            assert response["Location"] == "http://testserver/api/0/albertos-apples/"
+            assert (
+                response["Location"] == "http://testserver/api/0/albertos-apples/?querystring=value"
+            )
 
             response = self.client.get(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -283,6 +283,7 @@ class End2EndTest(APITestCase):
 
         middleware = provision_middleware()
         with override_settings(MIDDLEWARE=tuple(middleware)):
+            # GET request
             response = self.client.get(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
                 data={"querystring": "value"},
@@ -301,6 +302,22 @@ class End2EndTest(APITestCase):
                 "activeorg": None,
             }
             assert "activeorg" not in self.client.session
+
+            # POST request
+            response = self.client.post(
+                reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
+                data={"querystring": "value"},
+                HTTP_HOST="albertos-apples.testserver",
+            )
+            assert response.status_code == 400
+
+            # PUT request (not-supported)
+            response = self.client.put(
+                reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
+                data={"querystring": "value"},
+                HTTP_HOST="albertos-apples.testserver",
+            )
+            assert response.status_code == 400
 
     def test_with_middleware_and_is_staff(self):
         self.create_organization(name="albertos-apples")


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/37788.

This updates the customer domain middleware to redirect any ***authenticated*** non-Sentry staff users to `sentry.io`.

