### PR TITLE
ref(perf-issue): Remodel span evidence section

### DIFF
--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -181,6 +181,7 @@ function EventEntry({
 
       // TODO: Replace this with real data from the entry when possible
       const SAMPLE_SPAN_EVIDENCE: SpanEvidence = {
+        transaction: '/api/transaction/00',
         parentSpan: 'index',
         sourceSpan:
           'SELECT "sentry_useroption"."id", "sentry_useroption"."user_id", "sentry_useroption"."project_id", "sentry_useroption"."organization_id", "sentry_useroption"."key", "sentry_useroption"."value" FROM "sentry_useroption" WHERE ("sentry_useroption"."organization_id" IS NULL AND "sentry_useroption"."project_id" IS NULL AND "sentry_useroption"."user_id" = %s) ',

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -1,5 +1,3 @@
-import {Fragment} from 'react';
-
 import Breadcrumbs from 'sentry/components/events/interfaces/breadcrumbs';
 import {Csp} from 'sentry/components/events/interfaces/csp';
 import {DebugMeta} from 'sentry/components/events/interfaces/debugMeta';
@@ -177,16 +175,14 @@ function EventEntry({
       };
 
       return (
-        <Fragment>
-          <SpanEvidenceSection
-            issue={group as Group}
-            event={event}
-            organization={organization as Organization}
-            spanEvidence={SAMPLE_SPAN_EVIDENCE}
-            projectSlug={INTERNAL_PROJECT}
-            affectedSpanIds={affectedSpanIds}
-          />
-        </Fragment>
+        <SpanEvidenceSection
+          issue={group as Group}
+          event={event}
+          organization={organization as Organization}
+          spanEvidence={SAMPLE_SPAN_EVIDENCE}
+          projectSlug={INTERNAL_PROJECT}
+          affectedSpanIds={affectedSpanIds}
+        />
       );
     default:
       // this should not happen

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import Breadcrumbs from 'sentry/components/events/interfaces/breadcrumbs';
 import {Csp} from 'sentry/components/events/interfaces/csp';
 import {DebugMeta} from 'sentry/components/events/interfaces/debugMeta';
@@ -156,7 +158,7 @@ function EventEntry({
           organization={organization as Organization}
         />
       );
-    case EntryType.SPANTREE:
+    case EntryType.PERFORMANCE:
       if (!organization.features?.includes('performance-issues')) {
         return null;
       }
@@ -165,19 +167,6 @@ function EventEntry({
 
       // TODO: Need to dynamically determine the project slug for this issue
       const INTERNAL_PROJECT = 'sentry';
-
-      return (
-        <EmbeddedSpanTree
-          event={event}
-          organization={organization as Organization}
-          projectSlug={INTERNAL_PROJECT}
-          affectedSpanIds={affectedSpanIds}
-        />
-      );
-    case EntryType.PERFORMANCE:
-      if (!organization.features?.includes('performance-issues')) {
-        return null;
-      }
 
       // TODO: Replace this with real data from the entry when possible
       const SAMPLE_SPAN_EVIDENCE: SpanEvidence = {
@@ -190,12 +179,20 @@ function EventEntry({
       };
 
       return (
-        <PerformanceIssueSection
-          issue={group as Group}
-          event={event as EventError}
-          organization={organization as Organization}
-          spanEvidence={SAMPLE_SPAN_EVIDENCE}
-        />
+        <Fragment>
+          <PerformanceIssueSection
+            issue={group as Group}
+            event={event as EventError}
+            organization={organization as Organization}
+            spanEvidence={SAMPLE_SPAN_EVIDENCE}
+          />
+          <EmbeddedSpanTree
+            event={event}
+            organization={organization as Organization}
+            projectSlug={INTERNAL_PROJECT}
+            affectedSpanIds={affectedSpanIds}
+          />
+        </Fragment>
       );
     default:
       // this should not happen

--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -8,8 +8,8 @@ import ExceptionV2 from 'sentry/components/events/interfaces/exceptionV2';
 import {Generic} from 'sentry/components/events/interfaces/generic';
 import {Message} from 'sentry/components/events/interfaces/message';
 import {
-  PerformanceIssueSection,
   SpanEvidence,
+  SpanEvidenceSection,
 } from 'sentry/components/events/interfaces/performance';
 import {Request} from 'sentry/components/events/interfaces/request';
 import Spans from 'sentry/components/events/interfaces/spans';
@@ -19,9 +19,7 @@ import {Template} from 'sentry/components/events/interfaces/template';
 import Threads from 'sentry/components/events/interfaces/threads';
 import ThreadsV2 from 'sentry/components/events/interfaces/threadsV2';
 import {Group, Organization, Project, SharedViewOrganization} from 'sentry/types';
-import {Entry, EntryType, Event, EventError, EventTransaction} from 'sentry/types/event';
-
-import {EmbeddedSpanTree} from './interfaces/spans/embeddedSpanTree';
+import {Entry, EntryType, Event, EventTransaction} from 'sentry/types/event';
 
 type Props = Pick<React.ComponentProps<typeof Breadcrumbs>, 'route' | 'router'> & {
   entry: Entry;
@@ -180,15 +178,11 @@ function EventEntry({
 
       return (
         <Fragment>
-          <PerformanceIssueSection
+          <SpanEvidenceSection
             issue={group as Group}
-            event={event as EventError}
-            organization={organization as Organization}
-            spanEvidence={SAMPLE_SPAN_EVIDENCE}
-          />
-          <EmbeddedSpanTree
             event={event}
             organization={organization as Organization}
+            spanEvidence={SAMPLE_SPAN_EVIDENCE}
             projectSlug={INTERNAL_PROJECT}
             affectedSpanIds={affectedSpanIds}
           />

--- a/static/app/components/events/interfaces/performance/index.tsx
+++ b/static/app/components/events/interfaces/performance/index.tsx
@@ -10,6 +10,7 @@ export type SpanEvidence = {
   parentSpan: string;
   repeatingSpan: string;
   sourceSpan: string;
+  transaction: string;
 };
 
 interface Props {
@@ -20,21 +21,26 @@ interface Props {
 }
 
 export function PerformanceIssueSection({spanEvidence}: Props) {
-  const {parentSpan, sourceSpan, repeatingSpan} = spanEvidence;
+  const {transaction, parentSpan, sourceSpan, repeatingSpan} = spanEvidence;
 
   const data: KeyValueListData = [
     {
       key: '0',
+      subject: t('Transaction'),
+      value: transaction,
+    },
+    {
+      key: '1',
       subject: t('Parent Span'),
       value: parentSpan,
     },
     {
-      key: '1',
+      key: '2',
       subject: t('Source Span'),
       value: sourceSpan,
     },
     {
-      key: '2',
+      key: '3',
       subject: t('Repeating Span'),
       value: repeatingSpan,
     },

--- a/static/app/components/events/interfaces/performance/index.tsx
+++ b/static/app/components/events/interfaces/performance/index.tsx
@@ -2,9 +2,10 @@ import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {EventError, Group, KeyValueListData, Organization} from 'sentry/types';
+import {Event, Group, KeyValueListData, Organization} from 'sentry/types';
 
 import KeyValueList from '../keyValueList';
+import {EmbeddedSpanTree} from '../spans/embeddedSpanTree';
 
 export type SpanEvidence = {
   parentSpan: string;
@@ -14,13 +15,21 @@ export type SpanEvidence = {
 };
 
 interface Props {
-  event: EventError;
+  affectedSpanIds: string[];
+  event: Event;
   issue: Group;
   organization: Organization;
+  projectSlug: string;
   spanEvidence: SpanEvidence;
 }
 
-export function PerformanceIssueSection({spanEvidence}: Props) {
+export function SpanEvidenceSection({
+  spanEvidence,
+  event,
+  organization,
+  projectSlug,
+  affectedSpanIds,
+}: Props) {
   const {transaction, parentSpan, sourceSpan, repeatingSpan} = spanEvidence;
 
   const data: KeyValueListData = [
@@ -50,6 +59,12 @@ export function PerformanceIssueSection({spanEvidence}: Props) {
     <Wrapper>
       <h3>{t('Span Evidence')}</h3>
       <KeyValueList data={data} />
+      <EmbeddedSpanTree
+        event={event}
+        organization={organization as Organization}
+        projectSlug={projectSlug}
+        affectedSpanIds={affectedSpanIds}
+      />
     </Wrapper>
   );
 }

--- a/static/app/components/events/interfaces/performance/index.tsx
+++ b/static/app/components/events/interfaces/performance/index.tsx
@@ -94,7 +94,4 @@ export const Wrapper = styled('div')`
     margin-bottom: 0;
     text-transform: uppercase;
   }
-  div:first-child {
-    margin-right: ${space(3)};
-  }
 `;

--- a/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
+++ b/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
@@ -128,7 +128,6 @@ export function EmbeddedSpanTree(props: Props) {
 }
 
 export const Wrapper = styled('div')`
-  border-top: 1px solid ${p => p.theme.innerBorder};
   border-radius: ${p => p.theme.borderRadius};
   margin: 0;
   /* Padding aligns with Layout.Body */

--- a/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
+++ b/static/app/components/events/interfaces/spans/embeddedSpanTree.tsx
@@ -4,9 +4,7 @@ import styled from '@emotion/styled';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
-import QuickTrace from 'sentry/components/quickTrace';
 import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
 import {Event, EventTransaction, Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import GenericDiscoverQuery from 'sentry/utils/discover/genericDiscoverQuery';
@@ -18,15 +16,15 @@ import TraceView from './traceView';
 import WaterfallModel from './waterfallModel';
 
 type Props = {
+  affectedSpanIds: string[];
   event: Event;
   organization: Organization;
   projectSlug: string;
-  affectedSpanIds?: string[];
 };
 
 // This is a wrapper class that is intended to be used within Performance Issues
 export function EmbeddedSpanTree(props: Props) {
-  const {event, organization, projectSlug, affectedSpanIds} = props;
+  const {organization, projectSlug, affectedSpanIds} = props;
   const api = useApi();
   const location = useLocation();
   const quickTrace = useContext(QuickTraceContext);
@@ -88,31 +86,16 @@ export function EmbeddedSpanTree(props: Props) {
 
           return (
             <Wrapper>
-              <Header>
-                <h3>{t('Span Tree')}</h3>
-                <QuickTrace
-                  event={event}
-                  quickTrace={quickTrace!}
-                  location={location}
-                  organization={organization}
-                  anchor="left"
-                  errorDest="issue"
-                  transactionDest="performance"
-                />
-              </Header>
-
-              <Section>
-                <TraceView
-                  organization={organization}
-                  waterfallModel={
-                    new WaterfallModel(
-                      results.tableData as EventTransaction,
-                      affectedSpanIds
-                    )
-                  }
-                  isEmbedded
-                />
-              </Section>
+              <TraceView
+                organization={organization}
+                waterfallModel={
+                  new WaterfallModel(
+                    results.tableData as EventTransaction,
+                    affectedSpanIds
+                  )
+                }
+                isEmbedded
+              />
             </Wrapper>
           );
         }}
@@ -128,36 +111,6 @@ export function EmbeddedSpanTree(props: Props) {
 }
 
 export const Wrapper = styled('div')`
-  border-radius: ${p => p.theme.borderRadius};
-  margin: 0;
-  /* Padding aligns with Layout.Body */
-  padding: ${space(3)} ${space(2)} ${space(2)};
-  @media (min-width: ${p => p.theme.breakpoints.medium}) {
-    padding: ${space(3)} ${space(4)} ${space(3)};
-  }
-  & h3,
-  & h3 a {
-    font-size: 14px;
-    font-weight: 600;
-    line-height: 1.2;
-    color: ${p => p.theme.gray300};
-  }
-  & h3 {
-    font-size: 14px;
-    font-weight: 600;
-    line-height: 1.2;
-    padding: ${space(0.75)} 0;
-    margin-bottom: ${space(2)};
-    text-transform: uppercase;
-  }
-`;
-
-const Header = styled('div')`
-  display: flex;
-  justify-content: space-between;
-`;
-
-const Section = styled('div')`
   border: 1px solid ${p => p.theme.innerBorder};
   border-radius: ${p => p.theme.borderRadius};
 `;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -249,15 +249,10 @@ type EntrySpans = {
   type: EntryType.SPANS; // data is not used
 };
 
-export type EntrySpanTree = {
+export type EntryPerformance = {
   data: {
     affectedSpanIds: string[];
   };
-  type: EntryType.SPANTREE;
-};
-
-export type EntryPerformance = {
-  data: any; // data is not used
   type: EntryType.PERFORMANCE;
 };
 
@@ -310,7 +305,6 @@ export type Entry =
   | EntryException
   | EntryStacktrace
   | EntrySpans
-  | EntrySpanTree
   | EntryPerformance
   | EntryMessage
   | EntryRequest
@@ -438,7 +432,6 @@ export interface EventError extends Omit<EventBase, 'entries' | 'type'> {
     | EntryThreads
     | EntryDebugMeta
     | EntryPerformance
-    | EntrySpanTree
   )[];
   type: EventOrGroupType.ERROR;
 }

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -115,9 +115,6 @@ class GroupEventToolbar extends Component<Props> {
       evt.dateReceived &&
       Math.abs(+moment(evt.dateReceived) - +moment(evt.dateCreated)) > latencyThreshold;
 
-    // TODO: In the future we will be able to access a 'type' property on groups, we should use that instead
-    const isPerformanceIssue = !!evt.contexts?.performance_issue;
-
     return (
       <StyledDataSection>
         <StyledNavigationButtonGroup
@@ -166,15 +163,12 @@ class GroupEventToolbar extends Component<Props> {
           project={project}
           organization={organization}
         />
-        {/* If this is a Performance issue, the QuickTrace will be rendered along with the embedded span tree instead */}
-        {!isPerformanceIssue && (
-          <QuickTrace
-            event={evt}
-            group={group}
-            organization={organization}
-            location={location}
-          />
-        )}
+        <QuickTrace
+          event={evt}
+          group={group}
+          organization={organization}
+          location={location}
+        />
       </StyledDataSection>
     );
   }

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -15,7 +15,7 @@ import SentryTypes from 'sentry/sentryTypes';
 import GroupStore from 'sentry/stores/groupStore';
 import space from 'sentry/styles/space';
 import {AvatarProject, Group, Organization, Project} from 'sentry/types';
-import {EntrySpanTree, EntryType, Event} from 'sentry/types/event';
+import {EntryType, Event} from 'sentry/types/event';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {callIfFunction} from 'sentry/utils/callIfFunction';
 import {getUtcDateString} from 'sentry/utils/dates';
@@ -166,21 +166,16 @@ class GroupDetails extends Component<Props, State> {
   addPerformanceSpecificEntries(event: Event) {
     const performanceData = event.contexts.performance_issue;
 
-    const spanTreeEntry: EntrySpanTree = {
+    const performanceEntry = {
       data: {
         affectedSpanIds: performanceData.spans,
       },
-      type: EntryType.SPANTREE,
-    };
-
-    const performanceEntry = {
-      data: {},
       type: EntryType.PERFORMANCE,
     };
 
     const updatedEvent = {
       ...event,
-      entries: [performanceEntry, spanTreeEntry, ...event.entries],
+      entries: [performanceEntry, ...event.entries],
     };
     return updatedEvent;
   }


### PR DESCRIPTION
Updates the Span Evidence to be consistent with the new design mocks, the embedded span tree has been moved into the Span Evidence section and a `Transaction` row has been added. Additionally, I've also moved the QuickTrace navigator back into the top of the page, instead of in the embedded span tree.

### Before
![image](https://user-images.githubusercontent.com/16740047/188903742-2848aa90-d713-4d06-bbc9-2ad9a64f1fcc.png)


### After
![image](https://user-images.githubusercontent.com/16740047/188903621-16c33ef1-69ee-4d55-b8be-2252fc69ed33.png)
