### PR TITLE
fix(mep): Metrics meta bug with str tag values

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -468,7 +468,7 @@ register("api.deprecation.brownout-cron", default="0 12 * * *", type=String)
 register("api.deprecation.brownout-duration", default="PT1M")
 
 # switch all metrics usage over to using strings for tag values
-register("sentry-metrics.performance.tags-values-are-strings", default=True)
+register("sentry-metrics.performance.tags-values-are-strings", default=False)
 
 # Global and per-organization limits on the writes to the string indexer's DB.
 #

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -468,7 +468,7 @@ register("api.deprecation.brownout-cron", default="0 12 * * *", type=String)
 register("api.deprecation.brownout-duration", default="PT1M")
 
 # switch all metrics usage over to using strings for tag values
-register("sentry-metrics.performance.tags-values-are-strings", default=False)
+register("sentry-metrics.performance.tags-values-are-strings", default=True)
 
 # Global and per-organization limits on the writes to the string indexer's DB.
 #

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -223,7 +223,7 @@ class MetricsDatasetConfig(DatasetConfig):
                                         "equals",
                                         [
                                             self.builder.column("transaction"),
-                                            0,
+                                            "" if self.builder.tag_values_are_strings else 0,
                                         ],
                                     ),
                                 ],
@@ -252,7 +252,13 @@ class MetricsDatasetConfig(DatasetConfig):
                                         "and",
                                         [
                                             Function(
-                                                "notEquals", [self.builder.column("transaction"), 0]
+                                                "notEquals",
+                                                [
+                                                    self.builder.column("transaction"),
+                                                    ""
+                                                    if self.builder.tag_values_are_strings
+                                                    else 0,
+                                                ],
                                             ),
                                             Function(
                                                 "notEquals",
@@ -1191,14 +1197,6 @@ class MetricsDatasetConfig(DatasetConfig):
             quality_id = self.builder.resolve_tag_value(quality)
         except IncompatibleMetricsQuery:
             quality_id = None
-
-        if quality_id is None:
-            return Function(
-                # This matches the type from doing `select toTypeName(count()) ...` from clickhouse
-                "toUInt64",
-                [0],
-                alias,
-            )
 
         return Function(
             "countIf",

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -1198,6 +1198,14 @@ class MetricsDatasetConfig(DatasetConfig):
         except IncompatibleMetricsQuery:
             quality_id = None
 
+        if quality_id is None:
+            return Function(
+                # This matches the type from doing `select toTypeName(count()) ...` from clickhouse
+                "toUInt64",
+                [0],
+                alias,
+            )
+
         return Function(
             "countIf",
             [


### PR DESCRIPTION
- With str tag values we shouldn't use `0` for when the tag array
  doesn't have txn, but should instead use the empty string `''`
