### PR TITLE
ref(perf-issue): Add metric for emitted performance problems

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -275,10 +275,17 @@ def _detect_performance_problems(data: Event, sdk_span: Any) -> List[Performance
 
     truncated_problems = detected_problems[:PERFORMANCE_GROUP_COUNT_LIMIT]
 
-    return [
+    performance_problems = [
         prepare_problem_for_grouping(problem, data, detector_type)
         for problem, detector_type in truncated_problems
     ]
+
+    if len(performance_problems) > 0:
+        metrics.incr(
+            "performance.performance_issue.performance_problem_emitted", len(performance_problems)
+        )
+
+    return performance_problems
 
 
 # Uses options and flags to determine which orgs and which detectors automatically create performance issues.


### PR DESCRIPTION
This allows us to broadly track how many performance problems are being created instead of just detected, which we should have for rollout to check we're not getting excess number of issues.


