### PR TITLE
fix(api): add 'Operations' to example json for scim api patch docs

### DIFF
--- a/src/sentry/scim/endpoints/teams.py
+++ b/src/sentry/scim/endpoints/teams.py
@@ -327,48 +327,56 @@ class OrganizationSCIMTeamDetails(SCIMEndpoint, TeamDetailsEndpoint):
         * Renaming a team:
         ```json
         {
-            "op": "replace",
-            "value": {
-                "id": 23,
-                "displayName": "newName"
+            "Operations": {
+                "op": "replace",
+                "value": {
+                    "id": 23,
+                    "displayName": "newName"
+                }
             }
         }
         ```
         * Adding a member to a team:
         ```json
         {
-            "op": "add",
-            "path": "members",
-            "value": [
-                {
-                    "value": 23,
-                    "display": "testexample@example.com"
-                }
-            ]
+            "Operations": {
+                "op": "add",
+                "path": "members",
+                "value": [
+                    {
+                        "value": 23,
+                        "display": "testexample@example.com"
+                    }
+                ]
+            }
         }
         ```
         * Removing a member from a team:
         ```json
         {
-            "op": "remove",
-            "path": "members[value eq \"23\"]"
+            "Operations": {
+                "op": "remove",
+                "path": "members[value eq \"23\"]"
+            }
         }
         ```
         * Replacing an entire member set of a team:
         ```json
         {
-            "op": "replace",
-            "path": "members",
-            "value": [
-                {
-                    "value": 23,
-                    "display": "testexample2@sentry.io"
-                },
-                {
-                    "value": 24,
-                    "display": "testexample3@sentry.io"
-                }
-            ]
+            "Operations": {
+                "op": "replace",
+                "path": "members",
+                "value": [
+                    {
+                        "value": 23,
+                        "display": "testexample2@sentry.io"
+                    },
+                    {
+                        "value": 24,
+                        "display": "testexample3@sentry.io"
+                    }
+                ]
+            }
         }
         ```
         """


### PR DESCRIPTION
when trying to execute a curl command for a SCIM Team PATCH request using the sample json from the docs (https://docs.sentry.io/api/scim/update-a-teams-attributes/), it doesn't mention that you need to enclose everything in an "Operations" key, which is what the first line of the code looks for in the `patch` method

adding that here!