### PR TITLE
rfc(features): Add options check

### DIFF
--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -20,8 +20,6 @@ class FeatureHandler:
     option_ttl = 60  # cache the options for 60s
 
     def __init__(self):
-        super().__init__()
-
         self.last_updated = None
         self.cached_rollouts = {}
 

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 __all__ = ["FeatureHandler", "BatchFeatureHandler"]
 
 import abc
+from time import time
 from typing import TYPE_CHECKING, Mapping, MutableSet, Optional, Sequence
+
+from sentry import options
 
 if TYPE_CHECKING:
     from sentry.features.base import Feature
@@ -13,6 +16,25 @@ if TYPE_CHECKING:
 
 class FeatureHandler:
     features: MutableSet[str] = set()
+    rollout_options: MutableSet[str] = set()
+    option_ttl = 60  # cache the options for 60s
+
+    def __init__(self):
+        super().__init__()
+
+        self.last_updated = None
+        self.cached_rollouts = {}
+
+    def update_cache_options(self):
+        now = time()
+        if (
+            self.last_updated is None
+            or now - self.option_ttl < self.last_updated  # refetch if the cache is old
+        ):
+
+            self.last_updated = now
+            for rolloutOption in self.rollout_options:
+                self.cached_rollouts[rolloutOption] = options.get(rolloutOption)
 
     def __call__(self, feature: Feature, actor: User) -> Optional[bool]:
         if feature.name not in self.features:
@@ -25,6 +47,7 @@ class FeatureHandler:
         raise NotImplementedError
 
     def has_for_batch(self, batch: FeatureCheckBatch) -> Mapping[Project, bool]:
+        self.update_cache_options()
         # If not overridden, iterate over objects in the batch individually.
         return {
             obj: self.has(feature, batch.actor)
@@ -55,8 +78,10 @@ class BatchFeatureHandler(FeatureHandler):
         raise NotImplementedError
 
     def has(self, feature: Feature, actor: User, skip_entity: Optional[bool] = False) -> bool:
+        self.update_cache_options()
         return self._check_for_batch(feature.name, feature.get_subject(), actor)
 
     def has_for_batch(self, batch: FeatureCheckBatch) -> Mapping[Project, bool]:
+        self.update_cache_options()
         flag = self._check_for_batch(batch.feature_name, batch.subject, batch.actor)
         return {obj: flag for obj in batch.objects}


### PR DESCRIPTION
This came up since there was a pretty good pattern for using non-flagr features + rollout system options if we want to gradually rollout instead of relying on a deploy, which can take a long time. From this we could simple access `self.cached_rollouts[your-option-here]` and use a mod on org_id or project_id for rollouts.

See code where we are already doing it [here]( https://github.com/getsentry/getsentry/blob/master/getsentry/features.py#L607-L646)
