### PR TITLE
feat(perf-issues): Add analytics event to count num of perf issues on issues stream page

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -39,6 +39,11 @@ export type IssueEventParameters = {
     search_source: string;
     search_type: string;
   };
+  'issues_stream.count_perf_issues': {
+    num_perf_issues: number;
+    page: number;
+    query: string;
+  };
   'issues_stream.issue_assigned': IssueStream & {
     assigned_type: string;
     did_assign_suggestion: boolean;
@@ -96,4 +101,6 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
     'Performance Issue Details: Autogrouped Siblings Toggled',
   'issue_details.performance.hidden_spans_expanded':
     'Performance Issue Details: Hidden Spans Expanded',
+  'issues_stream.count_perf_issues':
+    'Issues Stream: Number of Performance Issues on Current Page',
 };

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -37,6 +37,7 @@ import {PageContent} from 'sentry/styles/organization';
 import {
   BaseGroup,
   Group,
+  IssueCategory,
   Member,
   Organization,
   PageFilters,
@@ -613,6 +614,19 @@ class IssueListOverview extends Component<Props, State> {
             GroupStore.remove(this.state.reviewedIds);
           }
         }
+
+        const numPerfIssues = data.filter(
+          (group: BaseGroup) => group.issueCategory === IssueCategory.PERFORMANCE
+        ).length;
+
+        const page = parseInt(this.props.location.query.page, 10);
+
+        trackAdvancedAnalyticsEvent('issues_stream.count_perf_issues', {
+          organization,
+          page,
+          query,
+          num_perf_issues: numPerfIssues,
+        });
 
         this.fetchStats(data.map((group: BaseGroup) => group.id));
 


### PR DESCRIPTION
Adds an analytics event to track the number of Performance Issues present on the current page in issues stream. Adds some other fields for further context, like page number and query (since the query will affect the num of issues present on the page)

Also, I opted to make this a separate event from `issues_tab.viewed`, since that had some conditions gating the event from firing. This event will always fire when a page on the issues stream is loaded, regardless of the query.