### PR TITLE
ref(writes-limiter): Add WriteLimiterFactory

### DIFF
--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -15,7 +15,7 @@ from sentry.sentry_metrics.indexer.base import (
 )
 from sentry.sentry_metrics.indexer.cache import CachingIndexer, StringIndexerCache
 from sentry.sentry_metrics.indexer.postgres.models import TABLE_MAPPING, IndexerTable
-from sentry.sentry_metrics.indexer.ratelimiters import writes_limiter
+from sentry.sentry_metrics.indexer.ratelimiters import writes_limiter_factory
 from sentry.sentry_metrics.indexer.strings import StaticStringIndexer
 from sentry.utils import metrics
 
@@ -77,10 +77,11 @@ class PGStringIndexerV2(StringIndexer):
         if db_write_keys.size == 0:
             return db_read_key_results
 
-        ratelimiter_namespace = get_ingest_config(use_case_id).writes_limiter_namespace
+        config = get_ingest_config(use_case_id)
+        writes_limiter = writes_limiter_factory.get_ratelimiter(config)
 
         with writes_limiter.check_write_limits(
-            use_case_id, ratelimiter_namespace, db_write_keys
+            use_case_id, config.writes_limiter_namespace, db_write_keys
         ) as writes_limiter_state:
             # After the DB has successfully committed writes, we exit this
             # context manager and consume quotas. If the DB crashes we

--- a/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
+++ b/src/sentry/sentry_metrics/indexer/postgres/postgres_v2.py
@@ -80,9 +80,7 @@ class PGStringIndexerV2(StringIndexer):
         config = get_ingest_config(use_case_id)
         writes_limiter = writes_limiter_factory.get_ratelimiter(config)
 
-        with writes_limiter.check_write_limits(
-            use_case_id, config.writes_limiter_namespace, db_write_keys
-        ) as writes_limiter_state:
+        with writes_limiter.check_write_limits(use_case_id, db_write_keys) as writes_limiter_state:
             # After the DB has successfully committed writes, we exit this
             # context manager and consume quotas. If the DB crashes we
             # shouldn't consume quota.

--- a/src/sentry/sentry_metrics/indexer/ratelimiters.py
+++ b/src/sentry/sentry_metrics/indexer/ratelimiters.py
@@ -173,7 +173,7 @@ class WritesLimiter:
 
 
 class WritesLimiterFactory:
-    def __init__(self):
+    def __init__(self) -> None:
         self.rate_limiters: MutableMapping[str, WritesLimiter] = {}
 
     def get_ratelimiter(self, config: MetricsIngestConfiguration) -> WritesLimiter:

--- a/src/sentry/sentry_metrics/indexer/ratelimiters.py
+++ b/src/sentry/sentry_metrics/indexer/ratelimiters.py
@@ -11,7 +11,7 @@ from sentry.ratelimits.sliding_windows import (
     RequestedQuota,
     Timestamp,
 )
-from sentry.sentry_metrics.configuration import UseCaseKey, get_ingest_config
+from sentry.sentry_metrics.configuration import MetricsIngestConfiguration, UseCaseKey
 from sentry.sentry_metrics.indexer.base import FetchType, FetchTypeExt, KeyCollection, KeyResult
 from sentry.utils import metrics
 
@@ -103,23 +103,15 @@ class RateLimitState:
         Consumes the rate limits returned by `check_write_limits`.
         """
         if exc_type is None:
-            self._writes_limiter._get_rate_limiter(self._use_case_id, self._namespace).use_quotas(
+            self._writes_limiter.rate_limiter.use_quotas(
                 self._requests, self._grants, self._timestamp
             )
 
 
 class WritesLimiter:
-    def __init__(self) -> None:
-        self.rate_limiters: MutableMapping[str, RedisSlidingWindowRateLimiter] = {}
-
-    def _get_rate_limiter(
-        self, use_case_id: UseCaseKey, namespace: str
-    ) -> RedisSlidingWindowRateLimiter:
-        if namespace not in self.rate_limiters:
-            options = get_ingest_config(use_case_id).writes_limiter_cluster_options
-            self.rate_limiters[namespace] = RedisSlidingWindowRateLimiter(**options)
-
-        return self.rate_limiters[namespace]
+    def __init__(self, namespace: str, **options: Any) -> None:
+        self.namespace = namespace
+        self.rate_limiter: RedisSlidingWindowRateLimiter = RedisSlidingWindowRateLimiter(**options)
 
     @metrics.wraps("sentry_metrics.indexer.check_write_limits")
     def check_write_limits(
@@ -139,9 +131,7 @@ class WritesLimiter:
         """
 
         org_ids, requests = _construct_quota_requests(use_case_id, namespace, keys)
-        timestamp, grants = self._get_rate_limiter(use_case_id, namespace).check_within_quotas(
-            requests
-        )
+        timestamp, grants = self.rate_limiter.check_within_quotas(requests)
 
         granted_key_collection = dict(keys.mapping)
         dropped_strings = []
@@ -182,4 +172,17 @@ class WritesLimiter:
         return state
 
 
-writes_limiter = WritesLimiter()
+class WritesLimiterFactory:
+    def __init__(self):
+        self.rate_limiters: MutableMapping[str, WritesLimiter] = {}
+
+    def get_ratelimiter(self, config: MetricsIngestConfiguration) -> WritesLimiter:
+        namespace = config.writes_limiter_namespace
+        if namespace not in self.rate_limiters:
+            writes_rate_limiter = WritesLimiter(namespace, **config.writes_limiter_cluster_options)
+            self.rate_limiters[namespace] = writes_rate_limiter
+
+        return self.rate_limiters[namespace]
+
+
+writes_limiter_factory = WritesLimiterFactory()

--- a/tests/sentry/sentry_metrics/test_ratelimiters.py
+++ b/tests/sentry/sentry_metrics/test_ratelimiters.py
@@ -28,9 +28,7 @@ def test_writes_limiter_no_limits(set_sentry_option):
         }
     )
 
-    with writes_limiter.check_write_limits(
-        UseCaseKey.PERFORMANCE, PERFORMANCE_PG_NAMESPACE, key_collection
-    ) as state:
+    with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
         assert not state.dropped_strings
         assert state.accepted_keys.as_tuples() == key_collection.as_tuples()
 
@@ -50,9 +48,7 @@ def test_writes_limiter_doesnt_limit(set_sentry_option):
         }
     )
 
-    with writes_limiter.check_write_limits(
-        UseCaseKey.PERFORMANCE, PERFORMANCE_PG_NAMESPACE, key_collection
-    ) as state:
+    with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
         assert not state.dropped_strings
         assert state.accepted_keys.as_tuples() == key_collection.as_tuples()
 
@@ -72,9 +68,7 @@ def test_writes_limiter_org_limit(set_sentry_option):
         }
     )
 
-    with writes_limiter.check_write_limits(
-        UseCaseKey.PERFORMANCE, PERFORMANCE_PG_NAMESPACE, key_collection
-    ) as state:
+    with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
         assert len(state.dropped_strings) == 2
         assert sorted(ds.key_result.org_id for ds in state.dropped_strings) == [1, 2]
         assert sorted(org_id for org_id, string in state.accepted_keys.as_tuples()) == [1, 1, 2, 2]
@@ -97,9 +91,7 @@ def test_writes_limiter_global_limit(set_sentry_option):
         }
     )
 
-    with writes_limiter.check_write_limits(
-        UseCaseKey.PERFORMANCE, PERFORMANCE_PG_NAMESPACE, key_collection
-    ) as state:
+    with writes_limiter.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
         assert len(state.dropped_strings) == 2
 
 
@@ -126,9 +118,7 @@ def test_writes_limiter_respects_namespaces(set_sentry_option):
         }
     )
 
-    with writes_limiter_perf.check_write_limits(
-        UseCaseKey.PERFORMANCE, PERFORMANCE_PG_NAMESPACE, key_collection
-    ) as state:
+    with writes_limiter_perf.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
         assert len(state.dropped_strings) == 2
 
     key_collection = KeyCollection(
@@ -138,14 +128,10 @@ def test_writes_limiter_respects_namespaces(set_sentry_option):
         }
     )
 
-    with writes_limiter_perf.check_write_limits(
-        UseCaseKey.PERFORMANCE, PERFORMANCE_PG_NAMESPACE, key_collection
-    ) as state:
+    with writes_limiter_perf.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
         assert len(state.dropped_strings) == 4
 
     writes_limiter_rh = get_writes_limiter(RELEASE_HEALTH_PG_NAMESPACE)
 
-    with writes_limiter_rh.check_write_limits(
-        UseCaseKey.PERFORMANCE, RELEASE_HEALTH_PG_NAMESPACE, key_collection
-    ) as state:
+    with writes_limiter_rh.check_write_limits(UseCaseKey.PERFORMANCE, key_collection) as state:
         assert not state.dropped_strings


### PR DESCRIPTION
Addressing https://github.com/getsentry/sentry/pull/37745#discussion_r949779591 in https://github.com/getsentry/sentry/pull/37745

Right the `check_writes_limits` does both checking the limits, but also initializes a new `RedisSlidingWindowRateLimiter`. This causes some complexity because we end up looking up the config in order to get the options stored on the config in order for the redis rate limiter to be initialized. 

Instead I've pulled the logic out of initializing the rate limiters into the `WritesLimiterFactory`, and `get_ratelimiter` will get the right rate limiter based on the config. This means that each `WritesLimiter` has it's own redis rate limiter, and the factory is in charge of mapping the namespace to the `WritesLimiter` instances. 

This means as we add parameters like `db_backend` to be used to get the config, we don't have to pass those along to the rate limiter.

