### PR TITLE
fix(replays): Fixes ReplayCurrentUrl styles

### DIFF
--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -12,13 +12,21 @@ import getCurrentUrl from 'sentry/utils/replays/getCurrentUrl';
 function ReplayCurrentUrl() {
   const {currentTime, replay} = useReplayContext();
   if (!replay) {
-    return <UrlCopyInput disabled>{''}</UrlCopyInput>;
+    return (
+      <UrlCopyInput size="sm" disabled>
+        {''}
+      </UrlCopyInput>
+    );
   }
 
   const replayRecord = replay.getReplay();
   const crumbs = replay.getRawCrumbs();
 
-  return <UrlCopyInput>{getCurrentUrl(replayRecord, crumbs, currentTime)}</UrlCopyInput>;
+  return (
+    <UrlCopyInput size="sm">
+      {getCurrentUrl(replayRecord, crumbs, currentTime)}
+    </UrlCopyInput>
+  );
 }
 
 const UrlCopyInput = styled(TextCopyInput)`
@@ -28,12 +36,13 @@ const UrlCopyInput = styled(TextCopyInput)`
   ${StyledInput} {
     border-right-width: 1px;
     border-radius: 0.25em;
-    background-color: ${p => p.theme.white};
+    background-color: ${p => p.theme.background};
+    border-right-color: ${p => p.theme.border};
 
     &:hover,
     &:focus {
       border-right-width: 1px;
-      background-color: ${p => p.theme.white};
+      background-color: ${p => p.theme.background};
     }
   }
   ${StyledCopyButton} {


### PR DESCRIPTION
### Changes
- Overrides border-right-color from transparent to border for current url input
- Updates button and input size to sm 
- Sets a proper background color to for dark mode

![Screen Shot 2022-08-31 at 5 52 55 PM](https://user-images.githubusercontent.com/3721977/187791928-150e6288-6f99-4b5c-8d1e-62e96ffb7db3.png)
![Screen Shot 2022-08-31 at 5 53 23 PM](https://user-images.githubusercontent.com/3721977/187791929-2d3fa3d8-21a8-4189-8ec2-8191f7b4cad5.png)

Closes #38012 

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
