### PR TITLE
feat(issue-stream): Disable merge and delete actions when performance issues are selected

### DIFF
--- a/fixtures/js-stubs/group.js
+++ b/fixtures/js-stubs/group.js
@@ -15,6 +15,8 @@ export function Group(params = {}) {
     isBookmarked: false,
     isPublic: false,
     isSubscribed: false,
+    issueCategory: 'error',
+    issueType: 'error',
     lastRelease: null,
     lastSeen: '2019-04-11T01:08:59Z',
     level: 'warning',

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -52,14 +52,10 @@ export enum IssueType {
   PERFORMANCE_N_PLUS_ONE = 'performance_n_plus_one',
 }
 
-type CapabilityInfo =
-  | {
-      enabled: true;
-    }
-  | {
-      disabledReason: string;
-      enabled: false;
-    };
+type CapabilityInfo = {
+  enabled: boolean;
+  disabledReason?: string;
+};
 
 /**
  * Defines what capabilities a category of issue has. Not all categories of

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -10,7 +10,14 @@ import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import space from 'sentry/styles/space';
-import {Organization, Project, ResolutionStatus} from 'sentry/types';
+import {
+  BaseGroup,
+  IssueCategoryCapabilities,
+  Organization,
+  Project,
+  ResolutionStatus,
+} from 'sentry/types';
+import {issueSupports} from 'sentry/utils/groupCapabilities';
 import Projects from 'sentry/utils/projects';
 import useMedia from 'sentry/utils/useMedia';
 
@@ -56,21 +63,43 @@ function ActionSet({
   const confirm = getConfirm(numIssues, allInQuerySelected, query, queryCount);
   const label = getLabel(numIssues, allInQuerySelected);
 
-  // merges require a single project to be active in an org context
-  // selectedProjectSlug is null when 0 or >1 projects are selected.
-  const mergeDisabled = !(multiSelected && selectedProjectSlug);
+  const selectedIssues = [...issues]
+    .map(issueId => GroupStore.get(issueId))
+    .filter(issue => issue) as BaseGroup[];
 
-  const selectedIssues = [...issues].map(GroupStore.get);
+  // Merges require multiple issues of a single project type
+  const multipleIssueProjectsSelected = multiSelected && !selectedProjectSlug;
+  const {enabled: mergeSupported, disabledReason: mergeDisabledReason} =
+    isActionSupported(selectedIssues, 'merge');
+  const {enabled: deleteSupported, disabledReason: deleteDisabledReason} =
+    isActionSupported(selectedIssues, 'delete');
+  const {enabled: ignoreSupported} = isActionSupported(selectedIssues, 'ignore');
+  const mergeDisabled =
+    !multiSelected || multipleIssueProjectsSelected || !mergeSupported;
+  const ignoreDisabled = !anySelected || !ignoreSupported;
+
   const canMarkReviewed =
     anySelected && (allInQuerySelected || selectedIssues.some(issue => !!issue?.inbox));
 
   // determine which ... dropdown options to show based on issue(s) selected
   const canAddBookmark =
-    allInQuerySelected || selectedIssues.some(issue => !issue?.isBookmarked);
+    allInQuerySelected || selectedIssues.some(issue => !issue.isBookmarked);
   const canRemoveBookmark =
-    allInQuerySelected || selectedIssues.some(issue => issue?.isBookmarked);
+    allInQuerySelected || selectedIssues.some(issue => issue.isBookmarked);
   const canSetUnresolved =
-    allInQuerySelected || selectedIssues.some(issue => issue?.status === 'resolved');
+    allInQuerySelected || selectedIssues.some(issue => issue.status === 'resolved');
+
+  const makeMergeTooltip = () => {
+    if (mergeDisabledReason) {
+      return mergeDisabledReason;
+    }
+
+    if (multipleIssueProjectsSelected) {
+      return t('Cannot merge issues from different projects');
+    }
+
+    return '';
+  };
 
   // Determine whether to nest "Merge" and "Mark as Reviewed" buttons inside
   // the dropdown menu based on the current screen size
@@ -82,6 +111,8 @@ function ActionSet({
       key: 'merge',
       label: t('Merge'),
       hidden: !nestMergeAndReview,
+      disabled: mergeDisabled,
+      tooltip: makeMergeTooltip(),
       onAction: () => {
         openConfirmModal({
           bypass: !onShouldConfirm(ConfirmAction.MERGE),
@@ -95,6 +126,7 @@ function ActionSet({
       key: 'mark-reviewed',
       label: t('Mark Reviewed'),
       hidden: !nestMergeAndReview,
+      disabled: !canMarkReviewed,
       onAction: () => onUpdate({inbox: false}),
     },
     {
@@ -140,6 +172,8 @@ function ActionSet({
       key: 'delete',
       label: t('Delete'),
       priority: 'danger',
+      disabled: !deleteSupported,
+      tooltip: deleteDisabledReason,
       onAction: () => {
         openConfirmModal({
           bypass: !onShouldConfirm(ConfirmAction.DELETE),
@@ -150,11 +184,6 @@ function ActionSet({
         });
       },
     },
-  ];
-
-  const disabledMenuItems = [
-    ...(mergeDisabled ? ['merge'] : []),
-    ...(canMarkReviewed ? [] : ['mark-reviewed']),
   ];
 
   return (
@@ -207,20 +236,21 @@ function ActionSet({
         shouldConfirm={onShouldConfirm(ConfirmAction.IGNORE)}
         confirmMessage={confirm(ConfirmAction.IGNORE, true)}
         confirmLabel={label('ignore')}
-        disabled={!anySelected}
+        disabled={ignoreDisabled}
       />
       {!nestMergeAndReview && (
         <ReviewAction disabled={!canMarkReviewed} onUpdate={onUpdate} />
       )}
       {!nestMergeAndReview && (
         <ActionLink
+          aria-label={t('Merge Selected Issues')}
           type="button"
           disabled={mergeDisabled}
           onAction={onMerge}
           shouldConfirm={onShouldConfirm(ConfirmAction.MERGE)}
           message={confirm(ConfirmAction.MERGE, false)}
           confirmLabel={label('merge')}
-          aria-label={t('Merge Selected Issues')}
+          title={makeMergeTooltip()}
         >
           {t('Merge')}
         </ActionLink>
@@ -234,12 +264,27 @@ function ActionSet({
           showChevron: false,
           size: 'xs',
         }}
-        disabledKeys={disabledMenuItems}
+        disabledKeys={menuItems.filter(item => item.disabled).map(item => item.key)}
         isDisabled={!anySelected}
       />
       <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />
     </Wrapper>
   );
+}
+
+function isActionSupported(
+  selectedIssues: BaseGroup[],
+  capability: keyof IssueCategoryCapabilities
+) {
+  for (const issue of selectedIssues) {
+    const info = issueSupports(issue.issueCategory, capability);
+
+    if (!info.enabled) {
+      return info;
+    }
+  }
+
+  return {enabled: true};
 }
 
 export default ActionSet;

--- a/static/app/views/issueList/actions/reviewAction.tsx
+++ b/static/app/views/issueList/actions/reviewAction.tsx
@@ -1,19 +1,27 @@
 import ActionLink from 'sentry/components/actions/actionLink';
+import Tooltip from 'sentry/components/tooltip';
 import {IconIssues} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 type Props = {
   onUpdate: (data: {inbox: boolean}) => void;
   disabled?: boolean;
+  tooltip?: string;
+  tooltipProps?: Omit<
+    React.ComponentProps<typeof Tooltip>,
+    'children' | 'title' | 'skipWrapper'
+  >;
 };
 
-function ReviewAction({disabled, onUpdate}: Props) {
+function ReviewAction({disabled, onUpdate, tooltipProps, tooltip}: Props) {
   return (
     <ActionLink
       type="button"
       disabled={disabled}
       onAction={() => onUpdate({inbox: false})}
       icon={<IconIssues size="xs" />}
+      title={tooltip}
+      tooltipProps={tooltipProps}
     >
       {t('Mark Reviewed')}
     </ActionLink>

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -24,7 +24,6 @@ import ResolveActions from 'sentry/components/actions/resolve';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import Button from 'sentry/components/button';
 import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import Tooltip from 'sentry/components/tooltip';
 import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
@@ -380,13 +379,12 @@ class Actions extends Component<Props, State> {
             disabled={disabled}
           />
         </GuideAnchor>
-        <Tooltip
-          disabled={!!group.inbox || disabled}
-          title={t('Issue has been reviewed')}
-          delay={300}
-        >
-          <ReviewAction onUpdate={this.onUpdate} disabled={!group.inbox || disabled} />
-        </Tooltip>
+        <ReviewAction
+          onUpdate={this.onUpdate}
+          disabled={!group.inbox || disabled}
+          tooltip={t('Issue has been reviewed')}
+          tooltipProps={{disabled: !!group.inbox || disabled, delay: 300}}
+        />
         <Feature
           hookName="feature-disabled:open-in-discover"
           features={['discover-basic']}


### PR DESCRIPTION
When merge or delete is disabled, shows tooltip text. Also added a tooltip for when merge is disabled because multiple projects are selected (previously was disabled without a tooltip).