### PR TITLE
fix/docs(backend): Change statsPeriod to timeframe in docs + minor backend fixes (API-2880)

### DIFF
--- a/api-docs/paths/releases/sessions.json
+++ b/api-docs/paths/releases/sessions.json
@@ -79,7 +79,7 @@
         }
       },
       {
-        "name": "statsPeriod",
+        "name": "timeframe",
         "in": "query",
         "description": "This defines the range of the time series, relative to now.\n\nThe range is given in a `\"<number><unit>\"` format.\n\nFor example `1d` for a one day range. Possible units are `m` for minutes, `h` for hours, `d` for days and `w` for weeks.\n\nIt defaults to `90d`.",
         "required": false,
@@ -88,19 +88,19 @@
       {
         "name": "interval",
         "in": "query",
-        "description": "This is the resolution of the time series, given in the same format as `statsPeriod`.\n\nThe default resolution is `1h` and the minimum resolution is currently restricted to `1h` as well.\n\nIntervals larger than `1d` are not supported, and the interval has to cleanly divide one day.",
+        "description": "This is the resolution of the time series, given in the same format as `timeframe`.\n\nThe default resolution is `1h` and the minimum resolution is currently restricted to `1h` as well.\n\nIntervals larger than `1d` are not supported, and the interval has to cleanly divide one day.",
         "required": false,
         "schema": {"type": "string"}
       },
       {
-        "name": "statsPeriodStart",
+        "name": "timeframeStart",
         "in": "query",
         "description": "This defines the start of the time series range, in the same format as the `interval`, relative to now.",
         "required": false,
         "schema": {"type": "string"}
       },
       {
-        "name": "statsPeriodEnd",
+        "name": "timeframeEnd",
         "in": "query",
         "description": "This defines the end of the time series range, in the same format as the `interval`, relative to now.",
         "required": false,

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -113,7 +113,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):  # type: ignore
 
     def quantize_date_params(self, request: Request, params: Dict[str, Any]) -> Dict[str, Any]:
         # We only need to perform this rounding on relative date periods
-        if "statsPeriod" not in request.GET:
+        # support old statsPeriod and new timeframe param
+        if not ([i for i in ["statsPeriod", "timeframe"] if i in request.GET]):
             return params
         results = params.copy()
         duration = (params["end"] - params["start"]).total_seconds()

--- a/src/sentry/api/bases/organizationissues.py
+++ b/src/sentry/api/bases/organizationissues.py
@@ -20,7 +20,7 @@ class OrganizationIssuesEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
         """
         Return a list of issues assigned to the given member.
         """
-        stats_period = request.GET.get("statsPeriod", request.GET.get("timeframe"))
+        stats_period = request.GET.get("timeframe", request.GET.get("statsPeriod"))
         if stats_period not in (None, "", "24h", "14d"):
             return Response({"detail": ERR_INVALID_TIMEFRAME}, status=400)
         elif stats_period is None:

--- a/src/sentry/api/bases/organizationissues.py
+++ b/src/sentry/api/bases/organizationissues.py
@@ -8,7 +8,7 @@ from sentry.models import Group, GroupStatus, OrganizationMemberTeam, Project, P
 
 from .organizationmember import OrganizationMemberEndpoint
 
-ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
+ERR_INVALID_TIMEFRAME = "Invalid timeframe. Valid choices are '', '24h', and '14d'"
 
 
 class OrganizationIssuesEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
@@ -20,9 +20,9 @@ class OrganizationIssuesEndpoint(OrganizationMemberEndpoint, EnvironmentMixin):
         """
         Return a list of issues assigned to the given member.
         """
-        stats_period = request.GET.get("statsPeriod")
+        stats_period = request.GET.get("statsPeriod", request.GET.get("timeframe"))
         if stats_period not in (None, "", "24h", "14d"):
-            return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
+            return Response({"detail": ERR_INVALID_TIMEFRAME}, status=400)
         elif stats_period is None:
             # default
             stats_period = "24h"

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -201,7 +201,7 @@ class OrganizationEventsEndpoint(OrganizationEventsV2EndpointBase):
             GLOBAL_PARAMS.ORG_SLUG,
             GLOBAL_PARAMS.PROJECT,
             GLOBAL_PARAMS.START,
-            GLOBAL_PARAMS.STATS_PERIOD,
+            GLOBAL_PARAMS.TIMEFRAME,
             VISIBILITY_PARAMS.FIELD,
             VISIBILITY_PARAMS.PER_PAGE,
             VISIBILITY_PARAMS.QUERY,

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -19,7 +19,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models import Project, ProjectStatus, Team
 from sentry.search.utils import tokenize_query
 
-ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', '14d', and '30d'"
+ERR_INVALID_TIMEFRAME = "Invalid timeframe. Valid choices are '', '24h', '14d', and '30d'"
 
 
 @extend_schema(tags=["Organizations"])
@@ -82,11 +82,11 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         """
         Return a list of projects bound to a organization.
         """
-        stats_period = request.GET.get("statsPeriod")
+        stats_period = request.GET.get("statsPeriod", request.GET.get("timeframe"))
         collapse = request.GET.getlist("collapse", [])
         if stats_period not in (None, "", "1h", "24h", "7d", "14d", "30d"):
             return Response(
-                {"error": {"params": {"stats_period": {"message": ERR_INVALID_STATS_PERIOD}}}},
+                {"error": {"params": {"timeframe": {"message": ERR_INVALID_TIMEFRAME}}}},
                 status=400,
             )
         elif not stats_period:

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -82,7 +82,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         """
         Return a list of projects bound to a organization.
         """
-        stats_period = request.GET.get("statsPeriod", request.GET.get("timeframe"))
+        stats_period = request.GET.get("timeframe", request.GET.get("statsPeriod"))
         collapse = request.GET.getlist("collapse", [])
         if stats_period not in (None, "", "1h", "24h", "7d", "14d", "30d"):
             return Response(

--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -33,18 +33,18 @@ class OrgStatsQueryParamsSerializer(serializers.Serializer):
     # TODO: refactor endpoint and use this to validate query parameters.
     # TODO: define fields for date parameters for use elsewhere
     # time params
-    statsPeriod = serializers.CharField(
+    timeframe = serializers.CharField(
         help_text=(
             "This defines the range of the time series, relative to now. "
             "The range is given in a `<number><unit>` format. "
             "For example `1d` for a one day range. Possible units are `m` for minutes, `h` for hours, `d` for days and `w` for weeks."
-            "You must either provide a `statsPeriod`, or a `start` and `end`."
+            "You must either provide a `timeframe`, or a `start` and `end`."
         ),
         required=False,
     )
     interval = serializers.CharField(
         help_text=(
-            "This is the resolution of the time series, given in the same format as `statsPeriod`. "
+            "This is the resolution of the time series, given in the same format as `timeframe`. "
             "The default resolution is `1h` and the minimum resolution is currently restricted to `1h` as well. "
             "Intervals larger than `1d` are not supported, and the interval has to cleanly divide one day."
         ),
@@ -52,13 +52,13 @@ class OrgStatsQueryParamsSerializer(serializers.Serializer):
     )
     start = serializers.DateTimeField(
         help_text="This defines the start of the time series range as an explicit datetime, either in UTC ISO8601 or epoch seconds."
-        "Use along with `end` instead of `statsPeriod`.",
+        "Use along with `end` instead of `timeframe`.",
         required=False,
     )
     end = serializers.DateTimeField(
         help_text=(
             "This defines the inclusive end of the time series range as an explicit datetime, either in UTC ISO8601 or epoch seconds."
-            "Use along with `start` instead of `statsPeriod`."
+            "Use along with `start` instead of `timeframe`."
         ),
         required=False,
     )

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -18,8 +18,8 @@ class GLOBAL_PARAMS:
         type=str,
         location="path",
     )
-    STATS_PERIOD = OpenApiParameter(
-        name="statsPeriod",
+    TIMEFRAME = OpenApiParameter(
+        name="timeframe",
         location="query",
         required=False,
         type=str,


### PR DESCRIPTION
Changes `statsPeriod` to `timeframe` in the docs where appropriate. Adds some slight additional logic to honor the new param.

Continues and completes work on https://github.com/getsentry/sentry/pull/37627 and https://github.com/getsentry/sentry/issues/36375