### PR TITLE
fix(ui): Set cursor default for disabled menu items

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -233,7 +233,7 @@ export const InnerWrap = styled('div', {
   &:hover {
     color: ${getTextColor};
   }
-  ${p => p.disabled && `cursor: initial;`}
+  ${p => p.disabled && `cursor: default;`}
 
   ${p =>
     p.isFocused &&


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/10888943/188999621-f17fd4bc-fd48-4247-a9d0-a637bdb99599.png)

After:

![image](https://user-images.githubusercontent.com/10888943/188999741-57a594a3-6a55-4795-bd25-b0ed0897b7d8.png)
