### PR TITLE
ref(dropdownMenu): Build a default disabledKeys list

### DIFF
--- a/static/app/components/dropdownMenuControl.tsx
+++ b/static/app/components/dropdownMenuControl.tsx
@@ -25,6 +25,25 @@ function removeHiddenItems(source: MenuItemProps[]): MenuItemProps[] {
     }));
 }
 
+/**
+ * Recursively finds and returns disabled items
+ */
+function getDisabledKeys(source: MenuItemProps[]): MenuItemProps['key'][] {
+  return source.reduce<string[]>((acc, cur) => {
+    if (cur.disabled) {
+      // If an item is disabled, then its children will be inaccessible, so we
+      // can skip them and just return the parent item
+      return acc.concat([cur.key]);
+    }
+
+    if (cur.children) {
+      return acc.concat(getDisabledKeys(cur.children));
+    }
+
+    return acc;
+  }, []);
+}
+
 type TriggerProps = {
   props: Omit<React.HTMLAttributes<Element>, 'children'> & {
     onClick?: (e: MouseEvent) => void;
@@ -190,10 +209,7 @@ function MenuControl({
   }
 
   const activeItems = useMemo(() => removeHiddenItems(items), [items]);
-  const defaultDisabledKeys = useMemo(
-    () => activeItems.filter(item => item.disabled).map(item => item.key),
-    [activeItems]
-  );
+  const defaultDisabledKeys = useMemo(() => getDisabledKeys(activeItems), [activeItems]);
 
   function renderMenu() {
     if (!state.isOpen) {

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -273,7 +273,6 @@ function ActionSet({
           showChevron: false,
           size: 'xs',
         }}
-        disabledKeys={menuItems.filter(item => item.disabled).map(item => item.key)}
         isDisabled={!anySelected}
       />
       <IssueListSortOptions sort={sort} query={query} onSelect={onSortChange} />


### PR DESCRIPTION
In `DropdownMenuControl`, build a default `disabledKeys` list comprising off all items with `disabled: true`. This is only a default value and can be overwritten by passing a `disabledKeys` prop to <DropdownMenuControl />

**Before:** if an item is marked with `disabled: true`, but `disabledKeys` isn't specified, then it will still be clickable
<img width="262" alt="Screen Shot 2022-09-08 at 1 25 28 PM" src="https://user-images.githubusercontent.com/44172267/189219012-038afd2f-56c1-4ce8-814c-597629552ef5.png">

**After:**
<img width="262" alt="Screen Shot 2022-09-08 at 1 24 35 PM" src="https://user-images.githubusercontent.com/44172267/189219022-747fd6f5-ec1a-42e8-903a-c0d64b124a06.png">