### PR TITLE
fix(profiling): Capture error and publish outcome for more steps in p…

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -43,10 +43,33 @@ def process_profile(
 ) -> None:
     project = Project.objects.get_from_cache(id=profile["project_id"])
 
-    if _should_symbolicate(profile):
-        _symbolicate(profile=profile, project=project)
-    elif _should_deobfuscate(profile):
-        _deobfuscate(profile=profile, project=project)
+    try:
+        if _should_symbolicate(profile):
+            _symbolicate(profile=profile, project=project)
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        _track_outcome(
+            profile=profile,
+            project=project,
+            outcome=Outcome.INVALID,
+            key_id=key_id,
+            reason="failed-symbolication",
+        )
+        return
+
+    try:
+        if _should_deobfuscate(profile):
+            _deobfuscate(profile=profile, project=project)
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
+        _track_outcome(
+            profile=profile,
+            project=project,
+            outcome=Outcome.INVALID,
+            key_id=key_id,
+            reason="failed-deobfuscation",
+        )
+        return
 
     organization = Organization.objects.get_from_cache(id=project.organization_id)
 


### PR DESCRIPTION
…rofile ingestion

It is possible that symbolication or deobfuscation can fail. Make sure to
capture the error and produce an outcome when this happens.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
