### PR TITLE
fix(perf): Remove snuba params from anomaly-detection-service API request

### DIFF
--- a/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
+++ b/src/sentry/api/endpoints/organization_transaction_anomaly_detection.py
@@ -113,7 +113,6 @@ class OrganizationTransactionAnomalyDetectionEndpoint(OrganizationEventsEndpoint
         datetime_format = "%Y-%m-%d %H:%M:%S"
         ads_request = {
             "query": query,
-            "params": query_params,
             "start": start.strftime(datetime_format),
             "end": end.strftime(datetime_format),
             "granularity": time_params.granularity,

--- a/tests/sentry/api/endpoints/test_organization_transaction_anomaly_detection.py
+++ b/tests/sentry/api/endpoints/test_organization_transaction_anomaly_detection.py
@@ -64,15 +64,6 @@ class OrganizationTransactionAnomalyDetectionEndpoint(APITestCase, SnubaTestCase
             "query": "transaction.duration:>5s event.type:transaction",
             "data": self.snuba_raw_data,
             "granularity": 600,
-            "params": {
-                "start": datetime(2022, 1, 25, 12, 0, tzinfo=timezone.utc),
-                "end": datetime(2022, 2, 8, 12, 0, tzinfo=timezone.utc),
-                "project_objects": [self.project],
-                "project_id": [self.project.id],
-                "organization_id": self.organization.id,
-                "user_id": self.user.id,
-                "team_id": [self.team.id],
-            },
             "start": "2022-02-01 00:00:00",
             "end": "2022-02-02 00:00:00",
         }
@@ -99,15 +90,6 @@ class OrganizationTransactionAnomalyDetectionEndpoint(APITestCase, SnubaTestCase
             "query": "transaction.duration:>5s event.type:transaction",
             "data": self.snuba_raw_data,
             "granularity": 600,
-            "params": {
-                "start": datetime(2022, 1, 28, 3, 21, 34, tzinfo=timezone.utc),
-                "end": datetime(2022, 2, 11, 3, 21, 34, tzinfo=timezone.utc),
-                "project_objects": [self.project],
-                "project_id": [self.project.id],
-                "organization_id": self.organization.id,
-                "user_id": self.user.id,
-                "team_id": [self.team.id],
-            },
             "start": "2022-02-10 14:21:34",
             "end": "2022-02-11 03:21:34",
         }
@@ -133,15 +115,6 @@ class OrganizationTransactionAnomalyDetectionEndpoint(APITestCase, SnubaTestCase
             "query": "event.type:transaction",
             "data": self.snuba_raw_data,
             "granularity": 1200,
-            "params": {
-                "start": datetime(2021, 12, 20, 0, 0, tzinfo=timezone.utc),
-                "end": datetime(2022, 1, 17, 0, 0, tzinfo=timezone.utc),
-                "project_objects": [self.project],
-                "project_id": [self.project.id],
-                "organization_id": self.organization.id,
-                "user_id": self.user.id,
-                "team_id": [self.team.id],
-            },
             "start": "2022-01-01 00:00:00",
             "end": "2022-01-05 00:00:00",
         }


### PR DESCRIPTION
The snuba `params` are not used by the ADS service, and the `project_objects` field in the snuba query params is causing an error because it is not JSON serializable (see [here](https://sentry.io/organizations/sentry/issues/3001503549/events/346f7fd09aa443f1a63a4c5012ea6114/?project=1&statsPeriod=14d))

```
"project_objects":[
"<Project at 0x7efe812bb790: id=1, team_id=None, name='Backend', slug='sentry'>"
],
```