### PR TITLE
ref(issueDetails): Stretch sidebar border to the bottom

### DIFF
--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -303,6 +303,9 @@ class GroupEventDetails extends Component<GroupEventDetailsProps, State> {
 const StyledLayoutBody = styled(Layout.Body)`
   /* Makes the borders align correctly */
   padding: 0 !important;
+  @media (min-width: ${p => p.theme.breakpoints.large}) {
+    align-content: stretch;
+  }
 `;
 
 const Wrapper = styled('div')`


### PR DESCRIPTION
**Before:** the sidebar's left border doesn't stretch all the way to the footer
<img width="1291" alt="Screen Shot 2022-09-09 at 10 22 02 AM" src="https://user-images.githubusercontent.com/44172267/189409521-de8aed81-367f-46bf-823c-a7a22c3f2e34.png">

**After:**
<img width="1291" alt="Screen Shot 2022-09-09 at 10 24 23 AM" src="https://user-images.githubusercontent.com/44172267/189409526-20f11703-822b-4222-b473-e90bf0f0ba9b.png">
