### PR TITLE
fix(profiling): flamegraph warning z-index

### DIFF
--- a/static/app/components/profiling/FlamegraphWarnings.tsx
+++ b/static/app/components/profiling/FlamegraphWarnings.tsx
@@ -59,6 +59,6 @@ const Overlay = styled('div')`
   display: grid;
   grid: auto/50%;
   place-content: center;
-  z-index: ${p => p.theme.zIndex.modal};
+  z-index: 1;
   text-align: center;
 `;

--- a/static/app/components/profiling/FlamegraphWarnings.tsx
+++ b/static/app/components/profiling/FlamegraphWarnings.tsx
@@ -59,6 +59,6 @@ const Overlay = styled('div')`
   display: grid;
   grid: auto/50%;
   place-content: center;
-  z-index: 1;
+  z-index: ${p => p.theme.zIndex.initial};
   text-align: center;
 `;


### PR DESCRIPTION
The flamegraph warning overlay took precedence over the thread selector making part of the selector unclickable, see area highlighted in red below;

before:
![image](https://user-images.githubusercontent.com/7349258/190484265-e326be29-cd49-4776-9f17-c2623256b85e.png)



after (you can't see my cursor but i've been able to correctly hover over a thread):
![image](https://user-images.githubusercontent.com/7349258/190484472-9f59e776-893f-41a4-9ee5-c53110e2645b.png)
