### PR TITLE
ref(orgSettings): Use <TextCopyInput /> to display org API key

### DIFF
--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -3,7 +3,7 @@ import {PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import AlertLink from 'sentry/components/alertLink';
-import AutoSelectText from 'sentry/components/autoSelectText';
+import TextCopyInput from 'sentry/components/forms/textCopyInput';
 import Button from 'sentry/components/button';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
@@ -11,7 +11,6 @@ import LinkWithConfirmation from 'sentry/components/links/linkWithConfirmation';
 import {PanelTable} from 'sentry/components/panels';
 import {IconAdd, IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import {inputStyles} from 'sentry/styles/input';
 import recreateRoute from 'sentry/utils/recreateRoute';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
@@ -107,9 +106,7 @@ function OrganizationApiKeysList({
                   <Link to={apiDetailsUrl}>{label}</Link>
                 </Cell>
 
-                <div>
-                  <AutoSelectTextInput readOnly>{key}</AutoSelectTextInput>
-                </div>
+                <TextCopyInput monospace>{key}</TextCopyInput>
 
                 <Cell>
                   <LinkWithConfirmation
@@ -133,10 +130,6 @@ function OrganizationApiKeysList({
 const Cell = styled('div')`
   display: flex;
   align-items: center;
-`;
-
-const AutoSelectTextInput = styled(AutoSelectText)<{readOnly: boolean}>`
-  ${p => inputStyles(p)}
 `;
 
 export default OrganizationApiKeysList;

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -3,8 +3,8 @@ import {PlainRoute, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import AlertLink from 'sentry/components/alertLink';
-import TextCopyInput from 'sentry/components/forms/textCopyInput';
 import Button from 'sentry/components/button';
+import TextCopyInput from 'sentry/components/forms/textCopyInput';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import LinkWithConfirmation from 'sentry/components/links/linkWithConfirmation';

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysList.tsx
@@ -106,7 +106,9 @@ function OrganizationApiKeysList({
                   <Link to={apiDetailsUrl}>{label}</Link>
                 </Cell>
 
-                <TextCopyInput monospace>{key}</TextCopyInput>
+                <TextCopyInput size="sm" monospace>
+                  {key}
+                </TextCopyInput>
 
                 <Cell>
                   <LinkWithConfirmation

--- a/static/app/views/settings/organizationApiKeys/organizationApiKeysView.spec.jsx
+++ b/static/app/views/settings/organizationApiKeys/organizationApiKeysView.spec.jsx
@@ -40,7 +40,7 @@ describe('OrganizationApiKeys', function () {
       />
     );
 
-    expect(wrapper.find('AutoSelectTextInput')).toHaveLength(1);
+    expect(wrapper.find('TextCopyInput')).toHaveLength(1);
     expect(getMock).toHaveBeenCalledTimes(1);
   });
 
@@ -62,6 +62,6 @@ describe('OrganizationApiKeys', function () {
     wrapper.update();
 
     expect(deleteMock).toHaveBeenCalledTimes(1);
-    expect(wrapper.find('AutoSelectTextInput')).toHaveLength(0);
+    expect(wrapper.find('TextCopyInput')).toHaveLength(0);
   });
 });


### PR DESCRIPTION
**Before –**
<img width="664" alt="Screen Shot 2022-08-31 at 12 39 30 PM" src="https://user-images.githubusercontent.com/44172267/187767621-8a76f925-1a69-4221-b39a-c77f8d6a021d.png">

**After –**
<img width="664" alt="Screen Shot 2022-08-31 at 12 40 48 PM" src="https://user-images.githubusercontent.com/44172267/187767836-58851f84-b6c0-4e9d-a394-d67f4abf9c86.png">
