### PR TITLE
fix(textareaControl): Allow react-autosize-textarea to freely control the height

### DIFF
--- a/static/app/components/forms/controls/textarea.tsx
+++ b/static/app/components/forms/controls/textarea.tsx
@@ -46,8 +46,8 @@ const TextArea = styled(TextAreaControl, {
   ${p =>
     p.autosize &&
     `
-      height: auto;
-      min-height: auto;
+      height: unset;
+      min-height: unset;
     `}
 `;
 

--- a/static/app/components/forms/controls/textarea.tsx
+++ b/static/app/components/forms/controls/textarea.tsx
@@ -41,6 +41,14 @@ const TextArea = styled(TextAreaControl, {
 })`
   ${inputStyles};
   line-height: ${p => p.theme.text.lineHeightBody};
+
+  /** Allow react-autosize-textarea to freely control height based on props. */
+  ${p =>
+    p.autosize &&
+    `
+      height: auto;
+      min-height: auto;
+    `}
 `;
 
 export default TextArea;


### PR DESCRIPTION
When we explicitly set a height on `<TextArea />` in `components/forms/controls/textArea` (which we do via `inputStyles`), `react-autosize-textarea` will take that height as the minimum height, disregarding its own [`rows` prop](https://www.npmjs.com/package/react-autosize-textarea). This is not the expected behavior.

To fix this, we can just reset the `height` and `min-height` properties to `unset` whenever we use `react-autosize-textarea`.

**Before –**
<img width="644" alt="Screen Shot 2022-09-06 at 10 50 24 AM" src="https://user-images.githubusercontent.com/44172267/188704927-3e17e7a9-820a-4b7c-b289-615daed1817c.png">


**After –**
<img width="644" alt="Screen Shot 2022-09-06 at 10 49 59 AM" src="https://user-images.githubusercontent.com/44172267/188704839-e2df558f-85dd-4d40-8fba-3afc23e96128.png">

