### PR TITLE
fix(perf): Stop the span tree from waving at me

### DIFF
--- a/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
+++ b/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
@@ -111,6 +111,7 @@ export function EmbeddedSpanTree(props: Props) {
                       focusedSpanIds
                     )
                   }
+                  isEmbedded
                 />
               </Section>
             </Wrapper>

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -71,6 +71,7 @@ type Props = {
   interactiveLayerRef: React.RefObject<HTMLDivElement>;
 
   dragProps?: DragManagerChildrenProps;
+  isEmbedded?: boolean;
 };
 
 type State = {
@@ -90,17 +91,14 @@ export class Provider extends Component<Props, State> {
 
     const anchoredSpanHash = window.location.hash.split('#')[1];
 
-    // If we're on the issues page, this is an embedded span tree. I know, this is hacky and weird but idk how else to check for this
-    const isEmbeddedSpanTree = window.location.href.includes('issues');
-
     // If the user is opening the span tree with an anchor link provided, we need to continuously reconnect the observers.
     // This is because we need to wait for the window to scroll to the anchored span first, or there will be inconsistencies in
     // the spans that are actually considered in the view. The IntersectionObserver API cannot keep up with the speed
     // at which the window scrolls to the anchored span, and will be unable to register the spans that went out of the view.
     // We stop reconnecting the observers once we've confirmed that the anchored span is in the view (or after a timeout).
 
-    if (anchoredSpanHash || isEmbeddedSpanTree) {
-      // We cannot assume the root is in view to start off, if there is an anchored span or if this is an embedded span tree
+    if (anchoredSpanHash) {
+      // We cannot assume the root is in view to start off, if there is an anchored span
       this.spansInView.isRootSpanInView = false;
       const anchoredSpanId = window.location.hash.replace(spanTargetHash(''), '');
 
@@ -163,7 +161,7 @@ export class Provider extends Component<Props, State> {
   wheelTimeout: NodeJS.Timeout | null = null;
   animationTimeout: NodeJS.Timeout | null = null;
   previousUserSelect: UserSelectValues | null = null;
-  spansInView: SpansInViewMap = new SpansInViewMap();
+  spansInView: SpansInViewMap = new SpansInViewMap(!this.props.isEmbedded);
   spanBars: SpanBar[] = [];
 
   getReferenceSpanBar() {

--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -90,14 +90,17 @@ export class Provider extends Component<Props, State> {
 
     const anchoredSpanHash = window.location.hash.split('#')[1];
 
+    // If we're on the issues page, this is an embedded span tree. I know, this is hacky and weird but idk how else to check for this
+    const isEmbeddedSpanTree = window.location.href.includes('issues');
+
     // If the user is opening the span tree with an anchor link provided, we need to continuously reconnect the observers.
     // This is because we need to wait for the window to scroll to the anchored span first, or there will be inconsistencies in
     // the spans that are actually considered in the view. The IntersectionObserver API cannot keep up with the speed
     // at which the window scrolls to the anchored span, and will be unable to register the spans that went out of the view.
     // We stop reconnecting the observers once we've confirmed that the anchored span is in the view (or after a timeout).
 
-    if (anchoredSpanHash) {
-      // We cannot assume the root is in view to start off, if there is an anchored span
+    if (anchoredSpanHash || isEmbeddedSpanTree) {
+      // We cannot assume the root is in view to start off, if there is an anchored span or if this is an embedded span tree
       this.spansInView.isRootSpanInView = false;
       const anchoredSpanId = window.location.hash.replace(spanTargetHash(''), '');
 

--- a/static/app/components/events/interfaces/spans/traceView.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.tsx
@@ -18,6 +18,7 @@ import WaterfallModel from './waterfallModel';
 type Props = {
   organization: Organization;
   waterfallModel: WaterfallModel;
+  isEmbedded?: boolean;
 };
 
 class TraceView extends PureComponent<Props> {
@@ -55,7 +56,7 @@ class TraceView extends PureComponent<Props> {
   );
 
   render() {
-    const {organization, waterfallModel} = this.props;
+    const {organization, waterfallModel, isEmbedded} = this.props;
 
     if (!getTraceContext(waterfallModel.event)) {
       return (
@@ -85,6 +86,7 @@ class TraceView extends PureComponent<Props> {
                             dividerPosition={dividerHandlerChildrenProps.dividerPosition}
                             interactiveLayerRef={this.virtualScrollBarContainerRef}
                             dragProps={dragProps}
+                            isEmbedded={isEmbedded}
                           >
                             {this.renderHeader(dragProps)}
                             <Observer>

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -789,7 +789,7 @@ export class SpansInViewMap {
     this.spanDepthsInView = new Map();
     this.treeDepthSum = 0;
     this.length = 0;
-    this.isRootSpanInView = false;
+    this.isRootSpanInView = true;
   }
 
   /**

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -785,11 +785,11 @@ export class SpansInViewMap {
   length: number;
   isRootSpanInView: boolean;
 
-  constructor() {
+  constructor(isRootSpanInView: boolean) {
     this.spanDepthsInView = new Map();
     this.treeDepthSum = 0;
     this.length = 0;
-    this.isRootSpanInView = true;
+    this.isRootSpanInView = isRootSpanInView;
   }
 
   /**


### PR DESCRIPTION
Fixes an annoying visual bug where the span tree would move back and forth when initially opening the Event Details page:

![Kapture 2022-08-17 at 12 12 23](https://user-images.githubusercontent.com/16740047/185190108-85fd1522-1cb1-4342-9e68-5deae3c5f19a.gif)

The reason why this was happening was because `isRootSpanInView` was set to false by default in the `SpansInViewMap` object, which controls the horizontal autoscroll functionality. If the root span is in view, this controller resets the horizontal positioning of the span tree. However, we're using an `IntersectionObserver` to determine whether the root span is in view or not. So this is the sequence of events that was occurring:

Page loads -> `isRootSpanInView` set to false -> IntersectionObserver loads and detects that there are spans in the view and calculates the horizontal position to scroll -> root span is detected in view and the scroll position is reset to the baseline

However, we can't assume that the root span is in view initially when viewing the span tree from a Performance issue, so we set `isRootSpanInView` to false in this case. If we don't set this flag to false, autoscrolling will not work in Performance Issues where the root is filtered out, since the IntersectionObserver will never detect that the root is in view and set the flag.