### PR TITLE
ref(hybrid): Rename customer silo to "region silo"

### DIFF
--- a/scripts/silo/add_silo_decorators.py
+++ b/scripts/silo/add_silo_decorators.py
@@ -19,7 +19,7 @@ SILO_KEYWORDS = {
     "control": Keywords(
         include_words=["User", "Auth", "Identity"],
     ),
-    "customer": Keywords(
+    "region": Keywords(
         include_words=["Organization", "Project", "Team", "Group", "Event", "Issue"],
         exclude_words=["JiraIssue"],
     ),

--- a/scripts/silo/decorate_models_by_relation.py
+++ b/scripts/silo/decorate_models_by_relation.py
@@ -16,18 +16,18 @@ This is an alternative to add_silo_decorators.py that uses an algorithmic defini
 the silos and aims for 100% coverage. It examines the fields of model classes and
 uses a graph traversal algorithm to find all models that point to the `Organization`
 model, either directly or through a number of steps. Those models are tagged for the
-customer silo, and all others for the control silo.
+region silo, and all others for the control silo.
 
 Instructions for use:
 
 1. Commit or stash any Git changes in progress.
-2. Update foreign key relationships to identify models in the customer silo.
+2. Update foreign key relationships to identify models in the region silo.
 2. From the Sentry project root, do
      ./scripts/silo/decorate_models_by_relation.py
 3. Do `git status` or `git diff` to observe the results. Commit if you're happy.
 """
 
-CUSTOMER_TARGET_RELATIONS = TargetRelations(
+REGION_TARGET_RELATIONS = TargetRelations(
     # Foreign key relationships
     models=[Organization],
     naming_conventions={
@@ -40,4 +40,4 @@ CUSTOMER_TARGET_RELATIONS = TargetRelations(
 )
 
 if __name__ == "__main__":
-    decorate_models_by_relation(target_relations=CUSTOMER_TARGET_RELATIONS)
+    decorate_models_by_relation(target_relations=REGION_TARGET_RELATIONS)

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -42,7 +42,7 @@ __all__ = [
     "EnvironmentMixin",
     "StatsMixin",
     "control_silo_endpoint",
-    "customer_silo_endpoint",
+    "region_silo_endpoint",
     "pending_silo_endpoint",
 ]
 
@@ -545,10 +545,10 @@ class EndpointSiloLimit(SiloLimit):
 
 
 control_silo_endpoint = EndpointSiloLimit(SiloMode.CONTROL)
-customer_silo_endpoint = EndpointSiloLimit(SiloMode.CUSTOMER)
+region_silo_endpoint = EndpointSiloLimit(SiloMode.REGION)
 
 # Use this decorator to mark endpoints that still need to be marked as either
-# control_silo_endpoint or customer_silo_endpoint. Marking a class with
+# control_silo_endpoint or region_silo_endpoint. Marking a class with
 # pending_silo_endpoint keeps it from tripping SiloLimitCoverageTest, while ensuring
 # that the test will fail if a new endpoint is added with no decorator at all.
 # Eventually we should replace all instances of this decorator and delete it.

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -18,7 +18,7 @@ __all__ = (
     "DefaultFieldsModel",
     "sane_repr",
     "control_silo_model",
-    "customer_silo_model",
+    "region_silo_model",
 )
 
 
@@ -206,5 +206,5 @@ class ModelSiloLimit(SiloLimit):
         return model_class
 
 
-control_silo_model = ModelSiloLimit(SiloMode.CONTROL, read_only=SiloMode.CUSTOMER)
-customer_silo_model = ModelSiloLimit(SiloMode.CUSTOMER)
+control_silo_model = ModelSiloLimit(SiloMode.CONTROL, read_only=SiloMode.REGION)
+region_silo_model = ModelSiloLimit(SiloMode.REGION)

--- a/src/sentry/silo.py
+++ b/src/sentry/silo.py
@@ -18,7 +18,7 @@ class SiloMode(Enum):
 
     MONOLITH = "MONOLITH"
     CONTROL = "CONTROL"
-    CUSTOMER = "CUSTOMER"
+    REGION = "REGION"
 
     @classmethod
     def resolve(cls, mode: str | SiloMode | None) -> SiloMode:

--- a/src/sentry/testutils/silo.py
+++ b/src/sentry/testutils/silo.py
@@ -23,7 +23,7 @@ class SiloModeTest:
     If the SILO_MODE_SPLICE_TESTS environment flag is set, any decorated test
     class will be modified by having new test methods inserted. These new
     methods run in the given modes and have generated names (such as
-    "test_response__in_customer_silo"). This can be used in a dev environment to
+    "test_response__in_region_silo"). This can be used in a dev environment to
     test in multiple modes conveniently during a single test run. Individually
     decorated methods and stand-alone functions are treated as normal.
     """
@@ -78,7 +78,7 @@ class SiloModeTest:
 
 
 control_silo_test = SiloModeTest(SiloMode.CONTROL)
-customer_silo_test = SiloModeTest(SiloMode.CUSTOMER)
+region_silo_test = SiloModeTest(SiloMode.REGION)
 
 
 @contextmanager
@@ -95,7 +95,7 @@ def exempt_from_silo_limits() -> Generator[None, None, None]:
     kludge when that's too inconvenient. For example:
 
     ```
-    @SiloModeTest(SiloMode.CUSTOMER)
+    @SiloModeTest(SiloMode.REGION)
     class MyTest(TestCase):
         def test_something(self):
             with exempt_from_mode_limits():

--- a/src/sentry/utils/silo/add_silo_decorators.py
+++ b/src/sentry/utils/silo/add_silo_decorators.py
@@ -10,7 +10,7 @@ from sentry.utils.silo.common import (
     Keywords,
     apply_decorators,
     has_control_name,
-    has_customer_name,
+    has_region_name,
 )
 
 
@@ -34,14 +34,14 @@ def add_silo_decorators(
     ####################################################################
     # Fill these predicates in with the logic you want to apply
 
-    def customer_model_predicate(c: TargetClass) -> bool:
+    def region_model_predicate(c: TargetClass) -> bool:
         return False  # For now, rely on decorate_models_by_relation instead
 
     def control_model_predicate(c: TargetClass) -> bool:
         return False  # For now, rely on decorate_models_by_relation instead
 
-    def customer_endpoint_predicate(c: TargetClass) -> bool:
-        return has_customer_name(c.name, silo_keywords)
+    def region_endpoint_predicate(c: TargetClass) -> bool:
+        return has_region_name(c.name, silo_keywords)
 
     def control_endpoint_predicate(c: TargetClass) -> bool:
         return has_control_name(c.name, silo_keywords)
@@ -49,10 +49,10 @@ def add_silo_decorators(
     ####################################################################
 
     execute(
-        "customer_silo_model",
-        "from sentry.db.models import customer_silo_model",
+        "region_silo_model",
+        "from sentry.db.models import region_silo_model",
         ClassCategory.MODEL,
-        customer_model_predicate,
+        region_model_predicate,
     )
     execute(
         "control_silo_model",
@@ -61,10 +61,10 @@ def add_silo_decorators(
         control_model_predicate,
     )
     execute(
-        "customer_silo_endpoint",
-        "from sentry.api.base import customer_silo_endpoint",
+        "region_silo_endpoint",
+        "from sentry.api.base import region_silo_endpoint",
         ClassCategory.ENDPOINT,
-        customer_endpoint_predicate,
+        region_endpoint_predicate,
     )
     execute(
         "control_silo_endpoint",
@@ -76,7 +76,7 @@ def add_silo_decorators(
         "pending_silo_endpoint",
         "from sentry.api.base import pending_silo_endpoint",
         ClassCategory.ENDPOINT,
-        (lambda c: not (customer_endpoint_predicate(c) or control_endpoint_predicate(c))),
+        (lambda c: not (region_endpoint_predicate(c) or control_endpoint_predicate(c))),
     )
 
 

--- a/src/sentry/utils/silo/common.py
+++ b/src/sentry/utils/silo/common.py
@@ -83,7 +83,7 @@ def apply_decorators(
         # decorator, or such.
         new_code = re.sub(
             (
-                r"(?:\n@((?:control|customer|pending)_silo_(?:model|endpoint|test)))?"
+                r"(?:\n@((?:control|region|pending)_silo_(?:model|endpoint|test)))?"
                 rf"\n(class\s+{class_name}\()"
             ),
             replace,
@@ -121,9 +121,9 @@ class Keywords:
         return has_included_word and not has_excluded_word
 
 
-def has_customer_name(name: str, keywords: Mapping[str, Keywords]) -> bool:
-    return keywords["customer"].check(name)
+def has_region_name(name: str, keywords: Mapping[str, Keywords]) -> bool:
+    return keywords["region"].check(name)
 
 
 def has_control_name(name: str, keywords: Mapping[str, Keywords]) -> bool:
-    return (not has_customer_name(name, keywords)) and keywords["control"].check(name)
+    return (not has_region_name(name, keywords)) and keywords["control"].check(name)

--- a/src/sentry/utils/silo/decorate_models_by_relation.py
+++ b/src/sentry/utils/silo/decorate_models_by_relation.py
@@ -36,8 +36,8 @@ def decorate_models_by_relation(
         target_classes=target_relations.models,
         naming_conventions=target_relations.naming_conventions,
     )
-    customer_classes = search.sweep_for_relations()
-    control_classes = model_classes.difference(customer_classes)
+    region_classes = search.sweep_for_relations()
+    control_classes = model_classes.difference(region_classes)
 
     def filtered_names(classes):
         return (
@@ -53,9 +53,9 @@ def decorate_models_by_relation(
         path_name,
     )
     apply_decorators(
-        "customer_silo_model",
-        "from sentry.db.models import customer_silo_model",
-        filtered_names(customer_classes),
+        "region_silo_model",
+        "from sentry.db.models import region_silo_model",
+        filtered_names(region_classes),
         path_name,
     )
 

--- a/src/sentry/utils/silo/decorate_unit_tests.py
+++ b/src/sentry/utils/silo/decorate_unit_tests.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Callable, Dict, Iterable, List, Mapping, Set, Tuple
 
-from sentry.utils.silo.common import Keywords, has_control_name, has_customer_name
+from sentry.utils.silo.common import Keywords, has_control_name, has_region_name
 
 
 def decorate_unit_tests(silo_keywords: Dict[str, Keywords]):
@@ -17,7 +17,7 @@ def decorate_unit_tests(silo_keywords: Dict[str, Keywords]):
     case_map = TestCaseMap(TestCaseFunction.parse(pytest_collection))
 
     for (decorator, count) in case_map.report(
-        "control_silo_test", "customer_silo_test", classes_only=True
+        "control_silo_test", "region_silo_test", classes_only=True
     ):
         print(f"{decorator or 'None'}: {count}")  # noqa
 
@@ -27,8 +27,8 @@ def decorate_unit_tests(silo_keywords: Dict[str, Keywords]):
 
         if has_control_name(match.case.name, silo_keywords):
             return "control_silo_test"
-        elif has_customer_name(match.case.name, silo_keywords):
-            return "customer_silo_test"
+        elif has_region_name(match.case.name, silo_keywords):
+            return "region_silo_test"
 
     count = case_map.add_decorators(condition)
     print(f"Decorated {count} case{'' if count == 1 else 's'}")  # noqa

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -234,13 +234,13 @@ class SiloModeTest(APITestCase):
                     # TODO: Make work with EndpointWithDecoratedMethod
 
     def test_with_active_mode(self):
-        self._test_active_on(SiloMode.CUSTOMER, SiloMode.CUSTOMER, True)
+        self._test_active_on(SiloMode.REGION, SiloMode.REGION, True)
         self._test_active_on(SiloMode.CONTROL, SiloMode.CONTROL, True)
 
     def test_with_inactive_mode(self):
-        self._test_active_on(SiloMode.CUSTOMER, SiloMode.CONTROL, False)
-        self._test_active_on(SiloMode.CONTROL, SiloMode.CUSTOMER, False)
+        self._test_active_on(SiloMode.REGION, SiloMode.CONTROL, False)
+        self._test_active_on(SiloMode.CONTROL, SiloMode.REGION, False)
 
     def test_with_monolith_mode(self):
-        self._test_active_on(SiloMode.CUSTOMER, SiloMode.MONOLITH, True)
+        self._test_active_on(SiloMode.REGION, SiloMode.MONOLITH, True)
         self._test_active_on(SiloMode.CONTROL, SiloMode.MONOLITH, True)

--- a/tests/sentry/models/test_base.py
+++ b/tests/sentry/models/test_base.py
@@ -18,11 +18,11 @@ class AvailableOnTest(TestCase):
     class ControlModel(TestModel):
         pass
 
-    @ModelSiloLimit(SiloMode.CUSTOMER)
-    class CustomerModel(TestModel):
+    @ModelSiloLimit(SiloMode.REGION)
+    class RegionModel(TestModel):
         pass
 
-    @ModelSiloLimit(SiloMode.CONTROL, read_only=SiloMode.CUSTOMER)
+    @ModelSiloLimit(SiloMode.CONTROL, read_only=SiloMode.REGION)
     class ReadOnlyModel(TestModel):
         pass
 
@@ -39,18 +39,18 @@ class AvailableOnTest(TestCase):
 
         self.ModelOnMonolith.objects.filter(id=1).delete()
 
-    @override_settings(SILO_MODE=SiloMode.CUSTOMER)
+    @override_settings(SILO_MODE=SiloMode.REGION)
     def test_available_on_same_mode(self):
-        assert list(self.CustomerModel.objects.all()) == []
-        with raises(self.CustomerModel.DoesNotExist):
-            self.CustomerModel.objects.get(id=1)
+        assert list(self.RegionModel.objects.all()) == []
+        with raises(self.RegionModel.DoesNotExist):
+            self.RegionModel.objects.get(id=1)
 
-        self.CustomerModel.objects.create()
-        assert self.CustomerModel.objects.count() == 1
+        self.RegionModel.objects.create()
+        assert self.RegionModel.objects.count() == 1
 
-        self.CustomerModel.objects.filter(id=1).delete()
+        self.RegionModel.objects.filter(id=1).delete()
 
-    @override_settings(SILO_MODE=SiloMode.CUSTOMER)
+    @override_settings(SILO_MODE=SiloMode.REGION)
     def test_unavailable_on_other_mode(self):
         with raises(ModelSiloLimit.AvailabilityError):
             list(self.ControlModel.objects.all())
@@ -61,7 +61,7 @@ class AvailableOnTest(TestCase):
         with raises(ModelSiloLimit.AvailabilityError):
             self.ControlModel.objects.filter(id=1).delete()
 
-    @override_settings(SILO_MODE=SiloMode.CUSTOMER)
+    @override_settings(SILO_MODE=SiloMode.REGION)
     def test_available_for_read_only(self):
         assert list(self.ReadOnlyModel.objects.all()) == []
         with raises(self.ReadOnlyModel.DoesNotExist):


### PR DESCRIPTION
In practice, we found that "customer" sounds too much like "control" and was easy to confuse with it. "Region" here isn't intended to mean strictly a geographic region, but can also mean a region of SaaS service in which a single-tenant customer is isolated.