### PR TITLE
feat(replay): Implement more Replay Details layouts for feedback

### DIFF
--- a/static/app/utils/replays/hooks/useReplayLayout.tsx
+++ b/static/app/utils/replays/hooks/useReplayLayout.tsx
@@ -82,7 +82,7 @@ export enum LayoutKey {
    * │          >        │
    * │          >^^^^^^^^┤
    * │          > Crumbs │
-   * │          >        │
+   * │          > Tabs   │
    * └──────────┴────────┘
    */
   sidebar_right = 'sidebar_right',

--- a/static/app/utils/replays/hooks/useReplayLayout.tsx
+++ b/static/app/utils/replays/hooks/useReplayLayout.tsx
@@ -9,6 +9,45 @@ import {getDefaultLayout} from 'sentry/views/replays/detail/layout/utils';
 
 export enum LayoutKey {
   /**
+   * ### Top
+   *┌────────────────────┐
+   *│ Timeline           │
+   *├───────────┬────────┤
+   *│ Video     > Crumbs │
+   *│           >        │
+   *├^^^^^^^^^^^>        |
+   *│ Details   >        │
+   *│           >        │
+   *└───────────┴────────┘
+   */
+  top = 'top',
+  /**
+   * ### Top
+   *┌────────────────────┐
+   *│ Timeline           │
+   *├───────────┬────────┤
+   *│ Details   > Crumbs │
+   *│           >        │
+   *│           >        |
+   *│           >        │
+   *│           >        │
+   *└───────────┴────────┘
+   */
+  no_video = 'no_video',
+  /**
+   * ### Video Only
+   *┌────────────────────┐
+   *│ Timeline           │
+   *├────────────────────┤
+   *│                    │
+   *│                    |
+   *│       Video        │
+   *│                    │
+   *│                    │
+   *└────────────────────┘
+   */
+  video_only = 'video_only',
+  /**
    * ### Topbar
    *┌────────────────────┐
    *│ Timeline           │

--- a/static/app/utils/replays/hooks/useReplayLayout.tsx
+++ b/static/app/utils/replays/hooks/useReplayLayout.tsx
@@ -69,7 +69,7 @@ export enum LayoutKey {
    * │        >          │
    * │^^^^^^^ >          |
    * │ Crumbs >          │
-   * │        >          │
+   * │ Tabs   >          │
    * └────────┴──────────┘
    */
   sidebar_left = 'sidebar_left',

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -25,9 +25,11 @@ function CrumbPlaceholder({number}: {number: number}) {
   );
 }
 
-type Props = {};
+type Props = {
+  showTitle: boolean;
+};
 
-function Breadcrumbs({}: Props) {
+function Breadcrumbs({showTitle = true}: Props) {
   const {currentHoverTime, currentTime, replay} = useReplayContext();
 
   const replayRecord = replay?.getReplay();
@@ -85,7 +87,7 @@ function Breadcrumbs({}: Props) {
     <Panel>
       <FluidPanel
         bodyRef={crumbListContainerRef}
-        title={<PanelHeader>{t('Breadcrumbs')}</PanelHeader>}
+        title={showTitle ? <PanelHeader>{t('Breadcrumbs')}</PanelHeader> : undefined}
       >
         {content}
       </FluidPanel>

--- a/static/app/views/replays/detail/focusTabs.tsx
+++ b/static/app/views/replays/detail/focusTabs.tsx
@@ -15,15 +15,15 @@ const ReplayTabs: Record<TabKey, string> = {
   memory: t('Memory'),
 };
 
-type Props = {};
+type Props = {className?: string};
 
-function FocusTabs({}: Props) {
+function FocusTabs({className}: Props) {
   const {pathname, query} = useLocation();
   const {getActiveTab, setActiveTab} = useActiveReplayTab();
   const activeTab = getActiveTab();
 
   return (
-    <NavTabs underlined>
+    <NavTabs underlined className={className}>
       {Object.entries(ReplayTabs).map(([tab, label]) => (
         <li key={tab} className={activeTab === tab ? 'active' : ''}>
           <a

--- a/static/app/views/replays/detail/layout/chooseLayout.tsx
+++ b/static/app/views/replays/detail/layout/chooseLayout.tsx
@@ -1,5 +1,5 @@
 import CompactSelect from 'sentry/components/forms/compactSelect';
-import {IconPanel} from 'sentry/icons';
+import {IconExpand, IconPanel, IconTerminal} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import useReplayLayout, {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
 
@@ -7,17 +7,22 @@ const layoutToLabel: Record<LayoutKey, string> = {
   topbar: t('Player Top'),
   sidebar_left: t('Player Left'),
   sidebar_right: t('Player Right'),
+  top: t('Top'),
+  no_video: t('Data'),
+  video_only: t('Video'),
 };
 
-const layoutToDir: Record<LayoutKey, string> = {
-  topbar: 'up',
-  sidebar_left: 'left',
-  sidebar_right: 'right',
+const layoutToIcon: Record<LayoutKey, JSX.Element> = {
+  topbar: <IconPanel size="sm" direction="up" />,
+  sidebar_left: <IconPanel size="sm" direction="left" />,
+  sidebar_right: <IconPanel size="sm" direction="right" />,
+  top: <IconPanel size="sm" direction="right" />,
+  no_video: <IconTerminal size="sm" />,
+  video_only: <IconExpand size="sm" />,
 };
 
-function getLayoutIcon(layout: string) {
-  const dir = layout in layoutToDir ? layoutToDir[layout] : 'up';
-  return <IconPanel size="sm" direction={dir} />;
+function getLayoutIcon(layout: LayoutKey) {
+  return layoutToIcon[layout];
 }
 
 type Props = {};
@@ -38,7 +43,7 @@ function ChooseLayout({}: Props) {
       options={Object.entries(layoutToLabel).map(([value, label]) => ({
         value,
         label,
-        leadingItems: getLayoutIcon(value),
+        leadingItems: getLayoutIcon(value as LayoutKey),
       }))}
     />
   );

--- a/static/app/views/replays/detail/layout/chooseLayout.tsx
+++ b/static/app/views/replays/detail/layout/chooseLayout.tsx
@@ -1,6 +1,9 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
 import CompactSelect from 'sentry/components/forms/compactSelect';
-import {IconExpand, IconPanel, IconTerminal} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
 import useReplayLayout, {LayoutKey} from 'sentry/utils/replays/hooks/useReplayLayout';
 
 const layoutToLabel: Record<LayoutKey, string> = {
@@ -8,45 +11,38 @@ const layoutToLabel: Record<LayoutKey, string> = {
   sidebar_left: t('Player Left'),
   sidebar_right: t('Player Right'),
   top: t('Top'),
-  no_video: t('Data'),
-  video_only: t('Video'),
+  no_video: t('Data Only'),
+  video_only: t('Video Only'),
 };
-
-const layoutToIcon: Record<LayoutKey, JSX.Element> = {
-  topbar: <IconPanel size="sm" direction="up" />,
-  sidebar_left: <IconPanel size="sm" direction="left" />,
-  sidebar_right: <IconPanel size="sm" direction="right" />,
-  top: <IconPanel size="sm" direction="right" />,
-  no_video: <IconTerminal size="sm" />,
-  video_only: <IconExpand size="sm" />,
-};
-
-function getLayoutIcon(layout: LayoutKey) {
-  return layoutToIcon[layout];
-}
 
 type Props = {};
 
 function ChooseLayout({}: Props) {
   const {getLayout, setLayout} = useReplayLayout();
 
+  const currentLabel = layoutToLabel[getLayout()];
   return (
     <CompactSelect
-      triggerProps={{
-        size: 'xs',
-        icon: getLayoutIcon(getLayout()),
-      }}
-      triggerLabel=""
+      triggerProps={{size: 'xs'}}
+      triggerLabel={
+        <Fragment>
+          Page Layout: <Current>{currentLabel}</Current>
+        </Fragment>
+      }
       value={getLayout()}
       placement="bottom right"
       onChange={opt => setLayout(opt?.value)}
       options={Object.entries(layoutToLabel).map(([value, label]) => ({
         value,
         label,
-        leadingItems: getLayoutIcon(value as LayoutKey),
       }))}
     />
   );
 }
+
+const Current = styled('span')`
+  font-weight: normal;
+  padding-left: ${space(0.5)};
+`;
 
 export default ChooseLayout;

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -210,7 +210,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
 
 function SideCrumbsTags() {
   const {getParamValue} = useUrlParams('t_side', 'crumbs');
-  const sideTabs = <SmallMarginSideTabs tags={['crumbs', 'tags']} />;
+  const sideTabs = <SmallMarginSideTabs />;
   if (getParamValue() === 'tags') {
     return (
       <FluidPanel title={sideTabs}>

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -165,17 +165,40 @@ function ReplayLayout({
   }
 
   if (layout === 'sidebar_left') {
+    const mainArea = (
+      <ErrorBoundary mini>
+        <FluidPanel title={<SmallMarginFocusTabs />}>
+          <FocusArea />
+        </FluidPanel>
+      </ErrorBoundary>
+    );
+
+    const sideContent = (
+      <SplitPanel
+        key={layout}
+        top={{
+          content: video,
+          default: '50%',
+          min: MIN_CONTENT_WIDTH,
+        }}
+        bottom={{
+          content: <SideCrumbsTags crumbs={crumbsWithoutTitle} />,
+          min: MIN_SIDEBAR_WIDTH,
+        }}
+      />
+    );
+
     return (
       <BodyContent>
         {timeline}
         <SplitPanel
           key={layout}
           left={{
-            content: <SidebarContent video={video} crumbs={crumbsWithTitle} />,
+            content: sideContent,
             min: MIN_SIDEBAR_WIDTH,
           }}
           right={{
-            content,
+            content: mainArea,
             default: '60%',
             min: MIN_CONTENT_WIDTH,
           }}

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -32,8 +32,8 @@ function Page({children, crumbs, orgSlug, replayRecord}: Props) {
         <DetailsPageBreadcrumbs orgSlug={orgSlug} replayRecord={replayRecord} />
       </HeaderContent>
       <ButtonActionsWrapper>
-        <FeatureFeedback featureName="replay" buttonProps={{size: 'xs'}} />
         <ChooseLayout />
+        <FeatureFeedback featureName="replay" buttonProps={{size: 'xs'}} />
       </ButtonActionsWrapper>
 
       {replayRecord && crumbs ? (

--- a/static/app/views/replays/detail/sideTabs.tsx
+++ b/static/app/views/replays/detail/sideTabs.tsx
@@ -4,7 +4,6 @@ import useUrlParams from 'sentry/utils/useUrlParams';
 
 const TABS = {
   crumbs: t('Breadcrumbs'),
-  video: t('Replay'),
   tags: t('Tags'),
 };
 type TabKey = keyof typeof TABS;
@@ -15,8 +14,7 @@ type Props = {
 };
 
 function SideTabs({tags, className}: Props) {
-  const defaultTab = tags.includes('video') ? 'video' : 'crumbs';
-  const {getParamValue, setParamValue} = useUrlParams('t_side', defaultTab);
+  const {getParamValue, setParamValue} = useUrlParams('t_side', 'crumbs');
   const active = getParamValue();
 
   return (

--- a/static/app/views/replays/detail/sideTabs.tsx
+++ b/static/app/views/replays/detail/sideTabs.tsx
@@ -6,28 +6,24 @@ const TABS = {
   crumbs: t('Breadcrumbs'),
   tags: t('Tags'),
 };
-type TabKey = keyof typeof TABS;
 
 type Props = {
-  tags: TabKey[];
   className?: string;
 };
 
-function SideTabs({tags, className}: Props) {
+function SideTabs({className}: Props) {
   const {getParamValue, setParamValue} = useUrlParams('t_side', 'crumbs');
   const active = getParamValue();
 
   return (
     <NavTabs underlined className={className}>
-      {Object.entries(TABS)
-        .filter(([tab]) => tags.includes(tab as TabKey))
-        .map(([tab, label]) => {
-          return (
-            <li key={tab} className={active === tab ? 'active' : ''}>
-              <a onClick={() => setParamValue(tab)}>{label}</a>
-            </li>
-          );
-        })}
+      {Object.entries(TABS).map(([tab, label]) => {
+        return (
+          <li key={tab} className={active === tab ? 'active' : ''}>
+            <a onClick={() => setParamValue(tab)}>{label}</a>
+          </li>
+        );
+      })}
     </NavTabs>
   );
 }

--- a/static/app/views/replays/detail/sideTabs.tsx
+++ b/static/app/views/replays/detail/sideTabs.tsx
@@ -2,26 +2,34 @@ import NavTabs from 'sentry/components/navTabs';
 import {t} from 'sentry/locale';
 import useUrlParams from 'sentry/utils/useUrlParams';
 
-type Props = {};
-
 const TABS = {
+  crumbs: t('Breadcrumbs'),
   video: t('Replay'),
   tags: t('Tags'),
 };
+type TabKey = keyof typeof TABS;
 
-function SideTabs({}: Props) {
-  const {getParamValue, setParamValue} = useUrlParams('t_side', 'video');
+type Props = {
+  tags: TabKey[];
+  className?: string;
+};
+
+function SideTabs({tags, className}: Props) {
+  const defaultTab = tags.includes('video') ? 'video' : 'crumbs';
+  const {getParamValue, setParamValue} = useUrlParams('t_side', defaultTab);
   const active = getParamValue();
 
   return (
-    <NavTabs underlined>
-      {Object.entries(TABS).map(([tab, label]) => {
-        return (
-          <li key={tab} className={active === tab ? 'active' : ''}>
-            <a onClick={() => setParamValue(tab)}>{label}</a>
-          </li>
-        );
-      })}
+    <NavTabs underlined className={className}>
+      {Object.entries(TABS)
+        .filter(([tab]) => tags.includes(tab as TabKey))
+        .map(([tab, label]) => {
+          return (
+            <li key={tab} className={active === tab ? 'active' : ''}>
+              <a onClick={() => setParamValue(tab)}>{label}</a>
+            </li>
+          );
+        })}
     </NavTabs>
   );
 }


### PR DESCRIPTION
The main one that's new is the `top` design from https://github.com/getsentry/sentry/issues/37202

**"Top" (could be the new default & only layout)**
<img width="1312" alt="Screen Shot 2022-09-14 at 9 56 25 AM" src="https://user-images.githubusercontent.com/187460/190216453-71a1d4e7-7885-4d86-a85c-b99bdd4a02ed.png">

**The original 'left' and 'right' layouts are also tweaked:**
the sidebar tabs are moved down below the video, and margin under all tabs is reduced
<img width="1312" alt="Screen Shot 2022-09-14 at 11 49 33 AM" src="https://user-images.githubusercontent.com/187460/190238252-269b64b4-175e-439a-9c34-84a1953ec491.png">



Also added are 2 more: no-video and only-video. They'd be cool when/if two pages could talk to each other (and if we could hide the sentry sidebar).

But also, I think I'd like the video-only layout during DEX to make it easier to demo a 'full pii' capture. Not super critical though in any way.

**No Video**
<img width="1312" alt="Screen Shot 2022-09-14 at 9 56 27 AM" src="https://user-images.githubusercontent.com/187460/190216529-85a8adf6-252e-40fd-be6f-7027c8b049bc.png">

**Only Video**
<img width="1312" alt="Screen Shot 2022-09-14 at 9 56 34 AM" src="https://user-images.githubusercontent.com/187460/190216545-662737ec-ff70-4a29-a26c-fc879ff871b4.png">


Fixes #37202
