### PR TITLE
ref(replays): Rename `release` field to `releases` to match api responses

### DIFF
--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -52,7 +52,7 @@ export type ReplayRecord = {
   };
   platform: string;
   projectId: string;
-  release: null | string;
+  releases: null | string[];
   sdk: {
     name: string;
     version: string;


### PR DESCRIPTION
The API responses were updated, and documented here: https://github.com/getsentry/replay-backend/commit/1d4f141411bd7b9b73aa51ebf7caff1ff4a05b12

So we need to keep up with that.

Fixes #38682