### PR TITLE
fix(perf-issues): Add space between performance issue type and description

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2018,7 +2018,7 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
 
                         problem = performance_problems_by_fingerprint[new_grouphash]
                         kwargs["type"] = problem.type.value
-                        kwargs["data"]["metadata"]["title"] = f"N+1 Query:{problem.desc}"
+                        kwargs["data"]["metadata"]["title"] = f"N+1 Query: {problem.desc}"
 
                         group = _create_group(project, event, **kwargs)
                         GroupHash.objects.create(project=project, hash=new_grouphash, group=group)
@@ -2048,7 +2048,7 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
                     is_new = False
 
                     description = performance_problems_by_fingerprint[existing_grouphash.hash].desc
-                    kwargs["data"]["metadata"]["title"] = f"N+1 Query:{description}"
+                    kwargs["data"]["metadata"]["title"] = f"N+1 Query: {description}"
 
                     is_regression = _process_existing_aggregate(
                         group=group, event=job["event"], data=kwargs, release=job["release"]

--- a/tests/sentry/performance_issues/test_performance_issues.py
+++ b/tests/sentry/performance_issues/test_performance_issues.py
@@ -54,14 +54,14 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             group = event.groups[0]
             assert (
                 group.title
-                == "N+1 Query:SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+                == "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
             )
             assert group.message == "/books/"
             assert group.culprit == "/books/"
             assert group.get_event_type() == "transaction"
             assert group.get_event_metadata() == {
                 "location": "/books/",
-                "title": "N+1 Query:SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+                "title": "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
             }
             assert group.location() == "/books/"
             assert group.level == 40
@@ -101,11 +101,11 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             group.refresh_from_db()
             assert (
                 group.title
-                == "N+1 Query:SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+                == "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
             )
             assert group.get_event_metadata() == {
                 "location": "/books/",
-                "title": "N+1 Query:SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+                "title": "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
             }
             assert group.location() == "/books/"
             assert group.message == "/books/"


### PR DESCRIPTION
This looks better when displayed in full, matches what we do for error groups, and also I'm pretty sure the frontend is splitting the title into two components using this colon.