### PR TITLE
 feat(perf_issues): Support multiple group ids in `Event` and `EventStream`

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -141,6 +141,7 @@ class SnubaProtocolEventStream(EventStream):
             extra_data=(
                 {
                     "group_id": event.group_id,
+                    "group_ids": event.group_ids,
                     "event_id": event.event_id,
                     "organization_id": project.organization_id,
                     "project_id": event.project_id,

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -26,6 +26,16 @@ class Columns(Enum):
         discover_name="group_id",
         alias="issue.id",
     )
+    # This is needed to query transactions by group id
+    # in the Issue Details page. This will not be
+    # exposed to users through discover search.
+    GROUP_IDS = Column(
+        group_name=None,
+        event_name="group_ids",
+        transaction_name="group_ids",
+        discover_name=None,
+        alias="performance.issue_ids",
+    )
     PROJECT_ID = Column(
         group_name="events.project_id",
         event_name="project_id",

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1954,7 +1954,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 self.fail(f"Query {query} errored. Error info: {e}")
 
         for key in SENTRY_SNUBA_MAP:
-            if key in ["project.id", "issue.id"]:
+            if key in ["project.id", "issue.id", "performance.issue_ids"]:
                 continue
             test_query("has:%s" % key)
             test_query("!has:%s" % key)


### PR DESCRIPTION
This adds a basic `group_ids` property to `Event`. This is used in `EventStream` to pass the
`group_ids` associated with a performance issue to snuba.

We don't add these to the Kafka message headers in `EventStream` yet. These are used for passing
information about a group to the post process forwarder. The format of these will need to change
going forward to have some kind of mapping of group -> post_process_group info.