### PR TITLE
feat(metrics): Adds aliasing behaviour to GroupBy [TET-357 TET-320]

### DIFF
--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -55,7 +55,7 @@ from sentry.release_health.base import (
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.snuba.metrics.datasource import get_series
 from sentry.snuba.metrics.naming_layer.public import SessionMetricKey
-from sentry.snuba.metrics.query import MetricField, MetricsQuery, OrderBy
+from sentry.snuba.metrics.query import MetricField, MetricGroupByField, MetricsQuery, OrderBy
 from sentry.snuba.metrics.utils import OrderByNotSupportedOverCompositeEntityException
 from sentry.snuba.sessions_v2 import (
     InvalidParams,
@@ -542,7 +542,13 @@ def run_sessions_query(
         query.end,
         Granularity(query.rollup),
         where=where,
-        groupby=list({column for field in fields.values() for column in field.get_groupby()}),
+        groupby=list(
+            {
+                MetricGroupByField(column)
+                for field in fields.values()
+                for column in field.get_groupby()
+            }
+        ),
         orderby=orderby_sequence,
         limit=limit,
         offset=Offset(query.offset or 0),

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -520,6 +520,8 @@ class GroupLimitFilters:
     - ``keys``: A tuple containing resolved tag names ("tag[123]") in the order
       of the ``groupBy`` clause.
 
+    - ``aliased_keys``: A tuple containing the group column name aliases
+
     - ``values``: A list of tuples containing the tag values of the group keys.
       The list is in the order returned by Snuba. The tuple elements are ordered
       like ``keys``.
@@ -529,6 +531,7 @@ class GroupLimitFilters:
     """
 
     keys: Tuple[Groupable]
+    aliased_keys: Tuple[str]
     values: List[Tuple[int]]
     conditions: ConditionGroup
 
@@ -543,16 +546,23 @@ def _get_group_limit_filters(
     # will be used to filter down and order the results of the 2nd query.
     # For example, (project_id, transaction) is translated to (project_id, tags[3])
     keys = tuple(
-        resolve_tag_key(use_case_id, metrics_query.org_id, field)
-        if field not in FIELD_ALIAS_MAPPINGS.values()
-        else field
-        for field in metrics_query.groupby
+        FIELD_ALIAS_MAPPINGS[metric_groupby_obj.name]
+        if metric_groupby_obj.name in FIELD_ALIAS_MAPPINGS
+        else resolve_tag_key(use_case_id, metrics_query.org_id, metric_groupby_obj.name)
+        if metric_groupby_obj.name not in FIELD_ALIAS_MAPPINGS.values()
+        else metric_groupby_obj.name
+        for metric_groupby_obj in metrics_query.groupby
+    )
+    aliased_group_keys = tuple(
+        metric_groupby_obj.alias for metric_groupby_obj in metrics_query.groupby
     )
 
     # Get an ordered list of tuples containing the values of the group keys.
     # This needs to be deduplicated since in timeseries queries the same
     # grouping key will reappear for every time bucket.
-    values = list(OrderedDict((tuple(row[col] for col in keys), None) for row in results).keys())
+    values = list(
+        OrderedDict((tuple(row[col] for col in aliased_group_keys), None) for row in results).keys()
+    )
     conditions = [
         Condition(Function("tuple", [Column(k) for k in keys]), Op.IN, Function("tuple", values))
     ]
@@ -561,13 +571,18 @@ def _get_group_limit_filters(
     # the group by columns, we need a separate condition for each of the columns
     # in the group by with their respective values so Clickhouse can filter the
     # results down before checking for the group by column combinations.
-    values_by_column = {col: list({row[col] for row in results}) for col in keys}
+    values_by_column = {
+        key: list({row[aliased_key] for row in results})
+        for key, aliased_key in zip(keys, aliased_group_keys)
+    }
     conditions += [
         Condition(Column(col), Op.IN, Function("tuple", col_values))
         for col, col_values in values_by_column.items()
     ]
 
-    return GroupLimitFilters(keys=keys, values=values, conditions=conditions)
+    return GroupLimitFilters(
+        keys=keys, aliased_keys=aliased_group_keys, values=values, conditions=conditions
+    )
 
 
 def _apply_group_limit_filters(query: Query, filters: GroupLimitFilters) -> Query:
@@ -604,7 +619,7 @@ def _sort_results_by_group_filters(
     # }
     rows_by_group_values = {}
     for row in results:
-        group_values = tuple(row[col] for col in filters.keys)
+        group_values = tuple(row[col] for col in filters.aliased_keys)
         rows_by_group_values.setdefault(group_values, []).append(row)
 
     # Order the results according to the results of the initial query, so that when
@@ -637,7 +652,7 @@ def _prune_extra_groups(results: dict, filters: GroupLimitFilters) -> None:
         for key, query_results in queries.items():
             filtered = []
             for row in query_results["data"]:
-                group_values = tuple(row[col] for col in filters.keys)
+                group_values = tuple(row[col] for col in filters.aliased_keys)
                 if group_values in valid_values:
                     filtered.append(row)
             queries[key]["data"] = filtered
@@ -823,13 +838,18 @@ def get_series(
     metrics_query_fields = {
         str(metric_field) for metric_field in converter._alias_to_metric_obj.keys()
     }
+    groupby_aliases = (
+        {metric_groupby_obj.alias for metric_groupby_obj in metrics_query.groupby}
+        if metrics_query.groupby
+        else set()
+    )
 
     return {
         "start": metrics_query.start,
         "end": metrics_query.end,
         "intervals": intervals,
         "groups": result_groups,
-        "meta": translate_meta_results(meta, metrics_query_fields, use_case_id, org_id)
+        "meta": translate_meta_results(meta, metrics_query_fields, groupby_aliases)
         if include_meta
         else [],
     }

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -439,30 +439,27 @@ class SnubaQueryBuilder:
     def _build_groupby(self) -> List[Column]:
         groupby_cols = []
 
-        def generate_aliased_expression(column: Column, alias: str) -> AliasedExpression:
-            return AliasedExpression(exp=column, alias=alias)
-
         for metric_groupby_obj in self._metrics_query.groupby or []:
             # Handles the case when we are trying to group by `project` for example, but we want
             # to translate it to `project_id` as that is what the metrics dataset understands
             if metric_groupby_obj.name in FIELD_ALIAS_MAPPINGS:
                 groupby_cols.append(
-                    generate_aliased_expression(
-                        Column(FIELD_ALIAS_MAPPINGS[metric_groupby_obj.name]),
-                        metric_groupby_obj.alias,
+                    AliasedExpression(
+                        exp=Column(FIELD_ALIAS_MAPPINGS[metric_groupby_obj.name]),
+                        alias=metric_groupby_obj.alias,
                     )
                 )
             elif metric_groupby_obj.name in FIELD_ALIAS_MAPPINGS.values():
                 groupby_cols.append(
-                    generate_aliased_expression(
-                        column=Column(metric_groupby_obj.name), alias=metric_groupby_obj.alias
+                    AliasedExpression(
+                        exp=Column(metric_groupby_obj.name), alias=metric_groupby_obj.alias
                     )
                 )
             else:
                 assert isinstance(metric_groupby_obj.name, Tag)
                 groupby_cols.append(
-                    generate_aliased_expression(
-                        column=Column(
+                    AliasedExpression(
+                        exp=Column(
                             resolve_tag_key(
                                 self._use_case_id, self._org_id, metric_groupby_obj.name
                             )

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -759,7 +759,7 @@ class SnubaResultConverter:
                     for data in subresults[k]["data"]:
                         self._extract_data(data, groups)
 
-        group_by_alias_to_group_by_column = (
+        groupby_alias_to_groupby_column = (
             {
                 metric_groupby_obj.alias: metric_groupby_obj.name
                 for metric_groupby_obj in self._metrics_query.groupby
@@ -777,7 +777,7 @@ class SnubaResultConverter:
                             self._use_case_id, self._organization_id, value, weak=True
                         ),
                     )
-                    if group_by_alias_to_group_by_column.get(key)
+                    if groupby_alias_to_groupby_column.get(key)
                     not in set(FIELD_ALIAS_MAPPINGS.values()) | set(FIELD_ALIAS_MAPPINGS.keys())
                     else (key, value)
                     for key, value in tags

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -425,23 +425,23 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
         assert response.status_code == 200
         expected_output = {
             prj_foo.id: {
-                "by": {"project_id": prj_foo.id},
+                "by": {"project": prj_foo.id},
                 "series": {"sum(sentry.sessions.session)": [3.0]},
                 "totals": {"sum(sentry.sessions.session)": 3.0},
             },
             self.project.id: {
-                "by": {"project_id": self.project.id},
+                "by": {"project": self.project.id},
                 "series": {"sum(sentry.sessions.session)": [2.0]},
                 "totals": {"sum(sentry.sessions.session)": 2.0},
             },
             prj_boo.id: {
-                "by": {"project_id": prj_boo.id},
+                "by": {"project": prj_boo.id},
                 "series": {"sum(sentry.sessions.session)": [5.0]},
                 "totals": {"sum(sentry.sessions.session)": 5.0},
             },
         }
         for grp in response.data["groups"]:
-            prj_id = grp["by"]["project_id"]
+            prj_id = grp["by"]["project"]
             assert grp == expected_output[prj_id]
 
     def test_pagination_limit_without_orderby(self):

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -11,6 +11,7 @@ from sentry.snuba.metrics import (
     DerivedMetricParseException,
     Groupable,
     MetricField,
+    MetricGroupByField,
     MetricsQuery,
     OrderBy,
     parse_query,
@@ -33,7 +34,7 @@ class MetricsQueryBuilder:
         self.granularity: Granularity = Granularity(3600)
         self.orderby: Optional[ConditionGroup] = None
         self.where: Optional[Sequence[Groupable]] = None
-        self.groupby: Optional[Sequence[OrderBy]] = None
+        self.groupby: Optional[Sequence[MetricGroupByField]] = None
         self.limit: Optional[Limit] = None
         self.offset: Optional[Offset] = None
         self.histogram_buckets: int = 100
@@ -80,7 +81,7 @@ class MetricsQueryBuilder:
         self.limit = limit
         return self
 
-    def with_groupby(self, groupby: Sequence[Groupable]) -> "MetricsQueryBuilder":
+    def with_groupby(self, groupby: Sequence[MetricGroupByField]) -> "MetricsQueryBuilder":
         self.groupby = groupby
         return self
 
@@ -407,7 +408,9 @@ def test_validate_groupby():
         InvalidParams, match="Tag name session.status cannot be used to groupBy query"
     ):
         MetricsQuery(
-            **MetricsQueryBuilder().with_groupby(["session.status"]).to_metrics_query_dict()
+            **MetricsQueryBuilder()
+            .with_groupby([MetricGroupByField("session.status")])
+            .to_metrics_query_dict()
         )
 
 

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -745,7 +745,7 @@ def test_build_snuba_query_with_derived_alias(mock_now, mock_now2):
         select=[select],
         groupby=[
             AliasedExpression(
-                Column(resolve_tag_key(use_case_id, org_id, "environment")), "environment"
+                Column(resolve_tag_key(use_case_id, org_id, "environment")), alias="environment"
             ),
             Column("bucketed_time"),
         ],

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -7,6 +7,7 @@ import pytz
 from django.utils.datastructures import MultiValueDict
 from freezegun import freeze_time
 from snuba_sdk import (
+    AliasedExpression,
     And,
     Column,
     Condition,
@@ -58,7 +59,7 @@ from sentry.snuba.metrics.fields.snql import (
 from sentry.snuba.metrics.naming_layer import SessionMetricKey
 from sentry.snuba.metrics.naming_layer.mapping import get_mri
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI
-from sentry.snuba.metrics.query import MetricField
+from sentry.snuba.metrics.query import MetricField, MetricGroupByField
 from sentry.snuba.metrics.query_builder import QueryDefinition
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -296,7 +297,7 @@ def test_build_snuba_query(mock_now, mock_now2):
         end=MOCK_NOW,
         granularity=Granularity(3600),
         where=[Condition(Column("release"), Op.EQ, "staging")],
-        groupby=["environment"],
+        groupby=[MetricGroupByField("environment")],
     )
     snuba_queries, _ = SnubaQueryBuilder(
         [PseudoProject(1, 1)], query_definition, use_case_id=UseCaseKey.RELEASE_HEALTH
@@ -325,7 +326,12 @@ def test_build_snuba_query(mock_now, mock_now2):
                     alias=f"{alias}({metric_name})",
                 )
             ],
-            groupby=[Column(resolve_tag_key(use_case_id, org_id, "environment"))] + extra_groupby,
+            groupby=[
+                AliasedExpression(
+                    Column(resolve_tag_key(use_case_id, org_id, "environment")), alias="environment"
+                )
+            ]
+            + extra_groupby,
             where=[
                 Condition(Column("org_id"), Op.EQ, 1),
                 Condition(Column("project_id"), Op.IN, [1]),
@@ -601,7 +607,9 @@ def test_build_snuba_query_orderby(mock_now, mock_now2):
         match=Entity("metrics_counters"),
         select=[select],
         groupby=[
-            Column(resolve_tag_key(use_case_id, org_id, "environment")),
+            AliasedExpression(
+                Column(resolve_tag_key(use_case_id, org_id, "environment")), alias="environment"
+            ),
         ],
         where=[
             Condition(Column("org_id"), Op.EQ, 1),
@@ -626,7 +634,9 @@ def test_build_snuba_query_orderby(mock_now, mock_now2):
         match=Entity("metrics_counters"),
         select=[select],
         groupby=[
-            Column(resolve_tag_key(use_case_id, org_id, "environment")),
+            AliasedExpression(
+                Column(resolve_tag_key(use_case_id, org_id, "environment")), alias="environment"
+            ),
             Column("bucketed_time"),
         ],
         where=[
@@ -706,7 +716,9 @@ def test_build_snuba_query_with_derived_alias(mock_now, mock_now2):
         match=Entity("metrics_distributions"),
         select=[select],
         groupby=[
-            Column(resolve_tag_key(use_case_id, org_id, "environment")),
+            AliasedExpression(
+                Column(resolve_tag_key(use_case_id, org_id, "environment")), alias="environment"
+            ),
         ],
         where=[
             Condition(Column("org_id"), Op.EQ, 1),
@@ -732,7 +744,9 @@ def test_build_snuba_query_with_derived_alias(mock_now, mock_now2):
         match=Entity("metrics_distributions"),
         select=[select],
         groupby=[
-            Column(resolve_tag_key(use_case_id, org_id, "environment")),
+            AliasedExpression(
+                Column(resolve_tag_key(use_case_id, org_id, "environment")), "environment"
+            ),
             Column("bucketed_time"),
         ],
         where=[
@@ -959,12 +973,12 @@ def test_get_intervals():
 def test_translate_meta_results():
     meta = [
         {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Array(Float64)"},
-        {"name": "tags[9223372036854776020]", "type": "UInt64"},
+        {"name": "transaction", "type": "UInt64"},
         {"name": "project_id", "type": "UInt64"},
         {"name": "metric_id", "type": "UInt64"},
     ]
     assert translate_meta_results(
-        meta, {"p50(transaction.measurements.lcp)"}, UseCaseKey.PERFORMANCE, 1
+        meta, {"p50(transaction.measurements.lcp)"}, {"transaction"}
     ) == sorted(
         [
             {"name": "p50(transaction.measurements.lcp)", "type": "Array(Float64)"},
@@ -980,13 +994,15 @@ def test_translate_meta_results_with_duplicates():
     meta = [
         {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Array(Float64)"},
         {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Array(Float64)"},
-        {"name": "tags[9223372036854776020]", "type": "UInt64"},
-        {"name": "tags[9223372036854776020]", "type": "UInt64"},
+        {"name": "transaction", "type": "UInt64"},
+        {"name": "transaction", "type": "UInt64"},
         {"name": "project_id", "type": "UInt64"},
         {"name": "project_id", "type": "UInt64"},
     ]
     assert translate_meta_results(
-        meta, {"p50(transaction.measurements.lcp)"}, UseCaseKey.RELEASE_HEALTH, 1
+        meta,
+        {"p50(transaction.measurements.lcp)"},
+        {"transaction"},
     ) == sorted(
         [
             {"name": "p50(transaction.measurements.lcp)", "type": "Array(Float64)"},


### PR DESCRIPTION
Continuation of aliasing in PR in the sense that
this PR adds the functionality to create an alias
for groupBy columns. It achieves this by the
addition of dataclass `MetricsGroupByField` which
accepts name and an alias as params
