### PR TITLE
feat(perf_issues): Default `sentry:performance_issue_creation_rate` to 1.0, and gate perf issue creation using `performance-issues-ingest`

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2004,11 +2004,13 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
         event = job["event"]
         project = event.project
 
+        if not features.has("organizations:performance-issues-ingest", project.organization):
+            continue
         # General system-wide option
         rate = options.get("performance.issues.all.problem-creation") or 0
 
         # More granular, per-project option
-        per_project_rate = project.get_option("sentry:performance_issue_creation_rate", 0)
+        per_project_rate = project.get_option("sentry:performance_issue_creation_rate", 1.0)
         if rate > random.random() and per_project_rate > random.random():
 
             kwargs = _create_kwargs(job)


### PR DESCRIPTION
We want to enable performance issues for EA. This means that we should default the project level setting to 1.0. Then we just gate creation behind `organizations:performance-issues-ingest`, which makes sure this will be enabled only for EA customers as we roll it out to them.

I think that at this point we could also remove the `performance.issues.all.problem-creation` option and just rely on this feature flag. It might also make sense to only check the `organizations:performance-issues-ingest` flag as part of ingest and move it out of the detection code.