### PR TITLE
feat(api-gateway): Initial code for the API Gateway

### DIFF
--- a/src/sentry/api_gateway/__init__.py
+++ b/src/sentry/api_gateway/__init__.py
@@ -1,0 +1,3 @@
+from .api_gateway import proxy_request_if_needed
+
+__all__ = ("proxy_request_if_needed",)

--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+
+def proxy_request_if_needed(request: Request) -> Response | None:
+    """
+    Main execution flow for the API Gateway
+    returns None if proxying is not required
+    """
+    return None

--- a/src/sentry/middleware/api_gateway.py
+++ b/src/sentry/middleware/api_gateway.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api_gateway import proxy_request_if_needed
+
+
+def api_gateway_middleware(
+    get_response: Callable[[Request], Response]
+) -> Callable[[Request], Response]:
+    def middleware(request: Request) -> Response:
+        proxy_response = proxy_request_if_needed(request)
+        return proxy_response if proxy_response is not None else get_response(request)
+
+    return middleware

--- a/tests/sentry/api_gateway/test_api_gateway.py
+++ b/tests/sentry/api_gateway/test_api_gateway.py
@@ -1,0 +1,14 @@
+from django.test.client import RequestFactory
+
+from sentry.api_gateway import proxy_request_if_needed
+from sentry.testutils import TestCase
+
+
+class ApiGatewayTest(TestCase):
+    def setUp(self):
+        self.control_url = "https://sentry.io/api/v1/users/johndoe"
+        self.customer_url = "https://sentry.io/api/v1/organizations/members/sentry/johndoe"
+
+    def test_simple(self):
+        request = RequestFactory().get(self.control_url)
+        assert proxy_request_if_needed(request) is None


### PR DESCRIPTION
Sets up the structure for what the API gateway will look like. We want all the logic for the proxying to be in a separate module in case we decide to run the gateway as it's own micro-service.

