### PR TITLE
feat(metrics): Support field aliasing on metrics layer [TET-322 TET-356]

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -820,7 +820,9 @@ def get_series(
     if len(result_groups) > metrics_query.limit.limit:
         result_groups = result_groups[0 : metrics_query.limit.limit]
 
-    metrics_query_fields = {str(metric_field) for metric_field in metrics_query.select}
+    metrics_query_fields = {
+        str(metric_field) for metric_field in converter._alias_to_metric_obj.keys()
+    }
 
     return {
         "start": metrics_query.start,

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -520,7 +520,7 @@ class MetricExpression(MetricExpressionDefinition, MetricExpressionBase):
     conversions to SnQL away from the query builder.
     """
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.metric_operation.op}({self.metric_object.metric_mri})"
 
     def get_entity(self, projects: Sequence[Project], use_case_id: UseCaseKey) -> MetricEntity:
@@ -552,7 +552,7 @@ class MetricExpression(MetricExpressionDefinition, MetricExpressionBase):
         projects: Sequence[Project],
         metrics_query: MetricsQuery,
         use_case_id: UseCaseKey,
-        alias: str = None,
+        alias: str,
     ) -> List[OrderBy]:
         self.metric_operation.validate_can_orderby()
         return [
@@ -594,7 +594,7 @@ class MetricExpression(MetricExpressionDefinition, MetricExpressionBase):
 
     def generate_bottom_up_derived_metrics_dependencies(
         self, alias: str
-    ) -> Iterable[Tuple[MetricOperationType, str, Optional[str]]]:
+    ) -> Iterable[Tuple[MetricOperationType, str, str]]:
         return [(self.metric_operation.op, self.metric_object.metric_mri, alias)]
 
     def build_conditional_aggregate_for_metric(
@@ -651,7 +651,7 @@ class DerivedMetricExpression(DerivedMetricExpressionDefinition, MetricExpressio
             f"{get_public_name_from_mri(self.metric_mri)} with a `projects` attribute."
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.metric_mri
 
 
@@ -752,6 +752,8 @@ class SingularEntityDerivedMetric(DerivedMetricExpression):
             arg_snql += cls.__recursively_generate_select_snql(org_id, arg, use_case_id)
 
         if alias is None:
+            # Aliases on components of SingularEntityDerivedMetric do not really matter as these evaluate to a single
+            # expression, and so what matters is the alias on that top level expression
             alias = derived_metric_mri
 
         assert derived_metric.snql is not None
@@ -931,7 +933,7 @@ class CompositeEntityDerivedMetric(DerivedMetricExpression):
         return entities_and_metric_mris
 
     def generate_bottom_up_derived_metrics_dependencies(
-        self, alias
+        self, alias: str
     ) -> Iterable[Tuple[Optional[MetricOperationType], str, str]]:
         # We are only interested in the dependency tree from instances of
         # CompositeEntityDerivedMetric as they don't have a direct mapping to SnQL and so
@@ -1328,7 +1330,7 @@ def metric_object_factory(
 
 
 def generate_bottom_up_dependency_tree_for_metrics(
-    metrics_query_fields_set: Set[Tuple[Optional[MetricOperationType], str]]
+    metrics_query_fields_set: Set[Tuple[Optional[MetricOperationType], str, str]]
 ) -> List[Tuple[Optional[MetricOperationType], str, str]]:
     """
     This function basically generates a dependency list for all instances of

--- a/src/sentry/snuba/metrics/naming_layer/mapping.py
+++ b/src/sentry/snuba/metrics/naming_layer/mapping.py
@@ -70,9 +70,11 @@ def get_public_name_from_mri(internal_name: Union[TransactionMRI, SessionMRI, st
 
 
 def get_operation_with_public_name(operation: Optional[str], metric_mri: str) -> str:
-    if operation is None:
-        return get_public_name_from_mri(metric_mri)
-    return f"{operation}({get_public_name_from_mri(metric_mri)})"
+    return (
+        f"{operation}({get_public_name_from_mri(metric_mri)})"
+        if operation is not None
+        else metric_mri
+    )
 
 
 def parse_expression(name: str) -> Tuple[Optional[str], str]:

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -32,6 +32,14 @@ from .utils import (
 class MetricField:
     op: Optional[MetricOperationType]
     metric_name: str
+    alias: Optional[str] = None
+
+    def __post_init__(self):
+        # ToDo(ahmed): Once we allow MetricField to accept MRI, we should set the alias to the operation and public
+        #  facing name
+        if not self.alias:
+            key = f"{self.op}({self.metric_name})" if self.op is not None else self.metric_name
+            object.__setattr__(self, "alias", key)
 
     def __str__(self) -> str:
         return f"{self.op}({self.metric_name})" if self.op else self.metric_name

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -34,7 +34,7 @@ class MetricField:
     metric_name: str
     alias: Optional[str] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         # ToDo(ahmed): Once we allow MetricField to accept MRI, we should set the alias to the operation and public
         #  facing name
         if not self.alias:

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1856,19 +1856,6 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
         assert group["totals"]["session.errored"] == 7
         assert group["series"]["session.errored"] == [0, 4, 0, 0, 0, 3]
 
-        response = self.get_success_response(
-            self.organization.slug,
-            field=["session.errored"],
-            statsPeriod="6m",
-            interval="1m",
-        )
-        group = response.data["groups"][0]
-        assert group == {
-            "by": {},
-            "totals": {"session.errored": 7},
-            "series": {"session.errored": [0, 4, 0, 0, 0, 3]},
-        }
-
     def test_orderby_composite_entity_derived_metric(self):
         self.store_session(
             self.build_session(

--- a/tests/sentry/snuba/metrics/fields/test_base.py
+++ b/tests/sentry/snuba/metrics/fields/test_base.py
@@ -17,6 +17,7 @@ from sentry.snuba.metrics import (
     SingularEntityDerivedMetric,
 )
 from sentry.snuba.metrics.fields.base import (
+    COMPOSITE_ENTITY_CONSTITUENT_ALIAS,
     DERIVED_ALIASES,
     CompositeEntityDerivedMetric,
     _get_known_entity_of_metric_mri,
@@ -515,22 +516,22 @@ class CompositeEntityDerivedMetricTestCase(TestCase):
             (
                 None,
                 SessionMRI.ERRORED_SET.value,
-                f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{alias}",
+                f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}",
             ),
             (
                 None,
                 SessionMRI.ERRORED_PREAGGREGATED.value,
-                f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{alias}",
+                f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}",
             ),
             (
                 None,
                 SessionMRI.CRASHED_AND_ABNORMAL.value,
-                f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{alias}",
+                f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}",
             ),
             (
                 None,
                 SessionMRI.ERRORED_ALL.value,
-                f"{SessionMRI.ERRORED_ALL.value}__CHILD_OF__{alias}",
+                f"{SessionMRI.ERRORED_ALL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}",
             ),
             (None, SessionMRI.ERRORED.value, alias),
         ]
@@ -544,24 +545,28 @@ class CompositeEntityDerivedMetricTestCase(TestCase):
             (
                 None,
                 SessionMRI.ERRORED_SET.value,
-                f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{alias}",
+                f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}",
             ),
             (
                 None,
                 SessionMRI.ERRORED_PREAGGREGATED.value,
-                f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{alias}",
+                f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}",
             ),
             (
                 None,
                 SessionMRI.CRASHED_AND_ABNORMAL.value,
-                f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{alias}",
+                f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}",
             ),
             (
                 None,
                 SessionMRI.ERRORED_ALL.value,
-                f"{SessionMRI.ERRORED_ALL.value}__CHILD_OF__{alias}",
+                f"{SessionMRI.ERRORED_ALL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}",
             ),
-            (None, SessionMRI.ERRORED.value, f"{SessionMRI.ERRORED.value}__CHILD_OF__{alias}"),
+            (
+                None,
+                SessionMRI.ERRORED.value,
+                f"{SessionMRI.ERRORED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}",
+            ),
             (None, "random_composite", alias),
         ]
 
@@ -569,18 +574,53 @@ class CompositeEntityDerivedMetricTestCase(TestCase):
         metrics_query = object()
         alias = "sessions_errored"
         totals = {
-            f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{alias}": 3,
-            f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{alias}": 4.0,
-            f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{alias}": 0,
-            f"{SessionMRI.ERRORED.value}__CHILD_OF__{alias}": 0,
-            f"{SessionMRI.ERRORED_ALL.value}__CHILD_OF__{alias}": 7,
+            f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": 3,
+            f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": 4.0,
+            f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": 0,
+            f"{SessionMRI.ERRORED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": 0,
+            f"{SessionMRI.ERRORED_ALL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": 7,
         }
         series = {
-            f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{alias}": [0, 0, 0, 0, 3, 0],
-            f"{SessionMRI.ERRORED.value}__CHILD_OF__{alias}": [0, 0, 0, 0, 0, 0],
-            f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{alias}": [4.0, 0, 0, 0, 0, 0],
-            f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{alias}": [0, 0, 0, 0, 0, 0],
-            f"{SessionMRI.ERRORED_ALL.value}__CHILD_OF__{alias}": [4.0, 0, 0, 0, 3, 0],
+            f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": [
+                0,
+                0,
+                0,
+                0,
+                3,
+                0,
+            ],
+            f"{SessionMRI.ERRORED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": [
+                4.0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+            ],
+            f"{SessionMRI.ERRORED_ALL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{alias}": [
+                4.0,
+                0,
+                0,
+                0,
+                3,
+                0,
+            ],
         }
         assert (
             self.sessions_errored.run_post_query_function(

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -1,15 +1,27 @@
 """
 Metrics Service Layer Tests for Performance
 """
+import time
 from datetime import timedelta
 from unittest import mock
 
 import pytest
+from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
+from freezegun import freeze_time
+from snuba_sdk import Direction, Granularity, Limit, Offset
 
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.snuba.metrics import (
+    MetricField,
+    MetricsQuery,
+    OrderBy,
+    TransactionStatusTagValue,
+    TransactionTagsKey,
+)
 from sentry.snuba.metrics.datasource import get_custom_measurements, get_series
+from sentry.snuba.metrics.naming_layer import TransactionMetricKey, TransactionMRI
 from sentry.snuba.metrics.query_builder import QueryDefinition
 from sentry.testutils import BaseMetricsTestCase, TestCase
 from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
@@ -49,6 +61,229 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             ],
             key=lambda elem: elem["name"],
         )
+
+    def test_alias_on_different_metrics_expression(self):
+        now = before_now(minutes=0)
+
+        for v_transaction, count in (("/foo", 1), ("/bar", 3), ("/baz", 2)):
+            for value in [123.4] * count:
+                self.store_metric(
+                    org_id=self.organization.id,
+                    project_id=self.project.id,
+                    type="distribution",
+                    name=TransactionMRI.MEASUREMENTS_LCP.value,
+                    tags={"transaction": v_transaction, "measurement_rating": "poor"},
+                    timestamp=int(time.time()),
+                    value=value,
+                    use_case_id=UseCaseKey.PERFORMANCE,
+                )
+
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="count",
+                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    alias="count_lcp",
+                ),
+                MetricField(
+                    op="count",
+                    metric_name=TransactionMetricKey.MEASUREMENTS_FCP.value,
+                    alias="count_fcp",
+                ),
+            ],
+            start=now - timedelta(hours=1),
+            end=now,
+            granularity=Granularity(granularity=3600),
+            groupby=["transaction"],
+            orderby=[
+                OrderBy(
+                    MetricField(
+                        op="count",
+                        metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                        alias="count_lcp",
+                    ),
+                    Direction.DESC,
+                ),
+                OrderBy(
+                    MetricField(
+                        op="count",
+                        metric_name=TransactionMetricKey.MEASUREMENTS_FCP.value,
+                        alias="count_fcp",
+                    ),
+                    Direction.DESC,
+                ),
+            ],
+            limit=Limit(limit=2),
+            offset=Offset(offset=0),
+            include_series=False,
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=True,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+        groups = data["groups"]
+        assert len(groups) == 2
+
+        expected = [
+            ("/bar", 3),
+            ("/baz", 2),
+        ]
+        for (expected_transaction, expected_count), group in zip(expected, groups):
+            # With orderBy, you only get totals:
+            assert group["by"] == {"transaction": expected_transaction}
+            assert group["totals"] == {
+                "count_lcp": expected_count,
+                "count_fcp": 0,
+            }
+
+        assert data["meta"] == sorted(
+            [
+                {"name": "count_fcp", "type": "UInt64"},
+                {"name": "count_lcp", "type": "UInt64"},
+                {"name": "transaction", "type": "string"},
+            ],
+            key=lambda elem: elem["name"],
+        )
+
+    def test_alias_on_same_metrics_expression_but_different_aliases(self):
+        now = before_now(minutes=0)
+        for v_transaction, count in (("/foo", 1), ("/bar", 3), ("/baz", 2)):
+            for value in [123.4] * count:
+                self.store_metric(
+                    org_id=self.organization.id,
+                    project_id=self.project.id,
+                    type="distribution",
+                    name=TransactionMRI.MEASUREMENTS_LCP.value,
+                    tags={"transaction": v_transaction, "measurement_rating": "poor"},
+                    timestamp=int(time.time()),
+                    value=value,
+                    use_case_id=UseCaseKey.PERFORMANCE,
+                )
+
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="count",
+                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    alias="count_lcp",
+                ),
+                MetricField(
+                    op="count",
+                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    alias="count_lcp_2",
+                ),
+            ],
+            start=now - timedelta(hours=1),
+            end=now,
+            granularity=Granularity(granularity=3600),
+            groupby=["transaction"],
+            orderby=[
+                OrderBy(
+                    MetricField(
+                        op="count",
+                        metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                        alias="count_lcp",
+                    ),
+                    Direction.DESC,
+                ),
+                OrderBy(
+                    MetricField(
+                        op="count",
+                        metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                        alias="count_lcp_2",
+                    ),
+                    Direction.DESC,
+                ),
+            ],
+            limit=Limit(limit=2),
+            offset=Offset(offset=0),
+            include_series=False,
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=True,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+        print(data["meta"])
+        groups = data["groups"]
+        assert len(groups) == 2
+
+        expected = [
+            ("/bar", 3),
+            ("/baz", 2),
+        ]
+        for (expected_transaction, expected_count), group in zip(expected, groups):
+            # With orderBy, you only get totals:
+            assert group["by"] == {"transaction": expected_transaction}
+            assert group["totals"] == {
+                "count_lcp": expected_count,
+                "count_lcp_2": expected_count,
+            }
+        assert data["meta"] == sorted(
+            [
+                {"name": "count_lcp", "type": "UInt64"},
+                {"name": "count_lcp_2", "type": "UInt64"},
+                {"name": "transaction", "type": "string"},
+            ],
+            key=lambda elem: elem["name"],
+        )
+
+    @freeze_time()
+    def test_alias_on_single_entity_derived_metrics(self):
+        now = timezone.now()
+
+        for value, tag_value in (
+            (3.4, TransactionStatusTagValue.OK.value),
+            (0.3, TransactionStatusTagValue.CANCELLED.value),
+            (2.3, TransactionStatusTagValue.UNKNOWN.value),
+            (0.5, TransactionStatusTagValue.ABORTED.value),
+        ):
+            self.store_metric(
+                org_id=self.organization.id,
+                project_id=self.project.id,
+                type="distribution",
+                name=TransactionMRI.DURATION.value,
+                tags={TransactionTagsKey.TRANSACTION_STATUS.value: tag_value},
+                timestamp=now.timestamp(),
+                value=value,
+                use_case_id=UseCaseKey.PERFORMANCE,
+            )
+
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op=None,
+                    metric_name=TransactionMetricKey.FAILURE_RATE.value,
+                    alias="failure_rate_alias",
+                ),
+            ],
+            start=now - timedelta(minutes=1),
+            end=now,
+            granularity=Granularity(granularity=60),
+            limit=Limit(limit=2),
+            offset=Offset(offset=0),
+            include_series=False,
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=True,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+        assert len(data["groups"]) == 1
+        group = data["groups"][0]
+        assert group["by"] == {}
+        assert group["totals"] == {"failure_rate_alias": 0.25}
+        assert data["meta"] == [{"name": "failure_rate_alias", "type": "Float64"}]
 
 
 class GetCustomMeasurementsTestCase(MetricsEnhancedPerformanceTestCase):

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -211,7 +211,6 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             include_meta=True,
             use_case_id=UseCaseKey.PERFORMANCE,
         )
-        print(data["meta"])
         groups = data["groups"]
         assert len(groups) == 2
 

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
@@ -5,10 +5,13 @@ import time
 
 import pytest
 from django.utils.datastructures import MultiValueDict
+from snuba_sdk import Granularity, Limit, Offset
 
 from sentry.sentry_metrics.configuration import UseCaseKey
+from sentry.snuba.metrics import MetricField, MetricsQuery
 from sentry.snuba.metrics.datasource import get_series
-from sentry.snuba.metrics.query_builder import QueryDefinition
+from sentry.snuba.metrics.naming_layer import SessionMetricKey, SessionMRI
+from sentry.snuba.metrics.query_builder import QueryDefinition, get_date_range
 from sentry.testutils import BaseMetricsTestCase, TestCase
 
 pytestmark = pytest.mark.sentry_metrics
@@ -41,6 +44,7 @@ class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             include_meta=True,
             use_case_id=UseCaseKey.RELEASE_HEALTH,
         )
+        print(data["meta"])
         assert data["meta"] == sorted(
             [
                 {"name": "environment", "type": "string"},
@@ -51,7 +55,7 @@ class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             key=lambda elem: elem["name"],
         )
 
-    def test_validate_include_meta_only_non_composite_derived_metrics_and_in_select(self):
+    def test_validate_include_meta_computes_meta_for_composite_derived_metrics(self):
         query_params = MultiValueDict(
             {
                 "field": [
@@ -62,12 +66,85 @@ class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             }
         )
         query = QueryDefinition([self.project], query_params)
-        assert (
-            get_series(
-                [self.project],
-                query.to_metrics_query(),
-                include_meta=True,
+        assert get_series(
+            [self.project],
+            query.to_metrics_query(),
+            include_meta=True,
+            use_case_id=UseCaseKey.RELEASE_HEALTH,
+        )["meta"] == sorted(
+            [
+                {"name": "session.errored", "type": "Float64"},
+                {"name": "session.healthy", "type": "Float64"},
+            ],
+            key=lambda elem: elem["name"],
+        )
+
+    def test_alias_on_composite_entity_derived_metric(self):
+        user_ts = time.time()
+        org_id = self.organization.id
+
+        for tag_value, count_value in (
+            ("errored_preaggr", 10),
+            ("crashed", 2),
+            ("abnormal", 4),
+            ("init", 15),
+        ):
+            self.store_metric(
+                org_id=org_id,
+                project_id=self.project.id,
+                type="counter",
+                name=str(SessionMRI.SESSION.value),
+                tags={"session.status": tag_value},
+                timestamp=(user_ts // 60 - 4) * 60,
+                value=count_value,
                 use_case_id=UseCaseKey.RELEASE_HEALTH,
-            )["meta"]
-            == []
+            )
+        for value in range(3):
+            self.store_metric(
+                org_id=org_id,
+                project_id=self.project.id,
+                type="set",
+                name=str(SessionMRI.ERROR.value),
+                tags={"release": "foo"},
+                timestamp=user_ts,
+                value=value,
+                use_case_id=UseCaseKey.RELEASE_HEALTH,
+            )
+        start, end, rollup = get_date_range(
+            {
+                "statsPeriod": "6m",
+                "interval": "1m",
+            }
+        )
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op=None,
+                    metric_name=str(SessionMetricKey.ERRORED.value),
+                    alias="errored_sessions_alias",
+                ),
+            ],
+            start=start,
+            end=end,
+            granularity=Granularity(granularity=rollup),
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=True,
+            use_case_id=UseCaseKey.RELEASE_HEALTH,
+        )
+        group = data["groups"][0]
+        assert group["totals"]["errored_sessions_alias"] == 7
+        assert group["series"]["errored_sessions_alias"] == [0, 4, 0, 0, 0, 3]
+        assert data["meta"] == sorted(
+            [
+                {"name": "errored_sessions_alias", "type": "Float64"},
+                {"name": "bucketed_time", "type": "DateTime('Universal')"},
+            ],
+            key=lambda elem: elem["name"],
         )

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
@@ -44,7 +44,6 @@ class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             include_meta=True,
             use_case_id=UseCaseKey.RELEASE_HEALTH,
         )
-        print(data["meta"])
         assert data["meta"] == sorted(
             [
                 {"name": "environment", "type": "string"},

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -44,6 +44,7 @@ from sentry.snuba.metrics import (
     resolve_tags,
     translate_meta_results,
 )
+from sentry.snuba.metrics.fields.base import COMPOSITE_ENTITY_CONSTITUENT_ALIAS
 from sentry.snuba.metrics.fields.snql import (
     abnormal_sessions,
     addition,
@@ -428,12 +429,12 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
             (
                 None,
                 SessionMRI.ERRORED_PREAGGREGATED.value,
-                f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}",
+                f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
             ),
             (
                 None,
                 SessionMRI.CRASHED_AND_ABNORMAL.value,
-                f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}",
+                f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
             ),
             (None, SessionMRI.CRASH_FREE_RATE.value, SessionMetricKey.CRASH_FREE_RATE.value),
             (None, SessionMRI.ALL.value, SessionMetricKey.ALL.value),
@@ -442,7 +443,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
             (
                 None,
                 SessionMRI.ERRORED_SET.value,
-                f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}",
+                f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
             ),
         ],
     }
@@ -455,7 +456,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
                     errored_preaggr_sessions(
                         org_id,
                         metric_ids=[resolve_weak(use_case_id, org_id, SessionMRI.SESSION.value)],
-                        alias=f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}",
+                        alias=f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
                     ),
                     addition(
                         crashed_sessions(
@@ -472,7 +473,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
                             ],
                             alias=SessionMRI.ABNORMAL.value,
                         ),
-                        alias=f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}",
+                        alias=f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
                     ),
                     complement(
                         division_float(
@@ -527,7 +528,7 @@ def test_build_snuba_query_derived_metrics(mock_now, mock_now2):
                 select=[
                     uniq_aggregation_on_metric(
                         metric_ids=[resolve_weak(use_case_id, org_id, SessionMRI.ERROR.value)],
-                        alias=f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}",
+                        alias=f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
                     ),
                 ],
                 groupby=groupby,
@@ -777,12 +778,12 @@ def test_translate_results_derived_metrics(_1, _2):
             (
                 None,
                 SessionMRI.ERRORED_PREAGGREGATED.value,
-                f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}",
+                f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
             ),
             (
                 None,
                 SessionMRI.CRASHED_AND_ABNORMAL.value,
-                f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}",
+                f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
             ),
             (None, SessionMRI.CRASH_FREE_RATE.value, SessionMetricKey.CRASH_FREE_RATE.value),
             (None, SessionMRI.ALL.value, SessionMetricKey.ALL.value),
@@ -791,7 +792,7 @@ def test_translate_results_derived_metrics(_1, _2):
             (
                 None,
                 SessionMRI.ERRORED_SET.value,
-                f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}",
+                f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}",
             ),
         ],
     }
@@ -806,8 +807,8 @@ def test_translate_results_derived_metrics(_1, _2):
                     {
                         SessionMetricKey.CRASH_FREE_RATE.value: 0.5,
                         SessionMetricKey.ALL.value: 8.0,
-                        f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}": 3,
-                        f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}": 0,
+                        f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}": 3,
+                        f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}": 0,
                     }
                 ],
             },
@@ -817,15 +818,15 @@ def test_translate_results_derived_metrics(_1, _2):
                         "bucketed_time": "2021-08-24T00:00Z",
                         SessionMetricKey.CRASH_FREE_RATE.value: 0.5,
                         SessionMetricKey.ALL.value: 4,
-                        f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}": 1,
-                        f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}": 0,
+                        f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}": 1,
+                        f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}": 0,
                     },
                     {
                         "bucketed_time": "2021-08-25T00:00Z",
                         SessionMetricKey.CRASH_FREE_RATE.value: 0.5,
                         SessionMetricKey.ALL.value: 4,
-                        f"{SessionMRI.ERRORED_PREAGGREGATED.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}": 2,
-                        f"{SessionMRI.CRASHED_AND_ABNORMAL.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}": 0,
+                        f"{SessionMRI.ERRORED_PREAGGREGATED.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}": 2,
+                        f"{SessionMRI.CRASHED_AND_ABNORMAL.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}": 0,
                     },
                 ],
             },
@@ -834,7 +835,7 @@ def test_translate_results_derived_metrics(_1, _2):
             "totals": {
                 "data": [
                     {
-                        f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}": 3,
+                        f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}": 3,
                     },
                 ],
             },
@@ -842,11 +843,11 @@ def test_translate_results_derived_metrics(_1, _2):
                 "data": [
                     {
                         "bucketed_time": "2021-08-24T00:00Z",
-                        f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}": 2,
+                        f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}": 2,
                     },
                     {
                         "bucketed_time": "2021-08-25T00:00Z",
-                        f"{SessionMRI.ERRORED_SET.value}__CHILD_OF__{SessionMetricKey.ERRORED.value}": 1,
+                        f"{SessionMRI.ERRORED_SET.value}{COMPOSITE_ENTITY_CONSTITUENT_ALIAS}{SessionMetricKey.ERRORED.value}": 1,
                     },
                 ],
             },


### PR DESCRIPTION
Adds logic that allows for aliasing on all instances of `MetricField`. If `MetricField` references an metrics expression or an instance of `SingleEntityDerivedMetric` then, the alias is propagated down to query level, and the response has the aliased names. If however, it references an instance of `CompositeEntityDerivedMetric`, then it creates alias that corresponds to the mri of the constituent suffixed with `__CHILD_OF__<parent_alias>`, and then post query the value of the composite derived metric is computed from the children values. This alias suffixing behaviour allows us to avoid naming collisions when requesting the same composite dervied metric more than once but with different arguments. This PR also adds meta type for composite entity derived metric.

ToDo:
- Will handle aliasing groupBy aliasing in a subsequent PR

