### PR TITLE
fix(suspect-resolutions-v2): Fix feature flag and add test 

### DIFF
--- a/src/sentry/utils/suspect_resolutions/commit_correlation.py
+++ b/src/sentry/utils/suspect_resolutions/commit_correlation.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Sequence, Set
 
-from sentry.models import CommitFileChange, Group, GroupRelease, Release, ReleaseCommit
+from sentry.models import CommitFileChange, Group, GroupRelease, ReleaseCommit
 
 
 @dataclass
@@ -47,13 +47,11 @@ def is_issue_commit_correlated(
 def get_files_changed_in_releases(
     resolved_issue_time: datetime, issue_id: int, project_id: int
 ) -> ReleaseCommitFileChanges:
-    releases = Release.objects.filter(
-        id__in=GroupRelease.objects.filter(
-            group_id=issue_id,
-            project_id=project_id,
-        ).values_list("release_id", flat=True),
-        date_added__gte=(resolved_issue_time - timedelta(hours=5)),
-    )
+    releases = GroupRelease.objects.filter(
+        group_id=issue_id,
+        project_id=project_id,
+        last_seen__gte=(resolved_issue_time - timedelta(hours=5)),
+    ).values_list("release_id", flat=True)
 
     if not releases:
         return ReleaseCommitFileChanges([], set())

--- a/src/sentry/utils/suspect_resolutions/commit_correlation.py
+++ b/src/sentry/utils/suspect_resolutions/commit_correlation.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Sequence, Set
 
-from sentry.models import CommitFileChange, Group, GroupRelease, ReleaseCommit
+from sentry.models import CommitFileChange, Group, GroupRelease, Release, ReleaseCommit
 
 
 @dataclass
@@ -47,11 +47,13 @@ def is_issue_commit_correlated(
 def get_files_changed_in_releases(
     resolved_issue_time: datetime, issue_id: int, project_id: int
 ) -> ReleaseCommitFileChanges:
-    releases = GroupRelease.objects.filter(
-        group_id=issue_id,
-        project_id=project_id,
-        last_seen__gte=(resolved_issue_time - timedelta(hours=5)),
-    ).values_list("release_id", flat=True)
+    releases = Release.objects.filter(
+        id__in=GroupRelease.objects.filter(
+            group_id=issue_id,
+            project_id=project_id,
+        ).values_list("release_id", flat=True),
+        date_added__gte=(resolved_issue_time - timedelta(hours=5)),
+    )
 
     if not releases:
         return ReleaseCommitFileChanges([], set())

--- a/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
+++ b/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Mapping, Sequence
+
+from django.utils import timezone
 
 from sentry import features
 from sentry.models import Group, GroupRelease, GroupStatus, Release, ReleaseProject
@@ -14,8 +16,8 @@ def record_suspect_resolutions_releases(release, **kwargs) -> None:
     if release.projects.exists() and features.has("projects:suspect-resolutions", release.projects):
         get_suspect_resolutions_releases.delay(
             release,
-            eta=datetime.now() + timedelta(hours=1),
-            expires=datetime.now() + timedelta(hours=1, minutes=30),
+            eta=timezone.now() + timedelta(hours=1),
+            expires=timezone.now() + timedelta(hours=1, minutes=30),
         )
 
 

--- a/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
+++ b/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Mapping, Sequence
 
 from sentry import features
@@ -13,13 +13,13 @@ from sentry.utils.suspect_resolutions_releases import ALGO_VERSION, analytics
 def record_suspect_resolutions_releases(release, **kwargs) -> None:
     if (
         release.projects
-        and len(release.projects) > 0
-        and features.has("projects:suspect-resolutions", release.projects[0])
+        and release.projects.exists()
+        and features.has("projects:suspect-resolutions", release.projects)
     ):
         get_suspect_resolutions_releases.delay(
             release,
-            eta=timezone.now() + timedelta(hours=1),
-            expires=timezone.now() + timedelta(hours=1, minutes=30),
+            eta=datetime.now() + timedelta(hours=1),
+            expires=datetime.now() + timedelta(hours=1, minutes=30),
         )
 
 

--- a/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
+++ b/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
@@ -11,11 +11,7 @@ from sentry.utils.suspect_resolutions_releases import ALGO_VERSION, analytics
 
 @release_created.connect(weak=False)
 def record_suspect_resolutions_releases(release, **kwargs) -> None:
-    if (
-        release.projects
-        and release.projects.exists()
-        and features.has("projects:suspect-resolutions", release.projects)
-    ):
+    if release.projects.exists() and features.has("projects:suspect-resolutions", release.projects):
         get_suspect_resolutions_releases.delay(
             release,
             eta=datetime.now() + timedelta(hours=1),

--- a/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
+++ b/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
@@ -13,7 +13,9 @@ from sentry.utils.suspect_resolutions_releases import ALGO_VERSION, analytics
 
 @release_created.connect(weak=False)
 def record_suspect_resolutions_releases(release, **kwargs) -> None:
-    if release.projects.exists() and features.has("projects:suspect-resolutions", release.projects):
+    if release.projects.exists() and features.has(
+        "projects:suspect-resolutions", list(release.projects.all())[0]
+    ):
         get_suspect_resolutions_releases.delay(
             release,
             eta=timezone.now() + timedelta(hours=1),

--- a/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
+++ b/src/sentry/utils/suspect_resolutions_releases/get_suspect_resolutions_releases.py
@@ -11,7 +11,11 @@ from sentry.utils.suspect_resolutions_releases import ALGO_VERSION, analytics
 
 @release_created.connect(weak=False)
 def record_suspect_resolutions_releases(release, **kwargs) -> None:
-    if features.has("projects:suspect-resolutions"):
+    if (
+        release.projects
+        and len(release.projects) > 0
+        and features.has("projects:suspect-resolutions", release.projects[0])
+    ):
         get_suspect_resolutions_releases.delay(
             release,
             eta=timezone.now() + timedelta(hours=1),


### PR DESCRIPTION
- Check if `release.projects` exists and pass it to `features.has()`
- Test `record_suspect_resolutions_releases()` is called when a release is created

Fixes [SENTRY-VVA](https://sentry.io/organizations/sentry/issues/3505536918/?query=is%3Aunresolved)