### PR TITLE
feat(replays): Adjust Replay Network table column width and empty labels

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -208,7 +208,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
               <Text>{network.description}</Text>
             </Tooltip>
           ) : (
-            <EmptyText>({t('Missing path')})</EmptyText>
+            <EmptyText>({t('Missing')})</EmptyText>
           )}
         </Item>
         <Item {...columnHandlers}>
@@ -218,7 +218,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
           {defined(network.data.size) ? (
             <FileSize bytes={network.data.size} />
           ) : (
-            <EmptyText>({t('Missing size')})</EmptyText>
+            <EmptyText>({t('Missing')})</EmptyText>
           )}
         </Item>
 
@@ -353,10 +353,7 @@ const UnstyledHeaderButton = styled(UnstyledButton)`
 `;
 
 const StyledPanelTable = styled(PanelTable)<{columns: number}>`
-  grid-template-columns: max-content minmax(200px, 1fr) repeat(
-      4,
-      minmax(max-content, 160px)
-    );
+  grid-template-columns: max-content minmax(200px, 1fr) repeat(4, max-content);
   grid-template-rows: 24px repeat(auto-fit, 28px);
   font-size: ${p => p.theme.fontSizeSmall};
   margin-bottom: 0;


### PR DESCRIPTION
Before the column had a min-width, so they would take up more space than needed, which removes space from the path
<img width="1002" alt="Screen Shot 2022-09-12 at 11 52 20 AM" src="https://user-images.githubusercontent.com/187460/189735565-b08fc061-5ad9-4c1c-ac25-a168ff23d288.png">


Now they're shrunk, and with narrower 'missing' labels more space is saved:
<img width="999" alt="Screen Shot 2022-09-12 at 11 51 39 AM" src="https://user-images.githubusercontent.com/187460/189735601-4b171bcc-e7a9-4c1d-8775-204c90d3548a.png">


Fixes #38218