### PR TITLE
fix: bump rate limits up for segment download endpoint

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
@@ -8,10 +8,19 @@ from sentry.api.serializers import serialize
 from sentry.models import File
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.serializers import ReplayRecordingSegmentSerializer
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectEndpoint):
     private = True
+
+    rate_limits = {
+        "GET": {
+            RateLimitCategory.IP: RateLimit(1000, 1),
+            RateLimitCategory.USER: RateLimit(200, 1),
+            RateLimitCategory.ORGANIZATION: RateLimit(1000, 1),
+        }
+    }
 
     def get(self, request: Request, project, replay_id, segment_id) -> Response:
         if not features.has(


### PR DESCRIPTION
because of the way the replay download endpoint currently works, a user must make many requests to download a replay, and these happen quickly. Right now our default rate limits sometimes throttle regular use.

This PR ups them from the default (40 / sec) to some higher numbers. Only internal users are using this right now, and we'll look to either throttle on the frontend and/or implement some kind of batching solution for downloading segments before going GA with this.

Fixes https://github.com/getsentry/replay-backend/issues/86