### PR TITLE
feat(replays): Be more specific when different failure modes happen while loading a replay

### DIFF
--- a/static/app/views/replays/details.tsx
+++ b/static/app/views/replays/details.tsx
@@ -29,16 +29,44 @@ function ReplayDetails({
   },
   params: {orgId: orgSlug, replaySlug},
 }: Props) {
-  const {fetching, onRetry, replay} = useReplayData({
+  const {fetching, onRetry, replay, fetchError} = useReplayData({
     replaySlug,
     orgSlug,
   });
 
-  if (!fetching && !replay) {
+  if (!fetching && !replay && fetchError) {
+    if (fetchError.statusText === 'Not Found') {
+      return (
+        <Page orgSlug={orgSlug}>
+          <PageContent>
+            <NotFound />
+          </PageContent>
+        </Page>
+      );
+    }
+
+    const reasons = [
+      t('The Replay is still processing and is on its way'),
+      t('There is an internal systems error or active issue'),
+    ];
     return (
       <Page orgSlug={orgSlug}>
         <PageContent>
-          <NotFound />
+          <DetailedError
+            onRetry={onRetry}
+            hideSupportLinks
+            heading={t('There was an error while fetching this Replay')}
+            message={
+              <Fragment>
+                <p>{t('This could be due to a couple of reasons:')}</p>
+                <ol className="detailed-error-list">
+                  {reasons.map((reason, i) => (
+                    <li key={i}>{reason}</li>
+                  ))}
+                </ol>
+              </Fragment>
+            }
+          />
         </PageContent>
       </Page>
     );
@@ -48,7 +76,6 @@ function ReplayDetails({
     return (
       <Page orgSlug={orgSlug} replayRecord={replay.getReplay()}>
         <DetailedError
-          onRetry={onRetry}
           hideSupportLinks
           heading={t('Expected two or more replay events')}
           message={


### PR DESCRIPTION
This is less of an issue with #38208, but #37127 is fixed now imo.

There is a race condition: Both `fetchReplay()` and `fetchAllRRwebEvents()` inside useReplayData can fail when the replay_id is not found, the race condition right now is that they can fail with different responses. This would be fixed with https://github.com/getsentry/replay-backend/issues/107

Fixes #37127