### PR TITLE
ref: upgrade xmlsec to 1.3.12

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -182,7 +182,7 @@ werkzeug==2.1.2
 wheel==0.37.1
 wrapt==1.14.1
 wsproto==1.1.0
-xmlsec==1.3.11
+xmlsec==1.3.12
 zstandard==0.18.0
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -121,7 +121,7 @@ urllib3==1.26.11
 uwsgi==2.0.20.0
 vine==1.3.0
 wsproto==1.1.0
-xmlsec==1.3.11
+xmlsec==1.3.12
 zstandard==0.18.0
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
this version is prebuilt in getsentry/pypi

changelog doesn't really have much interesting in it -- PR generated w/ pip-tools