### PR TITLE
ref(metrics): Adds extra test for aliasing

### DIFF
--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
@@ -147,3 +147,61 @@ class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             ],
             key=lambda elem: elem["name"],
         )
+
+    def test_aliasing_behavior_on_derived_op_and_derived_alias(self):
+        user_ts = time.time()
+        for tag_value, d_value in (
+            ("exited", [4, 5, 6, 1, 2, 3]),
+            ("crashed", [7, 8, 9]),
+        ):
+            for v in d_value:
+                self.store_metric(
+                    org_id=self.organization.id,
+                    project_id=self.project.id,
+                    type="distribution",
+                    name=str(SessionMRI.RAW_DURATION.value),
+                    tags={"session.status": tag_value},
+                    timestamp=user_ts,
+                    value=v,
+                    use_case_id=UseCaseKey.RELEASE_HEALTH,
+                )
+
+        start, end, rollup = get_date_range(
+            {
+                "statsPeriod": "1h",
+                "interval": "1h",
+            }
+        )
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="histogram",
+                    metric_name=SessionMetricKey.DURATION.value,
+                    alias="histogram_duration",
+                ),
+            ],
+            start=start,
+            end=end,
+            granularity=Granularity(granularity=rollup),
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            histogram_from=2,
+            histogram_buckets=2,
+            include_series=False,
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=True,
+            use_case_id=UseCaseKey.RELEASE_HEALTH,
+        )
+
+        hist = [(2.0, 4.0, 2), (4.0, 6.0, 3)]
+        assert data["groups"] == [
+            {
+                "by": {},
+                "totals": {"histogram_duration": hist},
+            }
+        ]


### PR DESCRIPTION
Adds forgotten test that tests aliasing on
MetricField with both a derived alias
and a derived op

