### PR TITLE
fix(hybrid-cloud): For invalid subdomains, redirect to url-prefix instead of passthrough

### DIFF
--- a/src/sentry/middleware/subdomain.py
+++ b/src/sentry/middleware/subdomain.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Callable
 
 from django.core.exceptions import DisallowedHost
+from django.http import HttpResponseRedirect
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -34,7 +35,8 @@ class SubdomainMiddleware:
         try:
             host = request.get_host().lower()
         except DisallowedHost:
-            return self.get_response(request)
+            url_prefix = options.get("system.url-prefix")
+            return HttpResponseRedirect(url_prefix)
 
         if not host.endswith(f".{self.base_hostname}"):
             return self.get_response(request)

--- a/tests/sentry/middleware/test_subdomain.py
+++ b/tests/sentry/middleware/test_subdomain.py
@@ -1,7 +1,14 @@
-from django.test import RequestFactory
+from django.conf import settings
+from django.conf.urls import url
+from django.http import HttpResponseRedirect
+from django.test import RequestFactory, override_settings
+from django.urls import reverse
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
 
+from sentry.api.base import Endpoint
 from sentry.middleware.subdomain import SubdomainMiddleware
-from sentry.testutils import TestCase
+from sentry.testutils import APITestCase, TestCase
 
 
 class SubdomainMiddlewareTest(TestCase):
@@ -25,7 +32,9 @@ class SubdomainMiddlewareTest(TestCase):
             assert request_with_host("foo.bar.us.dev.getsentry.net:8000").subdomain == "foo.bar"
             assert request_with_host("foo.BAR.us.dev.getsentry.net:8000").subdomain == "foo.bar"
             # Invalid subdomain according to RFC 1034/1035.
-            assert request_with_host("_smtp._tcp.us.dev.getsentry.net:8000").subdomain is None
+            assert isinstance(
+                request_with_host("_smtp._tcp.us.dev.getsentry.net:8000"), HttpResponseRedirect
+            )
 
         with self.options({}):
             assert request_with_host("foobar").subdomain is None
@@ -33,4 +42,57 @@ class SubdomainMiddlewareTest(TestCase):
             assert request_with_host("us.dev.getsentry.net:8000").subdomain is None
             assert request_with_host("foobar.us.dev.getsentry.net:8000").subdomain is None
             assert request_with_host("foo.bar.us.dev.getsentry.net:8000").subdomain is None
-            assert request_with_host("_smtp._tcp.us.dev.getsentry.net:8000").subdomain is None
+            assert isinstance(
+                request_with_host("_smtp._tcp.us.dev.getsentry.net:8000"), HttpResponseRedirect
+            )
+
+
+class APITestEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+
+    def get(self, request):
+        # return HttpResponse(status=status.HTTP_200_OK)
+        return Response(
+            {
+                "subdomain": request.subdomain,
+            }
+        )
+
+
+urlpatterns = [
+    url(
+        r"^api/0/test/$",
+        APITestEndpoint.as_view(),
+        name="test-endpoint",
+    ),
+]
+
+
+@override_settings(
+    ROOT_URLCONF=__name__,
+    SENTRY_SELF_HOSTED=False,
+)
+class End2EndTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.middleware = settings.MIDDLEWARE
+
+    def test_with_middleware_no_customer_domain(self):
+        self.create_organization(name="albertos-apples")
+
+        response = self.client.get(
+            reverse("test-endpoint"),
+            HTTP_HOST="albertos-apples.testserver",
+        )
+        assert response.status_code == 200
+        assert response.data == {
+            "subdomain": "albertos-apples",
+        }
+
+        response = self.client.get(
+            reverse("test-endpoint"),
+            SERVER_NAME="albertos_apples.testserver",
+            follow=True,
+        )
+        assert response.status_code == 200
+        assert response.redirect_chain == [("http://testserver", 302)]

--- a/tests/sentry/middleware/test_subdomain.py
+++ b/tests/sentry/middleware/test_subdomain.py
@@ -77,7 +77,7 @@ class End2EndTest(APITestCase):
         super().setUp()
         self.middleware = settings.MIDDLEWARE
 
-    def test_with_middleware_no_customer_domain(self):
+    def test_simple(self):
         self.create_organization(name="albertos-apples")
 
         response = self.client.get(


### PR DESCRIPTION
For subdomains that are invalid according to [RFC 1034](https://datatracker.ietf.org/doc/html/rfc1034.html)/[1035](https://datatracker.ietf.org/doc/html/rfc1035.html), the subdomain middleware would act as a passthrough, passing the request onto the next middleware. This was added in https://github.com/getsentry/sentry/pull/37023.

However, in doing so, the request would bork in `django.middleware.common.CommonMiddleware` when it calls [`HttpRequest.get_host()`](https://docs.djangoproject.com/en/4.0/ref/request-response/#django.http.HttpRequest.get_host), and thus raising the `django.core.exceptions.DisallowedHost` exception.

<img width="726" alt="Screen Shot 2022-09-12 at 5 02 41 PM" src="https://user-images.githubusercontent.com/139499/189762060-a4edda3c-8a11-4a02-bf0f-a1258e32868c.png">

I'm revising the behaviour here to instead redirect to the hostname defined in the `system.url-prefix` setting (which will be `sentry.io` in SaaS).

I've also added the end-to-end test suite to capture the expected behaviour for activated middlewares. 
