### PR TITLE
feat(replays): Upgrade `@sentry/replay` to 0.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@sentry/node": "7.11.0",
     "@sentry/react": "7.11.0",
     "@sentry/release-parser": "^1.3.1",
-    "@sentry/replay": "0.5.14",
+    "@sentry/replay": "0.5.15",
     "@sentry/tracing": "7.11.0",
     "@sentry/utils": "7.11.0",
     "@testing-library/jest-dom": "^5.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2322,10 +2322,10 @@
   resolved "https://registry.yarnpkg.com/@sentry/release-parser/-/release-parser-1.3.1.tgz#0ab8be23fd494d80dd0e4ec8ae5f3d13f805b13d"
   integrity sha512-/dGpCq+j3sJhqQ14RNEEL45Ot/rgq3jAlZDD/8ufeqq+W8p4gUhSrbGWCRL82NEIWY9SYwxYXGXjRcVPSHiA1Q==
 
-"@sentry/replay@0.5.14":
-  version "0.5.14"
-  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-0.5.14.tgz#9dcea46e6b00e2f0862ed356e694963430c88040"
-  integrity sha512-lhlYXOWMx4tBMXSgh+Z6onitL1rvUk5FHVquW6Tq0+P9P3yXZYF1JSqR6QeciyMgCoQ/d1BtcNZZHfbiIceLUw==
+"@sentry/replay@0.5.15":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-0.5.15.tgz#ecb8adfe13210549404c1dd10e64b8cb3fb3d073"
+  integrity sha512-gtk5m8HnGuc3K1RYIhSovSkP1TGgWveAbRbIoJ2jLGk89BqHC72YjXN5kwX9kT7qhs7NZW2gGluc2OmV39vzrw==
   dependencies:
     "@sentry/core" "^7.7.0"
     "@sentry/types" "^7.7.0"


### PR DESCRIPTION
* Reduce session idle time to 5 minutes
* Only track earliest event on new sessions
* Ignore navigation entries with 0 duration
