### PR TITLE
fix(issues): Apply all pending changes to groups

### DIFF
--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -24,7 +24,7 @@ type ChangeId = string;
 
 type Change = {
   data: any;
-  itemId: string;
+  itemIds: string[];
 };
 
 type Item = BaseGroup | Group | GroupCollapseRelease;
@@ -261,8 +261,10 @@ const storeConfig: GroupStoreDefinition = {
     const pendingById: Record<string, Change[]> = {};
 
     this.pendingChanges.forEach(change => {
-      const existing = pendingById[change.itemId] ?? [];
-      pendingById[change.itemId] = [...existing, change];
+      change.itemIds.forEach(itemId => {
+        const existing = pendingById[itemId] ?? [];
+        pendingById[itemId] = [...existing, change];
+      });
     });
 
     // Merge pending changes into the item if it has them
@@ -401,8 +403,8 @@ const storeConfig: GroupStoreDefinition = {
 
     ids.forEach(itemId => {
       this.addStatus(itemId, 'update');
-      this.pendingChanges.set(changeId, {itemId, data});
     });
+    this.pendingChanges.set(changeId, {itemIds: ids, data});
 
     this.trigger(new Set(ids));
   },

--- a/tests/js/spec/stores/groupStore.spec.tsx
+++ b/tests/js/spec/stores/groupStore.spec.tsx
@@ -149,6 +149,19 @@ describe('GroupStore', function () {
         expect(GroupStore.trigger).toHaveBeenCalledTimes(1);
         expect(GroupStore.trigger).toHaveBeenCalledWith(new Set(['1', '2', '3']));
       });
+      it('should apply optimistic updates', function () {
+        GroupStore.items = [g('1'), g('2')];
+        GroupStore.add([g('1'), g('2')]);
+
+        // Resolve 2 issues
+        const itemIds = ['1', '2'];
+        const data = {status: 'resolved', statusDetails: {}};
+        GroupStore.onUpdate('12345', itemIds, data);
+
+        expect(GroupStore.pendingChanges).toEqual(new Map([['12345', {itemIds, data}]]));
+        expect(GroupStore.get('1')).toEqual({...g('1'), ...data});
+        expect(GroupStore.get('2')).toEqual({...g('2'), ...data});
+      });
     });
 
     describe('onUpdateSuccess()', function () {


### PR DESCRIPTION
Apply pending changes to groups instead of just 1 group.

Fixes flakey test https://sentry.io/organizations/sentry/issues/3510409506