### PR TITLE
fix(ds): Handle case when sdk versions are not semver compatible

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -6,6 +6,7 @@ from dateutil.parser import parse as parse_date
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
+from sentry_relay.exceptions import RelayError
 from sentry_relay.processing import compare_version as compare_version_relay
 
 from sentry import features
@@ -221,14 +222,23 @@ class OrganizationDynamicSamplingSDKVersionsEndpoint(OrganizationEndpoint):
         # Essentially for each project, we fetch all the SDK versions from the previously
         # computed dictionary, and then we find the latest SDK version according to
         # semantic versioning and return the info for that particular project SDK version.
-        project_info_list = [
-            project_to_sdk_version_to_info_dict[project][
-                max(
-                    project_to_sdk_version_to_info_dict[project].keys(),
-                    key=cmp_to_key(compare_version_relay),
-                )
+        try:
+            project_info_list = [
+                project_to_sdk_version_to_info_dict[project][
+                    max(
+                        project_to_sdk_version_to_info_dict[project].keys(),
+                        key=cmp_to_key(compare_version_relay),
+                    )
+                ]
+                for project in project_to_sdk_version_to_info_dict
             ]
-            for project in project_to_sdk_version_to_info_dict
-        ]
+        except RelayError:
+            return Response(
+                status=status.HTTP_400_BAD_REQUEST,
+                data={
+                    "details": "Unable to parse sdk versions. "
+                    "Please check that sdk versions are valid semantic versions."
+                },
+            )
 
         return Response(project_info_list)

--- a/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
+++ b/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
@@ -415,3 +415,40 @@ class OrganizationDynamicSamplingSDKVersionsTest(APITestCase):
             )
             assert response.status_code == 200
             assert mock_query.mock_calls == calls
+
+    @mock.patch("sentry.api.endpoints.organization_dynamic_sampling_sdk_versions.discover.query")
+    def test_sdk_versions_incompatible_with_semantic_versions(self, mock_query):
+        self.login_as(self.user)
+        mock_query.return_value = {
+            "data": [
+                {
+                    "sdk.version": "dev-develop@39fa647",
+                    "sdk.name": "sentry.php",
+                    "project": "sentry-php",
+                    'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                    'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                    'equation|count_if(transaction.source, notEquals, "") / count()': 0.0,
+                    'count_if(transaction.source, notEquals, "")': 0,
+                    "count()": 2,
+                },
+                {
+                    "sdk.version": "dev-dsc@606d781",
+                    "sdk.name": "sentry.php",
+                    "project": "sentry-php",
+                    'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 0.0,
+                    'count_if(trace.client_sample_rate, notEquals, "")': 0,
+                    'equation|count_if(transaction.source, notEquals, "") / count()': 0.0,
+                    'count_if(transaction.source, notEquals, "")': 0,
+                    "count()": 11,
+                },
+            ]
+        }
+        with Feature({"organizations:server-side-sampling": True}):
+            response = self.client.get(
+                f"{self.endpoint}?project={self.project.id}&"
+                f"start=2022-08-06T00:02:00+00:00&"
+                f"end=2022-08-07T00:00:02+00:00"
+            )
+            assert response.json()["details"] == (
+                "Unable to parse sdk versions. Please check that sdk versions are valid semantic versions."
+            )


### PR DESCRIPTION
Handles internal server error that is raised
when sdk versions are not semver compatible which is a requirement to determine the latest sdk version

