### PR TITLE
ref(time-range-format-function): Update the logic to display trailing zero after the decimal point

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -51,7 +51,7 @@ import InlineDocs from './inlineDocs';
 import {ParsedTraceType, ProcessedSpanType, rawSpanKeys, RawSpanType} from './types';
 import {
   getCumulativeAlertLevelFromErrors,
-  getFormattedTimeRangeWithLeadingZero,
+  getFormattedTimeRangeWithLeadingAndTrailingZero,
   getTraceDateTimeRange,
   isGapSpan,
   isOrphanSpan,
@@ -358,7 +358,7 @@ class SpanDetail extends Component<Props, State> {
     const startTimestamp: number = span.start_timestamp;
     const endTimestamp: number = span.timestamp;
     const {start: startTimeWithLeadingZero, end: endTimeWithLeadingZero} =
-      getFormattedTimeRangeWithLeadingZero(startTimestamp, endTimestamp);
+      getFormattedTimeRangeWithLeadingAndTrailingZero(startTimestamp, endTimestamp);
 
     const duration = (endTimestamp - startTimestamp) * 1000;
     const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;

--- a/static/app/components/events/interfaces/spans/utils.spec.tsx
+++ b/static/app/components/events/interfaces/spans/utils.spec.tsx
@@ -1,27 +1,36 @@
 import {
   getCumulativeAlertLevelFromErrors,
-  getFormattedTimeRangeWithLeadingZero,
+  getFormattedTimeRangeWithLeadingAndTrailingZero,
 } from 'sentry/components/events/interfaces/spans/utils';
 
 describe('test utility functions', function () {
-  it('getFormattedTimeRangeWithLeadingZero', function () {
-    let result = getFormattedTimeRangeWithLeadingZero(
+  it('getFormattedTimeRangeWithLeadingAndTrailingZero', function () {
+    let result = getFormattedTimeRangeWithLeadingAndTrailingZero(
       1658925888.601534,
       1658925888.60193
     );
 
     expect(result.start).toEqual('1658925888.601534');
-    expect(result.end).toEqual('1658925888.060193');
+    expect(result.end).toEqual('1658925888.601930');
 
-    result = getFormattedTimeRangeWithLeadingZero(1658925888.601534, 165892588.060193);
+    result = getFormattedTimeRangeWithLeadingAndTrailingZero(
+      1658925888.601534,
+      165892588.060193
+    );
     expect(result.start).toEqual('1658925888.601534');
     expect(result.end).toEqual('0165892588.060193');
 
-    result = getFormattedTimeRangeWithLeadingZero(16589258.6015, 1658925888.060193);
-    expect(result.start).toEqual('0016589258.006015');
+    result = getFormattedTimeRangeWithLeadingAndTrailingZero(
+      16589258.6015,
+      1658925888.060193
+    );
+    expect(result.start).toEqual('0016589258.601500');
     expect(result.end).toEqual('1658925888.060193');
 
-    result = getFormattedTimeRangeWithLeadingZero(1658925888.601534, 1658925888.601935);
+    result = getFormattedTimeRangeWithLeadingAndTrailingZero(
+      1658925888.601534,
+      1658925888.601935
+    );
     expect(result.start).toEqual('1658925888.601534');
     expect(result.end).toEqual('1658925888.601935');
   });

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -907,13 +907,16 @@ const ERROR_LEVEL_WEIGHTS: Record<TraceError['level'], number> = {
 };
 
 /**
- * Formats start and end unix timestamps by inserting a leading zero if needed, so they can have the same length
+ * Formats start and end unix timestamps by inserting a leading and trailing zero if needed, so they can have the same length
  */
-export function getFormattedTimeRangeWithLeadingZero(start: number, end: number) {
+export function getFormattedTimeRangeWithLeadingAndTrailingZero(
+  start: number,
+  end: number
+) {
   const startStrings = String(start).split('.');
   const endStrings = String(end).split('.');
 
-  if (startStrings.length !== endStrings.length) {
+  if (startStrings.length !== 2 || endStrings.length !== 2) {
     return {
       start: String(start),
       end: String(end),
@@ -924,11 +927,19 @@ export function getFormattedTimeRangeWithLeadingZero(start: number, end: number)
     (acc, startString, index) => {
       if (startString.length > endStrings[index].length) {
         acc.start.push(startString);
-        acc.end.push(endStrings[index].padStart(startString.length, '0'));
+        acc.end.push(
+          index === 0
+            ? endStrings[index].padStart(startString.length, '0')
+            : endStrings[index].padEnd(startString.length, '0')
+        );
         return acc;
       }
 
-      acc.start.push(startString.padStart(endStrings[index].length, '0'));
+      acc.start.push(
+        index === 0
+          ? startString.padStart(endStrings[index].length, '0')
+          : startString.padEnd(endStrings[index].length, '0')
+      );
       acc.end.push(endStrings[index]);
       return acc;
     },

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -8,7 +8,7 @@ import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import Clipboard from 'sentry/components/clipboard';
 import DateTime from 'sentry/components/dateTime';
-import {getFormattedTimeRangeWithLeadingZero} from 'sentry/components/events/interfaces/spans/utils';
+import {getFormattedTimeRangeWithLeadingAndTrailingZero} from 'sentry/components/events/interfaces/spans/utils';
 import Link from 'sentry/components/links/link';
 import {
   ErrorDot,
@@ -177,7 +177,7 @@ class TransactionDetail extends Component<Props> {
     const startTimestamp = Math.min(transaction.start_timestamp, transaction.timestamp);
     const endTimestamp = Math.max(transaction.start_timestamp, transaction.timestamp);
     const {start: startTimeWithLeadingZero, end: endTimeWithLeadingZero} =
-      getFormattedTimeRangeWithLeadingZero(startTimestamp, endTimestamp);
+      getFormattedTimeRangeWithLeadingAndTrailingZero(startTimestamp, endTimestamp);
     const duration = (endTimestamp - startTimestamp) * 1000;
     const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;
 


### PR DESCRIPTION
**What this PR does:**

- Applies the feedback https://github.com/getsentry/sentry/pull/38202#issuecomment-1237272919 as trailing zeros after the decimal point do not affect the value of a number