### PR TITLE
fix(issues): Omit host from issue polling endpoint to fix problems in local dev

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -695,7 +695,9 @@ class IssueListOverview extends Component<Props, State> {
       // Remove collapse stats from endpoint before supplying to poller
       const issueEndpoint = new URL(links.previous.href, window.location.origin);
       issueEndpoint.searchParams.delete('collapse');
-      this._poller.setEndpoint(decodeURIComponent(issueEndpoint.href));
+      this._poller.setEndpoint(
+        decodeURIComponent(issueEndpoint.pathname + issueEndpoint.search)
+      );
       this._poller.enable();
     }
   };

--- a/tests/js/spec/views/issueList/overview.polling.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.polling.spec.jsx
@@ -144,7 +144,7 @@ describe('IssueList -> Polling', function () {
       body: [groupStats],
     });
     pollRequest = MockApiClient.addMockResponse({
-      url: `http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
+      url: `/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
       body: [],
       headers: {
         Link: DEFAULT_LINKS_HEADER,
@@ -197,7 +197,7 @@ describe('IssueList -> Polling', function () {
 
   it('stops polling for new issues when endpoint returns a 401', async function () {
     pollRequest = MockApiClient.addMockResponse({
-      url: `http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
+      url: `/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
       body: [],
       statusCode: 401,
     });
@@ -217,7 +217,7 @@ describe('IssueList -> Polling', function () {
 
   it('stops polling for new issues when endpoint returns a 403', async function () {
     pollRequest = MockApiClient.addMockResponse({
-      url: `http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
+      url: `/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
       body: [],
       statusCode: 403,
     });
@@ -238,7 +238,7 @@ describe('IssueList -> Polling', function () {
 
   it('stops polling for new issues when endpoint returns a 404', async function () {
     pollRequest = MockApiClient.addMockResponse({
-      url: `http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
+      url: `/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
       body: [],
       statusCode: 404,
     });


### PR DESCRIPTION
It was impossible to test the issues page realtime polling because:

- For `yarn dev:ui` and in the PR deployments it would be blocked by CORS
- When running everything locally, it would return a 401

Omitting the host solves both these issues.