### PR TITLE
feat(dev): Split and create tsconfig for test suite

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -113,7 +113,7 @@ jobs:
         if: steps.dependencies.outcome == 'success'
         run: |
           set -o pipefail
-          yarn tsc -p config/tsconfig.build.json --diagnostics --generateTrace /tmp/trace | tee /tmp/typescript-monitor.log
+          yarn tsc -p config/tsconfig.ci.json --diagnostics --generateTrace /tmp/trace | tee /tmp/typescript-monitor.log
 
       - name: monitor-tsc
         continue-on-error: true

--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -1,0 +1,59 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
+    "alwaysStrict": false,
+    "declaration": false,
+    "declarationMap": false,
+    "downlevelIteration": true,
+    "inlineSources": false,
+    "importHelpers": true,
+    "lib": ["esnext", "dom"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noEmitHelpers": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": false,
+    "noImplicitReturns": true,
+    "noImplicitUseStrict": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "pretty": false,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "es6",
+    "strictBindCallApply": false,
+    "experimentalDecorators": true,
+    "useUnknownInCatchVariables": false,
+    // Skip type checking of all declaration files
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "baseUrl": "../",
+    "outDir": "../src/sentry/static/sentry/dist",
+    "paths": {
+      "sentry/*": ["static/app/*"],
+      "sentry-test/*": ["tests/js/sentry-test/*"],
+      "sentry-images/*": ["static/images/*"],
+      "sentry-locale/*": ["src/sentry/locale/*"],
+      "sentry-logos/*": ["src/sentry/static/sentry/images/logos/*"],
+      "sentry-fonts/*": ["static/fonts/*"],
+      "docs-ui/*": ["docs-ui/*"],
+      // Use the stub file for typechecking. Webpack resolver will use the real files
+      // based on configuration.
+      "integration-docs-platforms": [
+        "fixtures/integration-docs/_platforms.json",
+        "src/sentry/integration-docs/_platforms.json"
+      ]
+    },
+    "plugins": [{"name": "typescript-styled-plugin"}]
+  },
+  "include": ["../static/app", "../tests/js", "../fixtures/js-stubs"],
+  "exclude": ["../node_modules", "../**/*.benchmark.ts"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/config/tsconfig.benchmark.json
+++ b/config/tsconfig.benchmark.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.build.json",
+  "extends": "./tsconfig.ci.json",
   "ts-node": {
     "transpileOnly": true,
     "compilerOptions": {

--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -1,59 +1,7 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": false,
-    "checkJs": false,
-    "alwaysStrict": false,
-    "declaration": false,
-    "declarationMap": false,
-    "downlevelIteration": true,
-    "inlineSources": false,
-    "importHelpers": true,
-    "lib": ["esnext", "dom"],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noEmit": true,
-    "noEmitHelpers": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": false,
-    "noImplicitReturns": true,
-    "noImplicitUseStrict": true,
-    "noImplicitThis": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "pretty": false,
-    "resolveJsonModule": true,
-    "sourceMap": true,
-    "strict": true,
-    "target": "es6",
-    "strictBindCallApply": false,
-    "experimentalDecorators": true,
-    "useUnknownInCatchVariables": false,
-    // Skip type checking of all declaration files
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "jsx": "preserve",
-    "baseUrl": "../",
-    "outDir": "../src/sentry/static/sentry/dist",
-    "paths": {
-      "sentry/*": ["static/app/*"],
-      "sentry-test/*": ["tests/js/sentry-test/*"],
-      "sentry-images/*": ["static/images/*"],
-      "sentry-locale/*": ["src/sentry/locale/*"],
-      "sentry-logos/*": ["src/sentry/static/sentry/images/logos/*"],
-      "sentry-fonts/*": ["static/fonts/*"],
-      "docs-ui/*": ["docs-ui/*"],
-      // Use the stub file for typechecking. Webpack resolver will use the real files
-      // based on configuration.
-      "integration-docs-platforms": [
-        "fixtures/integration-docs/_platforms.json",
-        "src/sentry/integration-docs/_platforms.json"
-      ]
-    },
-    "plugins": [{"name": "typescript-styled-plugin"}]
+    "allowJs": true
   },
-  "include": ["../static", "../tests/js", "../fixtures/js-stubs"],
-  "exclude": ["../node_modules", "../**/*.benchmark.ts"],
-  "ts-node": {
-    "transpileOnly": true
-  }
+  "exclude": ["tests/js", "fixtures/js-stubs", "../static/app/**/*.spec.*", "../static/app/**/*.benchmark.ts"]
 }

--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -3,5 +3,10 @@
   "compilerOptions": {
     "allowJs": true
   },
-  "exclude": ["tests/js", "fixtures/js-stubs", "../static/app/**/*.spec.*", "../static/app/**/*.benchmark.ts"]
+  "exclude": [
+    "tests/js",
+    "fixtures/js-stubs",
+    "../static/app/**/*.spec.*",
+    "../static/app/**/*.benchmark.ts"
+  ]
 }

--- a/config/tsconfig.ci.json
+++ b/config/tsconfig.ci.json
@@ -1,9 +1,5 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {},
-  "include": [
-    "../static/app",
-    "../tests/js",
-    "../fixtures/js-stubs"
-  ]
+  "include": ["../static/app", "../tests/js", "../fixtures/js-stubs"]
 }

--- a/config/tsconfig.ci.json
+++ b/config/tsconfig.ci.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {},
+  "include": [
+    "../static/app",
+    "../tests/js",
+    "../fixtures/js-stubs"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,5 @@
   "compilerOptions": {
     "allowJs": true
   },
-  "include": [
-    "static/app",
-    "tests/js",
-    "fixtures/js-stubs",
-    "docs-ui",
-    "config"
-  ]
+  "include": ["static/app", "tests/js", "fixtures/js-stubs", "docs-ui", "config"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,13 @@
 {
-  "extends": "./config/tsconfig.build.json",
+  "extends": "./config/tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true
   },
-  "include": ["static", "tests/js", "docs-ui"],
-  "exclude": ["node_modules", "**/*.benchmark.ts"]
+  "include": [
+    "static/app",
+    "tests/js",
+    "fixtures/js-stubs",
+    "docs-ui",
+    "config"
+  ]
 }


### PR DESCRIPTION
Change `tsconfig.build.json` into a "base" + "test" and create a new "build" config that does not typecheck our test suite. `tsconfig.json` in root will extend `test` as that will be the config used by IDEs and should include tests + src

| filename | targets | used by |
| -------- | ------ | ---- |
| `config/tsconfig.base.json` | n/a | Base configuration that is extended. Should not be used directly |
| `config/tsconfig.build.json` | application only (no tests) | [static build](https://github.com/getsentry/sentry/blob/1557e3b21c789084485df94010f09503560bdc7c/src/sentry/utils/distutils/commands/build_assets.py#L132) for self-hosted |
| `config/tsconfig.ci.json` | application + tests | Used by CI as we would like to typecheck the application *and* tests |
| `tsconfig.json` | application + tests + configuration files | storybook (almost everything) | TS configuration that is used when no conf is specified by a tool (e.g. `tsc`), typechecks almost everything, used by IDEs/LSP for example. |

This aims to change the behavior of `build_assets` where it typechecks both the application source as well as tests. The problem is that our build image does not install `devDependencies`, so it would fail if we were to add some devDeps to test files that would be type checked.