### PR TITLE
fix(eventstream): Fix random transaction partitioning mode

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1448,6 +1448,12 @@ SENTRY_NEWSLETTER_OPTIONS = {}
 SENTRY_EVENTSTREAM = "sentry.eventstream.snuba.SnubaEventStream"
 SENTRY_EVENTSTREAM_OPTIONS = {}
 
+# Send transaction events to random Kafka partitions. Currently
+# this defaults to false as transaction events are partitioned the same
+# as errors (by project ID). Eventually we will flip the default and remove
+# this from settings entirely.
+SENTRY_EVENTSTREAM_PARTITION_TRANSACTIONS_RANDOMLY = False
+
 # rollups must be ordered from highest granularity to lowest
 SENTRY_TSDB_ROLLUPS = (
     # (time in seconds, samples to keep)

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -26,8 +26,8 @@ class KafkaEventStream(SnubaProtocolEventStream):
     def __init__(self, **options):
         self.topic = settings.KAFKA_EVENTS
         self.transactions_topic = settings.KAFKA_TRANSACTIONS
-        self.assign_transaction_partitions_randomly = options.get(
-            "kafka.partition-transactions-randomly"
+        self.assign_transaction_partitions_randomly = (
+            settings.SENTRY_EVENTSTREAM_PARTITION_TRANSACTIONS_RANDOMLY
         )
 
     @cached_property

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -446,12 +446,6 @@ register("store.save-transactions-ingest-consumer-rate", default=0.0)
 # Drop delete_old_primary_hash messages for a particular project.
 register("reprocessing2.drop-delete-old-primary-hash", default=[])
 
-
-# Send transaction events to random Kafka partitions. Currently
-# this defaults to false as transaction events are partitioned the same
-# as errors (by project ID). Eventually we will flip the default.
-register("kafka.partition-transactions-randomly", default=False)
-
 # Send event messages for specific project IDs to random partitions in Kafka
 # contents are a list of project IDs to message types to be randomly assigned
 # e.g. [{"project_id": 2, "message_type": "error"}, {"project_id": 3, "message_type": "transaction"}]


### PR DESCRIPTION
This is now configured via settings and not options. Setting this via
option did not actually work as it was only being checked once on start
up and the value of an option was always initially None