### PR TITLE
ref(profiling): Do no use entity handler for profiling flag

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -126,7 +126,7 @@ default_manager.add(
     "organizations:performance-transaction-name-only-search", OrganizationFeature, True
 )
 default_manager.add("organizations:performance-extraneous-spans-poc", OrganizationFeature, True)
-default_manager.add("organizations:profiling", OrganizationFeature, True)
+default_manager.add("organizations:profiling", OrganizationFeature)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)
 default_manager.add("organizations:related-events", OrganizationFeature)
 default_manager.add("organizations:release-committer-assignees", OrganizationFeature, True)


### PR DESCRIPTION
The entity handler is not suitable for the profiling flag as we add more orgs,
moving to a regular feature handler. See getsentry/getsentry#8148.