### PR TITLE
fix: use same verbiage for all profiling set up titles

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -172,7 +172,7 @@ function SelectProjectStep({
   return (
     <ModalBody>
       <ModalHeader>
-        <h3>{t('Setup Profiling')}</h3>
+        <h3>{t('Set Up Profiling')}</h3>
       </ModalHeader>
       <form onSubmit={onFormSubmit}>
         <StyledList symbol="colored-numeric">
@@ -236,7 +236,7 @@ function AndroidInstallSteps() {
         </ExternalLink>
       </li>
       <li>
-        <StepTitle>{t('Setup Profiling')}</StepTitle>
+        <StepTitle>{t('Set Up Profiling')}</StepTitle>
         <CodeContainer>
           {`<application>
   <meta-data android:name="io.sentry.dsn" android:value="..." />
@@ -315,7 +315,7 @@ function AndroidSendDebugFilesInstruction({
   return (
     <ModalBody>
       <ModalHeader>
-        <h3>{t('Setup Profiling')}</h3>
+        <h3>{t('Set Up Profiling')}</h3>
       </ModalHeader>
       <p>
         {t(
@@ -378,7 +378,7 @@ function IOSSendDebugFilesInstruction({
   return (
     <ModalBody>
       <ModalHeader>
-        <h3>{t('Setup Profiling')}</h3>
+        <h3>{t('Set Up Profiling')}</h3>
       </ModalHeader>
       <p>
         {t(`The most straightforward way to provide Sentry with debug information files is to

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -162,7 +162,7 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                       {t('Read Docs')}
                     </Button>
                     <Button onClick={onSetupProfilingClick} priority="primary">
-                      {t('Setup Profiling')}
+                      {t('Set Up Profiling')}
                     </Button>
                   </ProfilingOnboardingPanel>
                 ) : (


### PR DESCRIPTION
We have a button that uses the correct verbiage ("Set Up Profiling") but a few other spots have "Setup Profiling" which this changes to be grammatically correct and consistent with the former: 
![](https://user-images.githubusercontent.com/3241469/184997563-f018f852-2488-4c96-b322-9f48d9ccedc7.png)
