### PR TITLE
fix(dashboards): update tooltip formatter to support multiple different types

### DIFF
--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -39,6 +39,7 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {
+  AggregationOutputType,
   isAggregateField,
   isEquation,
   isEquationAlias,
@@ -86,7 +87,7 @@ export interface WidgetViewerModalOptions {
   onEdit?: () => void;
   pageLinks?: string;
   seriesData?: Series[];
-  seriesResultsType?: string;
+  seriesResultsType?: Record<string, AggregationOutputType>;
   tableData?: TableDataWithTitle[];
   totalIssuesCount?: string;
 }
@@ -806,7 +807,7 @@ function WidgetViewerModal(props: Props) {
             {(!!seriesData || !!tableData) && chartUnmodified ? (
               <MemoizedWidgetCardChart
                 timeseriesResults={seriesData}
-                timeseriesResultsType={seriesResultsType}
+                timeseriesResultsTypes={seriesResultsType}
                 tableResults={tableData}
                 errorMessage={undefined}
                 loading={false}

--- a/static/app/views/dashboardsV2/datasetConfig/base.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/base.tsx
@@ -8,7 +8,11 @@ import {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/custo
 import {TableData} from 'sentry/utils/discover/discoverQuery';
 import {MetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
-import {isEquation, QueryFieldValue} from 'sentry/utils/discover/fields';
+import {
+  AggregationOutputType,
+  isEquation,
+  QueryFieldValue,
+} from 'sentry/utils/discover/fields';
 import {FieldValueOption} from 'sentry/views/eventsV2/table/queryField';
 import {FieldValue} from 'sentry/views/eventsV2/table/types';
 

--- a/static/app/views/dashboardsV2/datasetConfig/base.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/base.tsx
@@ -142,7 +142,7 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
   getSeriesResultType?: (
     data: SeriesResponse,
     widgetQuery: WidgetQuery
-  ) => string | undefined;
+  ) => Record<string, AggregationOutputType>;
   /**
    * Generate the request promises for fetching
    * tabular data.

--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -387,13 +387,18 @@ function transformEventsResponseToSeries(
 function getSeriesResultType(
   data: EventsStats | MultiSeriesEventsStats,
   widgetQuery: WidgetQuery
-) {
+): Record<string, string> {
   const field = widgetQuery.aggregates[0];
+  const resultTypes = {};
   // Need to use getAggregateAlias since events-stats still uses aggregate alias format
   if (isMultiSeriesStats(data)) {
-    return data[Object.keys(data)[0]].meta?.fields[getAggregateAlias(field)];
+    Object.keys(data).forEach(
+      key => (resultTypes[key] = data[key].meta?.fields[getAggregateAlias(key)])
+    );
+  } else {
+    resultTypes[field] = data.meta?.fields[getAggregateAlias(field)];
   }
-  return data.meta?.fields[getAggregateAlias(field)];
+  return resultTypes;
 }
 
 function renderEventIdAsLinkable(data, {eventView, organization}: RenderFunctionBaggage) {

--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -23,6 +23,7 @@ import {
   RenderFunctionBaggage,
 } from 'sentry/utils/discover/fieldRenderers';
 import {
+  AggregationOutputType,
   errorsAndTransactionsAggregateFunctionOutputType,
   getAggregateAlias,
   isEquation,
@@ -387,7 +388,7 @@ function transformEventsResponseToSeries(
 function getSeriesResultType(
   data: EventsStats | MultiSeriesEventsStats,
   widgetQuery: WidgetQuery
-): Record<string, string> {
+): Record<string, AggregationOutputType> {
   const field = widgetQuery.aggregates[0];
   const resultTypes = {};
   // Need to use getAggregateAlias since events-stats still uses aggregate alias format

--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -409,10 +409,15 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       },
       tooltip: {
         trigger: 'axis',
-        valueFormatter: (value: number, seriesName: string) =>
-          timeseriesResultsTypes
-            ? tooltipFormatter(value, timeseriesResultsTypes[seriesName])
-            : tooltipFormatter(value, aggregateOutputType(seriesName)),
+        valueFormatter: (value: number, seriesName: string) => {
+          const aggregateName = seriesName.split(':').pop()?.trim();
+          if (aggregateName) {
+            return timeseriesResultsTypes
+              ? tooltipFormatter(value, timeseriesResultsTypes[aggregateName])
+              : tooltipFormatter(value, aggregateOutputType(aggregateName));
+          }
+          return tooltipFormatter(value, 'number');
+        },
       },
       yAxis: {
         axisLabel: {

--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -409,11 +409,10 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       },
       tooltip: {
         trigger: 'axis',
-        valueFormatter: (value: number, seriesName: string) => {
-          return timeseriesResultsTypes
+        valueFormatter: (value: number, seriesName: string) =>
+          timeseriesResultsTypes
             ? tooltipFormatter(value, timeseriesResultsTypes[seriesName])
-            : tooltipFormatter(value, aggregateOutputType(seriesName));
-        },
+            : tooltipFormatter(value, aggregateOutputType(seriesName)),
       },
       yAxis: {
         axisLabel: {

--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -88,7 +88,7 @@ type WidgetCardChartProps = Pick<
   }>;
   onZoom?: AugmentedEChartDataZoomHandler;
   showSlider?: boolean;
-  timeseriesResultsType?: string;
+  timeseriesResultsTypes?: Record<string, AggregationOutputType>;
   windowWidth?: number;
 };
 
@@ -297,7 +297,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       showSlider,
       noPadding,
       chartZoomOptions,
-      timeseriesResultsType,
+      timeseriesResultsTypes,
     } = this.props;
 
     if (widget.displayType === 'table') {
@@ -409,17 +409,21 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       },
       tooltip: {
         trigger: 'axis',
-        valueFormatter: (value: number, seriesName: string) =>
-          timeseriesResultsType
-            ? tooltipFormatter(value, timeseriesResultsType as AggregationOutputType)
-            : tooltipFormatter(value, aggregateOutputType(seriesName)),
+        valueFormatter: (value: number, seriesName: string) => {
+          return timeseriesResultsTypes
+            ? tooltipFormatter(value, timeseriesResultsTypes[seriesName])
+            : tooltipFormatter(value, aggregateOutputType(seriesName));
+        },
       },
       yAxis: {
         axisLabel: {
           color: theme.chartLabel,
           formatter: (value: number) =>
-            timeseriesResultsType
-              ? axisLabelFormatterUsingAggregateOutputType(value, timeseriesResultsType)
+            timeseriesResultsTypes
+              ? axisLabelFormatterUsingAggregateOutputType(
+                  value,
+                  timeseriesResultsTypes[axisLabel]
+                )
               : axisLabelFormatter(value, aggregateOutputType(axisLabel)),
         },
       },

--- a/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
@@ -8,6 +8,7 @@ import {t} from 'sentry/locale';
 import {Organization, PageFilters} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import {AggregationOutputType} from 'sentry/utils/discover/fields';
 
 import {DatasetConfig} from '../datasetConfig/base';
 import {
@@ -38,7 +39,7 @@ export type OnDataFetchedProps = {
   pageLinks?: string;
   tableResults?: TableDataWithTitle[];
   timeseriesResults?: Series[];
-  timeseriesResultsType?: string;
+  timeseriesResultsTypes?: Record<string, AggregationOutputType>;
   totalIssuesCount?: string;
 };
 
@@ -48,7 +49,7 @@ export type GenericWidgetQueriesChildrenProps = {
   pageLinks?: string;
   tableResults?: TableDataWithTitle[];
   timeseriesResults?: Series[];
-  timeseriesResultsType?: string;
+  timeseriesResultsTypes?: Record<string, AggregationOutputType>;
   totalCount?: string;
 };
 
@@ -77,7 +78,7 @@ export type GenericWidgetQueriesProps<SeriesResponse, TableResponse> = {
     timeseriesResults,
     totalIssuesCount,
     pageLinks,
-    timeseriesResultsType,
+    timeseriesResultsTypes,
   }: OnDataFetchedProps) => void;
 };
 
@@ -89,7 +90,7 @@ type State<SeriesResponse> = {
   rawResults?: SeriesResponse[];
   tableResults?: GenericWidgetQueriesChildrenProps['tableResults'];
   timeseriesResults?: GenericWidgetQueriesChildrenProps['timeseriesResults'];
-  timeseriesResultsType?: string;
+  timeseriesResultsTypes?: Record<string, AggregationOutputType>;
 };
 
 class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
@@ -104,7 +105,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
     rawResults: undefined,
     tableResults: undefined,
     pageLinks: undefined,
-    timeseriesResultsType: undefined,
+    timeseriesResultsTypes: undefined,
   };
 
   componentDidMount() {
@@ -341,7 +342,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
 
     // Get series result type
     // Only used by custom measurements in errorsAndTransactions at the moment
-    const timeseriesResultsType = config.getSeriesResultType?.(
+    const timeseriesResultsTypes = config.getSeriesResultType?.(
       responses[0][0],
       widget.queries[0]
     );
@@ -349,12 +350,12 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
     if (this._isMounted && this.state.queryFetchID === queryFetchID) {
       onDataFetched?.({
         timeseriesResults: transformedTimeseriesResults,
-        timeseriesResultsType,
+        timeseriesResultsTypes,
       });
       this.setState({
         timeseriesResults: transformedTimeseriesResults,
         rawResults: rawResultsClone,
-        timeseriesResultsType,
+        timeseriesResultsTypes,
       });
     }
   }
@@ -403,7 +404,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       timeseriesResults,
       errorMessage,
       pageLinks,
-      timeseriesResultsType,
+      timeseriesResultsTypes,
     } = this.state;
 
     return children({
@@ -412,7 +413,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       timeseriesResults,
       errorMessage,
       pageLinks,
-      timeseriesResultsType,
+      timeseriesResultsTypes,
     });
   }
 }

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -24,7 +24,7 @@ import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
-import {parseFunction} from 'sentry/utils/discover/fields';
+import {AggregationOutputType, parseFunction} from 'sentry/utils/discover/fields';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
@@ -72,7 +72,7 @@ type Props = WithRouterProps & {
 type State = {
   pageLinks?: string;
   seriesData?: Series[];
-  seriesResultsType?: string;
+  seriesResultsType?: Record<string, AggregationOutputType>;
   tableData?: TableDataWithTitle[];
   totalIssuesCount?: string;
 };
@@ -200,12 +200,12 @@ class WidgetCard extends Component<Props, State> {
     timeseriesResults,
     totalIssuesCount,
     pageLinks,
-    timeseriesResultsType,
+    timeseriesResultsTypes,
   }: {
     pageLinks?: string;
     tableResults?: TableDataWithTitle[];
     timeseriesResults?: Series[];
-    timeseriesResultsType?: string;
+    timeseriesResultsTypes?: Record<string, AggregationOutputType>;
     totalIssuesCount?: string;
   }) => {
     this.setState({
@@ -213,7 +213,7 @@ class WidgetCard extends Component<Props, State> {
       tableData: tableResults,
       totalIssuesCount,
       pageLinks,
-      seriesResultsType: timeseriesResultsType,
+      seriesResultsType: timeseriesResultsTypes,
     });
   };
 

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -11,6 +11,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Organization, PageFilters} from 'sentry/types';
 import {EChartEventHandler, Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import {AggregationOutputType} from 'sentry/utils/discover/fields';
 
 import {DashboardFilters, Widget, WidgetType} from '../types';
 
@@ -35,7 +36,7 @@ type Props = WithRouterProps & {
     pageLinks?: string;
     tableResults?: TableDataWithTitle[];
     timeseriesResults?: Series[];
-    timeseriesResultsType?: string;
+    timeseriesResultsTypes?: Record<string, AggregationOutputType>;
     totalIssuesCount?: string;
   }) => void;
   onLegendSelectChanged?: EChartEventHandler<{
@@ -162,7 +163,7 @@ export function WidgetCardChartContainer({
         timeseriesResults,
         errorMessage,
         loading,
-        timeseriesResultsType,
+        timeseriesResultsTypes,
       }) => {
         return (
           <Fragment>
@@ -188,7 +189,7 @@ export function WidgetCardChartContainer({
               showSlider={showSlider}
               noPadding={noPadding}
               chartZoomOptions={chartZoomOptions}
-              timeseriesResultsType={timeseriesResultsType}
+              timeseriesResultsTypes={timeseriesResultsTypes}
             />
           </Fragment>
         );

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -18,6 +18,7 @@ import {Organization, PageFilters} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {
   getWidgetDiscoverUrl,
   getWidgetIssueUrl,
@@ -43,7 +44,7 @@ type Props = {
   onEdit?: () => void;
   pageLinks?: string;
   seriesData?: Series[];
-  seriesResultsType?: string;
+  seriesResultsType?: Record<string, AggregationOutputType>;
   showContextMenu?: boolean;
   showWidgetViewerButton?: boolean;
   tableData?: TableDataWithTitle[];

--- a/static/app/views/dashboardsV2/widgetViewer/widgetViewerContext.tsx
+++ b/static/app/views/dashboardsV2/widgetViewer/widgetViewerContext.tsx
@@ -2,18 +2,19 @@ import {createContext} from 'react';
 
 import {Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import {AggregationOutputType} from 'sentry/utils/discover/fields';
 
 export type WidgetViewerContextProps = {
   setData: (data: {
     pageLinks?: string;
     seriesData?: Series[];
-    seriesResultsType?: string;
+    seriesResultsType?: Record<string, AggregationOutputType>;
     tableData?: TableDataWithTitle[];
     totalIssuesCount?: string;
   }) => void;
   pageLinks?: string;
   seriesData?: Series[];
-  seriesResultsType?: string;
+  seriesResultsType?: Record<string, AggregationOutputType>;
   tableData?: TableDataWithTitle[];
   totalIssuesCount?: string;
 };

--- a/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
+++ b/tests/js/spec/components/modals/widgetViewerModal.spec.tsx
@@ -10,6 +10,7 @@ import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import space from 'sentry/styles/space';
 import {Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
+import {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {
   DisplayType,
   Widget,
@@ -51,7 +52,7 @@ async function renderModal({
   widget: any;
   pageLinks?: string;
   seriesData?: Series[];
-  seriesResultsType?: string;
+  seriesResultsType?: Record<string, AggregationOutputType>;
   tableData?: TableDataWithTitle[];
 }) {
   const rendered = render(
@@ -519,7 +520,7 @@ describe('Modals -> WidgetViewerModal', function () {
             initialData: initialDataWithFlag,
             widget: mockWidget,
             seriesData: [],
-            seriesResultsType: 'duration',
+            seriesResultsType: {'count()': 'duration'},
           });
           const calls = (ReactEchartsCore as jest.Mock).mock.calls;
           const yAxisFormatter =
@@ -552,7 +553,7 @@ describe('Modals -> WidgetViewerModal', function () {
             initialData: initialDataWithFlag,
             widget: mockWidget,
             seriesData: [],
-            seriesResultsType: 'duration',
+            seriesResultsType: {'count()': 'duration'},
           });
           expect(eventsMock).toHaveBeenCalledTimes(1);
           expect(screen.getByText('title')).toBeInTheDocument();

--- a/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/widgetCard.spec.tsx
@@ -893,9 +893,9 @@ describe('Dashboards > WidgetCard', function () {
       expect(tooltip).toBeDefined();
       expect(yAxis).toBeDefined();
       // @ts-ignore
-      expect(tooltip.valueFormatter(24, 'duration')).toEqual('24.00ms');
+      expect(tooltip.valueFormatter(24, 'p95(measurements.custom)')).toEqual('24.00ms');
       // @ts-ignore
-      expect(yAxis.axisLabel.formatter(24, 'duration')).toEqual('24ms');
+      expect(yAxis.axisLabel.formatter(24, 'p95(measurements.custom)')).toEqual('24ms');
     });
 
     it('displays indexed badge in preview mode', async function () {


### PR DESCRIPTION
Previously, chart tooltips would only be formatted using the first series type.
Updates behaviour to use type for each individual series.
<img width="582" alt="image" src="https://user-images.githubusercontent.com/83961295/185424017-81b594ca-19c9-40c9-9b4f-bb68f0779946.png">