### PR TITLE
fix(sampling): Update stepper to show 3/3

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
@@ -156,4 +156,26 @@ describe('Server-Side Sampling - Recommended Steps Modal', function () {
     userEvent.click(screen.getByRole('button', {name: 'Back'}));
     expect(onGoBack).toHaveBeenCalled();
   });
+
+  it('renders 3/3 footer', function () {
+    const {organization, project} = getMockData();
+
+    render(<GlobalModal />);
+
+    openModal(modalProps => (
+      <RecommendedStepsModal
+        {...modalProps}
+        organization={organization}
+        projectId={project.id}
+        recommendedSdkUpgrades={[]}
+        onGoBack={jest.fn()}
+        onSubmit={jest.fn()}
+        onReadDocs={jest.fn()}
+        clientSampleRate={uniformRule.sampleRate}
+        specifiedClientRate={0.1}
+      />
+    ));
+
+    expect(screen.getByText('Step 3 of 3')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
@@ -22,6 +22,7 @@ import {
   SamplingRule,
   UniformModalsSubmit,
 } from 'sentry/types/sampling';
+import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {formatPercentage} from 'sentry/utils/formatters';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
@@ -45,6 +46,7 @@ export type RecommendedStepsModalProps = ModalRenderProps & {
   onSubmit?: UniformModalsSubmit;
   recommendedSampleRate?: boolean;
   serverSampleRate?: number;
+  specifiedClientRate?: number;
   uniformRule?: SamplingRule;
 };
 
@@ -62,6 +64,7 @@ export function RecommendedStepsModal({
   serverSampleRate,
   uniformRule,
   projectId,
+  specifiedClientRate,
   recommendedSampleRate,
   onSetRules,
 }: RecommendedStepsModalProps) {
@@ -224,7 +227,9 @@ export function RecommendedStepsModal({
           <ButtonBar gap={1}>
             {onGoBack && (
               <Fragment>
-                <Stepper>{t('Step 2 of 2')}</Stepper>
+                <Stepper>
+                  {defined(specifiedClientRate) ? t('Step 3 of 3') : t('Step 2 of 2')}
+                </Stepper>
                 <Button onClick={handleGoBack}>{t('Back')}</Button>
               </Fragment>
             )}

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -351,6 +351,7 @@ export function UniformRateModal({
         projectId={project.id}
         recommendedSampleRate={!isEdited}
         onSetRules={setRules}
+        specifiedClientRate={specifiedClientRate}
       />
     );
   }


### PR DESCRIPTION
If you have to specify the client sample rate we have 3 steps in the wizard (otherwise we have 2).

The third one in the footer always showed `Step 2 of 2`.

Updating the logic so that it takes into account whether we had to specify the client rate or not.