### PR TITLE
ref: Do not constantly redefine defaults

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Literal, Optional, Union
 
 from sentry.tasks.post_process import post_process_group
 from sentry.utils.cache import cache_key_for_event
@@ -119,14 +119,14 @@ class EventStream(Service):
 
     def run_post_process_forwarder(
         self,
-        entity,
-        consumer_group,
+        entity: Union[Literal["all"], Literal["errors"], Literal["transactions"]],
+        consumer_group: str,
         topic: Optional[str],
-        commit_log_topic,
-        synchronize_commit_group,
-        commit_batch_size=100,
-        commit_batch_timeout_ms=5000,
-        initial_offset_reset="latest",
+        commit_log_topic: str,
+        synchronize_commit_group: str,
+        commit_batch_size: int,
+        commit_batch_timeout_ms: int,
+        initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
     ):
         assert not self.requires_post_process_forwarder()
         raise ForwarderNotRequired

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -195,9 +195,9 @@ class KafkaEventStream(SnubaProtocolEventStream):
         topic: Optional[str],
         commit_log_topic: str,
         synchronize_commit_group: str,
-        commit_batch_size: int = 100,
-        commit_batch_timeout_ms: int = 5000,
-        initial_offset_reset: Union[Literal["latest"], Literal["earliest"]] = "latest",
+        commit_batch_size: int,
+        commit_batch_timeout_ms: int,
+        initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
     ):
         concurrency = options.get(_CONCURRENCY_OPTION)
         logger.info(f"Starting post process forwarder to consume {entity} messages")
@@ -245,9 +245,9 @@ class KafkaEventStream(SnubaProtocolEventStream):
         topic: Optional[str],
         commit_log_topic: str,
         synchronize_commit_group: str,
-        commit_batch_size: int = 100,
-        commit_batch_timeout_ms: int = 5000,
-        initial_offset_reset: Union[Literal["latest"], Literal["earliest"]] = "latest",
+        commit_batch_size: int,
+        commit_batch_timeout_ms: int,
+        initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
     ):
         consumer = self._build_consumer(
             entity,
@@ -275,9 +275,9 @@ class KafkaEventStream(SnubaProtocolEventStream):
         topic: Optional[str],
         commit_log_topic: str,
         synchronize_commit_group: str,
-        commit_batch_size: int = 100,
-        commit_batch_timeout_ms: int = 5000,
-        initial_offset_reset: Union[Literal["latest"], Literal["earliest"]] = "latest",
+        commit_batch_size: int,
+        commit_batch_timeout_ms: int,
+        initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
     ):
         logger.debug("Starting post-process forwarder...")
 

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -686,6 +686,7 @@ class BatchedConsumerTest(TestCase):
             commit_log_topic=self.commit_log_topic,
             synchronize_commit_group=synchronize_commit_group,
             commit_batch_size=1,
+            commit_batch_timeout_ms=100,
             initial_offset_reset="earliest",
         )
 


### PR DESCRIPTION
We are defining the defaults in too many places. Some of them are
different to those defined in the CLI entrypoint which is confusing.
Let's clean this up since this code is going to be refactored soon
to use Arroyo and accept a --no-strict-offset-reset option.