### PR TITLE
ref(perf-issues): Separate `spans_involved` into 3 specific lists

### DIFF
--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -91,8 +91,9 @@ class PerformanceDetectionTest(unittest.TestCase):
                 op="db",
                 desc="SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-                spans_involved=[
-                    "9179e43ae844b174",
+                parent_span_ids=["8dd7a5869a4f4583"],
+                cause_span_ids=["9179e43ae844b174"],
+                offender_span_ids=[
                     "b8be6138369491dd",
                     "b2d4826e7b618f1b",
                     "b3fdeea42536dbf1",
@@ -517,7 +518,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_n_plus_one_db_fp",
                     "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
                 ),
-                call("_pi_n_plus_one_db", "9179e43ae844b174"),
+                call("_pi_n_plus_one_db", "b8be6138369491dd"),
             ]
         )
         assert perf_problems == [
@@ -526,8 +527,9 @@ class PerformanceDetectionTest(unittest.TestCase):
                 op="db",
                 desc="SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
                 type=GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-                spans_involved=[
-                    "9179e43ae844b174",
+                parent_span_ids=["8dd7a5869a4f4583"],
+                cause_span_ids=["9179e43ae844b174"],
+                offender_span_ids=[
                     "b8be6138369491dd",
                     "b2d4826e7b618f1b",
                     "b3fdeea42536dbf1",
@@ -650,7 +652,9 @@ class PrepareProblemForGroupingTest(unittest.TestCase):
             op="db",
             type=GroupType.PERFORMANCE_N_PLUS_ONE,
             desc="SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
-            spans_involved=["b3fdeea42536dbf1", "b2d4826e7b618f1b"],
+            parent_span_ids=None,
+            cause_span_ids=None,
+            offender_span_ids=["b3fdeea42536dbf1", "b2d4826e7b618f1b"],
         )
 
 


### PR DESCRIPTION
`spans_involved` wasn't used outside of the detector. Replace it with three specific lists (for parents, causes, and offenders) so that they can be added to the event in nodestore downstream.