### PR TITLE
fix: Add TS signatures for when `decodeInteger()` has a fallback set

### DIFF
--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -58,7 +58,6 @@ export function appendTagCondition(
 // This function has multiple signatures to help with typing in callers.
 export function decodeScalar(value: QueryValue): string | undefined;
 export function decodeScalar(value: QueryValue, fallback: string): string;
-
 export function decodeScalar(value: QueryValue, fallback?: string): string | undefined {
   if (!value) {
     return fallback;
@@ -79,6 +78,9 @@ export function decodeList(value: string[] | string | undefined | null): string[
   return Array.isArray(value) ? value : isString(value) ? [value] : [];
 }
 
+// This function has multiple signatures to help with typing in callers.
+export function decodeInteger(value: QueryValue): number | undefined;
+export function decodeInteger(value: QueryValue, fallback: number): number;
 export function decodeInteger(value: QueryValue, fallback?: number): number | undefined {
   const unwrapped = decodeScalar(value);
 

--- a/tests/js/spec/utils/queryString.spec.tsx
+++ b/tests/js/spec/utils/queryString.spec.tsx
@@ -87,6 +87,7 @@ describe('decodeScalar()', function () {
 
   it('handles falsey values', function () {
     expect(utils.decodeScalar(undefined)).toBeUndefined();
+    // @ts-expect-error
     expect(utils.decodeScalar(false)).toBeUndefined();
     expect(utils.decodeScalar('')).toBeUndefined();
   });
@@ -111,6 +112,7 @@ describe('decodeList()', function () {
 
   it('handles falsey values', function () {
     expect(utils.decodeList(undefined)).toEqual([]);
+    // @ts-expect-error
     expect(utils.decodeList(false)).toEqual([]);
     expect(utils.decodeList('')).toEqual([]);
   });
@@ -135,6 +137,7 @@ describe('decodeInteger()', function () {
 
   it('handles falsey values', function () {
     expect(utils.decodeInteger(undefined, 2020)).toEqual(2020);
+    // @ts-expect-error
     expect(utils.decodeInteger(false, 2020)).toEqual(2020);
     expect(utils.decodeInteger('', 2020)).toEqual(2020);
   });


### PR DESCRIPTION
`decodeScalar()` has fallbacks, which are nice because when you call something like `decodeScalar(foo, 'bar')` TS knows the return type must be `string`.

`decodeInteger` should work the same.