### PR TITLE
fix(replays): Add default label when no filters are selected

### DIFF
--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -85,6 +85,7 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
           triggerProps={{
             prefix: t('Log Level'),
           }}
+          triggerLabel={logLevel.length === 0 ? t('Any') : null}
           multiple
           options={getDistinctLogLevels(breadcrumbs).map(breadcrumbLogLevel => ({
             value: breadcrumbLogLevel,


### PR DESCRIPTION

<!-- Describe your PR here. -->
Added the word `Any` to the label of the console log level filter when there are no filters selected. Closes #38368 

![image](https://user-images.githubusercontent.com/39612839/189743958-aaa96d81-7479-4c99-beca-48678f08f3d1.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
