### PR TITLE
feat(sampling): Add more platforms to the allowlist

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
+++ b/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
@@ -174,6 +174,17 @@ def mocked_discover_query():
                 'count_if(transaction.source, notEquals, "")': 0,
                 "count()": 1,
             },
+            # project: timber
+            {
+                "sdk.version": "6.4.1",
+                "sdk.name": "sentry.java.android.timber",
+                "project": "timber",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 7,
+                'equation|count_if(transaction.source, notEquals, "") / count()': 1.0,
+                'count_if(transaction.source, notEquals, "")': 5,
+                "count()": 23,
+            },
             # project: dummy
             {
                 "sdk.version": "7.1.4",
@@ -323,6 +334,14 @@ class OrganizationDynamicSamplingSDKVersionsTest(APITestCase):
                     "latestSDKVersion": "7.1.4",
                     "isSendingSampleRate": False,
                     "isSendingSource": False,
+                    "isSupportedPlatform": True,
+                },
+                {
+                    "project": "timber",
+                    "latestSDKName": "sentry.java.android.timber",
+                    "latestSDKVersion": "6.4.1",
+                    "isSendingSampleRate": True,
+                    "isSendingSource": True,
                     "isSupportedPlatform": True,
                 },
                 {


### PR DESCRIPTION
Right now the `sentry.java.android.timber` is missing from the allow list.

This PR changes the logic so that all android integrations are allowed.

Also adding the support for react-native. We'll add it to the docs once all the e2e tests with the SDK team are finished.