### PR TITLE
fix(copy): tags tooltip copy

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/tags.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/tags.tsx
@@ -21,9 +21,7 @@ function Tags({event, organization, projectSlug, location}: Props) {
   return (
     <StyledDataSection
       title={t('Tags')}
-      description={t(
-        'Tags help you quickly both access related events and view the tag distribution for a set of events'
-      )}
+      description={t('The default and custom tags associated with this event')}
       data-test-id="event-tags"
     >
       <EventTags


### PR DESCRIPTION
Fixing the copy here because it doesn’t make sense.


## Before
<img width="274" alt="CleanShot 2022-09-07 at 15 09 40@2x" src="https://user-images.githubusercontent.com/1900676/188992590-2d5499ad-e883-424d-9356-fd768e5a4179.png">

## After
<img width="285" alt="CleanShot 2022-09-07 at 15 09 31@2x" src="https://user-images.githubusercontent.com/1900676/188992600-7741821e-3481-4e95-aaba-3e98cf76bf5d.png">
