### PR TITLE
feat: Add instrumentation to Celery tasks for weekly reports

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2136,10 +2136,6 @@ SENTRY_SDK_CONFIG = {
         "custom_measurements": True,
     },
 }
-# sentry/utils/sdk.py loads the upstream_dsn through this
-if os.environ.get("SENTRY_DSN"):
-    SENTRY_SDK_CONFIG["dsn"] = os.environ.get("SENTRY_DSN")
-
 # Callable to bind additional context for the Sentry SDK
 #
 # def get_org_context(scope, organization, **kwargs):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2136,6 +2136,10 @@ SENTRY_SDK_CONFIG = {
         "custom_measurements": True,
     },
 }
+# How does production configure the Sentry DSN?
+# sentry/utils/sdk.py loads the upstream_dsn through this
+if os.environ.get("SENTRY_DSN"):
+    SENTRY_SDK_CONFIG["dsn"] = os.environ.get("SENTRY_DSN")
 
 # Callable to bind additional context for the Sentry SDK
 #

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2136,7 +2136,6 @@ SENTRY_SDK_CONFIG = {
         "custom_measurements": True,
     },
 }
-# How does production configure the Sentry DSN?
 # sentry/utils/sdk.py loads the upstream_dsn through this
 if os.environ.get("SENTRY_DSN"):
     SENTRY_SDK_CONFIG["dsn"] = os.environ.get("SENTRY_DSN")

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -871,6 +871,7 @@ def has_valid_aggregates(interval, project__report):
 def deliver_organization_user_report(timestamp, duration, organization_id, user_id, dry_run=False):
     try:
         organization = _get_organization_queryset().get(id=organization_id)
+        set_tag("org.slug", organization.slug)
     except Organization.DoesNotExist:
         logger.warning(
             "reports.organization.missing",

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -869,6 +869,7 @@ def has_valid_aggregates(interval, project__report):
     acks_late=True,
 )
 def deliver_organization_user_report(timestamp, duration, organization_id, user_id, dry_run=False):
+    set_tag("report.dry_run", dry_run)
     try:
         organization = _get_organization_queryset().get(id=organization_id)
     except Organization.DoesNotExist:
@@ -917,14 +918,12 @@ def deliver_organization_user_report(timestamp, duration, organization_id, user_
         )
     )
 
+    set_tag("report.available", not reports)
     if not reports:
-        set_tag("report.available", False)
         logger.debug(
             f"Skipping report for {organization} to {user}, no qualifying reports to deliver."
         )
         return Skipped.NoReports
-    set_tag("report.available", True)
-    set_tag("report.dry_run", deliver_organization_user_report)
 
     message = build_message(timestamp, duration, organization, user, reports)
 

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -869,7 +869,6 @@ def has_valid_aggregates(interval, project__report):
     acks_late=True,
 )
 def deliver_organization_user_report(timestamp, duration, organization_id, user_id, dry_run=False):
-    set_tag("report.dry_run", dry_run)
     try:
         organization = _get_organization_queryset().get(id=organization_id)
     except Organization.DoesNotExist:
@@ -929,6 +928,7 @@ def deliver_organization_user_report(timestamp, duration, organization_id, user_
 
     if not dry_run:
         message.send()
+        set_tag("email_sent", True)
 
 
 # Series: An array of (timestamp, value) tuples

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -871,7 +871,6 @@ def has_valid_aggregates(interval, project__report):
 def deliver_organization_user_report(timestamp, duration, organization_id, user_id, dry_run=False):
     try:
         organization = _get_organization_queryset().get(id=organization_id)
-        set_tag("org.slug", organization.slug)
     except Organization.DoesNotExist:
         logger.warning(
             "reports.organization.missing",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -278,6 +278,7 @@ def configure_sdk():
     relay_dsn = sdk_options.pop("relay_dsn", None)
     experimental_dsn = sdk_options.pop("experimental_dsn", None)
     internal_project_key = get_project_key()
+    # Modify SENTRY_SDK_CONFIG in your deployment scripts to specify your desired DSN
     upstream_dsn = sdk_options.pop("dsn", None)
     sdk_options["traces_sampler"] = traces_sampler
     sdk_options["release"] = (

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -107,8 +107,8 @@ SAMPLED_TASKS = {
     "sentry.tasks.relay.invalidate_project_config": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
     # This is the parent task of the next two tasks.
     "sentry.tasks.reports.prepare_reports": settings.SAMPLED_DEFAULT_RATE,
-    "sentry.tasks.reports.prepare_organization_report": settings.SAMPLED_DEFAULT_RATE,
-    "sentry.tasks.reports.deliver_organization_user_report": settings.SAMPLED_DEFAULT_RATE,
+    "sentry.tasks.reports.prepare_organization_report": 0.1,
+    "sentry.tasks.reports.deliver_organization_user_report": 0.01,
     "sentry.tasks.process_buffer.process_incr": 0.01,
 }
 

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -86,6 +86,9 @@ SAMPLED_URL_NAMES = {
 if settings.ADDITIONAL_SAMPLED_URLS:
     SAMPLED_URL_NAMES.update(settings.ADDITIONAL_SAMPLED_URLS)
 
+# Tasks not included here are not sampled
+# If a parent task schedules other tasks you should add it in here or the children
+# tasks will not be sampled
 SAMPLED_TASKS = {
     "sentry.tasks.send_ping": settings.SAMPLED_DEFAULT_RATE,
     "sentry.tasks.store.symbolicate_event": settings.SENTRY_SYMBOLICATE_EVENT_APM_SAMPLING,
@@ -102,8 +105,10 @@ SAMPLED_TASKS = {
     "sentry.tasks.reprocessing2.finish_reprocessing": settings.SENTRY_REPROCESSING_APM_SAMPLING,
     "sentry.tasks.relay.build_project_config": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
     "sentry.tasks.relay.invalidate_project_config": settings.SENTRY_RELAY_TASK_APM_SAMPLING,
-    "sentry.tasks.reports.prepare_organization_report": 0.1,
-    "sentry.tasks.reports.deliver_organization_user_report": 0.01,
+    # This is the parent task of the next two tasks.
+    "sentry.tasks.reports.prepare_reports": settings.SAMPLED_DEFAULT_RATE,
+    "sentry.tasks.reports.prepare_organization_report": settings.SAMPLED_DEFAULT_RATE,
+    "sentry.tasks.reports.deliver_organization_user_report": settings.SAMPLED_DEFAULT_RATE,
     "sentry.tasks.process_buffer.process_incr": 0.01,
 }
 

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -429,7 +429,7 @@ class ReportTestCase(OutcomesSnubaTest, SnubaTestCase):
 
 
 class ReportAcceptanceTest(OutcomesSnubaTest, SnubaTestCase):
-    @mock.patch("sentry.tasks.reports.backend", DummyReportBackend())
+    @mock.patch("sentry.tasks.reports.redis_report_backend", DummyReportBackend())
     def test_deliver_organization_user_report(self):
         now = timezone.now()
         seven_days = timedelta(days=7)


### PR DESCRIPTION
It seems that if we don't include the parent celery task, it will not trace any of the children tasks.

This enables further investigation as to why the building of the report is slow.

Fixes WOR-2159.