### PR TITLE
fix(issues): Make sure host is always omitted for issues polling

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -183,9 +183,8 @@ class IssueListOverview extends Component<Props, State> {
   }
 
   componentDidMount() {
-    const links = parseLinkHeader(this.state.pageLinks);
     this._poller = new CursorPoller({
-      endpoint: links.previous?.href || '',
+      linkPreviousHref: parseLinkHeader(this.state.pageLinks)?.previous?.href,
       success: this.onRealtimePoll,
     });
 
@@ -692,12 +691,7 @@ class IssueListOverview extends Component<Props, State> {
     // Only resume polling if we're on the first page of results
     const links = parseLinkHeader(this.state.pageLinks);
     if (links && !links.previous.results && this.state.realtimeActive) {
-      // Remove collapse stats from endpoint before supplying to poller
-      const issueEndpoint = new URL(links.previous.href, window.location.origin);
-      issueEndpoint.searchParams.delete('collapse');
-      this._poller.setEndpoint(
-        decodeURIComponent(issueEndpoint.pathname + issueEndpoint.search)
-      );
+      this._poller.setEndpoint(links?.previous?.href);
       this._poller.enable();
     }
   };


### PR DESCRIPTION
Followup to https://github.com/getsentry/sentry/pull/38065

The endpoint actually gets set within `CursorPoller` when it finds more issues in the last poll, so this makes sure that the endpoint is always set without the host (by moving the logic to `CursorPoller`). Without this change the poll would work up until it found something. Then it would revert to giving CORS errors (in local dev).