### PR TITLE
fix(replays): Project badge rendering on replays

### DIFF
--- a/static/app/views/replays/detail/eventMetaData.tsx
+++ b/static/app/views/replays/detail/eventMetaData.tsx
@@ -9,6 +9,7 @@ import {IconCalendar, IconClock, IconFire} from 'sentry/icons';
 import space from 'sentry/styles/space';
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import {defined} from 'sentry/utils';
+import useProjects from 'sentry/utils/useProjects';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
@@ -22,14 +23,22 @@ function EventMetaData({crumbs, durationMs, replayRecord}: Props) {
   const {
     params: {replaySlug},
   } = useRouteContext();
-  const [slug, id] = replaySlug.split(':');
+  const {projects} = useProjects();
+  const [slug] = replaySlug.split(':');
 
   const errors = crumbs?.filter(crumb => crumb.type === 'error').length;
 
   return (
     <KeyMetrics>
       {replayRecord ? (
-        <ProjectBadge project={{slug, id}} avatarSize={16} />
+        <ProjectBadge
+          project={
+            projects.find(p => p.id === replayRecord.projectId) || {
+              slug,
+            }
+          }
+          avatarSize={16}
+        />
       ) : (
         <HeaderPlaceholder />
       )}


### PR DESCRIPTION

<!-- Describe your PR here. -->
Fixed project badge icon using the hook `useProjects()` in order to get the correct project object for `<ProjectBadge>`. Closes #37921 

![image](https://user-images.githubusercontent.com/39612839/185249837-66208122-6600-44a3-a812-2fb2c0119ed6.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
