### PR TITLE
feat(profiling): add transaction table sorting

### DIFF
--- a/static/app/components/gridEditable/sortLink.tsx
+++ b/static/app/components/gridEditable/sortLink.tsx
@@ -1,3 +1,4 @@
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {LocationDescriptorObject} from 'history';
 import omit from 'lodash/omit';
@@ -13,12 +14,20 @@ type Props = {
   canSort: boolean;
   direction: Directions;
   generateSortLink: () => LocationDescriptorObject | undefined;
-
   title: React.ReactNode;
   onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  replace?: boolean;
 };
 
-function SortLink({align, title, canSort, generateSortLink, onClick, direction}: Props) {
+function SortLink({
+  align,
+  title,
+  canSort,
+  generateSortLink,
+  onClick,
+  direction,
+  replace,
+}: Props) {
   const target = generateSortLink();
 
   if (!target || !canSort) {
@@ -29,8 +38,16 @@ function SortLink({align, title, canSort, generateSortLink, onClick, direction}:
     <StyledIconArrow size="xs" direction={direction === 'desc' ? 'down' : 'up'} />
   );
 
+  const handleOnClick: React.MouseEventHandler<HTMLAnchorElement> = e => {
+    if (replace) {
+      e.preventDefault();
+      browserHistory.replace(target);
+    }
+    onClick?.(e);
+  };
+
   return (
-    <StyledLink align={align} to={target} onClick={onClick}>
+    <StyledLink align={align} to={target} onClick={handleOnClick}>
       {title} {arrow}
     </StyledLink>
   );
@@ -40,7 +57,7 @@ type LinkProps = React.ComponentPropsWithoutRef<typeof Link>;
 type StyledLinkProps = LinkProps & {align: Alignments};
 
 const StyledLink = styled((props: StyledLinkProps) => {
-  const forwardProps = omit(props, ['align']);
+  const forwardProps = omit(props, ['align', 'css']);
   return <Link {...forwardProps} />;
 })`
   display: block;

--- a/static/app/components/profiling/functionsTable.tsx
+++ b/static/app/components/profiling/functionsTable.tsx
@@ -32,11 +32,11 @@ function FunctionsTable(props: FunctionsTableProps) {
 
   const sort = useMemo(() => {
     let column = props.sort;
-    let direction: 'asc' | 'desc' = 'asc' as const;
+    let order: 'asc' | 'desc' = 'asc' as const;
 
     if (props.sort.startsWith('-')) {
       column = props.sort.substring(1);
-      direction = 'desc' as const;
+      order = 'desc' as const;
     }
 
     if (!SORTABLE_COLUMNS.has(column as any)) {
@@ -44,8 +44,8 @@ function FunctionsTable(props: FunctionsTableProps) {
     }
 
     return {
-      column: column as TableColumnKey,
-      direction,
+      key: column as TableColumnKey,
+      order,
     };
   }, [props.sort]);
 
@@ -86,7 +86,7 @@ function FunctionsTable(props: FunctionsTableProps) {
       }
 
       const direction =
-        sort.column !== column ? 'desc' : sort.direction === 'desc' ? 'asc' : 'desc';
+        sort.key !== column ? 'desc' : sort.order === 'desc' ? 'asc' : 'desc';
 
       return () => ({
         ...location,

--- a/static/app/components/profiling/profileTransactionsTable.tsx
+++ b/static/app/components/profiling/profileTransactionsTable.tsx
@@ -1,10 +1,11 @@
-import {useMemo} from 'react';
+import {useMemo, useState} from 'react';
 
 import Count from 'sentry/components/count';
 import DateTime from 'sentry/components/dateTime';
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumnOrder,
+  GridColumnSortBy,
 } from 'sentry/components/gridEditable';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
@@ -29,11 +30,27 @@ function ProfileTransactionsTable(props: ProfileTransactionsTableProps) {
   const location = useLocation();
   const organization = useOrganization();
   const {projects} = useProjects();
+  const [currentSort, setCurrentSort] = useState<GridColumnSortBy<string> | null>(() => {
+    if (location.query.orderBy) {
+      const [key, order] = (location.query.orderBy as string).split(',');
+      return {
+        key,
+        order,
+      } as GridColumnSortBy<string>;
+    }
+    return null;
+  });
+
+  const sortableColumns = useMemo(
+    () => new Set(['transaction', 'project', 'lastSeen', 'p75', 'p95', 'count']),
+    []
+  );
 
   const transactions: TableDataRow[] = useMemo(() => {
-    return props.transactions.map(transaction => {
+    const rows = props.transactions.map(transaction => {
       const project = projects.find(proj => proj.id === transaction.project_id);
       return {
+        _transactionName: transaction.name,
         transaction: project ? (
           <Link
             to={generateProfileSummaryRouteWithQuery({
@@ -58,7 +75,66 @@ function ProfileTransactionsTable(props: ProfileTransactionsTableProps) {
         lastSeen: transaction.last_profile_at,
       };
     });
-  }, [props.transactions, location, organization, projects]);
+
+    if (currentSort) {
+      rows.sort((txA, txB) => {
+        const column = currentSort.key;
+        switch (column) {
+          case 'transaction':
+            return txA._transactionName.localeCompare(txB._transactionName);
+          case 'lastSeen':
+            return new Date(txA.lastSeen).getTime() - new Date(txB.lastSeen).getTime();
+          case 'project':
+            if (!txA.project?.slug || !txB.project?.slug) {
+              return 1;
+            }
+            return txA.project.slug.localeCompare(txB.project.slug);
+          case 'count':
+            return txA.count - txB.count;
+          case 'p75':
+            return txA.p75 - txB.p75;
+          case 'p95':
+            return txA.p95 - txB.p95;
+          default:
+            return 1;
+        }
+      });
+
+      if (currentSort.order === 'desc') {
+        rows.reverse();
+      }
+    }
+
+    return rows;
+  }, [props.transactions, location, organization, projects, currentSort]);
+
+  const generateSortLink = (column: string) => () => {
+    let dir = 'asc';
+    if (column === currentSort?.key && currentSort.order === 'asc') {
+      dir = 'desc';
+    }
+    return {
+      ...location,
+      query: {
+        ...location.query,
+        orderBy: `${column},${dir}`,
+      },
+    };
+  };
+
+  const handleHeadCellOnClick = (column: GridColumnOrder<string>) => {
+    if (currentSort?.key === column.key) {
+      setCurrentSort({
+        key: column.key,
+        order: currentSort.order === 'asc' ? 'desc' : 'asc',
+      });
+      return;
+    }
+    setCurrentSort({
+      key: column.key,
+      order: 'asc',
+    });
+  };
 
   return (
     <GridEditable
@@ -66,9 +142,15 @@ function ProfileTransactionsTable(props: ProfileTransactionsTableProps) {
       error={props.error}
       data={transactions}
       columnOrder={COLUMN_ORDER.map(key => COLUMNS[key])}
-      columnSortBy={[]}
+      columnSortBy={currentSort ? [currentSort] : []}
       grid={{
-        renderHeadCell: renderTableHead({rightAlignedColumns: RIGHT_ALIGNED_COLUMNS}),
+        renderHeadCell: renderTableHead<string>({
+          generateSortLink,
+          onClick: handleHeadCellOnClick,
+          sortableColumns,
+          currentSort,
+          rightAlignedColumns: RIGHT_ALIGNED_COLUMNS,
+        }),
         renderBodyCell: renderTableBody,
       }}
       location={location}
@@ -86,7 +168,7 @@ const RIGHT_ALIGNED_COLUMNS = new Set<TableColumnKey>([
 ]);
 
 function renderTableBody(
-  column: TableColumn,
+  column: GridColumnOrder,
   dataRow: TableDataRow,
   rowIndex: number,
   columnIndex: number
@@ -102,7 +184,7 @@ function renderTableBody(
 }
 
 interface ProfilingTransactionsTableCellProps {
-  column: TableColumn;
+  column: GridColumnOrder;
   columnIndex: number;
   dataRow: TableDataRow;
   rowIndex: number;

--- a/static/app/utils/profiling/tableRenderer.tsx
+++ b/static/app/utils/profiling/tableRenderer.tsx
@@ -1,16 +1,12 @@
 import {LocationDescriptorObject} from 'history';
 
-import {GridColumnOrder} from 'sentry/components/gridEditable';
+import {GridColumnOrder, GridColumnSortBy} from 'sentry/components/gridEditable';
 import SortLink from 'sentry/components/gridEditable/sortLink';
 
-type Sort<K> = {
-  column: K;
-  direction: 'asc' | 'desc';
-};
-
 interface TableHeadProps<K> {
-  currentSort?: Sort<K>;
+  currentSort?: GridColumnSortBy<K> | null;
   generateSortLink?: (column: K) => () => LocationDescriptorObject | undefined;
+  onClick?(column: GridColumnOrder<K>, e: React.MouseEvent<HTMLAnchorElement>): void;
   rightAlignedColumns?: Set<K>;
   sortableColumns?: Set<K>;
 }
@@ -20,17 +16,18 @@ export function renderTableHead<K>({
   generateSortLink,
   rightAlignedColumns,
   sortableColumns,
+  onClick,
 }: TableHeadProps<K>) {
   return (column: GridColumnOrder<K>, _columnIndex: number) => {
     return (
       <SortLink
+        onClick={e => onClick?.(column, e)}
         align={rightAlignedColumns?.has(column.key) ? 'right' : 'left'}
         title={column.name}
-        direction={
-          currentSort?.column === column.key ? currentSort?.direction : undefined
-        }
+        direction={currentSort?.key === column.key ? currentSort?.order : undefined}
         canSort={sortableColumns?.has(column.key) || false}
         generateSortLink={generateSortLink?.(column.key) ?? (() => undefined)}
+        replace
       />
     );
   };


### PR DESCRIPTION
This PR introduces sorting capability for the Transaction table present on the profiling page;

![image](https://user-images.githubusercontent.com/7349258/189182579-377157be-5303-4146-ad38-1111f53456c1.png)
![image](https://user-images.githubusercontent.com/7349258/189182621-6367905b-a362-4f04-933f-4c1aa419a747.png)
![image](https://user-images.githubusercontent.com/7349258/189182643-a4e5d22d-7bc8-4e24-8ad9-e3d4389886d6.png)


Closes: https://github.com/getsentry/team-profiling/issues/56

