### PR TITLE
ref: use internal pypi

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -107,14 +107,6 @@ runs:
         cache: pip
         cache-dependency-path: ${{ inputs.workdir }}/requirements-dev-frozen.txt
 
-    - name: Install system dependencies
-      shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends \
-          libxmlsec1-dev \
-          libmaxminddb-dev
-
     - name: Set up outputs
       id: config
       env:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -448,14 +448,10 @@ jobs:
 
       # We don't call setup-sentry, because we don't need devservices.
       - name: Setup backend typing
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends libxmlsec1-dev
-          pip install -r requirements-dev-frozen.txt
+        run: pip install -r requirements-dev-frozen.txt
 
       - name: Run backend typing (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
-        run: |
-          make backend-typing
+        run: make backend-typing
 
   # This check runs once all dependant jobs have passed
   # It symbolizes that all required Backend checks have succesfully passed (Or skipped)

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -50,10 +50,6 @@ jobs:
           sudo /Applications/Docker.app/Contents/MacOS/Docker --unattended --install-privileged-components
           open -a /Applications/Docker.app --args --unattended --accept-license
 
-      - name: Install missing brew packages
-        run: |
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install -v libxmlsec1
-
       - uses: ./.github/actions/setup-volta
 
       # This handles Python's cache
@@ -67,6 +63,9 @@ jobs:
       # This tests starting up the dev services, loading mocks and pre-commit installation
       # This can take over 15 minutes
       - name: make bootstrap
+        # GHA pythons are miscompiled and report macos 10.16
+        env:
+          SYSTEM_VERSION_COMPAT: 0
         run: |
           python -m venv .venv
           source .venv/bin/activate

--- a/Brewfile
+++ b/Brewfile
@@ -10,15 +10,6 @@ brew 'readline'
 # required for yarn test -u
 brew 'watchman'
 
-# required to build some of sentry's dependencies
-brew 'pkgconfig'
-brew 'libxslt'
-brew 'libxmlsec1'
-brew 'geoip'
-
-# Currently needed because on Big Sur there's no wheel for it
-brew 'librdkafka'
-
 # direnv isn't defined here, because we have it configured to check for a bootstrapped environment.
 # If it's installed in the early steps of the setup process, it just leads to confusion.
 # brew 'direnv'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,15 +58,6 @@ RUN set -x \
   wget \
   zlib1g-dev \
   " \
-  # maxminddb
-  && buildDeps="$buildDeps \
-  libmaxminddb-dev \
-  "\
-  # xmlsec
-  && buildDeps="$buildDeps \
-  libxmlsec1-dev \
-  pkg-config \
-  " \
   && apt-get update \
   && apt-get install -y --no-install-recommends $buildDeps \
   && pip install -r /tmp/requirements-frozen.txt \
@@ -78,26 +69,6 @@ RUN set -x \
   && mv dogstatsd_plugin.so /var/lib/uwsgi/ \
   && rm -rf /tmp/requirements-frozen.txt /tmp/uwsgi-dogstatsd .uwsgi_plugins_builder \
   && apt-get purge -y --auto-remove $buildDeps \
-  # We install run-time dependencies strictly after
-  # build dependencies to prevent accidental collusion.
-  # These are also installed last as they are needed
-  # during container run and can have the same deps w/
-  # build deps such as maxminddb.
-  && apt-get install -y --no-install-recommends \
-  # pillow
-  libjpeg-dev \
-  # rust bindings
-  libffi-dev \
-  # maxminddb bindings
-  libmaxminddb-dev \
-  # SAML needs these run-time
-  libxmlsec1-dev \
-  libxslt-dev \
-  # pyyaml needs this run-time
-  libyaml-dev \
-  # other
-  pkg-config \
-  \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   # Fully verify that the C extension is correctly installed, it unfortunately

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,3 +1,5 @@
+--index-url https://pypi.devinfra.sentry.io/simple
+
 beautifulsoup4>=4.7.1
 boto3>=1.22.12
 botocore>=1.25.12

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -1,5 +1,7 @@
 # DO NOT MODIFY. This file was generated with `make freeze-requirements`.
 
+--index-url https://pypi.devinfra.sentry.io/simple
+
 amqp==2.6.1
 async-generator==1.10
 attrs==19.2.0

--- a/requirements-dev-only-frozen.txt
+++ b/requirements-dev-only-frozen.txt
@@ -1,5 +1,7 @@
 # DO NOT MODIFY. This file was generated with `make freeze-requirements`.
 
+--index-url https://pypi.devinfra.sentry.io/simple
+
 attrs==21.4.0
 black==22.3.0
 build==0.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
+--index-url https://pypi.devinfra.sentry.io/simple
+
 docker>=3.7.0,<3.8.0
 exam>=0.10.6
 freezegun>=1.1.0

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -1,5 +1,7 @@
 # DO NOT MODIFY. This file was generated with `make freeze-requirements`.
 
+--index-url https://pypi.devinfra.sentry.io/simple
+
 amqp==2.6.1
 async-generator==1.10
 attrs==19.2.0

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -18,6 +18,10 @@ fi
 
 venv_name=".venv"
 
+pip-install() {
+    pip install $(grep ^-- requirements-base.txt) "$@"
+}
+
 # Check if a command is available
 require() {
     command -v "$1" >/dev/null 2>&1
@@ -29,21 +33,6 @@ configure-sentry-cli() {
             curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=2.0.4 bash
         fi
     fi
-}
-
-query-mac() {
-    [[ $(uname -s) = 'Darwin' ]]
-}
-
-query-big-sur() {
-    if require sw_vers && sw_vers -productVersion | grep -E "11\." >/dev/null; then
-        return 0
-    fi
-    return 1
-}
-
-query-apple-m1() {
-    query-mac && [[ $(uname -m) = 'arm64' ]]
 }
 
 query-valid-python-version() {
@@ -91,8 +80,7 @@ sudo-askpass() {
 }
 
 upgrade-pip() {
-    grep -E '^(pip|setuptools|wheel)==' requirements-dev-frozen.txt |
-        xargs pip install --upgrade
+    pip-install $(grep -E '^(pip|setuptools|wheel)==' requirements-dev-frozen.txt)
 }
 
 install-py-dev() {
@@ -102,14 +90,6 @@ install-py-dev() {
     cd "${HERE}/.." || exit
 
     echo "--> Installing Sentry (for development)"
-    if query-apple-m1; then
-        # This installs pyscopg-binary2 since there's no arm64 wheel
-        # This saves having to install postgresql on the Developer's machine + using flags
-        # https://github.com/psycopg/psycopg2/issues/1286
-        pip install https://storage.googleapis.com/python-arm64-wheels/psycopg2_binary-2.8.6-cp38-cp38-macosx_11_0_arm64.whl
-        # The LDFLAGS is needed for uWSGI --> https://github.com/unbit/uwsgi/issues/2361
-        export LDFLAGS="-L$(brew --prefix gettext)/lib"
-    fi
 
     # pip doesn't do well with swapping drop-ins
     pip uninstall -qqy uwsgi
@@ -117,7 +97,7 @@ install-py-dev() {
     # SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
     # Webpacked assets are only necessary for devserver (which does it lazily anyways)
     # and acceptance tests, which webpack automatically if run.
-    SENTRY_LIGHT_BUILD=1 pip install -e '.[dev]'
+    SENTRY_LIGHT_BUILD=1 pip-install -e '.[dev]'
 }
 
 setup-git-config() {
@@ -136,7 +116,7 @@ setup-git() {
         exit 1
     )
     if ! require pre-commit; then
-        pip install -r requirements-dev-only-frozen.txt
+        pip-install -r requirements-dev-only-frozen.txt
     fi
     pre-commit install --install-hooks
     echo ""
@@ -245,7 +225,7 @@ prerequisites() {
     if [ -z "${CI+x}" ]; then
         brew update -q && brew bundle -q
     else
-        HOMEBREW_NO_AUTO_UPDATE=on brew install libxmlsec1 pyenv
+        HOMEBREW_NO_AUTO_UPDATE=on brew install pyenv
     fi
 }
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ cmdclass = {
 
 def get_requirements(env):
     with open(f"requirements-{env}.txt") as fp:
-        return [x.strip() for x in fp.read().split("\n") if not x.startswith("#")]
+        return [x.strip() for x in fp.read().split("\n") if not x.startswith(("#", "--"))]
 
 
 # Only include dev requirements in non-binary distributions as we don't want these

--- a/tools/freeze_requirements.py
+++ b/tools/freeze_requirements.py
@@ -66,6 +66,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--no-header",
         "--quiet",
         "--strip-extras",
+        "--index-url=https://pypi.devinfra.sentry.io/simple",
     )
 
     executor = ThreadPoolExecutor(max_workers=3)

--- a/tools/lint_requirements.py
+++ b/tools/lint_requirements.py
@@ -10,8 +10,7 @@ def main() -> None:
     with open("requirements-frozen.txt") as reqs_file:
         for lineno, line in enumerate(reqs_file, start=1):
             line = line.strip()
-            line, _, _ = line.partition("#")
-            if not line:
+            if not line or line.startswith(("--", "#")):
                 continue
 
             try:


### PR DESCRIPTION
this has a bunch of things:
- speeds up `setup-sentry` by ~30-40 seconds
- removes a bunch of hacks for M1 since everything is prebuilt now
- avoids a whole class of failure modes with local development not having build deps set up properly
- allows pip-compile to succeed on M1 without needing a bunch of dependencies
- fully functional python setup on (macos (x86_64, arm64), linux (amd64, aarch64))
- enables further installation optimizations with everything being a wheel
- removes a bunch of unneeded apt dependencies

packages are sourced from https://github.com/getsentry/pypi