### PR TITLE
fix(teamfilter): account for null onchange

### DIFF
--- a/static/app/views/alerts/list/rules/teamFilter.tsx
+++ b/static/app/views/alerts/list/rules/teamFilter.tsx
@@ -103,7 +103,7 @@ function TeamFilter({
         if (!opts) {
           return handleChangeFilter([]);
         }
-        return handleChangeFilter((opts ?? []).map(opt => opt.value));
+        return handleChangeFilter(opts.map(opt => opt.value));
       }}
       triggerLabel={
         <Fragment>

--- a/static/app/views/alerts/list/rules/teamFilter.tsx
+++ b/static/app/views/alerts/list/rules/teamFilter.tsx
@@ -98,7 +98,13 @@ function TeamFilter({
       }
       value={selectedTeams}
       onInputChange={debounce(val => void onSearch(val), DEFAULT_DEBOUNCE_DURATION)}
-      onChange={opts => handleChangeFilter(opts.map(opt => opt.value))}
+      onChange={opts => {
+        // Compact select type inference does not work - onChange type is actually T | null.
+        if (!opts) {
+          return handleChangeFilter([]);
+        }
+        return handleChangeFilter((opts ?? []).map(opt => opt.value));
+      }}
       triggerLabel={
         <Fragment>
           {triggerLabel}


### PR DESCRIPTION
Fixes https://sentry.io/organizations/sentry/issues/3298982447/?project=11276&query=is%3Aunresolved&statsPeriod=14d, but we need to fix the compact select types so that inference works correctly here.