### PR TITLE
fix(issues): Prevent text selection when shift selecting

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -219,6 +219,7 @@ class StreamGroup extends Component<Props, State> {
 
     if (evt.shiftKey) {
       SelectedGroupStore.shiftToggleItems(this.state.data.id);
+      window.getSelection()?.removeAllRanges();
     } else {
       SelectedGroupStore.toggleSelect(this.state.data.id);
     }


### PR DESCRIPTION
Removes text highlight when selecting multiple issues in the issues stream
