### PR TITLE
feat(issue-details): Add tooltip for Span Evidence section

### DIFF
--- a/static/app/components/events/interfaces/performance/index.tsx
+++ b/static/app/components/events/interfaces/performance/index.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 
-import EventDataSection from 'sentry/components/events/eventDataSection';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Event, EventTransaction, KeyValueListData, Organization} from 'sentry/types';
 
+import DataSection from '../../eventTagsAndScreenshot/dataSection';
 import KeyValueList from '../keyValueList';
 import TraceView from '../spans/traceView';
 import WaterfallModel from '../spans/waterfallModel';
@@ -55,7 +55,12 @@ export function SpanEvidenceSection({
   ];
 
   return (
-    <EventDataSection type="span-evidence" title={t('Span Evidence')} wrapTitle>
+    <DataSection
+      title={t('Span Evidence')}
+      description={t(
+        'Span Evidence identifies the parent span where the N+1 occurs, the source span that occurs immediately before the repeating spans, and the repeating span itself.'
+      )}
+    >
       <KeyValueList data={data} />
 
       <TraceViewWrapper>
@@ -65,7 +70,7 @@ export function SpanEvidenceSection({
           isEmbedded
         />
       </TraceViewWrapper>
-    </EventDataSection>
+    </DataSection>
   );
 }
 


### PR DESCRIPTION
Adds a tooltip to explain what each value in Span Evidence represents

![image](https://user-images.githubusercontent.com/16740047/189691540-40d5e8ea-1e30-48c3-b2be-70b65307059d.png)
