### PR TITLE
fix(replays): Sorting null and undefined values in the Network Table

### DIFF
--- a/static/app/views/replays/detail/network/utils.tsx
+++ b/static/app/views/replays/detail/network/utils.tsx
@@ -1,3 +1,5 @@
+import {defined} from 'sentry/utils';
+
 export type NetworkSpan = {
   data: Record<string, any>;
   endTimestamp: number;
@@ -24,6 +26,15 @@ export function sortNetwork(
 
     valueA = typeof valueA === 'string' ? valueA.toUpperCase() : valueA;
     valueB = typeof valueB === 'string' ? valueB.toUpperCase() : valueB;
+
+    // if the values are not defined, we want to push them to the bottom of the list
+    if (!defined(valueA)) {
+      return 1;
+    }
+
+    if (!defined(valueB)) {
+      return -1;
+    }
 
     if (valueA === valueB) {
       return 0;


### PR DESCRIPTION


<!-- Describe your PR here. -->
### Changes
- Added 2 new conditions to make nullish or undefined values be moved to the bottom of the list. Closes #38473 


![image](https://user-images.githubusercontent.com/39612839/188913147-1ef0d0bb-7a32-4723-ad19-e0b7c37abb89.png)

![image](https://user-images.githubusercontent.com/39612839/188913195-a1ee0042-1dbc-47d7-995b-334885f42c5f.png)



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
