### PR TITLE
feat(build): Make freezing requirements idempotent

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,102 +1,102 @@
-beautifulsoup4>=4.7.1
-boto3>=1.22.12
-botocore>=1.25.12
-celery>=4.4.7
-click>=8.0.4
-confluent-kafka>=1.9.2
-croniter>=0.3.37
-datadog>=0.29.3
-django-crispy-forms>=1.14.0
-django-pg-zero-downtime-migrations>=0.11
-Django>=2.2.28
-djangorestframework>=3.12.4
-drf-spectacular>=0.22.1
-email-reply-parser>=0.5.12
-google-api-core>=1.32.0
+beautifulsoup4==4.7.1
+boto3==1.22.12
+botocore==1.25.12
+celery==4.4.7
+click==8.0.4
+confluent-kafka==1.9.2
+croniter==0.3.37
+datadog==0.29.3
+django-crispy-forms==1.14.0
+django-pg-zero-downtime-migrations==0.11
+Django==2.2.28
+djangorestframework==3.12.4
+drf-spectacular==0.22.1
+email-reply-parser==0.5.12
+google-api-core==1.32.0
 google-auth>=1.24.0
-google-cloud-bigtable>=1.6.1
-google-cloud-core>=1.5.0
-googleapis-common-protos>=1.56.2
-google-cloud-pubsub>=2.2.0
-google-cloud-storage>=1.35.0
-google-cloud-functions>=1.8.0
-google-cloud-spanner>=3.17.0
-google-crc32c>=1.3.0
-isodate>=0.6.1
-jsonschema>=3.2.0
-lxml>=4.6.5
-maxminddb>=2.0.3
-mistune>=2.0.3
-mmh3>=3.0.0
-packaging>=21.3
-parsimonious>=0.8.0
-petname>=2.6
-phonenumberslite>=8.12.0
-Pillow>=9.2.0
-progressbar2>=3.41.0
-python-rapidjson>=1.4
-psycopg2-binary>=2.8.6
-PyJWT>=2.4.0
-python-dateutil>=2.8.1
-python-memcached>=1.59
-python-u2flib-server>=5.0.0
-fido2>=0.9.2
-python3-saml>=1.14.0
-PyYAML>=5.4
-rb>=1.9.0
-redis-py-cluster>=2.1.0
-redis>=3.4.1
-requests-oauthlib>=1.2.0
-requests>=2.25.1
+google-cloud-bigtable==1.6.1
+google-cloud-core==1.5.0
+googleapis-common-protos==1.56.2
+google-cloud-pubsub==2.2.0
+google-cloud-storage==1.35.0
+google-cloud-functions==1.8.0
+google-cloud-spanner==3.17.0
+google-crc32c==1.3.0
+isodate==0.6.1
+jsonschema==3.2.0
+lxml==4.6.5
+maxminddb==2.0.3
+mistune==2.0.4
+mmh3==3.0.0
+packaging==21.3
+parsimonious==0.8.0
+petname==2.6
+phonenumberslite==8.12.0
+Pillow==9.2.0
+progressbar2==3.41.0
+python-rapidjson==1.4
+psycopg2-binary==2.8.6
+PyJWT==2.4.0
+python-dateutil==2.8.1
+python-memcached==1.59
+python-u2flib-server==5.0.0
+fido2==0.9.2
+python3-saml==1.14.0
+PyYAML==5.4
+rb==1.9.0
+redis-py-cluster==2.1.0
+redis==3.4.1
+requests-oauthlib==1.2.0
+requests==2.25.1
 # [start] jsonschema format validators
-rfc3339-validator>=0.1.2
-rfc3986-validator>=0.1.1
+rfc3339-validator==0.1.2
+rfc3986-validator==0.1.1
 # [end] jsonschema format validators
-sentry-arroyo>=1.0.3
-sentry-relay>=0.8.13
-sentry-sdk>=1.9.5
-snuba-sdk>=1.0.1
-simplejson>=3.17.6
-statsd>=3.3
-structlog>=21.1.0
-symbolic>=8.7.1
-toronado>=0.1.0
-typing-extensions>=3.10.0.2
-ua-parser>=0.10.0
-unidiff>=0.7.4
-urllib3[brotli]>=1.26.9
-brotli>=1.0.9
+sentry-arroyo==1.0.3
+sentry-relay==0.8.13
+sentry-sdk==1.9.5
+snuba-sdk==1.0.1
+simplejson==3.17.6
+statsd==3.3
+structlog==21.1.0
+symbolic==8.7.1
+toronado==0.1.0
+typing-extensions==3.10.0.2
+ua-parser==0.10.0
+unidiff==0.7.4
+urllib3[brotli]==1.26.11
+brotli==1.0.9
 # See if we can remove LDFLAGS from lib.sh
 # https://github.com/getsentry/sentry/pull/30094
 uWSGI==2.0.20.0
-zstandard>=0.18.0
+zstandard==0.18.0
 
-msgpack>=1.0.4
-cryptography>=3.4.8
+msgpack==1.0.4
+cryptography==37.0.2
 
 # celery
-billiard>=3.6.4
-kombu>=4.6.11
+billiard==3.6.4
+kombu==4.6.11
 
 # Note, grpcio>1.30.0 requires setting GRPC_POLL_STRATEGY=epoll1
 # See https://github.com/grpc/grpc/issues/23796 and
 # https://github.com/grpc/grpc/blob/v1.35.x/doc/core/grpc-polling-engines.md#polling-engine-implementations-in-grpc
-grpcio>=1.47.0
+grpcio==1.47.0
 
 # not directly used, but provides a speedup for redis
-hiredis>=0.3.1
+hiredis==0.3.1
 
 # not directly used, but pinned for at least semaphore/symbolic
-cffi>=1.15.0
+cffi==1.15.1
 
 # not directly used, but pinned for toronado because it doesn't pin these
-cssutils>=2.4.0
-cssselect>=1.0.3
+cssutils==2.4.0
+cssselect==1.0.3
 
 # sentry-plugins specific dependencies
-phabricator>=0.7.0
+phabricator==0.7.0
 
 # test dependencies, but unable to move to requirements-test until
 # sentry.utils.pytest and sentry.testutils are moved to tests/
-selenium>=4.1.5
-sqlparse>=0.2.4,<=0.3.0
+selenium==4.3.0
+sqlparse==0.3.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -13,7 +13,7 @@ djangorestframework==3.12.4
 drf-spectacular==0.22.1
 email-reply-parser==0.5.12
 google-api-core==1.32.0
-google-auth>=1.24.0
+google-auth==1.35.0
 google-cloud-bigtable==1.6.1
 google-cloud-core==1.5.0
 googleapis-common-protos==1.56.2


### PR DESCRIPTION
Running `make freeze-requirements` without changes to the base requirements file should not update to newer packages.

This makes it harder to make unintended changes