### PR TITLE
fix(issues): Reduce suggested assignees stack to 3

### DIFF
--- a/static/app/components/assigneeSelector.tsx
+++ b/static/app/components/assigneeSelector.tsx
@@ -476,7 +476,7 @@ class AssigneeSelector extends Component<Props, State> {
       />
     ) : suggestedActors && suggestedActors.length > 0 ? (
       <SuggestedAvatarStack
-        size={24}
+        size={28}
         owners={suggestedActors}
         tooltipOptions={{isHoverable: true}}
         tooltip={

--- a/static/app/components/avatar/suggestedAvatarStack.tsx
+++ b/static/app/components/avatar/suggestedAvatarStack.tsx
@@ -11,7 +11,7 @@ type Props = {
   Omit<React.ComponentProps<typeof ActorAvatar>, 'actor' | 'hasTooltip'>;
 
 // Constrain the number of visible suggestions
-const MAX_SUGGESTIONS = 5;
+const MAX_SUGGESTIONS = 3;
 
 const SuggestedAvatarStack = ({owners, tooltip, tooltipOptions, ...props}: Props) => {
   const [firstSuggestion, ...suggestedOwners] = owners;


### PR DESCRIPTION
Resize to make them the same size as other avatars even though they have a 2px border
