### PR TITLE
feat(perf_issues): Add `GroupEvent` and split some functionality in `Event` into a base class.

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -665,7 +665,7 @@ class Event(BaseEvent):
         from sentry.models import Group
 
         if not self.group_ids:
-            return
+            return []
 
         if not hasattr(self, "_groups_cache"):
             self._groups_cache = list(Group.objects.filter(id__in=self.group_ids))
@@ -695,12 +695,13 @@ class GroupEvent(BaseEvent):
         self.group = group
         self.data = data
 
+    def __eq__(self, other):
+        if not isinstance(other, GroupEvent):
+            return False
+        return other.event_id == self.event_id and other.group_id == self.group_id
+
     @property
     def group_id(self) -> int:
-        # TODO: Including this as a shim for now. I think it makes sense to remove this helper,
-        # since people may as well use `group.id` instead of `group_id`, but it breaks a lot of
-        # compatibility with `Event`. Including this here for now so that we don't have to rewrite
-        # the whole codebase at once.
         return self.group.id
 
     @property

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -668,7 +668,7 @@ class Event(BaseEvent):
             return
 
         if not hasattr(self, "_groups_cache"):
-            self._groups_cache = list(Group.objects.filter(id=self.group_ids))
+            self._groups_cache = list(Group.objects.filter(id__in=self.group_ids))
         return self._groups_cache
 
     def build_group_events(self):

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -573,11 +573,13 @@ class Event(BaseEvent):
         self,
         project_id: int,
         event_id: str,
+        group_id: int | None = None,
         data: Mapping[str, Any] | None = None,
         snuba_data: Mapping[str, Any] | None = None,
         group_ids: Sequence[int] | None = None,
     ):
         super().__init__(project_id, event_id, snuba_data=snuba_data)
+        self.group_id = group_id
         self.group_ids = group_ids
         self.data = data
 

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -705,9 +705,6 @@ class GroupEvent(BaseEvent):
 
     @classmethod
     def from_event(cls, event: Event, group: Group):
-        if group.id not in event.group_ids:
-            raise ValueError("Group invalid, it is not associated with this Event")
-
         return cls(
             project_id=event.project_id,
             event_id=event.event_id,

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -698,6 +698,9 @@ class GroupEvent(BaseEvent):
             return False
         return other.event_id == self.event_id and other.group_id == self.group_id
 
+    def __hash__(self):
+        return hash((self.group_id, self.event_id))
+
     @property
     def group_id(self) -> int:
         return self.group.id

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -696,6 +696,14 @@ class GroupEvent(BaseEvent):
         self.data = data
 
     @property
+    def group_id(self) -> int:
+        # TODO: Including this as a shim for now. I think it makes sense to remove this helper,
+        # since people may as well use `group.id` instead of `group_id`, but it breaks a lot of
+        # compatibility with `Event`. Including this here for now so that we don't have to rewrite
+        # the whole codebase at once.
+        return self.group.id
+
+    @property
     def data(self) -> NodeData:
         return self._data
 

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import abc
 import string
 from collections import OrderedDict
+from copy import deepcopy
 from datetime import datetime
 from hashlib import md5
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Sequence, Tuple, cast
@@ -41,7 +43,7 @@ def ref_func(x: Event) -> int:
     return x.project_id or x.project.id
 
 
-class Event:
+class BaseEvent(metaclass=abc.ABCMeta):
     """
     Event backed by nodestore and Snuba.
     """
@@ -50,16 +52,10 @@ class Event:
         self,
         project_id: int,
         event_id: str,
-        group_id: int | None = None,
-        data: Mapping[str, Any] | None = None,
         snuba_data: Mapping[str, Any] | None = None,
-        group_ids: Sequence[int] | None = None,
     ):
         self.project_id = project_id
         self.event_id = event_id
-        self.group_id = group_id
-        self.group_ids = group_ids
-        self.data = data
         self._snuba_data = snuba_data or {}
 
     def __getstate__(self) -> Mapping[str, Any]:
@@ -76,42 +72,14 @@ class Event:
         return state
 
     @property
+    @abc.abstractmethod
     def data(self) -> NodeData:
-        return self._data
+        pass
 
     @data.setter
-    def data(self, value: Mapping[str, Any]) -> None:
-        node_id = Event.generate_node_id(self.project_id, self.event_id)
-        self._data = NodeData(
-            node_id, data=value, wrapper=EventDict, ref_version=2, ref_func=ref_func
-        )
-
-    @property
-    def group_id(self) -> int | None:
-        if self._group_id:
-            return self._group_id
-
-        column = self.__get_column_name(Columns.GROUP_ID)
-
-        return self._snuba_data.get(column)
-
-    @group_id.setter
-    def group_id(self, value: int | None) -> None:
-        self._group_id = value
-
-    @property
-    def group_ids(self) -> Sequence[int] | None:
-        if self._group_ids:
-            return self._group_ids
-
-        # TODO: Should attempt to grab data from `Columns.GROUP_ID` as well?
-        column = self.__get_column_name(Columns.GROUP_IDS)
-
-        return self._snuba_data.get(column)
-
-    @group_ids.setter
-    def group_ids(self, values: Sequence[int] | None) -> None:
-        self._group_ids = values
+    @abc.abstractmethod
+    def data(self, value: NodeData | Mapping[str, Any]):
+        pass
 
     @property
     def platform(self) -> str | None:
@@ -296,25 +264,6 @@ class Event:
         same generated id when we only have project_id and event_id.
         """
         return md5(f"{project_id}:{event_id}".encode()).hexdigest()
-
-    # TODO We need a better way to cache these properties. functools
-    # doesn't quite do the trick as there is a reference bug with unsaved
-    # models. But the current _group_cache thing is also clunky because these
-    # properties need to be stripped out in __getstate__.
-    @property
-    def group(self) -> Group | None:
-        from sentry.models import Group
-
-        if not self.group_id:
-            return None
-        if not hasattr(self, "_group_cache"):
-            self._group_cache = Group.objects.get(id=self.group_id)
-        return self._group_cache
-
-    @group.setter
-    def group(self, group: Group) -> None:
-        self.group_id = group.id
-        self._group_cache = group
 
     @property
     def project(self) -> Project:
@@ -617,6 +566,155 @@ class Event:
     def __get_column_name(self, column: Column) -> str:
         # Events are currently populated from the Events dataset
         return cast(str, column.value.event_name)
+
+
+class Event(BaseEvent):
+    def __init__(
+        self,
+        project_id: int,
+        event_id: str,
+        group_id: int | None = None,
+        data: Mapping[str, Any] | None = None,
+        snuba_data: Mapping[str, Any] | None = None,
+        group_ids: Sequence[int] | None = None,
+    ):
+        super().__init__(project_id, event_id, snuba_data=snuba_data)
+        self.group_id = group_id
+        self.group_ids = group_ids
+        self.data = data
+
+    def __getstate__(self) -> Mapping[str, Any]:
+        state = super().__getstate__()
+        state.pop("_group_cache", None)
+        state.pop("_groups_cache", None)
+        return state
+
+    @property
+    def data(self) -> NodeData:
+        return self._data
+
+    @data.setter
+    def data(self, value: Mapping[str, Any]) -> None:
+        node_id = Event.generate_node_id(self.project_id, self.event_id)
+        self._data = NodeData(
+            node_id, data=value, wrapper=EventDict, ref_version=2, ref_func=ref_func
+        )
+
+    @property
+    def group_id(self) -> int | None:
+        # TODO: `group_id` and `group` are deprecated properties on `Event`. We will remove them
+        # going forward. Since events may now be associated with multiple `Group` models, we will
+        # require `GroupEvent` to be passed around. The `group_events` property should be used to
+        # iterate through all `Groups` associated with an `Event`
+        if self._group_id:
+            return self._group_id
+
+        column = self.__get_column_name(Columns.GROUP_ID)
+
+        return self._snuba_data.get(column)
+
+    @group_id.setter
+    def group_id(self, value: int | None) -> None:
+        self._group_id = value
+
+    # TODO We need a better way to cache these properties. functools
+    # doesn't quite do the trick as there is a reference bug with unsaved
+    # models. But the current _group_cache thing is also clunky because these
+    # properties need to be stripped out in __getstate__.
+    @property
+    def group(self) -> Group | None:
+        from sentry.models import Group
+
+        if not self.group_id:
+            return None
+        if not hasattr(self, "_group_cache"):
+            self._group_cache = Group.objects.get(id=self.group_id)
+        return self._group_cache
+
+    @group.setter
+    def group(self, group: Group) -> None:
+        self.group_id = group.id
+        self._group_cache = group
+
+    @property
+    def group_ids(self) -> Sequence[int]:
+        """
+        This property returns all `group_ids` associated with an event. It checks both the
+        `GROUP_ID` and `GROUP_IDS` columns in snuba.
+        """
+        if self._group_ids:
+            return self._group_ids
+
+        snuba_group_id = self.group_id
+        # TODO: Replace `snuba_group_id` with this once we deprecate `group_id`.
+        # snuba_group_id = self._snuba_data.get(self.__get_column_name(Columns.GROUP_ID))
+        snuba_group_ids = self._snuba_data.get(self.__get_column_name(Columns.GROUP_IDS))
+        group_ids = []
+        if snuba_group_id:
+            group_ids.append(snuba_group_id)
+        if snuba_group_ids:
+            group_ids.extend(snuba_group_ids)
+        return group_ids
+
+    @group_ids.setter
+    def group_ids(self, values: Sequence[int] | None) -> None:
+        self._group_ids = values
+
+    @property
+    def groups(self):
+        from sentry.models import Group
+
+        if not self.group_ids:
+            return
+
+        if not hasattr(self, "_group_cache"):
+            self._groups_cache = list(Group.objects.filter(id=self.group_ids))
+        return self._groups_cache
+
+    def build_group_events(self):
+        """
+        Yields a GroupEvent for each Group associated with this Event.
+        """
+        for group in self.groups:
+            yield GroupEvent.from_event(self, group)
+
+    def for_group(self, group: Group):
+        return GroupEvent.from_event(self, group)
+
+
+class GroupEvent(BaseEvent):
+    def __init__(
+        self,
+        project_id: int,
+        event_id: str,
+        group: Group,
+        data: NodeData,
+        snuba_data: Mapping[str, Any] | None = None,
+    ):
+        super().__init__(project_id, event_id, snuba_data=snuba_data)
+        self.group = group
+        self.data = data
+
+    @property
+    def data(self) -> NodeData:
+        return self._data
+
+    @data.setter
+    def data(self, value: NodeData) -> None:
+        self._data = value
+
+    @classmethod
+    def from_event(cls, event: Event, group: Group):
+        if group.id not in event.group_ids:
+            raise ValueError("Group invalid, it is not associated with this Event")
+
+        return cls(
+            project_id=event.project_id,
+            event_id=event.event_id,
+            group=group,
+            data=deepcopy(event.data),
+            snuba_data=deepcopy(event.snuba_data),
+        )
 
 
 class EventSubjectTemplate(string.Template):

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -718,7 +718,7 @@ class GroupEvent(BaseEvent):
             event_id=event.event_id,
             group=group,
             data=deepcopy(event.data),
-            snuba_data=deepcopy(event.snuba_data),
+            snuba_data=deepcopy(event._snuba_data),
         )
 
 

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -667,7 +667,7 @@ class Event(BaseEvent):
         if not self.group_ids:
             return
 
-        if not hasattr(self, "_group_cache"):
+        if not hasattr(self, "_groups_cache"):
             self._groups_cache = list(Group.objects.filter(id=self.group_ids))
         return self._groups_cache
 

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -141,7 +141,7 @@ class SnubaProtocolEventStream(EventStream):
             extra_data=(
                 {
                     "group_id": event.group_id,
-                    "group_ids": event.group_ids,
+                    "group_ids": [group.id for group in event.groups],
                     "event_id": event.event_id,
                     "organization_id": project.organization_id,
                     "project_id": event.project_id,

--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -283,7 +283,7 @@ class EventTest(TestCase):
         )
         # TODO: Remove this once snuba is writing group_ids, and we can create groups as part
         # of self.store_event
-        event_from_snuba.group_ids = [self.group.id]
+        event_from_snuba.groups = [self.group]
 
         assert event_from_nodestore.event_id == event_from_snuba.event_id
         assert event_from_nodestore.project_id == event_from_snuba.project_id
@@ -302,11 +302,11 @@ class EventTest(TestCase):
 
         # Group IDs must be fetched from Snuba since they are not present in nodestore
         assert not event_from_snuba.group_id
-        assert event_from_snuba.group_ids
+        assert event_from_snuba.groups == [self.group]
         assert not event_from_snuba.group
 
         assert not event_from_nodestore.group_id
-        assert not event_from_nodestore.group_ids
+        assert not event_from_nodestore.groups
         assert not event_from_nodestore.group
 
     def test_grouping_reset(self):
@@ -406,7 +406,7 @@ class EventGroupsTest(TestCase):
                 "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
             },
             project_id=self.project.id,
-            group_ids=[self.group.id],
+            groups=[self.group],
         )
         assert event.groups == [self.group]
 
@@ -467,7 +467,7 @@ class EventBuildGroupEventsTest(TestCase):
                 "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
             },
             project_id=self.project.id,
-            group_ids=[self.group.id],
+            groups=[self.group],
         )
         assert list(event.build_group_events()) == [GroupEvent.from_event(event, self.group)]
 
@@ -483,7 +483,7 @@ class EventBuildGroupEventsTest(TestCase):
                 "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
             },
             project_id=self.project.id,
-            group_ids=[self.group.id, self.group_2.id],
+            groups=[self.group, self.group_2],
         )
         sort_key = lambda group_event: (group_event.event_id, group_event.group_id)
         assert sorted(event.build_group_events(), key=sort_key) == sorted(

--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -123,7 +123,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         now = datetime.utcnow()
         event = self.__build_transaction_event()
         event.group_id = None
-        event.group_ids = [self.group.id]
+        event.groups = [self.group]
         insert_args = ()
         insert_kwargs = {
             "event": event,


### PR DESCRIPTION
Since we can now have events with multiple groups, we can no longer rely on the `Event.group` property. This pr adds in a `GroupEvent` subclass that should be passed around wherever we expect an event to have a single `Group` associated with it.

`Event` has been split up into `BaseEvent` and `Event`. We will deprecate and remove uses of `group_id` and `group` in the `Event` class going forward. If we need an event with a `Group`, we can use `build_group_events` to fetch all `GroupEvents` associated with the `Event`, or `for_group` if we just need a specific `Event`/`Group` pairing.

Going forward, the plan is to store all groups in the `groups` property. This means that error events being sent via eventstream will have their group included in `groups` as well. We'll need to update the errors processor in snuba to look there instead of `group_id`. This seems cleaner long term, instead of having both `group_id` and `group_ids` passed through.

To figure out where we need to use `build_group_events` and `for_group` we can do a mix of searching the codebase and commenting out the `group_id` and `group` properties and see how CI goes.