### PR TITLE
fix(mep): Tag value fixes

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1913,6 +1913,8 @@ class MetricsQueryBuilder(QueryBuilder):
 
     def resolve_metric_index(self, value: str) -> Optional[int]:
         """Layer on top of the metric indexer so we'll only hit it at most once per value"""
+        if self.dry_run:
+            return -1
         if value not in self._indexer_cache:
             if self.is_performance:
                 use_case_id = UseCaseKey.PERFORMANCE

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1944,7 +1944,7 @@ class MetricsQueryBuilder(QueryBuilder):
             lhs = lhs.exp
 
         # resolve_column will try to resolve this name with indexer, and if its a tag the Column will be tags[1]
-        is_tag = isinstance(lhs, Column) and lhs.subscriptable == "tags"
+        is_tag = isinstance(lhs, Column) and lhs.subscriptable in ["tags", "tags_raw"]
         if is_tag:
             if isinstance(value, list):
                 resolved_value = []
@@ -1987,8 +1987,8 @@ class MetricsQueryBuilder(QueryBuilder):
 
         return Condition(lhs, Op(search_filter.operator), value)
 
-    def _resolve_environment_filter_value(self, value: str) -> int:
-        value_id: Optional[int] = self.config.resolve_value(f"{value}")
+    def _resolve_environment_filter_value(self, value: str) -> Union[int, str]:
+        value_id: Optional[Union[int, str]] = self.resolve_tag_value(f"{value}")
         if value_id is None:
             raise IncompatibleMetricsQuery(f"Environment: {value} was not found")
 
@@ -2004,9 +2004,15 @@ class MetricsQueryBuilder(QueryBuilder):
         value = search_filter.value.value
         values_set = set(value if isinstance(value, (list, tuple)) else [value])
         # sorted for consistency
-        values = sorted(
-            self._resolve_environment_filter_value(value) if value else 0 for value in values_set
-        )
+        values = []
+        for value in values_set:
+            if value:
+                values.append(self._resolve_environment_filter_value(value))
+            elif self.tag_values_are_strings:
+                values.append("")
+            else:
+                values.append(0)
+        values.sort()
         environment = self.column("environment")
         if len(values) == 1:
             operator = Op.EQ if search_filter.operator in EQUALITY_OPERATORS else Op.NEQ
@@ -2152,7 +2158,10 @@ class MetricsQueryBuilder(QueryBuilder):
         """Check that the orderby doesn't include any direct tags, this shouldn't raise an error for project since we
         transform it"""
         for orderby in self.orderby:
-            if (isinstance(orderby.exp, Column) and orderby.exp.subscriptable == "tags") or (
+            if (
+                isinstance(orderby.exp, Column)
+                and orderby.exp.subscriptable in ["tags", "tags_raw"]
+            ) or (
                 isinstance(orderby.exp, Function) and orderby.exp.alias in ["transaction", "title"]
             ):
                 raise IncompatibleMetricsQuery("Can't orderby tags")

--- a/src/sentry/snuba/metrics_performance.py
+++ b/src/sentry/snuba/metrics_performance.py
@@ -21,6 +21,9 @@ def resolve_tags(results: Any, query_definition: MetricsQueryBuilder) -> Any:
     """Go through the results of a metrics query and reverse resolve its tags"""
     tags: List[str] = []
     cached_resolves: Dict[int, str] = {}
+    # no-op if they're already strings
+    if query_definition.tag_values_are_strings:
+        return results
 
     with sentry_sdk.start_span(op="mep", description="resolve_tags"):
         for column in query_definition.columns:

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -1467,7 +1467,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         meta = response.data["meta"]
 
         assert data[0]["transaction"] == "foo_transaction"
-        assert data[0]["environment"] is None
+        assert data[0]["environment"] is None or data[0]["environment"] == ""
         assert data[0]["p50(transaction.duration)"] == 100
         assert meta["isMetricsData"]
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 from django.urls import reverse
 
+from sentry import options
 from sentry.testutils import MetricsEnhancedPerformanceTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 
@@ -527,6 +528,8 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
         ]
 
     def test_search_query_if_environment_does_not_exist_on_indexer(self):
+        if options.get("sentry-metrics.performance.tags-values-are-strings"):
+            pytest.skip("test does not apply if tag values are in clickhouse")
         self.create_environment(self.project, name="prod")
         self.create_environment(self.project, name="dev")
         self.store_transaction_metric(


### PR DESCRIPTION
- Now that we've realized these tests weren't running with
  `SENTRY_METRICS_SIMULATE_TAG_VALUES_IN_CLICKHOUSE`, ran that locally
  and fixed all the cases where the tag value option was breaking things
