### PR TITLE
feat(sidebar): open up broadcasts if #whats-new is the hash

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -92,9 +92,9 @@ function Sidebar({location, organization}: Props) {
   }, [bcl]);
 
   useEffect(() => {
-    Object.values(SidebarPanelKey).forEach(sidebarValue => {
-      if (location?.hash === `#sidebar-${sidebarValue}`) {
-        togglePanel(sidebarValue);
+    Object.values(SidebarPanelKey).forEach(key => {
+      if (location?.hash === `#sidebar-${key}`) {
+        togglePanel(key);
       }
     });
   }, [location?.hash]);

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -92,12 +92,7 @@ function Sidebar({location, organization}: Props) {
   }, [bcl]);
 
   useEffect(() => {
-    [
-      SidebarPanelKey.Broadcasts,
-      SidebarPanelKey.OnboardingWizard,
-      SidebarPanelKey.PerformanceOnboarding,
-      SidebarPanelKey.ServiceIncidents,
-    ].forEach(sidebarValue => {
+    Object.values(SidebarPanelKey).forEach(sidebarValue => {
       if (location?.hash === `#sidebar-${sidebarValue}`) {
         togglePanel(sidebarValue);
       }

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -91,6 +91,12 @@ function Sidebar({location, organization}: Props) {
     return () => bcl.remove('body-sidebar');
   }, [bcl]);
 
+  useEffect(() => {
+    if (location?.hash === '#whats-new') {
+      togglePanel(SidebarPanelKey.Broadcasts);
+    }
+  }, [location?.hash]);
+
   // Add sidebar collapse classname to body
   useEffect(() => {
     if (collapsed) {

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -92,9 +92,16 @@ function Sidebar({location, organization}: Props) {
   }, [bcl]);
 
   useEffect(() => {
-    if (location?.hash === '#whats-new') {
-      togglePanel(SidebarPanelKey.Broadcasts);
-    }
+    [
+      SidebarPanelKey.Broadcasts,
+      SidebarPanelKey.OnboardingWizard,
+      SidebarPanelKey.PerformanceOnboarding,
+      SidebarPanelKey.ServiceIncidents,
+    ].forEach(sidebarValue => {
+      if (location?.hash === `#sidebar-${sidebarValue}`) {
+        togglePanel(sidebarValue);
+      }
+    });
   }, [location?.hash]);
 
   // Add sidebar collapse classname to body


### PR DESCRIPTION
We want to be able to send links to Sentry with the "What's new" section opened. We can do this with a hash parameter `#sidebar-broadcasts`.