### PR TITLE
ref(metrics-indexer): Turn process_messages into MessageProcessor

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
@@ -16,7 +16,7 @@ from django.conf import settings
 
 from sentry.sentry_metrics.configuration import MetricsIngestConfiguration
 from sentry.sentry_metrics.consumers.indexer.common import BatchMessages, MessageBatch, get_config
-from sentry.sentry_metrics.consumers.indexer.processing import process_messages
+from sentry.sentry_metrics.consumers.indexer.processing import MessageProcessor
 from sentry.utils import kafka_config, metrics
 from sentry.utils.batching_kafka_consumer import create_topics
 
@@ -69,9 +69,7 @@ class TransformStep(ProcessingStep[MessageBatch]):  # type: ignore
     def __init__(
         self, next_step: ProcessingStep[KafkaPayload], config: MetricsIngestConfiguration
     ) -> None:
-        self.__process_messages: Callable[[Message[MessageBatch]], MessageBatch] = partial(
-            process_messages, config.use_case_id
-        )
+        self.__message_processor: MessageProcessor = MessageProcessor(config.use_case_id)
         self.__next_step = next_step
         self.__closed = False
 
@@ -82,7 +80,7 @@ class TransformStep(ProcessingStep[MessageBatch]):  # type: ignore
         assert not self.__closed
 
         with metrics.timer("transform_step.process_messages"):
-            transformed_message_batch = self.__process_messages(message)
+            transformed_message_batch = self.__message_processor.process_messages(message)
 
         for transformed_message in transformed_message_batch:
             self.__next_step.submit(transformed_message)

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -111,9 +111,8 @@ class MetricsConsumerStrategyFactory(ProcessingStrategyFactory):  # type: ignore
         commit: Callable[[Mapping[Partition, Position]], None],
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
-        message_processor = MessageProcessor(self.__config.use_case_id)
         parallel_strategy = ParallelTransformStep(
-            message_processor.process_messages,
+            MessageProcessor(self.__config.use_case_id).process_messages,
             Unbatcher(
                 SimpleProduceStep(
                     commit_function=commit,

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from functools import partial
 from typing import Callable, Mapping, Optional, Union
 
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
@@ -17,7 +16,7 @@ from sentry.runner import configure
 from sentry.sentry_metrics.configuration import MetricsIngestConfiguration
 from sentry.sentry_metrics.consumers.indexer.common import BatchMessages, MessageBatch, get_config
 from sentry.sentry_metrics.consumers.indexer.multiprocess import SimpleProduceStep
-from sentry.sentry_metrics.consumers.indexer.processing import process_messages
+from sentry.sentry_metrics.consumers.indexer.processing import MessageProcessor
 from sentry.utils.batching_kafka_consumer import create_topics
 
 logger = logging.getLogger(__name__)
@@ -112,8 +111,9 @@ class MetricsConsumerStrategyFactory(ProcessingStrategyFactory):  # type: ignore
         commit: Callable[[Mapping[Partition, Position]], None],
         partitions: Mapping[Partition, int],
     ) -> ProcessingStrategy[KafkaPayload]:
+        message_processor = MessageProcessor(self.__config.use_case_id)
         parallel_strategy = ParallelTransformStep(
-            partial(process_messages, self.__config.use_case_id),
+            message_processor.process_messages,
             Unbatcher(
                 SimpleProduceStep(
                     commit_function=commit,

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -18,7 +18,7 @@ from sentry.sentry_metrics.consumers.indexer.common import (
     MetricsBatchBuilder,
 )
 from sentry.sentry_metrics.consumers.indexer.multiprocess import TransformStep
-from sentry.sentry_metrics.consumers.indexer.processing import process_messages
+from sentry.sentry_metrics.consumers.indexer.processing import MessageProcessor
 from sentry.sentry_metrics.indexer.mock import MockIndexer
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
 from sentry.utils import json
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 
 pytestmark = pytest.mark.sentry_metrics
+
+process_messages = MessageProcessor(UseCaseKey.RELEASE_HEALTH).process_messages
 
 
 def compare_messages_ignoring_mapping_metadata(actual: Message, expected: Message) -> None:
@@ -275,7 +277,7 @@ def test_process_messages() -> None:
     last = message_batch[-1]
     outer_message = Message(last.partition, last.offset, message_batch, last.timestamp)
 
-    new_batch = process_messages(use_case_id=UseCaseKey.RELEASE_HEALTH, outer_message=outer_message)
+    new_batch = process_messages(outer_message=outer_message)
     expected_new_batch = [
         Message(
             m.partition,
@@ -415,9 +417,7 @@ def test_process_messages_invalid_messages(
     outer_message = Message(last.partition, last.offset, message_batch, last.timestamp)
 
     with caplog.at_level(logging.ERROR):
-        new_batch = process_messages(
-            use_case_id=UseCaseKey.RELEASE_HEALTH, outer_message=outer_message
-        )
+        new_batch = process_messages(outer_message=outer_message)
 
     # we expect just the valid counter_payload msg to be left
     expected_msg = message_batch[0]
@@ -479,9 +479,7 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
     backend.indexer._strings[1]["rate_limited_test"] = None
 
     with caplog.at_level(logging.ERROR):
-        new_batch = process_messages(
-            use_case_id=UseCaseKey.RELEASE_HEALTH, outer_message=outer_message
-        )
+        new_batch = process_messages(outer_message=outer_message)
 
     # we expect just the counter_payload msg to be left, as that one didn't
     # cause/depend on string writes that have been rate limited

--- a/tests/sentry/sentry_metrics/test_multiprocess_steps.py
+++ b/tests/sentry/sentry_metrics/test_multiprocess_steps.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 pytestmark = pytest.mark.sentry_metrics
 
-process_messages = MessageProcessor(UseCaseKey.RELEASE_HEALTH).process_messages
+MESSAGE_PROCESSOR = MessageProcessor(UseCaseKey.RELEASE_HEALTH)
 
 
 def compare_messages_ignoring_mapping_metadata(actual: Message, expected: Message) -> None:
@@ -277,7 +277,7 @@ def test_process_messages() -> None:
     last = message_batch[-1]
     outer_message = Message(last.partition, last.offset, message_batch, last.timestamp)
 
-    new_batch = process_messages(outer_message=outer_message)
+    new_batch = MESSAGE_PROCESSOR.process_messages(outer_message=outer_message)
     expected_new_batch = [
         Message(
             m.partition,
@@ -417,7 +417,7 @@ def test_process_messages_invalid_messages(
     outer_message = Message(last.partition, last.offset, message_batch, last.timestamp)
 
     with caplog.at_level(logging.ERROR):
-        new_batch = process_messages(outer_message=outer_message)
+        new_batch = MESSAGE_PROCESSOR.process_messages(outer_message=outer_message)
 
     # we expect just the valid counter_payload msg to be left
     expected_msg = message_batch[0]
@@ -479,7 +479,7 @@ def test_process_messages_rate_limited(caplog, settings) -> None:
     backend.indexer._strings[1]["rate_limited_test"] = None
 
     with caplog.at_level(logging.ERROR):
-        new_batch = process_messages(outer_message=outer_message)
+        new_batch = MESSAGE_PROCESSOR.process_messages(outer_message=outer_message)
 
     # we expect just the counter_payload msg to be left, as that one didn't
     # cause/depend on string writes that have been rate limited


### PR DESCRIPTION
**context:**
addressing the comments in https://github.com/getsentry/sentry/pull/37745 specifically this comment https://github.com/getsentry/sentry/pull/37745#discussion_r949776817.

This change will allow me to initialize the indexer _not_ on every batch, but instead on when the strategy is created. If this would be recreating the indexer instance too often, we could move it farther up (aka when the factory is created vs the strategy). 

My idea is that in https://github.com/getsentry/sentry/pull/37745 we can add a `indexer_db_options` to the config which can be used to initialize the indexer. 

Something like:

```python
STORAGE_TO_INDEXER: Mapping[IndexerStorage, StringIndexer] = {
    IndexerStorage.CLOUDSPANNER: CloudSpannerIndexer,
    IndexerStorage.POSTGRES: PostgresIndexer,
    IndexerStorage.MOCK: MockIndexer,
}

class MessageProcessor:
    def __init__(self, config: MetricsIngestConfiguration):
        self._config = config
        self._indexer = STORAGE_TO_INDEXER[config.db_backend](**config.indexer_db_options)
