### PR TITLE
fix(mep): No compatible projects MEP alert

### DIFF
--- a/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
@@ -99,6 +99,22 @@ export function MetricsDataSwitcherAlert(
       </Link>
     );
     if (areMultipleProjectsSelected(props.eventView)) {
+      if ((props.compatibleProjects ?? []).length === 0) {
+        return (
+          <Alert
+            type="warning"
+            showIcon
+            data-test-id="landing-mep-alert-multi-project-all-incompatible"
+          >
+            {tct(
+              `A few projects are incompatible with server side sampling. To enable this feature [updateSDK].`,
+              {
+                updateSDK,
+              }
+            )}
+          </Alert>
+        );
+      }
       return (
         <Alert
           type="warning"


### PR DESCRIPTION
### Summary
This modifies the conditions for showing 'only view compatible projects' on the 'incompatible with server side sampling alert'. Previously it was possible if you enabled dynamic sampling but none of your projects were compatible to see this message, but clicking on the link would not do anything since you have no compatible projects to switch to. This changes the alert to only show the 'update sdk' CTA since that is the only action the user can do to start seeing metric-side data.


### Screenshots

Before
![Screen Shot 2022-08-17 at 2 13 23 PM](https://user-images.githubusercontent.com/6111995/185212686-c0ee3652-ecda-4713-9e40-b555dbc3750e.png)


After
![Screen Shot 2022-08-17 at 2 20 07 PM](https://user-images.githubusercontent.com/6111995/185214046-8327b602-57e7-4eaa-8f94-7113a8a8b13f.png)

Refs PERF-1702
