### PR TITLE
feat(backend): adds default_owner_id

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -257,6 +257,16 @@ class Organization(Model, SnowflakeIdMixin):
             self._default_owner = self.get_owners()[0]
         return self._default_owner
 
+    @property
+    def default_owner_id(self):
+        """
+        Similar to get_default_owner but won't raise a key error
+        if there is no owner. Used for analytics primarily.
+        """
+        if not hasattr(self, "_default_owner_id"):
+            self._default_owner_id = self.get_owners().values_list("id", flat=True).first()
+        return self._default_owner_id
+
     def has_single_owner(self):
         from sentry.models import OrganizationMember
 

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -178,6 +178,27 @@ class OrganizationTest(TestCase):
         org = self.create_organization(owner=user)
         assert org.get_default_owner() == user
 
+    def test_default_owner_id(self):
+        user = self.create_user("foo@example.com")
+        org = self.create_organization(owner=user)
+        assert org.default_owner_id == user.id
+
+    def test_default_owner_id_no_owner(self):
+        org = self.create_organization()
+        assert org.default_owner_id is None
+
+    @mock.patch.object(
+        Organization, "get_owners", side_effect=Organization.get_owners, autospec=True
+    )
+    def test_default_owner_id_cached(self, mock_get_owners):
+        user = self.create_user("foo@example.com")
+        org = self.create_organization(owner=user)
+        # mock_get_owners.return_value = [user]
+        assert org.default_owner_id == user.id
+        assert mock_get_owners.call_count == 1
+        assert org.default_owner_id == user.id
+        assert mock_get_owners.call_count == 1
+
     def test_flags_have_changed(self):
         org = self.create_organization()
         update_tracked_data(org)

--- a/tests/sentry/models/test_organization.py
+++ b/tests/sentry/models/test_organization.py
@@ -193,7 +193,6 @@ class OrganizationTest(TestCase):
     def test_default_owner_id_cached(self, mock_get_owners):
         user = self.create_user("foo@example.com")
         org = self.create_organization(owner=user)
-        # mock_get_owners.return_value = [user]
         assert org.default_owner_id == user.id
         assert mock_get_owners.call_count == 1
         assert org.default_owner_id == user.id


### PR DESCRIPTION
 This PR creates a new property called `default_owner_id` on the `Organization` which is similar to `get_default_owner`. The main difference is that if for some reason there is no owner for an organization, we return `None` instead of throwing a `IndexError`.

As for migration of `get_default_owner`, that's tricky because some places are catching an `IndexError` so we can't just do a drop-in replacement.