### PR TITLE
fix(dashboards): Don't default metric widget sort to transaction

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -649,10 +649,17 @@ function WidgetBuilder({
       if (datasetConfig.handleOrderByReset) {
         // If widget is metric backed, don't default to sorting by transaction unless its the only column
         // Sorting by transaction is not supported in metrics
-        if (isMetricsData && fieldStrings.length > 1) {
+        if (
+          isMetricsData &&
+          fieldStrings.some(
+            fieldString => !['transaction', 'title'].includes(fieldString)
+          )
+        ) {
           newQuery = datasetConfig.handleOrderByReset(
             newQuery,
-            fieldStrings.filter(fieldString => fieldString !== 'transaction')
+            fieldStrings.filter(
+              fieldString => !['transaction', 'title'].includes(fieldString)
+            )
           );
         } else {
           newQuery = datasetConfig.handleOrderByReset(newQuery, fieldStrings);

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -630,29 +630,40 @@ function WidgetBuilder({
       return {...newState, errors: undefined};
     });
   }
+  function getHandleColumnFieldChange(isMetricsData?: boolean) {
+    function handleColumnFieldChange(newFields: QueryFieldValue[]) {
+      const fieldStrings = newFields.map(generateFieldAsString);
+      const splitFields = getColumnsAndAggregatesAsStrings(newFields);
+      const newState = cloneDeep(state);
+      let newQuery = cloneDeep(newState.queries[0]);
 
-  function handleColumnFieldChange(newFields: QueryFieldValue[]) {
-    const fieldStrings = newFields.map(generateFieldAsString);
-    const splitFields = getColumnsAndAggregatesAsStrings(newFields);
-    const newState = cloneDeep(state);
-    let newQuery = cloneDeep(newState.queries[0]);
+      newQuery.fields = fieldStrings;
+      newQuery.aggregates = splitFields.aggregates;
+      newQuery.columns = splitFields.columns;
+      newQuery.fieldAliases = splitFields.fieldAliases;
 
-    newQuery.fields = fieldStrings;
-    newQuery.aggregates = splitFields.aggregates;
-    newQuery.columns = splitFields.columns;
-    newQuery.fieldAliases = splitFields.fieldAliases;
+      if (datasetConfig.handleColumnFieldChangeOverride) {
+        newQuery = datasetConfig.handleColumnFieldChangeOverride(newQuery);
+      }
 
-    if (datasetConfig.handleColumnFieldChangeOverride) {
-      newQuery = datasetConfig.handleColumnFieldChangeOverride(newQuery);
+      if (datasetConfig.handleOrderByReset) {
+        // If widget is metric backed, don't default to sorting by transaction unless its the only column
+        // Sorting by transaction is not supported in metrics
+        if (isMetricsData && fieldStrings.length > 1) {
+          newQuery = datasetConfig.handleOrderByReset(
+            newQuery,
+            fieldStrings.filter(fieldString => fieldString !== 'transaction')
+          );
+        } else {
+          newQuery = datasetConfig.handleOrderByReset(newQuery, fieldStrings);
+        }
+      }
+
+      set(newState, 'queries', [newQuery]);
+      set(newState, 'userHasModified', true);
+      setState(newState);
     }
-
-    if (datasetConfig.handleOrderByReset) {
-      newQuery = datasetConfig.handleOrderByReset(newQuery, fieldStrings);
-    }
-
-    set(newState, 'queries', [newQuery]);
-    set(newState, 'userHasModified', true);
-    setState(newState);
+    return handleColumnFieldChange;
   }
 
   function handleYAxisChange(newFields: QueryFieldValue[]) {
@@ -1079,18 +1090,24 @@ function WidgetBuilder({
                         hasReleaseHealthFeature={hasReleaseHealthFeature}
                       />
                       {isTabularChart && (
-                        <ColumnsStep
-                          dataSet={state.dataSet}
-                          queries={state.queries}
-                          displayType={state.displayType}
-                          widgetType={widgetType}
-                          queryErrors={state.errors?.queries}
-                          onQueryChange={handleQueryChange}
-                          handleColumnFieldChange={handleColumnFieldChange}
-                          explodedFields={explodedFields}
-                          tags={tags}
-                          organization={organization}
-                        />
+                        <DashboardsMEPConsumer>
+                          {({isMetricsData}) => (
+                            <ColumnsStep
+                              dataSet={state.dataSet}
+                              queries={state.queries}
+                              displayType={state.displayType}
+                              widgetType={widgetType}
+                              queryErrors={state.errors?.queries}
+                              onQueryChange={handleQueryChange}
+                              handleColumnFieldChange={getHandleColumnFieldChange(
+                                isMetricsData
+                              )}
+                              explodedFields={explodedFields}
+                              tags={tags}
+                              organization={organization}
+                            />
+                          )}
+                        </DashboardsMEPConsumer>
                       )}
                       {![DisplayType.TABLE].includes(state.displayType) && (
                         <YAxisStep

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -3766,6 +3766,52 @@ describe('WidgetBuilder', function () {
         });
         await screen.findByText('measurements.custom.measurement');
       });
+
+      it('does not default to sorting by transaction when columns change', async function () {
+        renderTestComponent({
+          query: {source: DashboardWidgetSource.DISCOVERV2},
+          dashboard: {
+            ...testDashboard,
+            widgets: [
+              {
+                title: 'Custom Measurement Widget',
+                interval: '1d',
+                id: '1',
+                widgetType: WidgetType.DISCOVER,
+                displayType: DisplayType.TABLE,
+                queries: [
+                  {
+                    conditions: '',
+                    name: '',
+                    fields: [
+                      'p99(measurements.custom.measurement)',
+                      'transaction',
+                      'count()',
+                    ],
+                    columns: ['transaction'],
+                    aggregates: ['p99(measurements.custom.measurement)', 'count()'],
+                    orderby: '-p99(measurements.custom.measurement)',
+                  },
+                ],
+              },
+            ],
+          },
+          params: {
+            widgetIndex: '0',
+          },
+          orgFeatures: [...defaultOrgFeatures, 'discover-frontend-use-events-endpoint'],
+        });
+        expect(
+          await screen.findByText('p99(measurements.custom.measurement)')
+        ).toBeInTheDocument();
+        // Delete p99(measurements.custom.measurement) column
+        userEvent.click(screen.getAllByLabelText('Remove column')[0]);
+        expect(
+          screen.queryByText('p99(measurements.custom.measurement)')
+        ).not.toBeInTheDocument();
+        expect(screen.getAllByText('transaction').length).toEqual(1);
+        expect(screen.getAllByText('count()').length).toEqual(2);
+      });
     });
   });
 });


### PR DESCRIPTION
Metrics backed widgets cannot be sorted by transaction name (it will fall back to discover dataset).
This update makes it so that anytime the sort by options change, the widget builder defaults to transaction name last to preserve metrics compatibility.