### PR TITLE
test(perf): Add test data for performance issue detection

### DIFF
--- a/tests/sentry/utils/performance_issues/events/n-plus-one-in-django-index-view.json
+++ b/tests/sentry/utils/performance_issues/events/n-plus-one-in-django-index-view.json
@@ -1,0 +1,323 @@
+{
+  "event_id": "da78af6000a6400aaa87cf6e14ddeb40",
+  "datetime": "2022-08-31T14:57:53.995835+00:00",
+  "culprit": "/books/",
+  "environment": "production",
+  "location": "/books/",
+  "spans": [
+    {
+      "timestamp": 1661957873.995433,
+      "start_timestamp": 1661957869.628498,
+      "exclusive_time": 0.129223,
+      "description": "django.middleware.security.SecurityMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "97b250f72d59f230",
+      "parent_span_id": "adecc71b05091633",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.security.SecurityMiddleware"
+      },
+      "hash": "0f43fb6f6e01ca52",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.995365,
+      "start_timestamp": 1661957869.628559,
+      "exclusive_time": 0.149727,
+      "description": "django.contrib.sessions.middleware.SessionMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "8036c3b6cbee46a9",
+      "parent_span_id": "97b250f72d59f230",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.contrib.sessions.middleware.SessionMiddleware"
+      },
+      "hash": "3dc5dd68b38e1730",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.99531,
+      "start_timestamp": 1661957869.628654,
+      "exclusive_time": 0.163079,
+      "description": "django.middleware.common.CommonMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "8cffaf9d9d2085da",
+      "parent_span_id": "8036c3b6cbee46a9",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.common.CommonMiddleware"
+      },
+      "hash": "424c6ae1641f0f0e",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.995261,
+      "start_timestamp": 1661957869.628768,
+      "exclusive_time": 0.087976,
+      "description": "django.middleware.csrf.CsrfViewMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "852d1fb01c3df4f3",
+      "parent_span_id": "8cffaf9d9d2085da",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.csrf.CsrfViewMiddleware"
+      },
+      "hash": "d5da18d7274b34a1",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.995238,
+      "start_timestamp": 1661957869.628833,
+      "exclusive_time": 0.069141,
+      "description": "django.contrib.auth.middleware.AuthenticationMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "9b5ca86add2c1a77",
+      "parent_span_id": "852d1fb01c3df4f3",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.contrib.auth.middleware.AuthenticationMiddleware"
+      },
+      "hash": "ac72fc0a4f5fe381",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.995221,
+      "start_timestamp": 1661957869.628885,
+      "exclusive_time": 0.172854,
+      "description": "django.contrib.messages.middleware.MessageMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "b66385cad8e05d12",
+      "parent_span_id": "9b5ca86add2c1a77",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.contrib.messages.middleware.MessageMiddleware"
+      },
+      "hash": "ac1468d8e11a0553",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.995151,
+      "start_timestamp": 1661957869.628988,
+      "exclusive_time": 0.289201,
+      "description": "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "9d95a06d2ca3ca0a",
+      "parent_span_id": "b66385cad8e05d12",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.clickjacking.XFrameOptionsMiddleware"
+      },
+      "hash": "d8681423cab4275f",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957869.629113,
+      "start_timestamp": 1661957869.629101,
+      "exclusive_time": 0.011921,
+      "description": "django.middleware.csrf.CsrfViewMiddleware.process_view",
+      "op": "django.middleware",
+      "span_id": "9cd865428b72dc0e",
+      "parent_span_id": "9d95a06d2ca3ca0a",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "tags": {
+        "django.function_name": "django.middleware.csrf.CsrfViewMiddleware.process_view",
+        "django.middleware_name": "django.middleware.csrf.CsrfViewMiddleware"
+      },
+      "hash": "e853d2eb7fb9ebb0",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.995039,
+      "start_timestamp": 1661957869.629177,
+      "exclusive_time": 34.107923,
+      "description": "index",
+      "op": "django.view",
+      "span_id": "8dd7a5869a4f4583",
+      "parent_span_id": "9d95a06d2ca3ca0a",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "6a992d5529f459a4",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957871.585034,
+      "start_timestamp": 1661957869.629686,
+      "exclusive_time": 1620.908975,
+      "description": "connect",
+      "op": "db",
+      "span_id": "82428e8ef4c5a539",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "b640a0ce465fa2a4",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957871.418989,
+      "start_timestamp": 1661957871.249481,
+      "exclusive_time": 169.507981,
+      "description": "\n                SELECT VERSION(),\n                       @@sql_mode,\n                       @@default_storage_engine,\n                       @@sql_auto_is_null,\n                       @@lower_case_table_names,\n                       CONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC') IS NOT NULL\n            ",
+      "op": "db",
+      "span_id": "b33db57efd994615",
+      "parent_span_id": "82428e8ef4c5a539",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "3a91b85ea92a26b9",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957871.58474,
+      "start_timestamp": 1661957871.419809,
+      "exclusive_time": 164.93082,
+      "description": "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+      "op": "db",
+      "span_id": "aae50fb6aa040c31",
+      "parent_span_id": "82428e8ef4c5a539",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "061710eb39a66089",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957871.899103,
+      "start_timestamp": 1661957871.58556,
+      "exclusive_time": 313.542843,
+      "description": "SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` LIMIT 10",
+      "op": "db",
+      "span_id": "9179e43ae844b174",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "c23d7b23e98a04c5",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957872.07855,
+      "start_timestamp": 1661957871.904139,
+      "exclusive_time": 174.411059,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "b8be6138369491dd",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957872.29085,
+      "start_timestamp": 1661957872.082648,
+      "exclusive_time": 208.201886,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "b2d4826e7b618f1b",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957872.46439,
+      "start_timestamp": 1661957872.293635,
+      "exclusive_time": 170.755148,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "b3fdeea42536dbf1",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957872.637623,
+      "start_timestamp": 1661957872.467851,
+      "exclusive_time": 169.772148,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "b409e78a092e642f",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957872.948552,
+      "start_timestamp": 1661957872.640274,
+      "exclusive_time": 308.277846,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "86d2ede57bbf48d4",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.123204,
+      "start_timestamp": 1661957872.952221,
+      "exclusive_time": 170.983076,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "8e554c84cdc9731e",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.338406,
+      "start_timestamp": 1661957873.126251,
+      "exclusive_time": 212.155103,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "94d6230f3f910e12",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.509047,
+      "start_timestamp": 1661957873.340917,
+      "exclusive_time": 168.129921,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "a210b87a2191ceb6",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.678543,
+      "start_timestamp": 1661957873.511186,
+      "exclusive_time": 167.357206,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "88a5ccaf25b9bd8f",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957873.993492,
+      "start_timestamp": 1661957873.680672,
+      "exclusive_time": 312.819958,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "bb32cf50fc56b296",
+      "parent_span_id": "8dd7a5869a4f4583",
+      "trace_id": "3c080d683c904cb68a18361a093aa6ce",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    }
+  ],
+  "start_timestamp": 1661957869.624976,
+  "timestamp": 1661957873.995835,
+  "title": "/books/",
+  "transaction": "/books/",
+  "transaction_info": {"source": "route"},
+  "type": "transaction"
+}

--- a/tests/sentry/utils/performance_issues/events/n-plus-one-in-django-new-view.json
+++ b/tests/sentry/utils/performance_issues/events/n-plus-one-in-django-new-view.json
@@ -1,0 +1,323 @@
+{
+  "event_id": "47829ecde95d42ac843f24592b7b7e46",
+  "datetime": "2022-08-31T14:53:43.393462+00:00",
+  "culprit": "/books/new",
+  "environment": "production",
+  "location": "/books/new",
+  "spans": [
+    {
+      "timestamp": 1661957623.393161,
+      "start_timestamp": 1661957619.183045,
+      "exclusive_time": 0.291109,
+      "description": "django.middleware.security.SecurityMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "8eef3b67bce8f9cf",
+      "parent_span_id": "9ca09a3af5e0cd92",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.security.SecurityMiddleware"
+      },
+      "hash": "0f43fb6f6e01ca52",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.392925,
+      "start_timestamp": 1661957619.1831,
+      "exclusive_time": 0.928163,
+      "description": "django.contrib.sessions.middleware.SessionMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "903aa226e55bc607",
+      "parent_span_id": "8eef3b67bce8f9cf",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.contrib.sessions.middleware.SessionMiddleware"
+      },
+      "hash": "3dc5dd68b38e1730",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.392854,
+      "start_timestamp": 1661957619.183957,
+      "exclusive_time": 0.700951,
+      "description": "django.middleware.common.CommonMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "8123c1f5094d1163",
+      "parent_span_id": "903aa226e55bc607",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.common.CommonMiddleware"
+      },
+      "hash": "424c6ae1641f0f0e",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.392803,
+      "start_timestamp": 1661957619.184607,
+      "exclusive_time": 0.078917,
+      "description": "django.middleware.csrf.CsrfViewMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "87b76e90daabd2fc",
+      "parent_span_id": "8123c1f5094d1163",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.csrf.CsrfViewMiddleware"
+      },
+      "hash": "d5da18d7274b34a1",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.392784,
+      "start_timestamp": 1661957619.184667,
+      "exclusive_time": 0.144005,
+      "description": "django.contrib.auth.middleware.AuthenticationMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "82bb32713b8ffb1c",
+      "parent_span_id": "87b76e90daabd2fc",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.contrib.auth.middleware.AuthenticationMiddleware"
+      },
+      "hash": "ac72fc0a4f5fe381",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.392689,
+      "start_timestamp": 1661957619.184716,
+      "exclusive_time": 3.510952,
+      "description": "django.contrib.messages.middleware.MessageMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "9971e680d1a74601",
+      "parent_span_id": "82bb32713b8ffb1c",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.contrib.messages.middleware.MessageMiddleware"
+      },
+      "hash": "ac1468d8e11a0553",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.392616,
+      "start_timestamp": 1661957619.188154,
+      "exclusive_time": 0.347376,
+      "description": "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "b5b3eddb45429c8d",
+      "parent_span_id": "9971e680d1a74601",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.clickjacking.XFrameOptionsMiddleware"
+      },
+      "hash": "d8681423cab4275f",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957619.1883,
+      "start_timestamp": 1661957619.188285,
+      "exclusive_time": 0.014782,
+      "description": "django.middleware.csrf.CsrfViewMiddleware.process_view",
+      "op": "django.middleware",
+      "span_id": "a559c9b71b3972bf",
+      "parent_span_id": "b5b3eddb45429c8d",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "tags": {
+        "django.function_name": "django.middleware.csrf.CsrfViewMiddleware.process_view",
+        "django.middleware_name": "django.middleware.csrf.CsrfViewMiddleware"
+      },
+      "hash": "e853d2eb7fb9ebb0",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.392504,
+      "start_timestamp": 1661957619.188404,
+      "exclusive_time": 34.817932,
+      "description": "new",
+      "op": "django.view",
+      "span_id": "86d3f8a7e85d7324",
+      "parent_span_id": "b5b3eddb45429c8d",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "22af645d1859cb5c",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957620.963074,
+      "start_timestamp": 1661957619.189688,
+      "exclusive_time": 1442.054749,
+      "description": "connect",
+      "op": "db",
+      "span_id": "ab6c7350134d1eec",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "b640a0ce465fa2a4",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957620.795072,
+      "start_timestamp": 1661957620.630262,
+      "exclusive_time": 164.81018,
+      "description": "\n                SELECT VERSION(),\n                       @@sql_mode,\n                       @@default_storage_engine,\n                       @@sql_auto_is_null,\n                       @@lower_case_table_names,\n                       CONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC') IS NOT NULL\n            ",
+      "op": "db",
+      "span_id": "86701746e76f2f16",
+      "parent_span_id": "ab6c7350134d1eec",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "3a91b85ea92a26b9",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957620.962568,
+      "start_timestamp": 1661957620.796047,
+      "exclusive_time": 166.521072,
+      "description": "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+      "op": "db",
+      "span_id": "a56e6d47e0e91141",
+      "parent_span_id": "ab6c7350134d1eec",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "061710eb39a66089",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957621.286672,
+      "start_timestamp": 1661957620.963648,
+      "exclusive_time": 323.024035,
+      "description": "SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` ORDER BY `books_book`.`id` DESC LIMIT 10",
+      "op": "db",
+      "span_id": "bc1f71fd71c8f594",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "858fea692d4d93e8",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957621.453721,
+      "start_timestamp": 1661957621.289976,
+      "exclusive_time": 163.745165,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "b150bdaa43ddec7c",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957621.679301,
+      "start_timestamp": 1661957621.456593,
+      "exclusive_time": 222.707987,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "968fdbd8bca7f2f6",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957621.849921,
+      "start_timestamp": 1661957621.682341,
+      "exclusive_time": 167.57989,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "b2d1eddd591d84ba",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.020631,
+      "start_timestamp": 1661957621.852634,
+      "exclusive_time": 167.997121,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "ae40cc8427bd68d2",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.337579,
+      "start_timestamp": 1661957622.023377,
+      "exclusive_time": 314.20207,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "9e902554055d3477",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.509795,
+      "start_timestamp": 1661957622.342078,
+      "exclusive_time": 167.71698,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "90302ecea560be76",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.733698,
+      "start_timestamp": 1661957622.513375,
+      "exclusive_time": 220.322848,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "a75f1cec8d07106f",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.903231,
+      "start_timestamp": 1661957622.73603,
+      "exclusive_time": 167.200804,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "8af15a555f92701e",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.072045,
+      "start_timestamp": 1661957622.906652,
+      "exclusive_time": 165.393114,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "9c3a569621230f03",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.391001,
+      "start_timestamp": 1661957623.074995,
+      "exclusive_time": 316.005946,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "8788fb3fc43ad948",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    }
+  ],
+  "start_timestamp": 1661957619.181783,
+  "timestamp": 1661957623.393462,
+  "title": "/books/new",
+  "transaction": "/books/new",
+  "transaction_info": {"source": "route"},
+  "type": "transaction"
+}

--- a/tests/sentry/utils/performance_issues/events/solved-n-plus-one-in-django-index-view.json
+++ b/tests/sentry/utils/performance_issues/events/solved-n-plus-one-in-django-index-view.json
@@ -1,0 +1,202 @@
+{
+  "event_id": "4e7c82a05f514c93b6101d255ca14f89",
+  "datetime": "2022-08-31T14:59:32.566927+00:00",
+  "culprit": "/books/",
+  "location": "/books/",
+  "spans": [
+    {
+      "timestamp": 1661957972.566523,
+      "start_timestamp": 1661957970.378754,
+      "exclusive_time": 0.157118,
+      "description": "django.middleware.security.SecurityMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "b35fe8bfc034fe6d",
+      "parent_span_id": "8c9cfb04076db458",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.security.SecurityMiddleware"
+      },
+      "hash": "0f43fb6f6e01ca52",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.566464,
+      "start_timestamp": 1661957970.378852,
+      "exclusive_time": 2.594948,
+      "description": "django.contrib.sessions.middleware.SessionMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "b4cc10cfb5bb0d0b",
+      "parent_span_id": "b35fe8bfc034fe6d",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.contrib.sessions.middleware.SessionMiddleware"
+      },
+      "hash": "3dc5dd68b38e1730",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.566396,
+      "start_timestamp": 1661957970.381379,
+      "exclusive_time": 1.232147,
+      "description": "django.middleware.common.CommonMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "84b7b23061a36e25",
+      "parent_span_id": "b4cc10cfb5bb0d0b",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.common.CommonMiddleware"
+      },
+      "hash": "424c6ae1641f0f0e",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.56635,
+      "start_timestamp": 1661957970.382565,
+      "exclusive_time": 0.113011,
+      "description": "django.middleware.csrf.CsrfViewMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "b6af0fe580697876",
+      "parent_span_id": "84b7b23061a36e25",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.csrf.CsrfViewMiddleware"
+      },
+      "hash": "d5da18d7274b34a1",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.566328,
+      "start_timestamp": 1661957970.382656,
+      "exclusive_time": 0.110864,
+      "description": "django.contrib.auth.middleware.AuthenticationMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "ad32d8a49d273bdc",
+      "parent_span_id": "b6af0fe580697876",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.contrib.auth.middleware.AuthenticationMiddleware"
+      },
+      "hash": "ac72fc0a4f5fe381",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.566309,
+      "start_timestamp": 1661957970.382748,
+      "exclusive_time": 9.091139,
+      "description": "django.contrib.messages.middleware.MessageMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "ac6091f22d9366a3",
+      "parent_span_id": "ad32d8a49d273bdc",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.contrib.messages.middleware.MessageMiddleware"
+      },
+      "hash": "ac1468d8e11a0553",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.566258,
+      "start_timestamp": 1661957970.391788,
+      "exclusive_time": 0.916005,
+      "description": "django.middleware.clickjacking.XFrameOptionsMiddleware.__call__",
+      "op": "django.middleware",
+      "span_id": "98f79ffd92d4a060",
+      "parent_span_id": "ac6091f22d9366a3",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "tags": {
+        "django.function_name": "django.utils.deprecation.MiddlewareMixin.__call__",
+        "django.middleware_name": "django.middleware.clickjacking.XFrameOptionsMiddleware"
+      },
+      "hash": "d8681423cab4275f",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957970.392034,
+      "start_timestamp": 1661957970.392019,
+      "exclusive_time": 0.01502,
+      "description": "django.middleware.csrf.CsrfViewMiddleware.process_view",
+      "op": "django.middleware",
+      "span_id": "b455d7ac30d3a0a0",
+      "parent_span_id": "98f79ffd92d4a060",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "tags": {
+        "django.function_name": "django.middleware.csrf.CsrfViewMiddleware.process_view",
+        "django.middleware_name": "django.middleware.csrf.CsrfViewMiddleware"
+      },
+      "hash": "e853d2eb7fb9ebb0",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.565666,
+      "start_timestamp": 1661957970.392127,
+      "exclusive_time": 3.560066,
+      "description": "index",
+      "op": "django.view",
+      "span_id": "975f73422c8b1592",
+      "parent_span_id": "98f79ffd92d4a060",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "hash": "6a992d5529f459a4",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.244459,
+      "start_timestamp": 1661957970.393029,
+      "exclusive_time": 1520.380972,
+      "description": "connect",
+      "op": "db",
+      "span_id": "9f31e1ee4ef94970",
+      "parent_span_id": "975f73422c8b1592",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "hash": "b640a0ce465fa2a4",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.078148,
+      "start_timestamp": 1661957971.911963,
+      "exclusive_time": 166.184903,
+      "description": "\n                SELECT VERSION(),\n                       @@sql_mode,\n                       @@default_storage_engine,\n                       @@sql_auto_is_null,\n                       @@lower_case_table_names,\n                       CONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC') IS NOT NULL\n            ",
+      "op": "db",
+      "span_id": "a05754d3fde2db29",
+      "parent_span_id": "9f31e1ee4ef94970",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "hash": "3a91b85ea92a26b9",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.244184,
+      "start_timestamp": 1661957972.07932,
+      "exclusive_time": 164.864064,
+      "description": "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
+      "op": "db",
+      "span_id": "8ed794ef6fc2ca5d",
+      "parent_span_id": "9f31e1ee4ef94970",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "hash": "061710eb39a66089",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957972.563516,
+      "start_timestamp": 1661957972.244967,
+      "exclusive_time": 318.548918,
+      "description": "SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id`, `books_author`.`id`, `books_author`.`name` FROM `books_book` INNER JOIN `books_author` ON (`books_book`.`author_id` = `books_author`.`id`) LIMIT 10",
+      "op": "db",
+      "span_id": "85dc61f6b5fbfa2b",
+      "parent_span_id": "975f73422c8b1592",
+      "trace_id": "679ca2e3ce344d689f7b42b0e8fb32a4",
+      "hash": "e5aa87dbfacc0120",
+      "same_process_as_parent": true
+    }
+  ],
+  "start_timestamp": 1661957970.376365,
+  "timestamp": 1661957972.566927,
+  "title": "/books/",
+  "transaction": "/books/",
+  "transaction_info": {"source": "route"},
+  "type": "transaction"
+}


### PR DESCRIPTION
Partially closes PERF-1732. Adds three JSON files of realistic events to test performance detection on. Two of them are N+1 query issues from a real app. One is the _solved_ version of an N+1 query, using `select_related`. Adds two tests that use these JSON files instead of stubbing out events.
