### PR TITLE
feat(perf-issues): introduce Grouptype-aware abstract methods for GroupSerializer stats data

### DIFF
--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -1,19 +1,35 @@
 from __future__ import annotations
 
 import functools
-from datetime import timedelta
+from abc import abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Mapping, MutableMapping, Optional, Sequence
 
 from django.utils import timezone
 
 from sentry import release_health, tsdb
-from sentry.api.serializers.models.group import GroupSerializer, GroupSerializerSnuba, snuba_tsdb
+from sentry.api.serializers.models.group import (
+    BaseGroupSerializerResponse,
+    GroupSerializer,
+    GroupSerializerSnuba,
+    SeenStats,
+    snuba_tsdb,
+)
 from sentry.constants import StatsPeriod
-from sentry.models import Environment
+from sentry.models import Environment, Group
 from sentry.models.groupinbox import get_inbox_details
 from sentry.models.groupowner import get_owner_details
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import hash_values
+
+
+@dataclass
+class GroupStatsQueryArgs:
+    stats_period: Optional[str]
+    stats_period_start: Optional[datetime]
+    stats_period_end: Optional[datetime]
 
 
 class GroupStatsMixin:
@@ -35,16 +51,21 @@ class GroupStatsMixin:
     CUSTOM_SEGMENTS_12H = 35  # for 12h 36 segments, otherwise 15-16-17 bars is too few
     CUSTOM_ROLLUP_6H = timedelta(hours=6).total_seconds()  # rollups should be increments of 6hs
 
-    def query_tsdb(self, group_ids, query_params):
-        raise NotImplementedError
+    @abstractmethod
+    def query_tsdb(self, group_ids: Sequence[int], query_params: MutableMapping[str, Any]):
+        pass
 
-    def get_stats(self, item_list, user, **kwargs):
-        if self.stats_period:
+    def get_stats(
+        self, item_list: Sequence[Group], user, stats_query_args: GroupStatsQueryArgs, **kwargs
+    ):
+        if stats_query_args and stats_query_args.stats_period:
             # we need to compute stats at 1d (1h resolution), and 14d or a custom given period
             group_ids = [g.id for g in item_list]
 
-            if self.stats_period == "auto":
-                total_period = (self.stats_period_end - self.stats_period_start).total_seconds()
+            if stats_query_args.stats_period == "auto":
+                total_period = (
+                    stats_query_args.stats_period_end - stats_query_args.stats_period_start
+                ).total_seconds()
                 if total_period < timedelta(hours=24).total_seconds():
                     rollup = total_period / self.CUSTOM_SEGMENTS
                 elif total_period < self.CUSTOM_SEGMENTS * self.CUSTOM_ROLLUP_CHOICES["1h"]:
@@ -66,12 +87,12 @@ class GroupStatsMixin:
                     rollup = round(total_period / (self.CUSTOM_SEGMENTS * delta_day)) * delta_day
 
                 query_params = {
-                    "start": self.stats_period_start,
-                    "end": self.stats_period_end,
+                    "start": stats_query_args.stats_period_start,
+                    "end": stats_query_args.stats_period_end,
                     "rollup": int(rollup),
                 }
             else:
-                segments, interval = self.STATS_PERIOD_CHOICES[self.stats_period]
+                segments, interval = self.STATS_PERIOD_CHOICES[stats_query_args.stats_period]
                 now = timezone.now()
                 query_params = {
                     "start": now - ((segments - 1) * interval),
@@ -103,17 +124,27 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
         self.matching_event_id = matching_event_id
         self.matching_event_environment = matching_event_environment
 
-    def get_attrs(self, item_list, user):
+    def get_attrs(
+        self, item_list: Sequence[Group], user: Any, **kwargs: Any
+    ) -> MutableMapping[Group, MutableMapping[str, Any]]:
         attrs = super().get_attrs(item_list, user)
 
         if self.stats_period:
-            stats = self.get_stats(item_list, user)
+            stats = self.get_stats(
+                item_list,
+                user,
+                GroupStatsQueryArgs(
+                    self.stats_period, self.stats_period_start, self.stats_period_end
+                ),
+            )
             for item in item_list:
                 attrs[item].update({"stats": stats[item.id]})
 
         return attrs
 
-    def serialize(self, obj, attrs, user):
+    def serialize(
+        self, obj: Group, attrs: MutableMapping[str, Any], user: Any, **kwargs: Any
+    ) -> BaseGroupSerializerResponse:
         result = super().serialize(obj, attrs, user)
 
         if self.stats_period:
@@ -148,7 +179,9 @@ class TagBasedStreamGroupSerializer(StreamGroupSerializer):
         super().__init__(**kwargs)
         self.tags = tags
 
-    def serialize(self, obj, attrs, user):
+    def serialize(
+        self, obj: Group, attrs: MutableMapping[str, Any], user: Any, **kwargs: Any
+    ) -> BaseGroupSerializerResponse:
         result = super().serialize(obj, attrs, user)
         result["tagLastSeen"] = self.tags[obj.id].last_seen
         result["tagFirstSeen"] = self.tags[obj.id].first_seen
@@ -190,7 +223,9 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         self.stats_period_end = stats_period_end
         self.matching_event_id = matching_event_id
 
-    def get_attrs(self, item_list, user):
+    def get_attrs(
+        self, item_list: Sequence[Group], user: Any, **kwargs: Any
+    ) -> MutableMapping[Group, MutableMapping[str, Any]]:
         if not self._collapse("base"):
             attrs = super().get_attrs(item_list, user)
         else:
@@ -202,7 +237,13 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
 
         if self.stats_period and not self._collapse("stats"):
             partial_get_stats = functools.partial(
-                self.get_stats, item_list=item_list, user=user, environment_ids=self.environment_ids
+                self.get_stats,
+                item_list=item_list,
+                user=user,
+                stats_query_args=GroupStatsQueryArgs(
+                    self.stats_period, self.stats_period_start, self.stats_period_end
+                ),
+                environment_ids=self.environment_ids,
             )
             stats = partial_get_stats()
             filtered_stats = (
@@ -271,7 +312,9 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
 
         return attrs
 
-    def serialize(self, obj, attrs, user):
+    def serialize(
+        self, obj: Group, attrs: MutableMapping[str, Any], user: Any, **kwargs: Any
+    ) -> BaseGroupSerializerResponse:
         if not self._collapse("base"):
             result = super().serialize(obj, attrs, user)
         else:
@@ -325,39 +368,46 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             **query_params,
         )
 
-    def _get_seen_stats(self, item_list, user):
-        if not self._collapse("stats"):
-            partial_execute_seen_stats_query = functools.partial(
-                self._execute_seen_stats_query,
-                item_list=item_list,
-                environment_ids=self.environment_ids,
-                start=self.start,
-                end=self.end,
+    def _seen_stats_error(self, error_issue_list: Sequence[Group], user) -> Mapping[Any, SeenStats]:
+        partial_execute_seen_stats_query = functools.partial(
+            self._execute_seen_stats_query,
+            item_list=error_issue_list,
+            environment_ids=self.environment_ids,
+            start=self.start,
+            end=self.end,
+        )
+        time_range_result = partial_execute_seen_stats_query()
+        filtered_result = (
+            partial_execute_seen_stats_query(conditions=self.conditions)
+            if self.conditions and not self._collapse("filtered")
+            else None
+        )
+        if not self._collapse("lifetime"):
+            lifetime_result = (
+                partial_execute_seen_stats_query(start=None, end=None)
+                if self.start or self.end
+                else time_range_result
             )
-            time_range_result = partial_execute_seen_stats_query()
-            filtered_result = (
-                partial_execute_seen_stats_query(conditions=self.conditions)
-                if self.conditions and not self._collapse("filtered")
-                else None
-            )
-            if not self._collapse("lifetime"):
-                lifetime_result = (
-                    partial_execute_seen_stats_query(start=None, end=None)
-                    if self.start or self.end
-                    else time_range_result
-                )
-            else:
-                lifetime_result = None
+        else:
+            lifetime_result = None
 
-            for item in item_list:
-                time_range_result[item].update(
-                    {
-                        "filtered": filtered_result.get(item) if filtered_result else None,
-                        "lifetime": lifetime_result.get(item) if lifetime_result else None,
-                    }
-                )
-            return time_range_result
-        return None
+        for item in error_issue_list:
+            time_range_result[item].update(
+                {
+                    "filtered": filtered_result.get(item) if filtered_result else None,
+                    "lifetime": lifetime_result.get(item) if lifetime_result else None,
+                }
+            )
+        return time_range_result
+
+    def _seen_stats_performance(
+        self, perf_issue_list: Sequence[Group], user
+    ) -> Mapping[Group, SeenStats]:
+        # TODO(gilbert): implement this to return real data
+        if perf_issue_list:
+            raise NotImplementedError
+
+        return {}
 
     def _build_session_cache_key(self, project_id):
         start_key = end_key = env_key = ""

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1678,6 +1678,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert "firstSeen" not in response.data[0]
         assert "lastSeen" not in response.data[0]
         assert "count" not in response.data[0]
+        assert "userCount" not in response.data[0]
         assert "lifetime" not in response.data[0]
         assert "filtered" not in response.data[0]
 

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -57,6 +57,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert "firstSeen" in response_data[0]
         assert "lastSeen" in response_data[0]
         assert "count" in response_data[0]
+        assert "userCount" in response_data[0]
         assert "lifetime" in response_data[0]
         assert "filtered" in response_data[0]
 


### PR DESCRIPTION
Split up of this [PR](https://github.com/getsentry/sentry/pull/37900)

To support Performance Issue Details, we need to update the various GroupSerializers to handle heterogeneous data appropriate for the group type. The current GroupSerializer assumes Issues are tightly coupled to errors. This PR attempts to separate the seams where we need to do issue type-specific stuff.

Things done:
- Introduce new abstractmethods `_seen_stats_error` and `_seen_stats_performance` to base class which will get called in the appropriate time to retrieve the stats data for a given list of issues based on type.
- Cleanup class design by marking methods as staticmethods. 
- Add as much type information as possible for clarity.