### PR TITLE
ref(MDC): Update Snuba eventstream and insert endpoints

### DIFF
--- a/bin/mock-replay
+++ b/bin/mock-replay
@@ -16,7 +16,9 @@ from sentry.replays.testutils import mock_replay
 
 
 def store_replay(replay):
-    response = requests.post(settings.SENTRY_SNUBA + "/tests/replays/insert", json=[replay])
+    response = requests.post(
+        settings.SENTRY_SNUBA + "/tests/entities/replays/insert", json=[replay]
+    )
     assert response.status_code == 200
 
 

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -392,13 +392,13 @@ class SnubaEventStream(SnubaProtocolEventStream):
 
         data = (self.EVENT_PROTOCOL_VERSION, _type) + extra_data
 
-        dataset = "events"
+        entity = "events"
         if is_transaction_event:
-            dataset = "transactions"
+            entity = "transactions"
         try:
             resp = snuba._snuba_pool.urlopen(
                 "POST",
-                f"/tests/{dataset}/eventstream",
+                f"/tests/{entity}/eventstream",
                 body=json.dumps(data),
                 headers={f"X-Sentry-{k}": v for k, v in headers.items()},
             )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -949,7 +949,7 @@ class SnubaTestCase(BaseTestCase):
     def bulk_store_sessions(self, sessions):
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/sessions/insert", data=json.dumps(sessions)
+                settings.SENTRY_SNUBA + "/tests/entities/sessions/insert", data=json.dumps(sessions)
             ).status_code
             == 200
         )
@@ -988,7 +988,8 @@ class SnubaTestCase(BaseTestCase):
         data = [self.__wrap_group(group)]
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/groupedmessage/insert", data=json.dumps(data)
+                settings.SENTRY_SNUBA + "/tests/entities/groupedmessage/insert",
+                data=json.dumps(data),
             ).status_code
             == 200
         )
@@ -997,7 +998,7 @@ class SnubaTestCase(BaseTestCase):
         data = [self.__wrap_group(group)]
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/outcomes/insert", data=json.dumps(data)
+                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert", data=json.dumps(data)
             ).status_code
             == 200
         )
@@ -1065,7 +1066,7 @@ class SnubaTestCase(BaseTestCase):
 
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/events/insert", data=json.dumps(events)
+                settings.SENTRY_SNUBA + "/tests/entities/events/insert", data=json.dumps(events)
             ).status_code
             == 200
         )
@@ -1337,7 +1338,7 @@ class OutcomesSnubaTest(TestCase):
 
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/outcomes/insert", data=json.dumps(outcomes)
+                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert", data=json.dumps(outcomes)
             ).status_code
             == 200
         )
@@ -1351,7 +1352,9 @@ class ReplaysSnubaTestCase(TestCase):
         assert requests.post(settings.SENTRY_SNUBA + "/tests/replays/drop").status_code == 200
 
     def store_replays(self, replay):
-        response = requests.post(settings.SENTRY_SNUBA + "/tests/replays/insert", json=[replay])
+        response = requests.post(
+            settings.SENTRY_SNUBA + "/tests/entities/replays/insert", json=[replay]
+        )
         assert response.status_code == 200
 
 

--- a/tests/acceptance/test_project_settings_sampling.py
+++ b/tests/acceptance/test_project_settings_sampling.py
@@ -93,7 +93,7 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
 
         assert (
             requests.post(
-                settings.SENTRY_SNUBA + "/tests/outcomes/insert", data=json.dumps(outcomes)
+                settings.SENTRY_SNUBA + "/tests/entities/outcomes/insert", data=json.dumps(outcomes)
             ).status_code
             == 200
         )


### PR DESCRIPTION
This PR is responsible for updating the Snuba eventstream and insert test endpoints 
* From: `POST /tests/{dataset}/eventstream` To: `POST /tests/{entity}/eventstream`
* From: `POST /tests/{dataset}/insert` To: `POST /tests/entities/{entity}/insert`

This change is required due to the removal of the `default_entity` attribute in the Dataset class in Snuba. As a result, every request sent to Snuba (e.g. query, eventstream, etc.) must specify both a dataset and entity. 
The changes to the server endpoint is specified here: https://github.com/getsentry/snuba/pull/3142