### PR TITLE
feat(dashboards): Widget Viewer Custom Perf Metrics dont disable open in discover button

### DIFF
--- a/static/app/components/modals/widgetViewerModal.spec.tsx
+++ b/static/app/components/modals/widgetViewerModal.spec.tsx
@@ -1172,32 +1172,6 @@ describe('Modals -> WidgetViewerModal', function () {
           });
         });
 
-        it('disables the Open in Discover button for a custom measurement widget', async function () {
-          const customMeasurementWidget = {
-            ...mockWidget,
-            queries: [
-              {
-                conditions: '',
-                fields: [],
-                aggregates: ['p99(measurements.custom.measurement)'],
-                columns: ['title'],
-                id: '1',
-                name: 'Query Name',
-                orderby: '',
-              },
-            ],
-          };
-          await renderModal({
-            initialData: initialDataWithFlag,
-            widget: customMeasurementWidget,
-            tableData: [],
-            pageLinks:
-              '<https://sentry.io>; rel="previous"; results="false"; cursor="0:0:1", <https://sentry.io>; rel="next"; results="true"; cursor="0:20:0"',
-          });
-          userEvent.click(screen.getByText('Open in Discover'));
-          expect(initialData.router.push).not.toHaveBeenCalled();
-        });
-
         it('displays table data with units correctly', async function () {
           const eventsMock = MockApiClient.addMockResponse({
             url: '/organizations/org-slug/events/',

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -56,7 +56,6 @@ import {
   getWidgetDiscoverUrl,
   getWidgetIssueUrl,
   getWidgetReleasesUrl,
-  isCustomMeasurementWidget,
 } from 'sentry/views/dashboardsV2/utils';
 import WidgetCardChart, {
   AugmentedEChartDataZoomHandler,
@@ -1032,12 +1031,6 @@ function OpenButton({
       to={path}
       priority="primary"
       type="button"
-      disabled={isCustomMeasurementWidget(widget)}
-      title={
-        isCustomMeasurementWidget(widget)
-          ? t('Widgets using custom performance metrics cannot be opened in Discover.')
-          : undefined
-      }
       onClick={() => {
         trackAdvancedAnalyticsEvent('dashboards_views.widget_viewer.open_source', {
           organization,


### PR DESCRIPTION
We used to disable the Open in Discover button in the Widget Viewer for Custom Perf Metric widgets.
Since we allow Custom Perf Metrics in Discover now, we can now leave the Open in Discover button enabled.
<img width="537" alt="image" src="https://user-images.githubusercontent.com/83961295/189166132-c173e9ee-7e1b-4882-b9b2-578b70f1e4b0.png">
