### PR TITLE
feat(profiling): Add new feature flag for open beta

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -991,6 +991,7 @@ SENTRY_FEATURES = {
     "organizations:performance-view": True,
     # Enable profiling
     "organizations:profiling": False,
+    "organizations:profiling-beta": False,
     # Enable multi project selection
     "organizations:global-views": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -128,6 +128,7 @@ default_manager.add(
 )
 default_manager.add("organizations:performance-extraneous-spans-poc", OrganizationFeature, True)
 default_manager.add("organizations:profiling", OrganizationFeature, True)
+default_manager.add("organizations:profiling-beta", OrganizationFeature)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)
 default_manager.add("organizations:related-events", OrganizationFeature)
 default_manager.add("organizations:release-comparison-performance", OrganizationFeature, True)


### PR DESCRIPTION
For the open beta, we need a new feature flag that is not tied to flagr for the
list orgs to enable profiling for.