### PR TITLE
chore(platformicons): upgrade to 5.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "papaparse": "^5.3.2",
     "pegjs": "^0.10.0",
     "pegjs-loader": "^0.5.6",
-    "platformicons": "^5.3.0",
+    "platformicons": "^5.3.1",
     "po-catalog-loader": "2.0.0",
     "prettier": "2.7.1",
     "prism-sentry": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11507,10 +11507,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-platformicons@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.3.0.tgz#8d32bcd7d6e123fe5ce72b38a5ec4f1cfc532d96"
-  integrity sha512-BFPhn9hO6C6MWoV/ho+a/Vpi6yg5s5HYUtna4Nk1tUowZQKB9SJegemmd/Bzx7ID1XQSSqBv69rJJPFshED1CA==
+platformicons@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-5.3.1.tgz#778c9bc4899e9f668cad5bb49efbcfeacbb890c3"
+  integrity sha512-P25aSE/3tup5fxLJHK7yhQEs1QOQny+sqw4o2SU2xLgSMo0zRPr9wkxZ3EEHDqCYOBsYqQtstTECFLUmk9yUFA==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
- Including Svelte logo