### PR TITLE
fix(perf-issues): Use details instead of tooltip in issue stream dropdown actions

### DIFF
--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -126,7 +126,7 @@ function ActionSet({
       label: t('Merge'),
       hidden: !nestMergeAndReview,
       disabled: mergeDisabled,
-      tooltip: makeMergeTooltip(),
+      details: makeMergeTooltip(),
       onAction: () => {
         openConfirmModal({
           bypass: !onShouldConfirm(ConfirmAction.MERGE),
@@ -187,7 +187,7 @@ function ActionSet({
       label: t('Delete'),
       priority: 'danger',
       disabled: !deleteSupported,
-      tooltip: deleteDisabledReason,
+      details: deleteDisabledReason,
       onAction: () => {
         openConfirmModal({
           bypass: !onShouldConfirm(ConfirmAction.DELETE),


### PR DESCRIPTION
This is what they look like on the issue details page, so doing this makes it consistent.