### PR TITLE
feat(perf-issues): Add span evidence section

### DIFF
--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -5,7 +5,10 @@ import Exception from 'sentry/components/events/interfaces/exception';
 import ExceptionV2 from 'sentry/components/events/interfaces/exceptionV2';
 import {Generic} from 'sentry/components/events/interfaces/generic';
 import {Message} from 'sentry/components/events/interfaces/message';
-import {PerformanceIssueSection} from 'sentry/components/events/interfaces/performance';
+import {
+  PerformanceIssueSection,
+  SpanEvidence,
+} from 'sentry/components/events/interfaces/performance';
 import {Request} from 'sentry/components/events/interfaces/request';
 import Spans from 'sentry/components/events/interfaces/spans';
 import StackTrace from 'sentry/components/events/interfaces/stackTrace';
@@ -176,11 +179,21 @@ function EventEntry({
         return null;
       }
 
+      // TODO: Replace this with real data from the entry when possible
+      const SAMPLE_SPAN_EVIDENCE: SpanEvidence = {
+        parentSpan: 'index',
+        sourceSpan:
+          'SELECT "sentry_useroption"."id", "sentry_useroption"."user_id", "sentry_useroption"."project_id", "sentry_useroption"."organization_id", "sentry_useroption"."key", "sentry_useroption"."value" FROM "sentry_useroption" WHERE ("sentry_useroption"."organization_id" IS NULL AND "sentry_useroption"."project_id" IS NULL AND "sentry_useroption"."user_id" = %s) ',
+        repeatingSpan:
+          'SELECT "sentry_project"."id", "sentry_project"."slug", "sentry_project"."name", "sentry_project"."forced_color", "sentry_project"."organization_id", "sentry_project"."public", "sentry_project"."date_added", "sentry_project"."status", "sentry_project"."first_event", "sentry_project"."flags", "sentry_project"."platform" FROM "sentry_project" WHERE ("sentry_project"."organization_id" = %s AND "sentry_project"."status" = %s AND "sentry_project"."id" IN (%s))',
+      };
+
       return (
         <PerformanceIssueSection
           issue={group as Group}
           event={event as EventError}
           organization={organization as Organization}
+          spanEvidence={SAMPLE_SPAN_EVIDENCE}
         />
       );
     default:

--- a/static/app/components/events/interfaces/performance/index.tsx
+++ b/static/app/components/events/interfaces/performance/index.tsx
@@ -2,48 +2,55 @@ import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {EventError, Group, Organization} from 'sentry/types';
-import {useLocation} from 'sentry/utils/useLocation';
+import {EventError, Group, KeyValueListData, Organization} from 'sentry/types';
 
-import {DurationChart} from './durationChart';
-import {SpanCountChart} from './spanCountChart';
+import KeyValueList from '../keyValueList';
+
+export type SpanEvidence = {
+  parentSpan: string;
+  repeatingSpan: string;
+  sourceSpan: string;
+};
 
 interface Props {
   event: EventError;
   issue: Group;
   organization: Organization;
+  spanEvidence: SpanEvidence;
 }
 
-export function PerformanceIssueSection({issue, event, organization}: Props) {
-  const location = useLocation();
+export function PerformanceIssueSection({spanEvidence}: Props) {
+  const {parentSpan, sourceSpan, repeatingSpan} = spanEvidence;
+
+  const data: KeyValueListData = [
+    {
+      key: '0',
+      subject: t('Parent Span'),
+      value: parentSpan,
+    },
+    {
+      key: '1',
+      subject: t('Source Span'),
+      value: sourceSpan,
+    },
+    {
+      key: '2',
+      subject: t('Repeating Span'),
+      value: repeatingSpan,
+    },
+  ];
 
   return (
     <Wrapper>
-      <Section>
-        <h3>{t('P75 Duration Change')}</h3>
-        <DurationChart
-          issue={issue}
-          location={location}
-          organization={organization}
-          event={event}
-        />
-      </Section>
-      <Section>
-        <h3>{t('Span Count Distribution')}</h3>
-        <SpanCountChart
-          issue={issue}
-          event={event}
-          location={location}
-          organization={organization}
-        />
-      </Section>
+      <h3>{t('Span Evidence')}</h3>
+      <KeyValueList data={data} />
     </Wrapper>
   );
 }
 
 export const Wrapper = styled('div')`
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   border-top: 1px solid ${p => p.theme.innerBorder};
   margin: 0;
   /* Padding aligns with Layout.Body */
@@ -69,8 +76,4 @@ export const Wrapper = styled('div')`
   div:first-child {
     margin-right: ${space(3)};
   }
-`;
-
-const Section = styled('div')`
-  width: 50%;
 `;


### PR DESCRIPTION
Adds the Span Evidence section to the performance issue details page. Right now, we're using hardcoded values for each entry in the section, which I will change in a follow up PR when the respective data is available from the backend.

This PR also assumes that only N+1 Performance Issues are available. In the future, when we introduce new Performance Issue types, this section likely will not exist for other issue types, and we will need to conditionally render some info/widgets respective to the issue.

![image](https://user-images.githubusercontent.com/16740047/188659074-49eb94ae-9eb3-4965-95f1-5fc2655ace0d.png)

Closes PERF-1738
