### PR TITLE
chore(sampling): Add new feature flag for incompatible platforms [TET-364]

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1164,6 +1164,8 @@ SENTRY_FEATURES = {
     "organizations:server-side-sampling": False,
     # Enable the server-side sampling feature (frontend)
     "organizations:server-side-sampling-ui": False,
+    # Enable creating DS rules on incompatible platforms (used by SDK teams for dev purposes)
+    "organizations:server-side-sampling-allow-incompatible-platforms": False,
     # Enable the mobile screenshots feature
     "organizations:mobile-screenshots": False,
     # Enable the release details performance section

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -138,6 +138,7 @@ default_manager.add("organizations:sandbox-kill-switch", OrganizationFeature, Tr
 default_manager.add("organizations:sentry-functions", OrganizationFeature, False)
 default_manager.add("organizations:server-side-sampling", OrganizationFeature)
 default_manager.add("organizations:server-side-sampling-ui", OrganizationFeature, True)
+default_manager.add("organizations:server-side-sampling-allow-incompatible-platforms", OrganizationFeature, True)
 default_manager.add("organizations:session-replay", OrganizationFeature)
 default_manager.add("organizations:session-replay-sdk", OrganizationFeature, True)
 default_manager.add("organizations:session-replay-ui", OrganizationFeature, True)


### PR DESCRIPTION
We'll use this flag to let SDK teams create DS rules on platforms that are not yet officially supported.