### PR TITLE
fix: enable admin login for dev

### DIFF
--- a/static/app/components/superuserAccessForm.tsx
+++ b/static/app/components/superuserAccessForm.tsx
@@ -67,10 +67,6 @@ class SuperuserAccessForm extends Component<Props, State> {
       return;
     }
 
-    if (disableU2FForSUForm) {
-      await api.requestPromise('/auth/', {method: 'PUT', data});
-    }
-
     if (this.state.showAccessForms && !disableU2FForSUForm) {
       this.setState({
         showAccessForms: false,
@@ -78,6 +74,7 @@ class SuperuserAccessForm extends Component<Props, State> {
         superuserReason: suReason,
       });
     } else {
+      await api.requestPromise('/auth/', {method: 'PUT', data});
       this.handleSuccess();
     }
   };

--- a/static/app/components/superuserAccessForm.tsx
+++ b/static/app/components/superuserAccessForm.tsx
@@ -53,7 +53,8 @@ class SuperuserAccessForm extends Component<Props, State> {
     });
   };
 
-  handleSubmit = data => {
+  handleSubmit = async data => {
+    const {api} = this.props;
     const {superuserAccessCategory, superuserReason, authenticators} = this.state;
     const disableU2FForSUForm = ConfigStore.get('disableU2FForSUForm');
 
@@ -64,6 +65,10 @@ class SuperuserAccessForm extends Component<Props, State> {
     if (!authenticators.length && !disableU2FForSUForm) {
       this.handleError(ErrorCodes.noAuthenticator);
       return;
+    }
+
+    if (disableU2FForSUForm) {
+      await api.requestPromise('/auth/', {method: 'PUT', data});
     }
 
     if (this.state.showAccessForms && !disableU2FForSUForm) {


### PR DESCRIPTION
Admin login is not submitting the form in development now that u2f has been required for production.

we _should_ still be firing the /auth/ api PUT when u2f is disabled to unblock local development