### PR TITLE
ref: disable flaky test_one_field_orderby_with_no_groupby_returns_one_row

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1165,6 +1165,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
 
         assert len(response.data["groups"]) == 1
 
+    @pytest.mark.skip(reason="flaky: INGEST-1174")
     def test_one_field_orderby_with_no_groupby_returns_one_row(self):
         # Create time series [1, 2, 3, 4] for every release:
         for minute in range(4):


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/INGEST-1174
https://sentry.io/organizations/sentry/issues/3104948117/?project=2423079&query=is%3Aunresolved+test_one_field_orderby_with_no_groupby_returns_one_row&statsPeriod=14d