### PR TITLE
feat(perf-issues): retrieve seen_stats for transaction/performance data 

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -882,9 +882,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
                 environment_ids=self.environment_ids,
             ),
             error_issue_list,
-            self.start,
-            self.end,
-            self.conditions,
+            self.start or self.end or self.conditions,
             self.environment_ids,
         )
 
@@ -900,9 +898,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
                 environment_ids=self.environment_ids,
             ),
             perf_issue_list,
-            self.start,
-            self.end,
-            self.conditions,
+            self.start or self.end or self.conditions,
             self.environment_ids,
         )
 
@@ -961,7 +957,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
 
     @staticmethod
     def _parse_seen_stats_results(
-        result, item_list, start=None, end=None, conditions=None, environment_ids=None
+        result, item_list, use_result_first_seen_times_seen, environment_ids=None
     ):
         seen_data = {
             issue["group_id"]: fix_tag_value_data(
@@ -971,7 +967,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         }
         user_counts = {item_id: value["count"] for item_id, value in seen_data.items()}
         last_seen = {item_id: value["last_seen"] for item_id, value in seen_data.items()}
-        if start or end or conditions:
+        if use_result_first_seen_times_seen:
             first_seen = {item_id: value["first_seen"] for item_id, value in seen_data.items()}
             times_seen = {item_id: value["times_seen"] for item_id, value in seen_data.items()}
         else:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -730,6 +730,8 @@ class GroupSerializer(GroupSerializerBase):
             [Sequence[int], Sequence[int], Sequence[int], str, str], Mapping[int, GroupTagValue]
         ],
     ) -> Mapping[Group, SeenStats]:
+        if not issue_list:
+            return {}
         try:
             environment = self.environment_func()
         except Environment.DoesNotExist:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -859,7 +859,9 @@ class GroupSerializerSnuba(GroupSerializerBase):
             else []
         )
 
-    def _seen_stats_error(self, error_issue_list: Sequence[Group], user) -> Mapping[Any, SeenStats]:
+    def _seen_stats_error(
+        self, error_issue_list: Sequence[Group], user
+    ) -> Mapping[Group, SeenStats]:
         return self._parse_seen_stats_results(
             self._execute_error_seen_stats_query(
                 item_list=error_issue_list,

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -369,14 +369,14 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         )
 
     def _seen_stats_error(self, error_issue_list: Sequence[Group], user) -> Mapping[Any, SeenStats]:
-        return self._seen_stats_impl(error_issue_list, self._execute_error_seen_stats_query)
+        return self.__seen_stats_impl(error_issue_list, self._execute_error_seen_stats_query)
 
     def _seen_stats_performance(
         self, perf_issue_list: Sequence[Group], user
     ) -> Mapping[Group, SeenStats]:
-        return self._seen_stats_impl(perf_issue_list, self._execute_perf_seen_stats_query)
+        return self.__seen_stats_impl(perf_issue_list, self._execute_perf_seen_stats_query)
 
-    def _seen_stats_impl(
+    def __seen_stats_impl(
         self,
         error_issue_list: Sequence[Group],
         seen_stats_func: Callable[[Any, Any, Any, Any, Any], Mapping[str, Any]],

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -391,18 +391,14 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         time_range_result = self._parse_seen_stats_results(
             partial_execute_seen_stats_query(),
             error_issue_list,
-            self.start,
-            self.end,
-            self.conditions,
+            self.start or self.end or self.conditions,
             self.environment_ids,
         )
         filtered_result = (
             self._parse_seen_stats_results(
                 partial_execute_seen_stats_query(conditions=self.conditions),
                 error_issue_list,
-                self.start,
-                self.end,
-                self.conditions,
+                self.start or self.end or self.conditions,
                 self.environment_ids,
             )
             if self.conditions and not self._collapse("filtered")
@@ -413,9 +409,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 self._parse_seen_stats_results(
                     partial_execute_seen_stats_query(start=None, end=None),
                     error_issue_list,
-                    None,
-                    None,
-                    None,
+                    False,
                     self.environment_ids,
                 )
                 if self.start or self.end

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -408,8 +408,8 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             if self.conditions and not self._collapse("filtered")
             else None
         )
-        if not self._collapse("lifetime"):
-            lifetime_result = (
+        lifetime_result = (
+            (
                 self._parse_seen_stats_results(
                     partial_execute_seen_stats_query(start=None, end=None),
                     error_issue_list,
@@ -421,8 +421,9 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 if self.start or self.end
                 else time_range_result
             )
-        else:
-            lifetime_result = None
+            if not self._collapse("lifetime")
+            else None
+        )
 
         for item in error_issue_list:
             time_range_result[item].update(

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -368,7 +368,9 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             **query_params,
         )
 
-    def _seen_stats_error(self, error_issue_list: Sequence[Group], user) -> Mapping[Any, SeenStats]:
+    def _seen_stats_error(
+        self, error_issue_list: Sequence[Group], user
+    ) -> Mapping[Group, SeenStats]:
         return self.__seen_stats_impl(error_issue_list, self._execute_error_seen_stats_query)
 
     def _seen_stats_performance(

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -226,8 +226,11 @@ class Referrer(Enum):
     OUTCOMES_TOTALS = "outcomes.totals"
     SEARCH = "search"
     SEARCH_SAMPLE = "search_sample"
-    SERIALIZERS_GROUPSERIALIZERSNUBA__EXECUTE_SEEN_STATS_QUERY = (
-        "serializers.groupserializersnuba._execute_seen_stats_query"
+    SERIALIZERS_GROUPSERIALIZERSNUBA__EXECUTE_ERROR_SEEN_STATS_QUERY = (
+        "serializers.groupserializersnuba._execute_error_seen_stats_query"
+    )
+    SERIALIZERS_GROUPSERIALIZERSNUBA__EXECUTE_PERF_SEEN_STATS_QUERY = (
+        "serializers.groupserializersnuba._execute_perf_seen_stats_query"
     )
     SESSIONS_CRASH_FREE_BREAKDOWN = "sessions.crash-free-breakdown"
     SESSIONS_GET_PROJECT_SESSIONS_COUNT = "sessions.get_project_sessions_count"

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -40,8 +40,10 @@ class TagStorage(Service):
             "get_group_tag_value",
             "get_group_tag_values",
             "get_group_list_tag_value",
+            "get_perf_group_list_tag_value",
             "get_tag_keys_for_projects",
             "get_groups_user_counts",
+            "get_perf_groups_user_counts",
             "get_group_event_filter",
             "get_group_tag_value_count",
             "get_top_group_tag_values",
@@ -181,8 +183,13 @@ class TagStorage(Service):
 
     def get_group_list_tag_value(self, project_ids, group_id_list, environment_ids, key, value):
         """
-        >>> get_group_tag_value([1, 2], [1, 2, 3, 4, 5], [3], "key1", "value1")
+        >>> get_group_list_tag_value([1, 2], [1, 2, 3, 4, 5], [3], "key1", "value1")
         """
+        raise NotImplementedError
+
+    def get_perf_group_list_tag_value(
+        self, project_ids, group_id_list, environment_ids, key, value
+    ):
         raise NotImplementedError
 
     def get_group_event_filter(self, project_id, group_id, environment_ids, tags, start, end):

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -250,6 +250,11 @@ class TagStorage(Service):
         """
         raise NotImplementedError
 
+    def get_perf_groups_user_counts(
+        self, project_ids, group_ids, environment_ids, start=None, end=None
+    ):
+        raise NotImplementedError
+
     def get_group_tag_value_count(self, project_id, group_id, environment_id, key):
         """
         >>> get_group_tag_value_count(1, 2, 3, 'key1')

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -449,8 +449,10 @@ class SnubaTagStorage(TagStorage):
         )
 
         return {
-            issue: GroupTagValue(group_id=issue, key=key, value=value, **fix_tag_value_data(data))
-            for issue, data in result.items()
+            group_id: GroupTagValue(
+                group_id=group_id, key=key, value=value, **fix_tag_value_data(data)
+            )
+            for group_id, data in result.items()
         }
 
     def get_perf_group_list_tag_value(
@@ -475,8 +477,8 @@ class SnubaTagStorage(TagStorage):
         )
 
         return {
-            issue: GroupTagValue(key=key, value=value, **fix_tag_value_data(data))
-            for issue, data in result.items()
+            group_id: GroupTagValue(key=key, value=value, **fix_tag_value_data(data))
+            for group_id, data in result.items()
         }
 
     def get_group_seen_values_for_environments(

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -725,7 +725,7 @@ class SnubaTagStorage(TagStorage):
     def get_perf_groups_user_counts(
         self, project_ids, group_ids, environment_ids, start=None, end=None
     ):
-        filters_keys = {"project_id": project_ids, "array_join_group_id": group_ids}
+        filters_keys = {"project_id": project_ids, "group_id": group_ids}
         if environment_ids:
             filters_keys["environment"] = environment_ids
 
@@ -735,10 +735,10 @@ class SnubaTagStorage(TagStorage):
             end=start,
             filter_keys=filters_keys,
             aggregations=[
-                ["arrayJoin", ["group_ids"], "array_join_group_id"],
+                ["arrayJoin", ["group_ids"], "group_id"],
                 ["uniq", "tags[sentry:user]", "user_counts"],
             ],
-            groupby=["array_join_group_id"],
+            groupby=["group_id"],
             referrer="tagstore.get_perf_groups_user_counts",
         )
 

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -1,9 +1,11 @@
 from datetime import timedelta
+from unittest import mock
 from unittest.mock import patch
 
 from django.utils import timezone
 
 from sentry.api.serializers import serialize
+from sentry.event_manager import _pull_out_data
 from sentry.models import (
     Group,
     GroupLink,
@@ -16,7 +18,9 @@ from sentry.models import (
 )
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import before_now
 from sentry.types.integrations import ExternalProviders
+from sentry.types.issues import GroupType
 
 
 class GroupSerializerTest(TestCase):
@@ -350,3 +354,31 @@ class GroupSerializerTest(TestCase):
                 "dateCreated": result["statusDetails"]["info"]["dateCreated"],
             },
         }
+
+    def test_perf_issue(self):
+        def inject_group_ids(jobs, projects):
+            _pull_out_data(jobs, projects)
+            for job in jobs:
+                job["event"].groups = [self.group]
+            return jobs, projects
+
+        with mock.patch("sentry.event_manager._pull_out_data", inject_group_ids):
+            cur_time = before_now(minutes=1)
+            event_data = {
+                "type": "transaction",
+                "level": "info",
+                "message": "transaction message",
+                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+                "timestamp": cur_time.timestamp(),
+                "start_timestamp": cur_time.timestamp(),
+                "received": cur_time.timestamp(),
+            }
+            self.store_event(
+                data=event_data,
+                project_id=self.project.id,
+            )
+            self.group.update(type=GroupType.PERFORMANCE_N_PLUS_ONE.value)
+            serialized = serialize(self.group)
+            assert serialized["count"] == "1"
+            assert serialized["issueCategory"] == "performance"
+            assert serialized["issueType"] == "performance_n_plus_one"

--- a/tests/sentry/api/serializers/test_group_stream.py
+++ b/tests/sentry/api/serializers/test_group_stream.py
@@ -2,8 +2,11 @@ from unittest import mock
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group_stream import StreamGroupSerializer
+from sentry.event_manager import _pull_out_data
 from sentry.models import Environment
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import before_now
+from sentry.types.issues import GroupType
 
 
 class StreamGroupSerializerTestCase(TestCase):
@@ -41,3 +44,31 @@ class StreamGroupSerializerTestCase(TestCase):
                 ),
             )
             assert make_series.call_count == 1
+
+    def test_perf_issue(self):
+        def inject_group_ids(jobs, projects):
+            _pull_out_data(jobs, projects)
+            for job in jobs:
+                job["event"].groups = [self.group]
+            return jobs, projects
+
+        with mock.patch("sentry.event_manager._pull_out_data", inject_group_ids):
+            cur_time = before_now(minutes=1)
+            event_data = {
+                "type": "transaction",
+                "level": "info",
+                "message": "transaction message",
+                "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+                "timestamp": cur_time.timestamp(),
+                "start_timestamp": cur_time.timestamp(),
+                "received": cur_time.timestamp(),
+            }
+            self.store_event(
+                data=event_data,
+                project_id=self.project.id,
+            )
+            self.group.update(type=GroupType.PERFORMANCE_N_PLUS_ONE.value)
+            serialized = serialize(self.group)
+            assert serialized["count"] == "1"
+            assert serialized["issueCategory"] == "performance"
+            assert serialized["issueType"] == "performance_n_plus_one"


### PR DESCRIPTION
The various GroupSerializers used for retrieving GroupDetails queries Snuba for the following 'seen stats' data:
* times_seen: int
* first_seen: datetime
* last_seen: datetime
* user_count: int

Before this PR, the serializer would query the underlying `Events` dataset which is tied to an error. With the intro of performance issues, we need to include a secondary set of 'seen stats' for `Transactions` which backs performance issues.

Fixes WOR-2115