### PR TITLE
fix(dashboards): Widget Viewer, dont allow sorting by transaction name when using metrics

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -445,11 +445,12 @@ function WidgetViewerModal(props: Props) {
     });
   }
 
-  const renderDiscoverTable = ({
+  function DiscoverTable({
     tableResults,
     loading,
     pageLinks,
-  }: GenericWidgetQueriesChildrenProps) => {
+  }: GenericWidgetQueriesChildrenProps) {
+    const {isMetricsData} = useDashboardsMEPContext();
     const links = parseLinkHeader(pageLinks ?? null);
     const isFirstPage = links.previous?.results === false;
     return (
@@ -472,6 +473,7 @@ function WidgetViewerModal(props: Props) {
                   setChartUnmodified(false);
                 }
               },
+              isMetricsData,
             }) as (column: GridColumnOrder, columnIndex: number) => React.ReactNode,
             renderBodyCell: renderGridBodyCell({
               ...props,
@@ -508,7 +510,7 @@ function WidgetViewerModal(props: Props) {
         )}
       </Fragment>
     );
-  };
+  }
 
   const renderIssuesTable = ({
     tableResults,
@@ -748,11 +750,13 @@ function WidgetViewerModal(props: Props) {
       case WidgetType.DISCOVER:
       default:
         if (tableData && chartUnmodified && widget.displayType === DisplayType.TABLE) {
-          return renderDiscoverTable({
-            tableResults: tableData,
-            loading: false,
-            pageLinks: defaultPageLinks,
-          });
+          return (
+            <DiscoverTable
+              tableResults={tableData}
+              loading={false}
+              pageLinks={defaultPageLinks}
+            />
+          );
         }
         return (
           <WidgetQueries
@@ -767,7 +771,13 @@ function WidgetViewerModal(props: Props) {
             }
             cursor={cursor}
           >
-            {renderDiscoverTable}
+            {({tableResults, loading, pageLinks}) => (
+              <DiscoverTable
+                tableResults={tableResults}
+                loading={loading}
+                pageLinks={pageLinks}
+              />
+            )}
           </WidgetQueries>
         );
     }

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -46,6 +46,7 @@ type Props = {
   selection: PageFilters;
   widget: Widget;
   isFirstPage?: boolean;
+  isMetricsData?: boolean;
   onHeaderClick?: () => void;
   tableData?: TableDataWithTitle;
 };
@@ -87,7 +88,15 @@ export const renderIssueGridHeaderCell =
   };
 
 export const renderDiscoverGridHeaderCell =
-  ({location, selection, widget, tableData, organization, onHeaderClick}: Props) =>
+  ({
+    location,
+    selection,
+    widget,
+    tableData,
+    organization,
+    onHeaderClick,
+    isMetricsData,
+  }: Props) =>
   (column: TableColumn<keyof TableDataRow>, _columnIndex: number): React.ReactNode => {
     const {orderby} = widget.queries[0];
     // Need to convert orderby to aggregate alias because eventView still uses aggregate alias format
@@ -123,7 +132,8 @@ export const renderDiscoverGridHeaderCell =
     }
 
     const currentSort = eventView.sortForField(field, tableMeta);
-    const canSort = isFieldSortable(field, tableMeta);
+    const canSort =
+      !(isMetricsData && field.field === 'title') && isFieldSortable(field, tableMeta);
     const titleText = isEquationAlias(column.name)
       ? eventView.getEquations()[getEquationAliasIndex(column.name)]
       : column.name;

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -526,6 +526,41 @@ describe('Modals -> WidgetViewerModal', function () {
             calls[calls.length - 1][0].option.yAxis.axisLabel.formatter;
           expect(yAxisFormatter(123)).toEqual('123ms');
         });
+
+        it('does not allow sorting by transaction name when widget is using metrics', async function () {
+          const eventsMock = MockApiClient.addMockResponse({
+            url: '/organizations/org-slug/events/',
+            body: {
+              data: [
+                {
+                  title: '/organizations/:orgId/dashboards/',
+                  id: '1',
+                  count: 1,
+                },
+              ],
+              meta: {
+                fields: {
+                  title: 'string',
+                  id: 'string',
+                  count: 1,
+                },
+                isMetricsData: true,
+              },
+            },
+          });
+          await renderModal({
+            initialData: initialDataWithFlag,
+            widget: mockWidget,
+            seriesData: [],
+            seriesResultsType: 'duration',
+          });
+          expect(eventsMock).toHaveBeenCalledTimes(1);
+          expect(screen.getByText('title')).toBeInTheDocument();
+          userEvent.click(screen.getByText('title'));
+          expect(initialData.router.push).not.toHaveBeenCalledWith({
+            query: {sort: ['-title']},
+          });
+        });
       });
     });
 


### PR DESCRIPTION
Disables sorting on Transaction Name column when viewing a metrics backed widget in the widget viewer. This is because sorting on Transaction Name isn't supported in metrics.