### PR TITLE
ref(writes-ratelimiter): Add namespace

### DIFF
--- a/src/sentry/sentry_metrics/configuration.py
+++ b/src/sentry/sentry_metrics/configuration.py
@@ -13,7 +13,7 @@ class UseCaseKey(Enum):
 # Rate limiter namespaces, the postgres (PG)
 # values are the same as UseCaseKey to keep
 # backwards compatibility
-RELEASE_HEALTH_PG_NAMESPACE = "release-health"
+RELEASE_HEALTH_PG_NAMESPACE = "releasehealth"
 PERFORMANCE_PG_NAMESPACE = "performance"
 
 
@@ -31,10 +31,6 @@ _METRICS_INGEST_CONFIG_BY_USE_CASE: MutableMapping[UseCaseKey, MetricsIngestConf
 
 
 def _register_ingest_config(config: MetricsIngestConfiguration) -> None:
-    for registered_config in _METRICS_INGEST_CONFIG_BY_USE_CASE.values():
-        assert (
-            registered_config.writes_limiter_namespace != config.writes_limiter_namespace
-        ), "namespace must be unique!"
     _METRICS_INGEST_CONFIG_BY_USE_CASE[config.use_case_id] = config
 
 

--- a/src/sentry/sentry_metrics/configuration.py
+++ b/src/sentry/sentry_metrics/configuration.py
@@ -31,6 +31,10 @@ _METRICS_INGEST_CONFIG_BY_USE_CASE: MutableMapping[UseCaseKey, MetricsIngestConf
 
 
 def _register_ingest_config(config: MetricsIngestConfiguration) -> None:
+    for registered_config in _METRICS_INGEST_CONFIG_BY_USE_CASE.values():
+        assert (
+            registered_config.writes_limiter_namespace != config.writes_limiter_namespace
+        ), "namespace must be unique!"
     _METRICS_INGEST_CONFIG_BY_USE_CASE[config.use_case_id] = config
 
 

--- a/src/sentry/sentry_metrics/configuration.py
+++ b/src/sentry/sentry_metrics/configuration.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import MutableMapping, Optional
+from typing import Any, Mapping, MutableMapping, Optional
 
 from django.conf import settings
 
@@ -23,7 +23,7 @@ class MetricsIngestConfiguration:
     output_topic: str
     use_case_id: UseCaseKey
     internal_metrics_tag: Optional[str]
-    writes_limiter_cluster_options: str
+    writes_limiter_cluster_options: Mapping[str, Any]
     writes_limiter_namespace: str
 
 

--- a/src/sentry/sentry_metrics/configuration.py
+++ b/src/sentry/sentry_metrics/configuration.py
@@ -10,13 +10,18 @@ class UseCaseKey(Enum):
     PERFORMANCE = "performance"
 
 
+class RateLimiterNamespace(Enum):
+    RELEASE_HEALTH = "releasehealth"
+    PERFORMANCE = "performance"
+
+
 @dataclass(frozen=True)
 class MetricsIngestConfiguration:
     input_topic: str
     output_topic: str
     use_case_id: UseCaseKey
     internal_metrics_tag: Optional[str]
-    writes_limiter_cluster_options: Mapping[str, Any]
+    writes_limiter_namespace: RateLimiterNamespace
 
 
 _METRICS_INGEST_CONFIG_BY_USE_CASE: MutableMapping[UseCaseKey, MetricsIngestConfiguration] = dict()
@@ -34,7 +39,7 @@ def get_ingest_config(use_case_key: UseCaseKey) -> MetricsIngestConfiguration:
                 output_topic=settings.KAFKA_SNUBA_METRICS,
                 use_case_id=UseCaseKey.RELEASE_HEALTH,
                 internal_metrics_tag="release-health",
-                writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS,
+                writes_limiter_namespace=RateLimiterNamespace.RELEASE_HEALTH,
             )
         )
         _register_ingest_config(
@@ -43,8 +48,40 @@ def get_ingest_config(use_case_key: UseCaseKey) -> MetricsIngestConfiguration:
                 output_topic=settings.KAFKA_SNUBA_GENERIC_METRICS,
                 use_case_id=UseCaseKey.PERFORMANCE,
                 internal_metrics_tag="perf",
-                writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE,
+                writes_limiter_namespace=RateLimiterNamespace.PERFORMANCE,
             )
         )
 
     return _METRICS_INGEST_CONFIG_BY_USE_CASE[use_case_key]
+
+
+@dataclass(frozen=True)
+class RateLimiterConfiguration:
+    namespace: RateLimiterNamespace
+    writes_limiter_cluster_options: Mapping[str, Any]
+
+
+_WRITES_RATELIMITER_BY_NAMESPACE: MutableMapping[
+    RateLimiterNamespace, RateLimiterConfiguration
+] = dict()
+
+
+def _register_ratelimiter_config(config: RateLimiterConfiguration) -> None:
+    _WRITES_RATELIMITER_BY_NAMESPACE[config.namespace] = config
+
+
+def get_writes_ratelimiter_config(namespace: RateLimiterNamespace) -> RateLimiterConfiguration:
+    if len(_WRITES_RATELIMITER_BY_NAMESPACE) == 0:
+        _register_ratelimiter_config(
+            RateLimiterConfiguration(
+                namespace=RateLimiterNamespace.RELEASE_HEALTH,
+                writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS,
+            )
+        )
+        _register_ratelimiter_config(
+            RateLimiterConfiguration(
+                namespace=RateLimiterNamespace.PERFORMANCE,
+                writes_limiter_cluster_options=settings.SENTRY_METRICS_INDEXER_WRITES_LIMITER_OPTIONS_PERFORMANCE,
+            )
+        )
+    return _WRITES_RATELIMITER_BY_NAMESPACE[namespace]

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -80,7 +80,7 @@ class PGStringIndexerV2(StringIndexer):
         ratelimiter_namespace = get_ingest_config(use_case_id).writes_limiter_namespace
 
         with writes_limiter.check_write_limits(
-            ratelimiter_namespace, db_write_keys
+            use_case_id, ratelimiter_namespace, db_write_keys
         ) as writes_limiter_state:
             # After the DB has successfully committed writes, we exit this
             # context manager and consume quotas. If the DB crashes we

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping, Optional, Set
 from django.conf import settings
 from django.db.models import Q
 
-from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.sentry_metrics.configuration import UseCaseKey, get_ingest_config
 from sentry.sentry_metrics.indexer.base import (
     FetchType,
     KeyCollection,
@@ -77,7 +77,11 @@ class PGStringIndexerV2(StringIndexer):
         if db_write_keys.size == 0:
             return db_read_key_results
 
-        with writes_limiter.check_write_limits(use_case_id, db_write_keys) as writes_limiter_state:
+        ratelimiter_namespace = get_ingest_config(use_case_id).writes_limiter_namespace
+
+        with writes_limiter.check_write_limits(
+            ratelimiter_namespace, db_write_keys
+        ) as writes_limiter_state:
             # After the DB has successfully committed writes, we exit this
             # context manager and consume quotas. If the DB crashes we
             # shouldn't consume quota.

--- a/src/sentry/sentry_metrics/indexer/ratelimiters.py
+++ b/src/sentry/sentry_metrics/indexer/ratelimiters.py
@@ -18,20 +18,15 @@ from sentry.utils import metrics
 OrgId = int
 
 
-def _build_quota_key(use_case_id: UseCaseKey, org_id: Optional[OrgId] = None) -> str:
-    use_case_str = {
-        UseCaseKey.PERFORMANCE: "performance",
-        UseCaseKey.RELEASE_HEALTH: "releasehealth",
-    }[use_case_id]
-
+def _build_quota_key(namespace: str, org_id: Optional[OrgId] = None) -> str:
     if org_id is not None:
-        return f"metrics-indexer-{use_case_str}-org-{org_id}"
+        return f"metrics-indexer-{namespace}-org-{org_id}"
     else:
-        return f"metrics-indexer-{use_case_str}-global"
+        return f"metrics-indexer-{namespace}-global"
 
 
 @metrics.wraps("sentry_metrics.indexer.construct_quotas")
-def _construct_quotas(use_case_id: UseCaseKey) -> Sequence[Quota]:
+def _construct_quotas(use_case_id: UseCaseKey, namespace: str) -> Sequence[Quota]:
     """
     Construct write limit's quotas based on current sentry options.
 
@@ -40,7 +35,7 @@ def _construct_quotas(use_case_id: UseCaseKey) -> Sequence[Quota]:
     """
     if use_case_id == UseCaseKey.PERFORMANCE:
         return [
-            Quota(prefix_override=_build_quota_key(UseCaseKey.PERFORMANCE, None), **args)
+            Quota(prefix_override=_build_quota_key(namespace, None), **args)
             for args in options.get("sentry-metrics.writes-limiter.limits.performance.global")
         ] + [
             Quota(prefix_override=None, **args)
@@ -48,7 +43,7 @@ def _construct_quotas(use_case_id: UseCaseKey) -> Sequence[Quota]:
         ]
     elif use_case_id == UseCaseKey.RELEASE_HEALTH:
         return [
-            Quota(prefix_override=_build_quota_key(UseCaseKey.RELEASE_HEALTH, None), **args)
+            Quota(prefix_override=_build_quota_key(namespace, None), **args)
             for args in options.get("sentry-metrics.writes-limiter.limits.releasehealth.global")
         ] + [
             Quota(prefix_override=None, **args)
@@ -60,18 +55,18 @@ def _construct_quotas(use_case_id: UseCaseKey) -> Sequence[Quota]:
 
 @metrics.wraps("sentry_metrics.indexer.construct_quota_requests")
 def _construct_quota_requests(
-    use_case_id: UseCaseKey, keys: KeyCollection
+    use_case_id: UseCaseKey, namespace: str, keys: KeyCollection
 ) -> Tuple[Sequence[OrgId], Sequence[RequestedQuota]]:
     org_ids = []
     requests = []
-    quotas = _construct_quotas(use_case_id)
+    quotas = _construct_quotas(use_case_id, namespace)
 
     if quotas:
         for org_id, strings in keys.mapping.items():
             org_ids.append(org_id)
             requests.append(
                 RequestedQuota(
-                    prefix=_build_quota_key(use_case_id, org_id),
+                    prefix=_build_quota_key(namespace, org_id),
                     requested=len(strings),
                     quotas=quotas,
                 )
@@ -143,7 +138,7 @@ class WritesLimiter:
         Upon (successful) exit, rate limits are consumed.
         """
 
-        org_ids, requests = _construct_quota_requests(use_case_id, keys)
+        org_ids, requests = _construct_quota_requests(use_case_id, namespace, keys)
         timestamp, grants = self._get_rate_limiter(use_case_id, namespace).check_within_quotas(
             requests
         )

--- a/src/sentry/sentry_metrics/indexer/ratelimiters.py
+++ b/src/sentry/sentry_metrics/indexer/ratelimiters.py
@@ -19,11 +19,15 @@ OrgId = int
 
 
 def _build_quota_key(use_case_id: UseCaseKey, org_id: Optional[OrgId] = None) -> str:
+    use_case_str = {
+        UseCaseKey.PERFORMANCE: "performance",
+        UseCaseKey.RELEASE_HEALTH: "releasehealth",
+    }[use_case_id]
 
     if org_id is not None:
-        return f"metrics-indexer-{use_case_id}-org-{org_id}"
+        return f"metrics-indexer-{use_case_str}-org-{org_id}"
     else:
-        return f"metrics-indexer-{use_case_id}-global"
+        return f"metrics-indexer-{use_case_str}-global"
 
 
 @metrics.wraps("sentry_metrics.indexer.construct_quotas")

--- a/src/sentry/sentry_metrics/indexer/ratelimiters.py
+++ b/src/sentry/sentry_metrics/indexer/ratelimiters.py
@@ -11,65 +11,63 @@ from sentry.ratelimits.sliding_windows import (
     RequestedQuota,
     Timestamp,
 )
-from sentry.sentry_metrics.configuration import RateLimiterNamespace, get_writes_ratelimiter_config
+from sentry.sentry_metrics.configuration import UseCaseKey, get_ingest_config
 from sentry.sentry_metrics.indexer.base import FetchType, FetchTypeExt, KeyCollection, KeyResult
 from sentry.utils import metrics
 
 OrgId = int
 
 
-def _build_quota_key(namespace: RateLimiterNamespace, org_id: Optional[OrgId] = None) -> str:
+def _build_quota_key(use_case_id: UseCaseKey, org_id: Optional[OrgId] = None) -> str:
 
     if org_id is not None:
-        return f"metrics-indexer-{namespace.value}-org-{org_id}"
+        return f"metrics-indexer-{use_case_id}-org-{org_id}"
     else:
-        return f"metrics-indexer-{namespace.value}-global"
+        return f"metrics-indexer-{use_case_id}-global"
 
 
 @metrics.wraps("sentry_metrics.indexer.construct_quotas")
-def _construct_quotas(namespace: RateLimiterNamespace) -> Sequence[Quota]:
+def _construct_quotas(use_case_id: UseCaseKey) -> Sequence[Quota]:
     """
     Construct write limit's quotas based on current sentry options.
 
     This value can potentially cached globally as long as it is invalidated
     when sentry.options are.
     """
-    if namespace == RateLimiterNamespace.PERFORMANCE:
+    if use_case_id == UseCaseKey.PERFORMANCE:
         return [
-            Quota(prefix_override=_build_quota_key(RateLimiterNamespace.PERFORMANCE, None), **args)
+            Quota(prefix_override=_build_quota_key(UseCaseKey.PERFORMANCE, None), **args)
             for args in options.get("sentry-metrics.writes-limiter.limits.performance.global")
         ] + [
             Quota(prefix_override=None, **args)
             for args in options.get("sentry-metrics.writes-limiter.limits.performance.per-org")
         ]
-    elif namespace == RateLimiterNamespace.RELEASE_HEALTH:
+    elif use_case_id == UseCaseKey.RELEASE_HEALTH:
         return [
-            Quota(
-                prefix_override=_build_quota_key(RateLimiterNamespace.RELEASE_HEALTH, None), **args
-            )
+            Quota(prefix_override=_build_quota_key(UseCaseKey.RELEASE_HEALTH, None), **args)
             for args in options.get("sentry-metrics.writes-limiter.limits.releasehealth.global")
         ] + [
             Quota(prefix_override=None, **args)
             for args in options.get("sentry-metrics.writes-limiter.limits.releasehealth.per-org")
         ]
     else:
-        raise ValueError(namespace)
+        raise ValueError(use_case_id)
 
 
 @metrics.wraps("sentry_metrics.indexer.construct_quota_requests")
 def _construct_quota_requests(
-    namespace: RateLimiterNamespace, keys: KeyCollection
+    use_case_id: UseCaseKey, keys: KeyCollection
 ) -> Tuple[Sequence[OrgId], Sequence[RequestedQuota]]:
     org_ids = []
     requests = []
-    quotas = _construct_quotas(namespace)
+    quotas = _construct_quotas(use_case_id)
 
     if quotas:
         for org_id, strings in keys.mapping.items():
             org_ids.append(org_id)
             requests.append(
                 RequestedQuota(
-                    prefix=_build_quota_key(namespace, org_id),
+                    prefix=_build_quota_key(use_case_id, org_id),
                     requested=len(strings),
                     quotas=quotas,
                 )
@@ -88,7 +86,8 @@ class DroppedString:
 @dataclasses.dataclass(frozen=True)
 class RateLimitState:
     _writes_limiter: WritesLimiter
-    _namespace: RateLimiterNamespace
+    _use_case_id: UseCaseKey
+    _namespace: str
     _requests: Sequence[RequestedQuota]
     _grants: Sequence[GrantedQuota]
     _timestamp: Timestamp
@@ -105,25 +104,27 @@ class RateLimitState:
         Consumes the rate limits returned by `check_write_limits`.
         """
         if exc_type is None:
-            self._writes_limiter._get_rate_limiter(self._namespace).use_quotas(
+            self._writes_limiter._get_rate_limiter(self._use_case_id, self._namespace).use_quotas(
                 self._requests, self._grants, self._timestamp
             )
 
 
 class WritesLimiter:
     def __init__(self) -> None:
-        self.rate_limiters: MutableMapping[RateLimiterNamespace, RedisSlidingWindowRateLimiter] = {}
+        self.rate_limiters: MutableMapping[str, RedisSlidingWindowRateLimiter] = {}
 
-    def _get_rate_limiter(self, namespace: RateLimiterNamespace) -> RedisSlidingWindowRateLimiter:
+    def _get_rate_limiter(
+        self, use_case_id: UseCaseKey, namespace: str
+    ) -> RedisSlidingWindowRateLimiter:
         if namespace not in self.rate_limiters:
-            options = get_writes_ratelimiter_config(namespace).writes_limiter_cluster_options
+            options = get_ingest_config(use_case_id).writes_limiter_cluster_options
             self.rate_limiters[namespace] = RedisSlidingWindowRateLimiter(**options)
 
         return self.rate_limiters[namespace]
 
     @metrics.wraps("sentry_metrics.indexer.check_write_limits")
     def check_write_limits(
-        self, namespace: RateLimiterNamespace, keys: KeyCollection
+        self, use_case_id: UseCaseKey, namespace: str, keys: KeyCollection
     ) -> RateLimitState:
         """
         Takes a KeyCollection and applies DB write limits as configured via sentry.options.
@@ -138,8 +139,10 @@ class WritesLimiter:
         Upon (successful) exit, rate limits are consumed.
         """
 
-        org_ids, requests = _construct_quota_requests(namespace, keys)
-        timestamp, grants = self._get_rate_limiter(namespace).check_within_quotas(requests)
+        org_ids, requests = _construct_quota_requests(use_case_id, keys)
+        timestamp, grants = self._get_rate_limiter(use_case_id, namespace).check_within_quotas(
+            requests
+        )
 
         granted_key_collection = dict(keys.mapping)
         dropped_strings = []
@@ -169,6 +172,7 @@ class WritesLimiter:
 
         state = RateLimitState(
             _writes_limiter=self,
+            _use_case_id=use_case_id,
             _namespace=namespace,
             _requests=requests,
             _grants=grants,

--- a/tests/sentry/sentry_metrics/test_configuration.py
+++ b/tests/sentry/sentry_metrics/test_configuration.py
@@ -1,0 +1,24 @@
+import pytest
+
+from sentry.sentry_metrics.configuration import (
+    RELEASE_HEALTH_PG_NAMESPACE,
+    MetricsIngestConfiguration,
+    UseCaseKey,
+    _register_ingest_config,
+    get_ingest_config,
+)
+
+
+def test_unique_namespaces() -> None:
+    get_ingest_config(UseCaseKey.RELEASE_HEALTH)
+    with pytest.raises(AssertionError):
+        _register_ingest_config(
+            MetricsIngestConfiguration(
+                input_topic="input-topic",
+                output_topic="output-topic",
+                use_case_id=UseCaseKey.RELEASE_HEALTH,
+                internal_metrics_tag="release-health",
+                writes_limiter_cluster_options={},
+                writes_limiter_namespace=RELEASE_HEALTH_PG_NAMESPACE,
+            )
+        )

--- a/tests/sentry/sentry_metrics/test_configuration.py
+++ b/tests/sentry/sentry_metrics/test_configuration.py
@@ -1,24 +1,13 @@
-import pytest
-
 from sentry.sentry_metrics.configuration import (
-    RELEASE_HEALTH_PG_NAMESPACE,
-    MetricsIngestConfiguration,
+    _METRICS_INGEST_CONFIG_BY_USE_CASE,
     UseCaseKey,
-    _register_ingest_config,
     get_ingest_config,
 )
 
 
 def test_unique_namespaces() -> None:
     get_ingest_config(UseCaseKey.RELEASE_HEALTH)
-    with pytest.raises(AssertionError):
-        _register_ingest_config(
-            MetricsIngestConfiguration(
-                input_topic="input-topic",
-                output_topic="output-topic",
-                use_case_id=UseCaseKey.RELEASE_HEALTH,
-                internal_metrics_tag="release-health",
-                writes_limiter_cluster_options={},
-                writes_limiter_namespace=RELEASE_HEALTH_PG_NAMESPACE,
-            )
-        )
+    namespaces = [
+        config.writes_limiter_namespace for config in _METRICS_INGEST_CONFIG_BY_USE_CASE.values()
+    ]
+    assert len(namespaces) == len(set(namespaces))

--- a/tests/sentry/sentry_metrics/test_ratelimiters.py
+++ b/tests/sentry/sentry_metrics/test_ratelimiters.py
@@ -1,5 +1,5 @@
 from sentry.ratelimits.sliding_windows import RedisSlidingWindowRateLimiter
-from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.sentry_metrics.configuration import RateLimiterNamespace
 from sentry.sentry_metrics.indexer.base import KeyCollection
 from sentry.sentry_metrics.indexer.ratelimiters import WritesLimiter
 
@@ -8,8 +8,8 @@ def get_writes_limiter():
     writes_limiter = WritesLimiter()
     redis_limiter = RedisSlidingWindowRateLimiter()
     writes_limiter.rate_limiters = {
-        UseCaseKey.RELEASE_HEALTH: redis_limiter,
-        UseCaseKey.PERFORMANCE: redis_limiter,
+        RateLimiterNamespace.RELEASE_HEALTH: redis_limiter,
+        RateLimiterNamespace.PERFORMANCE: redis_limiter,
     }
     return writes_limiter
 
@@ -26,7 +26,9 @@ def test_writes_limiter_no_limits(set_sentry_option):
         }
     )
 
-    with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
+    with writes_limiter.check_write_limits(
+        RateLimiterNamespace.PERFORMANCE, key_collection
+    ) as state:
         assert not state.dropped_strings
         assert state.accepted_keys.as_tuples() == key_collection.as_tuples()
 
@@ -46,7 +48,9 @@ def test_writes_limiter_doesnt_limit(set_sentry_option):
         }
     )
 
-    with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
+    with writes_limiter.check_write_limits(
+        RateLimiterNamespace.PERFORMANCE, key_collection
+    ) as state:
         assert not state.dropped_strings
         assert state.accepted_keys.as_tuples() == key_collection.as_tuples()
 
@@ -66,7 +70,9 @@ def test_writes_limiter_org_limit(set_sentry_option):
         }
     )
 
-    with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
+    with writes_limiter.check_write_limits(
+        RateLimiterNamespace.PERFORMANCE, key_collection
+    ) as state:
         assert len(state.dropped_strings) == 2
         assert sorted(ds.key_result.org_id for ds in state.dropped_strings) == [1, 2]
         assert sorted(org_id for org_id, string in state.accepted_keys.as_tuples()) == [1, 1, 2, 2]
@@ -89,5 +95,7 @@ def test_writes_limiter_global_limit(set_sentry_option):
         }
     )
 
-    with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
+    with writes_limiter.check_write_limits(
+        RateLimiterNamespace.PERFORMANCE, key_collection
+    ) as state:
         assert len(state.dropped_strings) == 2


### PR DESCRIPTION
**context**
Wanted to pull out some logic from https://github.com/getsentry/sentry/pull/37745, specifically handle the ratelimiting namespacing in this PR. 

**what is the namespace for?**
Right now we use the `use_case_id` to have separation between the ratelimiters. However, we want to be able to test different backends to the indexer, and the `use_case_id` for alternative backends are not going to change (i.e performance is still perfomance regardless if it's backed by postgres, cloudspanner etc.). In , I'm adding the `db_backend` attribute to the metrics configuration, but as is pointed out in https://github.com/getsentry/sentry/pull/37828#discussion_r946222414, we may want different configurations for the same backend i.e cloudspanner. So we shouldn't rely on the `db_backend` to namespace either. So let's have a separate configuration attribute `namespace` whose purpose is to allow namespacing and prevent clobbering for our ratelimiter instances. 

**quotas**
Quotas are product specific so they continue to use the `use_case_id` to determine what quota we want for each product, release health, performance..etc, but the key itself uses the `namespace` so that redis keys aren't clobbered