### PR TITLE
fix: explicitly define app label

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -339,7 +339,7 @@ INSTALLED_APPS = (
     "sentry.replays",
     "sentry.release_health",
     "sentry.search",
-    "sentry.sentry_metrics.indexer.postgres",
+    "sentry.sentry_metrics.indexer.postgres.apps.Config",
     "sentry.snuba",
     "sentry.lang.java.apps.Config",
     "sentry.lang.javascript.apps.Config",

--- a/src/sentry/sentry_metrics/indexer/postgres/__init__.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "sentry.sentry_metrics.indexer.postgres.apps.Config"  # noqa

--- a/src/sentry/sentry_metrics/indexer/postgres/apps.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class Config(AppConfig):  # type: ignore
+    name = "sentry.sentry_metrics.indexer.postgres"
+    label = "indexer.postgres.config"


### PR DESCRIPTION
This PR: https://github.com/getsentry/sentry/pull/37771 caused the following error

```
django.core.exceptions.ImproperlyConfigured: Application labels aren't unique, duplicates: postgres
```

It looks like the solution is to explicitly define what the label is using an `apps.py` file: https://stackoverflow.com/questions/24319558/how-to-resolve-django-core-exceptions-improperlyconfigured-application-labels.

It seems the default is the module name, in this case `postgres`. Which is not unique since there is already a module with that name