### PR TITLE
fix(groups): Avoid pickling GroupHash query set

### DIFF
--- a/src/sentry/api/endpoints/group_hashes.py
+++ b/src/sentry/api/endpoints/group_hashes.py
@@ -50,7 +50,7 @@ class GroupHashesEndpoint(GroupEndpoint):
         if id_list is None:
             return Response()
 
-        hash_list = (
+        hash_list = list(
             GroupHash.objects.filter(project_id=group.project_id, group=group.id, hash__in=id_list)
             .exclude(state=GroupHash.State.LOCKED_IN_MIGRATION)
             .values_list("hash", flat=True)


### PR DESCRIPTION
Evaluate the GroupHash query earlier. This avoids problems (see #36426) associated with pickling the QuerySet object when it's passed to `unmerge.delay`:

https://github.com/getsentry/sentry/blob/54ad1695c0e2cf570852a76ef679962a25d30942/src/sentry/api/endpoints/group_hashes.py#L61-L63

I don't think this causes any performance problems unless (for some reason I'm not seeing) it's especially important not to execute the query until after the delay, in which case I think we're already executing it on [line 58](https://github.com/getsentry/sentry/blob/54ad1695c0e2cf570852a76ef679962a25d30942/src/sentry/api/endpoints/group_hashes.py#L58).