### PR TITLE
fix(dashboard-filters): Pass timerange to release request

### DIFF
--- a/static/app/utils/releases/releasesProvider.tsx
+++ b/static/app/utils/releases/releasesProvider.tsx
@@ -2,6 +2,7 @@ import {createContext, useContext, useEffect, useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {Client} from 'sentry/api';
+import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {t} from 'sentry/locale';
 import {Organization, PageFilters, Release} from 'sentry/types';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
@@ -14,7 +15,7 @@ function fetchReleases(
   selection: PageFilters,
   search: string
 ) {
-  const {environments, projects} = selection;
+  const {environments, projects, datetime} = selection;
 
   return api.requestPromise(`/organizations/${orgSlug}/releases/`, {
     method: 'GET',
@@ -24,6 +25,7 @@ function fetchReleases(
       per_page: 50,
       environment: environments,
       query: search,
+      ...normalizeDateTimeParams(datetime),
     },
   });
 }


### PR DESCRIPTION
We weren't passing our time range selection to the release request,
so it would always show the 50 most recent release results.