### PR TITLE
feat(perf-issues): Add settings endpoint for detector options

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -1,0 +1,74 @@
+from rest_framework import serializers, status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features, projectoptions
+from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
+
+MAX_VALUE = 2147483647
+SETTINGS_PROJECT_OPTION_KEY = "sentry:performance_issue_settings"
+
+
+class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
+    n_plus_one_db_detection_rate = serializers.FloatField(required=False, min_value=0, max_value=1)
+    n_plus_one_db_issue_rate = serializers.FloatField(required=False, min_value=0, max_value=1)
+    n_plus_one_db_count = serializers.IntegerField(required=False, min_value=0, max_value=MAX_VALUE)
+    n_plus_one_db_duration_threshold = serializers.IntegerField(
+        required=False, min_value=0, max_value=MAX_VALUE
+    )
+
+
+class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
+    permission_classes = (ProjectSettingPermission,)
+
+    def has_feature(self, project, request) -> bool:
+        return features.has(
+            "organizations:performance-view", project.organization, actor=request.user
+        ) and features.has(
+            "organizations:performance-issues", project.organization, actor=request.user
+        )
+
+    def get(self, request: Request, project) -> Response:
+        """
+        Retrieve performance issue settings
+        ``````````````````
+
+        Return settings for performance issues
+
+        :pparam string organization_slug: the slug of the organization the
+                                          project belongs to.
+        :pparam string project_slug: the slug of the project to configure.
+        :auth: required
+        """
+
+        if not self.has_feature(project, request):
+            return self.respond(status=status.HTTP_404_NOT_FOUND)
+
+        performance_issue_settings_default = projectoptions.get_well_known_default(
+            SETTINGS_PROJECT_OPTION_KEY,
+            project=project,
+        )
+        performance_issue_settings = project.get_option(
+            SETTINGS_PROJECT_OPTION_KEY, default=performance_issue_settings_default
+        )
+        return Response({**performance_issue_settings_default, **performance_issue_settings})
+
+    def put(self, request: Request, project) -> Response:
+        if not self.has_feature(project, request):
+            return self.respond(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = ProjectPerformanceIssueSettingsSerializer(data=request.data)
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        performance_issue_settings = projectoptions.get_well_known_default(
+            SETTINGS_PROJECT_OPTION_KEY,
+            project=project,
+        )
+
+        data = serializer.validated_data
+
+        project.update_option(SETTINGS_PROJECT_OPTION_KEY, {**performance_issue_settings, **data})
+
+        return Response(data)

--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -19,6 +19,7 @@ class ProjectPerformanceIssueSettingsSerializer(serializers.Serializer):
 
 
 class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
+    private = True  # TODO: Remove after EA.
     permission_classes = (ProjectSettingPermission,)
 
     def has_feature(self, project, request) -> bool:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -398,6 +398,7 @@ from .endpoints.project_key_stats import ProjectKeyStatsEndpoint
 from .endpoints.project_keys import ProjectKeysEndpoint
 from .endpoints.project_member_index import ProjectMemberIndexEndpoint
 from .endpoints.project_ownership import ProjectOwnershipEndpoint
+from .endpoints.project_performance_issue_settings import ProjectPerformanceIssueSettingsEndpoint
 from .endpoints.project_platforms import ProjectPlatformsEndpoint
 from .endpoints.project_plugin_details import ProjectPluginDetailsEndpoint
 from .endpoints.project_plugins import ProjectPluginsEndpoint
@@ -2232,6 +2233,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/transaction-threshold/configure/$",
                     ProjectTransactionThresholdEndpoint.as_view(),
                     name="sentry-api-0-project-transaction-threshold",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/performance-issues/configure/$",
+                    ProjectPerformanceIssueSettingsEndpoint.as_view(),
+                    name="sentry-api-0-project-performance-issue-settings",
                 ),
                 # Load plugin project urls
                 url(

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -92,3 +92,14 @@ register(key="sentry:span_attributes", epoch_defaults={1: ["exclusive-time"]})
 
 # Rate at which performance issues are created per project. Defaults to off (rate of 0.0)
 register(key="sentry:performance_issue_creation_rate", default=0.0)
+
+# A dict containing all the specific detection thresholds and rates.
+register(
+    key="sentry:performance_issue_settings",
+    default={
+        "n_plus_one_db_detection_rate": 0,
+        "n_plus_one_db_issue_rate": 0,
+        "n_plus_one_db_count": 5,
+        "n_plus_one_db_duration_threshold": 500,
+    },
+)

--- a/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
@@ -1,0 +1,77 @@
+from django.urls import reverse
+from rest_framework.exceptions import ErrorDetail
+
+from sentry.testutils import APITestCase
+
+PERFORMANCE_ISSUE_FEATURES = {
+    "organizations:performance-view": True,
+    "organizations:performance-issues": True,
+}
+
+
+class ProjectPerformanceIssueSettingsTest(APITestCase):
+    endpoint = "sentry-api-0-project-performance-issue-settings"
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.login_as(user=self.user)
+        self.project = self.create_project()
+
+        self.url = reverse(
+            self.endpoint,
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+            },
+        )
+
+    def test_get_returns_default(self):
+        with self.feature(PERFORMANCE_ISSUE_FEATURES):
+            response = self.client.get(self.url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["n_plus_one_db_count"] == 5
+        assert response.data["n_plus_one_db_duration_threshold"] == 500
+
+    def test_get_returns_error_without_feature_enabled(self):
+        with self.feature({}):
+            response = self.client.get(self.url, format="json")
+            assert response.status_code == 404
+
+    def test_update_project_setting(self):
+        with self.feature(PERFORMANCE_ISSUE_FEATURES):
+            response = self.client.put(
+                self.url,
+                data={
+                    "n_plus_one_db_count": 17,
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data["n_plus_one_db_count"] == 17
+
+        with self.feature(PERFORMANCE_ISSUE_FEATURES):
+            get_response = self.client.get(self.url, format="json")
+
+        assert get_response.status_code == 200, response.content
+        assert get_response.data["n_plus_one_db_count"] == 17
+        assert get_response.data["n_plus_one_db_duration_threshold"] == 500
+
+    def test_update_project_setting_check_validation(self):
+        with self.feature(PERFORMANCE_ISSUE_FEATURES):
+            response = self.client.put(
+                self.url,
+                data={
+                    "n_plus_one_db_count": -1,
+                },
+            )
+
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "n_plus_one_db_count": [
+                ErrorDetail(
+                    string="Ensure this value is greater than or equal to 0.", code="min_value"
+                )
+            ]
+        }


### PR DESCRIPTION
The detector options will be far more numerous that the basic all issue rate previously added to the project detail endpoint. Made a new endpoint to get/set into the project option that will contain all the settings as a flat dict, making use of a serializer to do validation.



