### PR TITLE
fix(perf-issues) do not get perf issues settings when feature flag is not enabled

### DIFF
--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.jsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.jsx
@@ -8,7 +8,7 @@ describe('projectPerformance', function () {
   });
   const project = TestStubs.ProjectDetails();
   const configUrl = '/projects/org-slug/project-slug/transaction-threshold/configure/';
-  let getMock, postMock, deleteMock;
+  let getMock, postMock, deleteMock, performanceIssuesMock;
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
@@ -43,7 +43,7 @@ describe('projectPerformance', function () {
       body: {},
       statusCode: 200,
     });
-    MockApiClient.addMockResponse({
+    performanceIssuesMock = MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/performance-issues/configure/',
       method: 'GET',
       body: {},
@@ -104,5 +104,21 @@ describe('projectPerformance', function () {
 
     await tick();
     expect(deleteMock).toHaveBeenCalled();
+  });
+
+  it('does not get performance issues settings without the feature flag', async function () {
+    const org_without_perf_issues = TestStubs.Organization({
+      features: ['performance-view'],
+    });
+
+    mountWithTheme(
+      <ProjectPerformance
+        params={{orgId: org.slug, projectId: project.slug}}
+        organization={org_without_perf_issues}
+        project={project}
+      />
+    );
+    await tick();
+    expect(performanceIssuesMock).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -52,17 +52,22 @@ class ProjectPerformance extends AsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {params} = this.props;
+    const {params, organization} = this.props;
     const {orgId, projectId} = params;
 
     const endpoints: ReturnType<AsyncView['getEndpoints']> = [
       ['threshold', `/projects/${orgId}/${projectId}/transaction-threshold/configure/`],
-      [
-        'performance_issue_settings',
-        `/projects/${orgId}/${projectId}/performance-issues/configure/`,
-      ],
       ['project', `/projects/${orgId}/${projectId}/`],
     ];
+
+    if (organization.features.includes('performance-issues')) {
+      const performanceIssuesEndpoint = [
+        'performance_issue_settings',
+        `/projects/${orgId}/${projectId}/performance-issues/configure/`,
+      ] as [string, string];
+
+      endpoints.push(performanceIssuesEndpoint);
+    }
 
     return endpoints;
   }


### PR DESCRIPTION
This PR fixes project settings erroring out getting performance issue settings. `getEndpoints` was making a call to `performance-issues/configure/` even when the org didn't have a performance issues feature flag. Now there is a check in place for that.