### PR TITLE
feat(perf-issues): Add perf-issues options to settings

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -1,3 +1,4 @@
+import Feature from 'sentry/components/acl/feature';
 import {Form} from 'sentry/components/forms';
 import {Panel, PanelHeader} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
@@ -16,6 +17,10 @@ const optionsAvailable = [
   'auth.user-rate-limit',
   'api.rate-limit.org-create',
   'beacon.anonymous',
+  'performance.issues.all.problem-detection',
+  'performance.issues.all.problem-creation',
+  'performance.issues.n_plus_one.problem-detection',
+  'performance.issues.n_plus_one.problem-creation',
 ];
 
 type Field = ReturnType<typeof getOption>;
@@ -87,6 +92,16 @@ export default class AdminSettings extends AsyncView<{}, State> {
             <PanelHeader>Beacon</PanelHeader>
             {fields['beacon.anonymous']}
           </Panel>
+
+          <Feature features={['organizations:performance-issues']}>
+            <Panel>
+              <PanelHeader>Performance Issues</PanelHeader>
+              {fields['performance.issues.all.problem-detection']}
+              {fields['performance.issues.all.problem-creation']}
+              {fields['performance.issues.n_plus_one.problem-detection']}
+              {fields['performance.issues.n_plus_one.problem-creation']}
+            </Panel>
+          </Feature>
         </Form>
       </div>
     );

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -3,6 +3,7 @@ import keyBy from 'lodash/keyBy';
 import {
   BooleanField,
   EmailField,
+  NumberField,
   RadioBooleanField,
   TextField,
 } from 'sentry/components/forms';
@@ -19,13 +20,16 @@ type Field = {
   label: React.ReactNode;
   allowEmpty?: boolean;
   component?: React.ComponentType<any>;
-  defaultValue?: () => string | false;
+  defaultValue?: () => string | number | false;
   disabled?: boolean;
   disabledReason?: string;
   help?: React.ReactNode;
+  max?: number;
+  min?: number;
   noLabel?: string;
   placeholder?: string;
   required?: boolean;
+  step?: number;
   yesFirst?: boolean;
   yesLabel?: string;
 };
@@ -46,6 +50,49 @@ const sections: Section[] = [
   {
     key: 'beacon',
     heading: t('Beacon'),
+  },
+];
+
+const HIGH_THROUGHPUT_RATE_OPTION = {
+  defaultValue: () => '0',
+  component: NumberField,
+  min: 0.0,
+  max: 1.0,
+  step: 0.0001,
+};
+
+const performanceOptionDefinitions: Field[] = [
+  {
+    key: 'performance.issues.all.problem-detection',
+    label: t('Performance problem detection rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected across the entire system. A value of 0 will disable performance issue detection, and a value of 1.0 turns on detection for every ingested transaction.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'performance.issues.all.problem-creation',
+    label: t('Performance problem creation rate'),
+    help: t(
+      'Controls the rate at which performance issues are created across the entire system. A value of 0 will disable performance issue detection, and a value of 1.0 turns on creation for every detected performance problem.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'performance.issues.n_plus_one.problem-detection',
+    label: t('N+1 detection rate'),
+    help: t(
+      'Controls the rate at which performance problems are detected specifically for N+1 detection. Value of 0 will disable detection, a value of 1.0 fully enables it.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
+    key: 'performance.issues.n_plus_one.problem-creation',
+    label: t('N+1 creation rate'),
+    help: t(
+      'Controls the rate at which performance issues are created specifically for N+1 detection. Value of 0 will disable creation, a value of 1.0 fully enables it.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
   },
 ];
 
@@ -184,6 +231,7 @@ const definitions: Field[] = [
     component: BooleanField,
     defaultValue: () => false,
   },
+  ...performanceOptionDefinitions,
 ];
 
 const definitionsMap = keyBy(definitions, def => def.key);
@@ -198,7 +246,7 @@ export function getOption(option: string): Field {
   return definitionsMap[option];
 }
 
-export function getOptionDefault(option: string): string | false | undefined {
+export function getOptionDefault(option: string): string | number | false | undefined {
   const meta = getOption(option);
   return meta.defaultValue ? meta.defaultValue() : undefined;
 }


### PR DESCRIPTION
# Summary
This surfaces the performance issues system-wide options in the manage/settings page, which will allow them to be modified on the fly by superusers in production. Adding n+1 as an individual detector to start, still need to check that this works e2e with recent endpoint changes, and to introduce these new options into the pipeline.

Project options for both custom thresholds as well as regular tuning of performance issue events will be created in a separate PR.

![Screen Shot 2022-09-01 at 3 16 50 PM](https://user-images.githubusercontent.com/6111995/187995140-217969bf-7535-416d-84b1-1513d2401cd7.png)
