### PR TITLE
feat(sampling): Make client sample rate modal more inviting

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.spec.tsx
@@ -4,7 +4,6 @@ import {
   userEvent,
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
-import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import GlobalModal from 'sentry/components/globalModal';
@@ -39,15 +38,11 @@ describe('Server-Side Sampling - Specify Client Rate Modal', function () {
     // Header
     expect(
       await screen.findByRole('heading', {
-        name: 'Specify current client(SDK) sample rate',
+        name: 'Current SDK Sample Rate',
       })
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        textWithMarkupMatcher(
-          'Find the tracesSampleRate option in your SDK config, and copy it’s value into the field below.'
-        )
-      )
+      screen.getByText(/We are not able to estimate your client sample rate/)
     ).toBeInTheDocument();
 
     // Content
@@ -70,7 +65,7 @@ describe('Server-Side Sampling - Specify Client Rate Modal', function () {
 
     // Enter valid specified client-sample rate
     userEvent.type(screen.getByRole('spinbutton'), '0.2{enter}');
-    expect(handleChange).toHaveBeenCalled();
+    expect(handleChange).toHaveBeenCalledWith('0.2');
 
     // Click on the docs
     userEvent.click(screen.getByLabelText('Read Docs'));

--- a/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
 import styled from '@emotion/styled';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -34,6 +34,10 @@ export function SpecifyClientRateModal({
   value,
   onChange,
 }: SpecifyClientRateModalProps) {
+  useEffect(() => {
+    onChange(0.1);
+  }, [onChange]);
+
   function handleReadDocs() {
     trackAdvancedAnalyticsEvent('sampling.settings.modal.specify.client.rate_read_docs', {
       organization,
@@ -61,12 +65,12 @@ export function SpecifyClientRateModal({
   return (
     <Fragment>
       <Header closeButton>
-        <h4>{t('Specify current client(SDK) sample rate')}</h4>
+        <h4>{t('Current SDK Sample Rate')}</h4>
       </Header>
       <Body>
         <StyledNumberField
           label={tct(
-            'Find the [textHighlight:tracesSampleRate] option in your SDK config, and copy it’s value into the field below.',
+            'We are not able to estimate your client sample rate. For a more accurate estimation find the [textHighlight:tracesSampleRate] option in your SDK config, and copy it’s value into the field below.',
             {
               textHighlight: <TextHighlight />,
             }

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
@@ -299,14 +299,9 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
 
     expect(
       await screen.findByRole('heading', {
-        name: 'Specify current client(SDK) sample rate',
+        name: 'Current SDK Sample Rate',
       })
     ).toBeInTheDocument();
-
-    expect(screen.getByRole('button', {name: 'Next'})).toBeDisabled();
-
-    // Enter valid specified client-sample rate
-    userEvent.type(screen.getByRole('spinbutton'), '0.2{enter}');
 
     userEvent.click(screen.getByRole('button', {name: 'Next'}));
 
@@ -315,10 +310,10 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     ).toBeInTheDocument();
 
     // Content
-    expect(screen.getByText('20%')).toBeInTheDocument(); // Current client-side sample rate
+    expect(screen.getByText('10%')).toBeInTheDocument(); // Current client-side sample rate
     expect(screen.getByText('N/A')).toBeInTheDocument(); // Current server-side sample rate
     expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(100); // Suggested client-side sample rate
-    expect(screen.getAllByRole('spinbutton')[1]).toHaveValue(20); // Suggested server-side sample rate
+    expect(screen.getAllByRole('spinbutton')[1]).toHaveValue(10); // Suggested server-side sample rate
 
     // Footer
     expect(screen.getByText('Step 2 of 3')).toBeInTheDocument();
@@ -327,7 +322,7 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     userEvent.click(screen.getByRole('button', {name: 'Back'}));
 
     // Specified sample rate has to still be there
-    expect(screen.getByRole('spinbutton')).toHaveValue(0.2);
+    expect(screen.getByRole('spinbutton')).toHaveValue(0.1);
 
     // Close Modal
     userEvent.click(screen.getByRole('button', {name: 'Cancel'}));


### PR DESCRIPTION
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/9060071/187928897-d38258f4-c168-414a-8860-ace26b49a99c.png">

- we prefill the input so that the "Next" button is not scary and disabled
- improved copy