### PR TITLE
perf(replays): prefetch related FileBlobs

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
@@ -61,7 +61,9 @@ class ProjectReplayRecordingSegmentIndexEndpoint(ProjectEndpoint):
         get the files associated with the segment range requested. prefetch the files
         in a threadpool.
         """
-        recording_segment_files = File.objects.filter(id__in=[r.file_id for r in results])
+        recording_segment_files = File.objects.filter(
+            id__in=[r.file_id for r in results]
+        ).prefetch_related("blobs")
         # TODO: deflate files as theyre fetched, instead of having
         # to wait untill all of them are complete before starting work.
         with ThreadPoolExecutor(max_workers=4) as exe:


### PR DESCRIPTION
this endpoint's performance can be improved, and one low hanging fruit is to use `prefetch_related` to fix the N+1 queries on `FileBlobIndex`. see example event here: https://sentry.io/organizations/sentry/discover/sentry:d3c275c510994fed8d7f4e9fe2e0b01d/

