### PR TITLE
fix(admin): Fix typo in admin user creation form

### DIFF
--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -220,7 +220,7 @@ class UserAdmin(admin.ModelAdmin):
         defaults = {}
         if obj is None:
             defaults.update(
-                {"form": self.add_form, "fields": admin.util.flatten_fieldsets(self.add_fieldsets)}
+                {"form": self.add_form, "fields": admin.utils.flatten_fieldsets(self.add_fieldsets)}
             )
         defaults.update(kwargs)
         return super().get_form(request, obj, **defaults)


### PR DESCRIPTION
This fixes the error reported in https://github.com/getsentry/sentry/issues/38303, which appears to be due to a typo in the django module name.