### PR TITLE
ref(perf_issues): Remove `group` paramater from `EventStream.insert`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -983,7 +983,6 @@ def _eventstream_insert_many(jobs):
             )
 
         eventstream.insert(
-            group=job["group"],
             event=job["event"],
             is_new=job["is_new"],
             is_regression=job["is_regression"],

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -60,7 +60,6 @@ class EventStream(Service):
 
     def insert(
         self,
-        group,
         event,
         is_new,
         is_regression,

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -45,7 +45,6 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def _get_headers_for_insert(
         self,
-        group,
         event,
         is_new,
         is_regression,
@@ -94,7 +93,6 @@ class KafkaEventStream(SnubaProtocolEventStream):
         else:
             return {
                 **super()._get_headers_for_insert(
-                    group,
                     event,
                     is_new,
                     is_regression,
@@ -107,7 +105,6 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def insert(
         self,
-        group,
         event,
         is_new,
         is_regression,
@@ -131,7 +128,6 @@ class KafkaEventStream(SnubaProtocolEventStream):
             kwargs[KW_SKIP_SEMANTIC_PARTITIONING] = True
 
         return super().insert(
-            group,
             event,
             is_new,
             is_regression,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -78,7 +78,6 @@ class SnubaProtocolEventStream(EventStream):
 
     def _get_headers_for_insert(
         self,
-        group,
         event,
         is_new,
         is_regression,
@@ -95,7 +94,6 @@ class SnubaProtocolEventStream(EventStream):
 
     def insert(
         self,
-        group,
         event,
         is_new,
         is_regression,
@@ -120,7 +118,6 @@ class SnubaProtocolEventStream(EventStream):
             logger.error("%r received unexpected tags: %r", self, unexpected_tags)
 
         headers = self._get_headers_for_insert(
-            group,
             event,
             is_new,
             is_regression,
@@ -366,7 +363,6 @@ class SnubaEventStream(SnubaProtocolEventStream):
 
     def insert(
         self,
-        group,
         event,
         is_new,
         is_regression,
@@ -377,7 +373,6 @@ class SnubaEventStream(SnubaProtocolEventStream):
         **kwargs,
     ):
         super().insert(
-            group,
             event,
             is_new,
             is_regression,

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1300,7 +1300,6 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
         # Ensure that the first event in the (group, environment) pair is
         # marked as being part of a new environment.
         eventstream_insert.assert_called_with(
-            group=event.group,
             event=event,
             is_new=True,
             is_regression=False,
@@ -1315,7 +1314,6 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
         # Ensure that the next event in the (group, environment) pair is *not*
         # marked as being part of a new environment.
         eventstream_insert.assert_called_with(
-            group=event.group,
             event=event,
             is_new=False,
             is_regression=None,  # XXX: wut

--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -58,7 +58,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
             self.project.id,
             "insert",
             (payload1, payload2),
-            is_transaction_event=insert_kwargs["group"] is None,
+            is_transaction_event=insert_kwargs["event"].group_id is None,
         )
 
     @patch("sentry.eventstream.insert")
@@ -72,7 +72,6 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         assert not insert_args
         assert insert_kwargs == {
             "event": event,
-            "group": event.group,
             "is_new_group_environment": True,
             "is_new": True,
             "is_regression": False,
@@ -100,7 +99,6 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         insert_args = ()
         insert_kwargs = {
             "event": event,
-            "group": None,
             "is_new_group_environment": True,
             "is_new": True,
             "is_regression": False,


### PR DESCRIPTION
This parameter is unused. Removing it to make usage clearer, and to simplify passing multiple group
ids with an event.