### PR TITLE
fix(discover): fixes event details tag overflowing

### DIFF
--- a/static/app/components/tagsTableRow.tsx
+++ b/static/app/components/tagsTableRow.tsx
@@ -44,10 +44,10 @@ function TagsTableRow({tag, query, generateUrl, meta}: Props) {
         !!valueMetaData && !tag.value ? (
           <AnnotatedText value={tag.value} meta={valueMetaData} />
         ) : keyMetaData?.err?.length ? (
-          <span>{renderTagValue()}</span>
+          <ValueContainer>{renderTagValue()}</ValueContainer>
         ) : tagInQuery ? (
           <Tooltip title={t('This tag is in the current filter conditions')}>
-            <span>{renderTagValue()}</span>
+            <ValueContainer>{renderTagValue()}</ValueContainer>
           </Tooltip>
         ) : (
           <StyledTooltip title={renderTagValue()}>
@@ -63,4 +63,10 @@ export default TagsTableRow;
 
 const StyledTooltip = styled(Tooltip)`
   ${p => p.theme.overflowEllipsis};
+`;
+
+const ValueContainer = styled('span')`
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/static/app/components/tagsTableRow.tsx
+++ b/static/app/components/tagsTableRow.tsx
@@ -46,9 +46,9 @@ function TagsTableRow({tag, query, generateUrl, meta}: Props) {
         ) : keyMetaData?.err?.length ? (
           <ValueContainer>{renderTagValue()}</ValueContainer>
         ) : tagInQuery ? (
-          <Tooltip title={t('This tag is in the current filter conditions')}>
+          <StyledTooltip title={t('This tag is in the current filter conditions')}>
             <ValueContainer>{renderTagValue()}</ValueContainer>
-          </Tooltip>
+          </StyledTooltip>
         ) : (
           <StyledTooltip title={renderTagValue()}>
             <Link to={target || ''}>{renderTagValue()}</Link>

--- a/static/app/components/tagsTableRow.tsx
+++ b/static/app/components/tagsTableRow.tsx
@@ -69,4 +69,5 @@ const ValueContainer = styled('span')`
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: normal;
 `;


### PR DESCRIPTION
Fixes some tags overflowing out of table cell
<img width="343" alt="image" src="https://user-images.githubusercontent.com/83961295/185455627-0f411ea0-f0b6-48d3-a0a1-14b2a5204ad6.png">
