### PR TITLE
feat(perf): Improve N+1 API Calls detector

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -97,7 +97,7 @@ def get_default_detection_settings():
             {
                 "count": 5,
                 "start_time_threshold": 5.0,  # ms
-                "allowed_span_ops": ["http.client", "http.server"],
+                "allowed_span_ops": ["http.client"],
             }
         ],
     }

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -191,20 +191,22 @@ class PerformanceDetectionTest(unittest.TestCase):
 
     def test_calls_n_plus_one_spans_calls(self):
         # ├── GET list.json
-        # │   ├── GET 1.json
-        # │   ├──  GET 2.json
-        # │   ├──   GET 3.json
-        # │   ├──    GET 4.json
-        # │   └──      GET 5.json
+        # │   ├── GET /events.json?q=1
+        # │   ├──  GET /events.json?q=2
+        # │   ├──   GET /events.json?q=3
 
         n_plus_one_event = create_event(
             [
                 create_span("http.client", 250, "GET /list.json"),
-                modify_span_start(create_span("http.client", 180, "GET /1.json"), 101),
-                modify_span_start(create_span("http.client", 178, "GET /2.json"), 105),
-                modify_span_start(create_span("http.client", 163, "GET /3.json"), 109),
-                modify_span_start(create_span("http.client", 152, "GET /4.json"), 113),
-                modify_span_start(create_span("http.client", 191, "GET /5.json"), 116),
+                modify_span_start(
+                    create_span("http.client", 180, "GET /events.json?q=1", "c0c0c0c0"), 101
+                ),
+                modify_span_start(
+                    create_span("http.client", 178, "GET /events.json?q=2", "c0c0c0c0"), 105
+                ),
+                modify_span_start(
+                    create_span("http.client", 163, "GET /events.json?q=3", "c0c0c0c0"), 109
+                ),
             ]
         )
 


### PR DESCRIPTION
The N+1 API Calls detector has no similarity criterion, which is a problem. It flags _any_ set of more than five concurrent `http.client` spans. _Lots_ of our transactions make >5 concurrent requests for good reasons, though, if they need a lot of data! For example, `/organizations/:orgId/issues/:groupId/`. I originally shipped this detector with no similarity criterion because I was hoping that the requirement of 5 concurrent requests is strict enough, but it is not.

We need _some_ kind of way to detect if the spans are _similar_, which they would be in a true N+1 error. Span hashes to the rescue. [Span hashes for `http.client`](https://github.com/getsentry/sentry/pull/28184/files#diff-c11ec6bbfcb4c66f3b913b786ad2ceb78cc5ce73dbd7fc25f103fb099fb6776eR146-R181) spans are an md5 digest of the URL without the URL parameters. That's a great start for us! This should be enough to catch multiple concurrent requests to the same endpoint. In the future we can write our own similarity checking (then we can catch interpolated URLs like `/resources/773428/data`).

## Changes

- Tighten up the requirement for similarity. Spans must be concurrent _and_ have the same hash, which is equivalent to requiring them to have the same URL path
- Loosen up the requirement for concurrency. 3 concurrent spans or more to the same URL will be an issue, instead of 5. Now that we're checking similarity, we can loosen this up
- Remove the `http.server` op type. `http.server` doesn't use the same hashing strategy, so I'm leaving it out

Anecdotally, this approach will flag transactions like `/organizations/:orgId/dashboard/:dashboardId/` where multiple widgets are requesting event data and event stats for different data sets, but the same time range and projects.
