### PR TITLE
feat(dashboards): Allow selecting Custom Perf Metrics in table widget column select without aggregates

### DIFF
--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -152,7 +152,6 @@ export const ErrorsAndTransactionsConfig: DatasetConfig<
   },
   transformSeries: transformEventsResponseToSeries,
   transformTable: transformEventsResponseToTable,
-  filterTableOptions,
   filterAggregateParams,
   getSeriesResultType,
 };
@@ -592,11 +591,6 @@ function getEventsSeriesRequest(
   }
 
   return doEventsRequest<true>(api, requestData);
-}
-
-// Custom Measurements aren't selectable as columns/yaxis without using an aggregate
-function filterTableOptions(option: FieldValueOption) {
-  return option.value.kind !== FieldValueKind.CUSTOM_MEASUREMENT;
 }
 
 // Checks fieldValue to see what function is being used and only allow supported custom measurements

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -1169,7 +1169,7 @@ describe('WidgetBuilder', function () {
         await screen.findByText('12 MB');
       });
 
-      it('displays custom performance metric in column select', async function () {
+      it('displays saved custom performance metric in column select', async function () {
         renderTestComponent({
           query: {source: DashboardWidgetSource.DISCOVERV2},
           dashboard: {
@@ -1200,6 +1200,46 @@ describe('WidgetBuilder', function () {
           orgFeatures: [...defaultOrgFeatures, 'discover-frontend-use-events-endpoint'],
         });
         await screen.findByText('measurements.custom.measurement');
+      });
+
+      it('displays custom performance metric in column select dropdown', async function () {
+        measurementsMetaMock = MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/measurements-meta/',
+          method: 'GET',
+          body: {'measurements.custom.measurement': {functions: ['p99']}},
+        });
+        renderTestComponent({
+          query: {source: DashboardWidgetSource.DISCOVERV2},
+          dashboard: {
+            ...testDashboard,
+            widgets: [
+              {
+                title: 'Custom Measurement Widget',
+                interval: '1d',
+                id: '1',
+                widgetType: WidgetType.DISCOVER,
+                displayType: DisplayType.TABLE,
+                queries: [
+                  {
+                    conditions: '',
+                    name: '',
+                    fields: ['transaction', 'count()'],
+                    columns: ['transaction'],
+                    aggregates: ['count()'],
+                    orderby: '-count()',
+                  },
+                ],
+              },
+            ],
+          },
+          params: {
+            widgetIndex: '0',
+          },
+          orgFeatures: [...defaultOrgFeatures, 'discover-frontend-use-events-endpoint'],
+        });
+        await screen.findByText('transaction');
+        userEvent.click(screen.getAllByText('count()')[1]);
+        expect(screen.getByText('measurements.custom.measurement')).toBeInTheDocument();
       });
 
       it('does not default to sorting by transaction when columns change', async function () {


### PR DESCRIPTION
Since we now allow Custom Perf Metrics in Discover, we can also allow Custom Perf Metrics to be displayed per event in dashboard widgets via Discover fallback.

![image](https://user-images.githubusercontent.com/83961295/188963779-146399fb-918f-413c-a11e-d4a15bdb7f6b.png)
