### PR TITLE
ref(ingest) Log when events are discarded to tombstones

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -209,7 +209,7 @@ def get_stored_crashreports(cache_key, event, max_crashreports):
 
 class HashDiscarded(Exception):
     def __init__(
-        self, message: str, reason: Optional[str] = None, tombstone_id: Optional[int] = None
+        self, message: str = "", reason: Optional[str] = None, tombstone_id: Optional[int] = None
     ):
         super().__init__(message)
         self.reason = reason

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -208,7 +208,12 @@ def get_stored_crashreports(cache_key, event, max_crashreports):
 
 
 class HashDiscarded(Exception):
-    pass
+    def __init__(
+        self, message: str, reason: Optional[str] = None, tombstone_id: Optional[int] = None
+    ):
+        super().__init__(message)
+        self.reason = reason
+        self.tombstone_id = tombstone_id
 
 
 class ScoreClause(Func):
@@ -478,7 +483,14 @@ class EventManager:
                     **kwargs,
                 )
                 job["groups"] = [group_info]
-        except HashDiscarded:
+        except HashDiscarded as err:
+            logger.info(
+                "event_manager.save.discard",
+                extra={
+                    "reason": err.reason,
+                    "tombstone_id": err.tombstone_id,
+                },
+            )
             discard_event(job, attachments)
             raise
 
@@ -1224,7 +1236,7 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
                 "platform": event.platform,
             },
         ):
-            raise HashDiscarded("Load shedding group creation")
+            raise HashDiscarded("Load shedding group creation", reason="load_shed")
 
         with sentry_sdk.start_span(
             op="event_manager.create_group_transaction"
@@ -1402,7 +1414,11 @@ def _find_existing_grouphash(
         # be able to tombstone `hierarchical_hashes[4]` while still having a
         # group attached to `hierarchical_hashes[0]`? Maybe.
         if group_hash.group_tombstone_id is not None:
-            raise HashDiscarded("Matches group tombstone %s" % group_hash.group_tombstone_id)
+            raise HashDiscarded(
+                "Matches group tombstone %s" % group_hash.group_tombstone_id,
+                reason="discard",
+                tombstone_id=group_hash.group_tombstone_id,
+            )
 
     return None, root_hierarchical_hash
 
@@ -1416,7 +1432,7 @@ def _create_group(project, event, **kwargs):
             tags={"platform": event.platform or "unknown"},
         )
         sentry_sdk.capture_message("short_id.timeout")
-        raise HashDiscarded("Timeout when getting next_short_id")
+        raise HashDiscarded("Timeout when getting next_short_id", reason="timeout")
 
     # it's possible the release was deleted between
     # when we queried for the release and now, so


### PR DESCRIPTION
Log the category and tombstone that are being used. This context can be useful when encouraging customers to replace their discard-and-delete rules with more-efficient filtering options.