### PR TITLE
ref(ingest) Add metric to track eventprocessing_store reads

### DIFF
--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -313,7 +313,8 @@ def _load_event(
 
 
 def _store_event(data) -> str:
-    return event_processing_store.store(data)
+    with metrics.timer("ingest_consumer._store_event"):
+        return event_processing_store.store(data)
 
 
 @trace_func(name="ingest_consumer.process_event")


### PR DESCRIPTION
Reading from the eventprocessing store is one of the suspect areas of slow down in single-tenant environments that I'd like to understand further.