### PR TITLE
feat(replays): Display status code in Replay Network Table

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -140,7 +140,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
 
     return (
       <Fragment key={index}>
-        <Item center {...columnHandlers}>
+        <Item {...columnHandlers}>
           {network.data.statusCode ? (
             <StatusContainer>{network.data.statusCode}</StatusContainer>
           ) : (

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -95,27 +95,29 @@ function NetworkList({replayRecord, networkSpans}: Props) {
 
   const columns = [
     <SortItem key="status">
-      <UnstyledButton onClick={() => handleSort('status', row => row.data.statusCode)}>
+      <UnstyledHeaderButton
+        onClick={() => handleSort('status', row => row.data.statusCode)}
+      >
         {t('Status')} {sortArrow('status')}
-      </UnstyledButton>
+      </UnstyledHeaderButton>
     </SortItem>,
     <SortItem key="path">
-      <UnstyledButton onClick={() => handleSort('description')}>
+      <UnstyledHeaderButton onClick={() => handleSort('description')}>
         {t('Path')} {sortArrow('description')}
-      </UnstyledButton>
+      </UnstyledHeaderButton>
     </SortItem>,
     <SortItem key="type">
-      <UnstyledButton onClick={() => handleSort('op')}>
+      <UnstyledHeaderButton onClick={() => handleSort('op')}>
         {t('Type')} {sortArrow('op')}
-      </UnstyledButton>
+      </UnstyledHeaderButton>
     </SortItem>,
     <SortItem key="size">
-      <UnstyledButton onClick={() => handleSort('size', row => row.data.size)}>
+      <UnstyledHeaderButton onClick={() => handleSort('size', row => row.data.size)}>
         {t('Size')} {sortArrow('size')}
-      </UnstyledButton>
+      </UnstyledHeaderButton>
     </SortItem>,
     <SortItem key="duration">
-      <UnstyledButton
+      <UnstyledHeaderButton
         onClick={() =>
           handleSort('duration', row => {
             return row.endTimestamp - row.startTimestamp;
@@ -123,12 +125,12 @@ function NetworkList({replayRecord, networkSpans}: Props) {
         }
       >
         {t('Duration')} {sortArrow('duration')}
-      </UnstyledButton>
+      </UnstyledHeaderButton>
     </SortItem>,
     <SortItem key="timestamp">
-      <UnstyledButton onClick={() => handleSort('startTimestamp')}>
+      <UnstyledHeaderButton onClick={() => handleSort('startTimestamp')}>
         {t('Timestamp')} {sortArrow('startTimestamp')}
-      </UnstyledButton>
+      </UnstyledHeaderButton>
     </SortItem>,
   ];
 
@@ -217,6 +219,12 @@ const UnstyledButton = styled('button')`
   text-align: unset;
 `;
 
+const UnstyledHeaderButton = styled(UnstyledButton)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 const StyledPanelTable = styled(PanelTable)<{columns: number}>`
   grid-template-columns: max-content minmax(200px, 1fr) repeat(
       4,
@@ -253,12 +261,6 @@ const StyledPanelTable = styled(PanelTable)<{columns: number}>`
     color: ${p => p.theme.subText};
     line-height: 16px;
     text-transform: none;
-
-    ${/* sc-selector */ UnstyledButton} {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-    }
 
     /* Last, 2nd and 3rd last header columns. As these are flex direction columns we have to treat them separately */
     &:nth-child(${p => p.columns}n),

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -141,13 +141,9 @@ function NetworkList({replayRecord, networkSpans}: Props) {
     return (
       <Fragment key={index}>
         <Item {...columnHandlers}>
-          {network.data.statusCode ? (
-            <StatusContainer>{network.data.statusCode}</StatusContainer>
-          ) : (
-            <EmptyText>({t('Missing status')})</EmptyText>
-          )}
+          {network.data.statusCode ? network.data.statusCode : <EmptyText>---</EmptyText>}
         </Item>
-        <Item color="gray400" {...columnHandlers}>
+        <Item {...columnHandlers}>
           {network.description ? (
             <Tooltip
               title={network.description}
@@ -212,8 +208,20 @@ const Item = styled('div')<{center?: boolean; color?: ColorOrAlias; numeric?: bo
   ${p => p.numeric && 'font-variant-numeric: tabular-nums;'}
 `;
 
+const UnstyledButton = styled('button')`
+  border: 0;
+  background: none;
+  padding: 0;
+  text-transform: inherit;
+  width: 100%;
+  text-align: unset;
+`;
+
 const StyledPanelTable = styled(PanelTable)<{columns: number}>`
-  grid-template-columns: max-content minmax(200px, 1fr) repeat(4, max-content);
+  grid-template-columns: max-content minmax(200px, 1fr) repeat(
+      4,
+      minmax(max-content, 160px)
+    );
   grid-template-rows: 24px repeat(auto-fit, 28px);
   font-size: ${p => p.theme.fontSizeSmall};
   margin-bottom: 0;
@@ -244,28 +252,23 @@ const StyledPanelTable = styled(PanelTable)<{columns: number}>`
     border-radius: 0;
     color: ${p => p.theme.subText};
     line-height: 16px;
+    text-transform: none;
+
+    ${/* sc-selector */ UnstyledButton} {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
 
     /* Last, 2nd and 3rd last header columns. As these are flex direction columns we have to treat them separately */
     &:nth-child(${p => p.columns}n),
     &:nth-child(${p => p.columns}n - 1),
     &:nth-child(${p => p.columns}n - 2) {
       justify-content: center;
-      align-items: end;
+      align-items: flex-start;
+      text-align: start;
     }
   }
-`;
-
-const StatusContainer = styled('div')`
-  border: 1px solid ${p => p.theme.border};
-  border-radius: 17px;
-  max-width: 40px;
-  padding: ${space(0.25)} ${space(1)};
-  background-color: ${p => p.theme.backgroundSecondary};
-  color: ${p => p.theme.textColor};
-  font-size: ${p => p.theme.fontSizeSmall};
-  line-height: 1.3;
-  display: flex;
-  align-items: center;
 `;
 
 const Text = styled('p')`
@@ -286,17 +289,8 @@ const SortItem = styled('span')`
   width: 100%;
 
   svg {
-    vertical-align: text-top;
+    margin-left: ${space(0.25)};
   }
-`;
-
-const UnstyledButton = styled('button')`
-  border: 0;
-  background: none;
-  padding: 0;
-  text-transform: inherit;
-  width: 100%;
-  text-align: unset;
 `;
 
 export default NetworkList;

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -144,7 +144,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
           {network.data.statusCode ? (
             <StatusContainer>{network.data.statusCode}</StatusContainer>
           ) : (
-            <EmptyText>({t('Missing status code')})</EmptyText>
+            <EmptyText>({t('Missing status')})</EmptyText>
           )}
         </Item>
         <Item color="gray400" {...columnHandlers}>

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import FileSize from 'sentry/components/fileSize';
 import {PanelTable, PanelTableHeader} from 'sentry/components/panels';
-import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs, showPlayerTime} from 'sentry/components/replays/utils';
 import Tooltip from 'sentry/components/tooltip';
@@ -95,7 +94,11 @@ function NetworkList({replayRecord, networkSpans}: Props) {
   };
 
   const columns = [
-    <SortItem key="status">{t('Status')}</SortItem>,
+    <SortItem key="status">
+      <UnstyledButton onClick={() => handleSort('status', row => row.data.statusCode)}>
+        {t('Status')} {sortArrow('status')}
+      </UnstyledButton>
+    </SortItem>,
     <SortItem key="path">
       <UnstyledButton onClick={() => handleSort('description')}>
         {t('Path')} {sortArrow('description')}
@@ -138,7 +141,11 @@ function NetworkList({replayRecord, networkSpans}: Props) {
     return (
       <Fragment key={index}>
         <Item center {...columnHandlers}>
-          <StatusPlaceHolder height="20px" />
+          {network.data.statusCode ? (
+            <StatusContainer>{network.data.statusCode}</StatusContainer>
+          ) : (
+            <EmptyText>({t('Missing status code')})</EmptyText>
+          )}
         </Item>
         <Item color="gray400" {...columnHandlers}>
           {network.description ? (
@@ -248,10 +255,17 @@ const StyledPanelTable = styled(PanelTable)<{columns: number}>`
   }
 `;
 
-const StatusPlaceHolder = styled(Placeholder)`
+const StatusContainer = styled('div')`
   border: 1px solid ${p => p.theme.border};
   border-radius: 17px;
   max-width: 40px;
+  padding: ${space(0.25)} ${space(1)};
+  background-color: ${p => p.theme.backgroundSecondary};
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.fontSizeSmall};
+  line-height: 1.3;
+  display: flex;
+  align-items: center;
 `;
 
 const Text = styled('p')`


### PR DESCRIPTION

<!-- Describe your PR here. -->
Added status code value to the network table. Closes #37926 

![image](https://user-images.githubusercontent.com/39612839/185493934-4b81bedd-d744-4294-986a-710d885bd969.png)

![image](https://user-images.githubusercontent.com/39612839/185493873-9dfcf9c6-6fbd-48ba-8ad7-6d4e8f680507.png)

![image](https://user-images.githubusercontent.com/39612839/185472196-85e43084-8fd3-4a34-8a6b-2a97fa804435.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
