### PR TITLE
fix(dashboards): Fix custom metrics not displaying with units correctly in widget viewer

### DIFF
--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -174,6 +174,7 @@ export const renderGridBodyCell =
         if (!tableData || !tableData.meta) {
           return dataRow[column.key];
         }
+        const unit = tableData.meta.units?.[column.key];
         cell = getFieldRenderer(
           columnKey,
           tableData.meta,
@@ -181,6 +182,7 @@ export const renderGridBodyCell =
         )(dataRow, {
           organization,
           location,
+          unit,
         });
 
         const fieldName = getAggregateAlias(columnKey);

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -107,6 +107,7 @@ export enum FieldValueType {
   PERCENTAGE = 'percentage',
   STRING = 'string',
   NEVER = 'never',
+  SIZE = 'size',
 }
 
 export enum WebVital {


### PR DESCRIPTION
Columns with units weren't displaying properly in widget viewer.
![image](https://user-images.githubusercontent.com/83961295/184663508-befb7e86-2f02-42ad-b174-aeace45c9097.png)
