### PR TITLE
fix(replays): set UrlWalker item max-width

### DIFF
--- a/static/app/components/replays/walker/splitCrumbs.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.tsx
@@ -124,6 +124,7 @@ const Span = styled('span')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 0;
+  max-width: 120px;
 `;
 
 const Link = styled('a')`


### PR DESCRIPTION

### Changes
- Adds max-width of 120 to url walker items

Closes #38107 

![Screen Shot 2022-08-26 at 1 45 13 PM](https://user-images.githubusercontent.com/3721977/186962360-d227d8e7-0b1c-4589-990c-0435b6e73b1a.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
