### PR TITLE
ref(ts): Add noUncheckedIndexedAccess rule

### DIFF
--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -17,6 +17,7 @@
     "noImplicitAny": false,
     "noImplicitReturns": true,
     "noImplicitUseStrict": true,
+    "noUncheckedIndexedAccess": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
### Summary

We get a lot of array access errors since typescript does not treat items from an array as `T | undefined` but rather just `T`. It happens to make a lot of js issues when we are using arrays from responses.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#checked-indexed-accesses---nouncheckedindexedaccess


Putting this up to see where we are currently at for lint.
