### PR TITLE
feat(discover): Event detail page context menu for custom perf metrics

### DIFF
--- a/static/app/components/events/eventCustomPerformanceMetrics.spec.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.spec.tsx
@@ -1,10 +1,15 @@
+import {browserHistory} from 'react-router';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import EventCustomPerformanceMetrics from 'sentry/components/events/eventCustomPerformanceMetrics';
 import {Event} from 'sentry/types/event';
 
 describe('EventCustomPerformanceMetrics', function () {
+  beforeEach(function () {
+    browserHistory.push = jest.fn();
+  });
   it('should not render anything', function () {
     const {router, organization} = initializeOrg();
     render(
@@ -62,5 +67,28 @@ describe('EventCustomPerformanceMetrics', function () {
     screen.getByText('456.0 KiB');
     screen.getByText('30%');
     expect(screen.queryByText('Largest Contentful Paint')).not.toBeInTheDocument();
+  });
+
+  it('should render custom performance metrics context menu', function () {
+    const {router, organization} = initializeOrg();
+    const event = TestStubs.Event({
+      measurements: {
+        'custom.size': {unit: 'kibibyte', value: 456},
+      },
+    });
+    render(
+      <EventCustomPerformanceMetrics
+        location={router.location}
+        organization={organization}
+        event={event}
+      />
+    );
+
+    expect(screen.getByLabelText('Widget actions')).toBeInTheDocument();
+    userEvent.click(screen.getByLabelText('Widget actions'));
+    expect(screen.getByText('Show events with this value')).toBeInTheDocument();
+    expect(screen.getByText('Hide events with this value')).toBeInTheDocument();
+    expect(screen.getByText('Show events with values greater than')).toBeInTheDocument();
+    expect(screen.getByText('Show events with values less than')).toBeInTheDocument();
   });
 });

--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -2,12 +2,15 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
+import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
 import FeatureBadge from 'sentry/components/featureBadge';
 import {Panel} from 'sentry/components/panels';
+import {IconEllipsis} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
+import EventView from 'sentry/utils/discover/eventView';
 import {
   DURATION_UNITS,
   FIELD_FORMATTERS,
@@ -20,6 +23,7 @@ type Props = {
   event: Event;
   location: Location;
   organization: Organization;
+  fromPerformance?: boolean;
 };
 
 function isNotMarkMeasurement(field: string) {
@@ -30,6 +34,7 @@ export default function EventCustomPerformanceMetrics({
   event,
   location,
   organization,
+  fromPerformance,
 }: Props) {
   const measurementNames = Object.keys(event.measurements ?? {})
     .filter(name => isCustomMeasurement(`measurements.${name}`))
@@ -53,6 +58,7 @@ export default function EventCustomPerformanceMetrics({
               name={name}
               location={location}
               organization={organization}
+              fromPerformance={fromPerformance}
             />
           );
         })}
@@ -88,6 +94,7 @@ function EventCustomPerformanceMetric({
   name,
   location,
   organization,
+  fromPerformance,
 }: EventCustomPerformanceMetricProps) {
   const {value, unit} = event.measurements?.[name] ?? {};
   if (value === null) {
@@ -103,12 +110,63 @@ function EventCustomPerformanceMetric({
       )
     : value;
 
+  function generateDiscoverLinkWithQuery(query: string) {
+    const eventView = EventView.fromSavedQuery({
+      query,
+      fields: [],
+      id: undefined,
+      name: '',
+      projects: [],
+      version: 1,
+    });
+    if (fromPerformance) {
+      return eventView.getPerformanceTransactionEventsViewUrlTarget(
+        organization.slug,
+        {}
+      );
+    }
+    return eventView.getResultsViewUrlTarget(organization.slug);
+  }
   return (
     <StyledPanel>
-      <div>{name}</div>
-      <ValueRow>
-        <Value>{rendered}</Value>
-      </ValueRow>
+      <div>
+        <div>{name}</div>
+        <ValueRow>
+          <Value>{rendered}</Value>
+        </ValueRow>
+      </div>
+      <StyledDropdownMenuControl
+        items={[
+          {
+            key: 'includeEvents',
+            label: t('Show events with this value'),
+            to: generateDiscoverLinkWithQuery(`measurements.${name}:${value}`),
+          },
+          {
+            key: 'excludeEvents',
+            label: t('Hide events with this value'),
+            to: generateDiscoverLinkWithQuery(`!measurements.${name}:${value}`),
+          },
+          {
+            key: 'includeGreaterThanEvents',
+            label: t('Show events with values greater than'),
+            to: generateDiscoverLinkWithQuery(`measurements.${name}:>${value}`),
+          },
+          {
+            key: 'includeLessThanEvents',
+            label: t('Show events with values less than'),
+            to: generateDiscoverLinkWithQuery(`measurements.${name}:<${value}`),
+          },
+        ]}
+        triggerProps={{
+          'aria-label': t('Widget actions'),
+          size: 'xs',
+          borderless: true,
+          showChevron: false,
+          icon: <IconEllipsis direction="down" size="sm" />,
+        }}
+        placement="bottom right"
+      />
     </StyledPanel>
   );
 }
@@ -126,6 +184,7 @@ const Container = styled('div')`
 const StyledPanel = styled(Panel)`
   padding: ${space(1)} ${space(1.5)};
   margin-bottom: ${space(1)};
+  display: flex;
 `;
 
 const ValueRow = styled('div')`
@@ -135,4 +194,8 @@ const ValueRow = styled('div')`
 
 const Value = styled('span')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
+`;
+
+const StyledDropdownMenuControl = styled(DropdownMenuControl)`
+  margin-left: auto;
 `;

--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -18,6 +18,7 @@ import {
   SIZE_UNITS,
 } from 'sentry/utils/discover/fieldRenderers';
 import {isCustomMeasurement} from 'sentry/views/dashboardsV2/utils';
+import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 type Props = {
   event: Event;
@@ -110,7 +111,7 @@ function EventCustomPerformanceMetric({
       )
     : value;
 
-  function generateDiscoverLinkWithQuery(query: string) {
+  function generateLinkWithQuery(query: string) {
     const eventView = EventView.fromSavedQuery({
       query,
       fields: [],
@@ -120,10 +121,12 @@ function EventCustomPerformanceMetric({
       version: 1,
     });
     if (fromPerformance) {
-      return eventView.getPerformanceTransactionEventsViewUrlTarget(
-        organization.slug,
-        {}
-      );
+      return transactionSummaryRouteWithQuery({
+        orgSlug: organization.slug,
+        transaction: event.title,
+        projectID: event.projectID,
+        query: {query},
+      });
     }
     return eventView.getResultsViewUrlTarget(organization.slug);
   }
@@ -140,22 +143,22 @@ function EventCustomPerformanceMetric({
           {
             key: 'includeEvents',
             label: t('Show events with this value'),
-            to: generateDiscoverLinkWithQuery(`measurements.${name}:${value}`),
+            to: generateLinkWithQuery(`measurements.${name}:${value}`),
           },
           {
             key: 'excludeEvents',
             label: t('Hide events with this value'),
-            to: generateDiscoverLinkWithQuery(`!measurements.${name}:${value}`),
+            to: generateLinkWithQuery(`!measurements.${name}:${value}`),
           },
           {
             key: 'includeGreaterThanEvents',
             label: t('Show events with values greater than'),
-            to: generateDiscoverLinkWithQuery(`measurements.${name}:>${value}`),
+            to: generateLinkWithQuery(`measurements.${name}:>${value}`),
           },
           {
             key: 'includeLessThanEvents',
             label: t('Show events with values less than'),
-            to: generateDiscoverLinkWithQuery(`measurements.${name}:<${value}`),
+            to: generateLinkWithQuery(`measurements.${name}:<${value}`),
           },
         ]}
         triggerProps={{

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -5,7 +5,9 @@ import AsyncComponent from 'sentry/components/asyncComponent';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import NotFound from 'sentry/components/errors/notFound';
-import EventCustomPerformanceMetrics from 'sentry/components/events/eventCustomPerformanceMetrics';
+import EventCustomPerformanceMetrics, {
+  EventDetailPageSource,
+} from 'sentry/components/events/eventCustomPerformanceMetrics';
 import {BorderlessEventEntries} from 'sentry/components/events/eventEntries';
 import EventMetadata from 'sentry/components/events/eventMetadata';
 import EventVitals from 'sentry/components/events/eventVitals';
@@ -255,7 +257,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                           event={event}
                           location={location}
                           organization={organization}
-                          fromPerformance
+                          source={EventDetailPageSource.PERFORMANCE}
                         />
                       )}
                       <TagsTable

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -255,6 +255,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                           event={event}
                           location={location}
                           organization={organization}
+                          fromPerformance
                         />
                       )}
                       <TagsTable


### PR DESCRIPTION
Adds a dropdown menu to Custom Performance Metrics in Event Detail pages.
Dropdown items will open links to discover or performance (depending on where the user came from), with a filter applied using the custom performance metric selected.
![image](https://user-images.githubusercontent.com/83961295/188745988-485e2c98-345c-452e-b74d-26c16977571f.png)
