### PR TITLE
🚧 WIP - Create a workflow for testing Slack Installation on HC 

### DIFF
--- a/src/sentry/api/endpoints/integrations/doc_integrations/details.py
+++ b/src/sentry/api/endpoints/integrations/doc_integrations/details.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.base import pending_silo_endpoint
+from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.doc_integrations import DocIntegrationBaseEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import DocIntegrationSerializer
@@ -14,7 +14,7 @@ from sentry.models.integrations.integration_feature import IntegrationTypes
 logger = logging.getLogger(__name__)
 
 
-@pending_silo_endpoint
+@control_silo_endpoint
 class DocIntegrationDetailsEndpoint(DocIntegrationBaseEndpoint):
     def get(self, request: Request, doc_integration: DocIntegration) -> Response:
         return self.respond(serialize(doc_integration, request.user), status=status.HTTP_200_OK)

--- a/src/sentry/api/endpoints/integrations/doc_integrations/index.py
+++ b/src/sentry/api/endpoints/integrations/doc_integrations/index.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.base import pending_silo_endpoint
+from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.doc_integrations import DocIntegrationsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -15,7 +15,7 @@ from sentry.models import DocIntegration
 logger = logging.getLogger(__name__)
 
 
-@pending_silo_endpoint
+@control_silo_endpoint
 class DocIntegrationsEndpoint(DocIntegrationsBaseEndpoint):
     def get(self, request: Request):
         if is_active_superuser(request):

--- a/src/sentry/api/endpoints/integrations/sentry_apps/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/index.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
 
 from sentry import analytics, features
-from sentry.api.base import pending_silo_endpoint
+from sentry.api.base import control_silo_endpoint
 from sentry.api.bases import SentryAppsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -19,7 +19,7 @@ from sentry.utils import json
 logger = logging.getLogger(__name__)
 
 
-@pending_silo_endpoint
+@control_silo_endpoint
 class SentryAppsEndpoint(SentryAppsBaseEndpoint):
     def get(self, request: Request) -> Response:
         status = request.GET.get("status")

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/details.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/details.py
@@ -1,14 +1,14 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.base import pending_silo_endpoint
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import SentryAppInstallationBaseEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import SentryAppInstallationSerializer
 from sentry.mediators.sentry_app_installations import Destroyer, Updater
 
 
-@pending_silo_endpoint
+@region_silo_endpoint
 class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
     def get(self, request: Request, installation) -> Response:
 

--- a/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
+++ b/src/sentry/api/endpoints/integrations/sentry_apps/installation/index.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.base import pending_silo_endpoint
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import SentryAppInstallationsBaseEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -30,7 +30,7 @@ class SentryAppInstallationsSerializer(serializers.Serializer):
         return attrs
 
 
-@pending_silo_endpoint
+@region_silo_endpoint
 class SentryAppInstallationsEndpoint(SentryAppInstallationsBaseEndpoint):
     def get(self, request: Request, organization) -> Response:
         queryset = SentryAppInstallation.objects.filter(organization=organization)

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -128,7 +128,7 @@ class SlackIntegrationProvider(IntegrationProvider):  # type: ignore
         identity_pipeline_config = {
             "oauth_scopes": self.identity_oauth_scopes,
             "user_scopes": self.user_scopes,
-            "redirect_url": absolute_uri("/extensions/slack/setup/"),
+            "redirect_url": absolute_uri("/extensions/slack/setup/", True),
         }
 
         identity_pipeline_view = NestedPipelineView(
@@ -185,7 +185,6 @@ class SlackIntegrationProvider(IntegrationProvider):  # type: ignore
                 "data": {},
             },
         }
-
         return integration
 
     def post_install(

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -7,7 +7,8 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
 from sentry.api.authentication import ApiKeyAuthentication, TokenAuthentication
-from sentry.models import UserIP
+
+# from sentry.models import UserIP
 from sentry.utils.auth import AuthUserPasswordExpired, logger
 from sentry.utils.linksign import process_signature
 
@@ -35,7 +36,9 @@ def get_user(request):
                 )
                 user = AnonymousUser()
             else:
-                UserIP.log(user, request.META["REMOTE_ADDR"])
+                # HACK(Leander): Skipping this since it's throwing errors making requests to Control
+                # UserIP.log(user, request.META["REMOTE_ADDR"])
+                pass
         request._cached_user = user
     return request._cached_user
 

--- a/src/sentry/middleware/locale.py
+++ b/src/sentry/middleware/locale.py
@@ -37,6 +37,8 @@ class SentryLocaleMiddleware(LocaleMiddleware):
                 super().process_request(request)
 
     def load_user_conf(self, request: Request):
+        # HACK(Leander): Skipping this since it's throwing errors making requests to Control
+        return
         if not request.user.is_authenticated:
             return
 

--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -16,7 +16,6 @@ from sentry.db.models import (
     FlexibleForeignKey,
     Model,
     control_silo_model,
-    region_silo_model,
 )
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.types.integrations import ExternalProviders
@@ -174,7 +173,7 @@ class IdentityManager(BaseManager):
         return identity_model
 
 
-@region_silo_model
+@control_silo_model
 class Identity(Model):
     """
     A verified link between a user and a third party identity.

--- a/src/sentry/models/integrations/integration.py
+++ b/src/sentry/models/integrations/integration.py
@@ -4,7 +4,7 @@ from typing import Any, Sequence
 from django.db import IntegrityError, models
 
 from sentry.constants import ObjectStatus
-from sentry.db.models import BoundedPositiveIntegerField, DefaultFieldsModel, region_silo_model
+from sentry.db.models import BoundedPositiveIntegerField, DefaultFieldsModel, control_silo_model
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.db.models.manager import BaseManager
 from sentry.models.integrations.organization_integration import OrganizationIntegration
@@ -23,7 +23,7 @@ class IntegrationManager(BaseManager):
         )
 
 
-@region_silo_model
+@control_silo_model
 class Integration(DefaultFieldsModel):
     __include_in_export__ = False
 

--- a/src/sentry/models/integrations/organization_integration.py
+++ b/src/sentry/models/integrations/organization_integration.py
@@ -5,12 +5,12 @@ from sentry.db.models import (
     BoundedPositiveIntegerField,
     DefaultFieldsModel,
     FlexibleForeignKey,
-    region_silo_model,
+    control_silo_model,
 )
 from sentry.db.models.fields.jsonfield import JSONField
 
 
-@region_silo_model
+@control_silo_model
 class OrganizationIntegration(DefaultFieldsModel):
     __include_in_export__ = False
 

--- a/src/sentry/models/integrations/sentry_app.py
+++ b/src/sentry/models/integrations/sentry_app.py
@@ -20,7 +20,7 @@ from sentry.db.models import (
     FlexibleForeignKey,
     ParanoidManager,
     ParanoidModel,
-    region_silo_model,
+    control_silo_model,
 )
 from sentry.db.models.fields.jsonfield import JSONField
 from sentry.models.apiscopes import HasApiScopes
@@ -104,7 +104,7 @@ class SentryAppManager(ParanoidManager):
         return self.filter(status=SentryAppStatus.PUBLISHED)
 
 
-@region_silo_model
+@control_silo_model
 class SentryApp(ParanoidModel, HasApiScopes):
     __include_in_export__ = True
 

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -164,6 +164,12 @@ def main():
         "obj": {},
         "max_content_width": 100,
     }
+    if os.environ.get("SENTRY_SILO_MODE"):
+        logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
+        logger = logging.getLogger(__name__)
+        logger.info(
+            f"A silo mode was specified. Running Sentry as a {os.environ.get('SENTRY_SILO_MODE')} silo."
+        )
     # This variable is *only* set as part of direnv/.envrc, thus, we cannot affect production
     if os.environ.get("SENTRY_DEVSERVICES_DSN"):
         # We do this here because `configure_structlog` executes later

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -9,8 +9,16 @@ from sentry import options
 ParsedUriMatch = namedtuple("ParsedUriMatch", ["scheme", "domain", "path"])
 
 
-def absolute_uri(url: Optional[str] = None) -> str:
+def absolute_uri(url: Optional[str] = None, use_region: bool = False) -> str:
     prefix = options.get("system.url-prefix")
+    if use_region:
+        # HACK(Leander): Exact copy of generate_region_url()
+        region_url_template = options.get("system.region-api-url-template")
+        region = options.get("system.region") or None
+        if not region_url_template or not region:
+            prefix = options.get("system.url-prefix")
+        prefix = region_url_template.replace("{region}", region)
+
     if not url:
         return prefix
     return urljoin(prefix.rstrip("/") + "/", url.lstrip("/"))

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -339,6 +339,13 @@ export class Client {
    */
   request(path: string, options: Readonly<RequestOptions> = {}): Request {
     const method = options.method || (options.data ? 'POST' : 'GET');
+    const CONTROL = 'https://control-leeandher.ngrok.io';
+    const REGION = 'https://region-leeandher.ngrok.io';
+    const ORIGIN_MAP = {
+      '/doc-integrations/': CONTROL,
+      '/sentry-apps/': CONTROL,
+    };
+    const origin = ORIGIN_MAP[path] ?? REGION;
 
     let fullUrl = buildRequestUrl(this.baseUrl, path, options.query);
 
@@ -432,14 +439,14 @@ export class Client {
 
     // Do not set the X-CSRFToken header when making a request outside of the
     // current domain
-    const absoluteUrl = new URL(fullUrl, window.location.origin);
+    const absoluteUrl = new URL(fullUrl, origin);
     const isSameOrigin = window.location.origin === absoluteUrl.origin;
 
     if (!csrfSafeMethod(method) && isSameOrigin) {
       headers.set('X-CSRFToken', getCsrfToken());
     }
 
-    const fetchRequest = fetch(fullUrl, {
+    const fetchRequest = fetch(absoluteUrl, {
       method,
       body,
       headers,


### PR DESCRIPTION
This PR is a working branch while I test out changes and hacks that are required to get testing Slack installation working locally in a hybrid cloud environment.

As of the time of writing, my local environment involves spinning up two instances of Sentry:

```sh
SENTRY_SILO_MODE=CONTROL sentry devserver
SENTRY_DEVSERVER_BIND=localhost:8002 SENTRY_SILO_MODE=REGION sentry devserver
```

With separate ngrok addresses:

```ngrok.yml
version: "2"
authtoken: abc
tunnels:
    hc-control:
        proto: http
        hostname: control-leeandher.ngrok.io
        addr: 8000
    hc-region:
        proto: http
        hostname: region-leeandher.ngrok.io
        addr: 8002

```
and some configuration variables:

```config.yml
system.url-prefix: "https://control-leeandher.ngrok.io"
system.region: "region"
system.region-api-url-template: "https://{region}-leeandher.ngrok.io/"
```

To test, this PR assumes the user is already logged in, and is currently viewing Sentry on the region address.