### PR TITLE
fix(replays): Remove dashes from issues/trace requests

### DIFF
--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -45,7 +45,7 @@ function IssueList(props: Props) {
       fields: ['count(issue)', 'issue'],
       environment: selection.environments,
       projects: selection.projects,
-      query: `replayId:${props.replayId} AND event.type:error`,
+      query: `replayId:${props.replayId.replaceAll('-', '')} AND event.type:error`,
     };
     const result = EventView.fromNewQueryWithLocation(eventQueryParams, location);
     return result;
@@ -59,7 +59,7 @@ function IssueList(props: Props) {
         includeAllArgs: true,
         query: {
           project: props.projectId,
-          query: `replayId:${props.replayId}`,
+          query: `replayId:${props.replayId.replaceAll('-', '')}`,
         },
       });
 
@@ -78,7 +78,7 @@ function IssueList(props: Props) {
           query: {
             project: props.projectId,
             groups: issues[0]?.map(issue => issue.id),
-            query: `replayId:${props.replayId}`,
+            query: `replayId:${props.replayId.replaceAll('-', '')}`,
           },
         }
       );

--- a/static/app/views/replays/detail/trace.tsx
+++ b/static/app/views/replays/detail/trace.tsx
@@ -65,7 +65,7 @@ export default function Trace({replayRecord, organization}: Props) {
     location,
     params: {replaySlug, orgSlug},
   } = useRouteContext();
-  const [, eventId] = replaySlug.split(':');
+  const [, replayId] = replaySlug.split(':');
 
   const start = getUtcDateString(replayRecord.startedAt.getTime());
   const end = getUtcDateString(replayRecord.finishedAt.getTime());
@@ -74,10 +74,10 @@ export default function Trace({replayRecord, organization}: Props) {
     async function loadTraces() {
       const eventView = EventView.fromSavedQuery({
         id: undefined,
-        name: `Traces in replay ${eventId}`,
+        name: `Traces in replay ${replayId}`,
         fields: ['trace', 'count(trace)', 'min(timestamp)'],
         orderby: 'min_timestamp',
-        query: `replayId:${eventId} !title:"sentry-replay-event*"`,
+        query: `replayId:${replayId.replaceAll('-', '')} !title:"sentry-replay-event*"`,
         projects: [ALL_ACCESS_PROJECTS],
         version: 2,
 
@@ -99,7 +99,10 @@ export default function Trace({replayRecord, organization}: Props) {
           traceIds.map(traceId =>
             doDiscoverQuery(
               api,
-              `/organizations/${orgSlug}/events-trace/${traceId}/`,
+              `/organizations/${orgSlug}/events-trace/${String(traceId).replaceAll(
+                '-',
+                ''
+              )}/`,
               getTraceRequestPayload({
                 eventView: makeEventView({start, end}),
                 location,
@@ -129,7 +132,7 @@ export default function Trace({replayRecord, organization}: Props) {
     loadTraces();
 
     return () => {};
-  }, [api, eventId, orgSlug, location, start, end]);
+  }, [api, replayId, orgSlug, location, start, end]);
 
   if (state.isLoading) {
     return <LoadingIndicator />;


### PR DESCRIPTION
Show data in Issues and Traces tabs again:
<img width="736" alt="Screen Shot 2022-08-18 at 10 12 31 AM" src="https://user-images.githubusercontent.com/187460/185455414-82dbd3ab-5243-4ee4-ae28-483f32817605.png">
<img width="743" alt="Screen Shot 2022-08-18 at 10 12 38 AM" src="https://user-images.githubusercontent.com/187460/185455422-0cd2ae02-003e-47a6-8ce2-865de5ed6f1d.png">

Fixes #[#38002](https://github.com/getsentry/sentry/issues/38002)

