### PR TITLE
feat(perf issues): Add type and category to serializer

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -329,6 +329,8 @@ class GroupSerializerBase(Serializer, ABC):
             "subscriptionDetails": subscription_details,
             "hasSeen": attrs["has_seen"],
             "annotations": attrs["annotations"],
+            "issueType": obj.issue_type.name.lower(),
+            "issueCategory": obj.issue_category.name.lower(),
         }
 
         # This attribute is currently feature gated

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -329,10 +329,8 @@ class GroupSerializerBase(Serializer, ABC):
             "subscriptionDetails": subscription_details,
             "hasSeen": attrs["has_seen"],
             "annotations": attrs["annotations"],
-            "issue": {
-                "type": obj.issue_type.name.lower(),
-                "category": obj.issue_category.name.lower(),
-            },
+            "issueType": obj.issue_type.name.lower(),
+            "issueCategory": obj.issue_category.name.lower(),
         }
 
         # This attribute is currently feature gated

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -329,8 +329,10 @@ class GroupSerializerBase(Serializer, ABC):
             "subscriptionDetails": subscription_details,
             "hasSeen": attrs["has_seen"],
             "annotations": attrs["annotations"],
-            "issueType": obj.issue_type.name.lower(),
-            "issueCategory": obj.issue_category.name.lower(),
+            "issue": {
+                "type": obj.issue_type.name.lower(),
+                "category": obj.issue_category.name.lower(),
+            },
         }
 
         # This attribute is currently feature gated

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -203,3 +203,20 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         assert response.data["userCount"] is not None  # key shouldn't be present
         assert response.data["firstSeen"] is not None  # key shouldn't be present
         assert response.data["lastSeen"] is not None  # key shouldn't be present
+
+    def test_issue_type_category(self):
+        """Test that the issue's type and category is returned in the results"""
+
+        self.login_as(user=self.user)
+
+        event = self.store_event(
+            data={"timestamp": iso_format(before_now(minutes=3))},
+            project_id=self.project.id,
+        )
+
+        url = f"/api/0/issues/{event.group.id}/"
+        response = self.client.get(url, format="json")
+        assert response.status_code == 200
+        assert int(response.data["id"]) == event.group.id
+        assert response.data["issueType"] == "error"
+        assert response.data["issueCategory"] == "error"

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -218,5 +218,5 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert int(response.data["id"]) == event.group.id
-        assert response.data["issue"]["type"] == "error"
-        assert response.data["issue"]["category"] == "error"
+        assert response.data["issueType"] == "error"
+        assert response.data["issueCategory"] == "error"

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -218,5 +218,5 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert int(response.data["id"]) == event.group.id
-        assert response.data["issueType"] == "error"
-        assert response.data["issueCategory"] == "error"
+        assert response.data["issue"]["type"] == "error"
+        assert response.data["issue"]["category"] == "error"


### PR DESCRIPTION
Add the issue's type and category to the `GroupSerializerBase`. 