### PR TITLE
fix(replays): decompress whole file instead of chunking

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
@@ -13,7 +13,6 @@ from sentry.models.file import File
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.serializers import ReplayRecordingSegmentSerializer
 
-CHUNKSIZE = 4096
 FILE_FETCH_THREADPOOL_SIZE = 4
 
 
@@ -81,7 +80,8 @@ class ProjectReplayRecordingSegmentIndexEndpoint(ProjectEndpoint):
 
         for i, file in enumerate(recording_segments):
             if self.is_compressed(file):
-                yield from self.decompress_blob_stream(file)
+                buffer = file.read()
+                yield zlib.decompress(buffer, zlib.MAX_WBITS | 32)
             else:
                 yield file.read().decode("utf-8")
 
@@ -97,11 +97,3 @@ class ProjectReplayRecordingSegmentIndexEndpoint(ProjectEndpoint):
         if first_char == b"{":
             return False
         return True
-
-    @staticmethod
-    def decompress_blob_stream(blob):
-        decompressobj = zlib.decompressobj()
-        buffer = blob.read(CHUNKSIZE)
-        while buffer:
-            yield decompressobj.decompress(buffer).decode("utf-8")
-            buffer = blob.read(CHUNKSIZE)


### PR DESCRIPTION
- Since utf-8 encoding can be variable byte length, a fixed buffer window doesn't quite work and we are sometimes erroring because of it
There a few different options to resolve this:

1. on the client, when we compress, ensure a fixed chunk size and ensure chunks don't split a utf-8 character. this has the downside of being less flexible and more logic the sdk has to handle
2. Instead, server-side, simply keep adding to the buffer if the initial decoding fails.
3. Simply buffer the whole file, then decode and return it. 

We are going to try option 3 first, and see if there are any noticeable performance / resource usage issues, since it is by far the simplest to implement. 

TODO:
we should create some kind of performance test that we can run (doesn't have to be part of CI) to compare/contrast characteristics of solutions
