### PR TITLE
feat(perf-issues): Add DELETE for project options

### DIFF
--- a/src/sentry/api/endpoints/project_performance_issue_settings.py
+++ b/src/sentry/api/endpoints/project_performance_issue_settings.py
@@ -75,3 +75,10 @@ class ProjectPerformanceIssueSettingsEndpoint(ProjectEndpoint):
         project.update_option(SETTINGS_PROJECT_OPTION_KEY, {**performance_issue_settings, **data})
 
         return Response(data)
+
+    def delete(self, request: Request, project) -> Response:
+        if not self.has_feature(project, request):
+            return self.respond(status=status.HTTP_404_NOT_FOUND)
+
+        project.delete_option(SETTINGS_PROJECT_OPTION_KEY)
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
This allows us to delete any changes made to the project options via a 'reset all' button in the UI, which we can add in a subsequent PR. We will likely want to not use project options for tuning in the future except when adding a new detector since we want to easily be able to opt-in or opt-out a specific project quickly when rolling out.

