### PR TITLE
feat(replays): Upgrade `@sentry/replay` to 0.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@sentry/node": "7.11.0",
     "@sentry/react": "7.11.0",
     "@sentry/release-parser": "^1.3.1",
-    "@sentry/replay": "0.5.4",
+    "@sentry/replay": "0.5.7",
     "@sentry/tracing": "7.11.0",
     "@sentry/utils": "7.11.0",
     "@testing-library/jest-dom": "^5.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,10 +2322,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-1.3.1.tgz#0ab8be23fd494d80dd0e4ec8ae5f3d13f805b13d"
   integrity sha512-/dGpCq+j3sJhqQ14RNEEL45Ot/rgq3jAlZDD/8ufeqq+W8p4gUhSrbGWCRL82NEIWY9SYwxYXGXjRcVPSHiA1Q==
 
-"@sentry/replay@0.5.4":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-0.5.4.tgz#c7e52ac1df719eb6307ef431b3f3c4a6d543cbc4"
-  integrity sha512-ofyQiX3aRkIL77q72gDv+zLSHcmY0NCjuVDicsjvnaNEMkJ4oy7E6ZoX6QDRwEY1EoDagGMzRJqpmL+kMqVvrQ==
+"@sentry/replay@0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-0.5.7.tgz#1f4c6c83671e4563e4bf42a0c97dbed6e92fb753"
+  integrity sha512-k//fv8BvbAkUMQ0CucpLffx3SotW/MVUMu5UgsVTq9MwgA4EaO5lMdVQHR1e3x01Ab6Wb2YCQfg5ne7yVaQhoA==
   dependencies:
     "@sentry/core" "^7.7.0"
     "@sentry/types" "^7.7.0"


### PR DESCRIPTION
* Cleans-up/simplifies some blur/focus breadcrumb logic.
* Fixes serialization of complex objects (uses JSON.stringify to serialize before sending to web worker)
* De-dupes window.performance entries
