### PR TITLE
types(groupfilter): use interface

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -351,22 +351,22 @@ export type GroupActivity =
 
 export type Activity = GroupActivity;
 
-type GroupFiltered = {
+interface GroupFiltered {
   count: string;
   firstSeen: string;
   lastSeen: string;
   stats: Record<string, TimeseriesValue[]>;
   userCount: number;
-};
+}
 
-export type GroupStats = GroupFiltered & {
+export interface GroupStats extends GroupFiltered {
   filtered: GroupFiltered | null;
   id: string;
   lifetime?: GroupFiltered;
   sessionCount?: string | null;
-};
+}
 
-export type BaseGroupStatusReprocessing = {
+export interface BaseGroupStatusReprocessing {
   status: 'reprocessing';
   statusDetails: {
     info: {
@@ -375,7 +375,7 @@ export type BaseGroupStatusReprocessing = {
     } | null;
     pendingEvents: number;
   };
-};
+}
 
 /**
  * Issue Resolution
@@ -411,7 +411,7 @@ export type GroupRelease = {
 };
 
 // TODO(ts): incomplete
-export type BaseGroup = {
+export interface BaseGroup extends GroupRelease {
   activity: GroupActivity[];
   annotations: string[];
   assignedTo: Actor;
@@ -447,13 +447,26 @@ export type BaseGroup = {
   userReportCount: number;
   inbox?: InboxDetails | null | false;
   owners?: SuggestedOwner[] | null;
-} & GroupRelease;
+}
 
-export type GroupReprocessing = BaseGroup & GroupStats & BaseGroupStatusReprocessing;
-export type GroupResolution = BaseGroup & GroupStats & GroupStatusResolution;
+export interface GroupReprocessing
+  // BaseGroupStatusReprocessing status field (enum) incorrectly extends the BaseGroup status field (string) so we omit it.
+  // A proper fix for this would be to make the status field an enum or string and correctly extend it.
+  extends Omit<BaseGroup, 'status'>,
+    GroupStats,
+    BaseGroupStatusReprocessing {}
+
+export interface GroupResolution
+  // GroupStatusResolution status field (enum) incorrectly extends the BaseGroup status field (string) so we omit it.
+  // A proper fix for this would be to make the status field an enum or string and correctly extend it.
+  extends Omit<BaseGroup, 'status'>,
+    GroupStats,
+    GroupStatusResolution {}
+
 export type Group = GroupResolution | GroupReprocessing;
-export type GroupCollapseRelease = Omit<Group, keyof GroupRelease> &
-  Partial<GroupRelease>;
+export interface GroupCollapseRelease
+  extends Omit<Group, keyof GroupRelease>,
+    Partial<GroupRelease> {}
 
 export type GroupTombstone = {
   actor: AvatarUser;


### PR DESCRIPTION
Small update to groupfilters type definition. We need a larger change to properly extend the status field (extending via intersection was masking that)