### PR TITLE
feat(notifications): adds providers to notification settings endpint

### DIFF
--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -15,7 +15,13 @@ from sentry.notifications.types import (
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
-from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
+from sentry.types.integrations import (
+    EXTERNAL_PROVIDERS,
+    ExternalProviders,
+    get_provider_enum,
+    get_provider_enum_from_string,
+    get_provider_name,
+)
 
 if TYPE_CHECKING:
     from sentry.models import (
@@ -583,3 +589,29 @@ def get_values_by_provider(
         get_value_for_actor(notification_settings_by_scope, recipient),
         get_value_for_parent(notification_settings_by_scope, parent_id, type),
     )
+
+
+def get_providers_for_recipient(recipient: User | Team) -> Iterable[ExternalProviders]:
+    from sentry.models import ExternalActor, Identity, Team
+
+    possible_providers = NOTIFICATION_SETTING_DEFAULTS.keys()
+    if isinstance(recipient, Team):
+        return list(
+            map(
+                get_provider_enum,
+                ExternalActor.objects.filter(
+                    actor_id=recipient.actor_id, provider__in=possible_providers
+                ).values_list("provider", flat=True),
+            )
+        )
+
+    return list(
+        map(
+            get_provider_enum_from_string,
+            Identity.objects.filter(
+                user=recipient, idp__type__in=list(map(get_provider_name, possible_providers))
+            ).values_list("idp__type", flat=True),
+        )
+    ) + [
+        ExternalProviders.EMAIL
+    ]  # always add in email as an option

--- a/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
+++ b/src/sentry/notifications/notifications/strategies/role_based_recipient_strategy.py
@@ -38,7 +38,9 @@ class RoleBasedRecipientStrategy(metaclass=ABCMeta):
         for member in members:
             self.set_member_in_cache(member)
         # convert members to users
-        return map(lambda member: member.user, members)
+        user_map: Iterable[User] = map(lambda member: member.user, members)
+        # convert to list from an interterator
+        return list(user_map)
 
     @abstractmethod
     def determine_member_recipients(self) -> Iterable[OrganizationMember]:

--- a/src/sentry/types/integrations.py
+++ b/src/sentry/types/integrations.py
@@ -45,3 +45,14 @@ def get_provider_enum(value: Optional[str]) -> Optional[ExternalProviders]:
 
 def get_provider_choices(providers: Set[ExternalProviders]) -> Sequence[str]:
     return list(EXTERNAL_PROVIDERS.get(i) for i in providers)
+
+
+def get_provider_enum_from_string(provider: str) -> ExternalProviders:
+    for k, v in EXTERNAL_PROVIDERS.items():
+        if v == provider:
+            return k
+    raise InvalidProviderException("Invalid provider ${provider}")
+
+
+class InvalidProviderException(Exception):
+    pass

--- a/tests/sentry/api/endpoints/test_user_notification_settings.py
+++ b/tests/sentry/api/endpoints/test_user_notification_settings.py
@@ -100,6 +100,116 @@ class UserNotificationSettingsGetTest(UserNotificationSettingsTestBase):
         assert other_project.id not in response.data["workflow"]["project"]
 
 
+class UserNotificationSettingsTestBase(APITestCase):
+    endpoint = "sentry-api-0-user-notification-settings"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+
+class UserNotificationSettingsGetTestV2(UserNotificationSettingsTestBase):
+    def get_v2_response(self, qs_params=None, **kwargs):
+        qs_params = qs_params or {}
+        qs_params["v2"] = "1"
+        return self.get_success_response("me", qs_params=qs_params, **kwargs)
+
+    def test_simple(self):
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+        )
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+            organization=self.organization,
+        )
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.SLACK,
+            NotificationSettingTypes.DEPLOY,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
+            organization=self.organization,
+        )
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.SLACK,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+            user=self.user,
+        )
+
+        response = self.get_v2_response()
+
+        # Spot check.
+        preferences = response.data["preferences"]
+        assert preferences["alerts"]["user"][self.user.id]["email"] == "never"
+        assert preferences["deploy"]["organization"][self.organization.id]["email"] == "never"
+        assert preferences["deploy"]["organization"][self.organization.id]["slack"] == "always"
+        assert preferences["workflow"]["user"][self.user.id]["slack"] == "subscribe_only"
+
+        providers = response.data["providers"]
+        assert providers == ["email"]
+
+    def test_slack_enabled(self):
+        self.integration = self.create_slack_integration(self.organization, user=self.user)
+        response = self.get_v2_response()
+        providers = response.data["providers"]
+        assert sorted(providers) == ["email", "slack"]
+
+    def test_notification_settings_empty(self):
+        _ = self.organization  # HACK to force creation.
+
+        response = self.get_v2_response()
+
+        # Spot check.
+        preferences = response.data["preferences"]
+        assert preferences["alerts"]["user"][self.user.id]["email"] == "always"
+        assert preferences["deploy"]["organization"][self.organization.id]["email"] == "default"
+        assert preferences["deploy"]["organization"][self.organization.id]["slack"] == "default"
+        assert preferences["workflow"]["user"][self.user.id]["slack"] == "subscribe_only"
+
+    def test_type_querystring(self):
+        response = self.get_v2_response(qs_params={"type": "workflow"})
+
+        assert "alerts" not in response.data["preferences"]
+        assert "workflow" in response.data["preferences"]
+
+    def test_invalid_querystring(self):
+        self.get_error_response(
+            "me", qs_params={"type": "invalid"}, status_code=status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_invalid_user_id(self):
+        self.get_error_response("invalid", status_code=status.HTTP_404_NOT_FOUND)
+
+    def test_wrong_user_id(self):
+        other_user = self.create_user("bizbaz@example.com")
+
+        self.get_error_response(other_user.id, status_code=status.HTTP_403_FORBIDDEN)
+
+    def test_invalid_notification_setting(self):
+        other_organization = self.create_organization(name="Rowdy Tiger", owner=None)
+        other_project = self.create_project(
+            organization=other_organization, teams=[], name="Bengal"
+        )
+
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.SLACK,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+            user=self.user,
+            project=other_project,
+        )
+
+        response = self.get_v2_response()
+
+        assert other_project.id not in response.data["preferences"]["workflow"]["project"]
+
+
 class UserNotificationSettingsTest(UserNotificationSettingsTestBase):
     method = "put"
 


### PR DESCRIPTION
This PR adds a new `v2` option to the `UserNotificationSettingsDetailsEndpoint` which has the following fields in the response:
* `preferences`: This is the new name for settings. This reflects the _preferences_ for a notification with a provider but it's no guarantee that a notification can be sent on that channel. This is the full response of the v1 version of this endpoint.
* `providers`: These are the providers that the user has available based on the rows in the `Identity` model. Note that since in the UI sets the provider globally, we can provide a global set of providers for that user.

The intention behind this new API is so that in the UI settings, we only show options for the providers the user has available. For example, if they don't have their Slack identity mapped then we won't get `slack` in the list of providers and we won't render it as an option.

The migration path is to first land this new backend change, then add `v2=1` to the UI and make the modifications above, then remove the old format. Since this API has no usage by customers, we can make this breaking API change without issue once the UI is updated. 