### PR TITLE
Revert "ref: use uwsgi-dogstatsd-plugin pip package"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ ENV \
   # Thank to https://stackoverflow.com/a/25260588/90297
   UWSGI_PROFILE_OVERRIDE=ssl=false;xml=false;routing=false \
   # UWSGI dogstatsd plugin
-  UWSGI_NEED_PLUGIN=/usr/local/lib/dogstatsd_plugin.so \
+  UWSGI_NEED_PLUGIN=/var/lib/uwsgi/dogstatsd \
   # grpcio>1.30.0 requires this, see requirements.txt for more detail.
   GRPC_POLL_STRATEGY=epoll1
 
@@ -51,9 +51,10 @@ ENV \
 COPY /dist/requirements-frozen.txt /tmp/requirements-frozen.txt
 RUN set -x \
   && buildDeps="" \
-  # c deps
+  # uwsgi
   && buildDeps="$buildDeps \
   gcc \
+  wget \
   " \
   # maxminddb
   && buildDeps="$buildDeps \
@@ -67,7 +68,13 @@ RUN set -x \
   && apt-get update \
   && apt-get install -y --no-install-recommends $buildDeps \
   && pip install -r /tmp/requirements-frozen.txt \
-  && rm -f /tmp/requirements-frozen.txt \
+  && mkdir /tmp/uwsgi-dogstatsd \
+  && wget -O - https://github.com/eventbrite/uwsgi-dogstatsd/archive/filters-and-tags.tar.gz | \
+  tar -xzf - -C /tmp/uwsgi-dogstatsd --strip-components=1 \
+  && UWSGI_NEED_PLUGIN="" uwsgi --build-plugin /tmp/uwsgi-dogstatsd \
+  && mkdir -p /var/lib/uwsgi \
+  && mv dogstatsd_plugin.so /var/lib/uwsgi/ \
+  && rm -rf /tmp/requirements-frozen.txt /tmp/uwsgi-dogstatsd .uwsgi_plugins_builder \
   && apt-get purge -y --auto-remove $buildDeps \
   # We install run-time dependencies strictly after
   # build dependencies to prevent accidental collusion.

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -69,7 +69,6 @@ brotli>=1.0.9
 # See if we can remove LDFLAGS from lib.sh
 # https://github.com/getsentry/sentry/pull/30094
 uWSGI==2.0.20.0
-uwsgi-dogstatsd-plugin>=1.0.0
 zstandard>=0.18.0
 
 msgpack>=1.0.4

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -175,7 +175,6 @@ unidiff==0.7.4
 uritemplate==4.1.1
 urllib3==1.26.11
 uwsgi==2.0.20.0
-uwsgi-dogstatsd-plugin==1.0.0
 vine==1.3.0
 virtualenv==20.14.1
 websocket-client==1.3.2

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -119,7 +119,6 @@ unidiff==0.7.4
 uritemplate==4.1.1
 urllib3==1.26.11
 uwsgi==2.0.20.0
-uwsgi-dogstatsd-plugin==1.0.0
 vine==1.3.0
 wsproto==1.1.0
 xmlsec==1.3.11


### PR DESCRIPTION
Reverts getsentry/sentry#38027

this ended up not working -- the plugin needs to be built against the specific abi of whatever uwsgi is compiled against