### PR TITLE
fix(perf-issues): Fix adminSettings and options

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -19,8 +19,9 @@ const optionsAvailable = [
   'beacon.anonymous',
   'performance.issues.all.problem-detection',
   'performance.issues.all.problem-creation',
-  'performance.issues.n_plus_one.problem-detection',
-  'performance.issues.n_plus_one.problem-creation',
+  'performance.issues.n_plus_one_db.problem-creation',
+  'performance.issues.n_plus_one_db.count_threshold',
+  'performance.issues.n_plus_one_db.duration_threshold',
 ];
 
 type Field = ReturnType<typeof getOption>;
@@ -95,10 +96,12 @@ export default class AdminSettings extends AsyncView<{}, State> {
 
           <Feature features={['organizations:performance-issues-dev']}>
             <Panel>
-              <PanelHeader>Performance Issues</PanelHeader>
+              <PanelHeader>Performance Issues - All</PanelHeader>
               {fields['performance.issues.all.problem-detection']}
               {fields['performance.issues.all.problem-creation']}
-              {fields['performance.issues.n_plus_one_db.problem-detection']}
+            </Panel>
+            <Panel>
+              <PanelHeader>Performance Issues - Detectors</PanelHeader>
               {fields['performance.issues.n_plus_one_db.problem-creation']}
               {fields['performance.issues.n_plus_one_db.count_threshold']}
               {fields['performance.issues.n_plus_one_db.duration_threshold']}

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -123,7 +123,7 @@ const performanceOptionDefinitions: Field[] = [
     step: 1,
   },
   {
-    key: 'performance.issues.n_plus_one_db.duration_threshold',
+    key: 'performance.issues.n_plus_one_db.duration_threshold', // TODO: For fixing typo later.
     label: t('N+1 (DB) duration threshold'),
     help: t(
       'Detector threshold. Controls the threshold for the cumulative duration of involved spans required to trigger performance issues. This affects all organizations system-wide.'


### PR DESCRIPTION
### Summary
This fixes adminSettings by opt-ing in the system options, which weren't opted it in to the allowed fields before. It also preps for fixing the typo'd option name.

Needs #38772