### PR TITLE
feat(perf-issues): Get span evidence data from event

### DIFF
--- a/static/app/components/events/eventEntry.tsx
+++ b/static/app/components/events/eventEntry.tsx
@@ -5,10 +5,7 @@ import Exception from 'sentry/components/events/interfaces/exception';
 import ExceptionV2 from 'sentry/components/events/interfaces/exceptionV2';
 import {Generic} from 'sentry/components/events/interfaces/generic';
 import {Message} from 'sentry/components/events/interfaces/message';
-import {
-  SpanEvidence,
-  SpanEvidenceSection,
-} from 'sentry/components/events/interfaces/performance';
+import {SpanEvidenceSection} from 'sentry/components/events/interfaces/performance';
 import {Request} from 'sentry/components/events/interfaces/request';
 import Spans from 'sentry/components/events/interfaces/spans';
 import StackTrace from 'sentry/components/events/interfaces/stackTrace';
@@ -158,22 +155,10 @@ function EventEntry({
         group?.issueCategory === IssueCategory.PERFORMANCE &&
         organization?.features?.includes('performance-issues')
       ) {
-        // TODO: Replace this with real data from the entry when possible
-        const SAMPLE_SPAN_EVIDENCE: SpanEvidence = {
-          transaction: '/api/transaction/00',
-          parentSpan: 'index',
-          sourceSpan:
-            'SELECT "sentry_useroption"."id", "sentry_useroption"."user_id", "sentry_useroption"."project_id", "sentry_useroption"."organization_id", "sentry_useroption"."key", "sentry_useroption"."value" FROM "sentry_useroption" WHERE ("sentry_useroption"."organization_id" IS NULL AND "sentry_useroption"."project_id" IS NULL AND "sentry_useroption"."user_id" = %s) ',
-          repeatingSpan:
-            'SELECT "sentry_project"."id", "sentry_project"."slug", "sentry_project"."name", "sentry_project"."forced_color", "sentry_project"."organization_id", "sentry_project"."public", "sentry_project"."date_added", "sentry_project"."status", "sentry_project"."first_event", "sentry_project"."flags", "sentry_project"."platform" FROM "sentry_project" WHERE ("sentry_project"."organization_id" = %s AND "sentry_project"."status" = %s AND "sentry_project"."id" IN (%s))',
-        };
-
         return (
           <SpanEvidenceSection
-            event={event}
+            event={event as EventTransaction}
             organization={organization as Organization}
-            spanEvidence={SAMPLE_SPAN_EVIDENCE}
-            affectedSpanIds={[]}
           />
         );
       }

--- a/static/app/components/events/interfaces/performance/index.tsx
+++ b/static/app/components/events/interfaces/performance/index.tsx
@@ -13,7 +13,6 @@ export type SpanEvidence = {
   parentSpan: string;
   repeatingSpan: string;
   sourceSpan: string;
-  transaction: string;
 };
 
 interface Props {
@@ -26,7 +25,6 @@ export function SpanEvidenceSection({event, organization}: Props) {
     return null;
   }
 
-  // We won't be able to do this once it is possible to merge Performance Issues, but for now it is fine
   const {
     cause_span_ids: causes,
     offender_span_ids: offenders,
@@ -62,7 +60,6 @@ export function SpanEvidenceSection({event, organization}: Props) {
       return acc;
     },
     {
-      transaction: '',
       parentSpan: '',
       sourceSpan: '',
       repeatingSpan: '',

--- a/static/app/components/events/interfaces/performance/index.tsx
+++ b/static/app/components/events/interfaces/performance/index.tsx
@@ -26,9 +26,9 @@ export function SpanEvidenceSection({event, organization}: Props) {
   }
 
   const {
-    cause_span_ids: causes,
-    offender_span_ids: offenders,
-    parent_span_ids: parents,
+    causeSpanIds: causes,
+    offenderSpanIds: offenders,
+    parentSpanIds: parents,
   } = event.perfProblem;
 
   // For now, it is safe to assume that there is only one cause and parent span for N+1 issues

--- a/static/app/components/events/interfaces/performance/index.tsx
+++ b/static/app/components/events/interfaces/performance/index.tsx
@@ -22,8 +22,16 @@ interface Props {
 }
 
 export function SpanEvidenceSection({event, organization}: Props) {
+  if (!event.perfProblem) {
+    return null;
+  }
+
   // We won't be able to do this once it is possible to merge Performance Issues, but for now it is fine
-  const {causes, offenders, parents} = Object.values(event.performanceDetectorData!)[0];
+  const {
+    cause_span_ids: causes,
+    offender_span_ids: offenders,
+    parent_span_ids: parents,
+  } = event.perfProblem;
 
   // For now, it is safe to assume that there is only one cause and parent span for N+1 issues
   const sourceSpanId = causes[0];
@@ -66,7 +74,7 @@ export function SpanEvidenceSection({event, organization}: Props) {
     {
       key: '0',
       subject: t('Transaction'),
-      value: spanEvidence.transaction,
+      value: event.title,
     },
     {
       key: '1',

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -353,9 +353,9 @@ export type EventUser = {
 };
 
 export type PerformanceDetectorData = {
-  cause_span_ids: string[];
-  offender_span_ids: string[];
-  parent_span_ids: string[];
+  causeSpanIds: string[];
+  offenderSpanIds: string[];
+  parentSpanIds: string[];
 };
 
 interface EventBase {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -352,6 +352,12 @@ export type EventUser = {
   username?: string | null;
 };
 
+export type PerformanceDetectorData = {
+  causes: string[];
+  offenders: string[];
+  parents: string[];
+};
+
 interface EventBase {
   contexts: EventContexts;
   crashFile: IssueAttachment | null;
@@ -414,6 +420,7 @@ export interface EventTransaction
   endTimestamp: number;
   entries: (EntrySpans | EntryRequest)[];
   startTimestamp: number;
+  performanceDetectorData?: Record<string, PerformanceDetectorData>;
   type: EventOrGroupType.TRANSACTION;
 }
 

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -353,9 +353,9 @@ export type EventUser = {
 };
 
 export type PerformanceDetectorData = {
-  causes: string[];
-  offenders: string[];
-  parents: string[];
+  cause_span_ids: string[];
+  offender_span_ids: string[];
+  parent_span_ids: string[];
 };
 
 interface EventBase {
@@ -421,7 +421,7 @@ export interface EventTransaction
   entries: (EntrySpans | EntryRequest)[];
   startTimestamp: number;
   type: EventOrGroupType.TRANSACTION;
-  performanceDetectorData?: Record<string, PerformanceDetectorData>;
+  perfProblem?: PerformanceDetectorData;
 }
 
 export interface EventError extends Omit<EventBase, 'entries' | 'type'> {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -420,8 +420,8 @@ export interface EventTransaction
   endTimestamp: number;
   entries: (EntrySpans | EntryRequest)[];
   startTimestamp: number;
-  performanceDetectorData?: Record<string, PerformanceDetectorData>;
   type: EventOrGroupType.TRANSACTION;
+  performanceDetectorData?: Record<string, PerformanceDetectorData>;
 }
 
 export interface EventError extends Omit<EventBase, 'entries' | 'type'> {


### PR DESCRIPTION
Dependant on #38658

Uses data provided on the `event` object to pick out the data necessary for the span evidence section

Where/how the relevant span IDs are stored and fetched is currently TBD. All that needs to be done from here is to fetch the span IDs from a separate endpoint, and then pass those IDs into the SpanEvidenceSection

