### PR TITLE
feat(hybrid-cloud): Introduce Region info and sentry region config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -10,9 +10,11 @@ import socket
 import sys
 import tempfile
 from datetime import datetime, timedelta
+from typing import Mapping
 from urllib.parse import urlparse
 
 import sentry
+from sentry.types.region import Region
 from sentry.utils.celery import crontab_with_minute_jitter
 from sentry.utils.types import type_from_value
 
@@ -2791,3 +2793,5 @@ SILO_MODE_SPLICE_TESTS = bool(os.environ.get("SENTRY_SILO_MODE_SPLICE_TESTS", Fa
 DISALLOWED_CUSTOMER_DOMAINS = []
 
 SENTRY_PERFORMANCE_ISSUES_RATE_LIMITER_OPTIONS = {}
+
+SENTRY_REGION_CONFIG: Mapping[str, Region] = {}

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Region:
+    name: str
+    subdomain: str
+    is_private: bool

--- a/src/sentry/types/region.py
+++ b/src/sentry/types/region.py
@@ -5,4 +5,4 @@ from dataclasses import dataclass
 class Region:
     name: str
     subdomain: str
-    is_private: bool
+    is_private: bool = False


### PR DESCRIPTION
We will be storing region information for hybrid cloud in a configuration. In this repo, the configuration will be blank allowing everything to work out of the box. Region information will be saved as a new Region dataclass.

Note that any new fields added to the Region dataclass must be kwargs to maintain backwards compatibility.
