### PR TITLE
fix(perf-issues): Use repeating query as N+1 issue description

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -815,7 +815,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
             self.stored_problems[fingerprint] = PerformanceProblem(
                 fingerprint=fingerprint,
                 op="db",
-                desc=self.source_span.get("description", ""),
+                desc=self.n_spans[0].get("description", ""),
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
                 spans_involved=span_ids_involved,
             )

--- a/tests/sentry/performance_issues/test_performance_issues.py
+++ b/tests/sentry/performance_issues/test_performance_issues.py
@@ -54,14 +54,14 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             group = event.groups[0]
             assert (
                 group.title
-                == "N+1 Query:SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` LIMIT 10"
+                == "N+1 Query:SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
             )
             assert group.message == "/books/"
             assert group.culprit == "/books/"
             assert group.get_event_type() == "transaction"
             assert group.get_event_metadata() == {
                 "location": "/books/",
-                "title": "N+1 Query:SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` LIMIT 10",
+                "title": "N+1 Query:SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
             }
             assert group.location() == "/books/"
             assert group.level == 40
@@ -101,11 +101,11 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             group.refresh_from_db()
             assert (
                 group.title
-                == "N+1 Query:SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` LIMIT 10"
+                == "N+1 Query:SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
             )
             assert group.get_event_metadata() == {
                 "location": "/books/",
-                "title": "N+1 Query:SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` LIMIT 10",
+                "title": "N+1 Query:SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
             }
             assert group.location() == "/books/"
             assert group.message == "/books/"

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -477,7 +477,7 @@ class PerformanceDetectionTest(unittest.TestCase):
             PerformanceProblem(
                 fingerprint="1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
                 op="db",
-                desc="SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` LIMIT 10",
+                desc="SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
                 spans_involved=[
                     "9179e43ae844b174",

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -89,7 +89,7 @@ class PerformanceDetectionTest(unittest.TestCase):
             PerformanceProblem(
                 fingerprint="1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
                 op="db",
-                desc="SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` LIMIT 10",
+                desc="SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
                 spans_involved=[
                     "9179e43ae844b174",


### PR DESCRIPTION
Currently using the source query, but the designs use the repeating query instead.