### PR TITLE
ref(stores): Remove makeSafeRefluxStore from non-listening stores

### DIFF
--- a/static/app/components/actions/resolve.spec.jsx
+++ b/static/app/components/actions/resolve.spec.jsx
@@ -19,7 +19,6 @@ describe('ResolveActions', function () {
   afterEach(() => {
     spy.mockClear();
     MockApiClient.clearMockResponses();
-    ModalStore.teardown();
   });
 
   describe('disabled', function () {

--- a/static/app/components/assigneeSelector.spec.jsx
+++ b/static/app/components/assigneeSelector.spec.jsx
@@ -113,8 +113,6 @@ describe('AssigneeSelector', () => {
 
   afterEach(() => {
     Client.clearMockResponses();
-    MemberListStore.teardown();
-    GroupStore.teardown();
     ProjectsStore.teardown();
     TeamStore.teardown();
   });

--- a/static/app/components/customResolutionModal.spec.jsx
+++ b/static/app/components/customResolutionModal.spec.jsx
@@ -17,7 +17,6 @@ describe('CustomResolutionModal', () => {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
-    ConfigStore.teardown();
   });
 
   it('can select a version', async () => {

--- a/static/app/components/globalModal/globalModal.spec.jsx
+++ b/static/app/components/globalModal/globalModal.spec.jsx
@@ -14,9 +14,6 @@ describe('GlobalModal', function () {
   beforeEach(() => {
     ModalStore.reset();
   });
-  afterEach(() => {
-    ModalStore.teardown();
-  });
 
   it('uses actionCreators to open and close Modal', async function () {
     renderGlobalModal();

--- a/static/app/components/group/suggestedOwners.spec.jsx
+++ b/static/app/components/group/suggestedOwners.spec.jsx
@@ -44,7 +44,6 @@ describe('SuggestedOwners', function () {
   afterEach(function () {
     Client.clearMockResponses();
     TeamStore.teardown();
-    CommitterStore.teardown();
   });
 
   it('Renders suggested owners', async function () {

--- a/static/app/components/hook.spec.jsx
+++ b/static/app/components/hook.spec.jsx
@@ -12,7 +12,6 @@ const HookWrapper = props => (
 
 describe('Hook', function () {
   afterEach(function () {
-    HookStore.teardown();
     HookStore.init();
   });
 

--- a/static/app/components/modals/sudoModal.spec.jsx
+++ b/static/app/components/modals/sudoModal.spec.jsx
@@ -41,10 +41,6 @@ describe('Sudo Modal', function () {
     });
   });
 
-  afterEach(() => {
-    ConfigStore.teardown();
-  });
-
   it('can delete an org with sudo flow', async function () {
     setHasPasswordAuth(true);
 

--- a/static/app/components/organizations/environmentSelector.spec.tsx
+++ b/static/app/components/organizations/environmentSelector.spec.tsx
@@ -39,10 +39,6 @@ describe('EnvironmentSelector', function () {
     onUpdate.mockReset();
   });
 
-  afterEach(() => {
-    ConfigStore.teardown();
-  });
-
   const selectorProps = {
     organization,
     projects,

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
@@ -27,6 +27,7 @@ describe('ProfilingOnboarding', function () {
   beforeEach(() => {
     ProjectStore.teardown();
   });
+
   it('renders default step', () => {
     render(<ProfilingOnboardingModal {...MockRenderModalProps} />);
     expect(screen.getByText(/Select a Project/i)).toBeInTheDocument();

--- a/static/app/components/stream/streamGroup.spec.jsx
+++ b/static/app/components/stream/streamGroup.spec.jsx
@@ -36,7 +36,6 @@ describe('StreamGroup', function () {
   afterEach(function () {
     trackAdvancedAnalyticsEvent.mockClear();
     GroupStore.reset();
-    GroupStore.teardown();
   });
 
   it('renders with anchors', function () {

--- a/static/app/stores/committerStore.tsx
+++ b/static/app/stores/committerStore.tsx
@@ -1,7 +1,6 @@
 import {createStore} from 'reflux';
 
 import type {Committer, ReleaseCommitter} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   // Use `getCommitterStoreKey` to generate key
@@ -119,5 +118,5 @@ export function getCommitterStoreKey(
   return `${orgSlug} ${projectSlug} ${eventId}`;
 }
 
-const CommitterStore = createStore(makeSafeRefluxStore(storeConfig));
+const CommitterStore = createStore(storeConfig);
 export default CommitterStore;

--- a/static/app/stores/configStore.tsx
+++ b/static/app/stores/configStore.tsx
@@ -2,7 +2,6 @@ import moment from 'moment-timezone';
 import {createStore} from 'reflux';
 
 import {Config} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreDefinition} from './types';
 
@@ -81,4 +80,4 @@ const storeConfig: ConfigStoreDefinition = {
   },
 };
 
-export default createStore(makeSafeRefluxStore(storeConfig));
+export default createStore(storeConfig);

--- a/static/app/stores/externalIssueStore.tsx
+++ b/static/app/stores/externalIssueStore.tsx
@@ -1,7 +1,6 @@
 import {createStore, StoreDefinition} from 'reflux';
 
 import {PlatformExternalIssue} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 interface ExternalIssueStoreDefinition extends StoreDefinition {
   add(issue: PlatformExternalIssue): void;
@@ -39,5 +38,5 @@ const storeConfig: ExternalIssueStoreDefinition = {
   },
 };
 
-const ExternalIssueStore = createStore(makeSafeRefluxStore(storeConfig));
+const ExternalIssueStore = createStore(storeConfig);
 export default ExternalIssueStore;

--- a/static/app/stores/formSearchStore.tsx
+++ b/static/app/stores/formSearchStore.tsx
@@ -1,7 +1,6 @@
-import {createStore} from 'reflux';
+import {createStore, StoreDefinition} from 'reflux';
 
 import {FieldObject} from 'sentry/components/forms/type';
-import {makeSafeRefluxStore, SafeStoreDefinition} from 'sentry/utils/makeSafeRefluxStore';
 
 /**
  * Processed form field metadata.
@@ -24,7 +23,7 @@ type InternalDefinition = {
 };
 
 interface ExternalIssuesDefinition
-  extends SafeStoreDefinition,
+  extends StoreDefinition,
     InternalDefinition,
     StoreInterface {}
 
@@ -33,7 +32,6 @@ interface ExternalIssuesDefinition
  */
 const storeConfig: ExternalIssuesDefinition = {
   searchMap: null,
-  unsubscribeListeners: [],
 
   init() {
     this.reset();
@@ -62,5 +60,5 @@ const storeConfig: ExternalIssuesDefinition = {
   },
 };
 
-const FormSearchStore = createStore(makeSafeRefluxStore(storeConfig));
+const FormSearchStore = createStore(storeConfig);
 export default FormSearchStore;

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -11,7 +11,6 @@ import {
   GroupRelease,
   GroupStats,
 } from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreDefinition} from './types';
 
@@ -486,5 +485,5 @@ const storeConfig: GroupStoreDefinition = {
   },
 };
 
-const GroupStore = createStore(makeSafeRefluxStore(storeConfig));
+const GroupStore = createStore(storeConfig);
 export default GroupStore;

--- a/static/app/stores/groupingStore.spec.jsx
+++ b/static/app/stores/groupingStore.spec.jsx
@@ -101,13 +101,11 @@ describe('Grouping Store', function () {
   });
 
   afterEach(function () {
-    GroupingStore.teardown();
     trigger.mockReset();
   });
 
   describe('onFetch()', function () {
     beforeEach(() => GroupingStore.init());
-    afterEach(() => GroupingStore.teardown());
 
     it('initially gets called with correct state values', function () {
       GroupingStore.onFetch([]);
@@ -283,11 +281,8 @@ describe('Grouping Store', function () {
       ]);
     });
 
-    afterEach(() => GroupingStore.teardown());
-
     describe('onToggleMerge (checkbox state)', function () {
       beforeEach(() => GroupingStore.init());
-      afterEach(() => GroupingStore.teardown());
 
       // Attempt to check first item but its "locked" so should not be able to do anything
       it('can check and uncheck item', function () {
@@ -333,8 +328,6 @@ describe('Grouping Store', function () {
         });
         GroupingStore.init();
       });
-
-      afterEach(() => GroupingStore.teardown());
 
       it('disables rows to be merged', async function () {
         const mergeMock = jest.spyOn(GroupActionCreators, 'mergeGroups');
@@ -497,11 +490,9 @@ describe('Grouping Store', function () {
       unmergeState = new Map([...GroupingStore.unmergeState]);
     });
 
-    afterEach(() => GroupingStore.teardown());
-
     // WARNING: all the tests in this describe block are not running in isolated state.
     // There is a good chance that moving them around will break them. To simulate an isolated state,
-    // add a beforeEach(() => GroupingStore.init()) and afterEach(() => GroupingStore.teardown()).
+    // add a beforeEach(() => GroupingStore.init())
     describe('onToggleUnmerge (checkbox state for hashes)', function () {
       // Attempt to check first item but its "locked" so should not be able to do anything
       it('can not check locked item', function () {
@@ -593,7 +584,7 @@ describe('Grouping Store', function () {
 
     // WARNING: all the tests in this describe block are not running in isolated state.
     // There is a good chance that moving them around will break them. To simulate an isolated state,
-    // add a beforeEach(() => GroupingStore.init()) and afterEach(() => GroupingStore.teardown()).
+    // add a beforeEach(() => GroupingStore.init())
     describe('onUnmerge', function () {
       beforeEach(function () {
         Client.clearMockResponses();

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -10,7 +10,6 @@ import {
 import {Client} from 'sentry/api';
 import {Group, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreDefinition} from './types';
 
@@ -622,5 +621,5 @@ const storeConfig: GroupingStoreDefinition = {
   },
 };
 
-const GroupingStore = createStore(makeSafeRefluxStore(storeConfig));
+const GroupingStore = createStore(storeConfig);
 export default GroupingStore;

--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -1,7 +1,6 @@
 import {createStore, StoreDefinition} from 'reflux';
 
 import {HookName, Hooks} from 'sentry/types/hooks';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 interface Internals {
   // XXX(epurkhiser): We could type this as {[H in HookName]?:
@@ -52,5 +51,5 @@ const storeConfig: HookStoreDefinition = {
  * This functionality is primarily used by the SASS sentry.io product.
  */
 
-const HookStore = createStore(makeSafeRefluxStore(storeConfig));
+const HookStore = createStore(storeConfig);
 export default HookStore;

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -1,7 +1,6 @@
 import {createStore, StoreDefinition} from 'reflux';
 
 import {User} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 interface MemberListStoreDefinition extends StoreDefinition {
   getAll(): User[];
@@ -67,5 +66,5 @@ const storeConfig: MemberListStoreDefinition = {
   },
 };
 
-const MemberListStore = createStore(makeSafeRefluxStore(storeConfig));
+const MemberListStore = createStore(storeConfig);
 export default MemberListStore;

--- a/static/app/stores/modalStore.tsx
+++ b/static/app/stores/modalStore.tsx
@@ -1,7 +1,6 @@
 import {createStore, StoreDefinition} from 'reflux';
 
 import {ModalOptions, ModalRenderProps} from 'sentry/actionCreators/modal';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type Renderer = (renderProps: ModalRenderProps) => React.ReactNode;
 
@@ -20,8 +19,6 @@ interface ModalStoreDefinition extends StoreDefinition {
 }
 
 const storeConfig: ModalStoreDefinition = {
-  unsubscribeListeners: [],
-
   init() {
     this.reset();
   },
@@ -52,5 +49,5 @@ const storeConfig: ModalStoreDefinition = {
   },
 };
 
-const ModalStore = createStore(makeSafeRefluxStore(storeConfig));
+const ModalStore = createStore(storeConfig);
 export default ModalStore;

--- a/static/app/stores/organizationEnvironmentsStore.spec.jsx
+++ b/static/app/stores/organizationEnvironmentsStore.spec.jsx
@@ -4,9 +4,6 @@ describe('OrganizationEnvironmentsStore', function () {
   beforeEach(() => {
     OrganizationEnvironmentsStore.init();
   });
-  afterEach(() => {
-    OrganizationEnvironmentsStore.teardown();
-  });
 
   it('get()', function () {
     expect(OrganizationEnvironmentsStore.getState()).toEqual({

--- a/static/app/stores/organizationEnvironmentsStore.tsx
+++ b/static/app/stores/organizationEnvironmentsStore.tsx
@@ -2,7 +2,6 @@ import {createStore} from 'reflux';
 
 import {Environment} from 'sentry/types';
 import {getDisplayName, getUrlRoutingName} from 'sentry/utils/environment';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreDefinition} from './types';
 
@@ -25,8 +24,6 @@ interface OrganizationEnvironmentsStoreDefinition extends CommonStoreDefinition<
 }
 
 const storeConfig: OrganizationEnvironmentsStoreDefinition = {
-  unsubscribeListeners: [],
-
   state: {
     environments: null,
     error: null,
@@ -69,6 +66,6 @@ const storeConfig: OrganizationEnvironmentsStoreDefinition = {
   },
 };
 
-const OrganizationEnvironmentsStore = createStore(makeSafeRefluxStore(storeConfig));
+const OrganizationEnvironmentsStore = createStore(storeConfig);
 
 export default OrganizationEnvironmentsStore;

--- a/static/app/stores/preferencesStore.tsx
+++ b/static/app/stores/preferencesStore.tsx
@@ -1,7 +1,5 @@
 import {createStore} from 'reflux';
 
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
-
 import {CommonStoreDefinition} from './types';
 
 type Preferences = {
@@ -23,7 +21,6 @@ interface PreferenceStoreDefinition extends CommonStoreDefinition<Preferences> {
 
 const storeConfig: PreferenceStoreDefinition = {
   prefs: {},
-  unsubscribeListeners: [],
 
   init() {
     this.reset();
@@ -61,5 +58,5 @@ const storeConfig: PreferenceStoreDefinition = {
  * This store is used to hold local user preferences
  * Side-effects (like reading/writing to cookies) are done in associated actionCreators
  */
-const PreferenceStore = createStore(makeSafeRefluxStore(storeConfig));
+const PreferenceStore = createStore(storeConfig);
 export default PreferenceStore;

--- a/static/app/stores/releaseStore.tsx
+++ b/static/app/stores/releaseStore.tsx
@@ -2,7 +2,6 @@ import {createStore, StoreDefinition} from 'reflux';
 
 import OrganizationActions from 'sentry/actions/organizationActions';
 import {Deploy, Organization, Release} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type StoreRelease = Map<string, Release>;
 type StoreDeploys = Map<string, Array<Deploy>>;
@@ -232,5 +231,5 @@ const storeConfig: ReleaseStoreDefinition = {
   },
 };
 
-const ReleaseStore = createStore(makeSafeRefluxStore(storeConfig));
+const ReleaseStore = createStore(storeConfig);
 export default ReleaseStore;

--- a/static/app/stores/repositoryStore.tsx
+++ b/static/app/stores/repositoryStore.tsx
@@ -1,7 +1,6 @@
 import {createStore, StoreDefinition} from 'reflux';
 
 import {Repository} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 interface RepositoryStoreDefinition extends StoreDefinition {
   get(): {
@@ -79,5 +78,5 @@ const storeConfig: RepositoryStoreDefinition = {
   },
 };
 
-const RepositoryStore = createStore(makeSafeRefluxStore(storeConfig));
+const RepositoryStore = createStore(storeConfig);
 export default RepositoryStore;

--- a/static/app/stores/savedSearchesStore.tsx
+++ b/static/app/stores/savedSearchesStore.tsx
@@ -2,7 +2,6 @@ import findIndex from 'lodash/findIndex';
 import {createStore, StoreDefinition} from 'reflux';
 
 import {SavedSearch, SavedSearchType} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 type State = {
   hasError: boolean;
@@ -31,8 +30,6 @@ interface SavedSearchesStoreDefinition extends StoreDefinition {
 }
 
 const storeConfig: SavedSearchesStoreDefinition = {
-  unsubscribeListeners: [],
-
   state: {
     savedSearches: [],
     hasError: false,
@@ -221,5 +218,5 @@ const storeConfig: SavedSearchesStoreDefinition = {
   },
 };
 
-const SavedSearchesStore = createStore(makeSafeRefluxStore(storeConfig));
+const SavedSearchesStore = createStore(storeConfig);
 export default SavedSearchesStore;

--- a/static/app/stores/sdkUpdatesStore.tsx
+++ b/static/app/stores/sdkUpdatesStore.tsx
@@ -1,7 +1,6 @@
 import {createStore} from 'reflux';
 
 import {ProjectSdkUpdates} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreDefinition} from './types';
 
@@ -24,7 +23,6 @@ interface SdkUpdatesStoreDefinition
 
 const storeConfig: SdkUpdatesStoreDefinition = {
   orgSdkUpdates: new Map(),
-  unsubscribeListeners: [],
 
   loadSuccess(orgSlug, data) {
     this.orgSdkUpdates.set(orgSlug, data);
@@ -44,5 +42,5 @@ const storeConfig: SdkUpdatesStoreDefinition = {
   },
 };
 
-const SdkUpdatesStore = createStore(makeSafeRefluxStore(storeConfig));
+const SdkUpdatesStore = createStore(storeConfig);
 export default SdkUpdatesStore;

--- a/static/app/stores/sentryAppComponentsStore.tsx
+++ b/static/app/stores/sentryAppComponentsStore.tsx
@@ -1,7 +1,6 @@
 import {createStore, StoreDefinition} from 'reflux';
 
 import {SentryAppComponent} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 export interface SentryAppComponentsStoreDefinition extends StoreDefinition {
   get: (uuid: string) => SentryAppComponent | undefined;
@@ -12,7 +11,6 @@ export interface SentryAppComponentsStoreDefinition extends StoreDefinition {
 }
 
 const storeConfig: SentryAppComponentsStoreDefinition = {
-  unsubscribeListeners: [],
   items: [],
 
   init() {
@@ -46,5 +44,5 @@ const storeConfig: SentryAppComponentsStoreDefinition = {
   },
 };
 
-const SentryAppComponentsStore = createStore(makeSafeRefluxStore(storeConfig));
+const SentryAppComponentsStore = createStore(storeConfig);
 export default SentryAppComponentsStore;

--- a/static/app/stores/sentryAppInstallationsStore.tsx
+++ b/static/app/stores/sentryAppInstallationsStore.tsx
@@ -1,7 +1,6 @@
 import {createStore, StoreDefinition} from 'reflux';
 
 import {SentryAppInstallation} from 'sentry/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 interface SentryAppInstallationStoreDefinition extends StoreDefinition {
   getInitialState(): SentryAppInstallation[];
@@ -32,5 +31,5 @@ const storeConfig: SentryAppInstallationStoreDefinition = {
   },
 };
 
-const SentryAppInstallationStore = createStore(makeSafeRefluxStore(storeConfig));
+const SentryAppInstallationStore = createStore(storeConfig);
 export default SentryAppInstallationStore;

--- a/static/app/stores/serverSideSamplingStore.tsx
+++ b/static/app/stores/serverSideSamplingStore.tsx
@@ -2,7 +2,6 @@ import {createStore} from 'reflux';
 
 import {SeriesApi} from 'sentry/types';
 import {SamplingDistribution, SamplingSdkVersion} from 'sentry/types/sampling';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreDefinition} from './types';
 
@@ -231,4 +230,4 @@ const storeConfig: ServerSideSamplingStoreDefinition = {
   },
 };
 
-export const ServerSideSamplingStore = createStore(makeSafeRefluxStore(storeConfig));
+export const ServerSideSamplingStore = createStore(storeConfig);

--- a/static/app/stores/sidebarPanelStore.tsx
+++ b/static/app/stores/sidebarPanelStore.tsx
@@ -1,7 +1,6 @@
 import {createStore} from 'reflux';
 
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreDefinition} from './types';
 
@@ -17,7 +16,6 @@ interface SidebarPanelStoreDefinition extends CommonStoreDefinition<ActivePanelT
 
 const storeConfig: SidebarPanelStoreDefinition = {
   activePanel: '',
-  unsubscribeListeners: [],
 
   activatePanel(panel: SidebarPanelKey) {
     this.activePanel = panel;
@@ -46,5 +44,5 @@ const storeConfig: SidebarPanelStoreDefinition = {
  * This store is used to hold local user preferences
  * Side-effects (like reading/writing to cookies) are done in associated actionCreators
  */
-const SidebarPanelStore = createStore(makeSafeRefluxStore(storeConfig));
+const SidebarPanelStore = createStore(storeConfig);
 export default SidebarPanelStore;

--- a/static/app/stores/tagStore.tsx
+++ b/static/app/stores/tagStore.tsx
@@ -3,7 +3,6 @@ import {createStore} from 'reflux';
 import {Tag, TagCollection} from 'sentry/types';
 import {SEMVER_TAGS} from 'sentry/utils/discover/fields';
 import {FieldKey, ISSUE_FIELDS} from 'sentry/utils/fields';
-import {makeSafeRefluxStore} from 'sentry/utils/makeSafeRefluxStore';
 
 import {CommonStoreDefinition} from './types';
 
@@ -26,7 +25,6 @@ interface TagStoreDefinition extends CommonStoreDefinition<TagCollection> {
 
 const storeConfig: TagStoreDefinition = {
   state: {},
-  unsubscribeListeners: [],
 
   init() {
     this.state = {};
@@ -178,5 +176,5 @@ const storeConfig: TagStoreDefinition = {
   },
 };
 
-const TagStore = createStore(makeSafeRefluxStore(storeConfig));
+const TagStore = createStore(storeConfig);
 export default TagStore;

--- a/static/app/utils/useCommitters.spec.tsx
+++ b/static/app/utils/useCommitters.spec.tsx
@@ -39,7 +39,6 @@ describe('useCommitters hook', function () {
   afterEach(() => {
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
-    CommitterStore.teardown();
   });
 
   it('returns committers', async () => {

--- a/static/app/utils/withConfig.spec.jsx
+++ b/static/app/utils/withConfig.spec.jsx
@@ -8,9 +8,6 @@ describe('withConfig HoC', function () {
     ConfigStore.init();
   });
 
-  afterEach(() => {
-    ConfigStore.teardown();
-  });
   it('adds config prop', function () {
     const MyComponent = ({config}) => <div>{config.test}</div>;
     const Container = withConfig(MyComponent);

--- a/static/app/utils/withRepositories.spec.jsx
+++ b/static/app/utils/withRepositories.spec.jsx
@@ -22,10 +22,6 @@ describe('withRepositories HoC', function () {
     RepositoryStore.init();
   });
 
-  afterEach(() => {
-    RepositoryStore.teardown();
-  });
-
   it('adds repositories prop', async () => {
     const Component = () => null;
     const Container = withRepositories(Component);

--- a/static/app/utils/withSentryAppComponents.spec.jsx
+++ b/static/app/utils/withSentryAppComponents.spec.jsx
@@ -8,10 +8,6 @@ describe('withSentryAppComponents HoC', function () {
     SentryAppComponentsStore.init();
   });
 
-  afterEach(() => {
-    SentryAppComponentsStore.teardown();
-  });
-
   it('handles components without a type', function () {
     const MyComponent = () => null;
     const Container = withSentryAppComponents(MyComponent);

--- a/static/app/views/admin/installWizard.spec.jsx
+++ b/static/app/views/admin/installWizard.spec.jsx
@@ -13,7 +13,6 @@ describe('InstallWizard', function () {
   });
 
   afterEach(function () {
-    ConfigStore.teardown();
     MockApiClient.clearMockResponses();
   });
 

--- a/static/app/views/dashboardsV2/dashboard.spec.tsx
+++ b/static/app/views/dashboardsV2/dashboard.spec.tsx
@@ -216,9 +216,7 @@ describe('Dashboards > Dashboard', () => {
     beforeEach(() => {
       MemberListStore.init();
     });
-    afterEach(() => {
-      MemberListStore.teardown();
-    });
+
     const mount = (dashboard, mockedOrg = initialData.organization) => {
       render(
         <Dashboard

--- a/static/app/views/issueList/overview.polling.spec.jsx
+++ b/static/app/views/issueList/overview.polling.spec.jsx
@@ -161,7 +161,6 @@ describe('IssueList -> Polling', function () {
       wrapper.unmount();
     }
     wrapper = null;
-    TagStore.teardown();
   });
 
   it('toggles polling for new issues', async function () {

--- a/static/app/views/issueList/overview.spec.jsx
+++ b/static/app/views/issueList/overview.spec.jsx
@@ -176,7 +176,6 @@ describe('IssueList', function () {
       wrapper.unmount();
     }
     wrapper = null;
-    TagStore.teardown();
   });
 
   describe('withStores and feature flags', function () {

--- a/static/app/views/organizationGroupDetails/actions/actions.spec.tsx
+++ b/static/app/views/organizationGroupDetails/actions/actions.spec.tsx
@@ -28,10 +28,6 @@ describe('GroupActions', function () {
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => []);
   });
 
-  afterEach(() => {
-    ConfigStore.teardown();
-  });
-
   describe('render()', function () {
     it('renders correctly', function () {
       const wrapper = render(

--- a/static/app/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -30,7 +30,6 @@ describe('GroupActivity', function () {
     MockApiClient.clearMockResponses();
     jest.clearAllMocks();
     ProjectsStore.teardown();
-    GroupStore.teardown();
   });
 
   function createWrapper({activity, organization: additionalOrg} = {}) {

--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.spec.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.spec.tsx
@@ -182,7 +182,6 @@ describe('groupEventDetails', () => {
 
   afterEach(function () {
     MockApiClient.clearMockResponses();
-    CommitterStore.teardown();
     (browserHistory.replace as jest.Mock).mockClear();
   });
 
@@ -297,7 +296,6 @@ describe('EventCauseEmpty', () => {
   afterEach(function () {
     MockApiClient.clearMockResponses();
     (browserHistory.replace as jest.Mock).mockClear();
-    CommitterStore.teardown();
   });
 
   it('renders empty state', async function () {

--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetailsContainer.spec.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetailsContainer.spec.tsx
@@ -35,10 +35,6 @@ describe('groupEventDetailsContainer', () => {
     OrganizationEnvironmentsStore.init();
   });
 
-  afterEach(() => {
-    OrganizationEnvironmentsStore.teardown();
-  });
-
   it('fetches environments', async function () {
     const environmentsCall = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/environments/`,

--- a/static/app/views/organizationGroupDetails/groupMerged/groupMergedView.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupMerged/groupMergedView.spec.jsx
@@ -31,6 +31,7 @@ describe('Issues -> Merged View', function () {
       tags: [],
     },
   };
+
   beforeAll(function () {
     Client.addMockResponse({
       url: '/issues/groupId/hashes/?limit=50&query=',
@@ -41,9 +42,7 @@ describe('Issues -> Merged View', function () {
   beforeEach(() => {
     GroupingStore.init();
   });
-  afterEach(() => {
-    GroupingStore.teardown();
-  });
+
   it('renders initially with loading component', function () {
     const wrapper = mountWithTheme(
       <GroupMergedView

--- a/static/app/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/static/app/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -85,7 +85,6 @@ describe('IntegrationCodeMappings', function () {
   afterEach(() => {
     // Clear the fields from the GlobalModal after every test
     ModalStore.reset();
-    ModalStore.teardown();
   });
 
   it('shows the paths', () => {

--- a/static/app/views/settings/project/projectOwnership/ownershipInput.spec.jsx
+++ b/static/app/views/settings/project/projectOwnership/ownershipInput.spec.jsx
@@ -29,10 +29,6 @@ describe('Project Ownership Input', function () {
     ]);
   });
 
-  afterEach(() => {
-    MemberListStore.teardown();
-  });
-
   it('renders', function () {
     const wrapper = mountWithTheme(
       <OwnerInput


### PR DESCRIPTION
These stores do not have a `this.listenTo`, thus there is nothing to
tearndown / cleanup