### PR TITLE
fix(discover): Event Detail Custom Perf Metric links preserve existing filters

### DIFF
--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -117,14 +117,8 @@ function EventCustomPerformanceMetric({
     : value;
 
   function generateLinkWithQuery(query: string) {
-    const eventView = EventView.fromSavedQuery({
-      query,
-      fields: [],
-      id: undefined,
-      name: '',
-      projects: [],
-      version: 1,
-    });
+    const eventView = EventView.fromLocation(location);
+    eventView.query = query;
     switch (source) {
       case EventDetailPageSource.PERFORMANCE:
         return transactionSummaryRouteWithQuery({


### PR DESCRIPTION
Updates the Custom Perf Metric dropdown menu in the Event Detail page to use the browser location when creating links so existing page filters are preserved.