### PR TITLE
ref(multiPlatformPicker): Use SearchBar component

### DIFF
--- a/static/app/components/multiPlatformPicker.tsx
+++ b/static/app/components/multiPlatformPicker.tsx
@@ -7,6 +7,7 @@ import Button from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import ListLink from 'sentry/components/links/listLink';
 import NavTabs from 'sentry/components/navTabs';
+import SearchBar from 'sentry/components/searchBar';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import categoryList, {
   filterAliases,
@@ -14,9 +15,8 @@ import categoryList, {
   popularPlatformCategories,
 } from 'sentry/data/platformCategories';
 import platforms from 'sentry/data/platforms';
-import {IconClose, IconProject, IconSearch} from 'sentry/icons';
+import {IconClose, IconProject} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {inputStyles} from 'sentry/styles/input';
 import space from 'sentry/styles/space';
 import {Organization, PlatformIntegration} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -196,17 +196,12 @@ function PlatformPicker(props: PlatformPickerProps) {
             </ListLink>
           ))}
         </CategoryNav>
-        <SearchBar>
-          <IconSearch size="xs" />
-          <input
-            type="text"
-            value={filter}
-            placeholder={t('Filter Platforms')}
-            onChange={e => {
-              setFilter(e.target.value);
-            }}
-          />
-        </SearchBar>
+        <StyledSearchBar
+          size="sm"
+          query={filter}
+          placeholder={t('Filter Platforms')}
+          onChange={setFilter}
+        />
       </NavContainer>
       <PlatformList className={listClassName} {...listProps}>
         {platformList.map(platform => (
@@ -265,30 +260,10 @@ const NavContainer = styled('div')`
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 
-const SearchBar = styled('div')`
-  ${p => inputStyles(p)};
-  padding: 0 8px;
-  color: ${p => p.theme.subText};
-  display: flex;
-  align-items: center;
-  font-size: 15px;
-  margin-top: -${space(0.75)};
-
-  input {
-    border: none;
-    background: none;
-    padding: 2px 4px;
-    width: 100%;
-    /* Ensure a consistent line height to keep the input the desired height */
-    line-height: 24px;
-
-    &:focus {
-      outline: none;
-    }
-  }
-
+const StyledSearchBar = styled(SearchBar)`
   max-width: 300px;
   min-width: 150px;
+  margin-top: -${space(0.25)};
   margin-left: auto;
   flex-shrink: 0;
   flex-basis: 0;

--- a/tests/js/spec/components/multiPlatformPicker.spec.jsx
+++ b/tests/js/spec/components/multiPlatformPicker.spec.jsx
@@ -52,10 +52,11 @@ describe('MultiPlatformPicker', function () {
       ...baseProps,
       platforms: ['java'],
       removePlatform: jest.fn(),
+      noAutoFilter: true,
     };
 
     render(<MultiPlatformPicker {...props} />);
-    userEvent.click(screen.getByTestId('icon-close'));
+    userEvent.click(screen.getByRole('button', {name: 'Clear'}));
     expect(props.removePlatform).toHaveBeenCalledWith('java');
   });
 


### PR DESCRIPTION
Instead of building a custom search bar, we can just use the `SearchBar` component.

**Before:**
<img width="874" alt="Screen Shot 2022-08-17 at 3 22 47 PM" src="https://user-images.githubusercontent.com/44172267/185256004-bcb750a5-8432-4ba1-bacb-ab0a0f19a8e1.png">


**After:**
<img width="874" alt="Screen Shot 2022-08-17 at 3 22 17 PM" src="https://user-images.githubusercontent.com/44172267/185256007-3840add8-b444-4b28-8f6e-1795a9ee7d95.png">