### PR TITLE
fix(metrics): Fix startup crash in parallel indexer [sns-1490]

### DIFF
--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -26,6 +26,12 @@ class MessageProcessor:
         self._indexer = STORAGE_TO_INDEXER[config.db_backend](**config.db_backend_options)
         self._config = config
 
+    def __getstate__(self):
+        return self._config
+
+    def __setstate__(self, config):
+        self.__init__(config)
+
     def process_messages(
         self,
         outer_message: Message[MessageBatch],

--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -26,6 +26,12 @@ class MessageProcessor:
         self._indexer = STORAGE_TO_INDEXER[config.db_backend](**config.db_backend_options)
         self._config = config
 
+    # The following two methods are required to work such that the parallel
+    # indexer can spawn subprocesses correctly.
+    #
+    # We get/set just the config (assuming it's pickleable) and re-instantiate
+    # the indexer backend in the subprocess (assuming that it usually isn't)
+
     def __getstate__(self) -> MetricsIngestConfiguration:
         return self._config
 

--- a/src/sentry/sentry_metrics/consumers/indexer/processing.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/processing.py
@@ -26,11 +26,13 @@ class MessageProcessor:
         self._indexer = STORAGE_TO_INDEXER[config.db_backend](**config.db_backend_options)
         self._config = config
 
-    def __getstate__(self):
+    def __getstate__(self) -> MetricsIngestConfiguration:
         return self._config
 
-    def __setstate__(self, config):
-        self.__init__(config)
+    def __setstate__(self, config: MetricsIngestConfiguration) -> None:
+        # mypy: "cannot access init directly"
+        # yes I can, watch me.
+        self.__init__(config)  # type: ignore
 
     def process_messages(
         self,

--- a/tests/sentry/sentry_metrics/test_parallel_indexer.py
+++ b/tests/sentry/sentry_metrics/test_parallel_indexer.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timezone
+
+from arroyo.backends.kafka import KafkaPayload
+from arroyo.types import Message, Partition, Topic
+
+from sentry.sentry_metrics.configuration import (
+    IndexerStorage,
+    MetricsIngestConfiguration,
+    UseCaseKey,
+)
+from sentry.sentry_metrics.consumers.indexer.parallel import MetricsConsumerStrategyFactory
+from sentry.snuba.metrics.naming_layer.mri import SessionMRI
+from sentry.utils import json
+
+ts = int(datetime.now(tz=timezone.utc).timestamp())
+counter_payload = {
+    "name": SessionMRI.SESSION.value,
+    "tags": {
+        "environment": "production",
+        "session.status": "init",
+    },
+    "timestamp": ts,
+    "type": "c",
+    "value": 1.0,
+    "org_id": 1,
+    "project_id": 3,
+}
+
+
+def test_basic(request):
+    """
+    Integration test to verify that the parallel indexer can spawn subprocesses
+    properly. The main purpose is to verify that there are no
+    pickling/unpickling errors when passing the strategy into the
+    ParallelTransformStep, as that is easy to break.
+    """
+    processing_factory = MetricsConsumerStrategyFactory(
+        max_msg_batch_size=1,
+        max_msg_batch_time=1,
+        max_parallel_batch_size=1,
+        max_parallel_batch_time=1,
+        max_batch_size=1,
+        max_batch_time=1,
+        processes=1,
+        input_block_size=1,
+        output_block_size=1,
+        config=MetricsIngestConfiguration(
+            db_backend=IndexerStorage.MOCK,
+            db_backend_options={},
+            input_topic="ingest-metrics",
+            output_topic="snuba-metrics",
+            use_case_id=UseCaseKey.RELEASE_HEALTH,
+            internal_metrics_tag="test",
+            writes_limiter_cluster_options={},
+            writes_limiter_namespace="test",
+        ),
+    )
+
+    strategy = processing_factory.create_with_partitions(
+        lambda _: None,
+        {Partition(topic=Topic(name="ingest-bogus-metrics"), index=1): 1},
+    )
+
+    message = Message(
+        Partition(Topic("topic"), 0),
+        0,
+        KafkaPayload(None, json.dumps(counter_payload).encode("utf-8"), []),
+        datetime.now(),
+    )
+
+    # Just assert that the strategy does not crash. Further assertions, such as
+    # on the produced messages, would slow down the test significantly.
+    strategy.submit(message=message)
+    strategy.close()
+    strategy.join()

--- a/tests/sentry/sentry_metrics/test_parallel_indexer.py
+++ b/tests/sentry/sentry_metrics/test_parallel_indexer.py
@@ -42,8 +42,8 @@ def test_basic(request):
         max_batch_size=1,
         max_batch_time=1,
         processes=1,
-        input_block_size=1,
-        output_block_size=1,
+        input_block_size=1024,
+        output_block_size=1024,
         config=MetricsIngestConfiguration(
             db_backend=IndexerStorage.MOCK,
             db_backend_options={},


### PR DESCRIPTION
Since https://github.com/getsentry/sentry/pull/38225 the parallel
indexer fails to serialize the processing function here: https://github.com/getsentry/sentry/blob/9bf499ad95030ed1112f117c5c1be59b2e036509/src/sentry/sentry_metrics/consumers/indexer/parallel.py#L115

We need to make sure the message processor is pickleable. So the config
also needs to be pickleable.

The old code worked because it imported the config and indexer from
settings instead of attempting to pickle them.
