### PR TITLE
fix(datascrubbing): Limit sensitiveFields [INC-202]

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -50,8 +50,8 @@ from sentry.utils import json
 
 #: Maximum total number of characters in sensitiveFields.
 #: Relay compiles this list into a regex which cannot exceed a certain size.
-#: https://github.com/getsentry/relay/blob/2b40f88560c34a10300659f3b9ac2b6a0762307c/relay-general/src/pii/convert.rs#L50-L66
-MAX_SENSITIVE_FIELD_CHARS = 10_000
+#: Limit determined experimentally here: https://github.com/getsentry/relay/blob/3105d8544daca3a102c74cefcd77db980306de71/relay-general/src/pii/convert.rs#L289
+MAX_SENSITIVE_FIELD_CHARS = 4000
 
 
 def clean_newline_inputs(value, case_insensitive=True):

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -48,7 +48,7 @@ from sentry.notifications.utils.legacy_mappings import get_option_value_from_boo
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 
-#: Maximum number of sensitive fields the user can configure.
+#: Maximum total number of characters in sensitiveFields.
 #: Relay compiles this list into a regex which cannot exceed a certain size.
 #: https://github.com/getsentry/relay/blob/2b40f88560c34a10300659f3b9ac2b6a0762307c/relay-general/src/pii/convert.rs#L50-L66
 MAX_SENSITIVE_FIELD_CHARS = 10_000

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -709,6 +709,11 @@ class ProjectUpdateTest(APITestCase):
         ]
         assert resp.data["sensitiveFields"] == ["foobar.com", "https://example.com"]
 
+    def test_sensitive_fields_too_long(self):
+        value = 100 * ["0123456789"] + ["1"]
+        resp = self.get_response(self.org_slug, self.proj_slug, sensitiveFields=value)
+        assert resp.status_code == 400
+
     def test_data_scrubber(self):
         resp = self.get_success_response(self.org_slug, self.proj_slug, dataScrubber=False)
         assert self.project.get_option("sentry:scrub_data") is False

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -710,7 +710,7 @@ class ProjectUpdateTest(APITestCase):
         assert resp.data["sensitiveFields"] == ["foobar.com", "https://example.com"]
 
     def test_sensitive_fields_too_long(self):
-        value = 100 * ["0123456789"] + ["1"]
+        value = 1000 * ["0123456789"] + ["1"]
         resp = self.get_response(self.org_slug, self.proj_slug, sensitiveFields=value)
         assert resp.status_code == 400
 


### PR DESCRIPTION
Incident INC-202 showed that allowing the user to configure arbitrary sensitive fields will exceed the maximum limit on the compiled regex in Relay. This PR limits `sensitiveFields` to 4000 characters.

See also https://github.com/getsentry/relay/pull/1474.