### PR TITLE
feat(replays): Upgrade `@sentry/replay` to better capture replay upload errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@sentry/node": "7.11.0",
     "@sentry/react": "7.11.0",
     "@sentry/release-parser": "^1.3.1",
-    "@sentry/replay": "0.5.3",
+    "@sentry/replay": "0.5.4",
     "@sentry/tracing": "7.11.0",
     "@sentry/utils": "7.11.0",
     "@testing-library/jest-dom": "^5.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,10 +2323,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-1.3.1.tgz#0ab8be23fd494d80dd0e4ec8ae5f3d13f805b13d"
   integrity sha512-/dGpCq+j3sJhqQ14RNEEL45Ot/rgq3jAlZDD/8ufeqq+W8p4gUhSrbGWCRL82NEIWY9SYwxYXGXjRcVPSHiA1Q==
 
-"@sentry/replay@0.5.3":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-0.5.3.tgz#ea9a4b1ff3c3696c793ca8ab5a7f3767bfb4d9a4"
-  integrity sha512-QVNkp7O5m80cJUoeTic9SZbydsup3ANXw5cj9KlmVpEcvOGL4FAkRvEchxDF6p2+gTAi+gxyr/BMzpG6d4jSSg==
+"@sentry/replay@0.5.4":
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-0.5.4.tgz#c7e52ac1df719eb6307ef431b3f3c4a6d543cbc4"
+  integrity sha512-ofyQiX3aRkIL77q72gDv+zLSHcmY0NCjuVDicsjvnaNEMkJ4oy7E6ZoX6QDRwEY1EoDagGMzRJqpmL+kMqVvrQ==
   dependencies:
     "@sentry/core" "^7.7.0"
     "@sentry/types" "^7.7.0"


### PR DESCRIPTION
This should better help us diagnose client side issues when uploading replays.
