### PR TITLE
chore(auth): Update tests for /auth/login/

### DIFF
--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -59,10 +59,27 @@ class AuthLoginTest(TestCase):
         self.client.get(self.path)
 
         resp = self.client.post(
-            self.path, {"username": self.user.username, "password": "admin", "op": "login"}
+            self.path, {"username": self.user.username, "password": "admin", "op": "login"}, follow=True,
         )
-        assert resp.url == "/auth/login/"
-        assert resp.status_code == 302
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            ("/organizations/new/", 302),
+        ]
+
+    def test_login_valid_credentials_with_org(self):
+        org = self.create_organization(owner=self.user)
+        # load it once for test cookie
+        self.client.get(self.path)
+
+        resp = self.client.post(
+            self.path, {"username": self.user.username, "password": "admin", "op": "login"}, follow=True,
+        )
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [
+            (reverse("sentry-login"), 302),
+            (f"/organizations/{org.slug}/issues/", 302),
+        ]
 
     def test_login_valid_credentials_2fa_redirect(self):
         user = self.create_user("bar@example.com")

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -59,7 +59,9 @@ class AuthLoginTest(TestCase):
         self.client.get(self.path)
 
         resp = self.client.post(
-            self.path, {"username": self.user.username, "password": "admin", "op": "login"}, follow=True,
+            self.path,
+            {"username": self.user.username, "password": "admin", "op": "login"},
+            follow=True,
         )
         assert resp.status_code == 200
         assert resp.redirect_chain == [
@@ -73,7 +75,9 @@ class AuthLoginTest(TestCase):
         self.client.get(self.path)
 
         resp = self.client.post(
-            self.path, {"username": self.user.username, "password": "admin", "op": "login"}, follow=True,
+            self.path,
+            {"username": self.user.username, "password": "admin", "op": "login"},
+            follow=True,
         )
         assert resp.status_code == 200
         assert resp.redirect_chain == [


### PR DESCRIPTION
I've updated the tests for `/auth/login/` so that we can assert the redirects after login.

I plan to update the redirects for customer domains later on. So I'd like to preserve the current behaviour before I make those changes. 