### PR TITLE
fix(contexts): Disable context formatting when displaying raw

### DIFF
--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -110,6 +110,7 @@ export function geKnownData<Data, DataType>({
   data,
   knownDataTypes,
   meta,
+  raw,
   onGetKnownDataDetails,
 }: {
   data: Data;
@@ -121,6 +122,7 @@ export function geKnownData<Data, DataType>({
       }
     | undefined;
   meta?: Record<any, any>;
+  raw?: boolean;
 }): KeyValueListData {
   const filteredTypes = knownDataTypes.filter(knownDataType => {
     if (
@@ -147,7 +149,9 @@ export function geKnownData<Data, DataType>({
       return {
         key: type,
         ...knownDataDetails,
-        value: (
+        value: raw ? (
+          knownDataDetails.value
+        ) : (
           <ContextData
             data={knownDataDetails.value}
             meta={meta?.[type]}

--- a/static/app/components/events/eventExtraData/index.tsx
+++ b/static/app/components/events/eventExtraData/index.tsx
@@ -31,6 +31,7 @@ const EventExtraDataContext = memo(
               data: event.context,
               knownDataTypes: Object.keys(event.context),
               meta: event._meta?.context,
+              raw,
               onGetKnownDataDetails: v => getEventExtraDataKnownDataDetails(v),
             })}
             raw={raw}

--- a/tests/js/spec/components/events/contexts/utils.spec.tsx
+++ b/tests/js/spec/components/events/contexts/utils.spec.tsx
@@ -81,5 +81,35 @@ describe('contexts utils', function () {
         },
       ]);
     });
+
+    it('does not format the value when displaying raw', function () {
+      const data = {device_app_hash: 'abc'};
+      const knownDataTypes = ['device_app_hash'];
+
+      const knownData = geKnownData({
+        data,
+        knownDataTypes,
+        raw: true,
+        onGetKnownDataDetails: v => {
+          if (v.type === 'device_app_hash') {
+            return {
+              subject: 'Device App Hash',
+              value: v.data.device_app_hash,
+            };
+          }
+
+          return undefined;
+        },
+      });
+
+      expect(knownData).toEqual([
+        {
+          key: 'device_app_hash',
+          value: 'abc',
+          subject: 'Device App Hash',
+          meta: undefined,
+        },
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Fixes an issue where we were attempting to stringify a react component instead of the raw value.

related #37590