### PR TITLE
feat(platforms): Add Svelte as a platform (Backend)

### DIFF
--- a/src/sentry/utils/platform_categories.py
+++ b/src/sentry/utils/platform_categories.py
@@ -45,6 +45,7 @@ FRONTEND = [
     "javascript-vue",
     "javascript-nextjs",
     "javascript-remix",
+    "javascript-svelte",
     "unity",
 ]
 
@@ -216,6 +217,7 @@ RELEASE_HEALTH = [
     "javascript-vue",
     "javascript-nextjs",
     "javascript-remix",
+    "javascript-svelte",
     # mobile
     "android",
     "apple-ios",


### PR DESCRIPTION
As requested in #37909, this PR adds Svelte as a platform to the new `platform_categories.py` file.

Not sure if this PR or #37909 should be merged first. Would there be breakage if we did it one or the other way?

ref: https://github.com/getsentry/sentry-javascript/issues/5671