### PR TITLE
feat(replays): Check if replays are enabled before showing the transaction summary replay list

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionReplays/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.tsx
@@ -1,8 +1,11 @@
 import {Location} from 'history';
 
+import Feature from 'sentry/components/acl/feature';
+import Alert from 'sentry/components/alert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
+import {PageContent} from 'sentry/styles/organization';
 import {Organization, Project} from 'sentry/types';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
@@ -26,16 +29,30 @@ type Props = {
 function TransactionReplays(props: Props) {
   const {location, organization, projects} = props;
 
+  function renderNoAccess() {
+    return (
+      <PageContent>
+        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+      </PageContent>
+    );
+  }
+
   return (
-    <PageLayout
-      location={location}
+    <Feature
+      features={['session-replay-ui']}
       organization={organization}
-      projects={projects}
-      tab={Tab.Replays}
-      getDocumentTitle={getDocumentTitle}
-      generateEventView={generateEventView}
-      childComponent={ReplaysContentWrapper}
-    />
+      renderDisabled={renderNoAccess}
+    >
+      <PageLayout
+        location={location}
+        organization={organization}
+        projects={projects}
+        tab={Tab.Replays}
+        getDocumentTitle={getDocumentTitle}
+        generateEventView={generateEventView}
+        childComponent={ReplaysContentWrapper}
+      />
+    </Feature>
   );
 }
 


### PR DESCRIPTION
I noticed in #37860 that we have a guard around the link to this page, but if someone types the url directly there was no feature check to prevent them from seeing the page.

Now, when you visit the url the page will display a message instead of the data:
![Screen Shot 2022-08-16 at 11 03 02 AM](https://user-images.githubusercontent.com/187460/184948685-07c40c7b-41e9-4c22-b93d-b9d3043c180d.png)

