### PR TITLE
feat(replays): Negatively score replays sub 5 sec

### DIFF
--- a/static/app/components/replays/replayHighlight.tsx
+++ b/static/app/components/replays/replayHighlight.tsx
@@ -20,6 +20,11 @@ function ReplayHighlight({replay}: Props) {
     const pagesVisitedOverTime = pagesVisited / (duration || 1);
 
     score = (countErrors * 25 + pagesVisited * 5 + pagesVisitedOverTime) / 10;
+
+    if (duration <= 5) {
+      score = score - 10 / duration;
+    }
+
     score = Math.floor(Math.min(10, Math.max(1, score)));
   }
 

--- a/static/app/components/replays/replayHighlight.tsx
+++ b/static/app/components/replays/replayHighlight.tsx
@@ -20,9 +20,9 @@ function ReplayHighlight({replay}: Props) {
     const pagesVisitedOverTime = pagesVisited / (duration || 1);
 
     score = (countErrors * 25 + pagesVisited * 5 + pagesVisitedOverTime) / 10;
-
+    // negatively score sub 5 second replays
     if (duration <= 5) {
-      score = score - 10 / duration;
+      score = score - 10 / (duration || 1);
     }
 
     score = Math.floor(Math.min(10, Math.max(1, score)));


### PR DESCRIPTION


<!-- Describe your PR here. -->
Added a substraction for the score result if the replay has 5 secs or less. Closes #38005


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
