### PR TITLE
fix(alerts): Change the label for all event frequency alert conditions

### DIFF
--- a/static/app/views/alerts/rules/issue/details/textRule.tsx
+++ b/static/app/views/alerts/rules/issue/details/textRule.tsx
@@ -4,6 +4,7 @@ import {t} from 'sentry/locale';
 import type {Member, Team} from 'sentry/types';
 import type {IssueAlertRule} from 'sentry/types/alerts';
 import {AlertRuleComparisonType} from 'sentry/views/alerts/rules/metric/types';
+import {CHANGE_ALERT_CONDITION_IDS} from 'sentry/views/alerts/utils/constants';
 
 /**
  * Translate Issue Alert Conditions to text
@@ -13,9 +14,7 @@ export function TextCondition({
 }: {
   condition: IssueAlertRule['conditions'][number];
 }) {
-  if (
-    condition.id === 'sentry.rules.conditions.event_frequency.EventFrequencyCondition'
-  ) {
+  if (CHANGE_ALERT_CONDITION_IDS.includes(condition.id)) {
     if (condition.comparisonType === AlertRuleComparisonType.PERCENT) {
       return (
         <Fragment>


### PR DESCRIPTION
See: https://getsentry.atlassian.net/browse/ISSUE-1593


Follow up to https://github.com/getsentry/sentry/pull/37061

I believe all[ these rules ](https://github.com/getsentry/sentry/blob/master/static/app/views/alerts/utils/constants.tsx#L1-L5)can have their labels changed the same way.

![image](https://user-images.githubusercontent.com/35509934/187561648-7118c1a7-0557-4589-8837-cfab0cf66d80.png)

<!-- Describe your PR here. -->

![image](https://user-images.githubusercontent.com/35509934/187561353-1e641f21-9555-435e-a490-c18633d3e501.png)
