### PR TITLE
ref(perf-issues): Also use new option rate for detection

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -31,8 +31,11 @@ class DetectorType(Enum):
 # Facade in front of performance detection to limit impact of detection on our events ingestion
 def detect_performance_issue(data: Event):
     try:
-        rate = options.get("store.use-ingest-performance-detection-only")
-        if rate and rate > random.random():
+        rate = options.get(
+            "store.use-ingest-performance-detection-only"
+        )  # TODO: Remove this option once performance.issues option is working.
+        inner_rate = options.get("performance.issues.all.problem-detection")
+        if rate and rate > random.random() and inner_rate and inner_rate > random.random():
             # Add an experimental tag to be able to find these spans in production while developing. Should be removed later.
             sentry_sdk.set_tag("_did_analyze_performance_issue", "true")
             with metrics.timer(

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -61,7 +61,8 @@ class PerformanceDetectionTest(unittest.TestCase):
     def test_options_enabled(self, mock):
         event = {}
         with override_options({"store.use-ingest-performance-detection-only": 1.0}):
-            detect_performance_issue(event)
+            with override_options({"performance.issues.all.problem-detection": 1.0}):
+                detect_performance_issue(event)
         assert mock.call_count == 1
 
     def test_calls_detect_duplicate(self):


### PR DESCRIPTION
### Summary
This will double up the new setting page backed option behind the existing option (so we don't generate tons of errors in case this doesn't quite work when modifying from the uI). We can remove the old 'store.use-ingest-performance...' rate after we confirm this works.


