### PR TITLE
refs: Remove unused `get_(earliest|latest)_event_id` methods from eventstore

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -124,8 +124,6 @@ class EventStorage(Service):
         "get_unfetched_events",
         "get_prev_event_id",
         "get_next_event_id",
-        "get_earliest_event_id",
-        "get_latest_event_id",
         "bind_nodes",
         "get_unfetched_transactions",
     )
@@ -212,28 +210,6 @@ class EventStorage(Service):
     def get_prev_event_id(self, event, snuba_filter):
         """
         Gets the previous event given a current event and some conditions/filters.
-        Returns a tuple of (project_id, event_id)
-
-        Arguments:
-        event (Event): Event object
-        snuba_filter (Filter): Filter
-        """
-        raise NotImplementedError
-
-    def get_earliest_event_id(self, event, snuba_filter):
-        """
-        Gets the earliest event given a current event and some conditions/filters.
-        Returns a tuple of (project_id, event_id)
-
-        Arguments:
-        event (Event): Event object
-        snuba_filter (Filter): Filter
-        """
-        raise NotImplementedError
-
-    def get_latest_event_id(self, event, snuba_filter):
-        """
-        Gets the latest event given a current event and some conditions/filters.
         Returns a tuple of (project_id, event_id)
 
         Arguments:

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -249,22 +249,6 @@ class SnubaEventStorage(EventStorage):
 
         return event
 
-    def get_earliest_event_id(self, event, filter):
-        filter = deepcopy(filter)
-        filter.conditions = filter.conditions or []
-        filter.conditions.extend(get_before_event_condition(event))
-        filter.end = event.datetime
-
-        return self.__get_event_id_from_filter(filter=filter, orderby=ASC_ORDERING)
-
-    def get_latest_event_id(self, event, filter):
-        filter = deepcopy(filter)
-        filter.conditions = filter.conditions or []
-        filter.conditions.extend(get_after_event_condition(event))
-        filter.start = event.datetime
-
-        return self.__get_event_id_from_filter(filter=filter, orderby=DESC_ORDERING)
-
     def get_next_event_id(self, event, filter):
         """
         Returns (project_id, event_id) of a next event given a current event

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -279,23 +279,6 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
         assert prev_event == (str(project.id), "a" * 32)
         assert next_event is None
 
-    def test_get_latest_or_oldest_event_id(self):
-        # Returns a latest/oldest event
-        event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
-        _filter = Filter(project_ids=[self.project1.id, self.project2.id])
-        oldest_event = self.eventstore.get_earliest_event_id(event, filter=_filter)
-        latest_event = self.eventstore.get_latest_event_id(event, filter=_filter)
-        assert oldest_event == (str(self.project1.id), "a" * 32)
-        assert latest_event == (str(self.project2.id), "f" * 32)
-
-        # Returns none when no latest/oldest event that meets conditions
-        event = self.eventstore.get_event_by_id(self.project2.id, "b" * 32)
-        _filter = Filter(project_ids=[self.project1.id], group_ids=[self.event2.group_id])
-        oldest_event = self.eventstore.get_earliest_event_id(event, filter=_filter)
-        latest_event = self.eventstore.get_latest_event_id(event, filter=_filter)
-        assert oldest_event is None
-        assert latest_event is None
-
     def test_transaction_get_next_prev_event_id(self):
 
         _filter = Filter(


### PR DESCRIPTION
These are unused now, just removing
