### PR TITLE
feat(hybrid-cloud): Add customer domain support to the org switcher

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/index.spec.jsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.spec.jsx
@@ -2,6 +2,7 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import SidebarDropdown from 'sentry/components/sidebar/sidebarDropdown';
 import ConfigStore from 'sentry/stores/configStore';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 
 function renderDropdown(props) {
   const user = ConfigStore.get('user');
@@ -13,14 +14,16 @@ function renderDropdown(props) {
     },
   ]);
   return render(
-    <SidebarDropdown
-      orientation="left"
-      collapsed={false}
-      user={user}
-      config={config}
-      org={organization}
-      {...props}
-    />,
+    <OrganizationContext.Provider value={organization}>
+      <SidebarDropdown
+        orientation="left"
+        collapsed={false}
+        user={user}
+        config={config}
+        org={organization}
+        {...props}
+      />
+    </OrganizationContext.Provider>,
     {context: routerContext}
   );
 }

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -11,6 +11,7 @@ import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import space from 'sentry/styles/space';
 import {OrganizationSummary} from 'sentry/types';
+import shouldUseLegacyRoute from 'sentry/utils/shouldUseLegacyRoute';
 import useOrganization from 'sentry/utils/useOrganization';
 import withOrganizations from 'sentry/utils/withOrganizations';
 
@@ -60,16 +61,11 @@ function SwitchOrganization({organizations, canCreateOrganization}: Props) {
                   const {slug, links} = organization;
                   const {organizationUrl} = links;
 
-                  const shouldUseLegacyRoute =
-                    !organizationUrl ||
-                    !organization.features.includes('customer-domains') ||
-                    slug === 'alberto';
-
                   const menuItemProps: Partial<
                     React.ComponentProps<typeof SidebarMenuItem>
                   > = {};
 
-                  if (shouldUseLegacyRoute) {
+                  if (shouldUseLegacyRoute(organization)) {
                     if (currentOrganization.features.includes('customer-domains')) {
                       // If the current org is a customer domain, then we need to change the hostname in addition to
                       // updating the path.

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -25,10 +25,6 @@ function OrganizationMenuItem({organization}: {organization: OrganizationSummary
 
   const route = useResolveRoute(organization, `/organizations/${slug}/`);
 
-  if (!route) {
-    return null;
-  }
-
   if (shouldUseLegacyRoute(organization)) {
     if (currentOrganization.features.includes('customer-domains')) {
       menuItemProps.href = route;

--- a/static/app/components/sidebar/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/switchOrganization.spec.tsx
@@ -36,7 +36,17 @@ describe('SwitchOrganization', function () {
     expect(screen.getByRole('list')).toBeInTheDocument();
 
     expect(screen.getByText('Organization 1')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'org slug Organization 1'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/'
+    );
+
     expect(screen.getByText('Organization 2')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'org2 Organization 2'})).toHaveAttribute(
+      'href',
+      '/organizations/org2/'
+    );
+
     jest.useRealTimers();
   });
 
@@ -74,6 +84,43 @@ describe('SwitchOrganization', function () {
     const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
     expect(org2Link).toBeInTheDocument();
     expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io');
+    jest.useRealTimers();
+  });
+
+  it('does not use organizationUrl when customer domain is disabled', function () {
+    jest.useFakeTimers();
+    render(
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization={false}
+          organizations={[
+            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+            TestStubs.Organization({
+              name: 'Organization 2',
+              slug: 'org2',
+              links: {
+                organizationUrl: 'http://org2.sentry.io',
+                regionUrl: 'http://eu.sentry.io',
+              },
+              features: [],
+            }),
+          ]}
+        />
+      )
+    );
+
+    userEvent.hover(screen.getByTestId('sidebar-switch-org'));
+    act(() => void jest.advanceTimersByTime(500));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
+    expect(org1Link).toBeInTheDocument();
+    expect(org1Link).toHaveAttribute('href', '/organizations/org1/');
+
+    const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
+    expect(org2Link).toBeInTheDocument();
+    expect(org2Link).toHaveAttribute('href', '/organizations/org2/');
     jest.useRealTimers();
   });
 
@@ -115,6 +162,53 @@ describe('SwitchOrganization', function () {
     const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
     expect(org2Link).toBeInTheDocument();
     expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io');
+    jest.useRealTimers();
+  });
+
+  it('does not use sentryUrl when current org does not have customer domain feature', function () {
+    jest.useFakeTimers();
+    const org2 = TestStubs.Organization({
+      name: 'Organization 2',
+      slug: 'org2',
+      links: {
+        organizationUrl: 'http://org2.sentry.io',
+        regionUrl: 'http://eu.sentry.io',
+      },
+      features: [],
+    });
+    render(
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization={false}
+          organizations={[
+            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+            TestStubs.Organization({
+              name: 'Organization 3',
+              slug: 'org3',
+              links: {
+                organizationUrl: 'http://org3.sentry.io',
+                regionUrl: 'http://eu.sentry.io',
+              },
+              features: ['customer-domains'],
+            }),
+          ]}
+        />,
+        org2
+      )
+    );
+
+    userEvent.hover(screen.getByTestId('sidebar-switch-org'));
+    act(() => void jest.advanceTimersByTime(500));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
+    expect(org1Link).toBeInTheDocument();
+    expect(org1Link).toHaveAttribute('href', '/organizations/org1/');
+
+    const org3Link = screen.getByRole('link', {name: 'org3 Organization 3'});
+    expect(org3Link).toBeInTheDocument();
+    expect(org3Link).toHaveAttribute('href', 'http://org3.sentry.io');
     jest.useRealTimers();
   });
 

--- a/static/app/components/sidebar/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/switchOrganization.spec.tsx
@@ -83,7 +83,7 @@ describe('SwitchOrganization', function () {
 
     const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
     expect(org2Link).toBeInTheDocument();
-    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io');
+    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io/organizations/org2/');
     jest.useRealTimers();
   });
 
@@ -161,7 +161,7 @@ describe('SwitchOrganization', function () {
 
     const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
     expect(org2Link).toBeInTheDocument();
-    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io');
+    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io/organizations/org2/');
     jest.useRealTimers();
   });
 
@@ -208,7 +208,7 @@ describe('SwitchOrganization', function () {
 
     const org3Link = screen.getByRole('link', {name: 'org3 Organization 3'});
     expect(org3Link).toBeInTheDocument();
-    expect(org3Link).toHaveAttribute('href', 'http://org3.sentry.io');
+    expect(org3Link).toHaveAttribute('href', 'http://org3.sentry.io/organizations/org3/');
     jest.useRealTimers();
   });
 

--- a/static/app/components/sidebar/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/switchOrganization.spec.tsx
@@ -1,18 +1,33 @@
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {SwitchOrganization} from 'sentry/components/sidebar/sidebarDropdown/switchOrganization';
+import {Organization} from 'sentry/types';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('SwitchOrganization', function () {
+  function mountWithOrg(children, organization?: Organization) {
+    if (!organization) {
+      organization = TestStubs.Organization() as Organization;
+    }
+    return (
+      <OrganizationContext.Provider value={organization}>
+        {children}
+      </OrganizationContext.Provider>
+    );
+  }
+
   it('can list organizations', function () {
     jest.useFakeTimers();
     render(
-      <SwitchOrganization
-        canCreateOrganization={false}
-        organizations={[
-          TestStubs.Organization({name: 'Organization 1'}),
-          TestStubs.Organization({name: 'Organization 2', slug: 'org2'}),
-        ]}
-      />
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization={false}
+          organizations={[
+            TestStubs.Organization({name: 'Organization 1'}),
+            TestStubs.Organization({name: 'Organization 2', slug: 'org2'}),
+          ]}
+        />
+      )
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -25,9 +40,87 @@ describe('SwitchOrganization', function () {
     jest.useRealTimers();
   });
 
+  it('uses organizationUrl when customer domain is enabled', function () {
+    jest.useFakeTimers();
+    render(
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization={false}
+          organizations={[
+            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+            TestStubs.Organization({
+              name: 'Organization 2',
+              slug: 'org2',
+              links: {
+                organizationUrl: 'http://org2.sentry.io',
+                regionUrl: 'http://eu.sentry.io',
+              },
+              features: ['customer-domains'],
+            }),
+          ]}
+        />
+      )
+    );
+
+    userEvent.hover(screen.getByTestId('sidebar-switch-org'));
+    act(() => void jest.advanceTimersByTime(500));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
+    expect(org1Link).toBeInTheDocument();
+    expect(org1Link).toHaveAttribute('href', '/organizations/org1/');
+
+    const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
+    expect(org2Link).toBeInTheDocument();
+    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io');
+    jest.useRealTimers();
+  });
+
+  it('uses sentryUrl when current org has customer domain enabled', function () {
+    jest.useFakeTimers();
+    const org2 = TestStubs.Organization({
+      name: 'Organization 2',
+      slug: 'org2',
+      links: {
+        organizationUrl: 'http://org2.sentry.io',
+        regionUrl: 'http://eu.sentry.io',
+      },
+      features: ['customer-domains'],
+    });
+    render(
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization={false}
+          organizations={[
+            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+            org2,
+          ]}
+        />,
+        org2
+      )
+    );
+
+    userEvent.hover(screen.getByTestId('sidebar-switch-org'));
+    act(() => void jest.advanceTimersByTime(500));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
+    expect(org1Link).toBeInTheDocument();
+    // Current hostname in the URL is expected to be org2.sentry.io, so we need to make use of sentryUrl to link to an
+    // organization that does not support customer domains.
+    expect(org1Link).toHaveAttribute('href', 'https://sentry.io/organizations/org1/');
+
+    const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
+    expect(org2Link).toBeInTheDocument();
+    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io');
+    jest.useRealTimers();
+  });
+
   it('shows "Create an Org" if they have permission', function () {
     jest.useFakeTimers();
-    render(<SwitchOrganization canCreateOrganization organizations={[]} />);
+    render(mountWithOrg(<SwitchOrganization canCreateOrganization organizations={[]} />));
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
     act(() => void jest.advanceTimersByTime(500));
@@ -38,7 +131,11 @@ describe('SwitchOrganization', function () {
 
   it('does not have "Create an Org" if they do not have permission', function () {
     jest.useFakeTimers();
-    render(<SwitchOrganization canCreateOrganization={false} organizations={[]} />);
+    render(
+      mountWithOrg(
+        <SwitchOrganization canCreateOrganization={false} organizations={[]} />
+      )
+    );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
     act(() => void jest.advanceTimersByTime(500));
@@ -55,10 +152,12 @@ describe('SwitchOrganization', function () {
 
     jest.useFakeTimers();
     render(
-      <SwitchOrganization
-        canCreateOrganization
-        organizations={[TestStubs.Organization(), orgPendingDeletion]}
-      />
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization
+          organizations={[TestStubs.Organization(), orgPendingDeletion]}
+        />
+      )
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));

--- a/static/app/utils/shouldUseLegacyRoute.tsx
+++ b/static/app/utils/shouldUseLegacyRoute.tsx
@@ -1,0 +1,9 @@
+import {OrganizationSummary} from 'sentry/types';
+
+function shouldUseLegacyRoute(organization: OrganizationSummary) {
+  const {links} = organization;
+  const {organizationUrl} = links;
+  return !organizationUrl || !organization.features.includes('customer-domains');
+}
+
+export default shouldUseLegacyRoute;

--- a/static/app/utils/useResolveRoute.tsx
+++ b/static/app/utils/useResolveRoute.tsx
@@ -1,0 +1,25 @@
+import ConfigStore from 'sentry/stores/configStore';
+import {OrganizationSummary} from 'sentry/types';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import shouldUseLegacyRoute from './shouldUseLegacyRoute';
+
+function useResolveRoute(organization: OrganizationSummary, route: string) {
+  const currentOrganization = useOrganization();
+  const {links} = organization;
+  const {organizationUrl} = links;
+
+  const useLegacyRoute = shouldUseLegacyRoute(organization);
+  if (useLegacyRoute) {
+    if (currentOrganization.features.includes('customer-domains')) {
+      // If the current org is a customer domain, then we need to change the hostname in addition to
+      // updating the path.
+      const {sentryUrl} = ConfigStore.get('links');
+      return `${sentryUrl}${route}`;
+    }
+    return route;
+  }
+  return `${organizationUrl}${route}`;
+}
+
+export default useResolveRoute;


### PR DESCRIPTION
This pull request adds customer domain support to the org switcher menu on the frontend app.

If an organization has customer domain enabled, then we link to `https://orgslug.sentry.io`. Otherwise, we link to either `/organizations/orgslug/` or `https://sentry.io/organizations/orgslug/` depending on if the currently accessed organization has customer domain enabled.