### PR TITLE
ref: upgrade honcho to eliminate warning in python3.8

### DIFF
--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -57,7 +57,7 @@ grpc-google-iam-v1==0.12.4
 grpcio==1.47.0
 h11==0.13.0
 hiredis==0.3.1
-honcho==1.0.0
+honcho==1.1.0
 identify==2.5.1
 idna==2.10
 inflection==0.5.1

--- a/requirements-dev-only-frozen.txt
+++ b/requirements-dev-only-frozen.txt
@@ -18,7 +18,7 @@ filelock==3.7.1
 flake8==5.0.2
 flake8-bugbear==22.7.1
 freezegun==1.1.0
-honcho==1.0.0
+honcho==1.1.0
 identify==2.5.1
 idna==3.3
 importlib-resources==5.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 docker>=3.7.0,<3.8.0
 exam>=0.10.6
 freezegun>=1.1.0
-honcho>=1.0.0,<1.1.0
+honcho>=1.1.0
 openapi-core>=0.14.2
 pytest>=6.1.0
 pytest-cov>=3.0.0


### PR DESCRIPTION
```
/Users/mitsuhiko/.pyenv/versions/3.8.13/lib/python3.8/subprocess.py:848: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
```

@mitsuhiko has confirmed this fixes this warning ^