### PR TITLE
refs(eventstream): Change `_is_transaction_event` to be more reliable

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -90,7 +90,7 @@ class SnubaProtocolEventStream(EventStream):
 
     @staticmethod
     def _is_transaction_event(event) -> bool:
-        return event.group_id is None
+        return event.get_event_type() == "transaction"
 
     def insert(
         self,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -265,7 +265,7 @@ def post_process_group(
 
         set_current_event_project(event.project_id)
 
-        is_transaction_event = not bool(event.group_id)
+        is_transaction_event = event.get_event_type() == "transaction"
 
         from sentry.models import EventDict, Organization, Project
 

--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -58,7 +58,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
             self.project.id,
             "insert",
             (payload1, payload2),
-            is_transaction_event=insert_kwargs["event"].group_id is None,
+            is_transaction_event=insert_kwargs["event"].get_event_type() == "transaction",
         )
 
     @patch("sentry.eventstream.insert")


### PR DESCRIPTION
It makes more sense to directly check the event type than rely on whether a group id exists or not.
