### PR TITLE
fix(api): Fix N+1 organization queries in OrganizationTeams endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -80,9 +80,11 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
         if request.auth and hasattr(request.auth, "project"):
             return Response(status=403)
 
-        queryset = Team.objects.filter(
-            organization=organization, status=TeamStatus.VISIBLE
-        ).order_by("slug")
+        queryset = (
+            Team.objects.filter(organization=organization, status=TeamStatus.VISIBLE)
+            .order_by("slug")
+            .select_related("organization")  # Used in TeamSerializer
+        )
 
         query = request.GET.get("query")
 


### PR DESCRIPTION
Detected as a Performance Issue 🐶🥫

The organization is loaded once per team returned by the OrganizationTeams endpoint, and in the detected case, the calls totalled 368ms. (That is unusually slow for a simple lookup by ID, but even if the DB is uncharacteristically slow, we should still see net improvement by grouping into a single call. The issue has been detected more than once.)

Fixes SENTRY-VZG