### PR TITLE
feat(perf-issues): Issue creation project option UI

### DIFF
--- a/static/app/components/forms/controls/rangeSlider/index.tsx
+++ b/static/app/components/forms/controls/rangeSlider/index.tsx
@@ -127,13 +127,13 @@ function RangeSlider({
   }
 
   function handleInput(e: React.ChangeEvent<HTMLInputElement>) {
-    const newSliderValue = parseInt(e.target.value, 10);
+    const newSliderValue = parseFloat(e.target.value);
     setSliderValue(newSliderValue);
     onChange?.(getActualValue(newSliderValue), e);
   }
 
   function handleCustomInputChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setSliderValue(parseInt(e.target.value, 10) || 0);
+    setSliderValue(parseFloat(e.target.value) || 0);
   }
 
   function handleBlur(

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.jsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.jsx
@@ -3,7 +3,9 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import ProjectPerformance from 'sentry/views/settings/projectPerformance/projectPerformance';
 
 describe('projectPerformance', function () {
-  const org = TestStubs.Organization({features: ['performance-view']});
+  const org = TestStubs.Organization({
+    features: ['performance-view', 'performance-issues'],
+  });
   const project = TestStubs.ProjectDetails();
   const configUrl = '/projects/org-slug/project-slug/transaction-threshold/configure/';
   let getMock, postMock, deleteMock;
@@ -33,6 +35,12 @@ describe('projectPerformance', function () {
     deleteMock = MockApiClient.addMockResponse({
       url: configUrl,
       method: 'DELETE',
+      statusCode: 200,
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      method: 'GET',
+      body: {},
       statusCode: 200,
     });
   });

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -3,6 +3,7 @@ import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import Access from 'sentry/components/acl/access';
+import Feature from 'sentry/components/acl/feature';
 import Button from 'sentry/components/button';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
@@ -18,6 +19,7 @@ import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import PermissionAlert from 'sentry/views/settings/project/permissionAlert';
 
+type RouteParams = {orgId: string; projectId: string};
 type Props = RouteComponentProps<{orgId: string; projectId: string}, {}> & {
   organization: Organization;
   project: Project;
@@ -41,12 +43,17 @@ class ProjectPerformance extends AsyncView<Props, State> {
     return routeTitleGen(t('Performance'), projectId, false);
   }
 
+  getProjectEndpoint({orgId, projectId}: RouteParams) {
+    return `/projects/${orgId}/${projectId}/`;
+  }
+
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {params} = this.props;
     const {orgId, projectId} = params;
 
     const endpoints: ReturnType<AsyncView['getEndpoints']> = [
       ['threshold', `/projects/${orgId}/${projectId}/transaction-threshold/configure/`],
+      ['project', `/projects/${orgId}/${projectId}/`],
     ];
 
     return endpoints;
@@ -125,6 +132,23 @@ class ProjectPerformance extends AsyncView<Props, State> {
     return fields;
   }
 
+  get performanceIssueFormFields(): Field[] {
+    return [
+      {
+        name: 'performanceIssueCreationRate',
+        type: 'range',
+        label: t('Performance Issue Creation Rate'),
+        min: 0.0,
+        max: 1.0,
+        step: 0.01,
+        defaultValue: 0,
+        help: t(
+          'This determines the rate at which performance issues are created. A rate of 0.0 will disable performance issue creation.'
+        ),
+      },
+    ];
+  }
+
   get initialData() {
     const {threshold} = this.state;
 
@@ -135,9 +159,11 @@ class ProjectPerformance extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {organization, project} = this.props;
+    const {organization, project, params} = this.props;
     const endpoint = `/projects/${organization.slug}/${project.slug}/transaction-threshold/configure/`;
     const requiredScopes: Scope[] = ['project:write'];
+
+    const projectEndpoint = this.getProjectEndpoint(params);
 
     return (
       <Fragment>
@@ -180,6 +206,28 @@ class ProjectPerformance extends AsyncView<Props, State> {
             )}
           </Access>
         </Form>
+        <Feature features={['organizations:performance-issues']}>
+          <Form
+            saveOnBlur
+            allowUndo
+            initialData={{
+              performanceIssueCreationRate:
+                this.state.project.performanceIssueCreationRate,
+            }}
+            apiMethod="PUT"
+            apiEndpoint={projectEndpoint}
+          >
+            <Access access={requiredScopes}>
+              {({hasAccess}) => (
+                <JsonForm
+                  title={t('Performance Issues')}
+                  fields={this.performanceIssueFormFields}
+                  disabled={!hasAccess}
+                />
+              )}
+            </Access>
+          </Form>
+        </Feature>
       </Fragment>
     );
   }


### PR DESCRIPTION
### Summary
This adds a range slider we can use to opt-in a project to perf issues, which will help during rollout. UI is behind the performance-issues flag. Using a float for now for rollout, this can be switched to 'enabled by default'/boolean later if needed. Will follow up and add thresholds etc. but getting this blocking part in first.

### Screenshots

![Screen Shot 2022-09-06 at 1 58 02 PM](https://user-images.githubusercontent.com/6111995/188706255-c26000ca-16f1-477f-b1bd-6b4f66c02e93.png)
