### PR TITLE
fix(replays): fix bad uuid4 in project_replay_details test

### DIFF
--- a/tests/sentry/replays/test_project_replay_details.py
+++ b/tests/sentry/replays/test_project_replay_details.py
@@ -1,5 +1,5 @@
 import datetime
-import uuid
+from uuid import uuid4
 
 from django.urls import reverse
 
@@ -15,7 +15,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.replay_id = uuid.uuid4().hex
+        self.replay_id = uuid4().hex
         self.url = reverse(
             self.endpoint, args=(self.organization.slug, self.project.slug, self.replay_id)
         )
@@ -32,7 +32,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
     def test_get_one_replay(self):
         """Test only one replay returned."""
         replay1_id = self.replay_id
-        replay2_id = uuid.uuid4().hex
+        replay2_id = uuid4().hex
         seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=10)
         seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=5)
 
@@ -63,11 +63,13 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
     def test_get_replay_schema(self):
         """Test replay schema is well-formed."""
         replay1_id = self.replay_id
-        replay2_id = uuid.uuid4().hex
+        replay2_id = uuid4().hex
         seq1_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=25)
         seq2_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=7)
         seq3_timestamp = datetime.datetime.now() - datetime.timedelta(seconds=4)
 
+        trace_id_1 = uuid4().hex
+        trace_id_2 = uuid4().hex
         # Assert values from this non-returned replay do not pollute the returned
         # replay.
         self.store_replays(mock_replay(seq1_timestamp, self.project.id, replay2_id))
@@ -78,7 +80,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 seq1_timestamp,
                 self.project.id,
                 replay1_id,
-                trace_ids=["ffb5344a-41dd-4b21-9288-187a2cd1ad6d"],
+                trace_ids=[trace_id_1],
                 urls=["http://localhost:3000/"],
             )
         )
@@ -88,7 +90,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 self.project.id,
                 replay1_id,
                 segment_id=1,
-                trace_ids=["2a0dcb0e-a1fb-4350-b2664-7ae1aa57dfb"],
+                trace_ids=[trace_id_2],
                 urls=["http://www.sentry.io/"],
             )
         )
@@ -98,7 +100,7 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 self.project.id,
                 replay1_id,
                 segment_id=2,
-                trace_ids=["2a0dcb0e-a1fb-4350-b2664-7ae1aa57dfb"],
+                trace_ids=[trace_id_2],
                 urls=["http://localhost:3000/"],
             )
         )
@@ -116,8 +118,8 @@ class OrganizationReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                 seq1_timestamp,
                 seq3_timestamp,
                 trace_ids=[
-                    "2a0dcb0ea1fb4350b266f7ae1aa57dfb",
-                    "ffb5344a41dd4b219288187a2cd1ad6d",
+                    trace_id_1,
+                    trace_id_2,
                 ],
                 urls=[
                     "http://localhost:3000/",


### PR DESCRIPTION
one of these trace_ids wasn't a valid uuid, and after https://github.com/getsentry/snuba/pull/3074 we're now validating uuids, so this broke the test. solution is to replace the hardcoded bad uuid with `uuid4().hex`.