### PR TITLE
types(menulistitem): use interface

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -72,18 +72,17 @@ export type MenuListItemProps = {
   trailingItemsSpanFullHeight?: boolean;
 };
 
-type OtherProps = {
+interface OtherProps {
   as?: React.ElementType;
   detailsProps?: object;
   innerWrapProps?: object;
   isFocused?: boolean;
   labelProps?: object;
-};
+}
 
-type Props = MenuListItemProps &
-  OtherProps & {
-    forwardRef: React.ForwardedRef<HTMLLIElement>;
-  };
+interface Props extends MenuListItemProps, OtherProps {
+  forwardRef: React.ForwardedRef<HTMLLIElement>;
+}
 
 function BaseMenuListItem({
   label,

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -45,10 +45,10 @@ export type Writable<T> = {-readonly [K in keyof T]: T[K]};
 /**
  * The option format used by react-select based components
  */
-export type SelectValue<T> = MenuListItemProps & {
+export interface SelectValue<T> extends MenuListItemProps {
   label: string | number | React.ReactElement;
   value: T;
-};
+}
 
 /**
  * The 'other' option format used by checkboxes, radios and more.


### PR DESCRIPTION
Using an interface prevents future type collisions from being automatically merged (and possibly narrowed to `never`)