### PR TITLE
fix(profiling): Handle empty payloads

### DIFF
--- a/src/sentry/profiles/consumer.py
+++ b/src/sentry/profiles/consumer.py
@@ -25,6 +25,9 @@ class ProfilesConsumer(AbstractBatchWorker):  # type: ignore
         self, message: Message
     ) -> Tuple[Optional[int], Optional[MutableMapping[str, Any]]]:
         message = msgpack.unpackb(message.value(), use_list=False)
+        if not message["payload"]:
+            return None
+
         profile = cast(Dict[str, Any], json.loads(message["payload"]))
         profile.update(
             {

--- a/src/sentry/profiles/consumer.py
+++ b/src/sentry/profiles/consumer.py
@@ -23,7 +23,7 @@ def get_profiles_consumer(
 class ProfilesConsumer(AbstractBatchWorker):  # type: ignore
     def process_message(
         self, message: Message
-    ) -> Tuple[Optional[int], Optional[MutableMapping[str, Any]]]:
+    ) -> Optional[Tuple[Optional[int], Optional[MutableMapping[str, Any]]]]:
         message = msgpack.unpackb(message.value(), use_list=False)
         if not message["payload"]:
             return None


### PR DESCRIPTION
We're seeing some empty payloads come our way. Not sure yet of the origin but we need to discard them no matter what.