### PR TITLE
fix(replays): Remove "from" url for navigation breadcrumbs

### DIFF
--- a/static/app/components/replays/breadcrumbs/utils.tsx
+++ b/static/app/components/replays/breadcrumbs/utils.tsx
@@ -6,9 +6,7 @@ import {BreadcrumbType, Crumb} from 'sentry/types/breadcrumbs';
 export function getDescription(crumb: Crumb) {
   switch (crumb.type) {
     case BreadcrumbType.NAVIGATION:
-      return `${crumb.data?.from ? `${crumb.data?.from} => ` : ''}${
-        crumb.data?.to ?? ''
-      }`;
+      return `${crumb.data?.to ?? ''}`;
     case BreadcrumbType.DEFAULT:
       return JSON.stringify(crumb.data);
     default:


### PR DESCRIPTION


<!-- Describe your PR here. -->
Removed `from` url from navigation breadcrumbs. Closes #37264 

![image](https://user-images.githubusercontent.com/39612839/184669550-d228e00e-f6e8-459e-973e-7e718b6c0905.png)



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
