### PR TITLE
fix(metrics): Fixes bug that relies on metrics_query_args

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -2411,7 +2411,6 @@ class HistogramMetricQueryBuilder(MetricsQueryBuilder):
             raise InvalidSearchQuery("Organization id required to create a metrics query")
 
         self.zoom_params: Optional[Function] = metrics_histogram.zoom_histogram(
-            self.organization_id,
             self.num_buckets,
             self.min_bin,
             self.max_bin,

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -360,7 +360,7 @@ class DerivedOp(DerivedOpDefinition, MetricOperation):
             subdata = data[alias][idx]
 
         # Fetch the function args
-        metrics_query_args = set(inspect.signature(self.post_query_func).parameters.keys())
+        metrics_query_args = inspect.signature(self.post_query_func).parameters.keys()
 
         compute_func_dict = {}
         # ToDo(ahmed): Add support for other fields that might be required as function arguments in the future. For now,
@@ -389,7 +389,7 @@ class DerivedOp(DerivedOpDefinition, MetricOperation):
         self, org_id: int, use_case_id: UseCaseKey, params: Optional[MetricOperationParams] = None
     ) -> Optional[Function]:
         # Fetch the function args
-        metrics_query_args = set(inspect.signature(self.filter_conditions_func).parameters.keys())
+        metrics_query_args = inspect.signature(self.filter_conditions_func).parameters.keys()
 
         kwargs = {}
         if metrics_query_args and params is not None:

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -396,7 +396,7 @@ class DerivedOp(DerivedOpDefinition, MetricOperation):
             for field in metrics_query_args:
                 try:
                     # Adding this try/except because we do not want to override the defaults of the function with None
-                    kwargs[field] = params[field]  # type: ignore
+                    kwargs[field] = params[field]
                 except KeyError:
                     continue
         return self.filter_conditions_func(**kwargs)

--- a/src/sentry/snuba/metrics/fields/histogram.py
+++ b/src/sentry/snuba/metrics/fields/histogram.py
@@ -73,7 +73,6 @@ def rebucket_histogram(
 
 
 def zoom_histogram(
-    org_id: int,
     histogram_buckets: int = 100,
     histogram_from: Optional[float] = None,
     histogram_to: Optional[float] = None,


### PR DESCRIPTION
Prior to this PR, we were relying on creator of
a derived op to specifically define the args that will be required to be passed to the function generating the snql or the post query function that applies post query processing logic, which is error prone. In this PR, we instead fetch those function arguments directly and fetch their equivalent in the passed params from `MetricField` dynamically

