### PR TITLE
feat: Enable DS for PHP sdks

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -34,6 +34,9 @@ ALLOWED_SDK_NAMES = frozenset(
         "sentry.python",  # python, django, flask, FastAPI, Starlette, Bottle, Celery, pyramid, rq
         "sentry.python.serverless",  # AWS Lambda
         "sentry.cocoa",  # iOS
+        "sentry.php",  # PHP
+        "sentry.php.laravel",  # Laravel
+        "sentry.php.symfony",  # Symfony
     )
 )
 # We want sentry.java.android, sentry.java.android.timber, and all others to match


### PR DESCRIPTION
As I'm currently working on DS for our PHP SDKs, I whitelisted them to allow me to continue testing. As DS is feature-flagged, I do not think this will cause issues.