### PR TITLE
fix(perf): Filter out mark measurements

### DIFF
--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -22,6 +22,10 @@ type Props = {
   organization: Organization;
 };
 
+function isNotMarkMeasurement(field: string) {
+  return !field.startsWith('mark.');
+}
+
 export default function EventCustomPerformanceMetrics({
   event,
   location,
@@ -29,6 +33,7 @@ export default function EventCustomPerformanceMetrics({
 }: Props) {
   const measurementNames = Object.keys(event.measurements ?? {})
     .filter(name => isCustomMeasurement(`measurements.${name}`))
+    .filter(isNotMarkMeasurement)
     .sort();
 
   if (measurementNames.length === 0) {


### PR DESCRIPTION
### Summary
This will hide mark meausurements in the UI for now, as we work to remove them being emitted from the sdk.

