### PR TITLE
fix(ui): Boolean field should not pass 'type' down to SwitchButton

### DIFF
--- a/static/app/components/forms/booleanField.tsx
+++ b/static/app/components/forms/booleanField.tsx
@@ -45,13 +45,15 @@ export default class BooleanField extends Component<BooleanFieldProps> {
           disabled: boolean;
           onBlur: onEvent;
           onChange: onEvent;
+          type: string;
           value: any;
         }) => {
           // Create a function with required args bound
           const handleChange = this.handleChange.bind(this, value, onChange, onBlur);
 
+          const {type: _, ...propsWithoutType} = props;
           const switchProps = {
-            ...props,
+            ...propsWithoutType,
             size: 'lg' as React.ComponentProps<typeof Switch>['size'],
             isActive: !!value,
             isDisabled: disabled,

--- a/static/app/components/switchButton.tsx
+++ b/static/app/components/switchButton.tsx
@@ -34,7 +34,6 @@ const Switch = ({
     ref={forwardedRef}
     id={id}
     name={name}
-    type="button"
     className={className}
     onClick={isDisabled ? undefined : toggle}
     role="checkbox"
@@ -45,6 +44,7 @@ const Switch = ({
     size={size}
     data-test-id="switch"
     {...props}
+    type="button"
   >
     <Toggle
       isDisabled={isDisabled}

--- a/static/app/components/switchButton.tsx
+++ b/static/app/components/switchButton.tsx
@@ -34,6 +34,7 @@ const Switch = ({
     ref={forwardedRef}
     id={id}
     name={name}
+    type="button"
     className={className}
     onClick={isDisabled ? undefined : toggle}
     role="checkbox"
@@ -44,7 +45,6 @@ const Switch = ({
     size={size}
     data-test-id="switch"
     {...props}
-    type="button"
   >
     <Toggle
       isDisabled={isDisabled}


### PR DESCRIPTION
Previously a booleanField in a form would send down `type` as a prop to the `SwitchButton`, overriding the `SwitchButton`'s existing `type='button'` declaration. This caused it to respond to `enter` keypresses in any form such as the one below: 

(I am pressing enter in the `name` text box which is triggering a form submit which latches onto the first switch button)

![Kapture 2022-08-15 at 15 35 40](https://user-images.githubusercontent.com/9372512/184707160-b2ac7cb4-23c7-40f5-bdeb-b574ec3c9eae.gif)

This PR extracts the `type` property out of the props before sending it down to the `SwitchButton`