### PR TITLE
fix(replays): Fixes replay times exceeding duration

### DIFF
--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -85,7 +85,7 @@ export default class ReplayReader {
    * @returns Duration of Replay (milliseonds)
    */
   getDurationMs = () => {
-    return this.replayRecord.duration * 1000;
+    return this.replayRecord.finishedAt.getTime() - this.replayRecord.startedAt.getTime();
   };
 
   getReplay = () => {


### PR DESCRIPTION
### Issue
Actual replay time was exceeding the value of the replay duration causing overflow in the UI

### Changes
- Updates `getDurationMs` to be calculated based on finish and starting time 

Closes #38176 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
