### PR TITLE
chore(replays): remove custom rls on segment index details

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_details.py
@@ -8,19 +8,10 @@ from sentry.api.serializers import serialize
 from sentry.models import File
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.serializers import ReplayRecordingSegmentSerializer
-from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 
 class ProjectReplayRecordingSegmentDetailsEndpoint(ProjectEndpoint):
     private = True
-
-    rate_limits = {
-        "GET": {
-            RateLimitCategory.IP: RateLimit(1000, 1),
-            RateLimitCategory.USER: RateLimit(200, 1),
-            RateLimitCategory.ORGANIZATION: RateLimit(1000, 1),
-        }
-    }
 
     def get(self, request: Request, project, replay_id, segment_id) -> Response:
         if not features.has(


### PR DESCRIPTION
we temporarily set rate limits higher on our details download endpoint since the frontend had to download segments individually. we now have the index endpoint, so this customization is no longer needed.