### PR TITLE
ref(profiling): Move profiling beneath performance in sidebar

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -320,12 +320,12 @@ function Sidebar({location, organization}: Props) {
                 {projects}
                 {issues}
                 {performance}
+                {profiling}
                 {releases}
                 {userFeedback}
                 {alerts}
                 {discover2}
                 {dashboards}
-                {profiling}
               </SidebarSection>
 
               <SidebarSection>


### PR DESCRIPTION
As we get closer to the open beta for profiling, we want to move the profiling
tab higher for better visibility. Here it is moved directly under performance.