### PR TITLE
fix(replays): Fix console hovering to the exact time

### DIFF
--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -14,6 +14,7 @@ import type {
   BreadcrumbTypeDefault,
   Crumb,
 } from 'sentry/types/breadcrumbs';
+import {defined} from 'sentry/utils';
 import ConsoleMessage from 'sentry/views/replays/detail/console/consoleMessage';
 import {filterBreadcrumbs} from 'sentry/views/replays/detail/console/utils';
 import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
@@ -36,6 +37,16 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
     () => filterBreadcrumbs(breadcrumbs, searchTerm, logLevel),
     [logLevel, searchTerm, breadcrumbs]
   );
+
+  const getActiveTimeInSecs = (timestamp: string): boolean => {
+    if (!defined(currentHoverTime)) {
+      return false;
+    }
+    return (
+      Math.trunc(currentHoverTime / 1000) ===
+      Math.trunc(relativeTimeInMs(timestamp, startTimestampMs) / 1000)
+    );
+  };
 
   return (
     <Fragment>
@@ -61,10 +72,7 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
           {filteredBreadcrumbs.map((breadcrumb, i) => {
             return (
               <ConsoleMessage
-                isActive={
-                  currentHoverTime ===
-                  relativeTimeInMs(breadcrumb?.timestamp || '', startTimestampMs)
-                }
+                isActive={getActiveTimeInSecs(breadcrumb?.timestamp || '')}
                 startTimestampMs={startTimestampMs}
                 key={breadcrumb.id}
                 isLast={i === breadcrumbs.length - 1}

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -14,7 +14,6 @@ import type {
   BreadcrumbTypeDefault,
   Crumb,
 } from 'sentry/types/breadcrumbs';
-import {getPrevBreadcrumb} from 'sentry/utils/replays/getBreadcrumb';
 import ConsoleMessage from 'sentry/views/replays/detail/console/consoleMessage';
 import {filterBreadcrumbs} from 'sentry/views/replays/detail/console/utils';
 import EmptyMessage from 'sentry/views/settings/components/emptyMessage';
@@ -37,15 +36,6 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
     () => filterBreadcrumbs(breadcrumbs, searchTerm, logLevel),
     [logLevel, searchTerm, breadcrumbs]
   );
-
-  const closestUserAction =
-    currentHoverTime !== undefined
-      ? getPrevBreadcrumb({
-          crumbs: breadcrumbs,
-          targetTimestampMs: startTimestampMs + (currentHoverTime ?? 0),
-          allowExact: true,
-        })
-      : undefined;
 
   return (
     <Fragment>
@@ -71,7 +61,10 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
           {filteredBreadcrumbs.map((breadcrumb, i) => {
             return (
               <ConsoleMessage
-                isActive={closestUserAction?.id === breadcrumb.id}
+                isActive={
+                  currentHoverTime ===
+                  relativeTimeInMs(breadcrumb?.timestamp || '', startTimestampMs)
+                }
                 startTimestampMs={startTimestampMs}
                 key={breadcrumb.id}
                 isLast={i === breadcrumbs.length - 1}

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -38,7 +38,7 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
     [logLevel, searchTerm, breadcrumbs]
   );
 
-  const getActiveTimeInSecs = (timestamp: string): boolean => {
+  const isActiveInSeconds = (timestamp: string): boolean => {
     if (!defined(currentHoverTime)) {
       return false;
     }
@@ -72,7 +72,7 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
           {filteredBreadcrumbs.map((breadcrumb, i) => {
             return (
               <ConsoleMessage
-                isActive={getActiveTimeInSecs(breadcrumb?.timestamp || '')}
+                isActive={isActiveInSeconds(breadcrumb?.timestamp || '')}
                 startTimestampMs={startTimestampMs}
                 key={breadcrumb.id}
                 isLast={i === breadcrumbs.length - 1}


### PR DESCRIPTION


<!-- Describe your PR here. -->
Before when you hovered on a timestamp (for example a breadcrumb one), it would highlight the closest console message relative to that timestamp, which is not the correct behavior - changed it to highlight the console message only when the timestamp is exact to that of the console. Closes #36014 


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
