### PR TITLE
feat(perf): Add bucketed proj id as metric

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -586,16 +586,16 @@ def report_metrics_for_detectors(
     has_issues = issue_count > 0
 
     if has_issues:
-        sdk_span.containing_transaction.set_tag("_pi_all_issue_count", len(issue_count))
+        sdk_span.containing_transaction.set_tag("_pi_all_issue_count", issue_count)
         metrics.incr(
             "performance.performance_issue.aggregate",
-            len(issue_count),
+            issue_count,
         )
         if event_id:
             sdk_span.containing_transaction.set_tag("_pi_transaction", event_id)
 
-    detected_tags["is_main_project"] = event.project_id in [1]
-    detected_tags["project_id_bucket"] = event.project_id % 10
+    detected_tags["is_main_project"] = event.get("project_id", None) in [1]
+    detected_tags["project_id_bucket"] = event.get("project_id", None) % 10
 
     metrics.incr(
         "performance.performance_issue.detected",

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -594,8 +594,8 @@ def report_metrics_for_detectors(
         if event_id:
             sdk_span.containing_transaction.set_tag("_pi_transaction", event_id)
 
-    detected_tags["is_main_project"] = event.get("project_id", None) in [1]
-    detected_tags["project_id_bucket"] = event.get("project_id", None) % 10
+    detected_tags["is_main_project"] = event.get("project_id", 0) in [1]
+    detected_tags["project_id_bucket"] = event.get("project_id", 0) % 10
 
     metrics.incr(
         "performance.performance_issue.detected",

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -32,7 +32,7 @@ def create_span(op, duration=100.0, desc="SELECT count() FROM table WHERE id = %
 
 
 def create_event(spans, event_id="a" * 16):
-    return {"event_id": event_id, "spans": spans}
+    return {"event_id": event_id, "spans": spans, "project_id": 1}
 
 
 class PerformanceDetectionTest(unittest.TestCase):

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -78,7 +78,8 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_duplicates",
                     "bbbbbbbbbbbbbbbb",
                 ),
-            ]
+            ],
+            True,
         )
 
     def test_calls_detect_duplicate_hash(self):
@@ -116,7 +117,8 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_dupes_hash",
                     "bbbbbbbbbbbbbbbb",
                 ),
-            ]
+            ],
+            True,
         )
 
     def test_calls_detect_slow_span(self):
@@ -148,7 +150,8 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_slow_span",
                     "bbbbbbbbbbbbbbbb",
                 ),
-            ]
+            ],
+            True,
         )
 
     def test_calls_partial_span_op_allowed(self):
@@ -172,7 +175,8 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_slow_span",
                     "bbbbbbbbbbbbbbbb",
                 ),
-            ]
+            ],
+            True,
         )
 
     def test_calls_slow_span_threshold(self):
@@ -227,7 +231,8 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_n_plus_one",
                     "bbbbbbbbbbbbbbbb",
                 ),
-            ]
+            ],
+            True,
         )
 
     def test_calls_detect_sequential(self):
@@ -266,7 +271,8 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_sequential",
                     "bbbbbbbbbbbbbbbb",
                 ),
-            ]
+            ],
+            True,
         )
 
     def test_calls_detect_long_task(self):
@@ -301,7 +307,8 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_long_task",
                     "bbbbbbbbbbbbbbbb",
                 ),
-            ]
+            ],
+            True,
         )
 
         sdk_span_mock.reset_mock()
@@ -322,7 +329,8 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_long_task",
                     "bbbbbbbbbbbbbbbb",
                 ),
-            ]
+            ],
+            True,
         )
 
     def test_calls_detect_render_blocking_asset(self):
@@ -405,5 +413,6 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_render_blocking_assets",
                     "bbbbbbbbbbbbbbbb",
                 ),
-            ]
+            ],
+            True,
         )


### PR DESCRIPTION
This reduces the cardinality of project ids but still lets us check general differences in detection between projects to make sure we're not optimizing for a specific large outlier.

Other:
- Cleaned up some redundant / unnecessary code
