### PR TITLE
ref(smartSearchBar): open Read the Docs in new window

### DIFF
--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -98,8 +98,7 @@ const SearchDropdown = ({
       <Button
         size="xs"
         href="https://docs.sentry.io/product/sentry-basics/search/"
-        target="_blank"
-        rel="noopener noreferrer"
+        external
       >
         Read the docs
       </Button>

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -95,7 +95,12 @@ const SearchDropdown = ({
             </Button>
           ))}
       </ButtonBar>
-      <Button size="xs" href="https://docs.sentry.io/product/sentry-basics/search/">
+      <Button
+        size="xs"
+        href="https://docs.sentry.io/product/sentry-basics/search/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Read the docs
       </Button>
     </DropdownFooter>


### PR DESCRIPTION
While searching for a key you can now open the docs in a new window. Once you find what you're looking for, you are back in the focused search bar state that you left from, instead of the current flow of going back in browser history and reloading the page you came from.

### Before
https://user-images.githubusercontent.com/465250/187994726-15117bd2-e1c1-496a-9ef0-053e3884e9a6.mp4


### After
https://user-images.githubusercontent.com/465250/187994746-17ec584a-6a86-40a4-a4fa-522db4d42e0d.mp4


