### PR TITLE
ref: type devserver startup

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -69,12 +69,16 @@ files = src/sentry/analytics/,
         src/sentry/replays/consumers/,
         src/sentry/roles/manager.py,
         src/sentry/rules/,
+        src/sentry/runner/commands/devserver.py,
+        src/sentry/runner/initializer.py,
         src/sentry/search/base.py,
         src/sentry/search/events/builder.py,
         src/sentry/search/events/constants.py,
         src/sentry/search/events/types.py,
         src/sentry/search/snuba/,
         src/sentry/sentry_metrics/,
+        src/sentry/services/http.py,
+        src/sentry/services/base.py,
         src/sentry/shared_integrations/,
         src/sentry/silo.py,
         src/sentry/snuba/entity_subscription.py,
@@ -113,6 +117,7 @@ files = src/sentry/analytics/,
         src/sentry/utils/patch_set.py,
         src/sentry/utils/services.py,
         src/sentry/utils/time_window.py,
+        src/sentry/utils/yaml.py,
         src/sentry/web/decorators.py,
         tests/sentry/lang/native/test_appconnect.py,
         tests/sentry/processing/realtime_metrics/,
@@ -151,7 +156,11 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-google.*]
 ignore_missing_imports = True
+[mypy-honcho.*]
+ignore_missing_imports = True
 [mypy-jsonschema]
+ignore_missing_imports = True
+[mypy-kombu]
 ignore_missing_imports = True
 [mypy-lxml]
 ignore_missing_imports = True

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -168,6 +168,7 @@ trio-websocket==0.9.2
 types-freezegun==1.1.10
 types-python-dateutil==2.8.19
 types-pytz==2022.1.2
+types-pyyaml==6.0.11
 types-redis==4.3.13
 types-requests==2.28.8
 types-urllib3==1.26.22

--- a/requirements-dev-only-frozen.txt
+++ b/requirements-dev-only-frozen.txt
@@ -72,6 +72,7 @@ tomli==2.0.1
 types-freezegun==1.1.10
 types-python-dateutil==2.8.19
 types-pytz==2022.1.2
+types-pyyaml==6.0.11
 types-redis==4.3.13
 types-requests==2.28.8
 types-urllib3==1.26.22

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -30,6 +30,7 @@ packaging>=21.3
 msgpack-types>=0.2.0
 mypy>=0.971
 types-freezegun
+types-pyyaml
 types-python-dateutil
 types-pytz
 types-redis

--- a/src/sentry/services/base.py
+++ b/src/sentry/services/base.py
@@ -1,5 +1,5 @@
 class Service:
     name = ""
 
-    def __init__(self, debug=False):
+    def __init__(self, debug: bool = False) -> None:
         self.debug = debug

--- a/src/sentry/utils/yaml.py
+++ b/src/sentry/utils/yaml.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 from functools import partial
 
-from yaml import load as _load
+import yaml
 
-try:
-    # Try to load bindings with libyaml if available
-    from yaml import CSafeLoader as SafeLoader
-except ImportError:
-    from yaml import SafeLoader
+# Try to load bindings with libyaml if available
+SafeLoader: type[yaml.CSafeLoader] | type[yaml.SafeLoader]
+SafeLoader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
 
-safe_load = partial(_load, Loader=SafeLoader)
+safe_load = partial(yaml.load, Loader=SafeLoader)


### PR DESCRIPTION
I noticed `sentry devserver 127.0.0.1` produced this error and decided to prevent it using typing:

```console
$ sentry devserver 127.0.0.1
INFO:The Sentry runner will report development issues to Sentry.io. Use SENTRY_DEVENV_NO_REPORT to avoid reporting issues.
16:33:40 [WARNING] sentry.utils.geo: settings.GEOIP_PATH_MMDB not configured.
/Users/armenzg/code/sentry/src/sentry/runner/initializer.py:571: DeprecatedSettingWarning: The SENTRY_URL_PREFIX setting is deprecated. Please use SENTRY_OPTIONS['system.url-prefix'] instead.
  warnings.warn(DeprecatedSettingWarning(old, "SENTRY_OPTIONS['%s']" % new))
16:33:41 [INFO] sentry.plugins.github: apps-not-configured
16:33:41 [INFO] sentry.runner: We have reported the error below to Sentry
/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/sentry_sdk/worker.py:123: ResourceWarning: unclosed <ssl.SSLSocket fd=6, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('192.168.0.14', 58764), raddr=('34.120.195.249', 443)>
  callback = self._queue.get()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
Traceback (most recent call last):
  File "/Users/armenzg/code/sentry/.venv/bin/sentry", line 33, in <module>
    sys.exit(load_entry_point('sentry', 'console_scripts', 'sentry')())
  File "/Users/armenzg/code/sentry/src/sentry/runner/__init__.py", line 186, in main
    raise e
  File "/Users/armenzg/code/sentry/src/sentry/runner/__init__.py", line 178, in main
    func(**kwargs)
  File "/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/armenzg/code/sentry/src/sentry/runner/decorators.py", line 69, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/armenzg/code/sentry/src/sentry/runner/decorators.py", line 29, in inner
    return ctx.invoke(f, *args, **kwargs)
  File "/Users/armenzg/code/sentry/.venv/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/Users/armenzg/code/sentry/src/sentry/runner/commands/devserver.py", line 215, in devserver
    port = port + 1
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int
```