### PR TITLE
fix(replays): remove dashes on snuba queries

### DIFF
--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -16,10 +16,10 @@ def assert_expected_response(
         if isinstance(response_value, list):
             assert len(response_value) == len(value), f'"{response_value}" "{value}"'
             for item in response_value:
-                assert item in value
+                assert item in value, f"{key}, {item}"
                 value.remove(item)
         else:
-            assert response_value == value, f'"{response_value}" "{value}"'
+            assert response_value == value, f'"{key}, {response_value}" "{value}"'
 
     # Ensure no lingering unexpected keys exist.
     assert list(response.keys()) == []
@@ -38,12 +38,12 @@ def mock_expected_response(
         "title": kwargs.pop("title", "Title"),
         "projectId": str(project_id),
         "urls": urls,
-        "errorIds": kwargs.pop("error_ids", []),
-        "traceIds": kwargs.pop("trace_ids", []),
+        "errorIds": kwargs.pop("error_ids", ["a3a62ef6ac86415b83c2416fc2f76db1"]),
+        "traceIds": kwargs.pop("trace_ids", ["4491657243ba4dbebd2f6bd62b733080"]),
         "startedAt": datetime.datetime.strftime(started_at, "%Y-%m-%dT%H:%M:%S+00:00"),
         "finishedAt": datetime.datetime.strftime(finished_at, "%Y-%m-%dT%H:%M:%S+00:00"),
         "duration": (finished_at - started_at).seconds,
-        "countErrors": kwargs.pop("count_errors", 0),
+        "countErrors": kwargs.pop("count_errors", 1),
         "countSegments": kwargs.pop("count_segments", 1),
         "countUrls": len(urls),
         "longestTransaction": kwargs.pop("longest_transaction", 0),
@@ -103,8 +103,12 @@ def mock_replay(
                             "transaction": kwargs.pop("title", "Title"),
                         },
                         "urls": kwargs.pop("urls", []),
-                        "error_ids": kwargs.pop("error_ids", []),
-                        "trace_ids": kwargs.pop("trace_ids", []),
+                        "error_ids": kwargs.pop(
+                            "error_ids", ["a3a62ef6-ac86-415b-83c2-416fc2f76db1"]
+                        ),
+                        "trace_ids": kwargs.pop(
+                            "trace_ids", ["44916572-43ba-4dbe-bd2f-6bd62b733080"]
+                        ),
                         "dist": kwargs.pop("dist", "abc123"),
                         "platform": kwargs.pop("platform", "javascript"),
                         "timestamp": int(timestamp.timestamp()),

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -37,7 +37,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         """Test replays conform to the interchange format."""
         project = self.create_project(teams=[self.team])
 
-        replay1_id = str(uuid.uuid4())
+        replay1_id = uuid.uuid4().hex
         seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=22)
         seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=5)
         self.store_replays(
@@ -52,7 +52,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 urls=[
                     "http://localhost:3000/",
                     "http://localhost:3000/login",
-                ],  # duplicate urls are okay
+                ],  # duplicate urls are okay,
             )
         )
         self.store_replays(
@@ -86,7 +86,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 ],
                 count_segments=2,
                 # count_errors=3,
-                count_errors=0,
+                count_errors=1,
             )
             assert_expected_response(response_data["data"][0], expected_response)
 
@@ -94,8 +94,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         """Test returned replays must have a substantive duration."""
         project = self.create_project(teams=[self.team])
 
-        replay1_id = str(uuid.uuid4())
-        replay2_id = str(uuid.uuid4())
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
         replay1_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=15)
         replay1_timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=10)
         replay2_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=10)
@@ -118,7 +118,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         """Test returned replays can not partially fall outside of range."""
         project = self.create_project(teams=[self.team])
 
-        replay1_id = str(uuid.uuid4())
+        replay1_id = uuid.uuid4().hex
         replay1_timestamp0 = datetime.datetime.now() - datetime.timedelta(days=365)
         replay1_timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=10)
 
@@ -140,8 +140,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         self.create_environment(name="development", project=self.project)
         self.create_environment(name="production", project=self.project)
 
-        replay1_id = str(uuid.uuid4())
-        replay2_id = str(uuid.uuid4())
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
         timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=20)
         timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=10)
 
@@ -161,7 +161,6 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         with self.feature(REPLAYS_FEATURES):
             response = self.client.get(self.url + "?environment=development")
             assert response.status_code == 200
-            print(response.content.decode("utf-8"))
 
             response_data = response.json()
             assert "data" in response_data
@@ -177,8 +176,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
     def test_get_replays_started_at_sorted(self):
         project = self.create_project(teams=[self.team])
 
-        replay1_id = str(uuid.uuid4())
-        replay2_id = str(uuid.uuid4())
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
         replay1_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=15)
         replay1_timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=5)
         replay2_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=10)
@@ -205,8 +204,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
     def test_get_replays_finished_at_sorted(self):
         project = self.create_project(teams=[self.team])
 
-        replay1_id = str(uuid.uuid4())
-        replay2_id = str(uuid.uuid4())
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
         replay1_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=15)
         replay1_timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=5)
         replay2_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=10)
@@ -234,8 +233,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         """Test replays can be sorted by duration."""
         project = self.create_project(teams=[self.team])
 
-        replay1_id = str(uuid.uuid4())
-        replay2_id = str(uuid.uuid4())
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
         replay1_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=15)
         replay1_timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=10)
         replay2_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=9)
@@ -263,8 +262,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
         """Test replays can be paginated."""
         project = self.create_project(teams=[self.team])
 
-        replay1_id = str(uuid.uuid4())
-        replay2_id = str(uuid.uuid4())
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
         replay1_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=15)
         replay1_timestamp1 = datetime.datetime.now() - datetime.timedelta(seconds=5)
         replay2_timestamp0 = datetime.datetime.now() - datetime.timedelta(seconds=10)

--- a/tests/sentry/replays/test_project_replay_details.py
+++ b/tests/sentry/replays/test_project_replay_details.py
@@ -15,7 +15,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.replay_id = uuid.uuid4()
+        self.replay_id = uuid.uuid4().hex
         self.url = reverse(
             self.endpoint, args=(self.organization.slug, self.project.slug, self.replay_id)
         )
@@ -31,8 +31,8 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
 
     def test_get_one_replay(self):
         """Test only one replay returned."""
-        replay1_id = str(self.replay_id)
-        replay2_id = str(uuid.uuid4())
+        replay1_id = self.replay_id
+        replay2_id = uuid.uuid4().hex
         seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=10)
         seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=5)
 
@@ -62,8 +62,8 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
 
     def test_get_replay_schema(self):
         """Test replay schema is well-formed."""
-        replay1_id = str(self.replay_id)
-        replay2_id = str(uuid.uuid4())
+        replay1_id = self.replay_id
+        replay2_id = uuid.uuid4().hex
         seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=25)
         seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=7)
         seq3_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=4)
@@ -78,7 +78,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 seq1_timestamp,
                 self.project.id,
                 replay1_id,
-                trace_ids=["ffb5344a-41dd-4b21-9288-187a2cd1ad6d"],
+                trace_ids=["ffb5344a41dd4b219288187a2cd1ad6d"],
                 urls=["http://localhost:3000/"],
             )
         )
@@ -88,7 +88,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 self.project.id,
                 replay1_id,
                 segment_id=1,
-                trace_ids=["2a0dcb0e-a1fb-4350-b266-47ae1aa57dfb"],
+                trace_ids=["2a0dcb0ea1fb4350b26647ae1aa57dfb"],
                 urls=["http://www.sentry.io/"],
             )
         )
@@ -98,6 +98,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 self.project.id,
                 replay1_id,
                 segment_id=2,
+                trace_ids=["2a0dcb0ea1fb4350b26647ae1aa57dfb"],
                 urls=["http://localhost:3000/"],
             )
         )
@@ -115,8 +116,8 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 seq1_timestamp,
                 seq3_timestamp,
                 trace_ids=[
-                    "ffb5344a-41dd-4b21-9288-187a2cd1ad6d",
-                    "2a0dcb0e-a1fb-4350-b266-47ae1aa57dfb",
+                    "ffb5344a41dd4b219288187a2cd1ad6d",
+                    "2a0dcb0ea1fb4350b26647ae1aa57dfb",
                 ],
                 urls=[
                     "http://localhost:3000/",

--- a/tests/sentry/replays/test_project_replay_details.py
+++ b/tests/sentry/replays/test_project_replay_details.py
@@ -78,7 +78,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 seq1_timestamp,
                 self.project.id,
                 replay1_id,
-                trace_ids=["ffb5344a41dd4b219288187a2cd1ad6d"],
+                trace_ids=["ffb5344a-41dd-4b21-9288-187a2cd1ad6d"],
                 urls=["http://localhost:3000/"],
             )
         )
@@ -88,7 +88,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 self.project.id,
                 replay1_id,
                 segment_id=1,
-                trace_ids=["2a0dcb0ea1fb4350b26647ae1aa57dfb"],
+                trace_ids=["2a0dcb0e-a1fb-4350-b2664-7ae1aa57dfb"],
                 urls=["http://www.sentry.io/"],
             )
         )
@@ -98,7 +98,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 self.project.id,
                 replay1_id,
                 segment_id=2,
-                trace_ids=["2a0dcb0ea1fb4350b26647ae1aa57dfb"],
+                trace_ids=["2a0dcb0e-a1fb-4350-b2664-7ae1aa57dfb"],
                 urls=["http://localhost:3000/"],
             )
         )
@@ -116,8 +116,8 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 seq1_timestamp,
                 seq3_timestamp,
                 trace_ids=[
+                    "2a0dcb0ea1fb4350b266f7ae1aa57dfb",
                     "ffb5344a41dd4b219288187a2cd1ad6d",
-                    "2a0dcb0ea1fb4350b26647ae1aa57dfb",
                 ],
                 urls=[
                     "http://localhost:3000/",


### PR DESCRIPTION
confirming with our other snuba endpoints, remove dashes from the replay_id, trace_ids, and error_ids.