### PR TITLE
Revert "fix(active-release): change over ReleaseSummaryActivityNotifi…

### DIFF
--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -73,7 +73,6 @@ class NotificationSetting(Model):
             (NotificationSettingTypes.DEPLOY, "deploy"),
             (NotificationSettingTypes.ISSUE_ALERTS, "issue"),
             (NotificationSettingTypes.WORKFLOW, "workflow"),
-            (NotificationSettingTypes.ACTIVE_RELEASE, "activeRelease"),
             (NotificationSettingTypes.APPROVAL, "approval"),
             (NotificationSettingTypes.QUOTA, "quota"),
             (NotificationSettingTypes.QUOTA_ERRORS, "quotaErrors"),

--- a/src/sentry/notifications/notifications/active_release.py
+++ b/src/sentry/notifications/notifications/active_release.py
@@ -113,7 +113,7 @@ class ActiveReleaseIssueNotification(AlertRuleNotification):
             "users_seen": self.group.count_users_seen(),
             "event": self.event,
             "link": get_group_settings_link(
-                group, environment, rule_details=None, referrer="alert_email_release"
+                self.group, environment, rule_details=None, referrer="alert_email_release"
             ),
             "has_integrations": has_integrations(self.organization, self.project),
             "enhanced_privacy": enhanced_privacy,
@@ -127,6 +127,7 @@ class ActiveReleaseIssueNotification(AlertRuleNotification):
             if self.event_state and self.event_state.is_regression
             else False,
         }
+
         # if the organization has enabled enhanced privacy controls we don't send
         # data which may show PII or source code
         if not enhanced_privacy:

--- a/src/sentry/notifications/notifications/activity/release_summary.py
+++ b/src/sentry/notifications/notifications/activity/release_summary.py
@@ -31,9 +31,9 @@ from sentry.utils.http import absolute_uri
 from .base import ActivityNotification
 
 
-class ActiveReleaseSummaryNotification(ActivityNotification):
+class ReleaseSummaryActivityNotification(ActivityNotification):
     metrics_key = "release_summary"
-    notification_setting_type = NotificationSettingTypes.ACTIVE_RELEASE
+    notification_setting_type = NotificationSettingTypes.DEPLOY
     template_path = "sentry/emails/activity/release_summary"
 
     def __init__(self, activity: Activity) -> None:
@@ -76,12 +76,7 @@ class ActiveReleaseSummaryNotification(ActivityNotification):
     def get_participants_with_group_subscription_reason(
         self,
     ) -> Mapping[ExternalProviders, Mapping[Team | User, int]]:
-        return get_participants_for_release(
-            self.projects,
-            self.organization,
-            self.user_ids,
-            self.notification_setting_type,
-        )
+        return get_participants_for_release(self.projects, self.organization, self.user_ids)
 
     def get_users_by_teams(self) -> Mapping[int, list[int]]:
         if not self.user_id_team_lookup:

--- a/src/sentry/tasks/release_summary.py
+++ b/src/sentry/tasks/release_summary.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from sentry import features
 from sentry.models import Activity, Release, ReleaseActivity, ReleaseCommit
 from sentry.notifications.notifications.activity.release_summary import (
-    ActiveReleaseSummaryNotification,
+    ReleaseSummaryActivityNotification,
 )
 from sentry.notifications.utils.participants import _get_release_committers
 from sentry.tasks.base import instrumented_task
@@ -55,7 +55,7 @@ def prepare_release_summary():
         if not activity:
             continue
 
-        release_summary = ActiveReleaseSummaryNotification(activity)
+        release_summary = ReleaseSummaryActivityNotification(activity)
         release_summary.send()
         if features.has("organizations:active-release-monitor-alpha", release.organization):
             ReleaseActivity.objects.create(

--- a/tests/sentry/mail/activity/test_release_summary.py
+++ b/tests/sentry/mail/activity/test_release_summary.py
@@ -2,15 +2,11 @@ from urllib.parse import quote
 
 from django.core import mail
 
-from sentry.models import Activity, Environment, NotificationSetting, Repository
+from sentry.models import Activity, Environment, Repository
 from sentry.notifications.notifications.activity.release_summary import (
-    ActiveReleaseSummaryNotification,
+    ReleaseSummaryActivityNotification,
 )
-from sentry.notifications.types import (
-    GroupSubscriptionReason,
-    NotificationSettingOptionValues,
-    NotificationSettingTypes,
-)
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.testutils.cases import ActivityTestCase
 from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
@@ -48,7 +44,7 @@ class ReleaseSummaryTestCase(ActivityTestCase):
 
     def test_simple(self):
         with self.feature("organizations:active-release-notification-opt-in"):
-            release_summary = ActiveReleaseSummaryNotification(
+            release_summary = ReleaseSummaryActivityNotification(
                 Activity(
                     project=self.project,
                     user=self.user1,
@@ -57,30 +53,12 @@ class ReleaseSummaryTestCase(ActivityTestCase):
                 )
             )
 
-        assert NotificationSetting.objects.all().count() == 0
-
-        # opt-in to getting active_release notifications
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.ACTIVE_RELEASE,
-            NotificationSettingOptionValues.ALWAYS,
-            user=self.user1,
-            project=self.project,
-        )
-        assert (
-            NotificationSetting.objects.all()[0].type
-            == NotificationSettingTypes.ACTIVE_RELEASE.value
-        )
-
-        recipient_by_parent = NotificationSetting.objects.get_for_recipient_by_parent(
-            NotificationSettingTypes.ACTIVE_RELEASE, self.project, [self.user1, self.user2]
-        )
-        assert len(recipient_by_parent) == 1
-
         # user1 is included because they committed
-        participants = release_summary.get_participants_with_group_subscription_reason()
-        assert len(participants[ExternalProviders.EMAIL]) == 1
-        assert participants[ExternalProviders.EMAIL] == {
+        participants = release_summary.get_participants_with_group_subscription_reason()[
+            ExternalProviders.EMAIL
+        ]
+        assert len(participants) == 1
+        assert participants == {
             self.user1: GroupSubscriptionReason.committed,
         }
 

--- a/tests/sentry/tasks/test_release_summary.py
+++ b/tests/sentry/tasks/test_release_summary.py
@@ -45,7 +45,7 @@ class SendReleaseSummaryTest(ActivityTestCase):
         self.commit1 = self.another_commit(0, "a", self.user1, repository)
 
     @patch(
-        "sentry.notifications.notifications.activity.release_summary.ActiveReleaseSummaryNotification.send"
+        "sentry.notifications.notifications.activity.release_summary.ReleaseSummaryActivityNotification.send"
     )
     def test_simple(self, mock_release_summary_send):
         with self.feature("organizations:active-release-notification-opt-in"):
@@ -54,7 +54,7 @@ class SendReleaseSummaryTest(ActivityTestCase):
         assert len(mock_release_summary_send.mock_calls) == 1
 
     @patch(
-        "sentry.notifications.notifications.activity.release_summary.ActiveReleaseSummaryNotification.send"
+        "sentry.notifications.notifications.activity.release_summary.ReleaseSummaryActivityNotification.send"
     )
     def test_without_feature_flag(self, mock_release_summary_send):
         prepare_release_summary()


### PR DESCRIPTION
…cation to use the new notification settings (#37316)"

This reverts commit 8e0f5c14784aa5e08a6588b54737fbbb663730a0.

I have been receiving summaries of active release notifications for every BE and FE release.