### PR TITLE
feat(discover): Adds custom performance metrics field and unit meta to events-stats response

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -556,3 +556,70 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             [{"count": 0}],
         ]
         assert not response.data["isMetricsData"]
+
+    def test_custom_performance_metric_meta_contains_field_and_unit_data(self):
+        self.store_transaction_metric(
+            123,
+            timestamp=self.day_ago + timedelta(hours=1),
+            internal_metric="d:transactions/measurements.custom@kibibyte",
+            entity="metrics_distributions",
+        )
+        response = self.do_request(
+            data={
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=2)),
+                "interval": "1h",
+                "yAxis": "p99(measurements.custom)",
+                "query": "",
+            },
+        )
+
+        assert response.status_code == 200
+        meta = response.data["meta"]
+        print(meta)
+        assert meta["fields"] == {"time": "date", "p99_measurements_custom": "size"}
+        assert meta["units"] == {"time": None, "p99_measurements_custom": "kibibyte"}
+
+    def test_multi_series_custom_performance_metric_meta_contains_field_and_unit_data(self):
+        self.store_transaction_metric(
+            123,
+            timestamp=self.day_ago + timedelta(hours=1),
+            internal_metric="d:transactions/measurements.custom@kibibyte",
+            entity="metrics_distributions",
+        )
+        self.store_transaction_metric(
+            123,
+            timestamp=self.day_ago + timedelta(hours=1),
+            internal_metric="d:transactions/measurements.another.custom@pebibyte",
+            entity="metrics_distributions",
+        )
+        response = self.do_request(
+            data={
+                "start": iso_format(self.day_ago),
+                "end": iso_format(self.day_ago + timedelta(hours=2)),
+                "interval": "1h",
+                "yAxis": [
+                    "p95(measurements.custom)",
+                    "p99(measurements.custom)",
+                    "p99(measurements.another.custom)",
+                ],
+                "query": "",
+            },
+        )
+
+        assert response.status_code == 200
+        meta = response.data["p95(measurements.custom)"]["meta"]
+        assert meta["fields"] == {
+            "time": "date",
+            "p95_measurements_custom": "size",
+            "p99_measurements_custom": "size",
+            "p99_measurements_another_custom": "size",
+        }
+        assert meta["units"] == {
+            "time": None,
+            "p95_measurements_custom": "kibibyte",
+            "p99_measurements_custom": "kibibyte",
+            "p99_measurements_another_custom": "pebibyte",
+        }
+        assert meta == response.data["p99(measurements.custom)"]["meta"]
+        assert meta == response.data["p99(measurements.another.custom)"]["meta"]


### PR DESCRIPTION
Adds field and unit meta for discover dataset events-stats response, including for custom performance metrics