### PR TITLE
tests(perf_issues): Modify `EventTest.test_snuba_data_transaction` to write group ids to snuba

### DIFF
--- a/tests/sentry/eventstore/test_models.py
+++ b/tests/sentry/eventstore/test_models.py
@@ -253,7 +253,7 @@ class EventTest(TestCase):
         def hack_pull_out_data(jobs, projects):
             _pull_out_data(jobs, projects)
             for job in jobs:
-                job["event"].group_ids = [self.group.id]
+                job["event"].groups = [self.group]
             return jobs, projects
 
         with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):


### PR DESCRIPTION
This is a hack so that we can have this test actually send group ids to snuba in tests. We should
figure out nicer way going forward..
