### PR TITLE
ref(smartSearchBar): Fix overflow issue

### DIFF
--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -524,7 +524,7 @@ const FirstWordWrapper = styled('span')`
 `;
 
 const TagWrapper = styled('span')`
-  width: 5%;
+  flex-shrink: 0;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -532,18 +532,16 @@ const TagWrapper = styled('span')`
 `;
 
 const Documentation = styled('span')`
-  font-size: ${p => p.theme.fontSizeMedium};
-  font-family: ${p => p.theme.text.family};
-  color: ${p => p.theme.gray300};
   display: flex;
   flex: 2;
   padding: 0 ${space(1)};
+  min-width: 0;
 
+  ${p => p.theme.overflowEllipsis}
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-family: ${p => p.theme.text.family};
+  color: ${p => p.theme.subText};
   white-space: pre;
-
-  @media (max-width: ${p => p.theme.breakpoints.small}) {
-    display: none;
-  }
 `;
 
 const DropdownFooter = styled(`div`)`


### PR DESCRIPTION
Ellipsize token descriptions (the gray text) to prevent horizontal overflow.

**Before –**
<img width="513" alt="Screen Shot 2022-08-31 at 1 47 49 PM" src="https://user-images.githubusercontent.com/44172267/187779309-d6709129-34e0-48e8-bab3-4cb969f864fd.png">
<img width="513" alt="Screen Shot 2022-08-31 at 1 47 56 PM" src="https://user-images.githubusercontent.com/44172267/187779313-53fdef82-d6f3-4224-a88f-3f072539616e.png">

**After –**
<img width="513" alt="Screen Shot 2022-08-31 at 1 49 19 PM" src="https://user-images.githubusercontent.com/44172267/187779312-258af3e3-8d41-4ed2-b934-257e1908464b.png">
