### PR TITLE
fix(ds): Rename error message key to `detail`

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -238,7 +238,7 @@ class OrganizationDynamicSamplingSDKVersionsEndpoint(OrganizationEndpoint):
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={
-                    "details": "Unable to parse sdk versions. "
+                    "detail": "Unable to parse sdk versions. "
                     "Please check that sdk versions are valid semantic versions."
                 },
             )

--- a/src/sentry/api/endpoints/project_dynamic_sampling.py
+++ b/src/sentry/api/endpoints/project_dynamic_sampling.py
@@ -319,7 +319,7 @@ class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
                 return Response(
                     status=status.HTTP_400_BAD_REQUEST,
                     data={
-                        "details": "Way too many projects in the distributed trace's project breakdown"
+                        "detail": "Way too many projects in the distributed trace's project breakdown"
                     },
                 )
 

--- a/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
+++ b/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
@@ -451,6 +451,6 @@ class OrganizationDynamicSamplingSDKVersionsTest(APITestCase):
                 f"start=2022-08-06T00:02:00+00:00&"
                 f"end=2022-08-07T00:00:02+00:00"
             )
-            assert response.json()["details"] == (
+            assert response.json()["detail"] == (
                 "Unable to parse sdk versions. Please check that sdk versions are valid semantic versions."
             )

--- a/tests/sentry/api/endpoints/test_project_dynamic_sampling.py
+++ b/tests/sentry/api/endpoints/test_project_dynamic_sampling.py
@@ -436,7 +436,7 @@ class ProjectDynamicSamplingTest(APITestCase):
         with Feature({"organizations:server-side-sampling": True}):
             response = self.client.get(f"{self.endpoint}?sampleSize=2")
             assert response.json() == {
-                "details": "Way too many projects in the distributed trace's project breakdown"
+                "detail": "Way too many projects in the distributed trace's project breakdown"
             }
 
     @freeze_time()


### PR DESCRIPTION
The UI currently expects the error message
response to have the key `detail` to parse
the error message correctly. However, it
is currently `details` so this PR changes that


