### PR TITLE
ref(ui): Use inline-flex for group title

### DIFF
--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -186,7 +186,7 @@ const Title = styled('div')<{hasGroupingTreeUI: boolean; size: Size}>`
         `
       : css`
           > a:first-child {
-            display: flex;
+            display: inline-flex;
             min-height: ${space(3)};
           }
         `}


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/185268834-e7b6c4cc-b4b1-4584-8ce2-e62d422a6c83.png)


After
![image](https://user-images.githubusercontent.com/1421724/185268816-4feb4ced-9caa-48e1-af0b-e82d9d7f8435.png)

The hitbox was a bit too aggressive. Especially when trying to click the row to select