### PR TITLE
feat(perf issues): Return prev/next for transaction events

### DIFF
--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -44,9 +44,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
 
         if event.group_id:
             if (
-                features.has(
-                    "organizations:performance-issue-details-backend", project.organization
-                )
+                features.has("organizations:performance-issue", project.organization)
                 and event.get_event_type() == "transaction"
             ):
                 conditions = [[["has", ["group_ids", group_id]], "=", 1]]

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -44,7 +44,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
 
         if event.group_id:
             if (
-                features.has("organizations:performance-issue", project.organization)
+                features.has("organizations:performance-issues", project.organization)
                 and event.get_event_type() == "transaction"
             ):
                 conditions = [[["has", ["group_ids", group_id]], "=", 1]]

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -46,7 +46,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         if event.group_id:
             # TODO add behind feature flag
             if event.get_event_type() == "transaction":
-                conditions = [[["has", ["group_ids", group_id]], "=", event.group_id]]  
+                conditions = [[["has", ["group_ids", group_id]], "=", 1]] # 1 means true here, not a hardcoded event id  
                 _filter = eventstore.Filter(
                     conditions=conditions, project_ids=[event.project_id],
                 )

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -30,6 +30,7 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
         group_id = request.GET.get("group_id")
         group_id = int(group_id) if group_id else None
 
+        # CEO start here
         event = eventstore.get_event_by_id(project.id, event_id, group_id=group_id)
 
         if event is None:
@@ -44,7 +45,11 @@ class ProjectEventDetailsEndpoint(ProjectEndpoint):
 
         if event.group_id:
             requested_environments = set(request.GET.getlist("environment"))
-            conditions = [["event.type", "!=", "transaction"]]
+            event_category = event.get_event_type() # wow this naming sucks
+            if event_category == "transaction":
+                conditions = [["event.type", "=", "transaction"]]
+            else:
+                conditions = [["event.type", "!=", "transaction"]]
 
             if requested_environments:
                 conditions.append(["environment", "IN", requested_environments])

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from sentry_relay import meta_with_chunks
 
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import Event, GroupEvent
 from sentry.models import EventAttachment, EventError, Release, UserReport
 from sentry.sdk_updates import SdkSetupState, get_suggested_updates
 from sentry.search.utils import convert_user_tag_to_query
@@ -67,13 +67,13 @@ def get_tags_with_meta(event):
     return (tags, meta_with_chunks(tags, tags_meta))
 
 
+@register(GroupEvent)
 @register(Event)
 class EventSerializer(Serializer):
     _reserved_keys = frozenset(["user", "sdk", "device", "contexts"])
 
     def _get_entries(self, event, user, is_public=False):
         # XXX(dcramer): These are called entries for future-proofing
-
         platform = event.platform
         meta = event.data.get("_meta") or {}
         interface_list = []

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -703,10 +703,6 @@ class GroupEvent(BaseEvent):
 
     @property
     def group_id(self) -> int:
-        return self.group.id
-
-    @property
-    def group_id(self) -> int:
         # TODO: Including this as a shim for now. I think it makes sense to remove this helper,
         # since people may as well use `group.id` instead of `group_id`, but it breaks a lot of
         # compatibility with `Event`. Including this here for now so that we don't have to rewrite

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -706,6 +706,14 @@ class GroupEvent(BaseEvent):
         return self.group.id
 
     @property
+    def group_id(self) -> int:
+        # TODO: Including this as a shim for now. I think it makes sense to remove this helper,
+        # since people may as well use `group.id` instead of `group_id`, but it breaks a lot of
+        # compatibility with `Event`. Including this here for now so that we don't have to rewrite
+        # the whole codebase at once.
+        return self.group.id
+
+    @property
     def data(self) -> NodeData:
         return self._data
 

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -198,7 +198,7 @@ class SnubaEventStorage(EventStorage):
             if event.get_event_type() == "transaction":
                 logger.warning("eventstore.passed-group-id-for-transaction")
                 org = Project.objects.select_related("organization").get(id=project_id)
-                if features.has("organizations:performance-issue-details-backend", org):
+                if features.has("organizations:performance-issue", org):
                     return event.for_group(Group.objects.get(id=group_id))
             else:
                 event.group_id = group_id

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -198,7 +198,7 @@ class SnubaEventStorage(EventStorage):
             if event.get_event_type() == "transaction":
                 logger.warning("eventstore.passed-group-id-for-transaction")
                 org = Project.objects.select_related("organization").get(id=project_id)
-                if features.has("organizations:performance-issue", org):
+                if features.has("organizations:performance-issues", org):
                     return event.for_group(Group.objects.get(id=group_id))
             else:
                 event.group_id = group_id

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -525,9 +525,9 @@ def _prepare_query_params(query_params):
         forward, reverse = get_snuba_translators(
             query_params.filter_keys, is_grouprelease=query_params.is_grouprelease
         )
-    print("dataset: ", query_params.dataset)
+
     if query_params.dataset in [
-        Dataset.Events, 
+        Dataset.Events,
         Dataset.Discover,
         Dataset.Sessions,
         Dataset.Transactions,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -525,9 +525,9 @@ def _prepare_query_params(query_params):
         forward, reverse = get_snuba_translators(
             query_params.filter_keys, is_grouprelease=query_params.is_grouprelease
         )
-
+    print("dataset: ", query_params.dataset)
     if query_params.dataset in [
-        Dataset.Events,
+        Dataset.Events, 
         Dataset.Discover,
         Dataset.Sessions,
         Dataset.Transactions,

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -147,7 +147,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "timestamp": four_min_ago, 
                     "start_timestamp": four_min_ago, 
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    # "fingerprint": ["group-1"]
+                    "fingerprint": ["group-1"]
                     },
                 project_id=project.id,
             )
@@ -163,7 +163,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "timestamp": three_min_ago, 
                     "start_timestamp": three_min_ago, 
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    # "fingerprint": ["group-1"]
+                    "fingerprint": ["group-1"]
                     },
                 project_id=project.id,
             )
@@ -179,7 +179,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "timestamp": two_min_ago,
                     "start_timestamp": two_min_ago, 
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    # "fingerprint": ["group-1"],
+                    "fingerprint": ["group-1"],
                     "environment": "production",
                     "tags": {"environment": "production"},
                 },
@@ -198,7 +198,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "timestamp": one_min_ago,
                     "start_timestamp": one_min_ago, 
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    # "fingerprint": ["group-2"],
+                    "fingerprint": ["group-2"],
                     "environment": "production",
                     "tags": {"environment": "production"},
                 },

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -139,32 +139,32 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
         with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):
             self.prev_transaction_event = self.store_event(
                 data={
-                    "event_id": "a" * 32, 
+                    "event_id": "a" * 32,
                     "level": "info",
                     "message": "ayoo",
                     "type": "transaction",
                     "culprit": "app/components/events/eventEntries in map",
-                    "timestamp": four_min_ago, 
-                    "start_timestamp": four_min_ago, 
+                    "timestamp": four_min_ago,
+                    "start_timestamp": four_min_ago,
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    "fingerprint": ["group-1"]
-                    },
+                    "fingerprint": ["group-1"],
+                },
                 project_id=project.id,
             )
 
         with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):
             self.cur_transaction_event = self.store_event(
                 data={
-                    "event_id": "b" * 32, 
+                    "event_id": "b" * 32,
                     "level": "info",
                     "message": "ayoo",
                     "type": "transaction",
                     "culprit": "app/components/events/eventEntries in map",
-                    "timestamp": three_min_ago, 
-                    "start_timestamp": three_min_ago, 
+                    "timestamp": three_min_ago,
+                    "start_timestamp": three_min_ago,
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    "fingerprint": ["group-1"]
-                    },
+                    "fingerprint": ["group-1"],
+                },
                 project_id=project.id,
             )
 
@@ -177,7 +177,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "type": "transaction",
                     "culprit": "app/components/events/eventEntries in map",
                     "timestamp": two_min_ago,
-                    "start_timestamp": two_min_ago, 
+                    "start_timestamp": two_min_ago,
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
                     "fingerprint": ["group-1"],
                     "environment": "production",
@@ -196,7 +196,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "type": "transaction",
                     "culprit": "app/components/events/eventEntries in map",
                     "timestamp": one_min_ago,
-                    "start_timestamp": one_min_ago, 
+                    "start_timestamp": one_min_ago,
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
                     "fingerprint": ["group-2"],
                     "environment": "production",
@@ -217,7 +217,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                 "organization_slug": self.cur_transaction_event.project.organization.slug,
             },
         )
-        with self.feature("organizations:performance-issue-details-backend"):
+        with self.feature("organizations:performance-issue"):
             response = self.client.get(url, format="json", data={"group_id": self.group.id})
 
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -138,13 +138,33 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
 
         with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):
             self.prev_transaction_event = self.store_event(
-                data={"event_id": "a" * 32, "timestamp": four_min_ago, "fingerprint": ["group-1"]},
+                data={
+                    "event_id": "a" * 32, 
+                    "level": "info",
+                    "message": "ayoo",
+                    "type": "transaction",
+                    "culprit": "app/components/events/eventEntries in map",
+                    "timestamp": four_min_ago, 
+                    "start_timestamp": four_min_ago, 
+                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+                    # "fingerprint": ["group-1"]
+                    },
                 project_id=project.id,
             )
 
         with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):
             self.cur_transaction_event = self.store_event(
-                data={"event_id": "b" * 32, "timestamp": three_min_ago, "fingerprint": ["group-1"]},
+                data={
+                    "event_id": "b" * 32, 
+                    "level": "info",
+                    "message": "ayoo",
+                    "type": "transaction",
+                    "culprit": "app/components/events/eventEntries in map",
+                    "timestamp": three_min_ago, 
+                    "start_timestamp": three_min_ago, 
+                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+                    # "fingerprint": ["group-1"]
+                    },
                 project_id=project.id,
             )
 
@@ -152,8 +172,14 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
             self.next_transaction_event = self.store_event(
                 data={
                     "event_id": "c" * 32,
+                    "level": "info",
+                    "message": "ayoo",
+                    "type": "transaction",
+                    "culprit": "app/components/events/eventEntries in map",
                     "timestamp": two_min_ago,
-                    "fingerprint": ["group-1"],
+                    "start_timestamp": two_min_ago, 
+                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+                    # "fingerprint": ["group-1"],
                     "environment": "production",
                     "tags": {"environment": "production"},
                 },
@@ -165,8 +191,14 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
             self.store_event(
                 data={
                     "event_id": "d" * 32,
+                    "level": "info",
+                    "message": "ayoo",
+                    "type": "transaction",
+                    "culprit": "app/components/events/eventEntries in map",
                     "timestamp": one_min_ago,
-                    "fingerprint": ["group-2"],
+                    "start_timestamp": one_min_ago, 
+                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+                    # "fingerprint": ["group-2"],
                     "environment": "production",
                     "tags": {"environment": "production"},
                 },
@@ -185,7 +217,8 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                 "organization_slug": self.cur_transaction_event.project.organization.slug,
             },
         )
-        response = self.client.get(url, format="json", data={"group_id": self.group.id})
+        with self.feature("organizations:performance-issue-details-backend"):
+            response = self.client.get(url, format="json", data={"group_id": self.group.id})
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(self.cur_transaction_event.event_id)

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -147,7 +147,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "timestamp": four_min_ago,
                     "start_timestamp": four_min_ago,
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    "fingerprint": ["group-1"],
+                    # "fingerprint": ["group-1"],
                 },
                 project_id=project.id,
             )
@@ -163,7 +163,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "timestamp": three_min_ago,
                     "start_timestamp": three_min_ago,
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    "fingerprint": ["group-1"],
+                    # "fingerprint": ["group-1"],
                 },
                 project_id=project.id,
             )
@@ -179,7 +179,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "timestamp": two_min_ago,
                     "start_timestamp": two_min_ago,
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    "fingerprint": ["group-1"],
+                    # "fingerprint": ["group-1"],
                     "environment": "production",
                     "tags": {"environment": "production"},
                 },
@@ -198,7 +198,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                     "timestamp": one_min_ago,
                     "start_timestamp": one_min_ago,
                     "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    "fingerprint": ["group-2"],
+                    # "fingerprint": ["group-2"],
                     "environment": "production",
                     "tags": {"environment": "production"},
                 },
@@ -206,6 +206,9 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
             )
 
         self.group.update(type=GroupType.PERFORMANCE_SLOW_SPAN.value)
+        self.prev_transaction_event.group = self.group
+        self.cur_transaction_event.group = self.group
+        self.next_transaction_event.group = self.group
 
     def test_transaction_event(self):
         """Test that you can look up a transaction event w/ a prev and next event"""
@@ -217,7 +220,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                 "organization_slug": self.cur_transaction_event.project.organization.slug,
             },
         )
-        with self.feature("organizations:performance-issue"):
+        with self.feature("organizations:performance-issues"):
             response = self.client.get(url, format="json", data={"group_id": self.group.id})
 
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -130,6 +130,14 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
         three_min_ago = iso_format(before_now(minutes=3))
         four_min_ago = iso_format(before_now(minutes=4))
 
+        transaction_event_data = {
+            "level": "info",
+            "message": "ayoo",
+            "type": "transaction",
+            "culprit": "app/components/events/eventEntries in map",
+            "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
+        }
+
         def hack_pull_out_data(jobs, projects):
             _pull_out_data(jobs, projects)
             for job in jobs:
@@ -139,15 +147,10 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
         with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):
             self.prev_transaction_event = self.store_event(
                 data={
+                    **transaction_event_data,
                     "event_id": "a" * 32,
-                    "level": "info",
-                    "message": "ayoo",
-                    "type": "transaction",
-                    "culprit": "app/components/events/eventEntries in map",
                     "timestamp": four_min_ago,
                     "start_timestamp": four_min_ago,
-                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    # "fingerprint": ["group-1"],
                 },
                 project_id=project.id,
             )
@@ -155,15 +158,10 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
         with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):
             self.cur_transaction_event = self.store_event(
                 data={
+                    **transaction_event_data,
                     "event_id": "b" * 32,
-                    "level": "info",
-                    "message": "ayoo",
-                    "type": "transaction",
-                    "culprit": "app/components/events/eventEntries in map",
                     "timestamp": three_min_ago,
                     "start_timestamp": three_min_ago,
-                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    # "fingerprint": ["group-1"],
                 },
                 project_id=project.id,
             )
@@ -171,15 +169,10 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
         with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):
             self.next_transaction_event = self.store_event(
                 data={
+                    **transaction_event_data,
                     "event_id": "c" * 32,
-                    "level": "info",
-                    "message": "ayoo",
-                    "type": "transaction",
-                    "culprit": "app/components/events/eventEntries in map",
                     "timestamp": two_min_ago,
                     "start_timestamp": two_min_ago,
-                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    # "fingerprint": ["group-1"],
                     "environment": "production",
                     "tags": {"environment": "production"},
                 },
@@ -190,15 +183,10 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
             # Event in different group
             self.store_event(
                 data={
+                    **transaction_event_data,
                     "event_id": "d" * 32,
-                    "level": "info",
-                    "message": "ayoo",
-                    "type": "transaction",
-                    "culprit": "app/components/events/eventEntries in map",
                     "timestamp": one_min_ago,
                     "start_timestamp": one_min_ago,
-                    "contexts": {"trace": {"trace_id": "b" * 32, "span_id": "c" * 16, "op": ""}},
-                    # "fingerprint": ["group-2"],
                     "environment": "production",
                     "tags": {"environment": "production"},
                 },
@@ -228,6 +216,61 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
         assert response.data["nextEventID"] == str(self.next_transaction_event.event_id)
         assert response.data["previousEventID"] == str(self.prev_transaction_event.event_id)
         assert response.data["groupID"] == str(self.cur_transaction_event.group.id)
+
+    def test_no_previous_event(self):
+        """Test the case in which there is no previous event"""
+        url = reverse(
+            "sentry-api-0-project-event-details",
+            kwargs={
+                "event_id": self.prev_transaction_event.event_id,
+                "project_slug": self.prev_transaction_event.project.slug,
+                "organization_slug": self.prev_transaction_event.project.organization.slug,
+            },
+        )
+        with self.feature("organizations:performance-issues"):
+            response = self.client.get(url, format="json", data={"group_id": self.group.id})
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == str(self.prev_transaction_event.event_id)
+        assert response.data["previousEventID"] is None
+        assert response.data["nextEventID"] == self.cur_transaction_event.event_id
+        assert response.data["groupID"] == str(self.prev_transaction_event.group.id)
+
+    def test_ignores_different_group(self):
+        """Test that a different group's events aren't attributed to the one that was passed"""
+        url = reverse(
+            "sentry-api-0-project-event-details",
+            kwargs={
+                "event_id": self.next_transaction_event.event_id,
+                "project_slug": self.next_transaction_event.project.slug,
+                "organization_slug": self.next_transaction_event.project.organization.slug,
+            },
+        )
+        with self.feature("organizations:performance-issues"):
+            response = self.client.get(url, format="json", data={"group_id": self.group.id})
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == str(self.next_transaction_event.event_id)
+        assert response.data["nextEventID"] is None
+
+    def test_no_group_id(self):
+        """Test the case where a group_id was not passed"""
+        url = reverse(
+            "sentry-api-0-project-event-details",
+            kwargs={
+                "event_id": self.cur_transaction_event.event_id,
+                "project_slug": self.cur_transaction_event.project.slug,
+                "organization_slug": self.cur_transaction_event.project.organization.slug,
+            },
+        )
+        with self.feature("organizations:performance-issues"):
+            response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == str(self.cur_transaction_event.event_id)
+        assert response.data["previousEventID"] is None
+        assert response.data["nextEventID"] is None
+        assert response.data["groupID"] is None
 
 
 class ProjectEventJsonEndpointTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -133,7 +133,7 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
         def hack_pull_out_data(jobs, projects):
             _pull_out_data(jobs, projects)
             for job in jobs:
-                job["event"].group_ids = [self.group.id]
+                job["event"].groups = [self.group]
             return jobs, projects
 
         with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -179,19 +179,18 @@ class ProjectEventDetailsTransactionTest(APITestCase, SnubaTestCase):
                 project_id=project.id,
             )
 
-        with mock.patch("sentry.event_manager._pull_out_data", hack_pull_out_data):
-            # Event in different group
-            self.store_event(
-                data={
-                    **transaction_event_data,
-                    "event_id": "d" * 32,
-                    "timestamp": one_min_ago,
-                    "start_timestamp": one_min_ago,
-                    "environment": "production",
-                    "tags": {"environment": "production"},
-                },
-                project_id=project.id,
-            )
+        # Event in different group
+        self.store_event(
+            data={
+                **transaction_event_data,
+                "event_id": "d" * 32,
+                "timestamp": one_min_ago,
+                "start_timestamp": one_min_ago,
+                "environment": "production",
+                "tags": {"environment": "production"},
+            },
+            project_id=project.id,
+        )
 
         self.group.update(type=GroupType.PERFORMANCE_SLOW_SPAN.value)
         self.prev_transaction_event.group = self.group


### PR DESCRIPTION
Return a previous and next transaction event from the `ProjectEventDetailsEndpoint` as well as the group ID - previously it only returned a previous and next event for error events.

Relies on https://github.com/getsentry/sentry/pull/38143 being merged first.