### PR TITLE
feat(metrics): Add `count_web_vitals` to metrics layer [TET-161]

### DIFF
--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -340,3 +340,30 @@ def rate_snql_factory(aggregate_filter, numerator, denominator=1.0, alias=None):
         ],
         alias=alias,
     )
+
+
+def count_web_vitals_snql_factory(aggregate_filter, org_id, measurement_rating, alias=None):
+    return Function(
+        "countIf",
+        [
+            Column("value"),
+            Function(
+                "and",
+                [
+                    aggregate_filter,
+                    Function(
+                        "equals",
+                        (
+                            Column(
+                                resolve_tag_key(
+                                    UseCaseKey.PERFORMANCE, org_id, "measurement_rating"
+                                )
+                            ),
+                            resolve_tag_value(UseCaseKey.PERFORMANCE, org_id, measurement_rating),
+                        ),
+                    ),
+                ],
+            ),
+        ],
+        alias=alias,
+    )

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -203,18 +203,23 @@ OPERATIONS_PERCENTILES = (
     "p95",
     "p99",
 )
-
-# ToDo Dynamically generate this from OP_TO_SNUBA_FUNCTION
-OPERATIONS = (
-    "avg",
-    "count_unique",
-    "count",
-    "max",
-    "min",
-    "sum",
+DERIVED_OPERATIONS = (
     "histogram",
     "rate",
-) + OPERATIONS_PERCENTILES
+    "count_web_vitals",
+)
+OPERATIONS = (
+    (
+        "avg",
+        "count_unique",
+        "count",
+        "max",
+        "min",
+        "sum",
+    )
+    + OPERATIONS_PERCENTILES
+    + DERIVED_OPERATIONS
+)
 
 DEFAULT_AGGREGATES: Dict[MetricOperationType, Optional[Union[int, List[Tuple[float]]]]] = {
     "avg": None,
@@ -231,6 +236,7 @@ DEFAULT_AGGREGATES: Dict[MetricOperationType, Optional[Union[int, List[Tuple[flo
     "percentage": None,
     "histogram": [],
     "rate": 0,
+    "count_web_vitals": 0,
 }
 UNIT_TO_TYPE = {"sessions": "count", "percentage": "percentage", "users": "count"}
 UNALLOWED_TAGS = {"session.status"}

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -8,6 +8,7 @@ from snuba_sdk.conditions import ConditionGroup
 
 from sentry.api.utils import InvalidParams
 from sentry.snuba.metrics import (
+    OPERATIONS,
     DerivedMetricParseException,
     Groupable,
     MetricField,
@@ -104,10 +105,7 @@ def test_validate_select():
 
     with pytest.raises(
         InvalidParams,
-        match=(
-            "Invalid operation 'foo'. Must be one of avg, count_unique, count, max, min, sum, "
-            "histogram, rate, p50, p75, p90, p95, p99"
-        ),
+        match=(f"Invalid operation 'foo'. Must be one of {', '.join(OPERATIONS)}"),
     ):
         MetricsQuery(
             **MetricsQueryBuilder()
@@ -147,10 +145,7 @@ def test_validate_select_invalid_use_case_ids():
 def test_validate_order_by():
     with pytest.raises(
         InvalidParams,
-        match=(
-            "Invalid operation 'foo'. Must be one of avg, count_unique, count, max, min, sum, "
-            "histogram, rate, p50, p75, p90, p95, p99"
-        ),
+        match=(f"Invalid operation 'foo'. Must be one of {', '.join(OPERATIONS)}"),
     ):
         MetricsQuery(
             **MetricsQueryBuilder()


### PR DESCRIPTION
Adds `count_web_vitals` as a derived operation to
the metrics layer so that we are able to query
that with measurement_rating tag value

