### PR TITLE
ref: skip specific drf-spectacular untyped call rather than module

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -189,8 +189,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 # TODO: these cause type errors when followed
-[mypy-drf_spectacular.drainage]
-follow_imports = skip
 [mypy-sentry_sdk]
 follow_imports = skip
 [mypy-sentry_sdk.tracing]

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -33,7 +33,7 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
         view = f"{callback.__module__}.{callback.__name__}"
 
         if callback.view_class.public and callback.view_class.private:
-            warn(
+            warn(  # type: ignore[no-untyped-call]
                 "both `public` and `private` cannot be defined at the same time, "
                 "please remove one of the attributes."
             )
@@ -53,7 +53,7 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
             pass
         else:
             # any new endpoint that isn't accounted for should recieve this error when building api docs
-            warn(
+            warn(  # type: ignore[no-untyped-call]
                 f"{view} {method} is unaccounted for. "
                 "Either document the endpoint and define the `public` attribute on the endpoint "
                 "with the public HTTP methods, "


### PR DESCRIPTION
the `warn` function _is_ untyped -- but it's better to let mypy understand types in the rest of that module