### PR TITLE
feat: Support events and transactions topics being on seperate clusters

### DIFF
--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -18,7 +18,8 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         super().setUp()
 
         self.kafka_eventstream = KafkaEventStream()
-        self.kafka_eventstream.producer = Mock()
+        self.kafka_eventstream.errors_producer = Mock()
+        self.kafka_eventstream.transactions_producer = Mock()
 
     def __build_event(self, timestamp):
         raw_event = {
@@ -39,10 +40,19 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         return manager.save(self.project.id)
 
     def __produce_event(self, *insert_args, **insert_kwargs):
+
+        is_transaction_event = insert_kwargs["event"].get_event_type() == "transaction"
+
         # pass arguments on to Kafka EventManager
         self.kafka_eventstream.insert(*insert_args, **insert_kwargs)
 
-        produce_args, produce_kwargs = list(self.kafka_eventstream.producer.produce.call_args)
+        producer = (
+            self.kafka_eventstream.transactions_producer
+            if is_transaction_event
+            else self.kafka_eventstream.errors_producer
+        )
+
+        produce_args, produce_kwargs = list(producer.produce.call_args)
         assert not produce_args
         assert produce_kwargs["topic"] == settings.KAFKA_EVENTS
         assert produce_kwargs["key"] == str(self.project.id).encode("utf-8")
@@ -58,7 +68,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
             self.project.id,
             "insert",
             (payload1, payload2),
-            is_transaction_event=insert_kwargs["event"].get_event_type() == "transaction",
+            is_transaction_event=is_transaction_event,
         )
 
     @patch("sentry.eventstream.insert")


### PR DESCRIPTION
We are currently in the process of splitting the events and transactions topics.

The previous version of the post process forwarder assumed that `events`
and `transactions` were either using the same Kafka topic (as was the case
previously) or were different topics in the same cluster. It wouldn't work
properly if the two topics were in different Kafka clusters. This change drops
that requirement, and it enables us to move transactions to a new cluster to reduce
load on the main events cluster.