### PR TITLE
fix(replay): Fix sort icon on network tab

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -116,7 +116,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
       <IconArrow
         color="gray300"
         size="xs"
-        direction={sortConfig.by === sortedBy && !sortConfig.asc ? 'up' : 'down'}
+        direction={sortConfig.by === sortedBy && !sortConfig.asc ? 'down' : 'up'}
       />
     ) : null;
   };


### PR DESCRIPTION
### Before

<img width="1018" alt="Screen Shot 2022-09-12 at 2 40 11 PM" src="https://user-images.githubusercontent.com/139499/189731153-d5b8bd80-71e8-4f37-b793-7de9c5252384.png">


### After

<img width="1012" alt="Screen Shot 2022-09-12 at 2 40 16 PM" src="https://user-images.githubusercontent.com/139499/189731151-9238c47f-aa93-413e-9efe-62e927ec2ad4.png">
