### PR TITLE
fix(hybrid-cloud): Update customer domain middleware to support nameless routes

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -60,7 +60,7 @@ def _resolve_redirect_url(request, activeorg):
     kwargs = {**result.kwargs}
     if org_slug_path_mismatch:
         kwargs["organization_slug"] = activeorg
-    path = reverse(result.url_name, kwargs=kwargs)
+    path = reverse(result.url_name or result.func, kwargs=kwargs)
     qs = _query_string(request)
     redirect_url = f"{redirect_url}{path}{qs}"
     return redirect_url

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -444,7 +444,7 @@ urlpatterns += [
                     react_page_view,
                     name="sentry-organization-auth-settings",
                 ),
-                url(r"^(?P<organization_slug>[\w_-]+)/[\w_-]+/$", react_page_view),
+                url(r"^(?P<organization_slug>[\w_-]+)/(?P<sub_page>[\w_-]+)/$", react_page_view),
                 url(r"^", react_page_view),
             ]
         ),
@@ -552,7 +552,7 @@ urlpatterns += [
                     name="sentry-organization-disabled-member",
                 ),
                 # need to force these to React and ensure organization_slug is captured
-                url(r"^(?P<organization_slug>[\w_-]+)/[\w_-]+/", react_page_view),
+                url(r"^(?P<organization_slug>[\w_-]+)/(?P<sub_page>[\w_-]+)/", react_page_view),
             ]
         ),
     ),

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -444,7 +444,11 @@ urlpatterns += [
                     react_page_view,
                     name="sentry-organization-auth-settings",
                 ),
-                url(r"^(?P<organization_slug>[\w_-]+)/(?P<sub_page>[\w_-]+)/$", react_page_view),
+                url(
+                    r"^(?P<organization_slug>[\w_-]+)/(?P<sub_page>[\w_-]+)/$",
+                    react_page_view,
+                    name="sentry-organization-sub-page-settings",
+                ),
                 url(r"^", react_page_view),
             ]
         ),
@@ -552,7 +556,11 @@ urlpatterns += [
                     name="sentry-organization-disabled-member",
                 ),
                 # need to force these to React and ensure organization_slug is captured
-                url(r"^(?P<organization_slug>[\w_-]+)/(?P<sub_page>[\w_-]+)/", react_page_view),
+                url(
+                    r"^(?P<organization_slug>[\w_-]+)/(?P<sub_page>[\w_-]+)/",
+                    react_page_view,
+                    name="sentry-organization-sub-page",
+                ),
             ]
         ),
     ),

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -401,6 +401,8 @@ class End2EndTest(APITestCase):
                 HTTP_HOST="albertos-apples.testserver",
                 follow=True,
             )
+            assert response.status_code == 200
+            assert response.redirect_chain == [("/api/0/albertos-apples/nameless/", 302)]
             assert response.data == {
                 "organization_slug": "albertos-apples",
                 "subdomain": "albertos-apples",

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -146,6 +146,10 @@ urlpatterns = [
         OrganizationTestEndpoint.as_view(),
         name="org-events-endpoint",
     ),
+    url(
+        r"^api/0/(?P<organization_slug>[^\/]+)/nameless/$",
+        OrganizationTestEndpoint.as_view(),
+    ),
 ]
 
 
@@ -387,3 +391,20 @@ class End2EndTest(APITestCase):
             }
             assert "activeorg" in self.client.session
             assert self.client.session["activeorg"] == "test"
+
+    def test_with_middleware_and_nameless_view(self):
+        self.create_organization(name="albertos-apples")
+
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
+            response = self.client.get(
+                "/api/0/some-org/nameless/",
+                HTTP_HOST="albertos-apples.testserver",
+                follow=True,
+            )
+            assert response.data == {
+                "organization_slug": "albertos-apples",
+                "subdomain": "albertos-apples",
+                "activeorg": "albertos-apples",
+            }
+            assert "activeorg" in self.client.session
+            assert self.client.session["activeorg"] == "albertos-apples"


### PR DESCRIPTION
We have some routes that are nameless. According to Django docs for `reverse()`, I can pass a callable view object in place of a route name: https://docs.djangoproject.com/en/4.1/ref/urlresolvers/#reverse

In addition, I've given some URL parameter names to some routes as `resolve()` will match the appropriate route, but will discard any anonymous URL parameter values. 