### PR TITLE
feat(span-details): Add a function to format timestamps with leading zero - [TET-291]

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -51,6 +51,7 @@ import InlineDocs from './inlineDocs';
 import {ParsedTraceType, ProcessedSpanType, rawSpanKeys, RawSpanType} from './types';
 import {
   getCumulativeAlertLevelFromErrors,
+  getFormattedTimeRangeWithLeadingZero,
   getTraceDateTimeRange,
   isGapSpan,
   isOrphanSpan,
@@ -356,6 +357,8 @@ class SpanDetail extends Component<Props, State> {
 
     const startTimestamp: number = span.start_timestamp;
     const endTimestamp: number = span.timestamp;
+    const {start: startTimeWithLeadingZero, end: endTimeWithLeadingZero} =
+      getFormattedTimeRangeWithLeadingZero(startTimestamp, endTimestamp);
 
     const duration = (endTimestamp - startTimestamp) * 1000;
     const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;
@@ -421,7 +424,7 @@ class SpanDetail extends Component<Props, State> {
                   value: (
                     <Fragment>
                       <DateTime date={startTimestamp * 1000} year seconds timeZone />
-                      {` (${startTimestamp})`}
+                      {` (${startTimeWithLeadingZero})`}
                     </Fragment>
                   ),
                 })}
@@ -432,7 +435,7 @@ class SpanDetail extends Component<Props, State> {
                   value: (
                     <Fragment>
                       <DateTime date={endTimestamp * 1000} year seconds timeZone />
-                      {` (${endTimestamp})`}
+                      {` (${endTimeWithLeadingZero})`}
                     </Fragment>
                   ),
                 })}

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -360,6 +360,8 @@ class SpanDetail extends Component<Props, State> {
     const {start: startTimeWithLeadingZero, end: endTimeWithLeadingZero} =
       getFormattedTimeRangeWithLeadingZero(startTimestamp, endTimestamp);
 
+    console.log({startTimeWithLeadingZero, endTimeWithLeadingZero});
+
     const duration = (endTimestamp - startTimestamp) * 1000;
     const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;
 

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -360,8 +360,6 @@ class SpanDetail extends Component<Props, State> {
     const {start: startTimeWithLeadingZero, end: endTimeWithLeadingZero} =
       getFormattedTimeRangeWithLeadingZero(startTimestamp, endTimestamp);
 
-    console.log({startTimeWithLeadingZero, endTimeWithLeadingZero});
-
     const duration = (endTimestamp - startTimestamp) * 1000;
     const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;
 

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -928,7 +928,7 @@ export function getFormattedTimeRangeWithLeadingZero(start: number, end: number)
     };
   }
 
-  const newTimeStamps = startStrings.reduce(
+  const newTimestamps = startStrings.reduce(
     (acc, startString, index) => {
       if (startString.length > endStrings[index].length) {
         acc.start.push(startString);
@@ -947,7 +947,7 @@ export function getFormattedTimeRangeWithLeadingZero(start: number, end: number)
   );
 
   return {
-    start: newTimeStamps.start.join('.'),
-    end: newTimeStamps.end.join('.'),
+    start: newTimestamps.start.join('.'),
+    end: newTimestamps.end.join('.'),
   };
 }

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -3,6 +3,7 @@ import {Location} from 'history';
 import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
 import maxBy from 'lodash/maxBy';
+import padStart from 'lodash/padStart';
 import set from 'lodash/set';
 import moment from 'moment';
 
@@ -913,3 +914,45 @@ const ERROR_LEVEL_WEIGHTS: Record<TraceError['level'], number> = {
   sample: 2,
   info: 1,
 };
+
+/**
+ * Formats start and end unix timestamps by inserting a leading zero if needed, so they can have the same length
+ */
+export function getFormattedTimeRangeWithLeadingZero(start: number, end: number) {
+  const stringStart = String(start).split('.');
+  const stringEnd = String(end).split('.');
+
+  if (stringStart.length !== stringEnd.length) {
+    return {
+      start,
+      end,
+    };
+  }
+
+  const newTimeStamps = stringStart.reduce(
+    (acc, stringStartTimestamp, index) => {
+      if (stringStartTimestamp.length > stringEnd[index].length) {
+        acc.start.push(Number(stringStartTimestamp));
+        acc.end.push(
+          Number(padStart(stringEnd[index], stringStartTimestamp.length, '0'))
+        );
+        return acc;
+      }
+
+      acc.start.push(
+        Number(padStart(stringStartTimestamp, stringEnd[index].length, '0'))
+      );
+      acc.end.push(Number(stringEnd[index]));
+      return acc;
+    },
+    {start: [], end: []} as {
+      end: number[];
+      start: number[];
+    }
+  );
+
+  return {
+    start: newTimeStamps.start.join('.'),
+    end: newTimeStamps.end.join('.'),
+  };
+}

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -3,7 +3,6 @@ import {Location} from 'history';
 import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
 import maxBy from 'lodash/maxBy';
-import padStart from 'lodash/padStart';
 import set from 'lodash/set';
 import moment from 'moment';
 
@@ -919,35 +918,31 @@ const ERROR_LEVEL_WEIGHTS: Record<TraceError['level'], number> = {
  * Formats start and end unix timestamps by inserting a leading zero if needed, so they can have the same length
  */
 export function getFormattedTimeRangeWithLeadingZero(start: number, end: number) {
-  const stringStart = String(start).split('.');
-  const stringEnd = String(end).split('.');
+  const startStrings = String(start).split('.');
+  const endStrings = String(end).split('.');
 
-  if (stringStart.length !== stringEnd.length) {
+  if (startStrings.length !== endStrings.length) {
     return {
-      start,
-      end,
+      start: String(start),
+      end: String(end),
     };
   }
 
-  const newTimeStamps = stringStart.reduce(
-    (acc, stringStartTimestamp, index) => {
-      if (stringStartTimestamp.length > stringEnd[index].length) {
-        acc.start.push(Number(stringStartTimestamp));
-        acc.end.push(
-          Number(padStart(stringEnd[index], stringStartTimestamp.length, '0'))
-        );
+  const newTimeStamps = startStrings.reduce(
+    (acc, startString, index) => {
+      if (startString.length > endStrings[index].length) {
+        acc.start.push(startString);
+        acc.end.push(endStrings[index].padStart(startString.length, '0'));
         return acc;
       }
 
-      acc.start.push(
-        Number(padStart(stringStartTimestamp, stringEnd[index].length, '0'))
-      );
-      acc.end.push(Number(stringEnd[index]));
+      acc.start.push(startString.padStart(endStrings[index].length, '0'));
+      acc.end.push(endStrings[index]);
       return acc;
     },
     {start: [], end: []} as {
-      end: number[];
-      start: number[];
+      end: string[];
+      start: string[];
     }
   );
 

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -8,6 +8,7 @@ import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import Clipboard from 'sentry/components/clipboard';
 import DateTime from 'sentry/components/dateTime';
+import {getFormattedTimeRangeWithLeadingZero} from 'sentry/components/events/interfaces/spans/utils';
 import Link from 'sentry/components/links/link';
 import {
   ErrorDot,
@@ -175,6 +176,8 @@ class TransactionDetail extends Component<Props> {
     const {location, organization, transaction} = this.props;
     const startTimestamp = Math.min(transaction.start_timestamp, transaction.timestamp);
     const endTimestamp = Math.max(transaction.start_timestamp, transaction.timestamp);
+    const {start: startTimeWithLeadingZero, end: endTimeWithLeadingZero} =
+      getFormattedTimeRangeWithLeadingZero(startTimestamp, endTimestamp);
     const duration = (endTimestamp - startTimestamp) * 1000;
     const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;
 
@@ -214,7 +217,7 @@ class TransactionDetail extends Component<Props> {
                 value: (
                   <Fragment>
                     <DateTime date={startTimestamp * 1000} />
-                    {` (${startTimestamp})`}
+                    {` (${startTimeWithLeadingZero})`}
                   </Fragment>
                 ),
               })}
@@ -225,7 +228,7 @@ class TransactionDetail extends Component<Props> {
                 value: (
                   <Fragment>
                     <DateTime date={endTimestamp * 1000} />
-                    {` (${endTimestamp})`}
+                    {` (${endTimeWithLeadingZero})`}
                   </Fragment>
                 ),
               })}


### PR DESCRIPTION
Implement the GitHub suggestion: https://github.com/getsentry/sentry/issues/37114

**Before:**
![image](https://user-images.githubusercontent.com/29228205/187215822-07b8fa69-265f-4b6a-9322-5f405306a2ec.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/187218013-9e7e1589-784e-45e4-a29f-4e742aff7fc9.png)



