### PR TITLE
feat(js): useHotkeys learns `skipPreventDefault` and `includeInputs`

### DIFF
--- a/static/app/components/smartSearchBar/searchHotkeysListener.tsx
+++ b/static/app/components/smartSearchBar/searchHotkeysListener.tsx
@@ -14,10 +14,8 @@ const SearchHotkeysListener = ({
       .filter(shortcut => typeof shortcut.hotkeys !== 'undefined')
       .map(shortcut => ({
         match: shortcut.hotkeys?.actual ?? [],
-        callback: e => {
-          e.preventDefault();
-          runShortcut(shortcut);
-        },
+        includeInputs: true,
+        callback: () => runShortcut(shortcut),
       })),
     [visibleShortcuts]
   );

--- a/static/app/utils/useHotkeys.spec.jsx
+++ b/static/app/utils/useHotkeys.spec.jsx
@@ -6,6 +6,14 @@ import {useHotkeys} from 'sentry/utils/useHotkeys';
 describe('useHotkeys', function () {
   let events = {};
 
+  function makeKeyEvent(keyCode, options) {
+    return {
+      keyCode: getKeyCode(keyCode),
+      preventDefault: jest.fn(),
+      ...options,
+    };
+  }
+
   beforeEach(() => {
     // Empty our events before each test case
     events = {};
@@ -23,42 +31,38 @@ describe('useHotkeys', function () {
   it('handles a simple match', function () {
     const callback = jest.fn();
 
-    expect(events.keydown).toBeUndefined();
-
     reactHooks.renderHook(() => useHotkeys([{match: 'ctrl+s', callback}]));
 
     expect(events.keydown).toBeDefined();
     expect(callback).not.toHaveBeenCalled();
 
-    events.keydown({keyCode: getKeyCode('s'), ctrlKey: true});
+    const evt = makeKeyEvent('s', {ctrlKey: true});
+    events.keydown(evt);
 
+    expect(evt.preventDefault).toHaveBeenCalled();
     expect(callback).toHaveBeenCalled();
   });
 
   it('handles multiple matches', function () {
     const callback = jest.fn();
 
-    expect(events.keydown).toBeUndefined();
-
     reactHooks.renderHook(() => useHotkeys([{match: ['ctrl+s', 'cmd+m'], callback}]));
 
     expect(events.keydown).toBeDefined();
     expect(callback).not.toHaveBeenCalled();
 
-    events.keydown({keyCode: getKeyCode('s'), ctrlKey: true});
+    events.keydown(makeKeyEvent('s', {ctrlKey: true}));
 
     expect(callback).toHaveBeenCalled();
     callback.mockClear();
 
-    events.keydown({keyCode: getKeyCode('m'), metaKey: true});
+    events.keydown(makeKeyEvent('m', {metaKey: true}));
 
     expect(callback).toHaveBeenCalled();
   });
 
   it('handles a complex match', function () {
     const callback = jest.fn();
-
-    expect(events.keydown).toBeUndefined();
 
     reactHooks.renderHook(() =>
       useHotkeys([{match: ['cmd+control+option+shift+x'], callback}])
@@ -67,21 +71,20 @@ describe('useHotkeys', function () {
     expect(events.keydown).toBeDefined();
     expect(callback).not.toHaveBeenCalled();
 
-    events.keydown({
-      keyCode: getKeyCode('x'),
-      altKey: true,
-      metaKey: true,
-      shiftKey: true,
-      ctrlKey: true,
-    });
+    events.keydown(
+      makeKeyEvent('x', {
+        altKey: true,
+        metaKey: true,
+        shiftKey: true,
+        ctrlKey: true,
+      })
+    );
 
     expect(callback).toHaveBeenCalled();
   });
 
-  it('rerender', function () {
+  it('updates with rerender', function () {
     const callback = jest.fn();
-
-    expect(events.keydown).toBeUndefined();
 
     const {rerender} = reactHooks.renderHook(
       p => useHotkeys([{match: p.match, callback}]),
@@ -93,19 +96,53 @@ describe('useHotkeys', function () {
     expect(events.keydown).toBeDefined();
     expect(callback).not.toHaveBeenCalled();
 
-    events.keydown({keyCode: getKeyCode('s'), ctrlKey: true});
+    events.keydown(makeKeyEvent('s', {ctrlKey: true}));
 
     expect(callback).toHaveBeenCalled();
     callback.mockClear();
 
     rerender({match: 'cmd+m'});
 
-    events.keydown({keyCode: getKeyCode('s'), ctrlKey: true});
+    events.keydown(makeKeyEvent('s', {ctrlKey: true}));
     expect(callback).not.toHaveBeenCalled();
 
-    events.keydown({keyCode: getKeyCode('m'), metaKey: true});
+    events.keydown(makeKeyEvent('m', {metaKey: true}));
     expect(callback).toHaveBeenCalled();
   });
 
-  it('skips input and textarea', function () {});
+  it('skips input and textarea', function () {
+    const callback = jest.fn();
+
+    reactHooks.renderHook(() => useHotkeys([{match: ['/'], callback}]));
+
+    events.keydown(makeKeyEvent('/', {target: document.createElement('input')}));
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('does not skips input and textarea with includesInputs', function () {
+    const callback = jest.fn();
+
+    reactHooks.renderHook(() =>
+      useHotkeys([{match: ['/'], callback, includeInputs: true}])
+    );
+
+    events.keydown(makeKeyEvent('/', {target: document.createElement('input')}));
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('skips preventDefault', function () {
+    const callback = jest.fn();
+
+    reactHooks.renderHook(() =>
+      useHotkeys([{match: 'ctrl+s', callback, skipPreventDefault: true}])
+    );
+
+    const evt = makeKeyEvent('s', {ctrlKey: true});
+    events.keydown(evt);
+
+    expect(evt.preventDefault).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalled();
+  });
 });

--- a/static/app/utils/useHotkeys.tsx
+++ b/static/app/utils/useHotkeys.tsx
@@ -18,29 +18,59 @@ const isKeyPressed = (key: string, evt: KeyboardEvent): boolean => {
   }
 };
 
+type Hotkey = {
+  /**
+   * The callback triggered when the matching key is pressed
+   */
+  callback: (e: KeyboardEvent) => void;
+  /**
+   * Defines the matching shortcuts.
+   */
+  match: string[] | string;
+  /**
+   * Allow shortcuts to be triggered while a text input is foccused
+   */
+  includeInputs?: boolean;
+  /**
+   * Do not call preventDefault on the keydown event
+   */
+  skipPreventDefault?: boolean;
+};
+
 /**
- * Pass in the hotkey combinations under match and the corresponding callback function to be called.
- * Separate key names with +. For example, 'command+alt+shift+x'
+ * Pass in the hotkey combinations under match and the corresponding callback
+ * function to be called. Separate key names with +. For example,
+ * 'command+alt+shift+x'
+ *
  * Alternate matchings as an array: ['command+alt+backspace', 'ctrl+alt+delete']
  *
  * Note: you can only use one non-modifier (keys other than shift, ctrl, alt, command) key at a time.
  */
-export function useHotkeys(
-  hotkeys: {callback: (e: KeyboardEvent) => void; match: string[] | string}[],
-  deps: React.DependencyList
-): void {
+export function useHotkeys(hotkeys: Hotkey[], deps: React.DependencyList): void {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedHotkeys = useMemo(() => hotkeys, deps);
 
   const onKeyDown = useCallback(
     (evt: KeyboardEvent) => {
-      for (const set of memoizedHotkeys) {
-        const keysets = Array.isArray(set.match) ? set.match : [set.match];
+      for (const hotkey of memoizedHotkeys) {
+        const preventDefault = !hotkey.skipPreventDefault;
+        const keysets = Array.isArray(hotkey.match) ? hotkey.match : [hotkey.match];
+
         for (const keyset of keysets) {
           const keys = keyset.split('+');
 
-          if (keys.every(key => isKeyPressed(key, evt))) {
-            set.callback(evt);
+          const allKeysPressed = keys.every(key => isKeyPressed(key, evt));
+
+          const inputHasFocus =
+            !hotkey.includeInputs && evt.target instanceof HTMLElement
+              ? ['textarea', 'input'].includes(evt.target.tagName.toLowerCase())
+              : false;
+
+          if (allKeysPressed && !inputHasFocus) {
+            if (preventDefault) {
+              evt.preventDefault();
+            }
+            hotkey.callback(evt);
             return;
           }
         }

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -42,10 +42,8 @@ function App({children}: Props) {
     [
       {
         match: ['command+shift+p', 'command+k', 'ctrl+shift+p', 'ctrl+k'],
-        callback: e => {
-          openCommandPalette();
-          e.preventDefault();
-        },
+        includeInputs: true,
+        callback: () => openCommandPalette(),
       },
     ],
     []
@@ -56,10 +54,9 @@ function App({children}: Props) {
     [
       {
         match: ['command+shift+l', 'ctrl+shift+l'],
-        callback: e => {
-          ConfigStore.set('theme', config.theme === 'light' ? 'dark' : 'light');
-          e.preventDefault();
-        },
+        includeInputs: true,
+        callback: () =>
+          ConfigStore.set('theme', config.theme === 'light' ? 'dark' : 'light'),
       },
     ],
     [config.theme]


### PR DESCRIPTION
This changes the behavior of useHotkeys to always trigger preventDefault on the event.

It also changes the behavior so that you have to explicitly include the `includeInputs` option to have the keydown event trigger the callback when a input or textarea is focused.