### PR TITLE
feat(profiling): use static to determine empty profile

### DIFF
--- a/static/app/components/profiling/FlamegraphWarnings.tsx
+++ b/static/app/components/profiling/FlamegraphWarnings.tsx
@@ -12,6 +12,12 @@ interface FlamegraphWarningProps {
 export function FlamegraphWarnings(props: FlamegraphWarningProps) {
   const params = useParams();
 
+  // A profile may be empty while we are fetching it from the network; while that is happening an empty profile is
+  // passed down to the view so that all the components can be loaded and initialized ahead of time.
+  if (props.flamegraph.profile.isEmpty()) {
+    return null;
+  }
+
   if (props.flamegraph.profile.samples.length === 0) {
     return (
       <Overlay>

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -37,7 +37,7 @@ export class Flamegraph {
   timelineFormatter: (value: number) => string;
 
   static Empty(): Flamegraph {
-    return new Flamegraph(Profile.Empty(), 0, {
+    return new Flamegraph(Profile.Empty, 0, {
       inverted: false,
       leftHeavy: false,
     });

--- a/static/app/utils/profiling/profile/profile.spec.tsx
+++ b/static/app/utils/profiling/profile/profile.spec.tsx
@@ -62,7 +62,7 @@ stack top -> stack bottom`;
 
 describe('Profile', () => {
   it('Empty profile duration is not infinity', () => {
-    const profile = Profile.Empty();
+    const profile = Profile.Empty;
     expect(profile.duration).toEqual(1000);
     expect(profile.minFrameDuration).toEqual(1000);
   });

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -58,8 +58,10 @@ export class Profile {
     this.unit = unit;
   }
 
-  static Empty() {
-    return new Profile(1000, 0, 1000, '', 'milliseconds', 0).build();
+  static Empty = new Profile(1000, 0, 1000, '', 'milliseconds', 0).build();
+
+  isEmpty(): boolean {
+    return this === Profile.Empty;
   }
 
   trackSampleStats(duration: number) {

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -31,7 +31,7 @@ const LoadingGroup: ProfileGroup = {
   name: 'Loading',
   traceID: '',
   activeProfileIndex: 0,
-  profiles: [Profile.Empty()],
+  profiles: [Profile.Empty],
 };
 
 function ProfileFlamegraph(): React.ReactElement {


### PR DESCRIPTION
Dont show warning states when we are seeing the empty profile