### PR TITLE
feat(perf-issues): Skip performance issues for bulk actions [UP-145]

### DIFF
--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -14,13 +14,13 @@ import {
   BaseGroup,
   IssueCategory,
   IssueCategoryCapabilities,
-  Organization,
   Project,
   ResolutionStatus,
 } from 'sentry/types';
 import {getIssueCapability} from 'sentry/utils/groupCapabilities';
 import Projects from 'sentry/utils/projects';
 import useMedia from 'sentry/utils/useMedia';
+import useOrganization from 'sentry/utils/useOrganization';
 
 import ResolveActions from './resolveActions';
 import ReviewAction from './reviewAction';
@@ -37,7 +37,6 @@ type Props = {
   onShouldConfirm: (action: ConfirmAction) => boolean;
   onSortChange: (sort: string) => void;
   onUpdate: (data?: any) => void;
-  orgSlug: Organization['slug'];
   query: string;
   queryCount: number;
   sort: string;
@@ -45,7 +44,6 @@ type Props = {
 };
 
 function ActionSet({
-  orgSlug,
   queryCount,
   query,
   allInQuerySelected,
@@ -60,8 +58,16 @@ function ActionSet({
   sort,
   onSortChange,
 }: Props) {
+  const organization = useOrganization();
   const numIssues = issues.size;
-  const confirm = getConfirm(numIssues, allInQuerySelected, query, queryCount);
+  const confirm = getConfirm({
+    numIssues,
+    allInQuerySelected,
+    query,
+    queryCount,
+    organization,
+  });
+
   const label = getLabel(numIssues, allInQuerySelected);
 
   const selectedIssues = [...issues]
@@ -197,7 +203,7 @@ function ActionSet({
   return (
     <Wrapper>
       {selectedProjectSlug ? (
-        <Projects orgId={orgSlug} slugs={[selectedProjectSlug]}>
+        <Projects orgId={organization.slug} slugs={[selectedProjectSlug]}>
           {({projects, initiallyLoaded, fetchError}) => {
             const selectedProject = projects[0];
             return (
@@ -205,7 +211,7 @@ function ActionSet({
                 onShouldConfirm={onShouldConfirm}
                 onUpdate={onUpdate}
                 anySelected={anySelected}
-                orgSlug={orgSlug}
+                orgSlug={organization.slug}
                 params={{
                   hasReleases: selectedProject.hasOwnProperty('features')
                     ? (selectedProject as Project).features.includes('releases')
@@ -228,7 +234,7 @@ function ActionSet({
           onShouldConfirm={onShouldConfirm}
           onUpdate={onUpdate}
           anySelected={anySelected}
-          orgSlug={orgSlug}
+          orgSlug={organization.slug}
           params={{
             hasReleases: false,
             latestRelease: null,

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -78,13 +78,20 @@ function IssueListActions({
   function handleDelete() {
     const orgId = organization.slug;
 
+    // TODO: Remove this when deleting performance issues is supported
+    // This silently avoids performance issues for bulk actions
+    const modifiedQuery =
+      query && organization.features.includes('performance-issues')
+        ? query + ' ' + '!issue.category:performance'
+        : query;
+
     actionSelectedGroups(itemIds => {
       bulkDelete(
         api,
         {
           orgId,
           itemIds,
-          query,
+          query: modifiedQuery,
           project: selection.projects,
           environment: selection.environments,
           ...selection.datetime,
@@ -99,13 +106,20 @@ function IssueListActions({
   }
 
   function handleMerge() {
+    // TODO: Remove this when merging performance issues is supported
+    // This silently avoids performance issues for bulk actions
+    const modifiedQuery =
+      query && organization.features.includes('performance-issues')
+        ? query + ' ' + '!issue.category:performance'
+        : query;
+
     actionSelectedGroups(itemIds => {
       mergeGroups(
         api,
         {
           orgId: organization.slug,
           itemIds,
-          query,
+          query: modifiedQuery,
           project: selection.projects,
           environment: selection.environments,
           ...selection.datetime,
@@ -176,7 +190,6 @@ function IssueListActions({
           <ActionSet
             sort={sort}
             onSortChange={onSortChange}
-            orgSlug={organization.slug}
             queryCount={queryCount}
             query={query}
             issues={selectedIdsSet}

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -75,23 +75,22 @@ function IssueListActions({
     SelectedGroupStore.deselectAll();
   }
 
+  // TODO: Remove this when merging/deleting performance issues is supported
+  // This silently avoids performance issues for bulk actions
+  const queryExcludingPerformanceIssues = organization.features.includes(
+    'performance-issues'
+  )
+    ? `${query ?? ''} !issue.category:performance`
+    : query;
+
   function handleDelete() {
-    const orgId = organization.slug;
-
-    // TODO: Remove this when deleting performance issues is supported
-    // This silently avoids performance issues for bulk actions
-    const modifiedQuery =
-      query && organization.features.includes('performance-issues')
-        ? `${query} !issue.category:performance`
-        : query;
-
     actionSelectedGroups(itemIds => {
       bulkDelete(
         api,
         {
-          orgId,
+          orgId: organization.slug,
           itemIds,
-          query: modifiedQuery,
+          query: queryExcludingPerformanceIssues,
           project: selection.projects,
           environment: selection.environments,
           ...selection.datetime,
@@ -106,20 +105,13 @@ function IssueListActions({
   }
 
   function handleMerge() {
-    // TODO: Remove this when merging performance issues is supported
-    // This silently avoids performance issues for bulk actions
-    const modifiedQuery =
-      query && organization.features.includes('performance-issues')
-        ? `${query} !issue.category:performance`
-        : query;
-
     actionSelectedGroups(itemIds => {
       mergeGroups(
         api,
         {
           orgId: organization.slug,
           itemIds,
-          query: modifiedQuery,
+          query: queryExcludingPerformanceIssues,
           project: selection.projects,
           environment: selection.environments,
           ...selection.datetime,

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -82,7 +82,7 @@ function IssueListActions({
     // This silently avoids performance issues for bulk actions
     const modifiedQuery =
       query && organization.features.includes('performance-issues')
-        ? query + ' ' + '!issue.category:performance'
+        ? `${query} !issue.category:performance`
         : query;
 
     actionSelectedGroups(itemIds => {
@@ -110,7 +110,7 @@ function IssueListActions({
     // This silently avoids performance issues for bulk actions
     const modifiedQuery =
       query && organization.features.includes('performance-issues')
-        ? query + ' ' + '!issue.category:performance'
+        ? `${query} !issue.category:performance`
         : query;
 
     actionSelectedGroups(itemIds => {


### PR DESCRIPTION
1. Displays a message to the user that performance issues will be skipped for merging and deleting
2. Silently adds `!issue.category:performance` to the bulk action query (when the feature is enabled)

![image](https://user-images.githubusercontent.com/10888943/189449777-8795c2b9-17bb-4f8d-aadb-f2e10e01920b.png)
