### PR TITLE
feat(post-process-forwarder): Move concurrency option to CLI

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -126,6 +126,7 @@ class EventStream(Service):
         synchronize_commit_group: str,
         commit_batch_size: int,
         commit_batch_timeout_ms: int,
+        concurrency: int,
         initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
     ):
         assert not self.requires_post_process_forwarder()

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from sentry import options
 from sentry.eventstream.kafka.consumer import SynchronizedConsumer
 from sentry.eventstream.kafka.postprocessworker import (
-    _CONCURRENCY_OPTION,
     ErrorsPostProcessForwarderWorker,
     PostProcessForwarderType,
     PostProcessForwarderWorker,
@@ -208,9 +207,9 @@ class KafkaEventStream(SnubaProtocolEventStream):
         synchronize_commit_group: str,
         commit_batch_size: int,
         commit_batch_timeout_ms: int,
+        concurrency: int,
         initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
     ):
-        concurrency = options.get(_CONCURRENCY_OPTION)
         logger.info(f"Starting post process forwarder to consume {entity} messages")
         if entity == PostProcessForwarderType.TRANSACTIONS:
             worker = TransactionsPostProcessForwarderWorker(concurrency=concurrency)
@@ -260,6 +259,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
         synchronize_commit_group: str,
         commit_batch_size: int,
         commit_batch_timeout_ms: int,
+        concurrency: int,
         initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
     ):
         consumer = self._build_consumer(
@@ -270,6 +270,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
             synchronize_commit_group,
             commit_batch_size,
             commit_batch_timeout_ms,
+            concurrency,
             initial_offset_reset,
         )
 
@@ -290,6 +291,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
         synchronize_commit_group: str,
         commit_batch_size: int,
         commit_batch_timeout_ms: int,
+        concurrency: int,
         initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
     ):
         logger.debug("Starting post-process forwarder...")
@@ -302,5 +304,6 @@ class KafkaEventStream(SnubaProtocolEventStream):
             synchronize_commit_group,
             commit_batch_size,
             commit_batch_timeout_ms,
+            concurrency,
             initial_offset_reset,
         )

--- a/src/sentry/eventstream/kafka/postprocessworker.py
+++ b/src/sentry/eventstream/kafka/postprocessworker.py
@@ -108,9 +108,8 @@ class PostProcessForwarderWorker(AbstractBatchWorker):
     """
 
     def __init__(self, concurrency: Optional[int] = 1) -> None:
-        self.__current_concurrency = concurrency
         logger.info(f"Starting post process forwarder with {concurrency} threads")
-        self.__executor = ThreadPoolExecutor(max_workers=self.__current_concurrency)
+        self.__executor = ThreadPoolExecutor(max_workers=concurrency)
 
     def process_message(self, message: Message) -> Optional[Future]:
         """

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -336,6 +336,12 @@ def cron(**options):
     help="Time (in milliseconds) to wait before closing current batch and committing offsets.",
 )
 @click.option(
+    "--concurrency",
+    default=50,
+    type=int,
+    help="Thread pool size for post process worker.",
+)
+@click.option(
     "--initial-offset-reset",
     default="latest",
     type=click.Choice(["earliest", "latest"]),
@@ -362,6 +368,7 @@ def post_process_forwarder(**options):
             synchronize_commit_group=options["synchronize_commit_group"],
             commit_batch_size=options["commit_batch_size"],
             commit_batch_timeout_ms=options["commit_batch_timeout_ms"],
+            concurrency=options["concurrency"],
             initial_offset_reset=options["initial_offset_reset"],
         )
     except ForwarderNotRequired:

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -337,7 +337,7 @@ def cron(**options):
 )
 @click.option(
     "--concurrency",
-    default=50,
+    default=5,
     type=int,
     help="Thread pool size for post process worker.",
 )

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -687,6 +687,7 @@ class BatchedConsumerTest(TestCase):
             synchronize_commit_group=synchronize_commit_group,
             commit_batch_size=1,
             commit_batch_timeout_ms=100,
+            concurrency=1,
             initial_offset_reset="earliest",
         )
 

--- a/tests/sentry/eventstream/kafka/test_postprocessworker.py
+++ b/tests/sentry/eventstream/kafka/test_postprocessworker.py
@@ -71,7 +71,7 @@ def test_post_process_forwarder(
     """
     Tests that the post process forwarder calls dispatch_post_process_group_task with the correct arguments
     """
-    forwarder = PostProcessForwarderWorker(concurrency=2)
+    forwarder = PostProcessForwarderWorker(concurrency=1)
     future = forwarder.process_message(kafka_message_without_transaction_header)
 
     forwarder.flush_batch([future])
@@ -138,19 +138,6 @@ def test_post_process_forwarder_bad_message(kafka_message_payload):
 
     with pytest.raises(InvalidVersion):
         forwarder.flush_batch([future])
-
-    forwarder.shutdown()
-
-
-@pytest.mark.django_db
-def test_post_process_forwarder_concurrency(kafka_message_payload):
-    """
-    Tests that the number of threads change when the option is changed.
-    """
-    forwarder = PostProcessForwarderWorker(concurrency=5)
-
-    forwarder.flush_batch(None)
-    assert forwarder._PostProcessForwarderWorker__current_concurrency == 5
 
     forwarder.shutdown()
 

--- a/tests/sentry/eventstream/kafka/test_postprocessworker.py
+++ b/tests/sentry/eventstream/kafka/test_postprocessworker.py
@@ -4,7 +4,6 @@ import pytest
 
 from sentry import options
 from sentry.eventstream.kafka.postprocessworker import (
-    _CONCURRENCY_OPTION,
     ErrorsPostProcessForwarderWorker,
     PostProcessForwarderWorker,
     TransactionsPostProcessForwarderWorker,
@@ -72,7 +71,7 @@ def test_post_process_forwarder(
     """
     Tests that the post process forwarder calls dispatch_post_process_group_task with the correct arguments
     """
-    forwarder = PostProcessForwarderWorker(concurrency=1)
+    forwarder = PostProcessForwarderWorker(concurrency=2)
     future = forwarder.process_message(kafka_message_without_transaction_header)
 
     forwarder.flush_batch([future])
@@ -148,12 +147,8 @@ def test_post_process_forwarder_concurrency(kafka_message_payload):
     """
     Tests that the number of threads change when the option is changed.
     """
-    forwarder = PostProcessForwarderWorker(concurrency=1)
+    forwarder = PostProcessForwarderWorker(concurrency=5)
 
-    forwarder.flush_batch(None)
-    assert forwarder._PostProcessForwarderWorker__current_concurrency == 1
-
-    options.set(_CONCURRENCY_OPTION, 5)
     forwarder.flush_batch(None)
     assert forwarder._PostProcessForwarderWorker__current_concurrency == 5
 


### PR DESCRIPTION
This was an option previously as we were testing multiple values at runtime. Since this is no longer happening, move the concurrency setting to a CLI arg instead of a runtime option.