### PR TITLE
fix(perf-issues): Remove query from group title in the metadata

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1186,9 +1186,8 @@ def materialize_metadata(data, event_type, event_metadata):
 
 def inject_performance_problem_metadata(metadata, problem: PerformanceProblem):
     # TODO make type here dynamic, pull it from group type
-    metadata["type"] = "N+1 Query"
     metadata["value"] = problem.desc
-    metadata["title"] = f"N+1 Query: {problem.desc}"
+    metadata["title"] = "N+1 Query"
     return metadata
 
 

--- a/tests/sentry/performance_issues/test_performance_issues.py
+++ b/tests/sentry/performance_issues/test_performance_issues.py
@@ -52,10 +52,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             assert spans == [{"hash": hash_values([span["description"]])} for span in data["spans"]]
             assert len(event.groups) == 1
             group = event.groups[0]
-            assert (
-                group.title
-                == "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-            )
+            assert group.title == "N+1 Query"
             assert group.message == "/books/"
             assert group.culprit == "/books/"
             assert group.get_event_type() == "transaction"
@@ -100,10 +97,8 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
                 manager.save(self.project.id)
             # Make sure the original group is updated via buffers
             group.refresh_from_db()
-            assert (
-                group.title
-                == "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
-            )
+            assert group.title == "N+1 Query"
+
             assert group.get_event_metadata() == {
                 "location": "/books/",
                 "title": "N+1 Query",

--- a/tests/sentry/performance_issues/test_performance_issues.py
+++ b/tests/sentry/performance_issues/test_performance_issues.py
@@ -61,8 +61,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             assert group.get_event_type() == "transaction"
             assert group.get_event_metadata() == {
                 "location": "/books/",
-                "title": "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
-                "type": "N+1 Query",
+                "title": "N+1 Query",
                 "value": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
             }
             assert group.location() == "/books/"
@@ -107,8 +106,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             )
             assert group.get_event_metadata() == {
                 "location": "/books/",
-                "title": "N+1 Query: SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
-                "type": "N+1 Query",
+                "title": "N+1 Query",
                 "value": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
             }
             assert group.location() == "/books/"


### PR DESCRIPTION
Title shouldn't include the query. Query is displayed below the title as it comes from `metadata.value`

<img width="844" alt="image" src="https://user-images.githubusercontent.com/23648387/189401117-1e41dd77-5eda-4bc3-a8c6-eabacede5bf9.png">
