### PR TITLE
feat(profiling): hide perf setup step if already setup

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
@@ -64,4 +64,34 @@ describe('ProfilingOnboarding', function () {
     });
     expect(screen.getByRole('button', {name: /Next/i})).toBeDisabled();
   });
+
+  it('shows performance setup when "firstTransactionEvent=false"', () => {
+    ProjectStore.loadInitialData([
+      TestStubs.Project({
+        name: 'iOS Project',
+        platform: 'apple-ios',
+        firstTransactionEvent: false,
+      }),
+    ]);
+
+    render(<ProfilingOnboardingModal {...MockRenderModalProps} />);
+    selectProject(TestStubs.Project({name: 'iOS Project'}));
+
+    expect(screen.queryByText(/Setup Performance Monitoring/)).toBeInTheDocument();
+  });
+
+  it('hides performance setup  when "firstTransactionEvent=true"', () => {
+    ProjectStore.loadInitialData([
+      TestStubs.Project({
+        name: 'iOS Project',
+        platform: 'apple-ios',
+        firstTransactionEvent: true,
+      }),
+    ]);
+
+    render(<ProfilingOnboardingModal {...MockRenderModalProps} />);
+    selectProject(TestStubs.Project({name: 'iOS Project'}));
+
+    expect(screen.queryByText(/Setup Performance Monitoring/)).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -189,8 +189,12 @@ function SelectProjectStep({
               />
             </div>
           </li>
-          {project?.platform === 'android' ? <AndroidInstallSteps /> : null}
-          {project?.platform === 'apple-ios' ? <IOSInstallSteps /> : null}
+          {project?.platform === 'android' ? (
+            <AndroidInstallSteps hidePerformanceSetup={project.firstTransactionEvent} />
+          ) : null}
+          {project?.platform === 'apple-ios' ? (
+            <IOSInstallSteps hidePerformanceSetup={project.firstTransactionEvent} />
+          ) : null}
         </StyledList>
         <ModalFooter>
           <ModalActions>
@@ -230,7 +234,11 @@ function SetupPerformanceMonitoringStep({href}: {href: string}) {
   );
 }
 
-function AndroidInstallSteps() {
+interface InstallStepsProps {
+  hidePerformanceSetup: boolean;
+}
+
+function AndroidInstallSteps({hidePerformanceSetup}: InstallStepsProps) {
   return (
     <Fragment>
       <li>
@@ -241,9 +249,11 @@ function AndroidInstallSteps() {
           )}
         </p>
       </li>
-      <li>
-        <SetupPerformanceMonitoringStep href="https://docs.sentry.io/platforms/android/performance/" />
-      </li>
+      {!hidePerformanceSetup && (
+        <li>
+          <SetupPerformanceMonitoringStep href="https://docs.sentry.io/platforms/android/performance/" />
+        </li>
+      )}
       <li>
         <StepTitle>{t('Set Up Profiling')}</StepTitle>
         <CodeContainer>
@@ -258,7 +268,7 @@ function AndroidInstallSteps() {
   );
 }
 
-function IOSInstallSteps() {
+function IOSInstallSteps({hidePerformanceSetup}: InstallStepsProps) {
   return (
     <Fragment>
       <li>
@@ -269,9 +279,11 @@ function IOSInstallSteps() {
           )}
         </p>
       </li>
-      <li>
-        <SetupPerformanceMonitoringStep href="https://docs.sentry.io/platforms/apple/guides/ios/performance/" />
-      </li>
+      {!hidePerformanceSetup && (
+        <li>
+          <SetupPerformanceMonitoringStep href="https://docs.sentry.io/platforms/apple/guides/ios/performance/" />
+        </li>
+      )}
       <li>
         <StepTitle>
           {t('Enable profiling in your app by configuring the SDKs like below:')}


### PR DESCRIPTION
For projects who have performance setup, we will hide the "Setup Performance Monitoring" step during profiling onboarding.

`firstTransactionEvent=true`;
![image](https://user-images.githubusercontent.com/7349258/190481683-ff2ccd02-bff5-4f68-883c-ffbfe43f7e18.png)

`firstTransactionEvent=false`;
![image](https://user-images.githubusercontent.com/7349258/190481707-1fa0a9be-cf29-41e4-acab-3609dacd0a68.png)
