### PR TITLE
fix(replays): Fix Replay view tab links

### DIFF
--- a/static/app/views/replays/detail/focusTabs.tsx
+++ b/static/app/views/replays/detail/focusTabs.tsx
@@ -3,6 +3,7 @@ import {MouseEvent} from 'react';
 import NavTabs from 'sentry/components/navTabs';
 import {t} from 'sentry/locale';
 import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 const ReplayTabs: Record<TabKey, string> = {
   console: t('Console'),
@@ -16,23 +17,35 @@ const ReplayTabs: Record<TabKey, string> = {
 type Props = {};
 
 function FocusTabs({}: Props) {
+  const {location} = useRouteContext();
   const {getActiveTab, setActiveTab} = useActiveReplayTab();
   const activeTab = getActiveTab();
+
   return (
     <NavTabs underlined>
-      {Object.entries(ReplayTabs).map(([tab, label]) => (
-        <li key={tab} className={activeTab === tab ? 'active' : ''}>
-          <a
-            href={`#${tab}`}
-            onClick={(e: MouseEvent) => {
-              setActiveTab(tab);
-              e.preventDefault();
-            }}
-          >
-            <span>{label}</span>
-          </a>
-        </li>
-      ))}
+      {Object.entries(ReplayTabs).map(([tab, label]) => {
+        const href = Object.entries({
+          ...location.query,
+          t_main: tab,
+        }).reduce(
+          (acc, [queryParam, val], i) => `${acc}${i > 0 ? '&' : ''}${queryParam}=${val}`,
+          `${location.pathname}?`
+        );
+
+        return (
+          <li key={tab} className={activeTab === tab ? 'active' : ''}>
+            <a
+              href={href}
+              onClick={(e: MouseEvent) => {
+                setActiveTab(tab);
+                e.preventDefault();
+              }}
+            >
+              <span>{label}</span>
+            </a>
+          </li>
+        );
+      })}
     </NavTabs>
   );
 }

--- a/static/app/views/replays/detail/focusTabs.tsx
+++ b/static/app/views/replays/detail/focusTabs.tsx
@@ -1,9 +1,10 @@
 import {MouseEvent} from 'react';
+import queryString from 'query-string';
 
 import NavTabs from 'sentry/components/navTabs';
 import {t} from 'sentry/locale';
 import useActiveReplayTab, {TabKey} from 'sentry/utils/replays/hooks/useActiveReplayTab';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import {useLocation} from 'sentry/utils/useLocation';
 
 const ReplayTabs: Record<TabKey, string> = {
   console: t('Console'),
@@ -17,35 +18,25 @@ const ReplayTabs: Record<TabKey, string> = {
 type Props = {};
 
 function FocusTabs({}: Props) {
-  const {location} = useRouteContext();
+  const {pathname, query} = useLocation();
   const {getActiveTab, setActiveTab} = useActiveReplayTab();
   const activeTab = getActiveTab();
 
   return (
     <NavTabs underlined>
-      {Object.entries(ReplayTabs).map(([tab, label]) => {
-        const href = Object.entries({
-          ...location.query,
-          t_main: tab,
-        }).reduce(
-          (acc, [queryParam, val], i) => `${acc}${i > 0 ? '&' : ''}${queryParam}=${val}`,
-          `${location.pathname}?`
-        );
-
-        return (
-          <li key={tab} className={activeTab === tab ? 'active' : ''}>
-            <a
-              href={href}
-              onClick={(e: MouseEvent) => {
-                setActiveTab(tab);
-                e.preventDefault();
-              }}
-            >
-              <span>{label}</span>
-            </a>
-          </li>
-        );
-      })}
+      {Object.entries(ReplayTabs).map(([tab, label]) => (
+        <li key={tab} className={activeTab === tab ? 'active' : ''}>
+          <a
+            href={`${pathname}?${queryString.stringify({...query, t_main: tab})}`}
+            onClick={(e: MouseEvent) => {
+              setActiveTab(tab);
+              e.preventDefault();
+            }}
+          >
+            <span>{label}</span>
+          </a>
+        </li>
+      ))}
     </NavTabs>
   );
 }


### PR DESCRIPTION
### Changes
- Changes tab href from hash param to full path + search params 

Closes #37811 

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
