### PR TITLE
feat(replays): Add hover styles & currentHoverTime functionality to breadcrumb items inside tooltips

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -1,14 +1,13 @@
-import {useCallback} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import * as Timeline from 'sentry/components/replays/breadcrumbs/timeline';
-import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {getCrumbsByColumn, relativeTimeInMs} from 'sentry/components/replays/utils';
+import {getCrumbsByColumn} from 'sentry/components/replays/utils';
 import Tooltip from 'sentry/components/tooltip';
 import space from 'sentry/styles/space';
 import {Crumb} from 'sentry/types/breadcrumbs';
 import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
+import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import type {Color} from 'sentry/utils/theme';
 import theme from 'sentry/utils/theme';
 import BreadcrumbItem from 'sentry/views/replays/detail/breadcrumbs/breadcrumbItem';
@@ -67,17 +66,9 @@ function Event({
   startTimestampMs: number;
   className?: string;
 }) {
-  const {setCurrentTime} = useReplayContext();
   const {setActiveTab} = useActiveReplayTab();
-
-  const handleClick = useCallback(
-    (crumb: Crumb) => {
-      crumb.timestamp !== undefined
-        ? setCurrentTime(relativeTimeInMs(crumb.timestamp, startTimestampMs))
-        : null;
-    },
-    [setCurrentTime, startTimestampMs]
-  );
+  const {handleMouseEnter, handleMouseLeave, handleClick} =
+    useCrumbHandlers(startTimestampMs);
 
   const title = crumbs.map(crumb => (
     <BreadcrumbItem
@@ -86,6 +77,8 @@ function Event({
       startTimestampMs={startTimestampMs}
       isHovered={false}
       isSelected={false}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       onClick={handleClick}
     />
   ));

--- a/static/app/components/replays/walker/splitCrumbs.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.tsx
@@ -9,6 +9,7 @@ import Tooltip from 'sentry/components/tooltip';
 import {tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {BreadcrumbTypeNavigation, Crumb} from 'sentry/types/breadcrumbs';
+import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
 import BreadcrumbItem from 'sentry/views/replays/detail/breadcrumbs/breadcrumbItem';
 
 type MaybeOnClickHandler = null | ((crumb: Crumb) => void);
@@ -100,6 +101,8 @@ function SummarySegment({
   handleOnClick: MaybeOnClickHandler;
   startTimestampMs: number;
 }) {
+  const {handleMouseEnter, handleMouseLeave} = useCrumbHandlers(startTimestampMs);
+
   const summaryItems = crumbs.map(crumb => (
     <BreadcrumbItem
       key={crumb.id}
@@ -107,6 +110,8 @@ function SummarySegment({
       startTimestampMs={startTimestampMs}
       isHovered={false}
       isSelected={false}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
       onClick={handleOnClick}
     />
   ));

--- a/static/app/utils/replays/hooks/useMouseTracking.tsx
+++ b/static/app/utils/replays/hooks/useMouseTracking.tsx
@@ -94,6 +94,11 @@ function useMouseTracking<T extends Element>({
       onMouseEnter?.(e);
     },
     onMouseMove: (e: MouseEvent<T>) => {
+      // prevent outside elements from firing, for example a tooltip
+      if (!elem.current?.contains(e.target as Node)) {
+        return;
+      }
+
       handlePositionChange(e);
       onMouseMove?.(e);
     },

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -18,6 +18,7 @@ interface Props {
   isSelected: boolean;
   onClick: null | MouseCallback;
   startTimestampMs: number;
+  allowHover?: boolean;
   onMouseEnter?: MouseCallback;
   onMouseLeave?: MouseCallback;
 }
@@ -27,6 +28,7 @@ function BreadcrumbItem({
   isHovered,
   isSelected,
   startTimestampMs,
+  allowHover = true,
   onMouseEnter,
   onMouseLeave,
   onClick,
@@ -73,6 +75,7 @@ function BreadcrumbItem({
       isHovered={isHovered}
       isSelected={isSelected}
       aria-current={isSelected}
+      allowHover={allowHover}
     >
       <IconWrapper color={crumb.color}>
         <BreadcrumbIcon type={crumb.type} />
@@ -123,6 +126,7 @@ const Description = styled('span')`
 type CrumbItemProps = {
   isHovered: boolean;
   isSelected: boolean;
+  allowHover?: boolean;
 };
 
 const CrumbItem = styled(PanelItem)<CrumbItemProps>`
@@ -141,6 +145,12 @@ const CrumbItem = styled(PanelItem)<CrumbItemProps>`
   ${p => p.isSelected && `background-color: ${p.theme.purple100};`}
   ${p => p.isHovered && `background-color: ${p.theme.surface100};`}
   border-radius: ${p => p.theme.borderRadius};
+
+  ${p =>
+    p.allowHover &&
+    ` &:hover {
+    background-color: ${p.theme.surface100};
+  }`}
 
   /* Draw a vertical line behind the breadcrumb icon. The line connects each row together, but is truncated for the first and last items */
   &::after {

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -72,6 +72,8 @@ function Breadcrumbs({}: Props) {
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
           onClick={handleClick}
+          // We are controlling the hover state ourselves with `isHovered` prop
+          allowHover={false}
         />
       ))}
     </BreadcrumbContainer>


### PR DESCRIPTION

<!-- Describe your PR here. -->
### Changes
- Added hover styles to breadcrumb items inside tooltip
- Added currentHoverTime functionality to breadcrumb items inside tooltip
- Fixed onMouseover bug for breadcrumb items inside tooltip on timeline

Closes #37468 

https://user-images.githubusercontent.com/39612839/187291269-d6eeaf5a-7293-475c-b41f-aad9f988b7a1.mp4


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
