### PR TITLE
ref(metrics): Add organization_id argument to reverse_resolve [sns-1548]

### DIFF
--- a/src/sentry/release_health/metrics.py
+++ b/src/sentry/release_health/metrics.py
@@ -221,7 +221,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
 
         for row in count_data:
             project_data = data.setdefault(row["project_id"], {})
-            tag_value = reverse_resolve(USE_CASE_ID, row[session_status])
+            tag_value = reverse_resolve(USE_CASE_ID, org_id, row[session_status])
             project_data[tag_value] = row["value"]
 
         return data
@@ -644,7 +644,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         ) -> Callable[[Mapping[str, Union[int, str]]], ProjectOrRelease]:
             def f(row: Mapping[str, Union[int, str]]) -> ProjectOrRelease:
                 if include_releases:
-                    return row["project_id"], reverse_resolve(USE_CASE_ID, row.get(release_column_name))  # type: ignore
+                    return row["project_id"], reverse_resolve(USE_CASE_ID, org_id, row.get(release_column_name))  # type: ignore
                 else:
                     return row["project_id"]  # type: ignore
 
@@ -706,7 +706,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )
 
         def extract_row_info(row: Mapping[str, Union[OrganizationId, str]]) -> ReleaseName:
-            return reverse_resolve(USE_CASE_ID, row.get(release_column_name))  # type: ignore
+            return reverse_resolve(USE_CASE_ID, organization_id, row.get(release_column_name))  # type: ignore
 
         return {extract_row_info(row) for row in result["data"]}
 
@@ -763,7 +763,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             # See https://github.com/getsentry/snuba/blob/8680523617e06979427bfa18c6b4b4e8bf86130f/snuba/datasets/entities/metrics.py#L184 for quantiles
             key = (
                 row["project_id"],
-                reverse_resolve(USE_CASE_ID, row[release_column_name]),
+                reverse_resolve(USE_CASE_ID, org_id, row[release_column_name]),
             )
             rv_durations[key] = {
                 "duration_p50": row["percentiles"][0],
@@ -811,7 +811,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             ),
             referrer="release_health.metrics.get_errored_sessions_for_overview",
         )["data"]:
-            key = row["project_id"], reverse_resolve(USE_CASE_ID, row[release_column_name])
+            key = row["project_id"], reverse_resolve(USE_CASE_ID, org_id, row[release_column_name])
             rv_errored_sessions[key] = row["value"]
 
         return rv_errored_sessions
@@ -866,8 +866,8 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )["data"]:
             key = (
                 row["project_id"],
-                reverse_resolve(USE_CASE_ID, row[release_column_name]),
-                reverse_resolve(USE_CASE_ID, row[session_status_column_name]),
+                reverse_resolve(USE_CASE_ID, org_id, row[release_column_name]),
+                reverse_resolve(USE_CASE_ID, org_id, row[session_status_column_name]),
             )
             rv_sessions[key] = row["value"]
 
@@ -928,7 +928,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
             ),
             referrer="release_health.metrics.get_users_and_crashed_users_for_overview",
         )["data"]:
-            release = reverse_resolve(USE_CASE_ID, row[release_column_name])
+            release = reverse_resolve(USE_CASE_ID, org_id, row[release_column_name])
             for subkey in ("crashed_users", "all_users"):
                 key = (
                     row["project_id"],
@@ -1013,7 +1013,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
                 (parse_snuba_datetime(row["bucketed_time"]) - stats_start).total_seconds()
                 / stats_rollup
             )
-            key = row["project_id"], reverse_resolve(USE_CASE_ID, row[release_column_name])
+            key = row["project_id"], reverse_resolve(USE_CASE_ID, org_id, row[release_column_name])
             timeseries = rv[key]
             if time_bucket < len(timeseries):
                 timeseries[time_bucket][1] = row["value"]
@@ -1396,7 +1396,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )
 
         def extract_row_info(row: Mapping[str, Union[OrganizationId, str]]) -> ProjectRelease:
-            return row.get("project_id"), reverse_resolve(USE_CASE_ID, row.get(release_column_name))  # type: ignore
+            return row.get("project_id"), reverse_resolve(USE_CASE_ID, org_id, row.get(release_column_name))  # type: ignore
 
         return [extract_row_info(row) for row in result["data"]]
 
@@ -1460,7 +1460,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         for row in rows:
             result[
                 row["project_id"],
-                reverse_resolve(USE_CASE_ID, row[release_column_name]),
+                reverse_resolve(USE_CASE_ID, org_id, row[release_column_name]),
             ] = row["oldest"]
 
         return result
@@ -1641,7 +1641,7 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         for row in session_series_data:
             dt = parse_snuba_datetime(row["bucketed_time"])
             target = series[dt]
-            status = reverse_resolve(USE_CASE_ID, row[session_status_key])
+            status = reverse_resolve(USE_CASE_ID, org_id, row[session_status_key])
             value = int(row["value"])
             if status == "init":
                 target["sessions"] = value
@@ -2252,6 +2252,6 @@ class MetricsReleaseHealthBackend(ReleaseHealthBackend):
         )
 
         def extract_row_info(row: Mapping[str, Union[OrganizationId, str]]) -> ProjectRelease:
-            return row.get("project_id"), reverse_resolve(USE_CASE_ID, row.get(release_column_name))  # type: ignore
+            return row.get("project_id"), reverse_resolve(USE_CASE_ID, org_id, row.get(release_column_name))  # type: ignore
 
         return [extract_row_info(row) for row in rows["data"]]

--- a/src/sentry/release_health/release_monitor/metrics.py
+++ b/src/sentry/release_health/release_monitor/metrics.py
@@ -162,9 +162,11 @@ class MetricReleaseMonitorBackend(BaseReleaseMonitorBackend):
                         data = data[:-1]
 
                     for row in data:
-                        env_name = indexer.reverse_resolve(UseCaseKey.RELEASE_HEALTH, row[env_key])
+                        env_name = indexer.reverse_resolve(
+                            UseCaseKey.RELEASE_HEALTH, org_id, row[env_key]
+                        )
                         release_name = indexer.reverse_resolve(
-                            UseCaseKey.RELEASE_HEALTH, row[release_key]
+                            UseCaseKey.RELEASE_HEALTH, org_id, row[release_key]
                         )
                         row_totals = totals[row["project_id"]].setdefault(
                             env_name, {"total_sessions": 0, "releases": defaultdict(int)}  # type: ignore

--- a/src/sentry/sentry_metrics/indexer/base.py
+++ b/src/sentry/sentry_metrics/indexer/base.py
@@ -257,7 +257,7 @@ class StringIndexer(Service):
         """
         raise NotImplementedError()
 
-    def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
+    def reverse_resolve(self, use_case_id: UseCaseKey, org_id: int, id: int) -> Optional[str]:
         """Lookup the stored string for a given integer ID.
 
         Callers should not rely on the default use_case_id -- it exists only

--- a/src/sentry/sentry_metrics/indexer/cache.py
+++ b/src/sentry/sentry_metrics/indexer/cache.py
@@ -165,5 +165,5 @@ class CachingIndexer(StringIndexer):
 
         return id
 
-    def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
-        return self.indexer.reverse_resolve(use_case_id, id)
+    def reverse_resolve(self, use_case_id: UseCaseKey, org_id: int, id: int) -> Optional[str]:
+        return self.indexer.reverse_resolve(use_case_id, org_id, id)

--- a/src/sentry/sentry_metrics/indexer/cloudspanner/cloudspanner.py
+++ b/src/sentry/sentry_metrics/indexer/cloudspanner/cloudspanner.py
@@ -80,7 +80,7 @@ class RawCloudSpannerIndexer(StringIndexer):
     def resolve(self, use_case_id: UseCaseKey, org_id: int, string: str) -> Optional[int]:
         raise NotImplementedError
 
-    def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
+    def reverse_resolve(self, use_case_id: UseCaseKey, org_id: int, id: int) -> Optional[str]:
         raise NotImplementedError
 
 

--- a/src/sentry/sentry_metrics/indexer/mock.py
+++ b/src/sentry/sentry_metrics/indexer/mock.py
@@ -58,7 +58,7 @@ class RawSimpleIndexer(StringIndexer):
         strs = self._strings[org_id]
         return strs.get(string)
 
-    def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
+    def reverse_resolve(self, use_case_id: UseCaseKey, org_id: int, id: int) -> Optional[str]:
         return self._reverse.get(id)
 
     def _record(self, org_id: int, string: str) -> Optional[int]:

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -142,17 +142,19 @@ class PGStringIndexerV2(StringIndexer):
 
         return id
 
-    def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
+    def reverse_resolve(self, use_case_id: UseCaseKey, org_id: int, id: int) -> Optional[str]:
         """Lookup the stored string for a given integer ID.
 
         Returns None if the entry cannot be found.
         """
         table = self._table(use_case_id)
         try:
-            string: str = table.objects.get_from_cache(id=id, use_replica=True).string
+            obj = table.objects.get_from_cache(id=id, use_replica=True)
         except table.DoesNotExist:
             return None
 
+        assert obj.organization_id == org_id
+        string: str = obj.string
         return string
 
     def _table(self, use_case_id: UseCaseKey) -> IndexerTable:

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -166,7 +166,7 @@ class StaticStringIndexer(StringIndexer):
             return SHARED_STRINGS[string]
         return self.indexer.resolve(use_case_id=use_case_id, org_id=org_id, string=string)
 
-    def reverse_resolve(self, use_case_id: UseCaseKey, id: int) -> Optional[str]:
+    def reverse_resolve(self, use_case_id: UseCaseKey, org_id: int, id: int) -> Optional[str]:
         if id in REVERSE_SHARED_STRINGS:
             return REVERSE_SHARED_STRINGS[id]
-        return self.indexer.reverse_resolve(use_case_id=use_case_id, id=id)
+        return self.indexer.reverse_resolve(use_case_id=use_case_id, org_id=org_id, id=id)

--- a/src/sentry/sentry_metrics/utils.py
+++ b/src/sentry/sentry_metrics/utils.py
@@ -17,7 +17,7 @@ class MetricIndexNotFound(InvalidParams):  # type: ignore
 
 
 def reverse_resolve_tag_value(
-    use_case_id: UseCaseKey, index: Union[int, str, None], weak: bool = False
+    use_case_id: UseCaseKey, org_id: int, index: Union[int, str, None], weak: bool = False
 ) -> Optional[str]:
     # XXX(markus): Normally there would be a check for the option
     # "sentry-metrics.performance.tags-values-are-strings", but this function
@@ -26,14 +26,14 @@ def reverse_resolve_tag_value(
         return index
     else:
         if weak:
-            return reverse_resolve_weak(use_case_id, index)
+            return reverse_resolve_weak(use_case_id, org_id, index)
         else:
-            return reverse_resolve(use_case_id, index)
+            return reverse_resolve(use_case_id, org_id, index)
 
 
-def reverse_resolve(use_case_id: UseCaseKey, index: int) -> str:
+def reverse_resolve(use_case_id: UseCaseKey, org_id: int, index: int) -> str:
     assert index > 0
-    resolved = indexer.reverse_resolve(use_case_id, index)
+    resolved = indexer.reverse_resolve(use_case_id, org_id, index)
     # The indexer should never return None for integers > 0:
     if resolved is None:
         raise MetricIndexNotFound()
@@ -41,7 +41,7 @@ def reverse_resolve(use_case_id: UseCaseKey, index: int) -> str:
     return resolved
 
 
-def reverse_resolve_weak(use_case_id: UseCaseKey, index: int) -> Optional[str]:
+def reverse_resolve_weak(use_case_id: UseCaseKey, org_id: int, index: int) -> Optional[str]:
     """
     Resolve an index value back to a string, special-casing 0 to return None.
 
@@ -52,7 +52,7 @@ def reverse_resolve_weak(use_case_id: UseCaseKey, index: int) -> Optional[str]:
     if index == TAG_NOT_SET:
         return None
 
-    return reverse_resolve(use_case_id, index)
+    return reverse_resolve(use_case_id, org_id, index)
 
 
 def resolve(

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -426,7 +426,7 @@ class BaseCrashRateMetricsEntitySubscription(BaseMetricsEntitySubscription):
             session_status = resolve_tag_key(UseCaseKey.RELEASE_HEALTH, org_id, "session.status")
             for row in data:
                 tag_value = reverse_resolve_tag_value(
-                    UseCaseKey.RELEASE_HEALTH, row[session_status]
+                    UseCaseKey.RELEASE_HEALTH, org_id, row[session_status]
                 )
                 if tag_value is None:
                     raise MetricIndexNotFound()

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -321,15 +321,16 @@ def get_date_range(params: Mapping) -> Tuple[datetime, datetime, int]:
     return start, end, interval
 
 
-def parse_tag(use_case_id: UseCaseKey, tag_string: str) -> str:
+def parse_tag(use_case_id: UseCaseKey, org_id: int, tag_string: str) -> str:
     tag_key = int(tag_string.replace("tags_raw[", "").replace("tags[", "").replace("]", ""))
-    return reverse_resolve(use_case_id, tag_key)
+    return reverse_resolve(use_case_id, org_id, tag_key)
 
 
 def translate_meta_results(
     meta: Sequence[Dict[str, str]],
     query_metric_fields: Set[str],
     use_case_id: UseCaseKey,
+    org_id: int,
 ) -> Sequence[Dict[str, str]]:
     """
     Translate meta results:
@@ -368,7 +369,7 @@ def translate_meta_results(
                 continue
         else:
             if is_tag:
-                record["name"] = parse_tag(use_case_id, record["name"])
+                record["name"] = parse_tag(use_case_id, org_id, record["name"])
                 # since we changed value from int to str we need
                 # also want to change type
                 record["type"] = "string"
@@ -692,8 +693,10 @@ class SnubaResultConverter:
             dict(
                 by=dict(
                     (
-                        parse_tag(self._use_case_id, key),
-                        reverse_resolve_tag_value(self._use_case_id, value, weak=True),
+                        parse_tag(self._use_case_id, self._organization_id, key),
+                        reverse_resolve_tag_value(
+                            self._use_case_id, self._organization_id, value, weak=True
+                        ),
                     )
                     if key not in FIELD_ALIAS_MAPPINGS.values()
                     else (key, value)

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -37,7 +37,9 @@ def resolve_tags(results: Any, query_definition: MetricsQueryBuilder) -> Any:
         for tag in tags:
             for row in results["data"]:
                 if row[tag] not in cached_resolves:
-                    resolved_tag = indexer.reverse_resolve(UseCaseKey.PERFORMANCE, row[tag])
+                    resolved_tag = indexer.reverse_resolve(
+                        UseCaseKey.PERFORMANCE, query_definition.organization_id, row[tag]
+                    )
                     cached_resolves[row[tag]] = resolved_tag
                 row[tag] = cached_resolves[row[tag]]
             if tag in results["meta"]:

--- a/tests/sentry/sentry_metrics/test_all_indexers.py
+++ b/tests/sentry/sentry_metrics/test_all_indexers.py
@@ -152,7 +152,7 @@ def test_resolve_and_reverse_resolve(indexer, indexer_cache):
     # test resolve and reverse_resolve
     id = indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="hello")
     assert id is not None
-    assert indexer.reverse_resolve(use_case_id=use_case_id, id=id) == "hello"
+    assert indexer.reverse_resolve(use_case_id=use_case_id, org_id=org1_id, id=id) == "hello"
 
     # test record on a string that already exists
     indexer.record(use_case_id=use_case_id, org_id=org1_id, string="hello")
@@ -160,7 +160,7 @@ def test_resolve_and_reverse_resolve(indexer, indexer_cache):
 
     # test invalid values
     assert indexer.resolve(use_case_id=use_case_id, org_id=org1_id, string="beep") is None
-    assert indexer.reverse_resolve(use_case_id=use_case_id, id=1234) is None
+    assert indexer.reverse_resolve(use_case_id=use_case_id, org_id=org1_id, id=1234) is None
 
 
 def test_already_created_plus_written_results(indexer, indexer_cache) -> None:

--- a/tests/sentry/sentry_metrics/test_indexer.py
+++ b/tests/sentry/sentry_metrics/test_indexer.py
@@ -20,6 +20,6 @@ def test_resolve():
 
 
 def test_reverse_resolve():
-    assert INDEXER.reverse_resolve(UseCaseKey.RELEASE_HEALTH, 666) is None
+    assert INDEXER.reverse_resolve(UseCaseKey.RELEASE_HEALTH, 1, 666) is None
     id = SHARED_STRINGS[SessionMRI.USER.value]
-    assert INDEXER.reverse_resolve(UseCaseKey.RELEASE_HEALTH, id) == SessionMRI.USER.value
+    assert INDEXER.reverse_resolve(UseCaseKey.RELEASE_HEALTH, 1, id) == SessionMRI.USER.value

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -932,7 +932,7 @@ def test_translate_meta_results():
         {"name": "metric_id", "type": "UInt64"},
     ]
     assert translate_meta_results(
-        meta, {"p50(transaction.measurements.lcp)"}, UseCaseKey.PERFORMANCE
+        meta, {"p50(transaction.measurements.lcp)"}, UseCaseKey.PERFORMANCE, 1
     ) == sorted(
         [
             {"name": "p50(transaction.measurements.lcp)", "type": "Array(Float64)"},
@@ -954,7 +954,7 @@ def test_translate_meta_results_with_duplicates():
         {"name": "project_id", "type": "UInt64"},
     ]
     assert translate_meta_results(
-        meta, {"p50(transaction.measurements.lcp)"}, UseCaseKey.RELEASE_HEALTH
+        meta, {"p50(transaction.measurements.lcp)"}, UseCaseKey.RELEASE_HEALTH, 1
     ) == sorted(
         [
             {"name": "p50(transaction.measurements.lcp)", "type": "Array(Float64)"},


### PR DESCRIPTION
from the ticket:

----

The indexer reverse resolve function does not take the org id as a parameter. 
This can have dire consequences. 
- It caused INC-168
- it would prevent us from having per-org id spaces.