### PR TITLE
docs: Update Custom Perf Measurement link in Widget Library

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -452,7 +452,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                 'Filtering by these conditions automatically switch you to indexed events. [link:Learn more].',
                 {
                   link: (
-                    <ExternalLink href="https://docs.sentry.io/product/sentry-basics/metrics/" />
+                    <ExternalLink href="https://docs.sentry.io/product/sentry-basics/search/searchable-properties/#processed-event-properties" />
                   ),
                 }
               )}

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -327,7 +327,7 @@ class WidgetCard extends Component<Props, State> {
                             'You have inputs that are incompatible with [customPerformanceMetrics: custom performance metrics]. See all compatible fields and functions [here: here]. Update your inputs or remove any custom performance metrics.',
                             {
                               customPerformanceMetrics: (
-                                <ExternalLink href="https://docs.sentry.io/product/sentry-basics/metrics/#custom-performance-measurements" />
+                                <ExternalLink href="https://docs.sentry.io/product/performance/metrics/#custom-performance-metrics" />
                               ),
                               here: (
                                 <ExternalLink href="https://docs.sentry.io/product/sentry-basics/search/searchable-properties/#properties-table" />


### PR DESCRIPTION
relates to https://github.com/getsentry/sentry-docs/pull/5479 and
shouldn't be merged until the docs PR is merged