### PR TITLE
fix(mep): Adjust alert create to fallback with certain metrics data

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -34,9 +34,15 @@ export type CreateAlertFromViewButtonProps = ButtonProps & {
   alertType?: AlertType;
   className?: string;
   /**
+   * Passed in value to override any metrics decision and switch back to transactions dataset.
+   * We currently do a few checks on metrics data on performance pages and this passes the decision onward to alerts.
+   */
+  disableMetricDataset?: boolean;
+  /**
    * Called when the user is redirected to the alert builder
    */
   onClick?: () => void;
+
   referrer?: string;
 };
 
@@ -51,6 +57,7 @@ function CreateAlertFromViewButton({
   referrer,
   onClick,
   alertType,
+  disableMetricDataset,
   ...buttonProps
 }: CreateAlertFromViewButtonProps) {
   const project = projects.find(p => p.id === `${eventView.project[0]}`);
@@ -71,6 +78,7 @@ function CreateAlertFromViewButton({
     query: {
       ...queryParams,
       createFromDiscover: true,
+      disableMetricDataset,
       referrer,
       ...alertTemplate,
       project: project?.slug,

--- a/static/app/utils/performance/contexts/metricsCardinality.tsx
+++ b/static/app/utils/performance/contexts/metricsCardinality.tsx
@@ -1,0 +1,259 @@
+import {Fragment, ReactNode} from 'react';
+import {Location} from 'history';
+
+import {Organization} from 'sentry/types';
+import {parsePeriodToHours} from 'sentry/utils/dates';
+import EventView from 'sentry/utils/discover/eventView';
+import {canUseMetricsData} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
+import MetricsCompatibilityQuery, {
+  MetricsCompatibilityData,
+} from 'sentry/utils/performance/metricsEnhanced/metricsCompatibilityQuery';
+import MetricsCompatibilitySumsQuery, {
+  MetricsCompatibilitySumData,
+} from 'sentry/utils/performance/metricsEnhanced/metricsCompatibilityQuerySums';
+
+import {createDefinedContext} from './utils';
+
+export interface MetricDataSwitcherOutcome {
+  forceTransactionsOnly: boolean;
+  compatibleProjects?: number[];
+  shouldNotifyUnnamedTransactions?: boolean;
+  shouldWarnIncompatibleSDK?: boolean;
+}
+export interface MetricsCardinalityContext {
+  isLoading: boolean;
+  outcome?: MetricDataSwitcherOutcome;
+}
+
+type MergedMetricsData = MetricsCompatibilityData & MetricsCompatibilitySumData;
+
+const [_Provider, _useContext, _Context] =
+  createDefinedContext<MetricsCardinalityContext>({
+    name: 'MetricsCardinalityContext',
+    strict: false,
+  });
+
+/**
+ * This provider determines whether the metrics data is storing performance information correctly before we
+ * make dozens of requests on pages such as performance landing and dashboards.
+ */
+export const MetricsCardinalityProvider = (props: {
+  children: ReactNode;
+  location: Location;
+  organization: Organization;
+}) => {
+  const isUsingMetrics = canUseMetricsData(props.organization);
+
+  if (!isUsingMetrics) {
+    return (
+      <_Provider
+        value={{
+          isLoading: false,
+          outcome: {
+            forceTransactionsOnly: true,
+          },
+        }}
+      >
+        {props.children}
+      </_Provider>
+    );
+  }
+
+  const baseDiscoverProps = {
+    location: props.location,
+    orgSlug: props.organization.slug,
+    cursor: '0:0:0',
+  };
+  const eventView = EventView.fromLocation(props.location);
+  eventView.fields = [{field: 'tpm()'}];
+  const _eventView = adjustEventViewTime(eventView);
+
+  return (
+    <Fragment>
+      <MetricsCompatibilityQuery eventView={_eventView} {...baseDiscoverProps}>
+        {compatabilityResult => (
+          <MetricsCompatibilitySumsQuery eventView={_eventView} {...baseDiscoverProps}>
+            {sumsResult => (
+              <_Provider
+                value={{
+                  isLoading: compatabilityResult.isLoading || sumsResult.isLoading,
+                  outcome:
+                    compatabilityResult.isLoading || sumsResult.isLoading
+                      ? undefined
+                      : getMetricsOutcome(
+                          compatabilityResult.tableData && sumsResult.tableData
+                            ? {
+                                ...compatabilityResult.tableData,
+                                ...sumsResult.tableData,
+                              }
+                            : null,
+                          !!compatabilityResult.error && !!sumsResult.error
+                        ),
+                }}
+              >
+                {props.children}
+              </_Provider>
+            )}
+          </MetricsCompatibilitySumsQuery>
+        )}
+      </MetricsCompatibilityQuery>
+    </Fragment>
+  );
+};
+
+export const MetricCardinalityConsumer = _Context.Consumer;
+
+export const useMetricsCardinalityContext = _useContext;
+
+/**
+ * Logic for picking sides of metrics vs. transactions along with the associated warnings.
+ */
+function getMetricsOutcome(
+  dataCounts: MergedMetricsData | null,
+  hasOtherFallbackCondition: boolean
+) {
+  const fallbackOutcome: MetricDataSwitcherOutcome = {
+    forceTransactionsOnly: true,
+  };
+  const successOutcome: MetricDataSwitcherOutcome = {
+    forceTransactionsOnly: false,
+  };
+  if (!dataCounts) {
+    return fallbackOutcome;
+  }
+  const compatibleProjects = dataCounts.compatible_projects;
+
+  if (hasOtherFallbackCondition) {
+    return fallbackOutcome;
+  }
+
+  if (!dataCounts) {
+    return fallbackOutcome;
+  }
+
+  if (checkForSamplingRules(dataCounts)) {
+    return fallbackOutcome;
+  }
+
+  if (checkNoDataFallback(dataCounts)) {
+    return fallbackOutcome;
+  }
+
+  if (checkIncompatibleData(dataCounts)) {
+    return {
+      shouldWarnIncompatibleSDK: true,
+      forceTransactionsOnly: true,
+      compatibleProjects,
+    };
+  }
+
+  if (checkIfAllOtherData(dataCounts)) {
+    return {
+      shouldNotifyUnnamedTransactions: true,
+      forceTransactionsOnly: true,
+      compatibleProjects,
+    };
+  }
+
+  if (checkIfPartialOtherData(dataCounts)) {
+    return {
+      shouldNotifyUnnamedTransactions: true,
+      compatibleProjects,
+      forceTransactionsOnly: false,
+    };
+  }
+
+  return successOutcome;
+}
+
+/**
+ * Fallback if very similar amounts of metrics and transactions are found.
+ * No projects with dynamic sampling means no rules have been enabled yet.
+ */
+function checkForSamplingRules(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  if (!dataCounts.dynamic_sampling_projects?.length) {
+    return true;
+  }
+  if (counts.metricsCount === 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Fallback if no metrics found.
+ */
+function checkNoDataFallback(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  return !counts.metricsCount;
+}
+
+/**
+ * Fallback and warn if incompatible data found (old specific SDKs).
+ */
+function checkIncompatibleData(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  return counts.nullCount > 0;
+}
+
+/**
+ * Fallback and warn about unnamed transactions (specific SDKs).
+ */
+function checkIfAllOtherData(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  return counts.unparamCount >= counts.metricsCount;
+}
+
+/**
+ * Show metrics but warn about unnamed transactions.
+ */
+function checkIfPartialOtherData(dataCounts: MergedMetricsData) {
+  const counts = normalizeCounts(dataCounts);
+  return counts.unparamCount > 0;
+}
+
+/**
+ * Temporary function, can be removed after API changes.
+ */
+function normalizeCounts({sum}: MergedMetricsData) {
+  try {
+    const metricsCount = Number(sum.metrics);
+    const unparamCount = Number(sum.metrics_unparam);
+    const nullCount = Number(sum.metrics_null);
+    return {
+      metricsCount,
+      unparamCount,
+      nullCount,
+    };
+  } catch (_) {
+    return {
+      metricsCount: 0,
+      unparamCount: 0,
+      nullCount: 0,
+    };
+  }
+}
+
+/**
+ * Performance optimization to limit the amount of rows scanned before showing the landing page.
+ */
+function adjustEventViewTime(eventView: EventView) {
+  const _eventView = eventView.clone();
+
+  if (!_eventView.start && !_eventView.end) {
+    if (!_eventView.statsPeriod) {
+      _eventView.statsPeriod = '1h';
+      _eventView.start = undefined;
+      _eventView.end = undefined;
+    } else {
+      const periodHours = parsePeriodToHours(_eventView.statsPeriod);
+      if (periodHours > 1) {
+        _eventView.statsPeriod = '1h';
+        _eventView.start = undefined;
+        _eventView.end = undefined;
+      }
+    }
+  }
+  return _eventView;
+}

--- a/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuerySums.tsx
+++ b/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuerySums.tsx
@@ -7,13 +7,16 @@ import GenericDiscoverQuery, {
 } from 'sentry/utils/discover/genericDiscoverQuery';
 import useApi from 'sentry/utils/useApi';
 
-export interface MetricsCompatibilityData {
-  compatible_projects?: number[];
-  dynamic_sampling_projects?: number[];
+export interface MetricsCompatibilitySumData {
+  sum: {
+    metrics?: number;
+    metrics_null?: number;
+    metrics_unparam?: number;
+  };
 }
 
 type QueryProps = Omit<DiscoverQueryProps, 'eventView' | 'api'> & {
-  children: (props: GenericChildrenProps<MetricsCompatibilityData>) => React.ReactNode;
+  children: (props: GenericChildrenProps<MetricsCompatibilitySumData>) => React.ReactNode;
   eventView: EventView;
 };
 
@@ -29,11 +32,11 @@ function getRequestPayload({
   ]);
 }
 
-export default function MetricsCompatibilityQuery({children, ...props}: QueryProps) {
+export default function MetricsCompatibilitySumsQuery({children, ...props}: QueryProps) {
   const api = useApi();
   return (
-    <GenericDiscoverQuery<MetricsCompatibilityData, {}>
-      route="metrics-compatibility-sums"
+    <GenericDiscoverQuery<MetricsCompatibilitySumData, {}>
+      route="metrics-compatibility"
       getRequestPayload={getRequestPayload}
       {...props}
       api={api}

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -1,6 +1,6 @@
 import {PureComponent} from 'react';
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
 // eslint-disable-next-line no-restricted-imports
+import {browserHistory, withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import color from 'color';
 import type {LineSeriesOption} from 'echarts';

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -1,6 +1,6 @@
 import {PureComponent} from 'react';
-// eslint-disable-next-line no-restricted-imports
 import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+// eslint-disable-next-line no-restricted-imports
 import styled from '@emotion/styled';
 import color from 'color';
 import type {LineSeriesOption} from 'echarts';
@@ -52,10 +52,7 @@ import {
   TimePeriod,
 } from 'sentry/views/alerts/rules/metric/types';
 import {getChangeStatus} from 'sentry/views/alerts/utils/getChangeStatus';
-import {
-  AlertWizardAlertNames,
-  getMEPAlertsDataset,
-} from 'sentry/views/alerts/wizard/options';
+import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 
 import {Incident} from '../../../types';
@@ -65,6 +62,7 @@ import {
   isSessionAggregate,
   SESSION_AGGREGATE_TO_FIELD,
 } from '../../../utils';
+import {getMetricDatasetQueryExtras} from '../utils/getMetricDatasetQueryExtras';
 import {isCrashFreeAlert} from '../utils/isCrashFreeAlert';
 
 import {TimePeriodType} from './constants';
@@ -464,7 +462,8 @@ class MetricChart extends PureComponent<Props, State> {
   }
 
   render() {
-    const {api, rule, organization, timePeriod, project, interval, query} = this.props;
+    const {api, rule, organization, timePeriod, project, interval, query, location} =
+      this.props;
     const {aggregate, timeWindow, environment, dataset} = rule;
 
     // Fix for 7 days * 1m interval being over the max number of results from events api
@@ -493,12 +492,12 @@ class MetricChart extends PureComponent<Props, State> {
       moment.utc(timePeriod.end).add(timeWindow, 'minutes')
     );
 
-    const hasMetricDataset =
-      organization.features.includes('metrics-performance-alerts') ||
-      organization.features.includes('mep-rollout-flag');
-    const queryExtras: Record<string, string> = hasMetricDataset
-      ? {dataset: getMEPAlertsDataset(dataset, false)}
-      : {};
+    const queryExtras = getMetricDatasetQueryExtras({
+      organization,
+      location,
+      dataset,
+      newAlertOrQuery: false,
+    });
 
     return isCrashFreeAlert(dataset) ? (
       <SessionsRequest

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -779,6 +779,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       router,
       disableProjectSelector,
       eventView,
+      location,
     } = this.props;
     const {
       name,
@@ -804,6 +805,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       organization,
       projects: [project],
       triggers,
+      location,
       query: this.chartQuery,
       aggregate,
       dataset,

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -1,5 +1,6 @@
 import {Fragment, PureComponent} from 'react';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 import capitalize from 'lodash/capitalize';
 import isEqual from 'lodash/isEqual';
 import maxBy from 'lodash/maxBy';
@@ -36,10 +37,7 @@ import withApi from 'sentry/utils/withApi';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
 import {isSessionAggregate, SESSION_AGGREGATE_TO_FIELD} from 'sentry/views/alerts/utils';
 import {getComparisonMarkLines} from 'sentry/views/alerts/utils/getComparisonMarkLines';
-import {
-  AlertWizardAlertNames,
-  getMEPAlertsDataset,
-} from 'sentry/views/alerts/wizard/options';
+import {AlertWizardAlertNames} from 'sentry/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'sentry/views/alerts/wizard/utils';
 
 import {
@@ -51,6 +49,7 @@ import {
   TimeWindow,
   Trigger,
 } from '../../types';
+import {getMetricDatasetQueryExtras} from '../../utils/getMetricDatasetQueryExtras';
 
 import ThresholdsChart from './thresholdsChart';
 
@@ -61,6 +60,7 @@ type Props = {
   dataset: MetricRule['dataset'];
   environment: string | null;
   handleMEPAlertDataset: (data: EventsStats | MultiSeriesEventsStats | null) => void;
+  location: Location;
   newAlertOrQuery: boolean;
   organization: Organization;
   projects: Project[];
@@ -297,6 +297,7 @@ class TriggersChart extends PureComponent<Props, State> {
       projects,
       timeWindow,
       query,
+      location,
       aggregate,
       dataset,
       newAlertOrQuery,
@@ -312,14 +313,12 @@ class TriggersChart extends PureComponent<Props, State> {
       organization.features.includes('change-alerts') && comparisonDelta
     );
 
-    const hasMetricDataset =
-      organization.features.includes('metrics-performance-alerts') ||
-      organization.features.includes('mep-rollout-flag');
-    const queryExtras = {
-      ...(hasMetricDataset
-        ? {dataset: getMEPAlertsDataset(dataset, newAlertOrQuery)}
-        : {}),
-    };
+    const queryExtras = getMetricDatasetQueryExtras({
+      organization,
+      location,
+      dataset,
+      newAlertOrQuery,
+    });
 
     return isSessionAggregate(aggregate) ? (
       <SessionsRequest

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -25,7 +25,7 @@ export function getMetricDatasetQueryExtras({
 
   const queryExtras: Record<string, string> =
     hasMetricDataset && !disableMetricDataset
-      ? {dataset: getMEPAlertsDataset(dataset, !!newAlertOrQuery)}
+      ? {dataset: getMEPAlertsDataset(dataset, newAlertOrQuery)}
       : {};
 
   return queryExtras;

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -1,0 +1,32 @@
+import {Location} from 'history';
+
+import {Organization} from 'sentry/types';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {getMEPAlertsDataset} from 'sentry/views/alerts/wizard/options';
+
+import {MetricRule} from '../types';
+
+export function getMetricDatasetQueryExtras({
+  organization,
+  location,
+  dataset,
+  newAlertOrQuery,
+}: {
+  dataset: MetricRule['dataset'];
+  newAlertOrQuery: boolean;
+  organization: Organization;
+  location?: Location;
+}) {
+  const hasMetricDataset =
+    organization.features.includes('metrics-performance-alerts') ||
+    organization.features.includes('mep-rollout-flag');
+  const disableMetricDataset =
+    decodeScalar(location?.query?.disableMetricDataset) === 'true';
+
+  const queryExtras: Record<string, string> =
+    hasMetricDataset && !disableMetricDataset
+      ? {dataset: getMEPAlertsDataset(dataset, !!newAlertOrQuery)}
+      : {};
+
+  return queryExtras;
+}

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -37,6 +37,7 @@ import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
@@ -811,27 +812,32 @@ class DashboardDetail extends Component<Props, State> {
               </Layout.Header>
               <Layout.Body>
                 <Layout.Main fullWidth>
-                  {(organization.features.includes('dashboards-mep') ||
-                    organization.features.includes('mep-rollout-flag')) &&
-                  isDashboardUsingTransaction ? (
-                    <MetricsDataSwitcher
-                      organization={organization}
-                      eventView={eventView}
-                      location={location}
-                      hideLoadingIndicator
-                    >
-                      {metricsDataSide => (
-                        <MetricsDataSwitcherAlert
-                          organization={organization}
-                          eventView={eventView}
-                          projects={projects}
-                          location={location}
-                          router={router}
-                          {...metricsDataSide}
-                        />
-                      )}
-                    </MetricsDataSwitcher>
-                  ) : null}
+                  <MetricsCardinalityProvider
+                    organization={organization}
+                    location={location}
+                  >
+                    {(organization.features.includes('dashboards-mep') ||
+                      organization.features.includes('mep-rollout-flag')) &&
+                    isDashboardUsingTransaction ? (
+                      <MetricsDataSwitcher
+                        organization={organization}
+                        eventView={eventView}
+                        location={location}
+                        hideLoadingIndicator
+                      >
+                        {metricsDataSide => (
+                          <MetricsDataSwitcherAlert
+                            organization={organization}
+                            eventView={eventView}
+                            projects={projects}
+                            location={location}
+                            router={router}
+                            {...metricsDataSide}
+                          />
+                        )}
+                      </MetricsDataSwitcher>
+                    ) : null}
+                  </MetricsCardinalityProvider>
                   <FiltersBar
                     filters={(modifiedDashboard ?? dashboard).filters}
                     location={location}

--- a/static/app/views/performance/index.tsx
+++ b/static/app/views/performance/index.tsx
@@ -1,17 +1,21 @@
+import {Location} from 'history';
+
 import Feature from 'sentry/components/acl/feature';
 import Alert from 'sentry/components/alert';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import {Organization} from 'sentry/types';
+import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = {
   children: React.ReactChildren;
+  location: Location;
   organization: Organization;
 };
 
-function PerformanceContainer({organization, children}: Props) {
+function PerformanceContainer({organization, location, children}: Props) {
   function renderNoAccess() {
     return (
       <PageContent>
@@ -27,7 +31,9 @@ function PerformanceContainer({organization, children}: Props) {
       organization={organization}
       renderDisabled={renderNoAccess}
     >
-      <MEPSettingProvider>{children}</MEPSettingProvider>
+      <MetricsCardinalityProvider location={location} organization={organization}>
+        <MEPSettingProvider>{children}</MEPSettingProvider>
+      </MetricsCardinalityProvider>
     </Feature>
   );
 }

--- a/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
@@ -12,14 +12,13 @@ import {t, tct} from 'sentry/locale';
 import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {Organization, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
+import {MetricDataSwitcherOutcome} from 'sentry/utils/performance/contexts/metricsCardinality';
 
 import {
   areMultipleProjectsSelected,
   createUnnamedTransactionsDiscoverTarget,
   getSelectedProjectPlatformsArray,
 } from '../utils';
-
-import {MetricDataSwitcherOutcome} from './metricsDataSwitcher';
 
 interface MetricEnhancedDataAlertProps extends MetricDataSwitcherOutcome {
   eventView: EventView;

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -118,6 +118,7 @@ class TransactionHeader extends Component<Props> {
         referrer="performance"
         alertType="trans_duration"
         aria-label={t('Create Alert')}
+        disableMetricDataset={metricsCardinality?.outcome?.forceTransactionsOnly}
       />
     );
   }

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -17,6 +17,7 @@ import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import EventView from 'sentry/utils/discover/eventView';
+import {MetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import HasMeasurementsQuery from 'sentry/utils/performance/vitals/hasMeasurementsQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
@@ -73,6 +74,7 @@ type Props = {
   projectId: string;
   projects: Project[];
   transactionName: string;
+  metricsCardinality?: MetricsCardinalityContext;
   onChangeThreshold?: (threshold: number, metric: TransactionThresholdMetric) => void;
 };
 
@@ -101,7 +103,11 @@ class TransactionHeader extends Component<Props> {
   };
 
   renderCreateAlertButton() {
-    const {eventView, organization, projects} = this.props;
+    const {eventView, organization, projects, metricsCardinality} = this.props;
+
+    if (metricsCardinality?.isLoading) {
+      return <Fragment />;
+    }
 
     return (
       <CreateAlertFromViewButton

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -14,6 +14,7 @@ import {PageContent} from 'sentry/styles/organization';
 import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
+import {useMetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/performanceEventViewContext';
 import {decodeScalar} from 'sentry/utils/queryString';
 
@@ -62,6 +63,7 @@ function PageLayout(props: Props) {
   const projectId = decodeScalar(location.query.project);
   const transactionName = getTransactionName(location);
   const [error, setError] = useState<string | undefined>();
+  const metricsCardinality = useMetricsCardinalityContext();
   const [transactionThreshold, setTransactionThreshold] = useState<number | undefined>();
   const [transactionThresholdMetric, setTransactionThresholdMetric] = useState<
     TransactionThresholdMetric | undefined
@@ -108,6 +110,7 @@ function PageLayout(props: Props) {
                     setTransactionThreshold(threshold);
                     setTransactionThresholdMetric(metric);
                   }}
+                  metricsCardinality={metricsCardinality}
                 />
                 <Layout.Body>
                   {defined(error) && (

--- a/tests/js/spec/views/alerts/metricRules/triggersChart.spec.tsx
+++ b/tests/js/spec/views/alerts/metricRules/triggersChart.spec.tsx
@@ -23,11 +23,12 @@ describe('Incident Rules Create', () => {
   const api = new Client();
 
   it('renders a metric', async () => {
-    const {organization, project} = initializeOrg();
+    const {organization, project, router} = initializeOrg();
 
     render(
       <TriggersChart
         api={api}
+        location={router.location}
         organization={organization}
         projects={[project]}
         query="event.type:error"

--- a/tests/js/spec/views/performance/landing/metricsDataSwitcher.spec.tsx
+++ b/tests/js/spec/views/performance/landing/metricsDataSwitcher.spec.tsx
@@ -19,10 +19,17 @@ export function addMetricsDataMock(settings?: {
 
   MockApiClient.addMockResponse({
     method: 'GET',
-    url: `/organizations/org-slug/events-metrics-compatibility/`,
+    url: `/organizations/org-slug/metrics-compatibility/`,
     body: {
       compatible_projects: [],
       dynamic_sampling_projects,
+    },
+  });
+
+  MockApiClient.addMockResponse({
+    method: 'GET',
+    url: `/organizations/org-slug/metrics-compatibility-sums/`,
+    body: {
       sum: {
         metrics: metricsCount,
         metrics_unparam: unparamCount,


### PR DESCRIPTION
### Summary
This passes the decision along when creating alerts from performance to avoid the second set of requests again on the alerts page, although if there are more entry points we may have to wrap the alerts UI in the metrics-data-cardinality provider as well (I'd prefer not to for performance reasons).

#### Why does this exist?
- We can't be sure when we query the metrics dataset that the data will have been through the various relay conditions relating to whether it had it's transaction name dropped or not. Calling the metrics dataset with a transaction that doesn't qualify will simply return `count: 0` etc. the same as it would if there was just no data for that transaction. Currently it means that any potential discover query has to do an (expensive) preflight check, hence why we're doing it in the UI and informing subsequent queries to fall back to the transaction dataset.
- In the future we can reduce or fully eliminate the need for this check as sdks are updated and start sending source, along with a few other conditions.

Other:
- Moves the flag code and this param check into one function.

Going to wait for https://github.com/getsentry/sentry/pull/37881 to be in first (it's base branch), just making sure I didn't miss any test checks.