### PR TITLE
ref: Fix a useEffect react-hooks/exhaustive-deps error in reprocessAlert

### DIFF
--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/reprocessAlert.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/reprocessAlert.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Client} from 'sentry/api';
@@ -36,11 +36,7 @@ function ReprocessAlert({onReprocessEvent, api, orgSlug, projSlug, eventId}: Pro
     undefined | ReprocessableEvent
   >();
 
-  useEffect(() => {
-    checkEventReprocessable();
-  }, []);
-
-  async function checkEventReprocessable() {
+  const checkEventReprocessable = useCallback(async () => {
     try {
       const response = await api.requestPromise(
         `/projects/${orgSlug}/${projSlug}/events/${eventId}/reprocessable/`
@@ -49,7 +45,11 @@ function ReprocessAlert({onReprocessEvent, api, orgSlug, projSlug, eventId}: Pro
     } catch {
       // do nothing
     }
-  }
+  }, [api, eventId, orgSlug, projSlug]);
+
+  useEffect(() => {
+    checkEventReprocessable();
+  }, [checkEventReprocessable]);
 
   if (!reprocessableEvent) {
     return null;


### PR DESCRIPTION
ESLint was complaining in here:
```
React Hook useEffect has a missing dependency: 'checkEventReprocessable'. Either include it or remove the dependency array
```
So I've added dependencies and converted to useCallback

**Test Plan:**
I would need some help finding example data that triggers this component.