### PR TITLE
fix(mep): Use provider and both new endpoints

### DIFF
--- a/static/app/utils/performance/contexts/metricsCardinality.tsx
+++ b/static/app/utils/performance/contexts/metricsCardinality.tsx
@@ -1,0 +1,259 @@
+import {Fragment, ReactNode} from 'react';
+import {Location} from 'history';
+
+import {Organization} from 'sentry/types';
+import {parsePeriodToHours} from 'sentry/utils/dates';
+import EventView from 'sentry/utils/discover/eventView';
+import {canUseMetricsData} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import MetricsCompatibilityQuery, {
+  MetricsCompatibilityData,
+} from 'sentry/utils/performance/metricsEnhanced/metricsCompatibilityQuery';
+import MetricsCompatibilitySumsQuery, {
+  MetricsCompatibilitySumData,
+} from 'sentry/utils/performance/metricsEnhanced/metricsCompatibilityQuerySums';
+
+import {createDefinedContext} from './utils';
+
+export interface MetricDataSwitcherOutcome {
+  forceTransactionsOnly: boolean;
+  compatibleProjects?: number[];
+  shouldNotifyUnnamedTransactions?: boolean;
+  shouldWarnIncompatibleSDK?: boolean;
+}
+export interface MetricsCardinalityContext {
+  isLoading: boolean;
+  outcome?: MetricDataSwitcherOutcome;
+}
+
+type MergedMetricsData = MetricsCompatibilityData & MetricsCompatibilitySumData;
+
+const [_Provider, _useContext, _Context] =
+  createDefinedContext<MetricsCardinalityContext>({
+    name: 'MetricsCardinalityContext',
+    strict: false,
+  });
+
+/**
+ * This provider determines whether the metrics data is storing performance information correctly before we
+ * make dozens of requests on pages such as performance landing and dashboards.
+ */
+export const MetricsCardinalityProvider = (props: {
+  children: ReactNode;
+  location: Location;
+  organization: Organization;
+}) => {
+  const isUsingMetrics = canUseMetricsData(props.organization);
+
+  if (!isUsingMetrics) {
+    return (
+      <_Provider
+        value={{
+          isLoading: false,
+          outcome: {
+            forceTransactionsOnly: true,
+          },
+        }}
+      >
+        {props.children}
+      </_Provider>
+    );
+  }
+
+  const baseDiscoverProps = {
+    location: props.location,
+    orgSlug: props.organization.slug,
+    cursor: '0:0:0',
+  };
+  const eventView = EventView.fromLocation(props.location);
+  eventView.fields = [{field: 'tpm()'}];
+  const _eventView = adjustEventViewTime(eventView);
+
+  return (
+    <Fragment>
+      <MetricsCompatibilityQuery eventView={_eventView} {...baseDiscoverProps}>
+        {compatabilityResult => (
+          <MetricsCompatibilitySumsQuery eventView={_eventView} {...baseDiscoverProps}>
+            {sumsResult => (
+              <_Provider
+                value={{
+                  isLoading: compatabilityResult.isLoading || sumsResult.isLoading,
+                  outcome:
+                    compatabilityResult.isLoading || sumsResult.isLoading
+                      ? undefined
+                      : getMetricsOutcome(
+                          compatabilityResult.tableData && sumsResult.tableData
+                            ? {
+                                ...compatabilityResult.tableData,
+                                ...sumsResult.tableData,
+                              }
+                            : null,
+                          !!compatabilityResult.error && !!sumsResult.error
+                        ),
+                }}
+              >
+                {props.children}
+              </_Provider>
+            )}
+          </MetricsCompatibilitySumsQuery>
+        )}
+      </MetricsCompatibilityQuery>
+    </Fragment>
+  );
+};
+
+export const MetricCardinalityConsumer = _Context.Consumer;
+
+export const useMetricsCardinalityContext = _useContext;
+
+/**
+ * Logic for picking sides of metrics vs. transactions along with the associated warnings.
+ */
+function getMetricsOutcome(
+  dataCounts: MergedMetricsData | null,
+  hasOtherFallbackCondition: boolean
+) {
+  const fallbackOutcome: MetricDataSwitcherOutcome = {
+    forceTransactionsOnly: true,
+  };
+  const successOutcome: MetricDataSwitcherOutcome = {
+    forceTransactionsOnly: false,
+  };
+  if (!dataCounts) {
+    return fallbackOutcome;
+  }
+  const compatibleProjects = dataCounts.compatible_projects;
+
+  if (hasOtherFallbackCondition) {
+    return fallbackOutcome;
+  }
+
+  if (!dataCounts) {
+    return fallbackOutcome;
+  }
+
+  if (checkForSamplingRules(dataCounts)) {
+    return fallbackOutcome;
+  }
+
+  if (checkNoDataFallback(dataCounts)) {
+    return fallbackOutcome;
+  }
+
+  if (checkIncompatibleData(dataCounts)) {
+    return {
+      shouldWarnIncompatibleSDK: true,
+      forceTransactionsOnly: true,
+      compatibleProjects,
+    };
+  }
+
+  if (checkIfAllOtherData(dataCounts)) {
+    return {
+      shouldNotifyUnnamedTransactions: true,
+      forceTransactionsOnly: true,
+      compatibleProjects,
+    };
+  }
+
+  if (checkIfPartialOtherData(dataCounts)) {
+    return {
+      shouldNotifyUnnamedTransactions: true,
+      compatibleProjects,
+      forceTransactionsOnly: false,
+    };
+  }
+
+  return successOutcome;
+}
+
+/**
+ * Fallback if very similar amounts of metrics and transactions are found.
+ * No projects with dynamic sampling means no rules have been enabled yet.
+ */
+function checkForSamplingRules(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  if (!dataCounts.dynamic_sampling_projects?.length) {
+    return true;
+  }
+  if (counts.metricsCount === 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Fallback if no metrics found.
+ */
+function checkNoDataFallback(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  return !counts.metricsCount;
+}
+
+/**
+ * Fallback and warn if incompatible data found (old specific SDKs).
+ */
+function checkIncompatibleData(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  return counts.nullCount > 0;
+}
+
+/**
+ * Fallback and warn about unnamed transactions (specific SDKs).
+ */
+function checkIfAllOtherData(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  return counts.unparamCount >= counts.metricsCount;
+}
+
+/**
+ * Show metrics but warn about unnamed transactions.
+ */
+function checkIfPartialOtherData(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  return counts.unparamCount > 0;
+}
+
+/**
+ * Temporary function, can be removed after API changes.
+ */
+function normalizeCounts({sum}: MergedMetricsData) {
+  try {
+    const metricsCount = Number(sum.metrics);
+    const unparamCount = Number(sum.metrics_unparam);
+    const nullCount = Number(sum.metrics_null);
+    return {
+      metricsCount,
+      unparamCount,
+      nullCount,
+    };
+  } catch (_) {
+    return {
+      metricsCount: 0,
+      unparamCount: 0,
+      nullCount: 0,
+    };
+  }
+}
+
+/**
+ * Performance optimization to limit the amount of rows scanned before showing the landing page.
+ */
+function adjustEventViewTime(eventView: EventView) {
+  const _eventView = eventView.clone();
+
+  if (!_eventView.start && !_eventView.end) {
+    if (!_eventView.statsPeriod) {
+      _eventView.statsPeriod = '1h';
+      _eventView.start = undefined;
+      _eventView.end = undefined;
+    } else {
+      const periodHours = parsePeriodToHours(_eventView.statsPeriod);
+      if (periodHours > 1) {
+        _eventView.statsPeriod = '1h';
+        _eventView.start = undefined;
+        _eventView.end = undefined;
+      }
+    }
+  }
+  return _eventView;
+}

--- a/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuerySums.tsx
+++ b/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuerySums.tsx
@@ -7,13 +7,16 @@ import GenericDiscoverQuery, {
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import useApi from 'sentry/utils/useApi';
 
-export interface MetricsCompatibilityData {
-  compatible_projects?: number[];
-  dynamic_sampling_projects?: number[];
+export interface MetricsCompatibilitySumData {
+  sum: {
+    metrics?: number;
+    metrics_null?: number;
+    metrics_unparam?: number;
+  };
 }
 
 type QueryProps = Omit<DiscoverQueryProps, 'eventView' | 'api'> & {
-  children: (props: GenericChildrenProps<MetricsCompatibilityData>) => React.ReactNode;
+  children: (props: GenericChildrenProps<MetricsCompatibilitySumData>) => React.ReactNode;
   eventView: EventView;
 };
 
@@ -29,11 +32,11 @@ function getRequestPayload({
   ]);
 }
 
-export default function MetricsCompatibilityQuery({children, ...props}: QueryProps) {
+export default function MetricsCompatibilitySumsQuery({children, ...props}: QueryProps) {
   const api = useApi();
   return (
-    <GenericDiscoverQuery<MetricsCompatibilityData, {}>
-      route="metrics-compatibility-sums"
+    <GenericDiscoverQuery<MetricsCompatibilitySumData, {}>
+      route="metrics-compatibility"
       getRequestPayload={getRequestPayload}
       {...props}
       api={api}

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -37,6 +37,7 @@ import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
@@ -811,27 +812,32 @@ class DashboardDetail extends Component<Props, State> {
               </Layout.Header>
               <Layout.Body>
                 <Layout.Main fullWidth>
-                  {(organization.features.includes('dashboards-mep') ||
-                    organization.features.includes('mep-rollout-flag')) &&
-                  isDashboardUsingTransaction ? (
-                    <MetricsDataSwitcher
-                      organization={organization}
-                      eventView={eventView}
-                      location={location}
-                      hideLoadingIndicator
-                    >
-                      {metricsDataSide => (
-                        <MetricsDataSwitcherAlert
-                          organization={organization}
-                          eventView={eventView}
-                          projects={projects}
-                          location={location}
-                          router={router}
-                          {...metricsDataSide}
-                        />
-                      )}
-                    </MetricsDataSwitcher>
-                  ) : null}
+                  <MetricsCardinalityProvider
+                    organization={organization}
+                    location={location}
+                  >
+                    {(organization.features.includes('dashboards-mep') ||
+                      organization.features.includes('mep-rollout-flag')) &&
+                    isDashboardUsingTransaction ? (
+                      <MetricsDataSwitcher
+                        organization={organization}
+                        eventView={eventView}
+                        location={location}
+                        hideLoadingIndicator
+                      >
+                        {metricsDataSide => (
+                          <MetricsDataSwitcherAlert
+                            organization={organization}
+                            eventView={eventView}
+                            projects={projects}
+                            location={location}
+                            router={router}
+                            {...metricsDataSide}
+                          />
+                        )}
+                      </MetricsDataSwitcher>
+                    ) : null}
+                  </MetricsCardinalityProvider>
                   <FiltersBar
                     filters={(modifiedDashboard ?? dashboard).filters}
                     location={location}

--- a/static/app/views/performance/index.tsx
+++ b/static/app/views/performance/index.tsx
@@ -1,17 +1,21 @@
+import {Location} from 'history';
+
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
+import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = {
   children: React.ReactChildren;
+  location: Location;
   organization: Organization;
 };
 
-function PerformanceContainer({organization, children}: Props) {
+function PerformanceContainer({organization, location, children}: Props) {
   function renderNoAccess() {
     return (
       <PageContent>
@@ -27,7 +31,9 @@ function PerformanceContainer({organization, children}: Props) {
       organization={organization}
       renderDisabled={renderNoAccess}
     >
-      <MEPSettingProvider>{children}</MEPSettingProvider>
+      <MetricsCardinalityProvider location={location} organization={organization}>
+        <MEPSettingProvider>{children}</MEPSettingProvider>
+      </MetricsCardinalityProvider>
     </Feature>
   );
 }

--- a/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
@@ -12,14 +12,13 @@ import {t, tct} from 'sentry/locale';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {Organization, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
+import {MetricDataSwitcherOutcome} from 'sentry/utils/performance/contexts/metricsCardinality';
 
 import {
   areMultipleProjectsSelected,
   createUnnamedTransactionsDiscoverTarget,
   getSelectedProjectPlatformsArray,
 } from '../utils';
-
-import {MetricDataSwitcherOutcome} from './metricsDataSwitcher';
 
 interface MetricEnhancedDataAlertProps extends MetricDataSwitcherOutcome {
   eventView: EventView;

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -17,6 +17,7 @@ import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
+import {MetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import HasMeasurementsQuery from 'sentry/utils/performance/vitals/hasMeasurementsQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
@@ -73,6 +74,7 @@ type Props = {
   projectId: string;
   projects: Project[];
   transactionName: string;
+  metricsCardinality?: MetricsCardinalityContext;
   onChangeThreshold?: (threshold: number, metric: TransactionThresholdMetric) => void;
 };
 
@@ -101,7 +103,11 @@ class TransactionHeader extends Component<Props> {
   };
 
   renderCreateAlertButton() {
-    const {eventView, organization, projects} = this.props;
+    const {eventView, organization, projects, metricsCardinality} = this.props;
+
+    if (metricsCardinality?.isLoading) {
+      return <Fragment />;
+    }
 
     return (
       <CreateAlertFromViewButton

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -14,6 +14,7 @@ import {PageContent} from 'sentry/styles/organization';
 import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
+import {useMetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/performanceEventViewContext';
 import {decodeScalar} from 'sentry/utils/queryString';
 
@@ -62,6 +63,7 @@ function PageLayout(props: Props) {
   const projectId = decodeScalar(location.query.project);
   const transactionName = getTransactionName(location);
   const [error, setError] = useState<string | undefined>();
+  const metricsCardinality = useMetricsCardinalityContext();
   const [transactionThreshold, setTransactionThreshold] = useState<number | undefined>();
   const [transactionThresholdMetric, setTransactionThresholdMetric] = useState<
     TransactionThresholdMetric | undefined
@@ -108,6 +110,7 @@ function PageLayout(props: Props) {
                     setTransactionThreshold(threshold);
                     setTransactionThresholdMetric(metric);
                   }}
+                  metricsCardinality={metricsCardinality}
                 />
                 <Layout.Body>
                   {defined(error) && (

--- a/tests/js/spec/views/performance/landing/metricsDataSwitcher.spec.tsx
+++ b/tests/js/spec/views/performance/landing/metricsDataSwitcher.spec.tsx
@@ -19,10 +19,17 @@ export function addMetricsDataMock(settings?: {
 
   MockApiClient.addMockResponse({
     method: 'GET',
-    url: `/organizations/org-slug/events-metrics-compatibility/`,
+    url: `/organizations/org-slug/metrics-compatibility/`,
     body: {
       compatible_projects: [],
       dynamic_sampling_projects,
+    },
+  });
+
+  MockApiClient.addMockResponse({
+    method: 'GET',
+    url: `/organizations/org-slug/metrics-compatibility-sums/`,
+    body: {
       sum: {
         metrics: metricsCount,
         metrics_unparam: unparamCount,


### PR DESCRIPTION
### Summary
This adds a provider and context that split out the logic specifically to determine metrics data quality (due to us dropping high-cardinality transaction names) and provides the outcome and loading state of it's requests to any consumers downstream.

Other:
- Use the separate endpoints now to run the requests in parallel
- Some parts of this provider can go away once we eventually stop sending transaction:null from out of date sdks
