### PR TITLE
ref(audit-log): log raw dynamic sampling changes - [TET-341]

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -646,7 +646,8 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if "dynamicSampling" in result:
             raw_dynamic_sampling = result["dynamicSampling"]
             fixed_rules = self._fix_rule_ids(project, raw_dynamic_sampling)
-            project.update_option("sentry:dynamic_sampling", fixed_rules)
+            if project.update_option("sentry:dynamic_sampling", fixed_rules):
+                changed_proj_settings["sentry:dynamic_sampling"] = result["dynamicSampling"]
             changed_proj_settings["sentry:dynamic_sampling"] = result["dynamicSampling"]
 
         # TODO(dcramer): rewrite options to use standard API config

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -648,7 +648,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             fixed_rules = self._fix_rule_ids(project, raw_dynamic_sampling)
             if project.update_option("sentry:dynamic_sampling", fixed_rules):
                 changed_proj_settings["sentry:dynamic_sampling"] = result["dynamicSampling"]
-            changed_proj_settings["sentry:dynamic_sampling"] = result["dynamicSampling"]
 
         # TODO(dcramer): rewrite options to use standard API config
         if has_project_write:

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -647,7 +647,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             raw_dynamic_sampling = result["dynamicSampling"]
             fixed_rules = self._fix_rule_ids(project, raw_dynamic_sampling)
             project.update_option("sentry:dynamic_sampling", fixed_rules)
-            changed_proj_settings["sentry:dynamic_sampling"] = raw_dynamic_sampling.strip() or None
+            changed_proj_settings["sentry:dynamic_sampling"] = result["dynamicSampling"]
 
         # TODO(dcramer): rewrite options to use standard API config
         if has_project_write:

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -647,6 +647,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             raw_dynamic_sampling = result["dynamicSampling"]
             fixed_rules = self._fix_rule_ids(project, raw_dynamic_sampling)
             project.update_option("sentry:dynamic_sampling", fixed_rules)
+            changed_proj_settings["sentry:dynamic_sampling"] = raw_dynamic_sampling.strip() or None
 
         # TODO(dcramer): rewrite options to use standard API config
         if has_project_write:


### PR DESCRIPTION
Before we were logging just 'edited project settings' and now we log the whole updated dynamic sampling object