### PR TITLE
fix: org settings b64decode uuid

### DIFF
--- a/src/sentry/api/fields/avatar.py
+++ b/src/sentry/api/fields/avatar.py
@@ -41,9 +41,9 @@ class AvatarField(serializers.Field):
         return value.getvalue()
 
     def to_internal_value(self, data):
-        if not data:
+        if not data or not data.get("avatarUuid"):
             return None
-        data = b64decode(data)
+        data = b64decode(data.get("avatarUuid"))
         if len(data) > self.max_size:
             raise ImageTooLarge()
 


### PR DESCRIPTION
TypeError is being thrown whenever an org edits its settings.

https://sentry.io/organizations/sentry/issues/3142694249/?project=1

Looks like the `to_internal_value` is [expected to return](https://www.django-rest-framework.org/api-guide/fields/) a `uuid.UUID` instance, and looks like we're passing in an object _with_ a UUID as the attr.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
