### PR TITLE
chore(hybrid-cloud): Update test_with_middleware_and_customer_domain

### DIFF
--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlparse
-
 from django.conf import settings
 from django.conf.urls import url
 from django.test import RequestFactory, override_settings


### PR DESCRIPTION
Update the `test_with_middleware_and_customer_domain` test to make use of the `redirect_chain`.