### PR TITLE
feat(perf-issues): Have n+1 detector use project option thresholds

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -8,8 +8,9 @@ from typing import Any, Dict, List, Optional, Sequence, Union
 
 import sentry_sdk
 
-from sentry import options
+from sentry import options, projectoptions
 from sentry.eventstore.models import Event
+from sentry.models import ProjectOption
 from sentry.types.issues import GroupType
 from sentry.utils import metrics
 
@@ -79,7 +80,19 @@ def detect_performance_problems(data: Event) -> List[PerformanceProblem]:
 # Gets some of the thresholds to perform performance detection. Can be made configurable later.
 # Thresholds are in milliseconds.
 # Allowed span ops are allowed span prefixes. (eg. 'http' would work for a span with 'http.client' as its op)
-def get_default_detection_settings():
+def get_detection_settings(project_id: str):
+    default_settings = projectoptions.get_well_known_default(
+        "sentry:performance_issue_settings",
+        project=project_id,
+    )
+    issue_settings = ProjectOption.objects.get_value(
+        project_id, "sentry:performance_issue_settings", default_settings
+    )
+    settings = {
+        **default_settings,
+        **issue_settings,
+    }  # Merge saved settings into default so updating the default works in the future.
+
     return {
         DetectorType.DUPLICATE_SPANS: [
             {
@@ -132,8 +145,8 @@ def get_default_detection_settings():
             }
         ],
         DetectorType.N_PLUS_ONE_DB_QUERIES: {
-            "count": 5,
-            "duration_threshold": 500.0,  # ms
+            "count": settings["n_plus_one_db_count"],
+            "duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
         },
     }
 
@@ -141,8 +154,9 @@ def get_default_detection_settings():
 def _detect_performance_problems(data: Event, sdk_span: Any) -> List[PerformanceProblem]:
     event_id = data.get("event_id", None)
     spans = data.get("spans", [])
+    project_id = data.get("project")
 
-    detection_settings = get_default_detection_settings()
+    detection_settings = get_detection_settings(project_id)
     detectors = {
         DetectorType.DUPLICATE_SPANS: DuplicateSpanDetector(detection_settings, data),
         DetectorType.DUPLICATE_SPANS_HASH: DuplicateSpanHashDetector(detection_settings, data),

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -61,7 +61,7 @@ def create_event(spans, event_id="a" * 16):
 
 class PerformanceDetectionTest(unittest.TestCase):
     def setUp(self):
-        super(PerformanceDetectionTest, self).setUp()
+        super().setUp()
         patch_project_option_get = patch("sentry.models.ProjectOption.objects.get_value")
         self.project_option_mock = patch_project_option_get.start()
         self.addCleanup(patch_project_option_get.stop)

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -19,6 +19,7 @@ from tests.sentry.spans.grouping.test_strategy import SpanBuilder
 _fixture_path = os.path.join(os.path.dirname(__file__), "events")
 
 EVENTS = {}
+PROJECT_ID = 1
 
 for filename in os.listdir(_fixture_path):
     if not filename.endswith(".json"):
@@ -27,7 +28,9 @@ for filename in os.listdir(_fixture_path):
     [event_name, _extension] = filename.split(".")
 
     with open(os.path.join(_fixture_path, filename)) as f:
-        EVENTS[event_name] = json.load(f)
+        event = json.load(f)
+        event["project"] = PROJECT_ID
+        EVENTS[event_name] = event
 
 
 # Duration is in ms
@@ -53,10 +56,16 @@ def create_span(op, duration=100.0, desc="SELECT count() FROM table WHERE id = %
 
 
 def create_event(spans, event_id="a" * 16):
-    return {"event_id": event_id, "spans": spans}
+    return {"event_id": event_id, "project": PROJECT_ID, "spans": spans}
 
 
 class PerformanceDetectionTest(unittest.TestCase):
+    def setUp(self):
+        super(PerformanceDetectionTest, self).setUp()
+        patch_project_option_get = patch("sentry.models.ProjectOption.objects.get_value")
+        self.project_option_mock = patch_project_option_get.start()
+        self.addCleanup(patch_project_option_get.stop)
+
     @patch("sentry.utils.performance_issues.performance_detection._detect_performance_problems")
     def test_options_disabled(self, mock):
         event = {}
@@ -70,6 +79,40 @@ class PerformanceDetectionTest(unittest.TestCase):
             with override_options({"performance.issues.all.problem-detection": 1.0}):
                 detect_performance_problems(event)
         assert mock.call_count == 1
+
+    def test_project_option_overrides_default(self):
+        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
+        sdk_span_mock = Mock()
+
+        perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
+        assert perf_problems == [
+            PerformanceProblem(
+                fingerprint="1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
+                op="db",
+                desc="SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` LIMIT 10",
+                type=GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+                spans_involved=[
+                    "9179e43ae844b174",
+                    "b8be6138369491dd",
+                    "b2d4826e7b618f1b",
+                    "b3fdeea42536dbf1",
+                    "b409e78a092e642f",
+                    "86d2ede57bbf48d4",
+                    "8e554c84cdc9731e",
+                    "94d6230f3f910e12",
+                    "a210b87a2191ceb6",
+                    "88a5ccaf25b9bd8f",
+                    "bb32cf50fc56b296",
+                ],
+            )
+        ]
+
+        self.project_option_mock.return_value = {
+            "n_plus_one_db_duration_threshold": 100000,
+        }
+
+        perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
+        assert perf_problems == []
 
     def test_calls_detect_duplicate(self):
         no_duplicate_event = create_event([create_span("db")] * 4)
@@ -352,6 +395,7 @@ class PerformanceDetectionTest(unittest.TestCase):
     def test_calls_detect_render_blocking_asset(self):
         render_blocking_asset_event = {
             "event_id": "a" * 16,
+            "project": PROJECT_ID,
             "measurements": {
                 "fcp": {
                     "value": 2500.0,
@@ -364,6 +408,7 @@ class PerformanceDetectionTest(unittest.TestCase):
         }
         non_render_blocking_asset_event = {
             "event_id": "a" * 16,
+            "project": PROJECT_ID,
             "measurements": {
                 "fcp": {
                     "value": 2500.0,
@@ -379,6 +424,7 @@ class PerformanceDetectionTest(unittest.TestCase):
         }
         no_fcp_event = {
             "event_id": "a" * 16,
+            "project": PROJECT_ID,
             "measurements": {
                 "fcp": {
                     "value": None,
@@ -391,6 +437,7 @@ class PerformanceDetectionTest(unittest.TestCase):
         }
         short_render_blocking_asset_event = {
             "event_id": "a" * 16,
+            "project": PROJECT_ID,
             "measurements": {
                 "fcp": {
                     "value": 2500.0,


### PR DESCRIPTION
### Summary
This switches the n+1 detector (the sole detector currently) to use thresholds from project options, either the default value or a set project option value if it's been changed on the project settings UI. This will allow us to actively tune thresholds for detectors.

