### PR TITLE
ref: have mypy follow imports to 3rd party deps

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -138,11 +138,9 @@ warn_return_any=True
 no_implicit_reexport=True
 
 ; Set this to skip until more of the codebase is typed
+[mypy-sentry.*]
 follow_imports = skip
 
-
-[mypy-arroyo.*]
-follow_imports = normal
 [mypy-bs4]
 ignore_missing_imports = True
 [mypy-celery.*]
@@ -175,5 +173,13 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-rapidjson]
 ignore_missing_imports = True
-[mypy-drf_spectacular.utils]
-follow_imports = normal
+
+# TODO: these cause type errors when followed
+[mypy-drf_spectacular.drainage]
+follow_imports = skip
+[mypy-sentry_sdk]
+follow_imports = skip
+[mypy-sentry_sdk.tracing]
+follow_imports = skip
+[mypy-snuba_sdk.*]
+follow_imports = skip

--- a/src/sentry/apidocs/utils.py
+++ b/src/sentry/apidocs/utils.py
@@ -46,7 +46,7 @@ def inline_sentry_response_serializer(name: str, t: type) -> type:
     return serializer_class
 
 
-class SentryApiBuildError(UnableToProceedError):  # type: ignore
+class SentryApiBuildError(UnableToProceedError):
     def __init__(self, msg: str = "", *args: Any, **kwargs: Any) -> None:
         super().__init__(
             msg

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -67,7 +67,7 @@ class Field(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def select_params(self, dataset: Dataset) -> Tuple[str, str, str]:
+    def select_params(self, dataset: Dataset) -> Function:
         raise NotImplementedError()
 
 

--- a/src/sentry/utils/jwt.py
+++ b/src/sentry/utils/jwt.py
@@ -30,7 +30,7 @@ def peek_header(token: str) -> JSONData:
 
     :param token: The JWT token to extract the headers from.
     """
-    return pyjwt.get_unverified_header(token.encode("UTF-8"))
+    return pyjwt.get_unverified_header(token.encode("UTF-8"))  # type: ignore[no-untyped-call]
 
 
 def peek_claims(token: str) -> JSONData:
@@ -105,7 +105,7 @@ def encode(
     if headers is None:
         headers = {}
     # This type is checked in the tests so this is fine.
-    return pyjwt.encode(payload, key, algorithm=algorithm, headers=headers)  # type: ignore
+    return pyjwt.encode(payload, key, algorithm=algorithm, headers=headers)
 
 
 def authorization_header(token: str, *, scheme: str = "Bearer") -> Mapping[str, str]:
@@ -132,12 +132,12 @@ def rsa_key_from_jwk(jwk: str) -> str:
 
     :param jwk: The JSON Web Key as encoded JSON.
     """
-    key = pyjwt.algorithms.RSAAlgorithm.from_jwk(jwk)
+    key = pyjwt.algorithms.RSAAlgorithm.from_jwk(jwk)  # type: ignore[no-untyped-call]
     if isinstance(key, RSAPrivateKey):
         # The return type is verified in our own tests, this is fine.
-        return key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode("UTF-8")  # type: ignore
+        return key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode("UTF-8")
     elif isinstance(key, RSAPublicKey):
         # The return type is verified in our own tests, this is fine.
-        return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode("UTF-8")  # type: ignore
+        return key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode("UTF-8")
     else:
         raise ValueError("Unknown RSA JWK key")

--- a/tests/sentry/lang/native/test_appconnect.py
+++ b/tests/sentry/lang/native/test_appconnect.py
@@ -16,12 +16,12 @@ if TYPE_CHECKING:
 
 
 class TestAppStoreConnectConfig:
-    @pytest.fixture  # type: ignore
+    @pytest.fixture
     def now(self) -> datetime:
         # Fixture so we can have one "now" for the entire test and its fixtures.
         return datetime.utcnow()
 
-    @pytest.fixture  # type: ignore
+    @pytest.fixture
     def data(self, now: datetime) -> json.JSONData:
         return {
             "type": "appStoreConnect",
@@ -60,7 +60,7 @@ class TestAppStoreConnectConfig:
 
         assert new_data == data
 
-    @pytest.mark.django_db  # type: ignore
+    @pytest.mark.django_db
     def test_from_project_config_empty_sources(
         self, default_project: "Project", data: json.JSONData
     ) -> None:
@@ -69,7 +69,7 @@ class TestAppStoreConnectConfig:
 
 
 class TestAppStoreConnectConfigUpdateProjectSymbolSource:
-    @pytest.fixture  # type: ignore
+    @pytest.fixture
     def config(self) -> appconnect.AppStoreConnectConfig:
         return appconnect.AppStoreConnectConfig(
             type="appStoreConnect",
@@ -83,7 +83,7 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
             bundleId="com.example.app",
         )
 
-    @pytest.mark.django_db  # type: ignore
+    @pytest.mark.django_db
     def test_new_source(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
     ) -> None:
@@ -96,7 +96,7 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
         stored_sources = json.loads(raw)
         assert stored_sources == sources
 
-    @pytest.mark.django_db  # type: ignore
+    @pytest.mark.django_db
     def test_new_sources_with_existing(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
     ) -> None:
@@ -118,7 +118,7 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
         new_sources.append(cfg.to_json())
         assert stored_sources == new_sources
 
-    @pytest.mark.django_db  # type: ignore
+    @pytest.mark.django_db
     def test_update(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
     ) -> None:
@@ -141,7 +141,7 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
         current = appconnect.AppStoreConnectConfig.from_project_config(default_project, config.id)
         assert current.appconnectPrivateKey == "A NEW KEY"
 
-    @pytest.mark.django_db  # type: ignore
+    @pytest.mark.django_db
     def test_update_no_matching_id(
         self, default_project: "Project", config: appconnect.AppStoreConnectConfig
     ) -> None:
@@ -164,7 +164,7 @@ class TestAppStoreConnectConfigUpdateProjectSymbolSource:
 
 
 class TestDownloadDsyms:
-    @pytest.fixture  # type: ignore
+    @pytest.fixture
     def client(self) -> appconnect.AppConnectClient:
         return appconnect.AppConnectClient(
             app_id="honk",

--- a/tests/sentry/processing/realtime_metrics/test_base.py
+++ b/tests/sentry/processing/realtime_metrics/test_base.py
@@ -4,7 +4,7 @@ from sentry.processing.realtime_metrics import base
 
 
 class TestBucketedCounts:
-    @pytest.fixture  # type: ignore
+    @pytest.fixture
     def buckets(self) -> base.BucketedCounts:
         return base.BucketedCounts(timestamp=123, width=10, counts=[1, 2, 3])
 
@@ -65,7 +65,7 @@ class TestDurationsHistogram:
 
         assert hist.total_count() == 3
 
-    @pytest.mark.parametrize("percentile, result", [(0.70, 7), (0.75, 7), (0.80, 8)])  # type: ignore
+    @pytest.mark.parametrize("percentile, result", [(0.70, 7), (0.75, 7), (0.80, 8)])
     def test_percentile(self, percentile: float, result: int) -> None:
         hist = base.DurationsHistogram(bucket_size=1)
         for i in range(1, 10):

--- a/tests/sentry/processing/realtime_metrics/test_redis.py
+++ b/tests/sentry/processing/realtime_metrics/test_redis.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict
+from typing import Any, Dict
 
 import pytest
 
@@ -6,18 +6,6 @@ from sentry.exceptions import InvalidConfiguration
 from sentry.processing import realtime_metrics
 from sentry.processing.realtime_metrics.redis import RedisRealtimeMetricsStore
 from sentry.utils import redis
-
-if TYPE_CHECKING:
-    from typing import Callable
-
-    def _fixture(func: Callable[..., Any]) -> Callable[..., None]:
-        ...
-
-    def _xfail(func: Callable[..., Any]) -> Callable[..., None]:
-        ...
-
-    pytest.fixture = _fixture
-    pytest.mark.xfail = _xfail
 
 
 @pytest.fixture

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, Generator
 from unittest import mock
 
 import pytest
@@ -23,13 +25,8 @@ from sentry.tasks.low_priority_symbolication import (
 from sentry.testutils.helpers.task_runner import TaskRunner
 from sentry.utils.services import LazyServiceWrapper
 
-if TYPE_CHECKING:
-    from typing import Callable
-
-    def _fixture(func: Callable[..., Any]) -> Callable[..., None]:
-        ...
-
-    pytest.fixture = _fixture
+if TYPE_CHECKING:  # TODO: pytest 7.x
+    from _pytest.monkeypatch import MonkeyPatch
 
 
 @pytest.fixture
@@ -56,9 +53,9 @@ def store() -> Generator[RealtimeMetricsStore, None, None]:
 
 
 class TestScanForSuspectProjects:
-    @pytest.fixture  # type: ignore
+    @pytest.fixture
     def mock_update_lpq_eligibility(
-        self, monkeypatch: "pytest.MonkeyPatch"
+        self, monkeypatch: MonkeyPatch
     ) -> Generator[mock.Mock, None, None]:
         mock_fn = mock.Mock()
         monkeypatch.setattr(low_priority_symbolication, "update_lpq_eligibility", mock_fn)
@@ -113,7 +110,7 @@ class TestUpdateLpqEligibility:
 
     @freeze_time(datetime.fromtimestamp(0))
     def test_is_eligible_not_lpq(
-        self, store: RealtimeMetricsStore, monkeypatch: "pytest.MonkeyPatch"
+        self, store: RealtimeMetricsStore, monkeypatch: MonkeyPatch
     ) -> None:
         store.increment_project_event_counter(project_id=17, timestamp=0)
         assert store.get_lpq_projects() == set()
@@ -127,7 +124,7 @@ class TestUpdateLpqEligibility:
 
     @freeze_time(datetime.fromtimestamp(0))
     def test_is_eligible_in_lpq(
-        self, store: RealtimeMetricsStore, monkeypatch: "pytest.MonkeyPatch"
+        self, store: RealtimeMetricsStore, monkeypatch: MonkeyPatch
     ) -> None:
         store.add_project_to_lpq(17)
         monkeypatch.setattr(
@@ -149,7 +146,7 @@ class TestUpdateLpqEligibility:
 
     @freeze_time(datetime.fromtimestamp(0))
     def test_is_eligible_recently_moved(
-        self, store: RedisRealtimeMetricsStore, monkeypatch: "pytest.MonkeyPatch"
+        self, store: RedisRealtimeMetricsStore, monkeypatch: MonkeyPatch
     ) -> None:
         store._backoff_timer = 10
         # Abusing the fact that removing always updates the backoff timer even if it's a noop

--- a/tests/sentry/utils/appleconnect/test_appstore_connect.py
+++ b/tests/sentry/utils/appleconnect/test_appstore_connect.py
@@ -7,7 +7,7 @@ file with credentials.  See the ``api_credentials`` fixture for details.
 import pathlib
 import textwrap
 import urllib.parse
-from typing import Optional
+from typing import Generator, Optional
 from unittest import mock
 
 import pytest
@@ -23,7 +23,7 @@ class TestListBuilds:
     # mypy just can't cope with this function:
     # - The request fixture type is private: _pytest.fixtures.FixtureRequest.
     # - mypy has no idea that `pytest.skip()` raises and exception and terminates control flow.
-    @pytest.fixture(scope="session", params=["live", "responses"])  # type: ignore
+    @pytest.fixture(scope="session", params=["live", "responses"])
     def api_credentials(self, request) -> appstore_connect.AppConnectCredentials:  # type: ignore
         """An App Store Connect API key in the form of AppConnectCredentials.
 
@@ -71,7 +71,7 @@ class TestListBuilds:
                 ),
             )
 
-    @pytest.fixture(scope="session")  # type: ignore
+    @pytest.fixture(scope="session")
     def app_id(self) -> str:
         """The Sentry Cocoa Swift example app."""
         return "1549832463"
@@ -104,10 +104,10 @@ class TestListBuilds:
         pages_file = module_dir / "pages_data.json"
         pages_file.write_text(json.dumps(pages))
 
-    @pytest.fixture  # type: ignore
+    @pytest.fixture
     def mocked_list_builds_api(
         self, api_credentials: appstore_connect.AppConnectCredentials
-    ) -> Optional[responses_mod.RequestsMock]:
+    ) -> Generator[Optional[responses_mod.RequestsMock], None, None]:
         """Optionally mocks the App Store Connect list builds API.
 
         This fixture piggybacks on the ``api_credentials`` fixture's parametrisation and if


### PR DESCRIPTION
before mypy was set to `skip` all third party imports

this allows mypy to follow them by default, but opts out a few that were failing (will clean these up in a future PR -- wanted to keep these smaller)