### PR TITLE
fix(strictclick): fix crash

### DIFF
--- a/static/app/components/strictClick.tsx
+++ b/static/app/components/strictClick.tsx
@@ -1,62 +1,66 @@
-import {cloneElement, PureComponent} from 'react';
+import {cloneElement, useCallback, useRef} from 'react';
 
 type ClickProps<T> = {
   onClick?: React.HTMLAttributes<T>['onClick'];
 };
 
-type Props<T extends HTMLElement> = ClickProps<T> & {
-  children: React.ReactElement<T>;
-};
-
-type State = {
-  startCoords?: [number, number];
-};
+interface Props<T extends HTMLElement> extends ClickProps<T> {
+  children: React.ReactElement;
+}
 
 /**
  * Does not fire the onclick event if the mouse has moved outside of the
  * original click location upon release.
  *
- * <StrictClick onClick={this.onClickHandler}>
+ * <StrictClick onClick={onClickHandler}>
  *   <button>Some button</button>
  * </StrictClick>
  */
-class StrictClick<T extends HTMLElement> extends PureComponent<Props<T>, State> {
-  static MAX_DELTA_X = 10;
-  static MAX_DELTA_Y = 10;
+const MAX_DELTA_X = 10;
+const MAX_DELTA_Y = 10;
 
-  handleMouseDown = ({screenX, screenY}: React.MouseEvent<T>) =>
-    this.setState({startCoords: [screenX, screenY]});
+function StrictClick<T extends HTMLElement>({onClick, children}: Props<T>) {
+  const mouseDownCoordinates = useRef<[number, number] | null>(null);
 
-  handleMouseClick = (evt: React.MouseEvent<T>) => {
-    if (!this.props.onClick) {
-      return;
-    }
+  const handleMouseDown = useCallback((event: React.MouseEvent<T>) => {
+    mouseDownCoordinates.current = [event.screenX, event.screenY];
+  }, []);
 
-    // Click happens if mouse down/up in same element - click will not fire if
-    // either initial mouse down OR final mouse up occurs in different element
-    const [x, y] = this.state.startCoords!;
-    const deltaX = Math.abs(evt.screenX - x);
-    const deltaY = Math.abs(evt.screenY - y);
+  const handleMouseClick = useCallback(
+    (evt: React.MouseEvent<T>) => {
+      if (!onClick) {
+        return;
+      }
 
-    // If mouse hasn't moved more than 10 pixels in either Y or X direction,
-    // fire onClick
-    if (deltaX < StrictClick.MAX_DELTA_X && deltaY < StrictClick.MAX_DELTA_Y) {
-      this.props.onClick(evt);
-    }
-    this.setState({startCoords: undefined});
-  };
+      if (mouseDownCoordinates.current === null) {
+        return;
+      }
 
-  render() {
-    // Bail out early if there is no onClick handler
-    if (!this.props.onClick) {
-      return this.props.children;
-    }
+      // Click happens if mouse down/up in same element - click will not fire if
+      // either initial mouse down OR final mouse up occurs in different element
+      const [x, y] = mouseDownCoordinates.current;
+      const deltaX = Math.abs(evt.screenX - x);
+      const deltaY = Math.abs(evt.screenY - y);
 
-    return cloneElement(this.props.children, {
-      onMouseDown: this.handleMouseDown,
-      onClick: this.handleMouseClick,
-    });
+      // If mouse hasn't moved more than 10 pixels in either Y or X direction,
+      // fire onClick
+      if (deltaX < MAX_DELTA_X && deltaY < MAX_DELTA_Y) {
+        onClick(evt);
+      }
+      mouseDownCoordinates.current = null;
+    },
+    [onClick]
+  );
+
+  // Bail out early if there is no onClick handler
+  if (!onClick) {
+    return children;
   }
+
+  return cloneElement(children, {
+    onMouseDown: handleMouseDown,
+    onClick: handleMouseClick,
+  });
 }
 
 export default StrictClick;


### PR DESCRIPTION
Fixes a [crash](https://sentry.io/organizations/sentry/issues/2358698062/?project=11276&query=is%3Aunresolved&statsPeriod=14d) when onClick may have been invoked before mouseDown setState has had the chance to run.