### PR TITLE
ref(issueDetails); Remove bottom margin on ConfigureDistributedTracing panel

### DIFF
--- a/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/configureDistributedTracing.tsx
@@ -192,7 +192,7 @@ const ExampleQuickTracePanel = styled(Panel)`
   gap: ${space(1)};
   background: none;
   padding: ${space(2)};
-  margin: ${space(2)} 0;
+  margin: ${space(2)} 0 0;
 `;
 
 const Header = styled('h3')`


### PR DESCRIPTION
**Before:** there's too much space between the panel and the error alert
<img width="869" alt="Screen Shot 2022-08-17 at 2 56 22 PM" src="https://user-images.githubusercontent.com/44172267/185250611-76f529e6-3ac9-4333-9191-727f2f56c6fa.png">

**After:**
<img width="869" alt="Screen Shot 2022-08-17 at 2 56 50 PM" src="https://user-images.githubusercontent.com/44172267/185250612-3b040f68-52af-4960-a5ca-50b8ebd81844.png">

