### PR TITLE
fix(scim): use .get() to parse patch SCIM requests

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -126,11 +126,14 @@ class OrganizationSCIMMemberDetails(SCIMEndpoint, OrganizationMemberEndpoint):
             )
 
     def _should_delete_member(self, operation):
-        if operation["op"].lower() == MemberPatchOps.REPLACE:
-            if isinstance(operation["value"], dict) and operation["value"]["active"] is False:
+        if operation.get("op").lower() == MemberPatchOps.REPLACE:
+            if (
+                isinstance(operation.get("value"), dict)
+                and operation.get("value").get("active") is False
+            ):
                 # how okta sets active to false
                 return True
-            elif operation["path"] == "active" and operation["value"] is False:
+            elif operation.get("path") == "active" and operation.get("value") is False:
                 # how other idps set active to false
                 return True
         return False

--- a/tests/sentry/api/endpoints/test_scim_user_details.py
+++ b/tests/sentry/api/endpoints/test_scim_user_details.py
@@ -147,6 +147,13 @@ class SCIMMemberDetailsTests(SCIMTestCase):
             "detail": "Invalid Patch Operation.",
         }
 
+        response = self.client.patch(url, {"Operations": [{"op": "replace", "value": False}]})
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
+            "detail": "Invalid Patch Operation.",
+        }
+
     def test_member_detail_patch_too_many_ops(self):
         member = self.create_member(user=self.create_user(), organization=self.organization)
         url = reverse(


### PR DESCRIPTION
stops scim requests from erroring out on this line when the key doesn't exist, and returns with status code 400 instead
https://github.com/getsentry/sentry/blob/6d0f4a23244f2adcaa31c5161937c62e4d60317e/src/sentry/scim/endpoints/members.py#L133