### PR TITLE
fix(replays): Dont query for errors events when there are no ids in the condition list

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -191,6 +191,10 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
 
   const fetchErrors = useCallback(
     async errorIds => {
+      if (!errorIds.length) {
+        return [];
+      }
+
       const conditions = new MutableSearch('');
       errorIds.forEach((errorId, i) => {
         if (i > 0) {

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -7,7 +7,6 @@ import flattenListOfObjects from 'sentry/utils/replays/flattenListOfObjects';
 import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
 import ReplayReader from 'sentry/utils/replays/replayReader';
 import RequestError from 'sentry/utils/requestError/requestError';
-import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
 import type {
   RecordingEvent,
@@ -195,18 +194,10 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
         return [];
       }
 
-      const conditions = new MutableSearch('');
-      errorIds.forEach((errorId, i) => {
-        if (i > 0) {
-          conditions.addOp('OR');
-        }
-        conditions.addFilterValues('id', [errorId]);
-      });
-
       const response = await api.requestPromise(`/organizations/${orgSlug}/events/`, {
         query: {
           field: ['id', 'error.value', 'timestamp', 'error.type', 'issue.id'],
-          query: conditions.formatString(),
+          query: encodeURIComponent(`id:[${String(errorIds)}]`),
         },
       });
       return response.data;

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -206,13 +206,12 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
       const response = await api.requestPromise(`/organizations/${orgSlug}/events/`, {
         query: {
           field: ['id', 'error.value', 'timestamp', 'error.type', 'issue.id'],
-          projects: [projectSlug],
           query: conditions.formatString(),
         },
       });
       return response.data;
     },
-    [api, orgSlug, projectSlug]
+    [api, orgSlug]
   );
 
   const loadEvents = useCallback(async () => {


### PR DESCRIPTION
Previously we were always doing a query for errors, even if there were no errors to search for. This was returning lots of items because there was nothing to limit the response.

Now we do a search for `errorIds`, if there are items in the list. If the list is empty, do not search.

Fixes #38243

Depends on #38272