### PR TITLE
fix(widget-builder): Use unsaved dashboard filters in query

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.tsx
@@ -1,6 +1,7 @@
 import {CSSProperties, useCallback, useEffect, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 
@@ -15,6 +16,7 @@ import {Organization, PageFilters, SelectValue} from 'sentry/types';
 import usePrevious from 'sentry/utils/usePrevious';
 import {DashboardFilters, DisplayType, Widget} from 'sentry/views/dashboardsV2/types';
 
+import {getDashboardFiltersFromURL} from '../../utils';
 import WidgetCard, {WidgetCardPanel} from '../../widgetCard';
 import {displayTypes} from '../utils';
 
@@ -22,6 +24,7 @@ import {BuildStep} from './buildStep';
 
 interface Props {
   displayType: DisplayType;
+  location: Location;
   onChange: (displayType: DisplayType) => void;
   organization: Organization;
   pageFilters: PageFilters;
@@ -40,6 +43,7 @@ export function VisualizationStep({
   widget,
   noDashboardsMEPProvider,
   dashboardFilters,
+  location,
 }: Props) {
   const [debouncedWidget, setDebouncedWidget] = useState(widget);
 
@@ -104,7 +108,7 @@ export function VisualizationStep({
           organization={organization}
           selection={pageFilters}
           widget={debouncedWidget}
-          dashboardFilters={dashboardFilters}
+          dashboardFilters={getDashboardFiltersFromURL(location) ?? dashboardFilters}
           isEditing={false}
           widgetLimitReached={false}
           renderErrorMessage={errorMessage =>

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -1061,6 +1061,7 @@ function WidgetBuilder({
                     )}
                     <BuildSteps symbol="colored-numeric">
                       <VisualizationStep
+                        location={location}
                         widget={currentWidget}
                         dashboardFilters={dashboard.filters}
                         organization={organization}

--- a/tests/js/spec/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -149,4 +149,50 @@ describe('VisualizationStep', function () {
 
     await screen.findByText(/we've automatically adjusted your results/i);
   });
+
+  it('uses release from URL params when querying', async function () {
+    const {eventsv2Mock} = mockRequests(organization.slug);
+    render(
+      <WidgetBuilder
+        route={{}}
+        router={router}
+        routes={router.routes}
+        routeParams={router.params}
+        location={{
+          ...router.location,
+          query: {
+            ...router.location.query,
+            release: ['v1'],
+          },
+        }}
+        dashboard={{
+          id: 'new',
+          title: 'Dashboard',
+          createdBy: undefined,
+          dateCreated: '2020-01-01T00:00:00.000Z',
+          widgets: [],
+          projects: [],
+          filters: {},
+        }}
+        onSave={jest.fn()}
+        params={{
+          orgId: organization.slug,
+          dashboardId: 'new',
+        }}
+      />,
+      {
+        context: routerContext,
+        organization,
+      }
+    );
+
+    await waitFor(() =>
+      expect(eventsv2Mock).toHaveBeenCalledWith(
+        '/organizations/org-slug/eventsv2/',
+        expect.objectContaining({
+          query: expect.objectContaining({query: ' release:v1 '}),
+        })
+      )
+    );
+  });
 });


### PR DESCRIPTION
We weren't propagating the unsaved release filter down when making the request in widget builder.