### PR TITLE
fix: Load query sets to avoid pickling for async function

### DIFF
--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -111,7 +111,7 @@ class TeamManager(BaseManager):
                 update_code_owners_schema.apply_async(
                     kwargs={
                         "organization": instance.organization,
-                        "projects": instance.get_projects(),
+                        "projects": list(instance.get_projects()),
                     }
                 )
             except (Organization.DoesNotExist, Project.DoesNotExist):

--- a/src/sentry/notifications/notifications/activity/release.py
+++ b/src/sentry/notifications/notifications/activity/release.py
@@ -52,7 +52,7 @@ class ReleaseActivityNotification(ActivityNotification):
             return
 
         self.projects = set(self.release.projects.all())
-        self.commit_list = Commit.objects.get_for_release(self.release)
+        self.commit_list = list(Commit.objects.get_for_release(self.release))
         self.email_list = {c.author.email for c in self.commit_list if c.author}
         users = UserEmail.objects.get_users_by_emails(self.email_list, self.organization)
         self.user_ids = {u.id for u in users.values()}


### PR DESCRIPTION
Another fix in the vein of #37835. Prevents a bug that emerges in #38289.