### PR TITLE
ref(ui): Remove `Object` type part 2

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -125,7 +125,7 @@ class GridEditable<
   // Static methods do not allow the use of generics bounded to the parent class
   // For more info: https://github.com/microsoft/TypeScript/issues/14600
   static getDerivedStateFromProps(
-    props: Readonly<GridEditableProps<Object, keyof Object>>,
+    props: Readonly<GridEditableProps<any, any>>,
     prevState: GridEditableState
   ): GridEditableState {
     return {

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -125,7 +125,7 @@ class GridEditable<
   // Static methods do not allow the use of generics bounded to the parent class
   // For more info: https://github.com/microsoft/TypeScript/issues/14600
   static getDerivedStateFromProps(
-    props: Readonly<GridEditableProps<any, any>>,
+    props: Readonly<GridEditableProps<Record<string, any>, ObjectKey>>,
     prevState: GridEditableState
   ): GridEditableState {
     return {

--- a/static/app/views/replays/detail/console/consoleMessage.tsx
+++ b/static/app/views/replays/detail/console/consoleMessage.tsx
@@ -22,7 +22,7 @@ interface MessageFormatterProps {
 /**
  * Attempt to stringify
  */
-function renderString(arg: string | number | boolean | Object) {
+function renderString(arg: string | number | boolean | object) {
   if (typeof arg !== 'object') {
     return arg;
   }


### PR DESCRIPTION
Use lowercase `object` instead. Missed a few types in the first cleanup
