### PR TITLE
feat(sampling): Improve experience for unsupported use cases [TET-350]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.spec.tsx
@@ -66,7 +66,7 @@ describe('Server-Side Sampling - Specify Client Rate Modal', function () {
 
     // Hover over next button
     userEvent.hover(screen.getByRole('button', {name: 'Next'}));
-    expect(await screen.findByText('Sample rate is not valid')).toBeInTheDocument();
+    expect(await screen.findByText('Sample rate must not be empty')).toBeInTheDocument();
 
     // Enter valid specified client-sample rate
     userEvent.type(screen.getByRole('spinbutton'), '0.2{enter}');

--- a/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.tsx
@@ -9,9 +9,7 @@ import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 
-import {SamplingProjectIncompatibleAlert} from '../samplingProjectIncompatibleAlert';
 import {isValidSampleRate, SERVER_SIDE_SAMPLING_DOC_LINK} from '../utils';
-import {useRecommendedSdkUpgrades} from '../utils/useRecommendedSdkUpgrades';
 
 import {FooterActions, Stepper, StyledNumberField} from './uniformRateModal';
 
@@ -36,11 +34,6 @@ export function SpecifyClientRateModal({
   value,
   onChange,
 }: SpecifyClientRateModalProps) {
-  const {isProjectIncompatible} = useRecommendedSdkUpgrades({
-    orgSlug: organization.slug,
-    projectId,
-  });
-
   function handleReadDocs() {
     trackAdvancedAnalyticsEvent('sampling.settings.modal.specify.client.rate_read_docs', {
       organization,
@@ -90,11 +83,6 @@ export function SpecifyClientRateModal({
           flexibleControlStateSize
           inline={false}
         />
-        <SamplingProjectIncompatibleAlert
-          organization={organization}
-          projectId={projectId}
-          isProjectIncompatible={isProjectIncompatible}
-        />
       </Body>
       <Footer>
         <FooterActions>
@@ -107,8 +95,14 @@ export function SpecifyClientRateModal({
             <Button
               priority="primary"
               onClick={handleGoNext}
-              disabled={!isValid || isProjectIncompatible}
-              title={!isValid ? t('Sample rate is not valid') : undefined}
+              disabled={!isValid}
+              title={
+                !value
+                  ? t('Sample rate must not be empty')
+                  : !isValid
+                  ? t('Sample rate is not valid')
+                  : undefined
+              }
             >
               {t('Next')}
             </Button>

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -30,7 +30,6 @@ import useApi from 'sentry/utils/useApi';
 import {Outcome} from 'sentry/views/organizationStats/types';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-import {SamplingProjectIncompatibleAlert} from '../samplingProjectIncompatibleAlert';
 import {
   getClientSampleRates,
   isValidSampleRate,
@@ -577,12 +576,6 @@ export function UniformRateModal({
               </Projects>
             </Alert>
           )}
-
-          <SamplingProjectIncompatibleAlert
-            organization={organization}
-            projectId={project.id}
-            isProjectIncompatible={isProjectIncompatible}
-          />
         </Fragment>
       </Body>
       <Footer>

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -132,7 +132,6 @@ export function UniformRateModal({
     !defined(specifiedClientRate);
 
   const isWithoutTransactions =
-    projectStats30d.data?.groups.length === 0 ||
     projectStats30d.data?.groups.reduce(
       (acc, group) => acc + group.totals['sum(quantity)'],
       0

--- a/static/app/views/settings/project/server-side-sampling/samplingProjectIncompatibleAlert.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingProjectIncompatibleAlert.tsx
@@ -35,7 +35,7 @@ export function SamplingProjectIncompatibleAlert({
   return (
     <Alert
       data-test-id="incompatible-project-alert"
-      type="warning"
+      type="error"
       showIcon
       trailingItems={
         <Button

--- a/static/app/views/settings/project/server-side-sampling/samplingPromo.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingPromo.tsx
@@ -11,17 +11,11 @@ import {SERVER_SIDE_SAMPLING_DOC_LINK} from './utils';
 
 type Props = {
   hasAccess: boolean;
-  isProjectIncompatible: boolean;
   onGetStarted: () => void;
   onReadDocs: () => void;
 };
 
-export function SamplingPromo({
-  onGetStarted,
-  onReadDocs,
-  hasAccess,
-  isProjectIncompatible,
-}: Props) {
+export function SamplingPromo({onGetStarted, onReadDocs, hasAccess}: Props) {
   return (
     <OnboardingPanel image={<img src={onboardingServerSideSampling} />}>
       <h3>{t('Sample for relevancy')}</h3>
@@ -34,7 +28,7 @@ export function SamplingPromo({
         <Button
           priority="primary"
           onClick={onGetStarted}
-          disabled={!hasAccess || isProjectIncompatible}
+          disabled={!hasAccess}
           title={hasAccess ? undefined : t('You do not have permission to set up rules')}
         >
           {t('Start Setup')}

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -98,6 +98,18 @@ export function ServerSideSampling({project}: Props) {
     }
 
     async function fetchData() {
+      fetchProjectStats48h({
+        orgSlug: organization.slug,
+        api,
+        projId: project.id,
+      });
+
+      fetchProjectStats30d({
+        orgSlug: organization.slug,
+        api,
+        projId: project.id,
+      });
+
       await fetchSamplingDistribution({
         orgSlug: organization.slug,
         projSlug: project.slug,
@@ -108,18 +120,6 @@ export function ServerSideSampling({project}: Props) {
         orgSlug: organization.slug,
         api,
         projectID: project.id,
-      });
-
-      await fetchProjectStats48h({
-        orgSlug: organization.slug,
-        api,
-        projId: project.id,
-      });
-
-      await fetchProjectStats30d({
-        orgSlug: organization.slug,
-        api,
-        projId: project.id,
       });
     }
 
@@ -481,7 +481,6 @@ export function ServerSideSampling({project}: Props) {
             onGetStarted={handleGetStarted}
             onReadDocs={handleReadDocs}
             hasAccess={hasAccess}
-            isProjectIncompatible={isProjectIncompatible}
           />
         ) : (
           <RulesPanel>

--- a/static/app/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.tsx
@@ -10,8 +10,8 @@ type Props = {
 };
 
 export function useRecommendedSdkUpgrades({orgSlug, projectId}: Props) {
-  const {sdkVersions} = useLegacyStore(ServerSideSamplingStore);
-  const {data = [], loading} = sdkVersions;
+  const {sdkVersions, distribution} = useLegacyStore(ServerSideSamplingStore);
+  const {data = []} = sdkVersions;
 
   const sdksToUpdate = data.filter(
     ({isSendingSource, isSendingSampleRate, isSupportedPlatform}) => {
@@ -61,7 +61,7 @@ export function useRecommendedSdkUpgrades({orgSlug, projectId}: Props) {
     recommendedSdkUpgrades,
     incompatibleProjects,
     affectedProjects,
-    loading,
+    loading: sdkVersions.loading || distribution.loading,
     isProjectIncompatible,
   };
 }

--- a/tests/acceptance/test_project_settings_sampling.py
+++ b/tests/acceptance/test_project_settings_sampling.py
@@ -1,3 +1,4 @@
+import pytest
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
@@ -71,6 +72,7 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
         self.browser.get(self.path)
         self.browser.wait_until_not('[data-test-id="loading-indicator"]')
 
+    @pytest.mark.skip("We need to generate transactions from supported SDK")
     def test_add_uniform_rule_with_recommended_sampling_values(self):
         with self.feature(FEATURE_NAME):
             self.wait_until_page_loaded()
@@ -103,6 +105,7 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
                 == serializer.validated_data["rules"][0]
             )
 
+    @pytest.mark.skip("We need to generate transactions from supported SDK")
     def test_add_uniform_rule_with_custom_sampling_values(self):
         with self.feature(FEATURE_NAME):
             self.wait_until_page_loaded()


### PR DESCRIPTION
https://user-images.githubusercontent.com/9060071/187900644-872931f0-d6de-4c1a-9c78-698e0fc289c6.mp4

- enable the get started button all the time

- as a user with an outdated SDK i should be able to see the first step of the dialog that shows the breakdown

- as a user that is still waiting for the dialog to fetch the sample rate i should not be able to click next

- if i cannot continue the next button should be disabled and give me a good reason why

- as a user with a supported sdk and no transactions you have the same experience as an unsupported sdk