### PR TITLE
feat(hybrid-cloud): Add global setting to gatekeep customer domains feature holistically

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -87,6 +87,14 @@ register("mail.reply-hostname", default="", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORI
 register("mail.mailgun-api-key", default="", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register("mail.timeout", default=10, type=Int, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 
+# Hybrid Cloud
+register(
+    "hybrid-cloud.enable-customer-domains",
+    default=False,
+    type=Bool,
+    flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK,
+)
+
 # TOTP (Auth app)
 register(
     "totp.disallow-new-enrollment",


### PR DESCRIPTION
I'm introducing the `hybrid-cloud.enable-customer-domains` global setting that will control code paths that are specific for customer domains. 