### PR TITLE
ref(js): Don't set default for excludeEnvironment

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -309,7 +309,6 @@ class SmartSearchBar extends Component<Props, State> {
     defaultQuery: '',
     query: null,
     onSearch: function () {},
-    excludeEnvironment: false,
     placeholder: t('Search for events, users, tags, and more'),
     supportedTags: {},
     defaultSearchItems: [[], []],


### PR DESCRIPTION
Tiny change, but no need to set a default since it will just default to
undefined, which ~false. Just makes it easier in the future to have less
things to look at :shrug: