### PR TITLE
refs(api): Remove `matching_event_*` from group stream serializers

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -275,9 +275,10 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 }
                 groups = list(Group.objects.filter_by_event_id(direct_hit_projects, event_id))
                 if len(groups) == 1:
-                    response = Response(
-                        serialize(groups, request.user, serializer(matching_event_id=event_id))
-                    )
+                    serialized_groups = serialize(groups, request.user, serializer())
+                    if event_id:
+                        serialized_groups[0]["matchingEventId"] = event_id
+                    response = Response(serialized_groups)
                     response["X-Sentry-Direct-Hit"] = "1"
                     return response
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -120,16 +120,21 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                 except Environment.DoesNotExist:
                     pass
 
-                response = Response(
-                    serialize(
-                        [matching_group],
-                        request.user,
-                        serializer(
-                            matching_event_id=getattr(matching_event, "event_id", None),
-                            matching_event_environment=matching_event_environment,
-                        ),
-                    )
+                serialized_groups = serialize(
+                    [matching_group],
+                    request.user,
+                    serializer(),
                 )
+                matching_event_id = getattr(matching_event, "event_id", None)
+                if matching_event_id:
+                    serialized_groups[0]["matchingEventId"] = getattr(
+                        matching_event, "event_id", None
+                    )
+                if matching_event_environment:
+                    serialized_groups[0]["matchingEventEnvironment"] = matching_event_environment
+
+                response = Response(serialized_groups)
+
                 response["X-Sentry-Direct-Hit"] = "1"
                 return response
 

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -109,8 +109,6 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
         stats_period=None,
         stats_period_start=None,
         stats_period_end=None,
-        matching_event_id=None,
-        matching_event_environment=None,
     ):
         super().__init__(environment_func)
 
@@ -120,8 +118,6 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
         self.stats_period = stats_period
         self.stats_period_start = stats_period_start
         self.stats_period_end = stats_period_end
-        self.matching_event_id = matching_event_id
-        self.matching_event_environment = matching_event_environment
 
     def get_attrs(
         self, item_list: Sequence[Group], user: Any, **kwargs: Any
@@ -148,12 +144,6 @@ class StreamGroupSerializer(GroupSerializer, GroupStatsMixin):
 
         if self.stats_period:
             result["stats"] = {self.stats_period: attrs["stats"]}
-
-        if self.matching_event_id:
-            result["matchingEventId"] = self.matching_event_id
-
-        if self.matching_event_environment:
-            result["matchingEventEnvironment"] = self.matching_event_environment
 
         return result
 
@@ -194,7 +184,6 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         stats_period=None,
         stats_period_start=None,
         stats_period_end=None,
-        matching_event_id=None,
         start=None,
         end=None,
         search_filters=None,
@@ -220,7 +209,6 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
         self.stats_period = stats_period
         self.stats_period_start = stats_period_start
         self.stats_period_end = stats_period_end
-        self.matching_event_id = matching_event_id
 
     def get_attrs(
         self, item_list: Sequence[Group], user: Any, **kwargs: Any
@@ -322,9 +310,6 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             }
             if "times_seen" in attrs:
                 result.update(self._convert_seen_stats(attrs))
-
-        if self.matching_event_id:
-            result["matchingEventId"] = self.matching_event_id
 
         if not self._collapse("stats"):
             if self.stats_period:


### PR DESCRIPTION
These params are really just layering in specific data for some search endpoints. Moving that logic to the endpoints so that we can simplify these serializers.

Ideally I want to merge these to be the same serializer, so just trying to simplify them so that it becomes easier.