### PR TITLE
feat(discover): Allow arithmetic on datetime

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -172,6 +172,8 @@ class ArithmeticVisitor(NodeVisitor):
     # Implicitly an allowlist as well, once added the result will be a timestamp
     datefields = {
         "timestamp",
+        "timestamp.to_hour",
+        "timestamp.to_day",
     }
     function_allowlist = {
         "count",

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -135,6 +135,7 @@ ARRAY_FIELDS = {
     "spans_exclusive_time",
 }
 TIMESTAMP_FIELDS = {
+    "event.received",
     "timestamp",
     "timestamp.to_hour",
     "timestamp.to_day",


### PR DESCRIPTION
- This allows arithmetic on datetime fields by converting them to unix
  timestamps, doing the math, then converting them back
- eg. timestamp + 3600 becomes:
  `toDateTime64(toUnixTimestamp(timestamp) + 3600, 1)`