### PR TITLE
feat(metrics): Support rate for derived metric [TET-129 TET-127]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -50,9 +50,9 @@ from sentry.snuba.metrics.fields.snql import (
     errored_all_users,
     errored_preaggr_sessions,
     failure_count_transaction,
-    histogram,
+    histogram_snql_factory,
     miserable_users,
-    rate,
+    rate_snql_factory,
     satisfaction_count_transaction,
     session_duration_filters,
     subtraction,
@@ -1326,12 +1326,12 @@ DERIVED_OPS: Mapping[MetricOperationType, DerivedOp] = {
             op="histogram",
             can_orderby=False,
             post_query_func=rebucket_histogram,
-            snql_func=histogram,
+            snql_func=histogram_snql_factory,
         ),
         DerivedOp(
             op="rate",
             can_orderby=False,
-            snql_func=rate,
+            snql_func=rate_snql_factory,
         ),
     ]
 }

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -569,7 +569,7 @@ class MetricExpression(MetricExpressionDefinition, MetricExpressionBase):
         return f"{self.metric_operation.op}({self.metric_object.metric_mri})"
 
     def get_entity(self, projects: Sequence[Project], use_case_id: UseCaseKey) -> MetricEntity:
-        return _get_entity_of_metric_mri(projects, self.metric_object.metric_mri, use_case_id).value  # type: ignore
+        return _get_entity_of_metric_mri(projects, self.metric_object.metric_mri, use_case_id).value
 
     def generate_select_statements(
         self,

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -569,7 +569,7 @@ class MetricExpression(MetricExpressionDefinition, MetricExpressionBase):
         return f"{self.metric_operation.op}({self.metric_object.metric_mri})"
 
     def get_entity(self, projects: Sequence[Project], use_case_id: UseCaseKey) -> MetricEntity:
-        return _get_known_entity_of_metric_mri(self.metric_object.metric_mri).value  # type: ignore
+        return _get_entity_of_metric_mri(projects, self.metric_object.metric_mri, use_case_id).value  # type: ignore
 
     def generate_select_statements(
         self,

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -4,7 +4,7 @@ from snuba_sdk import Column, Function
 
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import resolve_tag_key, resolve_tag_value, resolve_tag_values
-from sentry.snuba.metrics.fields.histogram import zoom_histogram
+from sentry.snuba.metrics.fields.histogram import MAX_HISTOGRAM_BUCKET, zoom_histogram
 from sentry.snuba.metrics.naming_layer.public import (
     TransactionSatisfactionTagValue,
     TransactionStatusTagValue,
@@ -325,7 +325,7 @@ def histogram(
         conditions = aggregate_filter
 
     return Function(
-        "histogramIf(250)",
+        f"histogramIf({MAX_HISTOGRAM_BUCKET})",
         [Column("value"), conditions],
         alias=alias,
     )

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -331,9 +331,7 @@ def histogram(
     )
 
 
-def rate(aggregate_filter, numerator, denominator=None, alias=None):
-    if denominator is None:
-        denominator = 1.0
+def rate(aggregate_filter, numerator, denominator=1.0, alias=None):
     return Function(
         "divide",
         [

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -307,7 +307,7 @@ def session_duration_filters(org_id):
     ]
 
 
-def histogram(
+def histogram_snql_factory(
     aggregate_filter,
     histogram_buckets: int = 100,
     histogram_from: Optional[float] = None,
@@ -331,7 +331,7 @@ def histogram(
     )
 
 
-def rate(aggregate_filter, numerator, denominator=1.0, alias=None):
+def rate_snql_factory(aggregate_filter, numerator, denominator=1.0, alias=None):
     return Function(
         "divide",
         [

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -213,6 +213,7 @@ OPERATIONS = (
     "min",
     "sum",
     "histogram",
+    "rate",
 ) + OPERATIONS_PERCENTILES
 
 DEFAULT_AGGREGATES: Dict[MetricOperationType, Optional[Union[int, List[Tuple[float]]]]] = {
@@ -229,6 +230,7 @@ DEFAULT_AGGREGATES: Dict[MetricOperationType, Optional[Union[int, List[Tuple[flo
     "sum": 0,
     "percentage": None,
     "histogram": [],
+    "rate": 0,
 }
 UNIT_TO_TYPE = {"sessions": "count", "percentage": "percentage", "users": "count"}
 UNALLOWED_TAGS = {"session.status"}

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -456,6 +456,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             field=f"count({TransactionMetricKey.MEASUREMENTS_LCP.value})",
             groupBy="transaction",
             per_page=2,
+            useCase="performance",
         )
         assert response.status_code == 200
 
@@ -470,6 +471,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             groupBy="transaction",
             cursor=Cursor(0, 1),
             statsPeriod="1h",
+            useCase="performance",
         )
         assert response.status_code == 200, response.data
 
@@ -787,6 +789,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             interval="1h",
             groupBy=["project_id", "transaction"],
             orderBy=f"p50({TransactionMetricKey.MEASUREMENTS_LCP.value})",
+            useCase="performance",
         )
         groups = response.data["groups"]
         assert len(groups) == 0

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -1,6 +1,7 @@
 """
 Metrics Service Layer Tests for Performance
 """
+import re
 import time
 from datetime import timedelta
 from unittest import mock
@@ -11,6 +12,7 @@ from django.utils.datastructures import MultiValueDict
 from freezegun import freeze_time
 from snuba_sdk import Direction, Granularity, Limit, Offset
 
+from sentry.api.utils import InvalidParams
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.snuba.metrics import (
@@ -26,12 +28,16 @@ from sentry.snuba.metrics.naming_layer import TransactionMetricKey, TransactionM
 from sentry.snuba.metrics.query_builder import QueryDefinition, get_date_range
 from sentry.testutils import BaseMetricsTestCase, TestCase
 from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.helpers.datetime import before_now, iso_format
 
 pytestmark = pytest.mark.sentry_metrics
 
 
 class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
+    def setUp(self):
+        super().setUp()
+        self.now = timezone.now()
+
     def test_valid_filter_include_meta_derived_metrics(self):
         query_params = MultiValueDict(
             {
@@ -64,8 +70,6 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
         )
 
     def test_alias_on_different_metrics_expression(self):
-        now = before_now(minutes=0)
-
         for v_transaction, count in (("/foo", 1), ("/bar", 3), ("/baz", 2)):
             for value in [123.4] * count:
                 self.store_metric(
@@ -94,8 +98,8 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                     alias="count_fcp",
                 ),
             ],
-            start=now - timedelta(hours=1),
-            end=now,
+            start=self.now - timedelta(hours=1),
+            end=self.now,
             granularity=Granularity(granularity=3600),
             groupby=[MetricGroupByField(name="transaction", alias="transaction_group")],
             orderby=[
@@ -151,7 +155,6 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
         )
 
     def test_alias_on_same_metrics_expression_but_different_aliases(self):
-        now = before_now(minutes=0)
         for v_transaction, count in (("/foo", 1), ("/bar", 3), ("/baz", 2)):
             for value in [123.4] * count:
                 self.store_metric(
@@ -180,8 +183,8 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                     alias="count_lcp_2",
                 ),
             ],
-            start=now - timedelta(hours=1),
-            end=now,
+            start=self.now - timedelta(hours=1),
+            end=self.now,
             granularity=Granularity(granularity=3600),
             groupby=[
                 MetricGroupByField("transaction", alias="transaction_group"),
@@ -239,8 +242,6 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
 
     @freeze_time()
     def test_alias_on_single_entity_derived_metrics(self):
-        now = timezone.now()
-
         for value, tag_value in (
             (3.4, TransactionStatusTagValue.OK.value),
             (0.3, TransactionStatusTagValue.CANCELLED.value),
@@ -253,7 +254,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 type="distribution",
                 name=TransactionMRI.DURATION.value,
                 tags={TransactionTagsKey.TRANSACTION_STATUS.value: tag_value},
-                timestamp=now.timestamp(),
+                timestamp=self.now.timestamp(),
                 value=value,
                 use_case_id=UseCaseKey.PERFORMANCE,
             )
@@ -268,8 +269,8 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                     alias="failure_rate_alias",
                 ),
             ],
-            start=now - timedelta(minutes=1),
-            end=now,
+            start=self.now - timedelta(minutes=1),
+            end=self.now,
             granularity=Granularity(granularity=60),
             limit=Limit(limit=2),
             offset=Offset(offset=0),
@@ -406,8 +407,6 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
         )
 
     def test_histogram_transaction_duration(self):
-        now = timezone.now()
-
         for tag, value, numbers in (
             ("tag1", "value1", [1, 2, 3]),
             ("tag1", "value2", [10, 100, 1000]),
@@ -450,8 +449,8 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                     alias="histogram_lcp_2",
                 ),
             ],
-            start=now - timedelta(hours=1),
-            end=now,
+            start=self.now - timedelta(hours=1),
+            end=self.now,
             granularity=Granularity(granularity=3600),
             limit=Limit(limit=51),
             offset=Offset(offset=0),
@@ -473,6 +472,304 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 },
             }
         ]
+
+    def test_rate_epm_hour_rollup(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for hour, count in enumerate(event_counts):
+            for _ in range(count):
+                self.store_metric(
+                    org_id=self.organization.id,
+                    project_id=self.project.id,
+                    type="distribution",
+                    name=TransactionMRI.DURATION.value,
+                    tags={},
+                    timestamp=(self.now - timedelta(hours=hour)).timestamp(),
+                    value=1,
+                    use_case_id=UseCaseKey.PERFORMANCE,
+                )
+
+        start, end, rollup = get_date_range(
+            {
+                "statsPeriod": "6h",
+                "interval": "1h",
+            }
+        )
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="rate",
+                    metric_name=TransactionMetricKey.DURATION.value,
+                    params={"numerator": 3600, "denominator": 60},
+                ),
+                MetricField(
+                    op="count",
+                    metric_name=TransactionMetricKey.DURATION.value,
+                ),
+            ],
+            start=start,
+            end=end,
+            granularity=Granularity(granularity=rollup),
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            include_series=True,
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=True,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+
+        # The order they will be in is the reverse of the order they were inserted so -> [3, 0, 3, 6, 0, 6] and hence
+        # the expected rates would be each of those event counts divided by 3600 / 60
+        assert data["groups"] == [
+            {
+                "by": {},
+                "series": {
+                    "rate(transaction.duration)": [0.05, 0, 0.05, 0.1, 0, 0.1],
+                    "count(transaction.duration)": [3, 0, 3, 6, 0, 6],
+                },
+                "totals": {"rate(transaction.duration)": 0.3, "count(transaction.duration)": 18},
+            }
+        ]
+
+    def test_rate_epm_day_rollup(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for hour, count in enumerate(event_counts):
+            for minute in range(count):
+                self.store_metric(
+                    org_id=self.organization.id,
+                    project_id=self.project.id,
+                    type="distribution",
+                    name=TransactionMRI.DURATION.value,
+                    tags={},
+                    timestamp=(self.now - timedelta(hours=hour)).timestamp(),
+                    value=1,
+                    use_case_id=UseCaseKey.PERFORMANCE,
+                )
+
+        start, end, rollup = get_date_range(
+            {
+                "statsPeriod": "6h",
+                "interval": "1h",
+            }
+        )
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="rate",
+                    metric_name=TransactionMetricKey.DURATION.value,
+                    params={"numerator": 86400, "denominator": 60},
+                ),
+            ],
+            start=start,
+            end=end,
+            granularity=Granularity(granularity=rollup),
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            include_series=True,
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=True,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+
+        # The order they will be in is the reverse of the order they were inserted so -> [3, 0, 3, 6, 0, 6] and hence
+        # the expected rates would be each of those event counts divided by 86400 / 60
+        assert data["groups"] == [
+            {
+                "by": {},
+                "series": {
+                    "rate(transaction.duration)": [3 / 1440, 0, 3 / 1440, 6 / 1440, 0, 6 / 1440],
+                },
+                "totals": {"rate(transaction.duration)": 18 / 1440},
+            }
+        ]
+
+    @pytest.mark.skip(reason="Contains granularity/rollup logic that is not yet implemented")
+    def test_throughput_epm_hour_rollup_offset_of_hour(self):
+        # Each of these denotes how many events to create in each hour
+        day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
+
+        event_counts = [6, 0, 6, 3, 0, 3]
+
+        self.store_metric(
+            org_id=self.organization.id,
+            project_id=self.project.id,
+            type="distribution",
+            name=TransactionMRI.DURATION.value,
+            tags={},
+            timestamp=(day_ago + timedelta(hours=0, minutes=25)).timestamp(),
+            value=1,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+
+        for hour, count in enumerate(event_counts):
+            for minute in range(count):
+                self.store_metric(
+                    org_id=self.organization.id,
+                    project_id=self.project.id,
+                    type="distribution",
+                    name=TransactionMRI.DURATION.value,
+                    tags={},
+                    timestamp=(day_ago + timedelta(hours=hour, minutes=minute + 30)).timestamp(),
+                    value=1,
+                    use_case_id=UseCaseKey.PERFORMANCE,
+                )
+
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="rate",
+                    metric_name=TransactionMetricKey.DURATION.value,
+                    params={"numerator": 3600, "denominator": 60},
+                ),
+                MetricField(
+                    op="count",
+                    metric_name=TransactionMetricKey.DURATION.value,
+                ),
+            ],
+            start=day_ago + timedelta(minutes=30),
+            end=day_ago + timedelta(hours=6, minutes=30),
+            granularity=Granularity(granularity=1800),
+            limit=Limit(limit=5),
+            offset=Offset(offset=0),
+            include_series=True,
+        )
+
+        start, end, rollup = get_date_range(
+            {
+                "start": iso_format(day_ago + timedelta(minutes=30)),
+                "end": iso_format(day_ago + timedelta(hours=6, minutes=30)),
+            }
+        )
+
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=True,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+        assert data
+
+    def test_throughput_eps_minute_rollup(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for minute, count in enumerate(event_counts):
+            for _ in range(count):
+                self.store_metric(
+                    org_id=self.organization.id,
+                    project_id=self.project.id,
+                    type="distribution",
+                    name=TransactionMRI.DURATION.value,
+                    tags={},
+                    timestamp=(self.now - timedelta(minutes=minute)).timestamp(),
+                    value=1,
+                    use_case_id=UseCaseKey.PERFORMANCE,
+                )
+
+        start, end, rollup = get_date_range(
+            {
+                "statsPeriod": "6m",
+                "interval": "1m",
+            }
+        )
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="rate",
+                    metric_name=TransactionMetricKey.DURATION.value,
+                    params={"numerator": 60},
+                ),
+                MetricField(
+                    op="count",
+                    metric_name=TransactionMetricKey.DURATION.value,
+                ),
+            ],
+            start=start,
+            end=end,
+            granularity=Granularity(granularity=rollup),
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            include_series=True,
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=True,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+        # The order they will be in is the reverse of the order they were inserted so -> [3, 0, 3, 6, 0, 6] and hence
+        # the expected rates would be each of those event counts divided by 86400 / 60
+        assert data["groups"] == [
+            {
+                "by": {},
+                "series": {
+                    "rate(transaction.duration)": [3 / 60, 0, 3 / 60, 6 / 60, 0, 6 / 60],
+                    "count(transaction.duration)": [3, 0, 3, 6, 0, 6],
+                },
+                "totals": {
+                    "rate(transaction.duration)": 18 / 60,
+                    "count(transaction.duration)": 18,
+                },
+            }
+        ]
+
+    def test_rate_with_missing_numerator_value(self):
+        event_counts = [6, 0, 6, 3, 0, 3]
+        for minute, count in enumerate(event_counts):
+            for _ in range(count):
+                self.store_metric(
+                    org_id=self.organization.id,
+                    project_id=self.project.id,
+                    type="distribution",
+                    name=TransactionMRI.DURATION.value,
+                    tags={},
+                    timestamp=(self.now - timedelta(minutes=minute)).timestamp(),
+                    value=1,
+                    use_case_id=UseCaseKey.PERFORMANCE,
+                )
+        start, end, rollup = get_date_range(
+            {
+                "statsPeriod": "6m",
+                "interval": "1m",
+            }
+        )
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="rate",
+                    metric_name=TransactionMetricKey.DURATION.value,
+                ),
+            ],
+            start=start,
+            end=end,
+            granularity=Granularity(granularity=rollup),
+            limit=Limit(limit=51),
+            offset=Offset(offset=0),
+            include_series=True,
+        )
+        with pytest.raises(
+            InvalidParams,
+            match=re.escape("rate() missing 1 required positional argument: 'numerator'"),
+        ):
+            get_series(
+                [self.project],
+                metrics_query=metrics_query,
+                include_meta=True,
+                use_case_id=UseCaseKey.PERFORMANCE,
+            )
 
 
 class GetCustomMeasurementsTestCase(MetricsEnhancedPerformanceTestCase):

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -762,7 +762,9 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
         )
         with pytest.raises(
             InvalidParams,
-            match=re.escape("rate() missing 1 required positional argument: 'numerator'"),
+            match=re.escape(
+                "rate_snql_factory() missing 1 required positional argument: 'numerator'"
+            ),
         ):
             get_series(
                 [self.project],

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -106,7 +106,7 @@ def test_validate_select():
         InvalidParams,
         match=(
             "Invalid operation 'foo'. Must be one of avg, count_unique, count, max, min, sum, "
-            "histogram, p50, p75, p90, p95, p99"
+            "histogram, rate, p50, p75, p90, p95, p99"
         ),
     ):
         MetricsQuery(
@@ -149,7 +149,7 @@ def test_validate_order_by():
         InvalidParams,
         match=(
             "Invalid operation 'foo'. Must be one of avg, count_unique, count, max, min, sum, "
-            "histogram, p50, p75, p90, p95, p99"
+            "histogram, rate, p50, p75, p90, p95, p99"
         ),
     ):
         MetricsQuery(
@@ -324,7 +324,7 @@ def test_validate_many_order_by_fields_are_in_select():
     # This example should pass because both session crash free rate
     # and sum(session) both go to the entity counters
     metric_field_1 = MetricField(op=None, metric_name=SessionMetricKey.CRASH_FREE_RATE.value)
-    metric_field_2 = MetricField(op="sum", metric_name=SessionMetricKey.DURATION.value)
+    metric_field_2 = MetricField(op="sum", metric_name="sentry.sessions.session")
     metrics_query_dict = (
         MetricsQueryBuilder()
         .with_select([metric_field_1, metric_field_2])

--- a/tests/sentry/snuba/metrics/test_snql.py
+++ b/tests/sentry/snuba/metrics/test_snql.py
@@ -19,7 +19,7 @@ from sentry.snuba.metrics.fields.snql import (
     errored_preaggr_sessions,
     failure_count_transaction,
     miserable_users,
-    rate,
+    rate_snql_factory,
     satisfaction_count_transaction,
     session_duration_filters,
     subtraction,
@@ -406,7 +406,7 @@ class DerivedMetricSnQLTestCase(TestCase):
         ]
 
     def test_rate_snql(self):
-        assert rate(
+        assert rate_snql_factory(
             aggregate_filter=Function(
                 "equals",
                 [Column("metric_id"), 5],
@@ -425,7 +425,7 @@ class DerivedMetricSnQLTestCase(TestCase):
             alias="rate_alias",
         )
 
-        assert rate(
+        assert rate_snql_factory(
             aggregate_filter=Function(
                 "equals",
                 [Column("metric_id"), 5],

--- a/tests/sentry/snuba/metrics/test_snql.py
+++ b/tests/sentry/snuba/metrics/test_snql.py
@@ -4,32 +4,33 @@ from snuba_sdk import Column, Function
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import resolve_tag_key, resolve_tag_value
-from sentry.snuba.metrics import (
-    TransactionStatusTagValue,
-    TransactionTagsKey,
+from sentry.snuba.metrics.fields.snql import (
     abnormal_sessions,
     abnormal_users,
     addition,
     all_sessions,
     all_transactions,
     all_users,
+    complement,
     crashed_sessions,
     crashed_users,
+    division_float,
     errored_all_users,
     errored_preaggr_sessions,
-    session_duration_filters,
-    subtraction,
-    uniq_aggregation_on_metric,
-)
-from sentry.snuba.metrics.fields.snql import (
-    complement,
-    division_float,
     failure_count_transaction,
     miserable_users,
+    rate,
     satisfaction_count_transaction,
+    session_duration_filters,
+    subtraction,
     tolerated_count_transaction,
+    uniq_aggregation_on_metric,
 )
-from sentry.snuba.metrics.naming_layer.public import TransactionSatisfactionTagValue
+from sentry.snuba.metrics.naming_layer.public import (
+    TransactionSatisfactionTagValue,
+    TransactionStatusTagValue,
+    TransactionTagsKey,
+)
 from sentry.testutils import TestCase
 
 pytestmark = pytest.mark.sentry_metrics
@@ -403,3 +404,41 @@ class DerivedMetricSnQLTestCase(TestCase):
                 ),
             )
         ]
+
+    def test_rate_snql(self):
+        assert rate(
+            aggregate_filter=Function(
+                "equals",
+                [Column("metric_id"), 5],
+            ),
+            numerator=3600,
+            denominator=60,
+            alias="rate_alias",
+        ) == Function(
+            "divide",
+            [
+                Function(
+                    "countIf", [Column("value"), Function("equals", [Column("metric_id"), 5])]
+                ),
+                Function("divide", [3600, 60]),
+            ],
+            alias="rate_alias",
+        )
+
+        assert rate(
+            aggregate_filter=Function(
+                "equals",
+                [Column("metric_id"), 5],
+            ),
+            numerator=3600,
+            alias="rate_alias",
+        ) == Function(
+            "divide",
+            [
+                Function(
+                    "countIf", [Column("value"), Function("equals", [Column("metric_id"), 5])]
+                ),
+                Function("divide", [3600, 1]),
+            ],
+            alias="rate_alias",
+        )


### PR DESCRIPTION
Adds support for operation `rate` to be able to compute performance related metrics such as tpm, tps, epm, eps

This PR achieves this by:
- Defining rate as a derived operation that produces its own SnQL rather than trying to compute the data sketch aggregate and using that directly 
- Replaces `filter_conditions_func` that used to just produce a snql condition to be used a conditional aggregate with `snql_func` that instead produces a SnQL function
- Replaces the logic in `get_entity` on MetricsExpression to determine the entity from the MRI rather than from the aggregate applied