### PR TITLE
feat(perf-issues): Populate performance issue metadata with type and value

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2041,7 +2041,7 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
                         metric_tags["create_group_transaction.outcome"] = "no_group"
 
                         problem = performance_problems_by_fingerprint[new_grouphash]
-                        group_kwargs = kwargs
+                        group_kwargs = kwargs.copy()
                         group_kwargs["type"] = problem.type.value
 
                         group_kwargs["data"]["metadata"] = inject_performance_problem_metadata(
@@ -2076,7 +2076,7 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
                     is_new = False
 
                     problem = performance_problems_by_fingerprint[existing_grouphash.hash]
-                    group_kwargs = kwargs
+                    group_kwargs = kwargs.copy()
                     group_kwargs["data"]["metadata"] = inject_performance_problem_metadata(
                         group_kwargs["data"]["metadata"], problem
                     )

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2019,6 +2019,8 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
                         problem = performance_problems_by_fingerprint[new_grouphash]
                         kwargs["type"] = problem.type.value
                         kwargs["data"]["metadata"]["title"] = f"N+1 Query: {problem.desc}"
+                        kwargs["data"]["metadata"]["type"] = "N+1 Query"
+                        kwargs["data"]["metadata"]["value"] = problem.desc
 
                         group = _create_group(project, event, **kwargs)
                         GroupHash.objects.create(project=project, hash=new_grouphash, group=group)
@@ -2049,6 +2051,8 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
 
                     description = performance_problems_by_fingerprint[existing_grouphash.hash].desc
                     kwargs["data"]["metadata"]["title"] = f"N+1 Query: {description}"
+                    kwargs["data"]["metadata"]["type"] = "N+1 Query"
+                    kwargs["data"]["metadata"]["value"] = description
 
                     is_regression = _process_existing_aggregate(
                         group=group, event=job["event"], data=kwargs, release=job["release"]

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2041,12 +2041,14 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
                         metric_tags["create_group_transaction.outcome"] = "no_group"
 
                         problem = performance_problems_by_fingerprint[new_grouphash]
-                        kwargs["type"] = problem.type.value
-                        kwargs["data"]["metadata"] = inject_performance_problem_metadata(
-                            kwargs["data"]["metadata"], problem
+                        group_kwargs = kwargs
+                        group_kwargs["type"] = problem.type.value
+
+                        group_kwargs["data"]["metadata"] = inject_performance_problem_metadata(
+                            group_kwargs["data"]["metadata"], problem
                         )
 
-                        group = _create_group(project, event, **kwargs)
+                        group = _create_group(project, event, **group_kwargs)
                         GroupHash.objects.create(project=project, hash=new_grouphash, group=group)
 
                         is_new = True
@@ -2074,12 +2076,13 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
                     is_new = False
 
                     problem = performance_problems_by_fingerprint[existing_grouphash.hash]
-                    kwargs["data"]["metadata"] = inject_performance_problem_metadata(
-                        kwargs["data"]["metadata"], problem
+                    group_kwargs = kwargs
+                    group_kwargs["data"]["metadata"] = inject_performance_problem_metadata(
+                        group_kwargs["data"]["metadata"], problem
                     )
 
                     is_regression = _process_existing_aggregate(
-                        group=group, event=job["event"], data=kwargs, release=job["release"]
+                        group=group, event=job["event"], data=group_kwargs, release=job["release"]
                     )
 
                     job["groups"].append(

--- a/tests/sentry/performance_issues/test_performance_issues.py
+++ b/tests/sentry/performance_issues/test_performance_issues.py
@@ -62,6 +62,8 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             assert group.get_event_metadata() == {
                 "location": "/books/",
                 "title": "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+                "type": "N+1 Query",
+                "value": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
             }
             assert group.location() == "/books/"
             assert group.level == 40
@@ -106,6 +108,8 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             assert group.get_event_metadata() == {
                 "location": "/books/",
                 "title": "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+                "type": "N+1 Query",
+                "value": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
             }
             assert group.location() == "/books/"
             assert group.message == "/books/"


### PR DESCRIPTION
Issue details in the issues feed is populated based on the `metadata`. This adds the following metadata: `{ "title": "N+1 Query: <span.description>", "type": "N+1 Query", "value": "<span.description>"}`