### PR TITLE
fix(replays): use library offset/pagination functions

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_index.py
+++ b/src/sentry/replays/endpoints/organization_replay_index.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases.organization import NoProjects, OrganizationEndpoint
+from sentry.api.paginator import GenericOffsetPaginator
 from sentry.models.organization import Organization
 from sentry.replays.post_process import process_raw_response
 from sentry.replays.query import query_replays_collection
@@ -24,19 +25,24 @@ class OrganizationReplayIndexEndpoint(OrganizationEndpoint):
             if key not in filter_params:
                 filter_params[key] = value
 
-        snuba_response = query_replays_collection(
-            project_ids=filter_params["project_id"],
-            start=filter_params["start"],
-            end=filter_params["end"],
-            environment=filter_params.get("environment"),
-            sort=filter_params.get("sort"),
-            limit=filter_params.get("limit"),
-            offset=filter_params.get("offset"),
-        )
+        def data_fn(offset, limit):
+            return query_replays_collection(
+                project_ids=filter_params["project_id"],
+                start=filter_params["start"],
+                end=filter_params["end"],
+                environment=filter_params.get("environment"),
+                sort=filter_params.get("sort"),
+                limit=limit,
+                offset=offset,
+            )
 
-        response = process_raw_response(
-            snuba_response,
-            fields=request.query_params.getlist("field"),
+        return self.paginate(
+            request=request,
+            paginator=GenericOffsetPaginator(data_fn=data_fn),
+            on_results=lambda results: {
+                "data": process_raw_response(
+                    results,
+                    fields=request.query_params.getlist("field"),
+                )
+            },
         )
-
-        return Response({"data": response}, status=200)

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 
 from sentry.replays.testutils import assert_expected_response, mock_expected_response, mock_replay
 from sentry.testutils import APITestCase, ReplaysSnubaTestCase
+from sentry.utils.cursors import Cursor
 
 REPLAYS_FEATURES = {"organizations:session-replay": True}
 
@@ -276,26 +277,33 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
 
         with self.feature(REPLAYS_FEATURES):
             # First page.
-            response = self.client.get(self.url + "?limit=1")
-            assert response.status_code == 200
-
+            response = self.get_success_response(
+                self.organization.slug,
+                cursor=Cursor(0, 0),
+                per_page=1,
+            )
             response_data = response.json()
             assert "data" in response_data
             assert len(response_data["data"]) == 1
             assert response_data["data"][0]["id"] == replay2_id
 
             # Next page.
-            response = self.client.get(self.url + "?limit=1&offset=1")
-            assert response.status_code == 200
-
+            response = self.get_success_response(
+                self.organization.slug,
+                cursor=Cursor(0, 1),
+                per_page=1,
+            )
             response_data = response.json()
             assert "data" in response_data
             assert len(response_data["data"]) == 1
             assert response_data["data"][0]["id"] == replay1_id
 
             # Beyond pages.
-            response = self.client.get(self.url + "?limit=1&offset=2")
-            assert response.status_code == 200
+            response = self.get_success_response(
+                self.organization.slug,
+                cursor=Cursor(0, 2),
+                per_page=1,
+            )
 
             response_data = response.json()
             assert "data" in response_data


### PR DESCRIPTION
switch the replays index endpoint to use our standard pagination functions / `GenericOffsetPaginator`.