### PR TITLE
ref(imports): Phase out imports from sentry.app to reduce import graph

### DIFF
--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -1,10 +1,10 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import ratelimits as ratelimiter
 from sentry.api.base import Endpoint
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
-from sentry.app import ratelimiter
 from sentry.utils import auth, metrics
 from sentry.utils.hashlib import md5_text
 from sentry.web.forms.accounts import AuthenticationForm

--- a/src/sentry/api/endpoints/integrations/sentry_apps/stats/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/stats/details.py
@@ -1,9 +1,9 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import tsdb
 from sentry.api.base import StatsMixin
 from sentry.api.bases import SentryAppBaseEndpoint, SentryAppStatsPermission
-from sentry.app import tsdb
 from sentry.models import SentryAppInstallation
 
 

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -5,13 +5,14 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, audit_log, features, options, roles
+from sentry import analytics, audit_log, features, options
+from sentry import ratelimits as ratelimiter
+from sentry import roles
 from sentry.api.base import Endpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.paginator import DateTimePaginator, OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization import BaseOrganizationSerializer
-from sentry.app import ratelimiter
 from sentry.auth.superuser import is_active_superuser
 from sentry.db.models.query import in_iexact
 from sentry.models import (

--- a/src/sentry/api/endpoints/organization_member/index.py
+++ b/src/sentry/api/endpoints/organization_member/index.py
@@ -12,7 +12,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models import organization_member as organization_member_serializers
 from sentry.api.serializers.rest_framework import ListField
 from sentry.api.validators import AllowedEmailField
-from sentry.app import locks
+from sentry.locks import locks
 from sentry.models import ExternalActor, InviteStatus, OrganizationMember, Team, TeamStatus
 from sentry.models.authenticator import available_authenticators
 from sentry.search.utils import tokenize_query

--- a/src/sentry/api/endpoints/organization_member/requests/invite/index.py
+++ b/src/sentry/api/endpoints/organization_member/requests/invite/index.py
@@ -8,7 +8,7 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPerm
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.organization_member import OrganizationMemberWithTeamsSerializer
-from sentry.app import locks
+from sentry.locks import locks
 from sentry.models import InviteStatus, OrganizationMember
 from sentry.notifications.notifications.organization_request import InviteRequestNotification
 from sentry.notifications.utils.tasks import async_send_notification

--- a/src/sentry/api/endpoints/organization_member/requests/join.py
+++ b/src/sentry/api/endpoints/organization_member/requests/join.py
@@ -6,9 +6,9 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import ratelimits as ratelimiter
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.validators import AllowedEmailField
-from sentry.app import ratelimiter
 from sentry.models import AuthProvider, InviteStatus, OrganizationMember
 from sentry.notifications.notifications.organization_request import JoinRequestNotification
 from sentry.notifications.utils.tasks import async_send_notification

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -1,10 +1,10 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import tsdb
 from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.app import tsdb
 from sentry.models import Environment, Group
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 

--- a/src/sentry/api/endpoints/project_user_stats.py
+++ b/src/sentry/api/endpoints/project_user_stats.py
@@ -4,10 +4,10 @@ from django.utils import timezone
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import tsdb
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.app import tsdb
 from sentry.models import Environment
 
 

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -8,11 +8,11 @@ from rest_framework.fields import SkipField
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import ratelimits as ratelimiter
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import email_verification_required, sudo_required
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_cookie
 from sentry.api.serializers import serialize
-from sentry.app import ratelimiter
 from sentry.auth.authenticators.base import EnrollmentStatus, NewEnrollmentDisallowed
 from sentry.auth.authenticators.sms import SMSRateLimitExceeded
 from sentry.models import Authenticator

--- a/src/sentry/api/endpoints/user_emails_confirm.py
+++ b/src/sentry/api/endpoints/user_emails_confirm.py
@@ -48,7 +48,7 @@ class UserEmailsConfirmEndpoint(UserEndpoint):
         :auth required:
         """
 
-        from sentry.app import ratelimiter
+        from sentry import ratelimits as ratelimiter
 
         if ratelimiter.is_limited(
             f"auth:confirm-email:{user.id}",

--- a/src/sentry/api/serializers/models/environment.py
+++ b/src/sentry/api/serializers/models/environment.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry import tsdb
 from sentry.api.serializers import Serializer, register
-from sentry.app import tsdb
 from sentry.models import Environment, EnvironmentProject
 
 StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry import tsdb
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.app import tsdb
 from sentry.models import GroupRelease, Release
 
 StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -9,7 +9,7 @@ from sentry_relay.auth import PublicKey
 from sentry_relay.exceptions import RelayError
 from typing_extensions import TypedDict
 
-from sentry import features, roles
+from sentry import features, quotas, roles
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models import UserSerializer
 from sentry.api.serializers.models.project import ProjectSerializerResponse
@@ -20,7 +20,6 @@ from sentry.api.serializers.models.role import (
 )
 from sentry.api.serializers.models.team import TeamSerializerResponse
 from sentry.api.utils import generate_organization_url, generate_region_url
-from sentry.app import quotas
 from sentry.auth.access import Access
 from sentry.constants import (
     ACCOUNT_RATE_LIMIT_DEFAULT,

--- a/src/sentry/app.py
+++ b/src/sentry/app.py
@@ -1,9 +1,5 @@
 from threading import local
 
-from sentry.utils import redis
-from sentry.utils.locking.backends.redis import RedisLockBackend
-from sentry.utils.locking.manager import LockManager
-
 
 class State(local):
     request = None
@@ -12,17 +8,17 @@ class State(local):
 
 env = State()
 
-
-# COMPAT
-from sentry import search, tsdb  # NOQA
 from sentry.utils.sdk import RavenShim
-
-from .buffer import backend as buffer  # NOQA
-from .digests import backend as digests  # NOQA
-from .nodestore import backend as nodestore  # NOQA
-from .quotas import backend as quotas  # NOQA
-from .ratelimits import backend as ratelimiter  # NOQA
 
 raven = client = RavenShim()
 
-locks = LockManager(RedisLockBackend(redis.clusters.get("default")))
+
+# These are backwards incompatible imports that should no longer be used.
+# They will be removed to reduce the size of the import graph
+from sentry import search, tsdb  # NOQA
+from sentry.buffer import backend as buffer  # NOQA
+from sentry.digests import backend as digests  # NOQA
+from sentry.locks import locks  # NOQA
+from sentry.nodestore import backend as nodestore  # NOQA
+from sentry.quotas import backend as quotas  # NOQA
+from sentry.ratelimits import backend as ratelimiter  # NOQA

--- a/src/sentry/auth/authenticators/sms.py
+++ b/src/sentry/auth/authenticators/sms.py
@@ -3,7 +3,7 @@ from hashlib import md5
 
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.app import ratelimiter
+from sentry import ratelimits as ratelimiter
 from sentry.utils.decorators import classproperty
 from sentry.utils.otp import TOTP
 from sentry.utils.sms import phone_number_as_e164, send_sms, sms_available

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -20,7 +20,6 @@ from django.views import View
 
 from sentry import audit_log, features
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_cookie
-from sentry.app import locks
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.idpmigration import (
@@ -29,6 +28,7 @@ from sentry.auth.idpmigration import (
 )
 from sentry.auth.provider import MigratingIdentityId, Provider
 from sentry.auth.superuser import is_active_superuser
+from sentry.locks import locks
 from sentry.models import (
     AuditLogEntry,
     AuthIdentity,

--- a/src/sentry/digests/notifications.py
+++ b/src/sentry/digests/notifications.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict, namedtuple
 from typing import Any, Mapping, MutableMapping, MutableSequence, Sequence
 
-from sentry.app import tsdb
+from sentry import tsdb
 from sentry.digests import Digest, Record
 from sentry.eventstore.models import Event
 from sentry.models import Group, GroupStatus, Project, Rule

--- a/src/sentry/integrations/bitbucket/repository.py
+++ b/src/sentry/integrations/bitbucket/repository.py
@@ -1,4 +1,4 @@
-from sentry.app import locks
+from sentry.locks import locks
 from sentry.models import OrganizationOption
 from sentry.models.apitoken import generate_token
 from sentry.plugins.providers import IntegrationRepositoryProvider

--- a/src/sentry/locks.py
+++ b/src/sentry/locks.py
@@ -1,0 +1,5 @@
+from sentry.utils import redis
+from sentry.utils.locking.backends.redis import RedisLockBackend
+from sentry.utils.locking.manager import LockManager
+
+locks = LockManager(RedisLockBackend(redis.clusters.get("default")))

--- a/src/sentry/models/deploy.py
+++ b/src/sentry/models/deploy.py
@@ -8,13 +8,13 @@ from django.db import models
 from django.utils import timezone
 
 from sentry import features
-from sentry.app import locks
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
     Model,
 )
+from sentry.locks import locks
 from sentry.types.activity import ActivityType
 from sentry.types.releaseactivity import ReleaseActivityType
 from sentry.utils.retries import TimedRetryPolicy

--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -16,7 +16,6 @@ from django.core.files.storage import get_storage_class
 from django.db import IntegrityError, models, router, transaction
 from django.utils import timezone
 
-from sentry.app import locks
 from sentry.db.models import (
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
@@ -24,6 +23,7 @@ from sentry.db.models import (
     JSONField,
     Model,
 )
+from sentry.locks import locks
 from sentry.tasks.files import delete_file as delete_file_task
 from sentry.tasks.files import delete_unreferenced_blobs
 from sentry.utils import metrics

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -14,7 +14,6 @@ from django.utils.functional import cached_property
 
 from bitfield import BitField
 from sentry import features, roles
-from sentry.app import locks
 from sentry.constants import (
     ALERTS_MEMBER_WRITE_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
@@ -23,6 +22,7 @@ from sentry.constants import (
 )
 from sentry.db.models import BaseManager, BoundedPositiveIntegerField, Model, sane_repr
 from sentry.db.models.utils import slugify_instance
+from sentry.locks import locks
 from sentry.roles.manager import Role
 from sentry.utils.http import absolute_uri
 from sentry.utils.retries import TimedRetryPolicy

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -18,7 +18,6 @@ from django.utils.translation import ugettext_lazy as _
 
 from bitfield import BitField
 from sentry import projectoptions
-from sentry.app import locks
 from sentry.constants import RESERVED_PROJECT_SLUGS, ObjectStatus
 from sentry.db.mixin import PendingDeletionMixin, delete_pending_deletion_option
 from sentry.db.models import (
@@ -29,6 +28,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.db.models.utils import slugify_instance
+from sentry.locks import locks
 from sentry.snuba.models import SnubaQuery
 from sentry.utils import metrics
 from sentry.utils.colors import get_hashed_color

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -16,7 +16,6 @@ from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from sentry_relay import RelayError, parse_release
 
-from sentry.app import locks
 from sentry.constants import BAD_RELEASE_CHARS, COMMIT_RANGE_DELIMITER
 from sentry.db.models import (
     ArrayField,
@@ -29,6 +28,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.exceptions import InvalidSearchQuery
+from sentry.locks import locks
 from sentry.models import (
     Activity,
     BaseManager,

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError, connections, models, router, transaction
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.app import env, locks
+from sentry.app import env
 from sentry.db.models import (
     BaseManager,
     BoundedPositiveIntegerField,
@@ -16,6 +16,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.db.models.utils import slugify_instance
+from sentry.locks import locks
 from sentry.utils.retries import TimedRetryPolicy
 
 if TYPE_CHECKING:

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -151,8 +151,7 @@ def cleanup(days, project, concurrency, silent, model, router, timed):
 
         from django.db import router as db_router
 
-        from sentry import models
-        from sentry.app import nodestore
+        from sentry import models, nodestore
         from sentry.constants import ObjectStatus
         from sentry.data_export.models import ExportedData
         from sentry.db.deletion import BulkDeleteQuery

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -63,7 +63,7 @@ def organizations(metrics, since, until):
     """
     from django.utils import timezone
 
-    from sentry.app import tsdb
+    from sentry import tsdb
     from sentry.models import Organization
 
     stdout = click.get_text_stream("stdout")

--- a/src/sentry/runner/commands/upgrade.py
+++ b/src/sentry/runner/commands/upgrade.py
@@ -87,7 +87,7 @@ def upgrade(ctx, verbosity, traceback, noinput, lock, no_repair, with_nodestore)
     "Perform any pending database migrations and upgrades."
 
     if lock:
-        from sentry.app import locks
+        from sentry.locks import locks
         from sentry.utils.locking import UnableToAcquireLock
 
         lock = locks.get("upgrade", duration=0, name="command_upgrade")

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -8,9 +8,10 @@ from django.conf import settings
 from django.utils import timezone
 
 import sentry
-from sentry.app import locks, tsdb
+from sentry import tsdb
 from sentry.debug.utils.packages import get_all_package_versions
 from sentry.http import safe_urlopen, safe_urlread
+from sentry.locks import locks
 from sentry.tasks.base import instrumented_task
 from sentry.utils import json
 

--- a/src/sentry/tasks/files.py
+++ b/src/sentry/tasks/files.py
@@ -14,7 +14,7 @@ from sentry.utils.db import atomic_transaction
     acks_late=True,
 )
 def delete_file(path, checksum, **kwargs):
-    from sentry.app import locks
+    from sentry.locks import locks
     from sentry.models.file import FileBlob, get_storage
     from sentry.utils.retries import TimedRetryPolicy
 

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
-from sentry.app import locks
+from sentry.locks import locks
 from sentry.models import Commit, Project, Release
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.tasks.base import instrumented_task

--- a/src/sentry/tasks/merge.py
+++ b/src/sentry/tasks/merge.py
@@ -3,8 +3,7 @@ import logging
 from django.db import DataError, IntegrityError, router, transaction
 from django.db.models import F
 
-from sentry import eventstream, similarity
-from sentry.app import tsdb
+from sentry import eventstream, similarity, tsdb
 from sentry.tasks.base import instrumented_task, track_group_async_operation
 
 logger = logging.getLogger("sentry.merge")

--- a/src/sentry/tasks/process_buffer.py
+++ b/src/sentry/tasks/process_buffer.py
@@ -16,7 +16,7 @@ def process_pending(partition=None):
     Process pending buffers.
     """
     from sentry import buffer
-    from sentry.app import locks
+    from sentry.locks import locks
 
     if partition is None:
         lock_key = "buffer:process_pending"

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -21,8 +21,8 @@ from snuba_sdk.function import Function
 from snuba_sdk.orderby import Direction, OrderBy
 from snuba_sdk.query import Limit, Query
 
+from sentry import tsdb
 from sentry.api.serializers.snuba import zerofill
-from sentry.app import tsdb
 from sentry.cache import default_cache
 from sentry.constants import DataCategory
 from sentry.models import (

--- a/src/sentry/tasks/scheduler.py
+++ b/src/sentry/tasks/scheduler.py
@@ -2,7 +2,7 @@ import logging
 
 from django.utils import timezone
 
-from sentry.app import locks
+from sentry.locks import locks
 from sentry.models import ScheduledJob
 from sentry.tasks.base import instrumented_task
 

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -5,8 +5,7 @@ from typing import Any, Mapping, Optional, Tuple
 
 from django.db import transaction
 
-from sentry import eventstore, similarity
-from sentry.app import tsdb
+from sentry import eventstore, similarity, tsdb
 from sentry.constants import DEFAULT_LOGGER_NAME, LOG_LEVELS_MAP
 from sentry.event_manager import generate_culprit
 from sentry.models import (

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -186,7 +186,7 @@ def set_current_event_project(project_id):
 
 
 def get_project_key():
-    from sentry.models import ProjectKey
+    from sentry.models.projectkey import ProjectKey
 
     if not settings.SENTRY_PROJECT:
         return None

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -12,7 +12,7 @@ from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import newsletter, options
-from sentry.app import ratelimiter
+from sentry import ratelimits as ratelimiter
 from sentry.auth import password_validation
 from sentry.models import User
 from sentry.utils.auth import find_users, logger

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -45,7 +45,7 @@ def expired(request, user):
 
 
 def recover(request):
-    from sentry.app import ratelimiter
+    from sentry import ratelimits as ratelimiter
 
     extra = {
         "ip_address": request.META["REMOTE_ADDR"],
@@ -146,7 +146,7 @@ set_password_confirm = update_wrapper(set_password_confirm, recover)
 @login_required
 @require_http_methods(["POST"])
 def start_confirm_email(request):
-    from sentry.app import ratelimiter
+    from sentry import ratelimits as ratelimiter
 
     if ratelimiter.is_limited(
         f"auth:confirm-email:{request.user.id}",

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -180,7 +180,7 @@ class AuthLoginView(BaseView):
             return self.redirect(self.get_post_register_url(request))
 
         elif request.method == "POST":
-            from sentry.app import ratelimiter
+            from sentry import ratelimits as ratelimiter
             from sentry.utils.hashlib import md5_text
 
             login_attempt = (

--- a/src/sentry/web/frontend/twofactor.py
+++ b/src/sentry/web/frontend/twofactor.py
@@ -8,7 +8,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
-from sentry.app import ratelimiter
+from sentry import ratelimits as ratelimiter
 from sentry.auth.authenticators.sms import SMSRateLimitExceeded
 from sentry.auth.authenticators.u2f import U2fInterface
 from sentry.models import Authenticator

--- a/src/sentry_plugins/bitbucket/repository_provider.py
+++ b/src/sentry_plugins/bitbucket/repository_provider.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from sentry.app import locks
+from sentry.locks import locks
 from sentry.models import OrganizationOption
 from sentry.plugins.providers import RepositoryProvider
 from sentry.shared_integrations.exceptions import ApiError

--- a/src/sentry_plugins/github/plugin.py
+++ b/src/sentry_plugins/github/plugin.py
@@ -6,9 +6,9 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import options
-from sentry.app import locks
 from sentry.exceptions import PluginError
 from sentry.integrations import FeatureDescription, IntegrationFeatures
+from sentry.locks import locks
 from sentry.models import Integration, Organization, OrganizationOption, Repository
 from sentry.plugins.bases.issue2 import IssueGroupActionEndpoint, IssuePlugin2
 from sentry.plugins.providers import RepositoryProvider

--- a/tests/acceptance/test_organization_rate_limits.py
+++ b/tests/acceptance/test_organization_rate_limits.py
@@ -16,7 +16,7 @@ class OrganizationRateLimitsTest(AcceptanceTestCase):
         self.login_as(self.user)
         self.path = f"/organizations/{self.org.slug}/rate-limits/"
 
-    @patch("sentry.app.quotas.get_maximum_quota", Mock(return_value=(100, 60)))
+    @patch("sentry.quotas.get_maximum_quota", Mock(return_value=(100, 60)))
     def test_with_rate_limits(self):
         self.project.update(first_event=timezone.now())
         self.browser.get(self.path)
@@ -25,7 +25,7 @@ class OrganizationRateLimitsTest(AcceptanceTestCase):
         self.browser.snapshot("organization rate limits with quota")
         assert self.browser.element_exists_by_test_id("rate-limit-editor")
 
-    @patch("sentry.app.quotas.get_maximum_quota", Mock(return_value=(0, 60)))
+    @patch("sentry.quotas.get_maximum_quota", Mock(return_value=(0, 60)))
     def test_without_rate_limits(self):
         self.project.update(first_event=timezone.now())
         self.browser.get(self.path)

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -6,8 +6,8 @@ import pytz
 from django.urls import reverse
 
 from sentry.api.endpoints.organization_release_details import OrganizationReleaseSerializer
-from sentry.app import locks
 from sentry.constants import MAX_VERSION_LENGTH
+from sentry.locks import locks
 from sentry.models import (
     Activity,
     Environment,

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -12,9 +12,9 @@ from sentry.api.endpoints.organization_releases import (
     ReleaseHeadCommitSerializer,
     ReleaseSerializerWithProjects,
 )
-from sentry.app import locks
 from sentry.auth import access
 from sentry.constants import BAD_RELEASE_CHARS, MAX_COMMIT_LENGTH, MAX_VERSION_LENGTH
+from sentry.locks import locks
 from sentry.models import (
     Activity,
     ApiKey,

--- a/tests/sentry/api/endpoints/test_project_group_stats.py
+++ b/tests/sentry/api/endpoints/test_project_group_stats.py
@@ -1,4 +1,4 @@
-from sentry.app import tsdb
+from sentry import tsdb
 from sentry.testutils import APITestCase
 
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -19,8 +19,7 @@ from fixtures.github import (
     GET_PRIOR_COMMIT_EXAMPLE,
     LATER_COMMIT_SHA,
 )
-from sentry import nodestore
-from sentry.app import tsdb
+from sentry import nodestore, tsdb
 from sentry.attachments import CachedAttachment, attachment_cache
 from sentry.constants import MAX_VERSION_LENGTH, DataCategory
 from sentry.event_manager import (

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -2,8 +2,8 @@ from unittest.mock import patch
 
 from django.core import mail
 
-from sentry.app import locks
 from sentry.exceptions import InvalidIdentity, PluginError
+from sentry.locks import locks
 from sentry.models import (
     Commit,
     Deploy,

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -9,7 +9,7 @@ import pytz
 from django.core import mail
 from django.utils import timezone
 
-from sentry.app import tsdb
+from sentry import tsdb
 from sentry.cache import default_cache
 from sentry.constants import DataCategory
 from sentry.models import GroupStatus, Project, UserOption

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -10,8 +10,7 @@ from unittest.mock import patch
 import pytz
 from django.utils import timezone
 
-from sentry import eventstream, tagstore
-from sentry.app import tsdb
+from sentry import eventstream, tagstore, tsdb
 from sentry.models import Environment, Group, GroupHash, GroupRelease, Release, UserReport
 from sentry.similarity import _make_index_backend, features
 from sentry.tasks.merge import merge_groups


### PR DESCRIPTION
This PR phases out the use of `sentry.app` imports largely within the sentry codebase. This currently pulls in large parts of the import graph early on which makes further optimizations about imports harder than it needs to be.

We can already import from the underlying backends directly and the use in the codebase is already inconsistent. I will retain the re-exports until the changes in getsentry also land.