### PR TITLE
Fix sentry e2e tests

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -41,6 +41,7 @@ steps:
       - '-c'
       - |
         mkdir self-hosted && cd self-hosted
+        echo "no" > .reporterrors
         curl -L "https://github.com/getsentry/self-hosted/archive/master.tar.gz" | tar xzf - --strip-components=1
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
   - name: 'gcr.io/$PROJECT_ID/docker-compose'


### PR DESCRIPTION
In https://github.com/getsentry/self-hosted/pull/1679 we require a `.reporterrors` file, this adds it to the cloudbuild config