### PR TITLE
chore(deps): Bump sentry-sdk to 1.9.5

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -54,7 +54,7 @@ rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
 sentry-arroyo>=1.0.3
 sentry-relay>=0.8.13
-sentry-sdk>=1.9.4
+sentry-sdk>=1.9.5
 snuba-sdk>=1.0.1
 simplejson>=3.17.6
 statsd>=3.3

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -145,7 +145,7 @@ s3transfer==0.5.2
 selenium==4.3.0
 sentry-arroyo==1.0.3
 sentry-relay==0.8.13
-sentry-sdk==1.9.4
+sentry-sdk==1.9.5
 simplejson==3.17.6
 six==1.16.0
 sniffio==1.2.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -98,7 +98,7 @@ s3transfer==0.5.2
 selenium==4.3.0
 sentry-arroyo==1.0.3
 sentry-relay==0.8.13
-sentry-sdk==1.9.4
+sentry-sdk==1.9.5
 simplejson==3.17.6
 six==1.16.0
 sniffio==1.2.0


### PR DESCRIPTION
Fixes `rediscluster` pipeline monkeypatch not being applied
