### PR TITLE
fix: Use BaseManager for ReleaseFile.objects

### DIFF
--- a/src/sentry/models/releasefile.py
+++ b/src/sentry/models/releasefile.py
@@ -14,6 +14,7 @@ from django.db import models, router
 
 from sentry import options
 from sentry.db.models import (
+    BaseManager,
     BoundedBigIntegerField,
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
@@ -78,7 +79,7 @@ class ReleaseFile(Model):
 
     __repr__ = sane_repr("release", "ident")
 
-    objects = models.Manager()  # The default manager.
+    objects = BaseManager()  # The default manager.
     public_objects = PublicReleaseFileManager()
 
     class Meta:


### PR DESCRIPTION
Tweaks a change made in #26529. The explicit `objects` field was added in conjunction with `public_objects`, and not because there was a specific need to use `models.Manager` over `BaseManager` (which the model would otherwise inherit, like all `sentry.db.models.base.BaseModel` subclasses).

I'd like to change this because `BaseManager` plays nicer with code introduced in #35994.