### PR TITLE
feat(perf-issues): Add flag for dev-only perf issues code

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1147,6 +1147,8 @@ SENTRY_FEATURES = {
     "organizations:performance-issues": False,
     # Enable the creation of performance issues in the ingest pipeline. Turning this on will eventually make performance issues be created with default settings.
     "organizations:performance-issues-ingest": False,
+    # Enable performance issues dev options, includes changing detection thresholds and other parts of issues that we're using for development.
+    "organizations:performance-issues-dev": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
     # Enable the UI for the overage alert settings

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -116,6 +116,7 @@ default_manager.add("organizations:performance-dry-run-mep", OrganizationFeature
 default_manager.add("organizations:performance-frontend-use-events-endpoint", OrganizationFeature, True)
 default_manager.add("organizations:performance-issues", OrganizationFeature, True)
 default_manager.add("organizations:performance-issues-ingest", OrganizationFeature)
+default_manager.add("organizations:performance-issues-dev", OrganizationFeature, True)
 default_manager.add("organizations:performance-onboarding-checklist", OrganizationFeature, True)
 default_manager.add("organizations:performance-span-histogram-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-span-tree-autoscroll", OrganizationFeature, True)


### PR DESCRIPTION
### Summary
Considering we'll likely be using the 'performance-issues' flag as our EA / go-live flag, this extra flag will let us split up code that we're using solely for development at the moment (detection thresholds etc) that we also don't want showing up in ST / self-hosted.
