### PR TITLE
fix(sessions): Suppress issues sent from invalid search filters

### DIFF
--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -11,7 +11,6 @@ from sentry import release_health
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import get_date_range_from_params
-from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Organization
 from sentry.snuba.sessions_v2 import SNUBA_LIMIT, InvalidField, InvalidParams, QueryDefinition
 from sentry.utils.cursors import Cursor, CursorResult
@@ -81,7 +80,7 @@ class OrganizationSessionsEndpoint(OrganizationEventsEndpointBase):
             # TODO: this context manager should be decoupled from `OrganizationEventsEndpointBase`?
             with super().handle_query_errors():
                 yield
-        except (InvalidField, InvalidParams, NoProjects, InvalidSearchQuery) as error:
+        except (InvalidField, InvalidParams, NoProjects) as error:
             raise ParseError(detail=str(error))
 
 

--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -30,6 +30,7 @@ from sentry_sdk import (
 )
 
 from sentry import features
+from sentry.exceptions import InvalidSearchQuery
 from sentry.models import Organization, Project
 from sentry.release_health.base import (
     CrashFreeBreakdown,
@@ -811,9 +812,10 @@ class DuplexReleaseHealthBackend(ReleaseHealthBackend):
             try:
                 with timer("releasehealth.metrics.duration", tags=tags, sample_rate=1.0):
                     metrics_result = metrics_fn(*args)
-            except InvalidParams:
-                # This is a valid result from metrics, not a crash
-                # -> no need to fall back to session_fn, just re-raise
+            except (InvalidParams, InvalidSearchQuery):
+                # This is a valid result from metrics, not a crash -> no need to fall back to session_fn, just re-raise
+                # There is no need to also send an issue to Sentry on InvalidSearchQuery exception instances as these
+                # are not crashes, and just the result of incompatible search filters.
                 raise
             except Exception:
                 capture_exception()


### PR DESCRIPTION
Prevents sending exceptions to sentry as a result of
InvalidSearchQuery exception instances that are raised
from invalid search filters

Fixes SENTRY-VYH
Fixes SENTRY-VY7


