### PR TITLE
ref(datePickerField): Use new Input and Overlay component

### DIFF
--- a/static/app/utils/useOverlay.tsx
+++ b/static/app/utils/useOverlay.tsx
@@ -119,6 +119,7 @@ function useOverlay({
 
   return {
     isOpen: openState.isOpen,
+    state: openState,
     triggerProps: {
       ref: setTriggerElement,
       ...mergeProps(buttonProps, triggerProps),


### PR DESCRIPTION
For `DatePickerField`:
* Use the `Input` component (from `components/input`) instead of importing `inputStyles`
* Remove `DeprecaredDropdownMenu` in favor of the new `Overlay` and `useOverlay`

[–> Storybook Example](https://storybook-2l5mxsrsb.sentry.dev/?path=/story/components-forms-fields--date-picker-field)

**Before:**
<img width="732" alt="Screen Shot 2022-08-30 at 1 28 28 PM" src="https://user-images.githubusercontent.com/44172267/187536890-59d2dffd-8d0f-4079-90d1-4494a6e71da2.png">
<img width="546" alt="Screen Shot 2022-08-30 at 1 30 33 PM" src="https://user-images.githubusercontent.com/44172267/187537285-fb01b1dd-4752-47fe-911d-518b78f497b8.png">

**After:**
<img width="732" alt="Screen Shot 2022-08-30 at 1 28 51 PM" src="https://user-images.githubusercontent.com/44172267/187536966-df829f0d-48b0-4e6f-b3b9-dde3f0c82e8a.png">
<img width="546" alt="Screen Shot 2022-08-30 at 1 30 43 PM" src="https://user-images.githubusercontent.com/44172267/187537310-3c1c209b-0952-446a-920a-4ff17f00c974.png">
