### PR TITLE
fix(replays): Fix broken Trace tab in Replay view

### DIFF
--- a/static/app/views/replays/detail/trace.tsx
+++ b/static/app/views/replays/detail/trace.tsx
@@ -63,9 +63,9 @@ export default function Trace({replayRecord, organization}: Props) {
 
   const {
     location,
-    params: {eventSlug, orgSlug},
+    params: {replaySlug, orgSlug},
   } = useRouteContext();
-  const [, eventId] = eventSlug.split(':');
+  const [, eventId] = replaySlug.split(':');
 
   const start = getUtcDateString(replayRecord.startedAt.getTime());
   const end = getUtcDateString(replayRecord.finishedAt.getTime());


### PR DESCRIPTION
### Changes
- renames eventSlug to replaySlug

Closes #37873 

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
