### PR TITLE
chore(sampling): Add analytics to the specify client rate modal

### DIFF
--- a/static/app/utils/analytics/samplingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/samplingAnalyticsEvents.tsx
@@ -33,6 +33,9 @@ export type SamplingEventParameters = {
     conditions: SamplingInnerName[] | string[];
     project_id: string;
   };
+  'sampling.settings.modal.specify.client.open': {
+    project_id: string;
+  };
   'sampling.settings.modal.specify.client.rate_cancel': {
     project_id: string;
   };
@@ -131,6 +134,7 @@ export const samplingEventMap: Record<SamplingAnalyticsKey, string> = {
   'sampling.settings.modal.specify.client.rate_cancel':
     'Cancel at specify client rate step',
   'sampling.settings.modal.specify.client.rate_next': 'Go to uniform rate step',
+  'sampling.settings.modal.specify.client.open': 'Open specify client step',
   'sampling.settings.rule.specific_create': 'Create specific sampling rule',
   'sampling.settings.rule.specific_delete': 'Delete specific sampling rule',
   'sampling.settings.rule.specific_save': 'Save specific sampling rule', // fired for both create and update

--- a/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specifyClientRateModal.tsx
@@ -35,6 +35,13 @@ export function SpecifyClientRateModal({
   onChange,
 }: SpecifyClientRateModalProps) {
   useEffect(() => {
+    trackAdvancedAnalyticsEvent('sampling.settings.modal.specify.client.open', {
+      organization,
+      project_id: projectId,
+    });
+  }, [organization, projectId]);
+
+  useEffect(() => {
     onChange(0.1);
   }, [onChange]);
 


### PR DESCRIPTION
We want to measure the dropoff between seeing this step and going to the uniform rate modal.