### PR TITLE
fix(copy): attachments not found copy

### DIFF
--- a/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -78,7 +78,7 @@ class GroupEventAttachments extends AsyncComponent<Props, State> {
   renderNoQueryResults() {
     return (
       <EmptyStateWarning>
-        <p>{t('Sorry, no event attachments match your search query.')}</p>
+        <p>{t('No crash reports found')}</p>
       </EmptyStateWarning>
     );
   }
@@ -86,7 +86,7 @@ class GroupEventAttachments extends AsyncComponent<Props, State> {
   renderEmpty() {
     return (
       <EmptyStateWarning>
-        <p>{t("There don't seem to be any event attachments yet.")}</p>
+        <p>{t('No attachments found')}</p>
       </EmptyStateWarning>
     );
   }


### PR DESCRIPTION
In the Attachments tab of issue details, the copy when there’s no attachments found is apologetic. So fixing that here.

## Before

<img width="1099" alt="CleanShot 2022-08-12 at 14 43 12@2x" src="https://user-images.githubusercontent.com/1900676/184448990-642267b6-9b4a-4202-ab2a-d0cfa5c71108.png">
<img width="1106" alt="CleanShot 2022-08-12 at 14 43 04@2x" src="https://user-images.githubusercontent.com/1900676/184449013-b14c7e12-76b6-443e-8a55-71c8a9241095.png">

## After
<img width="1096" alt="CleanShot 2022-08-12 at 14 48 05@2x" src="https://user-images.githubusercontent.com/1900676/184678728-f9ce411e-9bee-42eb-a7a0-f24322d6adee.png">
<img width="1091" alt="CleanShot 2022-08-12 at 14 48 00@2x" src="https://user-images.githubusercontent.com/1900676/184678743-476d88aa-4428-49a0-a9d3-4476eabcf4e8.png">

