### PR TITLE
ref(perf): Don't use 'mark.<vital>' for drawing web vitals in event details

### DIFF
--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -14,6 +14,7 @@ import {Organization} from 'sentry/types';
 import {EntryType, EventTransaction} from 'sentry/types/event';
 import {assert} from 'sentry/types/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {WebVital} from 'sentry/utils/fields';
 import {TraceError} from 'sentry/utils/performance/quickTrace/types';
 import {WEB_VITAL_DETAILS} from 'sentry/utils/performance/vitals/constants';
 import {getPerformanceTransaction} from 'sentry/utils/performanceForSentry';
@@ -512,6 +513,7 @@ export const durationlessBrowserOps = ['mark', 'paint'];
 
 type Measurements = {
   [name: string]: {
+    failedThreshold: boolean;
     timestamp: number;
     value: number | undefined;
   };
@@ -541,18 +543,29 @@ export function getMeasurements(
   event: EventTransaction,
   generateBounds: (bounds: SpanBoundsType) => SpanGeneratedBoundsType
 ): Map<number, VerticalMark> {
-  if (!event.measurements) {
+  if (!event.measurements || !event.startTimestamp) {
     return new Map();
   }
 
+  const {startTimestamp} = event;
+
+  // Note: CLS and INP should not be included here, since they are not timeline-based measurements.
+  const allowedVitals = new Set<string>([
+    WebVital.FCP,
+    WebVital.FP,
+    WebVital.FID,
+    WebVital.LCP,
+    WebVital.TTFB,
+  ]);
+
   const measurements = Object.keys(event.measurements)
-    .filter(name => name.startsWith('mark.'))
+    .filter(name => allowedVitals.has(`measurements.${name}`))
     .map(name => {
-      const slug = name.slice('mark.'.length);
-      const associatedMeasurement = event.measurements![slug];
+      const associatedMeasurement = event.measurements![name];
       return {
         name,
-        timestamp: event.measurements![name].value,
+        // Time timestamp is in seconds, but the measurement value is given in ms so convert it here
+        timestamp: startTimestamp + associatedMeasurement.value / 1000,
         value: associatedMeasurement ? associatedMeasurement.value : undefined,
       };
     });
@@ -560,7 +573,7 @@ export function getMeasurements(
   const mergedMeasurements = new Map<number, VerticalMark>();
 
   measurements.forEach(measurement => {
-    const name = measurement.name.slice('mark.'.length);
+    const name = measurement.name;
     const value = measurement.value;
 
     const bounds = generateBounds({
@@ -584,11 +597,14 @@ export function getMeasurements(
       if (positionDelta <= MERGE_LABELS_THRESHOLD_PERCENT) {
         const verticalMark = mergedMeasurements.get(otherPos)!;
 
+        const {poorThreshold} = WEB_VITAL_DETAILS[`measurements.${name}`];
+
         verticalMark.marks = {
           ...verticalMark.marks,
           [name]: {
             value,
             timestamp: measurement.timestamp,
+            failedThreshold: value ? value >= poorThreshold : false,
           },
         };
 
@@ -601,8 +617,14 @@ export function getMeasurements(
       }
     }
 
+    const {poorThreshold} = WEB_VITAL_DETAILS[`measurements.${name}`];
+
     const marks = {
-      [name]: {value, timestamp: measurement.timestamp},
+      [name]: {
+        value,
+        timestamp: measurement.timestamp,
+        failedThreshold: value ? value >= poorThreshold : false,
+      },
     };
 
     mergedMeasurements.set(roundedPos, {
@@ -610,6 +632,7 @@ export function getMeasurements(
       failedThreshold: hasFailedThreshold(marks),
     });
   });
+
   return mergedMeasurements;
 }
 

--- a/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/spans/traceView.spec.tsx
@@ -734,9 +734,9 @@ describe('TraceView', () => {
     generateSampleSpan('browser', 'test5', 'f000000000000000', 'a000000000000000', event);
 
     event.measurements = {
-      'mark.fcp': {value: 1000},
-      'mark.fp': {value: 1050},
-      'mark.lcp': {value: 1100},
+      fcp: {value: 1000},
+      fp: {value: 1050},
+      lcp: {value: 1100},
     };
 
     const waterfallModel = new WaterfallModel(event);
@@ -758,9 +758,12 @@ describe('TraceView', () => {
     const event = generateSampleEvent();
     generateSampleSpan('browser', 'test1', 'b000000000000000', 'a000000000000000', event);
 
+    event.startTimestamp = 1;
+    event.endTimestamp = 100;
+
     event.measurements = {
-      'mark.fcp': {value: 1000},
-      'mark.lcp': {value: 200000000},
+      fcp: {value: 858.3002090454102, unit: 'millisecond'},
+      lcp: {value: 1000363.800048828125, unit: 'millisecond'},
     };
 
     const waterfallModel = new WaterfallModel(event);


### PR DESCRIPTION
As mentioned in https://github.com/getsentry/sentry-javascript/pull/5605, mark measurements use up quota for custom measurements, so this PR refactors the Event Details view to not be dependent on them.

The timestamp for these web vitals is now being calculated on the frontend instead of taken from the `mark` measurements sent by the SDK.