### PR TITLE
feat(active-release) cleanup feature flags for active release notifications

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -948,8 +948,8 @@ SENTRY_FEATURES = {
     "auth:register": True,
     # Workflow 2.0 Alpha Functionality for sentry users only
     "organizations:active-release-monitor-alpha": False,
-    # Workflow 2.0 Experimental ReleaseMembers who opt-in to get notified as a release committer
-    "organizations:active-release-notification-opt-in": False,
+    # Workflow 2.0 Active Release Notifications
+    "organizations:active-release-notifications-enable": False,
     # Enable advanced search features, like negation and wildcard matching.
     "organizations:advanced-search": True,
     # Use metrics as the dataset for crash free metric alerts
@@ -1165,8 +1165,6 @@ SENTRY_FEATURES = {
     "organizations:team-insights": True,
     # Enable setting team-level roles and receiving permissions from them
     "organizations:team-roles": False,
-    # Enable sending Active release notifications without creating an explicit rule in DB
-    "projects:active-release-monitor-default-on": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -58,7 +58,7 @@ default_manager.add("organizations:create")
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:active-release-monitor-alpha", OrganizationFeature, True)
-default_manager.add("organizations:active-release-notification-opt-in", OrganizationFeature, True)
+default_manager.add("organizations:active-release-notifications-enable", OrganizationFeature, True)
 default_manager.add("organizations:alert-filters", OrganizationFeature)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, True)
 default_manager.add("organizations:api-keys", OrganizationFeature)
@@ -193,7 +193,6 @@ default_manager.add("organizations:sso-saml2", OrganizationFeature)
 default_manager.add("organizations:team-insights", OrganizationFeature)
 
 # Project scoped features
-default_manager.add("projects:active-release-monitor-default-on", ProjectFeature)
 default_manager.add("projects:alert-filters", ProjectFeature)
 default_manager.add("projects:custom-inbound-filters", ProjectFeature)
 default_manager.add("projects:data-forwarding", ProjectFeature)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -58,7 +58,7 @@ default_manager.add("organizations:create")
 
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:active-release-monitor-alpha", OrganizationFeature, True)
-default_manager.add("organizations:active-release-notifications-enable", OrganizationFeature, True)
+default_manager.add("organizations:active-release-notifications-enable", OrganizationFeature)
 default_manager.add("organizations:alert-filters", OrganizationFeature)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, True)
 default_manager.add("organizations:api-keys", OrganizationFeature)

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -303,27 +303,6 @@ class NotificationsManager(BaseManager["NotificationSetting"]):
         notification_settings_by_recipient = transform_to_notification_settings_by_recipient(
             notification_settings, recipients
         )
-        # XXX(gilbert): remove this when organizations:active-release-notification-opt-in is removed
-        # injects the notification settings since no Notification settings will exist in the db
-        from sentry import features
-        from sentry.models import Organization, User
-
-        if isinstance(parent, Organization):
-            notification_settings_by_recipient = dict(notification_settings_by_recipient)
-            for user_recipient in filter(lambda x: isinstance(x, User), recipients):
-                if type == NotificationSettingTypes.ACTIVE_RELEASE and features.has(
-                    "organizations:active-release-notification-opt-in",
-                    parent,
-                    actor=user_recipient,
-                ):
-                    notification_settings_by_recipient[user_recipient] = {
-                        {
-                            NotificationScopeType.USER: {
-                                ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS,
-                                ExternalProviders.SLACK: NotificationSettingOptionValues.ALWAYS,
-                            }
-                        }
-                    }
 
         mapping = defaultdict(set)
         for recipient in recipients:

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -319,27 +319,16 @@ def _get_release_committers(
     # commit_author_id : Author
     author_users: Mapping[str, Author] = get_users_for_commits(commits)
 
+    release_committers = list(
+        User.objects.filter(id__in={au["id"] for au in author_users.values() if au.get("id")})
+    )
     # TODO(scttcper): Remove this after the experiment
     if release_dry_run:
-        return list(
-            User.objects.filter(id__in={au["id"] for au in author_users.values() if au.get("id")})
-        )
+        return release_committers
 
-    # XXX(gilbert): this is inefficient since this evaluates flagr once per user
-    # it should be ok since this method should only be called for projects within sentry
-    # do not copy this unless you know the risk; you've been warned!
-    return list(
-        filter(
-            lambda u: features.has(
-                "organizations:active-release-notification-opt-in", release.organization, actor=u
-            ),
-            list(
-                User.objects.filter(
-                    id__in={au["id"] for au in author_users.values() if au.get("id")}
-                )
-            ),
-        )
-    )
+    if features.has("organizations:active-release-notifications-enable", release.organization):
+        return release_committers
+    return []
 
 
 def get_send_to(

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -340,7 +340,9 @@ class RuleProcessor:
             self._get_active_release_rule_actions(),
             1,
             1,
-            not features.has("projects:active-release-monitor-default-on", self.project),
+            not features.has(
+                "organizations:active-release-notifications-enable", self.project.organization
+            ),
         )
 
         return self.grouped_futures.values()

--- a/src/sentry/tasks/release_summary.py
+++ b/src/sentry/tasks/release_summary.py
@@ -7,7 +7,6 @@ from sentry.models import Activity, Release, ReleaseActivity, ReleaseCommit
 from sentry.notifications.notifications.activity.release_summary import (
     ActiveReleaseSummaryNotification,
 )
-from sentry.notifications.utils.participants import _get_release_committers
 from sentry.tasks.base import instrumented_task
 from sentry.types.activity import ActivityType
 from sentry.types.releaseactivity import ReleaseActivityType
@@ -34,10 +33,9 @@ def prepare_release_summary():
         if not release_has_commits:
             continue
 
-        # Check if any participants are members of the feature flag
-        # TODO(workflow): can remove with active-release-notification-opt-in
-        participants = _get_release_committers(release)
-        if not participants:
+        if not features.has(
+            "organizations:active-release-notifications-enable", release.organization
+        ):
             continue
 
         # Find the activity created in Deploy.notify_if_ready

--- a/tests/sentry/integrations/slack/notifications/test_active_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_active_release.py
@@ -62,7 +62,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_notify_user(self, mock_func, mock_get_release_committers):
         mock_get_release_committers.return_value = [self.user]
-        with self.tasks(), self.feature("projects:active-release-monitor-default-on"):
+        with self.tasks(), self.feature("organizations:active-release-notifications-enable"):
             rp = RuleProcessor(
                 self.event,
                 is_new=True,

--- a/tests/sentry/mail/activity/test_release_summary.py
+++ b/tests/sentry/mail/activity/test_release_summary.py
@@ -47,7 +47,7 @@ class ReleaseSummaryTestCase(ActivityTestCase):
         self.commit2 = self.another_commit(1, "b", self.user2, repository)
 
     def test_simple(self):
-        with self.feature("organizations:active-release-notification-opt-in"):
+        with self.feature("organizations:active-release-notifications-enable"):
             release_summary = ActiveReleaseSummaryNotification(
                 Activity(
                     project=self.project,

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -197,7 +197,7 @@ class GetSentToReleaseMembersTest(TestCase):
     def test_default_committer(self, spy_get_release_committers):
         event = self.store_event("empty.lol")
         event.group = self.group
-        with self.feature("organizations:active-release-notification-opt-in"):
+        with self.feature("organizations:active-release-notifications-enable"):
             assert self.get_send_to_release_members(event) == {
                 ExternalProviders.EMAIL: {self.user},
                 ExternalProviders.SLACK: {self.user},

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -483,7 +483,7 @@ class RuleProcessorActiveReleaseTest(TestCase):
     @mock.patch("sentry.notifications.utils.participants.get_release_committers")
     def test_default_notification_setting_off(self, mock_get_release_committers):
         mock_get_release_committers.return_value = [self.user]
-        with self.tasks(), self.feature("projects:active-release-monitor-default-on"):
+        with self.tasks(), self.feature("organizations:active-release-notifications-enable"):
             mail.outbox = []
             rp = RuleProcessor(
                 self.event,
@@ -506,7 +506,7 @@ class RuleProcessorActiveReleaseTest(TestCase):
             user=self.user,
             project=self.project,
         )
-        with self.tasks(), self.feature("projects:active-release-monitor-default-on"):
+        with self.tasks(), self.feature("organizations:active-release-notifications-enable"):
             mail.outbox = []
             rp = RuleProcessor(
                 self.event,
@@ -545,7 +545,7 @@ class RuleProcessorActiveReleaseTest(TestCase):
                 ],
             },
         )
-        with self.tasks(), self.feature("projects:active-release-monitor-default-on"):
+        with self.tasks(), self.feature("organizations:active-release-notifications-enable"):
             mail.outbox = []
             rp = RuleProcessor(
                 self.event,
@@ -583,7 +583,7 @@ class RuleProcessorActiveReleaseTest(TestCase):
         )
 
         mock_get_release_committers.return_value = [self.user, user2]
-        with self.tasks(), self.feature("projects:active-release-monitor-default-on"):
+        with self.tasks(), self.feature("organizations:active-release-notifications-enable"):
             mail.outbox = []
             rp = RuleProcessor(
                 self.event,
@@ -603,7 +603,9 @@ class RuleProcessorActiveReleaseTest(TestCase):
     @mock.patch("sentry.analytics.record")
     def test_active_release_disabled(self, mock_record, mock_get_release_committers):
         mock_get_release_committers.return_value = [self.user]
-        with self.tasks(), self.feature({"projects:active-release-monitor-default-on": False}):
+        with self.tasks(), self.feature(
+            {"organizations:active-release-notifications-enable": False}
+        ):
             mail.outbox = []
             rp = RuleProcessor(
                 self.event,

--- a/tests/sentry/tasks/test_release_summary.py
+++ b/tests/sentry/tasks/test_release_summary.py
@@ -48,7 +48,7 @@ class SendReleaseSummaryTest(ActivityTestCase):
         "sentry.notifications.notifications.activity.release_summary.ActiveReleaseSummaryNotification.send"
     )
     def test_simple(self, mock_release_summary_send):
-        with self.feature("organizations:active-release-notification-opt-in"):
+        with self.feature("organizations:active-release-notifications-enable"):
             prepare_release_summary()
 
         assert len(mock_release_summary_send.mock_calls) == 1


### PR DESCRIPTION
Cleanup feature flags for release notifications:

* Remove `organizations:active-release-notification-opt-in`, removing per-user access.
* Replace `projects:active-release-monitor-default-on` with `organizations:active-release-notifications-enable`

With this change, `organizations:active-release-notifications-enable` is main flag to add organizations for release notifications. `organizations:active-release-monitor-alpha` is still around and should be the only other flag related to release notifications.

Fixes WOR-2072