### PR TITLE
feat(perf): Improve permissions and auditing on options endpoint

### DIFF
--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -1,4 +1,7 @@
+import logging
+
 from django.conf import settings
+from django.db import transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -7,6 +10,8 @@ from sentry import options
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.utils.email import is_smtp_enabled
+
+logger = logging.getLogger("sentry")
 
 
 class SystemOptionsEndpoint(Endpoint):
@@ -51,6 +56,9 @@ class SystemOptionsEndpoint(Endpoint):
         return Response(results)
 
     def put(self, request: Request):
+        if not request.access.has_permission("options.admin"):
+            return Response(status=403)
+
         # TODO(dcramer): this should validate options before saving them
         for k, v in request.data.items():
             if v and isinstance(v, str):
@@ -64,10 +72,21 @@ class SystemOptionsEndpoint(Endpoint):
                 )
 
             try:
-                if not (option.flags & options.FLAG_ALLOW_EMPTY) and not v:
-                    options.delete(k)
-                else:
-                    options.set(k, v)
+                with transaction.atomic():
+                    if not (option.flags & options.FLAG_ALLOW_EMPTY) and not v:
+                        options.delete(k)
+                    else:
+                        options.set(k, v)
+
+                    logger.info(
+                        "options.update",
+                        extra={
+                            "ip_address": request.META["REMOTE_ADDR"],
+                            "user_id": request.user.id,
+                            "option_key": k,
+                            "option_value": v,
+                        },
+                    )
             except (TypeError, AssertionError) as e:
                 # TODO(chadwhitacre): Use a custom exception for the
                 # immutability case, especially since asserts disappear with

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2374,7 +2374,7 @@ INVALID_EMAIL_ADDRESS_PATTERN = re.compile(r"\@qq\.com$", re.I)
 
 # This is customizable for sentry.io, but generally should only be additive
 # (currently the values not used anymore so this is more for documentation purposes)
-SENTRY_USER_PERMISSIONS = ("broadcasts.admin", "users.admin")
+SENTRY_USER_PERMISSIONS = ("broadcasts.admin", "users.admin", "options.admin")
 
 KAFKA_CLUSTERS = {
     "default": {

--- a/tests/sentry/api/endpoints/test_user_permissions_config.py
+++ b/tests/sentry/api/endpoints/test_user_permissions_config.py
@@ -15,6 +15,7 @@ class UserPermissionsConfigGetTest(UserPermissionsConfigTest):
     def test_lookup_self(self):
         resp = self.get_response("me")
         assert resp.status_code == 200
-        assert len(resp.data) == 2, resp.data
+        assert len(resp.data) == 3, resp.data
         assert "broadcasts.admin" in resp.data
         assert "users.admin" in resp.data
+        assert "options.admin" in resp.data


### PR DESCRIPTION
Makes modifying system options via /manage require 'options.admin'
permission, which can be added via /_admin. Also adds a simple audit log
on changes to options through this endpoint.

This is some prerequisite work since we will be adding quite a few options 
for the upcoming performance issues project.

![Screen Shot 2022-08-31 at 3 40 47 PM](https://user-images.githubusercontent.com/6111995/187950196-6333be25-68ec-48a5-95e0-da76dfa2d2ea.png)


