### PR TITLE
ref(perf-issues): Bring back activity tab

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -240,7 +240,7 @@ class GroupHeader extends Component<Props, State> {
   }
 
   getPerformanceIssueTabs() {
-    const {baseUrl, currentTab, location} = this.props;
+    const {baseUrl, currentTab, location, group} = this.props;
 
     const disabledTabs = this.getDisabledTabs();
 
@@ -259,6 +259,17 @@ class GroupHeader extends Component<Props, State> {
         >
           {t('Details')}
         </ListLink>
+        <StyledListLink
+          to={`${baseUrl}activity/${location.search}`}
+          isActive={() => currentTab === Tab.ACTIVITY}
+          disabled={disabledTabs.includes(Tab.ACTIVITY)}
+        >
+          {t('Activity')}
+          <Badge>
+            {group.numComments}
+            <IconChat size="xs" />
+          </Badge>
+        </StyledListLink>
         <ListLink
           to={`${baseUrl}tags/${location.search}`}
           isActive={() => currentTab === Tab.TAGS}


### PR DESCRIPTION
The Activity tab features are functional on the backend, so we don't need to hide it