### PR TITLE
fix(pre): Remove unnecessary scrollbars

### DIFF
--- a/static/less/base.less
+++ b/static/less/base.less
@@ -397,7 +397,6 @@ pre {
   white-space: pre-wrap;
   word-wrap: break-word;
   border-radius: @border-radius-base;
-  overflow: auto;
 
   // Account for some code outputs that place code tags in pre tags
   code {


### PR DESCRIPTION
When the user chooses to always show scrollbars (from within their OS settings), all elements with `overflow: auto` will have a scrollbar whether there is any content overflow or not. We don't need this rule for `pre` elements (within the main app, we wrap code instead of letting them overflow), and should remove it.

**Before:**
<img width="979" alt="image" src="https://user-images.githubusercontent.com/44172267/184959957-252b0620-37af-4a79-89e6-9c2b018f13f1.png">


**After:**
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/44172267/184956924-3c272d4a-fd1f-489a-967e-821ba906d82b.png">

Documentation code blocks still have their own overflow rules, and so they're not affected (they still have horizontal scroll, same as before):
<img width="555" alt="image" src="https://user-images.githubusercontent.com/44172267/184958733-51cd3e4e-6afd-4c30-b578-30ca34206f79.png">

