### PR TITLE
ref: use pyuwsgi instead of uwsgi for easier installation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,10 +51,12 @@ ENV \
 COPY /dist/requirements-frozen.txt /tmp/requirements-frozen.txt
 RUN set -x \
   && buildDeps="" \
-  # uwsgi
+  # uwsgi-dogstatsd
   && buildDeps="$buildDeps \
   gcc \
+  libpcre3-dev \
   wget \
+  zlib1g-dev \
   " \
   # maxminddb
   && buildDeps="$buildDeps \

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -68,7 +68,7 @@ urllib3[brotli]>=1.26.9
 brotli>=1.0.9
 # See if we can remove LDFLAGS from lib.sh
 # https://github.com/getsentry/sentry/pull/30094
-uWSGI==2.0.20.0
+pyuwsgi==2.0.20.0
 zstandard>=0.18.0
 
 msgpack>=1.0.4

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -131,6 +131,7 @@ python-utils==3.3.3
 python3-saml==1.14.0
 pytz==2018.9
 pyupgrade==2.37.2
+pyuwsgi==2.0.20.0
 pyyaml==5.4
 rb==1.9.0
 redis==3.4.1
@@ -174,7 +175,6 @@ ua-parser==0.10.0
 unidiff==0.7.4
 uritemplate==4.1.1
 urllib3==1.26.11
-uwsgi==2.0.20.0
 vine==1.3.0
 virtualenv==20.14.1
 websocket-client==1.3.2

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -85,6 +85,7 @@ python-u2flib-server==5.0.0
 python-utils==3.3.3
 python3-saml==1.14.0
 pytz==2018.9
+pyuwsgi==2.0.20.0
 pyyaml==5.4
 rb==1.9.0
 redis==3.4.1
@@ -118,7 +119,6 @@ ua-parser==0.10.0
 unidiff==0.7.4
 uritemplate==4.1.1
 urllib3==1.26.11
-uwsgi==2.0.20.0
 vine==1.3.0
 wsproto==1.1.0
 xmlsec==1.3.11

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -111,6 +111,9 @@ install-py-dev() {
         export LDFLAGS="-L$(brew --prefix gettext)/lib"
     fi
 
+    # pip doesn't do well with swapping drop-ins
+    pip uninstall -qqy uwsgi
+
     # SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
     # Webpacked assets are only necessary for devserver (which does it lazily anyways)
     # and acceptance tests, which webpack automatically if run.

--- a/src/sentry/services/http.py
+++ b/src/sentry/services/http.py
@@ -3,6 +3,20 @@ import sys
 
 from sentry.services.base import Service
 
+PYUWSGI_PROG = """\
+import os
+import sys
+
+orig = sys.getdlopenflags()
+sys.setdlopenflags(orig | os.RTLD_GLOBAL)
+try:
+    import pyuwsgi
+finally:
+    sys.setdlopenflags(orig)
+
+pyuwsgi.run()
+"""
+
 
 def convert_options_to_env(options):
     for k, v in options.items():
@@ -168,4 +182,6 @@ class SentryHTTPServer(Service):
             httpd = make_server(host, int(port), application)
             httpd.serve_forever()
         else:
-            os.execvp("uwsgi", ("uwsgi",))
+            # TODO: https://github.com/lincolnloop/pyuwsgi-wheels/pull/17
+            cmd = (sys.executable, "-c", PYUWSGI_PROG)
+            os.execvp(cmd[0], cmd)


### PR DESCRIPTION
`uwsgi` isn't really "wheelable" due to static linking libpython.  `pyuwsgi` is just `uwsgi` but compiled as a python module (so it gets `libpython` symbols via the import system instead)

this needs to be merged after https://github.com/getsentry/getsentry/pull/8149