### PR TITLE
fix(suspect-resolutions): Pass issue resolution time to get_files_changed_in_releases()

### DIFF
--- a/src/sentry/utils/suspect_resolutions/__init__.py
+++ b/src/sentry/utils/suspect_resolutions/__init__.py
@@ -2,4 +2,4 @@ from .analytics import *  # NOQA
 
 # make sure to increment this when making changes to anything within the 'suspect_resolutions' directory
 # keeps track of changes to how we process suspect commits, so we can filter out analytics events by the algo version
-ALGO_VERSION = "0.0.2"
+ALGO_VERSION = "0.0.3"


### PR DESCRIPTION
Query the `Group` table for the `resolved_issue`'s `resolved_at` and pass the timestamp to `get_files_changed_in_releases()` instead of `timezone.now()`