### PR TITLE
feat(dashboards): allow opening Custom Perf Metric widgets in discover

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/widgetCard.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCard.spec.tsx
@@ -267,7 +267,7 @@ describe('Dashboards > WidgetCard', function () {
     );
   });
 
-  it('disables Open in Discover when the widget contains custom measurements', async function () {
+  it('allows Open in Discover when the widget contains custom measurements', async function () {
     render(
       <WidgetCard
         api={api}
@@ -278,6 +278,7 @@ describe('Dashboards > WidgetCard', function () {
           queries: [
             {
               ...multipleQueryWidget.queries[0],
+              conditions: '',
               fields: [],
               columns: [],
               aggregates: ['p99(measurements.custom.measurement)'],
@@ -301,7 +302,9 @@ describe('Dashboards > WidgetCard', function () {
     userEvent.click(await screen.findByLabelText('Widget actions'));
     expect(screen.getByText('Open in Discover')).toBeInTheDocument();
     userEvent.click(screen.getByText('Open in Discover'));
-    expect(router.push).not.toHaveBeenCalledWith();
+    expect(router.push).toHaveBeenCalledWith(
+      '/organizations/org-slug/discover/results/?environment=prod&field=p99%28measurements.custom.measurement%29&name=Errors&project=1&query=&statsPeriod=14d&yAxis=p99%28measurements.custom.measurement%29'
+    );
   });
 
   it('calls onDuplicate when Duplicate Widget is clicked', async function () {

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -10,7 +10,6 @@ import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
 import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
 import {isWidgetViewerPath} from 'sentry/components/modals/widgetViewerModal/utils';
 import Tag from 'sentry/components/tag';
-import Tooltip from 'sentry/components/tooltip';
 import {IconEllipsis, IconExpand} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -19,11 +18,7 @@ import {Series} from 'sentry/types/echarts';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {AggregationOutputType} from 'sentry/utils/discover/fields';
-import {
-  getWidgetDiscoverUrl,
-  getWidgetIssueUrl,
-  isCustomMeasurementWidget,
-} from 'sentry/views/dashboardsV2/utils';
+import {getWidgetDiscoverUrl, getWidgetIssueUrl} from 'sentry/views/dashboardsV2/utils';
 
 import {Widget, WidgetType} from '../types';
 import {WidgetViewerContext} from '../widgetViewer/widgetViewerContext';
@@ -77,8 +72,7 @@ function WidgetCardContextMenu({
   }
 
   const menuOptions: MenuItemProps[] = [];
-  const usingCustomMeasurements = isCustomMeasurementWidget(widget);
-  const disabledKeys: string[] = usingCustomMeasurements ? ['open-in-discover'] : [];
+  const disabledKeys: string[] = [];
 
   const openWidgetViewerPath = (id: string | undefined) => {
     if (!isWidgetViewerPath(location.pathname)) {
@@ -164,38 +158,22 @@ function WidgetCardContextMenu({
       );
       menuOptions.push({
         key: 'open-in-discover',
-        label: usingCustomMeasurements ? (
-          <Tooltip
-            skipWrapper
-            title={t(
-              'Widget using custom performance metrics cannot be opened in Discover.'
-            )}
-          >
-            {t('Open in Discover')}
-          </Tooltip>
-        ) : (
-          t('Open in Discover')
-        ),
-        to:
-          !usingCustomMeasurements && widget.queries.length === 1
-            ? discoverPath
-            : undefined,
+        label: t('Open in Discover'),
+        to: widget.queries.length === 1 ? discoverPath : undefined,
         onAction: () => {
-          if (!usingCustomMeasurements) {
-            if (widget.queries.length === 1) {
-              trackAdvancedAnalyticsEvent('dashboards_views.open_in_discover.opened', {
-                organization,
-                widget_type: widget.displayType,
-              });
-              return;
-            }
-
-            trackAdvancedAnalyticsEvent('dashboards_views.query_selector.opened', {
+          if (widget.queries.length === 1) {
+            trackAdvancedAnalyticsEvent('dashboards_views.open_in_discover.opened', {
               organization,
               widget_type: widget.displayType,
             });
-            openDashboardWidgetQuerySelectorModal({organization, widget, isMetricsData});
+            return;
           }
+
+          trackAdvancedAnalyticsEvent('dashboards_views.query_selector.opened', {
+            organization,
+            widget_type: widget.displayType,
+          });
+          openDashboardWidgetQuerySelectorModal({organization, widget, isMetricsData});
         },
       });
     }


### PR DESCRIPTION
Allows opening Custom Perf Metric widgets in discover.
Automatically falls back to indexed data in the discover results page.
![image](https://user-images.githubusercontent.com/83961295/188935769-9c07842e-c0c7-4b7b-bd6b-02dd4a8f02c8.png)
