### PR TITLE
feat(issues): Add integration details to issue activity

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -352,6 +352,10 @@ export interface GroupActivityAssigned extends GroupActivityBase {
     assigneeType: string;
     user: Team | User;
     assigneeEmail?: string;
+    /** If the user was assigned via an integration */
+    integration?: 'projectOwnership' | 'codeowners' | 'slack' | 'msteams';
+    /** Codeowner or Project owner rule as a string */
+    rule?: string;
   };
   type: GroupActivityType.ASSIGNED;
 }

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -352,7 +352,9 @@ export interface GroupActivityAssigned extends GroupActivityBase {
     assigneeType: string;
     user: Team | User;
     assigneeEmail?: string;
-    /** If the user was assigned via an integration */
+    /**
+     * If the user was assigned via an integration
+     */
     integration?: 'projectOwnership' | 'codeowners' | 'slack' | 'msteams';
     /** Codeowner or Project owner rule as a string */
     rule?: string;

--- a/static/app/views/organizationGroupDetails/groupActivity.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupActivity.spec.jsx
@@ -94,6 +94,52 @@ describe('GroupActivity', function () {
     );
   });
 
+  it('renders an assigned via codeowners activity', function () {
+    createWrapper({
+      activity: [
+        {
+          data: {
+            assignee: '123',
+            assigneeEmail: 'anotheruser@sentry.io',
+            assigneeType: 'user',
+            integration: 'codeowners',
+            rule: 'path:something/*.py #workflow',
+          },
+          dateCreated: '2021-10-01T15:31:38.950115Z',
+          id: '117',
+          type: 'assigned',
+          user: null,
+        },
+      ],
+    });
+    expect(screen.getAllByTestId('activity-item').at(-1)).toHaveTextContent(
+      /Sentry auto-assigned this issue to anotheruser@sentry.io/
+    );
+  });
+
+  it('renders an assigned via slack activity', function () {
+    const user = TestStubs.User({id: '301', name: 'Mark'});
+    createWrapper({
+      activity: [
+        {
+          data: {
+            assignee: '123',
+            assigneeEmail: 'anotheruser@sentry.io',
+            assigneeType: 'user',
+            integration: 'slack',
+          },
+          dateCreated: '2021-10-01T15:31:38.950115Z',
+          id: '117',
+          type: 'assigned',
+          user,
+        },
+      ],
+    });
+    const item = screen.getAllByTestId('activity-item').at(-1);
+    expect(item).toHaveTextContent(/Mark assigned this issue to anotheruser@sentry.io/);
+    expect(item).toHaveTextContent(/Assigned via Slack/);
+  });
+
   it('resolved in commit with no releases', function () {
     createWrapper({
       activity: [
@@ -212,7 +258,7 @@ describe('GroupActivity', function () {
     });
 
     await waitFor(() => expect(teamRequest).toHaveBeenCalledTimes(1));
-    expect(await screen.findByText(team.slug)).toBeInTheDocument();
+    expect(await screen.findByText(`#${team.slug}`)).toBeInTheDocument();
     expect(screen.getAllByTestId('activity-item').at(-1)).toHaveTextContent(
       /Sentry assigned this issue to #team-slug/
     );

--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -118,7 +118,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
             {t('Assigned via %s', integrationName[data.integration])}
             {data.rule && (
               <Fragment>
-                : <StyledCode>{data.rule}</StyledCode>
+                : <StyledRuleSpan>{data.rule}</StyledRuleSpan>
               </Fragment>
             )}
           </CodeWrapper>
@@ -353,6 +353,6 @@ const CodeWrapper = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
-const StyledCode = styled('span')`
+const StyledRuleSpan = styled('span')`
   font-family: ${p => p.theme.text.familyMono};
 `;


### PR DESCRIPTION
Displays the codeowner or project owner rule and switches "assigned" to "auto-assigned"
![Screen Shot 2022-09-08 at 4 25 07 PM](https://user-images.githubusercontent.com/1400464/189414513-220719ee-71ce-4143-993d-c09a8124757e.png)


Adds additional information when assigning via ms teams or slack
![Screen Shot 2022-09-08 at 4 22 33 PM](https://user-images.githubusercontent.com/1400464/189414529-78982570-1a2a-450b-aecf-88f303006f48.png)
