### PR TITLE
ref(js): Enforce group.statusDetails when updating status

### DIFF
--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -12,10 +12,10 @@ import Tooltip from 'sentry/components/tooltip';
 import {IconChevron, IconMute} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {
+  GroupStatusResolution,
   ResolutionStatus,
   ResolutionStatusDetails,
   SelectValue,
-  UpdateResolutionStatus,
 } from 'sentry/types';
 
 const IGNORE_DURATIONS = [30, 120, 360, 60 * 24, 60 * 24 * 7];
@@ -27,7 +27,7 @@ const IGNORE_WINDOWS: SelectValue<number>[] = [
 ];
 
 type Props = {
-  onUpdate: (params: UpdateResolutionStatus) => void;
+  onUpdate: (params: GroupStatusResolution) => void;
   confirmLabel?: string;
   confirmMessage?: React.ReactNode;
   disabled?: boolean;
@@ -43,7 +43,7 @@ const IgnoreActions = ({
   confirmLabel = t('Ignore'),
   isIgnored = false,
 }: Props) => {
-  const onIgnore = (statusDetails?: ResolutionStatusDetails) => {
+  const onIgnore = (statusDetails: ResolutionStatusDetails | undefined = {}) => {
     openConfirmModal({
       bypass: !shouldConfirm,
       onConfirm: () =>
@@ -66,7 +66,9 @@ const IgnoreActions = ({
         <Button
           priority="primary"
           size="xs"
-          onClick={() => onUpdate({status: ResolutionStatus.UNRESOLVED})}
+          onClick={() =>
+            onUpdate({status: ResolutionStatus.UNRESOLVED, statusDetails: {}})
+          }
           aria-label={t('Unignore')}
           icon={<IconMute size="xs" />}
         />

--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -12,11 +12,11 @@ import Tooltip from 'sentry/components/tooltip';
 import {IconCheckmark, IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {
+  GroupStatusResolution,
   Organization,
   Release,
   ResolutionStatus,
   ResolutionStatusDetails,
-  UpdateResolutionStatus,
 } from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {formatVersion} from 'sentry/utils/formatters';
@@ -30,7 +30,7 @@ const defaultProps = {
 
 type Props = {
   hasRelease: boolean;
-  onUpdate: (data: UpdateResolutionStatus) => void;
+  onUpdate: (data: GroupStatusResolution) => void;
   orgSlug: string;
   organization: Organization;
   confirmMessage?: React.ReactNode;
@@ -114,7 +114,9 @@ class ResolveActions extends Component<Props> {
           icon={<IconCheckmark size="xs" />}
           aria-label={t('Unresolve')}
           disabled={isAutoResolved}
-          onClick={() => onUpdate({status: ResolutionStatus.UNRESOLVED})}
+          onClick={() =>
+            onUpdate({status: ResolutionStatus.UNRESOLVED, statusDetails: {}})
+          }
         />
       </Tooltip>
     );
@@ -256,7 +258,7 @@ class ResolveActions extends Component<Props> {
     const onResolve = () =>
       openConfirmModal({
         bypass: !shouldConfirm,
-        onConfirm: () => onUpdate({status: ResolutionStatus.RESOLVED}),
+        onConfirm: () => onUpdate({status: ResolutionStatus.RESOLVED, statusDetails: {}}),
         message: confirmMessage,
         confirmText: confirmLabel,
       });

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -400,12 +400,7 @@ export type ResolutionStatusDetails = {
   inRelease?: string;
 };
 
-export type UpdateResolutionStatus = {
-  status: ResolutionStatus;
-  statusDetails?: ResolutionStatusDetails;
-};
-
-type BaseGroupStatusResolution = {
+export type GroupStatusResolution = {
   status: ResolutionStatus;
   statusDetails: ResolutionStatusDetails;
 };
@@ -455,7 +450,7 @@ export type BaseGroup = {
 } & GroupRelease;
 
 export type GroupReprocessing = BaseGroup & GroupStats & BaseGroupStatusReprocessing;
-export type GroupResolution = BaseGroup & GroupStats & BaseGroupStatusResolution;
+export type GroupResolution = BaseGroup & GroupStats & GroupStatusResolution;
 export type Group = GroupResolution | GroupReprocessing;
 export type GroupCollapseRelease = Omit<Group, keyof GroupRelease> &
   Partial<GroupRelease>;

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -31,11 +31,11 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {
   Group,
+  GroupStatusResolution,
   Organization,
   Project,
   ResolutionStatus,
   SavedQueryVersions,
-  UpdateResolutionStatus,
 } from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {analytics} from 'sentry/utils/analytics';
@@ -160,7 +160,7 @@ class Actions extends Component<Props, State> {
       | {isBookmarked: boolean}
       | {isSubscribed: boolean}
       | {inbox: boolean}
-      | UpdateResolutionStatus
+      | GroupStatusResolution
   ) => {
     const {group, project, organization, api} = this.props;
 
@@ -179,8 +179,8 @@ class Actions extends Component<Props, State> {
       }
     );
 
-    if ((data as UpdateResolutionStatus).status) {
-      this.trackIssueAction((data as UpdateResolutionStatus).status);
+    if ((data as GroupStatusResolution).status) {
+      this.trackIssueAction((data as GroupStatusResolution).status);
     }
     if ((data as {inbox: boolean}).inbox !== undefined) {
       this.trackIssueAction('mark_reviewed');

--- a/tests/js/spec/components/actions/ignore.spec.jsx
+++ b/tests/js/spec/components/actions/ignore.spec.jsx
@@ -32,7 +32,7 @@ describe('IgnoreActions', function () {
       expect(button).toHaveTextContent('');
 
       userEvent.click(button);
-      expect(spy).toHaveBeenCalledWith({status: 'unresolved'});
+      expect(spy).toHaveBeenCalledWith({status: 'unresolved', statusDetails: {}});
     });
   });
 
@@ -42,7 +42,7 @@ describe('IgnoreActions', function () {
       const button = screen.getByRole('button', {name: 'Ignore'});
       userEvent.click(button);
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith({status: 'ignored'});
+      expect(spy).toHaveBeenCalledWith({status: 'ignored', statusDetails: {}});
     });
   });
 

--- a/tests/js/spec/components/actions/resolve.spec.jsx
+++ b/tests/js/spec/components/actions/resolve.spec.jsx
@@ -80,7 +80,7 @@ describe('ResolveActions', function () {
       expect(button).toHaveTextContent('');
 
       userEvent.click(button);
-      expect(spy).toHaveBeenCalledWith({status: 'unresolved'});
+      expect(spy).toHaveBeenCalledWith({status: 'unresolved', statusDetails: {}});
     });
   });
 
@@ -115,7 +115,7 @@ describe('ResolveActions', function () {
       );
       userEvent.click(screen.getByRole('button', {name: 'Resolve'}));
       expect(spy).toHaveBeenCalledTimes(1);
-      expect(spy).toHaveBeenCalledWith({status: 'resolved'});
+      expect(spy).toHaveBeenCalledWith({status: 'resolved', statusDetails: {}});
     });
   });
 

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -83,7 +83,7 @@ describe('IssueListActions', function () {
             query: {
               project: [1],
             },
-            data: {status: 'resolved'},
+            data: {status: 'resolved', statusDetails: {}},
           })
         );
 
@@ -150,7 +150,7 @@ describe('IssueListActions', function () {
             query: {
               project: [1],
             },
-            data: {status: 'resolved'},
+            data: {status: 'resolved', statusDetails: {}},
           })
         );
 
@@ -210,7 +210,7 @@ describe('IssueListActions', function () {
               id: ['3', '6', '9'],
               project: [1],
             },
-            data: {status: 'resolved'},
+            data: {status: 'resolved', statusDetails: {}},
           })
         );
       });


### PR DESCRIPTION
The Group type expects the statusDetails to exist on the Group. When updating the status we need to include this.

GH-37898 fixes optimistic updates, which exposed this regression.