### PR TITLE
fix(dashboard-filters): Pin selected releases at top of menu

### DIFF
--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -12,7 +12,6 @@ import {Location} from 'history';
 import cloneDeep from 'lodash/cloneDeep';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
-import omit from 'lodash/omit';
 
 import {validateWidget} from 'sentry/actionCreators/dashboards';
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -48,13 +47,7 @@ import {
   Position,
 } from './layoutUtils';
 import SortableWidget from './sortableWidget';
-import {
-  DashboardDetails,
-  DashboardFilterKeys,
-  DashboardWidgetSource,
-  Widget,
-  WidgetType,
-} from './types';
+import {DashboardDetails, DashboardWidgetSource, Widget, WidgetType} from './types';
 import {getDashboardFiltersFromURL} from './utils';
 
 export const DRAG_HANDLE_CLASS = 'widget-drag';
@@ -408,10 +401,7 @@ class Dashboard extends Component<Props, State> {
       onEdit: this.handleEditWidget(widget, index),
       onDuplicate: this.handleDuplicateWidget(widget, index),
       isPreview,
-      dashboardFilters: omit(
-        getDashboardFiltersFromURL(location) ?? dashboard.filters,
-        DashboardFilterKeys.RELEASE_ID
-      ),
+      dashboardFilters: getDashboardFiltersFromURL(location) ?? dashboard.filters,
     };
 
     if (organization.features.includes('dashboard-grid-layout')) {

--- a/static/app/views/dashboardsV2/releasesSelectControl.tsx
+++ b/static/app/views/dashboardsV2/releasesSelectControl.tsx
@@ -51,6 +51,8 @@ function ReleasesSelectControl({
     t('All Releases')
   );
 
+  const activeReleasesSet = new Set(activeReleases);
+
   return (
     <CompactSelect
       multiple
@@ -75,12 +77,18 @@ function ReleasesSelectControl({
           options: releases.length
             ? [
                 ...ALIASED_RELEASES,
-                ...releases.map(release => {
-                  return {
-                    label: release.shortVersion ?? release.version,
-                    value: release.version,
-                  };
-                }),
+                ...activeReleases
+                  .filter(version => version !== 'latest')
+                  .map(version => ({
+                    label: version,
+                    value: version,
+                  })),
+                ...releases
+                  .filter(({version}) => !activeReleasesSet.has(version))
+                  .map(({version}) => ({
+                    label: version,
+                    value: version,
+                  })),
               ]
             : [],
         },
@@ -88,19 +96,8 @@ function ReleasesSelectControl({
       onChange={opts => setActiveReleases(opts.map(opt => opt.value))}
       onClose={() => {
         resetSearch();
-        const activeReleasesVersions = new Set(activeReleases);
-
-        const activeReleasesById = releases
-          .filter(release => activeReleasesVersions.has(release.version))
-          .map(release => release.id);
-
-        if (activeReleasesVersions.has('latest')) {
-          activeReleasesById.push('latest');
-        }
-
         handleChangeFilter?.({
           [DashboardFilterKeys.RELEASE]: activeReleases,
-          [DashboardFilterKeys.RELEASE_ID]: activeReleasesById,
         });
       }}
       value={activeReleases}

--- a/static/app/views/dashboardsV2/types.tsx
+++ b/static/app/views/dashboardsV2/types.tsx
@@ -78,12 +78,10 @@ export type DashboardListItem = {
 
 export enum DashboardFilterKeys {
   RELEASE = 'release',
-  RELEASE_ID = 'releaseId',
 }
 
 export type DashboardFilters = {
   [DashboardFilterKeys.RELEASE]?: string[];
-  [DashboardFilterKeys.RELEASE_ID]?: string[];
 };
 
 /**

--- a/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
@@ -1548,5 +1548,65 @@ describe('Dashboards > Detail', function () {
         })
       );
     });
+
+    it('sets releaseId in query params when release filter was selected during search', async function () {
+      // Default response
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/releases/',
+        body: [
+          TestStubs.Release({
+            shortVersion: 'sentry-android-shop@1.2.0',
+            version: 'sentry-android-shop@1.2.0',
+          }),
+        ],
+      });
+      // Mocked search results
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/releases/',
+        body: [
+          TestStubs.Release({
+            id: '9',
+            shortVersion: 'search-result',
+            version: 'search-result',
+          }),
+        ],
+        match: [MockApiClient.matchData({query: 's'})],
+      });
+      const testData = initializeOrg({
+        organization: TestStubs.Organization({
+          features: [
+            'global-views',
+            'dashboards-basic',
+            'dashboards-edit',
+            'discover-basic',
+            'discover-query',
+            'dashboard-grid-layout',
+            'dashboards-top-level-filter',
+          ],
+        }),
+        router: {
+          location: TestStubs.location(),
+        },
+      });
+      render(
+        <ViewEditDashboard
+          organization={testData.organization}
+          params={{orgId: 'org-slug', dashboardId: '1'}}
+          router={testData.router}
+          location={testData.router.location}
+        />,
+        {context: testData.routerContext, organization: testData.organization}
+      );
+
+      userEvent.click(await screen.findByText('All Releases'));
+      userEvent.type(screen.getByText('Search\u2026'), 's');
+      await act(async () => {
+        userEvent.click(await screen.findByText('search-result'));
+      });
+
+      // Validate that after search is cleared, search result still appears
+      await screen.findByText('Latest Release(s)');
+      screen.getByTestId('search-result');
+    });
   });
 });

--- a/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/gridLayout/detail.spec.jsx
@@ -1549,7 +1549,7 @@ describe('Dashboards > Detail', function () {
       );
     });
 
-    it('sets releaseId in query params when release filter was selected during search', async function () {
+    it('persists release selections made during search requests that do not appear in default query', async function () {
       // Default response
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/releases/',

--- a/tests/js/spec/views/dashboardsV2/releasesSelectControl.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/releasesSelectControl.spec.tsx
@@ -100,4 +100,21 @@ describe('Dashboards > ReleasesSelectControl', function () {
     userEvent.click(document.body);
     await waitFor(() => expect(mockOnSearch).toBeCalledWith(''));
   });
+
+  it('triggers handleChangeFilter with the release versions', function () {
+    const mockHandleChangeFilter = jest.fn();
+    renderReleasesSelect({handleChangeFilter: mockHandleChangeFilter});
+    expect(screen.getByText('All Releases')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('All Releases'));
+    userEvent.click(screen.getByText('Latest Release(s)'));
+    userEvent.click(screen.getByText('sentry-android-shop@1.2.0'));
+    userEvent.click(screen.getByText('sentry-android-shop@1.4.0'));
+
+    userEvent.click(document.body);
+
+    expect(mockHandleChangeFilter).toHaveBeenCalledWith({
+      release: ['latest', 'sentry-android-shop@1.2.0', 'sentry-android-shop@1.4.0'],
+    });
+  });
 });

--- a/tests/js/spec/views/dashboardsV2/releasesSelectControl.spec.tsx
+++ b/tests/js/spec/views/dashboardsV2/releasesSelectControl.spec.tsx
@@ -100,22 +100,4 @@ describe('Dashboards > ReleasesSelectControl', function () {
     userEvent.click(document.body);
     await waitFor(() => expect(mockOnSearch).toBeCalledWith(''));
   });
-
-  it('triggers handleChangeFilter with the release versions and IDs', function () {
-    const mockHandleChangeFilter = jest.fn();
-    renderReleasesSelect({handleChangeFilter: mockHandleChangeFilter});
-    expect(screen.getByText('All Releases')).toBeInTheDocument();
-
-    userEvent.click(screen.getByText('All Releases'));
-    userEvent.click(screen.getByText('Latest Release(s)'));
-    userEvent.click(screen.getByText('sentry-android-shop@1.2.0'));
-    userEvent.click(screen.getByText('sentry-android-shop@1.4.0'));
-
-    userEvent.click(document.body);
-
-    expect(mockHandleChangeFilter).toHaveBeenCalledWith({
-      release: ['latest', 'sentry-android-shop@1.2.0', 'sentry-android-shop@1.4.0'],
-      releaseId: ['1', '3', 'latest'],
-    });
-  });
 });


### PR DESCRIPTION
Manually inject selected releases into the selector underneath `Latest Release(s)`.
We've dropped adding `releaseId` because we won't be using it for any requests
this time, and the releases endpoint doesn't query by ID, only by version which we
already have available.