### PR TITLE
ref(debugFiles): Get input padding from theme

### DIFF
--- a/static/app/components/modals/debugFileCustomRepository/http.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/http.tsx
@@ -14,12 +14,10 @@ import {
 } from 'sentry/data/debugFileSources';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t, tct} from 'sentry/locale';
-import {INPUT_PADDING} from 'sentry/styles/input';
 import space from 'sentry/styles/space';
 import {uniqueId} from 'sentry/utils/guid';
 
 const CLEAR_PASSWORD_BUTTON_SIZE = 22;
-const PASSWORD_INPUT_PADDING_RIGHT = INPUT_PADDING + CLEAR_PASSWORD_BUTTON_SIZE;
 
 type InitialData = {
   id: string;
@@ -263,7 +261,8 @@ const StyledSelectField = styled(SelectField)`
 `;
 
 const PasswordInput = styled(Input)`
-  padding-right: ${PASSWORD_INPUT_PADDING_RIGHT}px;
+  padding-right: ${p =>
+    p.theme.formPadding.md.paddingRight + CLEAR_PASSWORD_BUTTON_SIZE}px;
 `;
 
 const ClearPasswordButton = styled(ActionButton)`


### PR DESCRIPTION
Instead of importing `INPUT_PADDING` from `styles/input`, we can get it from `theme.formPadding`.

**Before:**
<img width="613" alt="Screen Shot 2022-09-07 at 3 44 24 PM" src="https://user-images.githubusercontent.com/44172267/188996559-0eccbc65-22bd-4806-a950-379b636ddfea.png">

**After:**
<img width="613" alt="Screen Shot 2022-09-07 at 3 43 41 PM" src="https://user-images.githubusercontent.com/44172267/188996566-af4b955e-5a7f-4516-afcd-0fa8c3029af7.png">
