### PR TITLE
fix(issues): Prevent getQuery() from returning an array

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -53,6 +53,7 @@ import getCurrentSentryReactTransaction from 'sentry/utils/getCurrentSentryReact
 import parseApiError from 'sentry/utils/parseApiError';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import {decodeScalar} from 'sentry/utils/queryString';
 import StreamManager from 'sentry/utils/streamManager';
 import withApi from 'sentry/utils/withApi';
 import withIssueTags from 'sentry/utils/withIssueTags';
@@ -289,8 +290,8 @@ class IssueListOverview extends Component<Props, State> {
 
     const {query} = location.query;
 
-    if (typeof query === 'string') {
-      return query;
+    if (query !== undefined) {
+      return decodeScalar(query, '');
     }
 
     return DEFAULT_QUERY;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -289,8 +289,8 @@ class IssueListOverview extends Component<Props, State> {
 
     const {query} = location.query;
 
-    if (query !== undefined) {
-      return query as string;
+    if (typeof query === 'string') {
+      return query;
     }
 
     return DEFAULT_QUERY;


### PR DESCRIPTION
Had a sentry error show up where the reload captured a `query` of type 'list' instead of a string: https://sentry.io/organizations/sentry/issues/3506994029/events/a99bf1ee69734c5a8188b2ace4f02453/?project=133215

Looking into it, the only way I think this could have happened is if a user went to the issues page with a query string that looks like: `?query=test1&query=test2`. That would make `location.query` be the array `['test1', 'test2']`.

Instead of returning the array, I changed the behavior so that it falls back to the default query in that case, since I don't think the array would ever make sense.