### PR TITLE
feat(perf-issues): Put perf detection settings behind dev flag

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -93,7 +93,7 @@ export default class AdminSettings extends AsyncView<{}, State> {
             {fields['beacon.anonymous']}
           </Panel>
 
-          <Feature features={['organizations:performance-issues']}>
+          <Feature features={['organizations:performance-issues-dev']}>
             <Panel>
               <PanelHeader>Performance Issues</PanelHeader>
               {fields['performance.issues.all.problem-detection']}

--- a/static/app/views/settings/projectPerformance/projectPerformance.spec.jsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.spec.jsx
@@ -4,7 +4,7 @@ import ProjectPerformance from 'sentry/views/settings/projectPerformance/project
 
 describe('projectPerformance', function () {
   const org = TestStubs.Organization({
-    features: ['performance-view', 'performance-issues'],
+    features: ['performance-view', 'performance-issues-dev'],
   });
   const project = TestStubs.ProjectDetails();
   const configUrl = '/projects/org-slug/project-slug/transaction-threshold/configure/';

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -60,7 +60,7 @@ class ProjectPerformance extends AsyncView<Props, State> {
       ['project', `/projects/${orgId}/${projectId}/`],
     ];
 
-    if (organization.features.includes('performance-issues')) {
+    if (organization.features.includes('performance-issues-dev')) {
       const performanceIssuesEndpoint = [
         'performance_issue_settings',
         `/projects/${orgId}/${projectId}/performance-issues/configure/`,
@@ -259,7 +259,7 @@ class ProjectPerformance extends AsyncView<Props, State> {
             )}
           </Access>
         </Form>
-        <Feature features={['organizations:performance-issues']}>
+        <Feature features={['organizations:performance-issues-dev']}>
           <Fragment>
             <Form
               saveOnBlur


### PR DESCRIPTION
### Summary
This puts the performance detection settings behind a dev flag so we can still use these settings during EA as we roll out new detectors.

Requires https://github.com/getsentry/sentry/pull/38630