### PR TITLE
feat(perf-issues): Add non-flagr feature flag for ingest

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1143,6 +1143,8 @@ SENTRY_FEATURES = {
     "organizations:native-stack-trace-v2": False,
     # Enable performance issues
     "organizations:performance-issues": False,
+    # Enable the creation of performance issues in the ingest pipeline. Turning this on will eventually make performance issues be created with default settings.
+    "organizations:performance-issues-ingest": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
     # Enable the UI for the overage alert settings

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -114,6 +114,7 @@ default_manager.add("organizations:performance-chart-interpolation", Organizatio
 default_manager.add("organizations:performance-dry-run-mep", OrganizationFeature, True)
 default_manager.add("organizations:performance-frontend-use-events-endpoint", OrganizationFeature, True)
 default_manager.add("organizations:performance-issues", OrganizationFeature, True)
+default_manager.add("organizations:performance-issues-ingest", OrganizationFeature)
 default_manager.add("organizations:performance-onboarding-checklist", OrganizationFeature, True)
 default_manager.add("organizations:performance-span-histogram-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-span-tree-autoscroll", OrganizationFeature, True)


### PR DESCRIPTION
### Summary
This splits out the creation/ingest portion of performance issues into a non-flagr feature flag, since we don't want to use flagr in the ingest pipeline for speed / stability purposes. This feature exists for the final internal / EA / GA rollout, and when an organization is opted in via a separate getsentry PR they will start having performance issues created immediately (since we are defaulting performance issue creation to 'On' for rollout, given it shouldn't have a cost impact). 

