### PR TITLE
feat(sampling): Add ui support for the latest release [TET-311]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/conditions.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/conditions.tsx
@@ -12,7 +12,7 @@ import {SamplingInnerName} from 'sentry/types/sampling';
 import {getInnerNameLabel} from '../../utils';
 
 import {TagValueAutocomplete, TagValueAutocompleteProps} from './tagValueAutocomplete';
-import {getMatchFieldPlaceholder, getTagKey} from './utils';
+import {getMatchFieldAriaLabel, getMatchFieldPlaceholder, getTagKey} from './utils';
 
 export type Condition = {
   category: SamplingInnerName;
@@ -50,12 +50,18 @@ export function Conditions({conditions, orgSlug, projectId, onDelete, onChange}:
             <CenterCell>
               {isAutoCompleteField ? (
                 <TagValueAutocomplete
-                  category={category}
                   tagKey={getTagKey(condition)}
                   orgSlug={orgSlug}
                   projectId={projectId}
                   value={match}
                   onChange={value => onChange(index, 'match', value)}
+                  placeholder={getMatchFieldPlaceholder(category)}
+                  ariaLabel={getMatchFieldAriaLabel(category)}
+                  prependOptions={
+                    category === SamplingInnerName.TRACE_RELEASE
+                      ? [{value: 'latest', label: t('Latest Release(s)')}]
+                      : []
+                  }
                 />
               ) : (
                 <StyledTextareaField

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.spec.tsx
@@ -110,7 +110,6 @@ describe('TagValueAutocomplete', function () {
       />
     );
 
-
     // Open the select
     userEvent.click(screen.getByLabelText('Search or add an environment'));
 

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.spec.tsx
@@ -1,7 +1,6 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
-import {SamplingInnerName} from 'sentry/types/sampling';
 import {TagValueAutocomplete} from 'sentry/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete';
 
 describe('TagValueAutocomplete', function () {
@@ -23,12 +22,12 @@ describe('TagValueAutocomplete', function () {
   it('correctly offers new value option', async function () {
     render(
       <TagValueAutocomplete
-        category={SamplingInnerName.TRACE_ENVIRONMENT}
         onChange={() => {}}
         orgSlug="org-slug"
         projectId="1"
         tagKey="environment"
         value=""
+        ariaLabel="Search or add an environment"
       />
     );
 
@@ -72,12 +71,12 @@ describe('TagValueAutocomplete', function () {
   it('displays the counts of tag values', async function () {
     render(
       <TagValueAutocomplete
-        category={SamplingInnerName.TRACE_ENVIRONMENT}
         onChange={() => {}}
         orgSlug="org-slug"
         projectId="1"
         tagKey="environment"
         value=""
+        ariaLabel="Search or add an environment"
       />
     );
 
@@ -96,5 +95,27 @@ describe('TagValueAutocomplete', function () {
     // Assert the filtered out value count is not there anymore
     expect(await screen.findByText(199)).toBeInTheDocument();
     expect(screen.queryByText(97)).not.toBeInTheDocument();
+  });
+
+  it('accepts prependOptions', async function () {
+    render(
+      <TagValueAutocomplete
+        onChange={() => {}}
+        orgSlug="org-slug"
+        projectId="1"
+        tagKey="environment"
+        value=""
+        ariaLabel="Search or add an environment"
+        prependOptions={[{value: 'prepended', label: 'Prepended'}]}
+      />
+    );
+
+    const input = screen.getByLabelText('Search or add an environment');
+
+    // Open the select
+    userEvent.click(input);
+
+    // Assert the custom prepended options are there
+    expect(await screen.findByText('Prepended')).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.spec.tsx
@@ -110,10 +110,9 @@ describe('TagValueAutocomplete', function () {
       />
     );
 
-    const input = screen.getByLabelText('Search or add an environment');
 
     // Open the select
-    userEvent.click(input);
+    userEvent.click(screen.getByLabelText('Search or add an environment'));
 
     // Assert the custom prepended options are there
     expect(await screen.findByText('Prepended')).toBeInTheDocument();

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/tagValueAutocomplete.tsx
@@ -5,13 +5,16 @@ import debounce from 'lodash/debounce';
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import Count from 'sentry/components/count';
 import SelectField from 'sentry/components/forms/selectField';
-import {t} from 'sentry/locale';
-import {Organization, Project, TagValue as IssueTagValue} from 'sentry/types';
-import {SamplingInnerName} from 'sentry/types/sampling';
+import {
+  Organization,
+  Project,
+  SelectValue,
+  TagValue as IssueTagValue,
+} from 'sentry/types';
 import useApi from 'sentry/utils/useApi';
 
 import {TruncatedLabel} from './truncatedLabel';
-import {formatCreateTagLabel, getMatchFieldPlaceholder} from './utils';
+import {formatCreateTagLabel} from './utils';
 
 type TagValue = Pick<
   IssueTagValue,
@@ -19,10 +22,12 @@ type TagValue = Pick<
 >;
 
 export interface TagValueAutocompleteProps {
-  category: SamplingInnerName.TRACE_ENVIRONMENT | SamplingInnerName.TRACE_RELEASE;
   onChange: (value: string) => void;
   orgSlug: Organization['slug'];
   projectId: Project['id'];
+  ariaLabel?: string;
+  placeholder?: string;
+  prependOptions?: SelectValue<string>[];
   tagKey?: string;
   value?: string;
 }
@@ -30,23 +35,14 @@ export interface TagValueAutocompleteProps {
 function TagValueAutocomplete({
   orgSlug,
   projectId,
-  category,
   onChange,
   value,
   tagKey,
+  placeholder,
+  ariaLabel,
+  prependOptions = [],
 }: TagValueAutocompleteProps) {
   const api = useApi();
-
-  function getAriaLabel() {
-    switch (category) {
-      case SamplingInnerName.TRACE_RELEASE:
-        return t('Search or add a release');
-      case SamplingInnerName.TRACE_ENVIRONMENT:
-        return t('Search or add an environment');
-      default:
-        return undefined;
-    }
-  }
 
   const debouncedFetchValues = debounce(async (inputValue, resolve) => {
     if (!tagKey) {
@@ -78,6 +74,7 @@ function TagValueAutocomplete({
       ? value
           .split('\n')
           .filter(v => !response.some(tagValue => tagValue.value === v))
+          .filter(v => !prependOptions.some(option => option.value === v))
           .map(v => ({
             value: v,
             name: v,
@@ -88,11 +85,13 @@ function TagValueAutocomplete({
           }))
       : [];
 
-    return [...response, ...createdOptions].map(tagValue => ({
+    const options = [...response, ...createdOptions].map(tagValue => ({
       value: tagValue.value,
       label: <TruncatedLabel value={tagValue.value} />,
       trailingItems: <StyledCount value={tagValue.count} />,
     }));
+
+    return [...prependOptions, ...options];
   };
 
   return (
@@ -101,7 +100,7 @@ function TagValueAutocomplete({
       // The key is used as a way to force a reload of the options:
       // https://github.com/JedWatson/react-select/issues/1879#issuecomment-316871520
       key={tagKey}
-      aria-label={getAriaLabel()}
+      aria-label={ariaLabel}
       value={value ? value?.split('\n').map(v => ({value: v, label: v})) : []}
       onChange={newValue => {
         onChange(newValue?.join('\n'));
@@ -131,7 +130,7 @@ function TagValueAutocomplete({
         );
       }}
       filterOption={(option, filterText) => option.data.value.indexOf(filterText) > -1}
-      placeholder={getMatchFieldPlaceholder(category)}
+      placeholder={placeholder}
       inline={false}
       multiple
       hideControlState

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/utils.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/utils.tsx
@@ -24,6 +24,17 @@ export function getMatchFieldPlaceholder(category: SamplingInnerName) {
   }
 }
 
+export function getMatchFieldAriaLabel(category: SamplingInnerName) {
+  switch (category) {
+    case SamplingInnerName.TRACE_RELEASE:
+      return t('Search or add a release');
+    case SamplingInnerName.TRACE_ENVIRONMENT:
+      return t('Search or add an environment');
+    default:
+      return undefined;
+  }
+}
+
 export function getNewCondition(condition: Condition): SamplingConditionLogicalInner {
   const newValue = (condition.match ?? '')
     .split('\n')


### PR DESCRIPTION
This PR adds a support for the `latest` release sampling rule.

The latest is dynamic so it always targets the newest release that came out.

https://user-images.githubusercontent.com/9060071/189329783-f2d5ca23-3f0c-4af1-9a59-994f0a14f3dc.mp4

This can be merged once the backend counterpart is ready: https://github.com/getsentry/sentry/pull/38660