### PR TITLE
feat(sampling): Allow creating rules on unsupported platforms [TET-364]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
@@ -69,7 +69,7 @@ export function RecommendedStepsModal({
   onSetRules,
 }: RecommendedStepsModalProps) {
   const {isProjectIncompatible} = useRecommendedSdkUpgrades({
-    orgSlug: organization.slug,
+    organization,
     projectId,
   });
   const [saving, setSaving] = useState(false);

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -100,7 +100,7 @@ export function UniformRateModal({
     isProjectOnOldSDK,
     loading: sdkUpgradesLoading,
   } = useRecommendedSdkUpgrades({
-    orgSlug: organization.slug,
+    organization,
     projectId: project.id,
   });
 

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -126,7 +126,7 @@ export function ServerSideSampling({project}: Props) {
     isProjectIncompatible,
     loading: loadingRecommendedSdkUpgrades,
   } = useRecommendedSdkUpgrades({
-    orgSlug: organization.slug,
+    organization,
     projectId: project.id,
   });
 

--- a/static/app/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/useRecommendedSdkUpgrades.spec.tsx
@@ -18,7 +18,7 @@ describe('useRecommendedSdkUpgrades', function () {
     ServerSideSamplingStore.sdkVersionsRequestSuccess(mockedSamplingSdkVersions);
 
     const {result} = reactHooks.renderHook(() =>
-      useRecommendedSdkUpgrades({orgSlug: 'org-slug', projectId: '3'})
+      useRecommendedSdkUpgrades({organization: TestStubs.Organization(), projectId: '3'})
     );
 
     expect(result.current.recommendedSdkUpgrades.length).toBe(2);


### PR DESCRIPTION
There are 3 checks that SDK needs to pass in order to be allowed to create a DS rule.

```
"isSendingSampleRate": true,
"isSendingSource": true,
"isSupportedPlatform": true
```

Example URL:
https://sentry.io/api/0/organizations/sentry-test/dynamic-sampling/sdk-versions/?end=2022-09-10T00%3A00%3A00Z&project=5270453&project=5270453&start=2022-09-09T00%3A00%3A00Z

isSupportedPlatform is controlled by this array:
https://github.com/getsentry/sentry/blob/2975a322a2466ffd7e7b0a569d54eab93f7ae9e7/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py#L22

Sometimes when SDK teams are working on adding DS support to the new SDK platform, they don't have a good way of testing it on production, because that platform is still not in the ALLOWED_SDK_NAMES. We only want to put it there once SDK is finished and properly tested.

With this PR, with the right feature flag, they will be able to create rules even before the platform is considered officially supported.

Feature flag config: https://flagr.getsentry.net/#/flags/240