### PR TITLE
fix(perf_issues): Fix bug where we fail to fetch perf events when no perf evidence is stored

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -334,7 +334,8 @@ class DetailedEventSerializer(EventSerializer):
             ]
         )
         for event_problem in problems:
-            results[event_problem.event]["perf_problem"] = event_problem.problem.to_dict()
+            if event_problem:
+                results[event_problem.event]["perf_problem"] = event_problem.problem.to_dict()
         return results
 
     def _get_sdk_updates(self, obj):

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -108,20 +108,16 @@ class EventPerformanceProblem:
 
     @classmethod
     def fetch(cls, event: Event, problem_hash: str) -> EventPerformanceProblem:
-        return cls(
-            event,
-            PerformanceProblem.from_dict(
-                nodestore.get(cls.build_identifier(event.event_id, problem_hash))
-            ),
-        )
         return cls.fetch_multi((event, problem_hash))[0]
 
     @classmethod
-    def fetch_multi(cls, items: Sequence[Tuple[Event, str]]) -> Sequence[EventPerformanceProblem]:
+    def fetch_multi(
+        cls, items: Sequence[Tuple[Event, str]]
+    ) -> Sequence[Optional[EventPerformanceProblem]]:
         ids = [cls.build_identifier(event.event_id, problem_hash) for event, problem_hash in items]
         results = nodestore.get_multi(ids)
         return [
-            cls(event, PerformanceProblem.from_dict(results[_id]))
+            cls(event, PerformanceProblem.from_dict(results[_id])) if results.get(_id) else None
             for _id, (event, _) in zip(ids, items)
         ]
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -108,7 +108,7 @@ class EventPerformanceProblem:
 
     @classmethod
     def fetch(cls, event: Event, problem_hash: str) -> EventPerformanceProblem:
-        return cls.fetch_multi((event, problem_hash))[0]
+        return cls.fetch_multi([(event, problem_hash)])[0]
 
     @classmethod
     def fetch_multi(

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -768,8 +768,6 @@ class EventPerformanceProblemTest(TestCase):
                 for event, problem in all_event_problems + [(event, unsaved_problem)]
             ]
         )
-        print(result)
-
         assert [r.problem if r else None for r in result] == [
             problem for _, problem in all_event_problems
         ] + [None]

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -752,8 +752,25 @@ class EventPerformanceProblemTest(TestCase):
         ]
         for event, problem in all_event_problems:
             EventPerformanceProblem(event, problem).save()
-        result = EventPerformanceProblem.fetch_multi(
-            [(event, problem.fingerprint) for event, problem in all_event_problems]
-        )
 
-        assert [r.problem for r in result] == [problem for _, problem in all_event_problems]
+        unsaved_problem = PerformanceProblem(
+            "fake_fingerprint",
+            "db",
+            "hello",
+            GroupType.PERFORMANCE_SLOW_SPAN,
+            ["234"],
+            ["fdgh", "gdhgf", "gdgh"],
+            ["gdf", "yu", "kjl"],
+        )
+        result = EventPerformanceProblem.fetch_multi(
+            [
+                (event, problem.fingerprint)
+                for event, problem in all_event_problems + [(event, unsaved_problem)]
+            ]
+        )
+        print(result)
+
+        assert [r.problem if r else None for r in result] == [
+            problem for _, problem in all_event_problems
+        ] + [None]
+        assert False

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -771,4 +771,3 @@ class EventPerformanceProblemTest(TestCase):
         assert [r.problem if r else None for r in result] == [
             problem for _, problem in all_event_problems
         ] + [None]
-        assert False


### PR DESCRIPTION
For events going forward we should always have this, but handle this case for older events + just in case.

Fixes SENTRY-W0P