### PR TITLE
fix(discover): Fixes mangled drilldown links in Discover aggregated results tables

### DIFF
--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -350,10 +350,6 @@ describe('utils/tokenizeSearch', function () {
       results.removeFilter('b');
       expect(results.formatString()).toEqual('( ( a:a OR c:c ) )');
 
-      results = new MutableSearch(['a:a', '!b:b']);
-      results.removeFilter('b');
-      expect(results.formatString()).toEqual('a:a');
-
       results = new MutableSearch(['a:a', '(b:b1', 'OR', 'b:b2', 'OR', 'b:b3)', 'c:c']);
       results.removeFilter('b');
       expect(results.formatString()).toEqual('a:a c:c');

--- a/static/app/utils/tokenizeSearch.spec.tsx
+++ b/static/app/utils/tokenizeSearch.spec.tsx
@@ -349,6 +349,14 @@ describe('utils/tokenizeSearch', function () {
       results = new MutableSearch(['(((a:a', 'OR', 'b:b1)', 'OR', 'c:c)', 'OR', 'b:b2)']);
       results.removeFilter('b');
       expect(results.formatString()).toEqual('( ( a:a OR c:c ) )');
+
+      results = new MutableSearch(['a:a', '!b:b']);
+      results.removeFilter('b');
+      expect(results.formatString()).toEqual('a:a');
+
+      results = new MutableSearch(['a:a', '(b:b1', 'OR', 'b:b2', 'OR', 'b:b3)', 'c:c']);
+      results.removeFilter('b');
+      expect(results.formatString()).toEqual('a:a c:c');
     });
 
     it('can return the tag keys', function () {

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -215,9 +215,7 @@ export class MutableSearch {
       } while (toRemove >= 0);
     };
 
-    this.tokens = this.tokens.filter(
-      token => token.key !== key && token.key !== `!${key}`
-    );
+    this.tokens = this.tokens.filter(token => token.key !== key);
 
     // Remove any AND/OR operators that have become erroneous due to filtering out tokens
     removeErroneousAndOrOps();

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -184,7 +184,43 @@ export class MutableSearch {
   }
 
   removeFilter(key: string) {
-    this.tokens = this.tokens.filter(token => token.key !== key);
+    const removeErroneousAndOrOps = () => {
+      let toRemove = -1;
+      do {
+        if (toRemove >= 0) {
+          this.tokens.splice(toRemove, 1);
+          toRemove = -1;
+        }
+
+        for (let i = 0; i < this.tokens.length; i++) {
+          const token = this.tokens[i];
+          const prev = this.tokens[i - 1];
+          const next = this.tokens[i + 1];
+          if (isOp(token) && isBooleanOp(token.value)) {
+            if (prev === undefined || isOp(prev) || next === undefined || isOp(next)) {
+              // Want to avoid removing `(term) OR (term)` and `term OR (term)`
+              if (
+                prev &&
+                next &&
+                (isParen(prev, ')') || !isOp(prev)) &&
+                (isParen(next, '(') || !isOp(next))
+              ) {
+                continue;
+              }
+              toRemove = i;
+              break;
+            }
+          }
+        }
+      } while (toRemove >= 0);
+    };
+
+    this.tokens = this.tokens.filter(
+      token => token.key !== key && token.key !== `!${key}`
+    );
+
+    // Remove any AND/OR operators that have become erroneous due to filtering out tokens
+    removeErroneousAndOrOps();
 
     // Now the really complicated part: removing parens that only have one element in them.
     // Since parens are themselves tokens, this gets tricky. In summary, loop through the
@@ -237,29 +273,7 @@ export class MutableSearch {
     // cases like `a OR OR b` would remove both operators, when only one should be removed. So
     // instead, we loop until we find an operator to remove, then go back to the start and loop
     // again.
-    let toRemove = -1;
-    do {
-      if (toRemove >= 0) {
-        this.tokens.splice(toRemove, 1);
-        toRemove = -1;
-      }
-
-      for (let i = 0; i < this.tokens.length; i++) {
-        const token = this.tokens[i];
-        const prev = this.tokens[i - 1];
-        const next = this.tokens[i + 1];
-        if (isOp(token) && isBooleanOp(token.value)) {
-          if (prev === undefined || isOp(prev) || next === undefined || isOp(next)) {
-            // Want to avoid removing `(term) OR (term)`
-            if (isParen(prev, ')') && isParen(next, '(')) {
-              continue;
-            }
-            toRemove = i;
-            break;
-          }
-        }
-      }
-    } while (toRemove >= 0);
+    removeErroneousAndOrOps();
 
     return this;
   }


### PR DESCRIPTION
Better detects erroneous or/and operators due to parenthesis and also removes negated filters on the supplied key.
Previously, when drilling down on a field `b` with query filters `a:a1 (b:b1 OR b:b2) c:c1`, the result of `removeFilter` would be `a:a1 OR c:c1` which is incorrect. This PR fixes it by correcting the result to `a:a1 c:c1`.



![image](https://user-images.githubusercontent.com/83961295/188699736-2b11577b-752f-4f5c-a649-0222b36da07d.png)
