### PR TITLE
fix(perf): handle events with a null FCP value

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -438,8 +438,9 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
         # Only concern ourselves with transactions where the FCP is within the
         # range we care about.
         fcp_hash = self.event().get("measurements", {}).get("fcp", {})
-        if "value" in fcp_hash and ("unit" not in fcp_hash or fcp_hash["unit"] == "millisecond"):
-            fcp = timedelta(milliseconds=fcp_hash.get("value"))
+        fcp_value = fcp_hash.get("value")
+        if fcp_value and ("unit" not in fcp_hash or fcp_hash["unit"] == "millisecond"):
+            fcp = timedelta(milliseconds=fcp_value)
             fcp_minimum_threshold = timedelta(
                 milliseconds=self.settings.get("fcp_minimum_threshold")
             )

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -312,6 +312,18 @@ class PerformanceDetectionTest(unittest.TestCase):
                 ),
             ],
         }
+        no_fcp_event = {
+            "event_id": "a" * 16,
+            "measurements": {
+                "fcp": {
+                    "value": None,
+                    "unit": "millisecond",
+                }
+            },
+            "spans": [
+                create_span("resource.script", duration=1000.0),
+            ],
+        }
         short_render_blocking_asset_event = {
             "event_id": "a" * 16,
             "measurements": {
@@ -331,6 +343,9 @@ class PerformanceDetectionTest(unittest.TestCase):
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
 
         _detect_performance_issue(short_render_blocking_asset_event, sdk_span_mock)
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
+
+        _detect_performance_issue(no_fcp_event, sdk_span_mock)
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
 
         _detect_performance_issue(render_blocking_asset_event, sdk_span_mock)


### PR DESCRIPTION
If the FCP measurement is given but with a value of null, the render-blocking asset detector was throwing `TypeError: unsupported type for timedelta milliseconds component: NoneType`. Gracefully handle this case.