### PR TITLE
fix(autocomplete): Only scroll highlighted index into view when using keyboard [UP-139]

### DIFF
--- a/static/app/components/autoComplete.spec.jsx
+++ b/static/app/components/autoComplete.spec.jsx
@@ -502,6 +502,20 @@ describe('AutoComplete', function () {
       expect(input).toHaveValue('Pineapple');
     });
 
+    it('only scrolls highlighted item into view on keyboard events', function () {
+      const scrollIntoViewMock = jest.fn();
+      Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+      createWrapper({isOpen: true});
+      expect(screen.getByTestId('test-autocomplete')).toBeInTheDocument();
+
+      fireEvent.mouseEnter(screen.getByText('Pineapple'));
+      expect(scrollIntoViewMock).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(input, {key: 'ArrowDown', charCode: 40});
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+    });
+
     it('can reset input value when menu closes', function () {
       const wrapper = createWrapper({isOpen: true});
       jest.useFakeTimers();

--- a/static/app/components/dropdownAutoComplete/row.tsx
+++ b/static/app/components/dropdownAutoComplete/row.tsx
@@ -28,10 +28,6 @@ type Props<T> = Pick<
     style?: React.CSSProperties;
   };
 
-function scrollIntoView(element: HTMLDivElement) {
-  element?.scrollIntoView?.({block: 'nearest'});
-}
-
 function Row<T extends Item>({
   item,
   style,
@@ -64,7 +60,6 @@ function Row<T extends Item>({
       disabled={item.disabled}
       isHighlighted={isHighlighted}
       style={style}
-      ref={isHighlighted ? scrollIntoView : undefined}
       {...itemProps}
     >
       {typeof item.label === 'function' ? item.label({inputValue}) : item.label}


### PR DESCRIPTION
AutoComplete was scrolling items into view when moused over, which was causing some erratic behavior:

https://user-images.githubusercontent.com/10888943/190218415-b258bfc8-dd4f-4499-89d6-c7065f0ed053.mp4

Items will now only be scrolled into view when using the keyboard to navigate up and down.

This uses the same approach that Downshift does - generating unique IDs and calling document.getElementById() to avoid having to maintain a bunch of refs: https://github.com/downshift-js/downshift/blob/a6bcd2247f4757b9a6c4077fdd9cf07554049054/src/downshift.js#L225