### PR TITLE
fix(perf-issues): Fix typo in option name

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -539,4 +539,4 @@ register("performance.issues.render_blocking_assets.problem-creation", default=0
 
 # System-wide options for default performance detection settings for any org opted into the performance-issues-ingest feature. Meant for rollout.
 register("performance.issues.n_plus_one_db.count_threshold", default=5)
-register("performnace.issues.n_plus_one_db.duration_threshold", default=100.0)
+register("performance.issues.n_plus_one_db.duration_threshold", default=100.0)


### PR DESCRIPTION
Fixes this before we start using it so it's less of a pain, option has yet to be used anywhere except for UI at the moment, and it won't have been set yet.


