### PR TITLE
fix(replays): Improve console hovering so it can be more informative

### DIFF
--- a/static/app/utils/replays/getBreadcrumb.tsx
+++ b/static/app/utils/replays/getBreadcrumb.tsx
@@ -4,9 +4,11 @@ export function getPrevBreadcrumb({
   crumbs,
   targetTimestampMs,
   allowExact = false,
+  allowEqual = false,
 }: {
   crumbs: Crumb[];
   targetTimestampMs: number;
+  allowEqual?: boolean;
   allowExact?: boolean;
 }) {
   return crumbs.reduce<Crumb | undefined>((prev, crumb) => {
@@ -18,7 +20,12 @@ export function getPrevBreadcrumb({
     ) {
       return prev;
     }
-    if (!prev || crumbTimestampMS > +new Date(prev.timestamp || '')) {
+    if (
+      !prev ||
+      (allowEqual
+        ? crumbTimestampMS >= +new Date(prev.timestamp || '')
+        : crumbTimestampMS > +new Date(prev.timestamp || ''))
+    ) {
       return crumb;
     }
     return prev;

--- a/static/app/views/replays/detail/console/consoleMessage.tsx
+++ b/static/app/views/replays/detail/console/consoleMessage.tsx
@@ -114,6 +114,7 @@ export function MessageFormatter({breadcrumb}: MessageFormatterProps) {
 interface ConsoleMessageProps extends MessageFormatterProps {
   hasOccurred: boolean;
   isActive: boolean;
+  isCurrent: boolean;
   isLast: boolean;
   startTimestampMs: number;
 }
@@ -122,6 +123,7 @@ function ConsoleMessage({
   isActive = false,
   hasOccurred,
   isLast,
+  isCurrent,
   startTimestampMs = 0,
 }: ConsoleMessageProps) {
   const ICONS = {
@@ -142,6 +144,7 @@ function ConsoleMessage({
         isLast={isLast}
         level={breadcrumb.level}
         isActive={isActive}
+        isCurrent={isCurrent}
         hasOccurred={hasOccurred}
         onMouseOver={handleOnMouseOver}
         onMouseOut={handleOnMouseOut}
@@ -150,6 +153,8 @@ function ConsoleMessage({
       </Icon>
       <Message
         isLast={isLast}
+        isActive={isActive}
+        isCurrent={isCurrent}
         level={breadcrumb.level}
         hasOccurred={hasOccurred}
         onMouseOver={handleOnMouseOver}
@@ -161,6 +166,8 @@ function ConsoleMessage({
       </Message>
       <ConsoleTimestamp
         isLast={isLast}
+        isCurrent={isCurrent}
+        isActive={isActive}
         level={breadcrumb.level}
         hasOccurred={hasOccurred}
       >
@@ -179,10 +186,13 @@ function ConsoleMessage({
 }
 
 const Common = styled('div')<{
+  isActive: boolean;
+  isCurrent: boolean;
   isLast: boolean;
   level: string;
   hasOccurred?: boolean;
 }>`
+  position: relative;
   background-color: ${p =>
     ['warning', 'error'].includes(p.level)
       ? p.theme.alert[p.level].backgroundLight
@@ -218,6 +228,25 @@ const Common = styled('div')<{
   &:nth-last-child(3) {
     border-bottom-left-radius: 3px;
   }
+
+  &:after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+    height: 2px;
+    width: 100%;
+    background-color: ${p => {
+      if (p.isActive) {
+        return p.theme.purple200;
+      }
+      if (p.isCurrent) {
+        return p.theme.purple300;
+      }
+      return 'transparent';
+    }};
+  }
 `;
 
 const ConsoleTimestamp = styled(Common)`
@@ -229,20 +258,10 @@ const ConsoleTimestampButton = styled('button')`
   border: none;
 `;
 
-const Icon = styled(Common)<{isActive: boolean}>`
+const Icon = styled(Common)`
   padding: ${space(0.5)} ${space(1)};
   position: relative;
 
-  &:after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 1;
-    height: 100%;
-    width: ${space(0.5)};
-    background-color: ${p => (p.isActive ? p.theme.focus : 'transparent')};
-  }
   &:nth-child(1):after {
     border-top-left-radius: 3px;
   }

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -42,6 +42,7 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
     crumbs: breadcrumbs,
     targetTimestampMs: startTimestampMs + currentTime,
     allowExact: true,
+    allowEqual: true,
   });
 
   const closestUserAction =
@@ -50,6 +51,7 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
           crumbs: breadcrumbs,
           targetTimestampMs: startTimestampMs + (currentHoverTime ?? 0),
           allowExact: true,
+          allowEqual: true,
         })
       : undefined;
 

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -38,6 +38,12 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
     [logLevel, searchTerm, breadcrumbs]
   );
 
+  const currentUserAction = getPrevBreadcrumb({
+    crumbs: breadcrumbs,
+    targetTimestampMs: startTimestampMs + currentTime,
+    allowExact: true,
+  });
+
   const closestUserAction =
     currentHoverTime !== undefined
       ? getPrevBreadcrumb({
@@ -72,6 +78,7 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
             return (
               <ConsoleMessage
                 isActive={closestUserAction?.id === breadcrumb.id}
+                isCurrent={currentUserAction?.id === breadcrumb.id}
                 startTimestampMs={startTimestampMs}
                 key={breadcrumb.id}
                 isLast={i === breadcrumbs.length - 1}


### PR DESCRIPTION

<!-- Describe your PR here. -->
Second approach which aims to close #36014. 

### Changes
- Changed hovering behavior so it now shows a bottom line - indicating those console messages that have occurred before it.
- Added new bottom line to the active console message - indicating which messages have occurred before it.



https://user-images.githubusercontent.com/39612839/185672559-06607d3d-4742-4823-9bf8-4a7f55b5ee97.mp4




<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
