### PR TITLE
fix(perf-issues): Make sure issue stream ignore button is not disabled for performance issues

### DIFF
--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -80,10 +80,9 @@ function ActionSet({
     isActionSupported(selectedIssues, 'merge');
   const {enabled: deleteSupported, disabledReason: deleteDisabledReason} =
     isActionSupported(selectedIssues, 'delete');
-  const {enabled: ignoreSupported} = isActionSupported(selectedIssues, 'ignore');
   const mergeDisabled =
     !multiSelected || multipleIssueProjectsSelected || !mergeSupported;
-  const ignoreDisabled = !anySelected || !ignoreSupported;
+  const ignoreDisabled = !anySelected;
 
   const canMarkReviewed =
     anySelected && (allInQuerySelected || selectedIssues.some(issue => !!issue?.inbox));


### PR DESCRIPTION
Ignoring got disabled accidentally when disabling the ignore options on the issue details page. The issue stream was checking the issue capabilities file which got set to disabled:

https://github.com/getsentry/sentry/blob/7cc7176f56639adb0af74cb304190bb218d0f286/static/app/utils/groupCapabilities.tsx#L31

I went ahead and removed the check since the default ignore functionality will always be enabled.