### PR TITLE
feat(perf-issues): Save performance issue evidence with transaction event

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -285,6 +285,7 @@ class EventSerializer(Serializer):
             "endTimestamp": obj.data.get("timestamp"),
             "measurements": obj.data.get("measurements"),
             "breakdowns": obj.data.get("breakdowns"),
+            "performanceDetectorData": obj.data.get("performance_detector_data"),
         }
 
     def __serialize_error_attrs(self, attrs, obj):

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2007,6 +2007,14 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
             all_group_hashes = [problem.fingerprint for problem in performance_problems]
             group_hashes = all_group_hashes[:MAX_GROUPS]
 
+            if len(group_hashes) > 0:
+                job["event"].data["performance_detector_data"] = {}
+
+            for hash in group_hashes:
+                job["event"].data["performance_detector_data"][
+                    hash
+                ] = performance_problems_by_fingerprint[hash].to_json()
+
             existing_grouphashes = GroupHash.objects.filter(
                 project=project, hash__in=group_hashes
             ).select_related("group")

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -58,6 +58,13 @@ class PerformanceProblem:
     cause_span_ids: Optional[Sequence[str]]
     offender_span_ids: Sequence[str]
 
+    def to_json(self):
+        return {
+            "parents": self.parent_span_ids or [],
+            "causes": self.cause_span_ids or [],
+            "offenders": self.offender_span_ids or [],
+        }
+
 
 # Facade in front of performance detection to limit impact of detection on our events ingestion
 def detect_performance_problems(data: Event) -> List[PerformanceProblem]:

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -665,3 +665,24 @@ class DetectorTypeToGroupTypeTest(unittest.TestCase):
             assert (
                 detector_type in DETECTOR_TYPE_TO_GROUP_TYPE
             ), f"{detector_type} must have a corresponding entry in DETECTOR_TYPE_TO_GROUP_TYPE"
+
+
+class PerformanceProblemTest(unittest.TestCase):
+    def test_serializes_json(self):
+        problem = PerformanceProblem(
+            fingerprint="7f3650f4ac0901d47ca7320f070abd5b",
+            op="db",
+            desc="SELECT * FROM events;",
+            type=GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+            parent_span_ids=None,
+            cause_span_ids=["234067843ab03"],
+            offender_span_ids=["3e9a58f9e3c", "98b452cdc6cbe9"],
+        )
+
+        output = problem.to_json()
+
+        json.dumps(output)  # Ensure is serializable
+
+        assert output["parents"] == []
+        assert output["causes"] == ["234067843ab03"]
+        assert output["offenders"] == ["3e9a58f9e3c", "98b452cdc6cbe9"]


### PR DESCRIPTION
Closes PERF-1745. Saves performance issue detection output along with the event in `nodestore`, and returns it when fetching event information.

**e.g.,**
![Screen Shot 2022-09-09 at 2 24 25 PM](https://user-images.githubusercontent.com/989898/189418813-319760e9-7b6a-420d-8b03-32215fe32e49.png)


## Notes

- I added `to_json` to `PerformanceProblem` because it's not JSON-serializable otherwise, so saving failed. If there's a better way to do this, let me know!
- Does the `performanceDetectorData` key need to be behind a feature flag?
