### PR TITLE
feat(snuba): Add threads.name field to Alerts and Discovery

### DIFF
--- a/fixtures/js-stubs/projectAlertRuleConfiguration.js
+++ b/fixtures/js-stubs/projectAlertRuleConfiguration.js
@@ -202,6 +202,7 @@ export function ProjectAlertRuleConfiguration(params = {}) {
               ['stacktrace.filename', 'stacktrace.filename'],
               ['stacktrace.abs_path', 'stacktrace.abs_path'],
               ['stacktrace.package', 'stacktrace.package'],
+              ['threads.name', 'threads.name'],
             ],
           },
           match: {

--- a/fixtures/js-stubs/ruleConditions.js
+++ b/fixtures/js-stubs/ruleConditions.js
@@ -104,6 +104,7 @@ export const MOCK_RESP_VERBOSE = [
           ['stacktrace.code', 'stacktrace.code'],
           ['stacktrace.module', 'stacktrace.module'],
           ['stacktrace.filename', 'stacktrace.filename'],
+          ['threads.name', 'threads.name'],
         ],
       },
       value: {

--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -25,6 +25,7 @@ ATTR_CHOICES = [
     "stacktrace.filename",
     "stacktrace.abs_path",
     "stacktrace.package",
+    "threads.name",
 ]
 
 
@@ -46,6 +47,7 @@ class EventAttributeCondition(EventCondition):
     - user.{id,ip_address,email,FIELD}
     - http.{method,url}
     - stacktrace.{code,module,filename,abs_path,package}
+    - threads.{name}
     - extra.{FIELD}
     """
 
@@ -144,6 +146,13 @@ class EventAttributeCondition(EventCondition):
                         if frame.post_context:
                             result.extend(frame.post_context)
             return result
+
+        elif path[0] == "threads":
+            if path[1] not in ("name"):
+                return []
+
+            return [e.get(path[1]) for e in event.interfaces["threads"].values]
+
         return []
 
     def render_label(self) -> str:

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -130,6 +130,7 @@ ARRAY_FIELDS = {
     "stack.module",
     "stack.package",
     "stack.stack_level",
+    "threads.name",
     "spans_op",
     "spans_group",
     "spans_exclusive_time",

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -436,6 +436,13 @@ class Columns(Enum):
         discover_name="exception_frames.stack_level",
         alias="stack.stack_level",
     )
+    THREADS_NAME = Column(
+        group_name="events.threads.name",
+        event_name="threads.name",
+        transaction_name=None,
+        discover_name="threads.name",
+        alias="threads.name",
+    )
     CONTEXTS_KEY = Column(
         group_name="events.contexts.key",
         event_name="contexts.key",

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -78,6 +78,7 @@ export enum FieldKey {
   STACK_PACKAGE = 'stack.package',
   STACK_RESOURCE = 'stack.resource',
   STACK_STACK_LEVEL = 'stack.stack_level',
+  THREADS_NAME = 'threads.name',
   TIMESTAMP = 'timestamp',
   TIMESTAMP_TO_DAY = 'timestamp.to_day',
   TIMESTAMP_TO_HOUR = 'timestamp.to_hour',
@@ -747,6 +748,11 @@ export const FIELDS: Record<FieldKey & AggregationKey & MobileVital, FieldDefini
     kind: FieldKind.FIELD,
     valueType: FieldValueType.NUMBER,
   },
+  [FieldKey.THREADS_NAME]: {
+    desc: t('Name of the thread'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+  },
   [FieldKey.TIMES_SEEN]: {
     desc: t('Total number of events'),
     kind: FieldKind.FIELD,
@@ -892,6 +898,7 @@ export const ISSUE_FIELDS = [
   FieldKey.STACK_MODULE,
   FieldKey.STACK_PACKAGE,
   FieldKey.STACK_STACK_LEVEL,
+  FieldKey.THREADS_NAME,
   FieldKey.TIMESTAMP,
   FieldKey.TIMES_SEEN,
   FieldKey.TITLE,
@@ -969,6 +976,7 @@ export const DISCOVER_FIELDS = [
   FieldKey.STACK_COLNO,
   FieldKey.STACK_LINENO,
   FieldKey.STACK_STACK_LEVEL,
+  FieldKey.THREADS_NAME,
   // contexts.key and contexts.value omitted on purpose.
 
   // Transaction event fields.

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -33,6 +33,13 @@ class EventAttributeConditionTest(RuleTestCase):
                     }
                 ]
             },
+            "threads": {
+                "values": [
+                    {
+                        "name": "awesome-thread",
+                    }
+                ]
+            },
             "tags": [("environment", "production")],
             "extra": {"foo": {"bar": "baz"}, "biz": ["baz"], "bar": "foo"},
             "platform": "php",
@@ -568,5 +575,17 @@ class EventAttributeConditionTest(RuleTestCase):
                 "attribute": "stacktrace.package",
                 "value": "package/otherotherpackage.lib",
             }
+        )
+        self.assertDoesNotPass(rule, event)
+
+    def test_threads_name(self):
+        event = self.get_event()
+        rule = self.get_rule(
+            data={"match": MatchType.EQUAL, "attribute": "threads.name", "value": "awesome-thread"}
+        )
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule(
+            data={"match": MatchType.EQUAL, "attribute": "threads.name", "value": "foo bar"}
         )
         self.assertDoesNotPass(rule, event)


### PR DESCRIPTION
[WIP] Ability to use `threads.name` in discovery, issues filter and alerts.