### PR TITLE
ref(ui): Fix jest eslint `toBeCalledWith`, fix story

### DIFF
--- a/docs-ui/stories/utilities/clipboard.stories.js
+++ b/docs-ui/stories/utilities/clipboard.stories.js
@@ -15,7 +15,7 @@ export default {
 
 export const Default = ({...args}) => (
   <Clipboard {...args}>
-    <span priority="primary">Click to Copy</span>
+    <span>Click to Copy</span>
   </Clipboard>
 );
 

--- a/static/app/views/dashboardsV2/releasesSelectControl.spec.tsx
+++ b/static/app/views/dashboardsV2/releasesSelectControl.spec.tsx
@@ -83,7 +83,7 @@ describe('Dashboards > ReleasesSelectControl', function () {
     userEvent.click(screen.getByText('All Releases'));
     userEvent.type(screen.getByText('Search\u2026'), 'se');
 
-    await waitFor(() => expect(mockOnSearch).toBeCalledWith('se'));
+    await waitFor(() => expect(mockOnSearch).toHaveBeenCalledWith('se'));
   });
 
   it('resets search on close', async function () {
@@ -95,10 +95,10 @@ describe('Dashboards > ReleasesSelectControl', function () {
     userEvent.click(screen.getByText('All Releases'));
     userEvent.type(screen.getByText('Search\u2026'), 'se');
 
-    await waitFor(() => expect(mockOnSearch).toBeCalledWith('se'));
+    await waitFor(() => expect(mockOnSearch).toHaveBeenCalledWith('se'));
 
     userEvent.click(document.body);
-    await waitFor(() => expect(mockOnSearch).toBeCalledWith(''));
+    await waitFor(() => expect(mockOnSearch).toHaveBeenCalledWith(''));
   });
 
   it('triggers handleChangeFilter with the release versions', function () {

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1273,7 +1273,7 @@ describe('WidgetBuilder', function () {
       await selectEvent.select(screen.getByText('(Required)'), /count_unique/);
 
       await waitFor(() => {
-        expect(eventsStatsMock).toBeCalledWith(
+        expect(eventsStatsMock).toHaveBeenCalledWith(
           '/organizations/org-slug/events-stats/',
           expect.objectContaining({
             query: expect.objectContaining({excludeOther: '1'}),
@@ -1294,7 +1294,7 @@ describe('WidgetBuilder', function () {
       userEvent.click(screen.getByText('Add Query'));
 
       await waitFor(() => {
-        expect(eventsStatsMock).toBeCalledWith(
+        expect(eventsStatsMock).toHaveBeenCalledWith(
           '/organizations/org-slug/events-stats/',
           expect.objectContaining({
             query: expect.objectContaining({excludeOther: '1'}),
@@ -1314,7 +1314,7 @@ describe('WidgetBuilder', function () {
       await selectEvent.select(await screen.findByText('Select group'), 'project');
 
       await waitFor(() => {
-        expect(eventsStatsMock).toBeCalledWith(
+        expect(eventsStatsMock).toHaveBeenCalledWith(
           '/organizations/org-slug/events-stats/',
           expect.objectContaining({
             query: expect.not.objectContaining({excludeOther: '1'}),


### PR DESCRIPTION
The new jest eslint plugin errors on `toBeCalledWith`
The story is setting a property that does not exist

see related: https://github.com/getsentry/eslint-config-sentry/pull/157
