### PR TITLE
feat(custom-measurements): Enable experiment

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -31,7 +31,7 @@ from sentry.utils.cursors import Cursor
 from sentry.utils.dates import to_datetime
 from sentry.utils.http import absolute_uri, is_valid_origin, origin_from_request
 from sentry.utils.numbers import format_grouped_length
-from sentry.utils.sdk import capture_exception
+from sentry.utils.sdk import capture_exception, set_measurement
 
 from .authentication import ApiKeyAuthentication, TokenAuthentication
 from .paginator import BadPaginationError, Paginator
@@ -353,7 +353,7 @@ class Endpoint(APIView):
                 description=type(self).__name__,
             ) as span:
                 span.set_data("Limit", per_page)
-                span.containing_transaction.set_measurement("query.per_page", per_page)
+                set_measurement("query.per_page", per_page)
                 sentry_sdk.set_tag("query.per_page", per_page)
                 sentry_sdk.set_tag(
                     "query.per_page.grouped", format_grouped_length(per_page, [1, 10, 50, 100])

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -353,6 +353,7 @@ class Endpoint(APIView):
                 description=type(self).__name__,
             ) as span:
                 span.set_data("Limit", per_page)
+                span.containing_transaction.set_measurement("query.per_page", per_page)
                 sentry_sdk.set_tag("query.per_page", per_page)
                 sentry_sdk.set_tag(
                     "query.per_page.grouped", format_grouped_length(per_page, [1, 10, 50, 100])

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -326,6 +326,8 @@ class OrganizationEndpoint(Endpoint):
         len_projects = len(projects)
         sentry_sdk.set_tag("query.num_projects", len_projects)
         sentry_sdk.set_tag("query.num_projects.grouped", format_grouped_length(len_projects))
+        transaction = sentry_sdk.Hub.current.scope.transaction
+        transaction.set_measurement("query.num_projects", len_projects)
 
         params = {
             "start": start,

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -27,7 +27,7 @@ from sentry.models import (
 from sentry.utils import auth
 from sentry.utils.hashlib import hash_values
 from sentry.utils.numbers import format_grouped_length
-from sentry.utils.sdk import bind_organization_context
+from sentry.utils.sdk import bind_organization_context, set_measurement
 
 
 class NoProjects(Exception):
@@ -326,8 +326,7 @@ class OrganizationEndpoint(Endpoint):
         len_projects = len(projects)
         sentry_sdk.set_tag("query.num_projects", len_projects)
         sentry_sdk.set_tag("query.num_projects.grouped", format_grouped_length(len_projects))
-        transaction = sentry_sdk.Hub.current.scope.transaction
-        transaction.set_measurement("query.num_projects", len_projects)
+        set_measurement("query.num_projects", len_projects)
 
         params = {
             "start": start,

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -310,14 +310,16 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):  # 
     def record_analytics(
         transactions: Sequence[SnubaTransaction], trace_id: str, user_id: int, org_id: int
     ) -> None:
-        with sentry_sdk.start_span(op="recording.analytics"):
+        with sentry_sdk.start_span(op="recording.analytics") as span:
             len_transactions = len(transactions)
 
+            sdk_transaction = span.containing_transaction
             sentry_sdk.set_tag("trace_view.trace", trace_id)
             sentry_sdk.set_tag("trace_view.transactions", len_transactions)
             sentry_sdk.set_tag(
                 "trace_view.transactions.grouped", format_grouped_length(len_transactions)
             )
+            sdk_transaction.set_measurement("trace_view.transactions", len_transactions)
             projects: Set[int] = set()
             for transaction in transactions:
                 projects.add(transaction["project.id"])
@@ -325,6 +327,7 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):  # 
             len_projects = len(projects)
             sentry_sdk.set_tag("trace_view.projects", len_projects)
             sentry_sdk.set_tag("trace_view.projects.grouped", format_grouped_length(len_projects))
+            sdk_transaction.set_measurement("trace_view.projects", len_projects)
 
     def get(self, request: HttpRequest, organization: Organization, trace_id: str) -> HttpResponse:
         if not self.has_feature(organization, request):

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -120,11 +120,13 @@ def project_threshold_config_expression(organization_id, project_ids):
     )
 
     num_project_thresholds = project_threshold_configs.count()
+    sdk_transaction = sentry_sdk.Hub.current.scope.transaction
     sentry_sdk.set_tag("project_threshold.count", num_project_thresholds)
     sentry_sdk.set_tag(
         "project_threshold.count.grouped",
         format_grouped_length(num_project_thresholds, [10, 100, 250, 500]),
     )
+    sdk_transaction.set_measurement("project_threshold.count", num_project_thresholds)
 
     num_transaction_thresholds = transaction_threshold_configs.count()
     sentry_sdk.set_tag("txn_threshold.count", num_transaction_thresholds)
@@ -132,6 +134,7 @@ def project_threshold_config_expression(organization_id, project_ids):
         "txn_threshold.count.grouped",
         format_grouped_length(num_transaction_thresholds, [10, 100, 250, 500]),
     )
+    sdk_transaction.set_measurement("txn_threshold.count", num_transaction_thresholds)
 
     if num_project_thresholds + num_transaction_thresholds == 0:
         return ["tuple", [f"'{DEFAULT_PROJECT_THRESHOLD_METRIC}'", DEFAULT_PROJECT_THRESHOLD]]
@@ -265,12 +268,14 @@ def team_key_transaction_expression(organization_id, team_ids, project_ids):
 
     count = len(team_key_transactions)
 
+    sdk_transaction = sentry_sdk.Hub.current.scope.transaction
     # NOTE: this raw count is not 100% accurate because if it exceeds
     # `MAX_QUERYABLE_TEAM_KEY_TRANSACTIONS`, it will not be reflected
     sentry_sdk.set_tag("team_key_txns.count", count)
     sentry_sdk.set_tag(
         "team_key_txns.count.grouped", format_grouped_length(count, [10, 100, 250, 500])
     )
+    sdk_transaction.set_measurement("team_key_txns.count", count)
 
     # There are no team key transactions marked, so hard code false into the query.
     if count == 0:

--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -41,6 +41,7 @@ from sentry.search.events.constants import (
 from sentry.search.events.types import NormalizedArg, ParamsType
 from sentry.search.utils import InvalidQuery, parse_duration
 from sentry.utils.numbers import format_grouped_length
+from sentry.utils.sdk import set_measurement
 from sentry.utils.snuba import (
     SESSIONS_SNUBA_MAP,
     get_json_type,
@@ -120,13 +121,12 @@ def project_threshold_config_expression(organization_id, project_ids):
     )
 
     num_project_thresholds = project_threshold_configs.count()
-    sdk_transaction = sentry_sdk.Hub.current.scope.transaction
     sentry_sdk.set_tag("project_threshold.count", num_project_thresholds)
     sentry_sdk.set_tag(
         "project_threshold.count.grouped",
         format_grouped_length(num_project_thresholds, [10, 100, 250, 500]),
     )
-    sdk_transaction.set_measurement("project_threshold.count", num_project_thresholds)
+    set_measurement("project_threshold.count", num_project_thresholds)
 
     num_transaction_thresholds = transaction_threshold_configs.count()
     sentry_sdk.set_tag("txn_threshold.count", num_transaction_thresholds)
@@ -134,7 +134,7 @@ def project_threshold_config_expression(organization_id, project_ids):
         "txn_threshold.count.grouped",
         format_grouped_length(num_transaction_thresholds, [10, 100, 250, 500]),
     )
-    sdk_transaction.set_measurement("txn_threshold.count", num_transaction_thresholds)
+    set_measurement("txn_threshold.count", num_transaction_thresholds)
 
     if num_project_thresholds + num_transaction_thresholds == 0:
         return ["tuple", [f"'{DEFAULT_PROJECT_THRESHOLD_METRIC}'", DEFAULT_PROJECT_THRESHOLD]]
@@ -268,14 +268,13 @@ def team_key_transaction_expression(organization_id, team_ids, project_ids):
 
     count = len(team_key_transactions)
 
-    sdk_transaction = sentry_sdk.Hub.current.scope.transaction
     # NOTE: this raw count is not 100% accurate because if it exceeds
     # `MAX_QUERYABLE_TEAM_KEY_TRANSACTIONS`, it will not be reflected
     sentry_sdk.set_tag("team_key_txns.count", count)
     sentry_sdk.set_tag(
         "team_key_txns.count.grouped", format_grouped_length(count, [10, 100, 250, 500])
     )
-    sdk_transaction.set_measurement("team_key_txns.count", count)
+    set_measurement("team_key_txns.count", count)
 
     # There are no team key transactions marked, so hard code false into the query.
     if count == 0:

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -430,3 +430,12 @@ def bind_organization_context(organization):
                     "internal-error.organization-context",
                     extra={"organization_id": organization.id},
                 )
+
+
+def set_measurement(measurement_name, value, unit=None):
+    try:
+        transaction = sentry_sdk.Hub.current.scope.transaction
+        if transaction is not None:
+            transaction.set_measurement(measurement_name, value, unit)
+    except Exception:
+        pass

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -379,6 +379,9 @@ def configure_sdk():
             RedisIntegration(),
             ThreadingIntegration(propagate_hub=True),
         ],
+        _experiments={
+            "custom_measurements": True,
+        },
         **sdk_options,
     )
 


### PR DESCRIPTION
- This enables the custom_measurements experiment on the sentry SDK so we can dogfood
- Unfortunately need to do sentry_sdk.Hub.current.scope.transaction to get the transaction for now, there's a conversation in the [internal slack](https://sentry.slack.com/archives/CA2V2LBDL/p1659530059013969) about improving this