### PR TITLE
fix(js): Pass `group_id` when fetching specific events

### DIFF
--- a/static/app/views/organizationGroupDetails/utils.tsx
+++ b/static/app/views/organizationGroupDetails/utils.tsx
@@ -26,7 +26,7 @@ export async function fetchGroupEvent(
   const url =
     eventId === 'latest' || eventId === 'oldest'
       ? `/issues/${groupId}/events/${eventId}/`
-      : `/projects/${orgId}/${projectId}/events/${eventId}/`;
+      : `/projects/${orgId}/${projectId}/events/${eventId}/?group_id=${groupId}`;
 
   const query: {environment?: string[]} = {};
   if (envNames.length !== 0) {


### PR DESCRIPTION
This is important for performance issues, since one event may be part of multiple groups, so we 
use the `group_id` to provide more context in the response.

This fixes navigating between events.