### PR TITLE
ref(sidebarStore): move sidebar store to context

### DIFF
--- a/static/app/components/globalSdkUpdateAlert.spec.tsx
+++ b/static/app/components/globalSdkUpdateAlert.spec.tsx
@@ -8,6 +8,8 @@ import {PageFilters, ProjectSdkUpdates} from 'sentry/types';
 import {DEFAULT_SNOOZE_PROMPT_DAYS} from 'sentry/utils/promptIsDismissed';
 import importedUsePageFilters from 'sentry/utils/usePageFilters';
 
+import {SidebarProvider} from '../stores/sidebarProvider';
+
 jest.mock('sentry/utils/usePageFilters');
 
 const usePageFilters = importedUsePageFilters as jest.MockedFunction<
@@ -73,9 +75,14 @@ describe('GlobalSDKUpdateAlert', () => {
       body: promptResponse,
     });
 
-    const {rerender} = render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: TestStubs.Organization(),
-    });
+    const {rerender} = render(
+      <SidebarProvider>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />
+      </SidebarProvider>,
+      {
+        organization: TestStubs.Organization(),
+      }
+    );
 
     expect(
       await screen.findByText(/You have outdated SDKs in your projects/)
@@ -84,7 +91,11 @@ describe('GlobalSDKUpdateAlert', () => {
     usePageFilters.mockImplementation(() => makeFilterProps({projects: [2]}));
 
     // ProjectId no longer matches, so updates should not be shown anymore
-    rerender(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />);
+    rerender(
+      <SidebarProvider>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />
+      </SidebarProvider>
+    );
 
     expect(
       screen.queryByText(/You have outdated SDKs in your projects/)
@@ -104,9 +115,14 @@ describe('GlobalSDKUpdateAlert', () => {
       body: {data: promptResponse},
     });
 
-    render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: TestStubs.Organization(),
-    });
+    render(
+      <SidebarProvider>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />
+      </SidebarProvider>,
+      {
+        organization: TestStubs.Organization(),
+      }
+    );
 
     expect(
       await screen.findByText(/You have outdated SDKs in your projects/)
@@ -129,9 +145,14 @@ describe('GlobalSDKUpdateAlert', () => {
       body: {data: promptResponse},
     });
 
-    render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: TestStubs.Organization(),
-    });
+    render(
+      <SidebarProvider>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />
+      </SidebarProvider>,
+      {
+        organization: TestStubs.Organization(),
+      }
+    );
 
     await waitFor(() =>
       expect(
@@ -156,9 +177,14 @@ describe('GlobalSDKUpdateAlert', () => {
       body: {data: promptResponse},
     });
 
-    render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: TestStubs.Organization(),
-    });
+    render(
+      <SidebarProvider>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />
+      </SidebarProvider>,
+      {
+        organization: TestStubs.Organization(),
+      }
+    );
 
     expect(
       await screen.findByText(/You have outdated SDKs in your projects/)
@@ -181,9 +207,14 @@ describe('GlobalSDKUpdateAlert', () => {
       body: {data: promptResponse},
     });
 
-    render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: TestStubs.Organization(),
-    });
+    render(
+      <SidebarProvider>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />
+      </SidebarProvider>,
+      {
+        organization: TestStubs.Organization(),
+      }
+    );
 
     await waitFor(() =>
       expect(
@@ -208,9 +239,14 @@ describe('GlobalSDKUpdateAlert', () => {
       body: promptResponse,
     });
 
-    render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: TestStubs.Organization(),
-    });
+    render(
+      <SidebarProvider>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />
+      </SidebarProvider>,
+      {
+        organization: TestStubs.Organization(),
+      }
+    );
 
     expect(
       await screen.findByText(/You have outdated SDKs in your projects/)
@@ -230,9 +266,14 @@ describe('GlobalSDKUpdateAlert', () => {
       body: {data: promptResponse},
     });
 
-    render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
-      organization: TestStubs.Organization(),
-    });
+    render(
+      <SidebarProvider>
+        <InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />
+      </SidebarProvider>,
+      {
+        organization: TestStubs.Organization(),
+      }
+    );
 
     userEvent.click(await screen.findByText(/Remind me later/));
 

--- a/static/app/components/globalSdkUpdateAlert.tsx
+++ b/static/app/components/globalSdkUpdateAlert.tsx
@@ -4,7 +4,7 @@ import {promptsCheck, promptsUpdate} from 'sentry/actionCreators/prompts';
 import Alert, {AlertProps} from 'sentry/components/alert';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
-import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
+import {useSidebarDispatch} from 'sentry/stores/sidebarProvider';
 import {ProjectSdkUpdates} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
@@ -27,6 +27,7 @@ function InnerGlobalSdkUpdateAlert(
   const api = useApi();
   const organization = useOrganization();
   const {selection} = usePageFilters();
+  const dispatchSidebar = useSidebarDispatch();
 
   const [showUpdateAlert, setShowUpdateAlert] = useState<boolean>(false);
 
@@ -42,9 +43,9 @@ function InnerGlobalSdkUpdateAlert(
   }, [api, organization]);
 
   const handleReviewUpdatesClick = useCallback(() => {
-    SidebarPanelStore.activatePanel(SidebarPanelKey.Broadcasts);
+    dispatchSidebar({type: 'activate panel', payload: SidebarPanelKey.Broadcasts});
     trackAdvancedAnalyticsEvent('sdk_updates.clicked', {organization});
-  }, [organization]);
+  }, [organization, dispatchSidebar]);
 
   useEffect(() => {
     trackAdvancedAnalyticsEvent('sdk_updates.seen', {organization});

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -32,6 +32,7 @@ import {filterProjects} from './utils';
 
 function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
   const {currentPanel, collapsed, hidePanel, orientation} = props;
+
   const isActive = currentPanel === SidebarPanelKey.PerformanceOnboarding;
   const organization = useOrganization();
   const hasProjectAccess = organization.access.includes('project:read');

--- a/static/app/components/sidebar/index.spec.jsx
+++ b/static/app/components/sidebar/index.spec.jsx
@@ -5,6 +5,7 @@ import * as incidentActions from 'sentry/actionCreators/serviceIncidents';
 import SidebarContainer from 'sentry/components/sidebar';
 import ConfigStore from 'sentry/stores/configStore';
 import {PersistedStoreProvider} from 'sentry/stores/persistedStore';
+import {SidebarProvider} from 'sentry/stores/sidebarProvider';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 import {RouteContext} from 'sentry/views/routeContext';
 
@@ -28,9 +29,15 @@ describe('Sidebar', function () {
       }}
     >
       <OrganizationContext.Provider value={organization}>
-        <PersistedStoreProvider>
-          <SidebarContainer organization={organization} location={location} {...props} />
-        </PersistedStoreProvider>
+        <SidebarProvider>
+          <PersistedStoreProvider>
+            <SidebarContainer
+              organization={organization}
+              location={location}
+              {...props}
+            />
+          </PersistedStoreProvider>
+        </SidebarProvider>
       </OrganizationContext.Provider>
     </RouteContext.Provider>
   );

--- a/static/app/stores/sidebarProvider.spec.tsx
+++ b/static/app/stores/sidebarProvider.spec.tsx
@@ -1,0 +1,40 @@
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
+
+import {SidebarReducer} from './sidebarProvider';
+
+describe('sidebarReducer', () => {
+  it('activates panel', () => {
+    expect(
+      SidebarReducer('', {
+        type: 'activate panel',
+        payload: SidebarPanelKey.PerformanceOnboarding,
+      })
+    ).toBe(SidebarPanelKey.PerformanceOnboarding);
+  });
+
+  it('hides panel', () => {
+    expect(
+      SidebarReducer(SidebarPanelKey.PerformanceOnboarding, {
+        type: 'hide panel',
+      })
+    ).toBe('');
+  });
+
+  it('toggles panel hides panel if it is currently open', () => {
+    expect(
+      SidebarReducer(SidebarPanelKey.PerformanceOnboarding, {
+        type: 'toggle panel',
+        payload: SidebarPanelKey.PerformanceOnboarding,
+      })
+    ).toBe('');
+  });
+
+  it('toggles panel shiows panel if it is not currently open', () => {
+    expect(
+      SidebarReducer(SidebarPanelKey.Broadcasts, {
+        type: 'toggle panel',
+        payload: SidebarPanelKey.PerformanceOnboarding,
+      })
+    ).toBe(SidebarPanelKey.PerformanceOnboarding);
+  });
+});

--- a/static/app/stores/sidebarProvider.tsx
+++ b/static/app/stores/sidebarProvider.tsx
@@ -1,0 +1,62 @@
+import {createContext, useContext, useReducer} from 'react';
+
+function assertNever(x: never) {
+  throw new TypeError('Unhandled sidebar reducer action: ' + x);
+}
+
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
+
+type State = SidebarPanelKey | '';
+
+type HidePanelAction = {type: 'hide panel'};
+type TogglePanelAction = {payload: SidebarPanelKey; type: 'toggle panel'};
+type ActivatePanelAction = {payload: SidebarPanelKey; type: 'activate panel'};
+type SidebarAction = HidePanelAction | TogglePanelAction | ActivatePanelAction;
+
+const SidebarContext = createContext<[State, React.Dispatch<SidebarAction>] | null>(null);
+
+export function SidebarReducer(state: State, action: SidebarAction) {
+  switch (action.type) {
+    case 'activate panel':
+      return action.payload;
+    case 'hide panel':
+      return '';
+    case 'toggle panel':
+      if (state === action.payload) {
+        return '';
+      }
+      return action.payload;
+    default:
+      assertNever(action);
+      return state;
+  }
+}
+
+interface Props {
+  children: React.ReactNode;
+  initialPanel?: State;
+}
+
+export function SidebarProvider(props: Props) {
+  const reducer = useReducer(SidebarReducer, props.initialPanel ?? '');
+
+  return (
+    <SidebarContext.Provider value={reducer}>{props.children}</SidebarContext.Provider>
+  );
+}
+
+export function useSidebarDispatch() {
+  const context = useContext(SidebarContext);
+  if (context === null) {
+    throw new Error('useSidebarDispatch was called outside of SidebarProvider');
+  }
+  return context[1];
+}
+
+export function useSidebar() {
+  const context = useContext(SidebarContext);
+  if (context === null) {
+    throw new Error('useSidebar was called outside of SidebarProvider');
+  }
+  return context;
+}

--- a/static/app/views/organizationContextContainer.tsx
+++ b/static/app/views/organizationContextContainer.tsx
@@ -19,6 +19,7 @@ import SentryTypes from 'sentry/sentryTypes';
 import ConfigStore from 'sentry/stores/configStore';
 import HookStore from 'sentry/stores/hookStore';
 import OrganizationStore from 'sentry/stores/organizationStore';
+import {SidebarProvider} from 'sentry/stores/sidebarProvider';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {metric} from 'sentry/utils/analytics';
@@ -328,12 +329,14 @@ class OrganizationContextContainer extends Component<Props, State> {
     return (
       <SentryDocumentTitle noSuffix title={this.getTitle()}>
         <OrganizationContext.Provider value={this.state.organization}>
-          <div className="app">
-            <SentryReplayInit organization={this.state.organization} />
-            {this.state.hooks}
-            {this.renderSidebar()}
-            {this.props.children}
-          </div>
+          <SidebarProvider>
+            <div className="app">
+              <SentryReplayInit organization={this.state.organization} />
+              {this.state.hooks}
+              {this.renderSidebar()}
+              {this.props.children}
+            </div>
+          </SidebarProvider>
         </OrganizationContext.Provider>
       </SentryDocumentTitle>
     );

--- a/static/app/views/performance/content.spec.jsx
+++ b/static/app/views/performance/content.spec.jsx
@@ -7,6 +7,7 @@ import {act} from 'sentry-test/reactTestingLibrary';
 import * as pageFilters from 'sentry/actionCreators/pageFilters';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import {SidebarProvider} from 'sentry/stores/sidebarProvider';
 import TeamStore from 'sentry/stores/teamStore';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {OrganizationContext} from 'sentry/views/organizationContext';
@@ -27,9 +28,11 @@ function WrappedComponent({organization, isMEPEnabled = false, router}) {
       }}
     >
       <OrganizationContext.Provider value={organization}>
-        <MEPSettingProvider _isMEPEnabled={isMEPEnabled}>
-          <PerformanceContent organization={organization} location={router.location} />
-        </MEPSettingProvider>
+        <SidebarProvider>
+          <MEPSettingProvider _isMEPEnabled={isMEPEnabled}>
+            <PerformanceContent organization={organization} location={router.location} />
+          </MEPSettingProvider>
+        </SidebarProvider>
       </OrganizationContext.Provider>
     </RouteContext.Provider>
   );

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 import {initializeData} from 'sentry-test/performance/initializePerformanceData';
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {SidebarProvider} from 'sentry/stores/sidebarProvider';
 import TeamStore from 'sentry/stores/teamStore';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {OrganizationContext} from 'sentry/views/organizationContext';
@@ -20,24 +21,26 @@ const WrappedComponent = ({data, withStaticFilters = false}) => {
 
   return (
     <OrganizationContext.Provider value={data.organization}>
-      <MetricsCardinalityProvider
-        location={data.router.location}
-        organization={data.organization}
-      >
-        <PerformanceLanding
-          router={data.router}
-          organization={data.organization}
+      <SidebarProvider>
+        <MetricsCardinalityProvider
           location={data.router.location}
-          eventView={eventView}
-          projects={data.projects}
-          selection={eventView.getPageFilters()}
-          onboardingProject={undefined}
-          handleSearch={() => {}}
-          handleTrendsClick={() => {}}
-          setError={() => {}}
-          withStaticFilters={withStaticFilters}
-        />
-      </MetricsCardinalityProvider>
+          organization={data.organization}
+        >
+          <PerformanceLanding
+            router={data.router}
+            organization={data.organization}
+            location={data.router.location}
+            eventView={eventView}
+            projects={data.projects}
+            selection={eventView.getPageFilters()}
+            onboardingProject={undefined}
+            handleSearch={() => {}}
+            handleTrendsClick={() => {}}
+            setError={() => {}}
+            withStaticFilters={withStaticFilters}
+          />
+        </MetricsCardinalityProvider>
+      </SidebarProvider>
     </OrganizationContext.Provider>
   );
 };

--- a/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcher.spec.tsx
@@ -1,6 +1,7 @@
 import {initializeData} from 'sentry-test/performance/initializePerformanceData';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
+import {SidebarProvider} from 'sentry/stores/sidebarProvider';
 import TeamStore from 'sentry/stores/teamStore';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {OrganizationContext} from 'sentry/views/organizationContext';
@@ -58,24 +59,26 @@ const WrappedComponent = ({data, withStaticFilters = true}) => {
 
   return (
     <OrganizationContext.Provider value={data.organization}>
-      <MetricsCardinalityProvider
-        location={data.router.location}
-        organization={data.organization}
-      >
-        <PerformanceLanding
-          router={data.router}
-          organization={data.organization}
+      <SidebarProvider>
+        <MetricsCardinalityProvider
           location={data.router.location}
-          eventView={eventView}
-          projects={data.projects}
-          selection={eventView.getPageFilters()}
-          onboardingProject={undefined}
-          handleSearch={() => {}}
-          handleTrendsClick={() => {}}
-          setError={() => {}}
-          withStaticFilters={withStaticFilters}
-        />
-      </MetricsCardinalityProvider>
+          organization={data.organization}
+        >
+          <PerformanceLanding
+            router={data.router}
+            organization={data.organization}
+            location={data.router.location}
+            eventView={eventView}
+            projects={data.projects}
+            selection={eventView.getPageFilters()}
+            onboardingProject={undefined}
+            handleSearch={() => {}}
+            handleTrendsClick={() => {}}
+            setError={() => {}}
+            withStaticFilters={withStaticFilters}
+          />
+        </MetricsCardinalityProvider>
+      </SidebarProvider>
     </OrganizationContext.Provider>
   );
 };

--- a/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
@@ -9,7 +9,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import {t, tct} from 'sentry/locale';
-import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
+import {useSidebarDispatch} from 'sentry/stores/sidebarProvider';
 import {Organization, Project} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {MetricDataSwitcherOutcome} from 'sentry/utils/performance/contexts/metricsCardinality';
@@ -55,9 +55,11 @@ const UNSUPPORTED_TRANSACTION_NAME_DOCS = [
 export function MetricsDataSwitcherAlert(
   props: MetricEnhancedDataAlertProps
 ): React.ReactElement | null {
+  const dispatchSidebar = useSidebarDispatch();
+
   const handleReviewUpdatesClick = useCallback(() => {
-    SidebarPanelStore.activatePanel(SidebarPanelKey.Broadcasts);
-  }, []);
+    dispatchSidebar({type: 'activate panel', payload: SidebarPanelKey.Broadcasts});
+  }, [dispatchSidebar]);
 
   const docsLink = useMemo(() => {
     const platforms = getSelectedProjectPlatformsArray(props.location, props.projects);

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -26,7 +26,7 @@ import {filterProjects} from 'sentry/components/performanceOnboarding/utils';
 import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import {withPerformanceOnboarding} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
-import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
+import {useSidebarDispatch} from 'sentry/stores/sidebarProvider';
 import {Organization, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import useApi from 'sentry/utils/useApi';
@@ -102,6 +102,7 @@ function Onboarding({organization, project}: Props) {
 
   const {projects} = useProjects();
   const {location} = useRouteContext();
+  const dispatchSidebar = useSidebarDispatch();
 
   const {projectsForOnboarding} = filterProjects(projects);
 
@@ -115,9 +116,18 @@ function Onboarding({organization, project}: Props) {
       location.hash === '#performance-sidequest' &&
       projectsForOnboarding.some(p => p.id === project.id)
     ) {
-      SidebarPanelStore.activatePanel(SidebarPanelKey.PerformanceOnboarding);
+      dispatchSidebar({
+        type: 'activate panel',
+        payload: SidebarPanelKey.PerformanceOnboarding,
+      });
     }
-  }, [location.hash, projectsForOnboarding, project.id, showOnboardingChecklist]);
+  }, [
+    location.hash,
+    projectsForOnboarding,
+    project.id,
+    showOnboardingChecklist,
+    dispatchSidebar,
+  ]);
 
   function handleAdvance(step: number, duration: number) {
     trackAdvancedAnalyticsEvent('performance_views.tour.advance', {
@@ -157,7 +167,10 @@ function Onboarding({organization, project}: Props) {
         onClick={event => {
           event.preventDefault();
           window.location.hash = 'performance-sidequest';
-          SidebarPanelStore.activatePanel(SidebarPanelKey.PerformanceOnboarding);
+          dispatchSidebar({
+            type: 'activate panel',
+            payload: SidebarPanelKey.PerformanceOnboarding,
+          });
         }}
       >
         {t('Start Checklist')}

--- a/static/app/views/projectDetail/index.spec.tsx
+++ b/static/app/views/projectDetail/index.spec.tsx
@@ -4,6 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import {SidebarProvider} from 'sentry/stores/sidebarProvider';
 import ProjectDetails from 'sentry/views/projectDetail/projectDetail';
 
 describe('ProjectDetail', function () {
@@ -51,10 +52,15 @@ describe('ProjectDetail', function () {
 
       ProjectsStore.loadInitialData(projects);
 
-      render(<ProjectDetails organization={organization} {...router} params={params} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <SidebarProvider>
+          <ProjectDetails organization={organization} {...router} params={params} />
+        </SidebarProvider>,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       expect(
         screen.queryByText(
@@ -86,10 +92,15 @@ describe('ProjectDetail', function () {
         body: projects[0],
       });
 
-      render(<ProjectDetails organization={organization} {...router} params={params} />, {
-        context: routerContext,
-        organization,
-      });
+      render(
+        <SidebarProvider>
+          <ProjectDetails organization={organization} {...router} params={params} />
+        </SidebarProvider>,
+        {
+          context: routerContext,
+          organization,
+        }
+      );
 
       expect(
         await screen.findByText(


### PR DESCRIPTION
Poc PR that drops reflux for sidebar store and just uses context. I've opted not to add the provider to the global providers, but I think it may as well be added there due to how simple exposing a initialPanel would be. + not adding it causes a lot of tests to fail and it feels "annoying to add them around".

The store itself can probably be simplified to a single toggle/hide too, but keeping that outside of the scope here.