### PR TITLE
ci(backend): Exclude the backend label from test changes

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -46,7 +46,7 @@ backend_build_changes: &backend_build_changes
   - 'Makefile'
   - 'pyproject.toml'
 
-backend: &backend
+backend_no_tests: &backend_no_tests
   - *backend_build_changes
   - *backend_dependencies
   - '!(tests)/**/*.py'
@@ -56,6 +56,10 @@ backend: &backend
   - 'migrations_lockfile.txt'
   - 'config/**/*'
   - 'fixtures/search-syntax/**/*'
+
+backend: &backend
+  - *backend_no_tests
+  - '**/*.py'
 
 # This is the ultimate controller for acceptance.yml
 acceptance: &acceptance

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -37,10 +37,6 @@ frontend_components_modified_lintable:
 backend_dependencies: &backend_dependencies
   - 'requirements-*.txt'
 
-backend_lintable: &backend_lintable
-  - '**/*.py'
-  - *backend_dependencies
-
 backend_build_changes: &backend_build_changes
   # If you change this line make sure that workflows using this action (e.g. acceptance, api_docs)
   # *and* file-filters would be updated as well
@@ -52,7 +48,8 @@ backend_build_changes: &backend_build_changes
 
 backend: &backend
   - *backend_build_changes
-  - *backend_lintable
+  - *backend_dependencies
+  - '!(tests)/**/*.py'
   - '**/*.sh'
   - '**/*.pysnap'
   - 'src/sentry/!(static)/**'
@@ -92,6 +89,7 @@ migrations_modified:
 # These files will trigger our wokrflow to check if lockfile
 # updates are needed
 migration_lockfile:
-  - *backend_lintable
+  - *backend_dependencies
+  - '**/*.py'
   - .github/workflows/check-if-migration-is-required.yml
   - .github/workflows/scripts/migration-check.sh

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -34,7 +34,6 @@ frontend_src: &frontend_src
 frontend_all: &frontend_all
   - *frontend_src
   - '**/*.[tj]{s,sx}'
-  - 'tests/js/**'
 
 frontend_modified_lintable:
   - added|modified: *frontend_lintable

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -3,7 +3,7 @@
 # TODO: There are some meta files that we potentially could ignore for both front/backend,
 # as well as some configuration files that should trigger both
 frontend_components_lintable: &frontend_components_lintable
-  - '!(tests)/**/*.[tj]{s,sx}'
+  - '**/*.[tj]{s,sx}'
 
 frontend_lintable: &frontend_lintable
   - *frontend_components_lintable
@@ -18,8 +18,8 @@ eslint_config: &eslint_config
 
 frontend_src: &frontend_src
   - *yarn_lockfile
-  - *frontend_lintable
   - *eslint_config
+  - '!(test)/**/*.[tj]{s,sx}'
   - '**/*.less'
   - 'docs-ui/**'
   - 'static/**'
@@ -28,6 +28,7 @@ frontend_src: &frontend_src
 
 frontend_all: &frontend_all
   - *frontend_src
+  - '**/*.[tj]{s,sx}'
   - 'tests/js/**'
 
 frontend_modified_lintable:

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -22,7 +22,7 @@ eslint_config: &eslint_config
 frontend_src: &frontend_src
   - *yarn_lockfile
   - *eslint_config
-  - '!(test)/**/*.[tj]{s,sx}'
+  - '!(tests)/**/*.[tj]{s,sx}'
   - '**/tsconfig*.json'
   - '{package,now,vercel}.json'
   - '**/*.less'

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -16,10 +16,15 @@ yarn_lockfile: &yarn_lockfile
 eslint_config: &eslint_config
   - '.eslint*'
 
+# `frontend_src` filters on files that are frontend changes excluding
+# changes to the tests/ directory.
+# If you want to filter on *all* frontend files, use the `frontend_all` filter.
 frontend_src: &frontend_src
   - *yarn_lockfile
   - *eslint_config
   - '!(test)/**/*.[tj]{s,sx}'
+  - '**/tsconfig*.json'
+  - '{package,now,vercel}.json'
   - '**/*.less'
   - 'docs-ui/**'
   - 'static/**'

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -70,7 +70,7 @@ backend_all: &backend_all
 # This is the ultimate controller for acceptance.yml
 acceptance: &acceptance
   - *backend_all
-  - *frontend
+  - *frontend_all
   # This is verbose because backend_build_changes includes it, however,
   - '.github/actions/setup-sentry/action.yml'
   - '.github/workflows/acceptance.yml'

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -46,10 +46,10 @@ backend_build_changes: &backend_build_changes
   - 'Makefile'
   - 'pyproject.toml'
 
-# `backend_no_tests` filters on files that are backend changes excluding
+# `backend_src` filters on files that are backend changes excluding
 # changes to the tests/ directory.
-# If you want to filter on *all* backend files, use the `backend` filter.
-backend_no_tests: &backend_no_tests
+# If you want to filter on *all* backend files, use the `backend_all` filter.
+backend_src: &backend_src
   - *backend_build_changes
   - *backend_dependencies
   - '!(tests)/**/*.py'
@@ -60,30 +60,30 @@ backend_no_tests: &backend_no_tests
   - 'config/**/*'
   - 'fixtures/search-syntax/**/*'
 
-backend: &backend
-  - *backend_no_tests
+backend_all: &backend_all
+  - *backend_src
   - '**/*.py'
 
 # This is the ultimate controller for acceptance.yml
 acceptance: &acceptance
-  - *backend
+  - *backend_src
   - *frontend
   # This is verbose because backend_build_changes includes it, however,
   - '.github/actions/setup-sentry/action.yml'
   - '.github/workflows/acceptance.yml'
 
 plugins: &plugins
-  - *backend
+  - *backend_src
   - 'src/sentry_plugins/**/*.html'
 
 api_docs: &api_docs
-  - *backend
+  - *backend_src
   - 'api-docs/**'
   - 'tests/apidocs/**'
 
 # This is the ultimate controller for backend.yml
 backend_any_type: &backend_any_type
-  - *backend
+  - *backend_src
   - *api_docs
   - *plugins
 

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -46,6 +46,9 @@ backend_build_changes: &backend_build_changes
   - 'Makefile'
   - 'pyproject.toml'
 
+# `backend_no_tests` filters on files that are backend changes excluding
+# changes to the tests/ directory.
+# If you want to filter on *all* backend files, use the `backend` filter.
 backend_no_tests: &backend_no_tests
   - *backend_build_changes
   - *backend_dependencies

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -3,7 +3,7 @@
 # TODO: There are some meta files that we potentially could ignore for both front/backend,
 # as well as some configuration files that should trigger both
 frontend_components_lintable: &frontend_components_lintable
-  - '**/*.[tj]{s,sx}'
+  - '!(tests)/**/*.[tj]{s,sx}'
 
 frontend_lintable: &frontend_lintable
   - *frontend_components_lintable
@@ -16,16 +16,19 @@ yarn_lockfile: &yarn_lockfile
 eslint_config: &eslint_config
   - '.eslint*'
 
-frontend: &frontend
+frontend_src: &frontend_src
   - *yarn_lockfile
   - *frontend_lintable
   - *eslint_config
   - '**/*.less'
   - 'docs-ui/**'
   - 'static/**'
-  - 'tests/js/**'
   - 'fixtures/search-syntax/**/*'
   - '.github/workflows/frontend.yml'
+
+frontend_all: &frontend_all
+  - *frontend_src
+  - 'tests/js/**'
 
 frontend_modified_lintable:
   - added|modified: *frontend_lintable
@@ -66,24 +69,24 @@ backend_all: &backend_all
 
 # This is the ultimate controller for acceptance.yml
 acceptance: &acceptance
-  - *backend_src
+  - *backend_all
   - *frontend
   # This is verbose because backend_build_changes includes it, however,
   - '.github/actions/setup-sentry/action.yml'
   - '.github/workflows/acceptance.yml'
 
 plugins: &plugins
-  - *backend_src
+  - *backend_all
   - 'src/sentry_plugins/**/*.html'
 
 api_docs: &api_docs
-  - *backend_src
+  - *backend_all
   - 'api-docs/**'
   - 'tests/apidocs/**'
 
 # This is the ultimate controller for backend.yml
 backend_any_type: &backend_any_type
-  - *backend_src
+  - *backend_all
   - *api_docs
   - *plugins
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -31,7 +31,7 @@ jobs:
     # Map a step output to a job output
     outputs:
       acceptance: ${{ steps.changes.outputs.acceptance }}
-      backend: ${{ steps.changes.outputs.backend }}
+      backend: ${{ steps.changes.outputs.backend_all }}
     steps:
       - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
 
@@ -186,7 +186,7 @@ jobs:
 
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: needs.files-changed.outputs.backend == 'true'
+        if: needs.files-changed.outputs.backend_all == 'true'
 
   chartcuterie:
     if: needs.files-changed.outputs.acceptance == 'true'
@@ -249,7 +249,7 @@ jobs:
 
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
-        if: needs.files-changed.outputs.backend == 'true'
+        if: needs.files-changed.outputs.backend_all == 'true'
 
   visual-diff:
     if: always()

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,7 +24,7 @@ jobs:
     # Map a step output to a job output
     outputs:
       api_docs: ${{ steps.changes.outputs.api_docs }}
-      backend: ${{ steps.changes.outputs.backend }}
+      backend: ${{ steps.changes.outputs.backend_all }}
       backend_dependencies: ${{ steps.changes.outputs.backend_dependencies }}
       backend_any_type: ${{ steps.changes.outputs.backend_any_type }}
       migration_lockfile: ${{ steps.changes.outputs.migration_lockfile }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -24,7 +24,7 @@ jobs:
     # Map a step output to a job output
     outputs:
       eslint_config: ${{ steps.changes.outputs.eslint_config }}
-      frontend: ${{ steps.changes.outputs.frontend }}
+      frontend: ${{ steps.changes.outputs.frontend_all }}
       frontend_components_modified_lintable: ${{ steps.changes.outputs.frontend_components_modified_lintable }}
       frontend_components_modified_lintable_files: ${{ steps.changes.outputs.frontend_components_modified_lintable_files }}
       frontend_modified_lintable_files: ${{ steps.changes.outputs.frontend_modified_lintable_files }}

--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Add frontend label
         uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: steps.changes.outputs.frontend == 'true'
+        if: steps.changes.outputs.frontend_src == 'true'
         with:
           labels: 'Scope: Frontend'
 
@@ -46,7 +46,7 @@ jobs:
       - name: Add frontend/backend warning comment
         uses: peter-evans/create-or-update-comment@b95e16d2859ad843a14218d1028da5b2c4cbc4b4
         if: >
-          steps.changes.outputs.frontend == 'true' &&
+          steps.changes.outputs.frontend_src == 'true' &&
           steps.changes.outputs.backend_src == 'true' &&
           steps.fc.outputs.comment-id == 0
         with:

--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Add backend label
         uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: steps.changes.outputs.backend_no_tests == 'true'
+        if: steps.changes.outputs.backend_src == 'true'
         with:
           labels: 'Scope: Backend'
 
@@ -47,7 +47,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@b95e16d2859ad843a14218d1028da5b2c4cbc4b4
         if: >
           steps.changes.outputs.frontend == 'true' &&
-          steps.changes.outputs.backend_no_tests == 'true' &&
+          steps.changes.outputs.backend_src == 'true' &&
           steps.fc.outputs.comment-id == 0
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Add backend label
         uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf
-        if: steps.changes.outputs.backend == 'true'
+        if: steps.changes.outputs.backend_no_tests == 'true'
         with:
           labels: 'Scope: Backend'
 
@@ -47,7 +47,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@b95e16d2859ad843a14218d1028da5b2c4cbc4b4
         if: >
           steps.changes.outputs.frontend == 'true' &&
-          steps.changes.outputs.backend == 'true' &&
+          steps.changes.outputs.backend_no_tests == 'true' &&
           steps.fc.outputs.comment-id == 0
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/scripts/deploy.js
+++ b/.github/workflows/scripts/deploy.js
@@ -13,7 +13,7 @@ module.exports = {
    */
   updateChangeType: async ({github, context, fileChanges}) => {
     // Note that `fileChanges` bools and ints will get cast to strings
-    const {frontend, backend} = fileChanges;
+    const {frontend_all: frontend, backend_all: backend} = fileChanges;
     const frontendOnly = frontend === 'true' && backend === 'false';
     const backendOnly = backend === 'true' && frontend === 'false';
 

--- a/.github/workflows/scripts/getsentry-dispatch.js
+++ b/.github/workflows/scripts/getsentry-dispatch.js
@@ -22,7 +22,7 @@ const DISPATCHES = [
 module.exports = {
   dispatch: async ({github, context, fileChanges}) => {
     const shouldSkip = {
-      frontend: fileChanges.frontend !== 'true',
+      frontend: fileChanges.frontend_all !== 'true',
       backend_dependencies: fileChanges.backend_dependencies !== 'true',
     };
 


### PR DESCRIPTION
Tested on a fork to ensure changes to the `tests/**/*.py` files didn't add the label.

Because the filter is used by acceptance and backend workflows I've kept the backend filter the same.
