### PR TITLE
fix(perf): Fix transaction start timestamp property name

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -441,7 +441,7 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
 
     def init(self):
         self.stored_issues = {}
-        self.transaction_start = timedelta(seconds=self.event().get("transaction_start", 0))
+        self.transaction_start = timedelta(seconds=self.event().get("start_timestamp", 0))
         self.fcp = None
 
         # Only concern ourselves with transactions where the FCP is within the


### PR DESCRIPTION
The detector for render-blocking asset spans was using the incorrect property name for the transaction start time (should be [`start_timestamp`](https://github.com/getsentry/relay/blob/bc11b3409eafac018cdc1bd5b07730362ff99f41/relay-general/src/protocol/event.rs#L260)).