### PR TITLE
ref(perf-issues): Disable share dropdown for performance issues

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -78,6 +78,10 @@ export type IssueCategoryCapabilities = {
    * Can the issue be merged
    */
   merge: CapabilityInfo;
+  /**
+   * Can the issue be shared
+   */
+  share: CapabilityInfo;
 };
 
 // endpoint: /api/0/issues/:issueId/attachments/?limit=50

--- a/static/app/utils/groupCapabilities.tsx
+++ b/static/app/utils/groupCapabilities.tsx
@@ -10,6 +10,7 @@ const ISSUE_CATEGORY_CAPABILITIES: Record<IssueCategory, IssueCategoryCapabiliti
     deleteAndDiscard: {enabled: true},
     merge: {enabled: true},
     ignore: {enabled: true},
+    share: {enabled: true},
   },
   [IssueCategory.PERFORMANCE]: {
     delete: {
@@ -30,6 +31,10 @@ const ISSUE_CATEGORY_CAPABILITIES: Record<IssueCategory, IssueCategoryCapabiliti
     ignore: {
       enabled: false,
       disabledReason: t('This ignore option is not yet supported for performance issues'),
+    },
+    share: {
+      enabled: false,
+      disabledReason: t('Sharing is not yet supported for performance issues'),
     },
   },
 };

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -369,6 +369,7 @@ class Actions extends Component<Props, State> {
 
     const deleteCap = getIssueCapability(group.issueCategory, 'delete');
     const deleteDiscardCap = getIssueCapability(group.issueCategory, 'deleteAndDiscard');
+    const shareCap = getIssueCapability(group.issueCategory, 'share');
 
     return (
       <Wrapper>
@@ -416,7 +417,8 @@ class Actions extends Component<Props, State> {
         </Feature>
         {orgFeatures.has('shared-issues') && (
           <ShareIssue
-            disabled={disabled}
+            disabled={disabled || !shareCap.enabled}
+            disabledReason={shareCap.disabledReason}
             loading={this.state.shareBusy}
             isShared={group.isPublic}
             shareUrl={this.getShareUrl(group.shareId)}

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -422,6 +422,7 @@ class Actions extends Component<Props, State> {
             shareUrl={this.getShareUrl(group.shareId)}
             onToggle={this.onToggleShare}
             onReshare={() => this.onShare(true)}
+            issueCategory={group.issueCategory}
           />
         )}
         <SubscribeAction

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -424,7 +424,6 @@ class Actions extends Component<Props, State> {
             shareUrl={this.getShareUrl(group.shareId)}
             onToggle={this.onToggleShare}
             onReshare={() => this.onShare(true)}
-            issueCategory={group.issueCategory}
           />
         )}
         <SubscribeAction

--- a/static/app/views/organizationGroupDetails/actions/shareIssue.tsx
+++ b/static/app/views/organizationGroupDetails/actions/shareIssue.tsx
@@ -13,7 +13,6 @@ import Tooltip from 'sentry/components/tooltip';
 import {IconChevron, IconCopy, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {IssueCategory} from 'sentry/types';
 
 type ContainerProps = {
   onCancel: () => void;
@@ -23,7 +22,6 @@ type ContainerProps = {
 };
 
 type Props = {
-  issueCategory: IssueCategory;
   loading: boolean;
   /**
    * Called when refreshing an existing link

--- a/static/app/views/organizationGroupDetails/actions/shareIssue.tsx
+++ b/static/app/views/organizationGroupDetails/actions/shareIssue.tsx
@@ -77,7 +77,7 @@ function ShareIssue({
     <DropdownLink
       shouldIgnoreClickOutside={() => hasConfirmModal}
       customTitle={
-        <ActionButton disabled={disabled}>
+        <ActionButton disabled={disabled || !enabled}>
           <DropdownTitleContent>
             <IndicatorDot isShared={isShared} />
             {t('Share')}

--- a/static/app/views/organizationGroupDetails/actions/shareIssue.tsx
+++ b/static/app/views/organizationGroupDetails/actions/shareIssue.tsx
@@ -14,7 +14,6 @@ import {IconChevron, IconCopy, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {IssueCategory} from 'sentry/types';
-import {getIssueCapability} from 'sentry/utils/groupCapabilities';
 
 type ContainerProps = {
   onCancel: () => void;
@@ -32,6 +31,7 @@ type Props = {
   onReshare: () => void;
   onToggle: () => void;
   disabled?: boolean;
+  disabledReason?: string;
   /**
    * Link is public
    */
@@ -44,9 +44,9 @@ function ShareIssue({
   onReshare,
   onToggle,
   disabled,
+  disabledReason,
   isShared,
   shareUrl,
-  issueCategory,
 }: Props) {
   const [hasConfirmModal, setHasConfirmModal] = useState(false);
 
@@ -71,13 +71,11 @@ function ShareIssue({
     }
   };
 
-  const {enabled, disabledReason} = getIssueCapability(issueCategory, 'share');
-
   const renderDropdown = () => (
     <DropdownLink
       shouldIgnoreClickOutside={() => hasConfirmModal}
       customTitle={
-        <ActionButton disabled={disabled || !enabled}>
+        <ActionButton disabled={disabled}>
           <DropdownTitleContent>
             <IndicatorDot isShared={isShared} />
             {t('Share')}
@@ -87,7 +85,7 @@ function ShareIssue({
         </ActionButton>
       }
       onOpen={handleOpen}
-      disabled={disabled || !enabled}
+      disabled={disabled}
       keepMenuOpen
     >
       <DropdownContent>
@@ -114,10 +112,10 @@ function ShareIssue({
     </DropdownLink>
   );
 
-  return enabled ? (
-    renderDropdown()
-  ) : (
+  return disabled ? (
     <Tooltip title={disabledReason}>{renderDropdown()}</Tooltip>
+  ) : (
+    renderDropdown()
   );
 }
 

--- a/static/app/views/organizationGroupDetails/actions/shareIssue.tsx
+++ b/static/app/views/organizationGroupDetails/actions/shareIssue.tsx
@@ -9,9 +9,12 @@ import Confirm from 'sentry/components/confirm';
 import DropdownLink from 'sentry/components/dropdownLink';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import Switch from 'sentry/components/switchButton';
+import Tooltip from 'sentry/components/tooltip';
 import {IconChevron, IconCopy, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import {IssueCategory} from 'sentry/types';
+import {getIssueCapability} from 'sentry/utils/groupCapabilities';
 
 type ContainerProps = {
   onCancel: () => void;
@@ -21,6 +24,7 @@ type ContainerProps = {
 };
 
 type Props = {
+  issueCategory: IssueCategory;
   loading: boolean;
   /**
    * Called when refreshing an existing link
@@ -35,7 +39,15 @@ type Props = {
   shareUrl?: string | null;
 };
 
-function ShareIssue({loading, onReshare, onToggle, disabled, isShared, shareUrl}: Props) {
+function ShareIssue({
+  loading,
+  onReshare,
+  onToggle,
+  disabled,
+  isShared,
+  shareUrl,
+  issueCategory,
+}: Props) {
   const [hasConfirmModal, setHasConfirmModal] = useState(false);
 
   // State of confirm modal so we can keep dropdown menu opn
@@ -59,7 +71,9 @@ function ShareIssue({loading, onReshare, onToggle, disabled, isShared, shareUrl}
     }
   };
 
-  return (
+  const {enabled, disabledReason} = getIssueCapability(issueCategory, 'share');
+
+  const renderDropdown = () => (
     <DropdownLink
       shouldIgnoreClickOutside={() => hasConfirmModal}
       customTitle={
@@ -73,7 +87,7 @@ function ShareIssue({loading, onReshare, onToggle, disabled, isShared, shareUrl}
         </ActionButton>
       }
       onOpen={handleOpen}
-      disabled={disabled}
+      disabled={disabled || !enabled}
       keepMenuOpen
     >
       <DropdownContent>
@@ -98,6 +112,12 @@ function ShareIssue({loading, onReshare, onToggle, disabled, isShared, shareUrl}
         )}
       </DropdownContent>
     </DropdownLink>
+  );
+
+  return enabled ? (
+    renderDropdown()
+  ) : (
+    <Tooltip title={disabledReason}>{renderDropdown()}</Tooltip>
   );
 }
 


### PR DESCRIPTION
Sharing public links to Performance issues does not yet have proper support yet, so we'll disable it.

Leaving this in draft for now, since there is no styling to indicate that the component is disabled. 