### PR TITLE
fix(mep): Also hide sidebar metrics on less-than

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarMEPCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarMEPCharts.tsx
@@ -128,7 +128,8 @@ function getDataCounts({
     chartData?.series[0]?.data.reduce((sum, {value}) => sum + value, 0) ?? 0;
   const metricsCount =
     metricsChartData?.series[0]?.data.reduce((sum, {value}) => sum + value, 0) ?? 0;
-  const missingMetrics = !metricsCount && transactionCount;
+  const missingMetrics =
+    (!metricsCount && transactionCount) || metricsCount < transactionCount;
   return {
     transactionCount,
     metricsCount,


### PR DESCRIPTION
### Summary
This will hide the sidebar comparison if the metrics data is for some reason less than transaction data count for now, since it's showing odd results.

