### PR TITLE
ref: prevent ResourceWarning when using docker client

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -123,8 +123,8 @@ def devserver(
     if ingest:
         # Ingest requires kakfa+zookeeper to be running.
         # They're too heavyweight to startup on-demand with devserver.
-        docker = get_docker_client()
-        containers = {c.name for c in docker.containers.list(filters={"status": "running"})}
+        with get_docker_client() as docker:
+            containers = {c.name for c in docker.containers.list(filters={"status": "running"})}
         if "sentry_zookeeper" not in containers or "sentry_kafka" not in containers:
             raise SystemExit(
                 """

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import contextlib
 import os
 import signal
 import subprocess
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import TYPE_CHECKING, Any, Literal, overload
+from typing import TYPE_CHECKING, Any, Generator, Literal, overload
 
 import click
 import requests
@@ -26,36 +27,39 @@ if os.path.exists(RAW_SOCKET_HACK_PATH):
 DARWIN = sys.platform == "darwin"
 
 
-def get_docker_client() -> docker.DockerClient:
+@contextlib.contextmanager
+def get_docker_client() -> Generator[docker.DockerClient, None, None]:
     import docker
 
-    client = docker.from_env()
-    try:
-        client.ping()
-        return client
-    except (requests.exceptions.ConnectionError, docker.errors.APIError):
-        click.echo("Attempting to start docker...")
-        if DARWIN:
-            subprocess.check_call(
-                ("open", "-a", "/Applications/Docker.app", "--args", "--unattended")
-            )
-        else:
-            click.echo("Unable to start docker.")
-            raise click.ClickException("Make sure docker is running.")
+    with contextlib.closing(docker.from_env()) as client:
+        try:
+            client.ping()
+        except (requests.exceptions.ConnectionError, docker.errors.APIError):
+            click.echo("Attempting to start docker...")
+            if DARWIN:
+                subprocess.check_call(
+                    ("open", "-a", "/Applications/Docker.app", "--args", "--unattended")
+                )
+            else:
+                click.echo("Unable to start docker.")
+                raise click.ClickException("Make sure docker is running.")
 
-        max_wait = 60
-        timeout = time.monotonic() + max_wait
+            max_wait = 60
+            timeout = time.monotonic() + max_wait
 
-        click.echo(f"Waiting for docker to be ready.... (timeout in {max_wait}s)")
-        while time.monotonic() < timeout:
-            time.sleep(1)
-            try:
-                client.ping()
-                return client
-            except (requests.exceptions.ConnectionError, docker.errors.APIError):
-                continue
+            click.echo(f"Waiting for docker to be ready.... (timeout in {max_wait}s)")
+            while time.monotonic() < timeout:
+                time.sleep(1)
+                try:
+                    client.ping()
+                except (requests.exceptions.ConnectionError, docker.errors.APIError):
+                    continue
+                else:
+                    break
+            else:
+                raise click.ClickException("Failed to start docker.")
 
-        raise click.ClickException("Failed to start docker.")
+        yield client
 
 
 @overload
@@ -116,15 +120,12 @@ def ensure_interface(ports: dict[str, int | tuple[str, int]]) -> dict[str, tuple
 
 
 @click.group()
-@click.pass_context
-def devservices(ctx: click.Context) -> None:
+def devservices() -> None:
     """
     Manage dependent development services required for Sentry.
 
     Do not use in production!
     """
-    ctx.obj["client"] = get_docker_client()
-
     # Disable backend validation so no devservices commands depend on like,
     # redis to be already running.
     os.environ["SENTRY_SKIP_BACKEND_VALIDATION"] = "1"
@@ -134,8 +135,7 @@ def devservices(ctx: click.Context) -> None:
 @click.option("--project", default="sentry")
 @click.option("--fast", is_flag=True, default=False, help="Never pull and reuse containers.")
 @click.argument("service", nargs=1)
-@click.pass_context
-def attach(ctx: click.Context, project: str, fast: bool, service: str) -> None:
+def attach(project: str, fast: bool, service: str) -> None:
     """
     Run a single devservice in the foreground.
 
@@ -154,29 +154,30 @@ def attach(ctx: click.Context, project: str, fast: bool, service: str) -> None:
     if service not in containers:
         raise click.ClickException(f"Service `{service}` is not known or not enabled.")
 
-    container = _start_service(
-        ctx.obj["client"],
-        service,
-        containers,
-        project,
-        fast=fast,
-        always_start=True,
-    )
+    with get_docker_client() as docker_client:
+        container = _start_service(
+            docker_client,
+            service,
+            containers,
+            project,
+            fast=fast,
+            always_start=True,
+        )
 
-    def exit_handler(*_: Any) -> None:
-        try:
-            click.echo(f"Stopping {service}")
-            container.stop()
-            click.echo(f"Removing {service}")
-            container.remove()
-        except KeyboardInterrupt:
-            pass
+        def exit_handler(*_: Any) -> None:
+            try:
+                click.echo(f"Stopping {service}")
+                container.stop()
+                click.echo(f"Removing {service}")
+                container.remove()
+            except KeyboardInterrupt:
+                pass
 
-    signal.signal(signal.SIGINT, exit_handler)
-    signal.signal(signal.SIGTERM, exit_handler)
+        signal.signal(signal.SIGINT, exit_handler)
+        signal.signal(signal.SIGTERM, exit_handler)
 
-    for line in container.logs(stream=True, since=int(time.time() - 20)):
-        click.echo(line, nl=False)
+        for line in container.logs(stream=True, since=int(time.time() - 20)):
+            click.echo(line, nl=False)
 
 
 @devservices.command()
@@ -187,9 +188,7 @@ def attach(ctx: click.Context, project: str, fast: bool, service: str) -> None:
 @click.option(
     "--skip-only-if", is_flag=True, default=False, help="Skip 'only_if' checks for services"
 )
-@click.pass_context
 def up(
-    ctx: click.Context,
     services: list[str],
     project: str,
     exclude: list[str],
@@ -243,34 +242,35 @@ def up(
             fg="red",
         )
 
-    get_or_create(ctx.obj["client"], "network", project)
+    with get_docker_client() as docker_client:
+        get_or_create(docker_client, "network", project)
 
-    with ThreadPoolExecutor(max_workers=len(selected_services)) as executor:
-        futures = []
-        for name in selected_services:
-            futures.append(
-                executor.submit(
-                    _start_service,
-                    ctx.obj["client"],
-                    name,
-                    containers,
-                    project,
-                    fast=fast,
+        with ThreadPoolExecutor(max_workers=len(selected_services)) as executor:
+            futures = []
+            for name in selected_services:
+                futures.append(
+                    executor.submit(
+                        _start_service,
+                        docker_client,
+                        name,
+                        containers,
+                        project,
+                        fast=fast,
+                    )
                 )
-            )
-        for future in as_completed(futures):
-            # If there was an exception, reraising it here to the main thread
-            # will not terminate the whole python process. We'd like to report
-            # on this exception and stop as fast as possible, so terminate
-            # ourselves. I believe (without verification) that the OS is now
-            # free to cleanup these threads, but not sure if they'll remain running
-            # in the background. What matters most is that we regain control
-            # of the terminal.
-            e = future.exception()
-            if e:
-                click.echo(e)
-                me = os.getpid()
-                os.kill(me, signal.SIGTERM)
+            for future in as_completed(futures):
+                # If there was an exception, reraising it here to the main thread
+                # will not terminate the whole python process. We'd like to report
+                # on this exception and stop as fast as possible, so terminate
+                # ourselves. I believe (without verification) that the OS is now
+                # free to cleanup these threads, but not sure if they'll remain running
+                # in the background. What matters most is that we regain control
+                # of the terminal.
+                e = future.exception()
+                if e:
+                    click.echo(e)
+                    me = os.getpid()
+                    os.kill(me, signal.SIGTERM)
 
 
 def _prepare_containers(
@@ -441,8 +441,7 @@ def _start_service(
 @devservices.command()
 @click.option("--project", default="sentry")
 @click.argument("service", nargs=-1)
-@click.pass_context
-def down(ctx: click.Context, project: str, service: list[str]) -> None:
+def down(project: str, service: list[str]) -> None:
     """
     Shut down services without deleting their underlying containers and data.
     Useful if you want to temporarily relieve resources on your computer.
@@ -452,7 +451,7 @@ def down(ctx: click.Context, project: str, service: list[str]) -> None:
     """
     # TODO: make more like devservices rm
 
-    def _down(container: docker.Container) -> None:
+    def _down(container: docker.models.containers.Container) -> None:
         click.secho(f"> Stopping '{container.name}' container", fg="red")
         container.stop()
         click.secho(f"> Stopped '{container.name}' container", fg="red")
@@ -460,37 +459,37 @@ def down(ctx: click.Context, project: str, service: list[str]) -> None:
     containers = []
     prefix = f"{project}_"
 
-    for container in ctx.obj["client"].containers.list(all=True):
-        if not container.name.startswith(prefix):
-            continue
-        if service and not container.name[len(prefix) :] in service:
-            continue
-        containers.append(container)
+    with get_docker_client() as docker_client:
+        for container in docker_client.containers.list(all=True):
+            if not container.name.startswith(prefix):
+                continue
+            if service and not container.name[len(prefix) :] in service:
+                continue
+            containers.append(container)
 
-    with ThreadPoolExecutor(max_workers=len(containers)) as executor:
-        futures = []
-        for container in containers:
-            futures.append(executor.submit(_down, container))
-        for future in as_completed(futures):
-            # If there was an exception, reraising it here to the main thread
-            # will not terminate the whole python process. We'd like to report
-            # on this exception and stop as fast as possible, so terminate
-            # ourselves. I believe (without verification) that the OS is now
-            # free to cleanup these threads, but not sure if they'll remain running
-            # in the background. What matters most is that we regain control
-            # of the terminal.
-            e = future.exception()
-            if e:
-                click.echo(e)
-                me = os.getpid()
-                os.kill(me, signal.SIGTERM)
+        with ThreadPoolExecutor(max_workers=len(containers)) as executor:
+            futures = []
+            for container in containers:
+                futures.append(executor.submit(_down, container))
+            for future in as_completed(futures):
+                # If there was an exception, reraising it here to the main thread
+                # will not terminate the whole python process. We'd like to report
+                # on this exception and stop as fast as possible, so terminate
+                # ourselves. I believe (without verification) that the OS is now
+                # free to cleanup these threads, but not sure if they'll remain running
+                # in the background. What matters most is that we regain control
+                # of the terminal.
+                e = future.exception()
+                if e:
+                    click.echo(e)
+                    me = os.getpid()
+                    os.kill(me, signal.SIGTERM)
 
 
 @devservices.command()
 @click.option("--project", default="sentry")
 @click.argument("services", nargs=-1)
-@click.pass_context
-def rm(ctx: click.Context, project: str, services: list[str]) -> None:
+def rm(project: str, services: list[str]) -> None:
     """
     Shut down and delete all services and associated data.
     Useful if you'd like to start with a fresh slate.
@@ -533,39 +532,40 @@ Are you sure you want to continue?"""
         abort=True,
     )
 
-    volume_to_service = {}
-    for service_name, container_options in containers.items():
-        try:
-            container = ctx.obj["client"].containers.get(container_options["name"])
-        except NotFound:
-            click.secho(
-                "> WARNING: non-existent container '%s'" % container_options["name"],
-                err=True,
-                fg="yellow",
-            )
-            continue
+    with get_docker_client() as docker_client:
+        volume_to_service = {}
+        for service_name, container_options in containers.items():
+            try:
+                container = docker_client.containers.get(container_options["name"])
+            except NotFound:
+                click.secho(
+                    "> WARNING: non-existent container '%s'" % container_options["name"],
+                    err=True,
+                    fg="yellow",
+                )
+                continue
 
-        click.secho("> Stopping '%s' container" % container_options["name"], err=True, fg="red")
-        container.stop()
-        click.secho("> Removing '%s' container" % container_options["name"], err=True, fg="red")
-        container.remove()
-        for volume in container_options.get("volumes") or ():
-            volume_to_service[volume] = service_name
+            click.secho("> Stopping '%s' container" % container_options["name"], err=True, fg="red")
+            container.stop()
+            click.secho("> Removing '%s' container" % container_options["name"], err=True, fg="red")
+            container.remove()
+            for volume in container_options.get("volumes") or ():
+                volume_to_service[volume] = service_name
 
-    prefix = project + "_"
+        prefix = project + "_"
 
-    for volume in ctx.obj["client"].volumes.list():
-        if volume.name.startswith(prefix):
-            local_name = volume.name[len(prefix) :]
-            if not services or volume_to_service.get(local_name) in services:
-                click.secho("> Removing '%s' volume" % volume.name, err=True, fg="red")
-                volume.remove()
+        for volume in docker_client.volumes.list():
+            if volume.name.startswith(prefix):
+                local_name = volume.name[len(prefix) :]
+                if not services or volume_to_service.get(local_name) in services:
+                    click.secho("> Removing '%s' volume" % volume.name, err=True, fg="red")
+                    volume.remove()
 
-    if not services:
-        try:
-            network = ctx.obj["client"].networks.get(project)
-        except NotFound:
-            pass
-        else:
-            click.secho("> Removing '%s' network" % network.name, err=True, fg="red")
-            network.remove()
+        if not services:
+            try:
+                network = docker_client.networks.get(project)
+            except NotFound:
+                pass
+            else:
+                click.secho("> Removing '%s' network" % network.name, err=True, fg="red")
+                network.remove()

--- a/src/sentry/utils/pytest/relay.py
+++ b/src/sentry/utils/pytest/relay.py
@@ -106,10 +106,9 @@ def relay_server_setup(live_server, tmpdir_factory):
 
     # we have a config path for relay that is set up with the current live serve as upstream
     # check if we have the test relay docker container
-    docker_client = get_docker_client()
-    container_name = _relay_server_container_name()
-    _remove_container_if_exists(docker_client, container_name)
-    docker_client.close()
+    with get_docker_client() as docker_client:
+        container_name = _relay_server_container_name()
+        _remove_container_if_exists(docker_client, container_name)
 
     options = {
         "image": RELAY_TEST_IMAGE,
@@ -129,18 +128,18 @@ def relay_server_setup(live_server, tmpdir_factory):
     # cleanup
     shutil.rmtree(config_path)
     if not environ.get("RELAY_TEST_KEEP_CONTAINER", False):
-        docker_client = get_docker_client()
-        _remove_container_if_exists(docker_client, container_name)
+        with get_docker_client() as docker_client:
+            _remove_container_if_exists(docker_client, container_name)
 
 
 @pytest.fixture(scope="function")
 def relay_server(relay_server_setup, settings):
     adjust_settings_for_relay_tests(settings)
     options = relay_server_setup["options"]
-    docker_client = get_docker_client()
-    container_name = _relay_server_container_name()
-    _remove_container_if_exists(docker_client, container_name)
-    container = docker_client.containers.run(**options)
+    with get_docker_client() as docker_client:
+        container_name = _relay_server_container_name()
+        _remove_container_if_exists(docker_client, container_name)
+        container = docker_client.containers.run(**options)
 
     _log.info("Waiting for Relay container to start")
 


### PR DESCRIPTION
diff is best viewed with [?w=1](https://github.com/getsentry/sentry/pull/38906/files?w=1)

working around https://github.com/docker/docker-py/issues/1293

before:

```console
$ pytest -Wonce tests/symbolicator/test_minidump_full.py::SymbolicatorMinidumpIntegrationTest::test_full_minidump
============================= test session starts ==============================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: forked-1.4.0, rerunfailures-10.2, xdist-2.4.0, sentry-0.1.9, django-4.4.0, cov-3.0.0
collected 1 item                                                               

tests/symbolicator/test_minidump_full.py .                               [100%]

=============================== warnings summary ===============================
tests/symbolicator/test_minidump_full.py::SymbolicatorMinidumpIntegrationTest::test_full_minidump
  /Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/django/utils/regex_helper.py:147: ResourceWarning: unclosed <socket.socket fd=17, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/Users/asottile/Library/Containers/com.docker.docker/Data/docker.raw.sock>
    result.append(Group((("%%(%s)s" % param), param)))
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/symbolicator/test_minidump_full.py::SymbolicatorMinidumpIntegrationTest::test_full_minidump
  /Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/django/utils/regex_helper.py:147: ResourceWarning: unclosed <socket.socket fd=18, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/Users/asottile/Library/Containers/com.docker.docker/Data/docker.raw.sock>
    result.append(Group((("%%(%s)s" % param), param)))
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/symbolicator/test_minidump_full.py::SymbolicatorMinidumpIntegrationTest::test_full_minidump
  /Users/asottile/workspace/sentry/.venv/lib/python3.8/site-packages/django/utils/regex_helper.py:147: ResourceWarning: unclosed <socket.socket fd=19, family=AddressFamily.AF_UNIX, type=SocketKind.SOCK_STREAM, proto=0, raddr=/Users/asottile/Library/Containers/com.docker.docker/Data/docker.raw.sock>
    result.append(Group((("%%(%s)s" % param), param)))
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 1 passed, 3 warnings in 12.34s ========================
%4|1663268253.516|TERMINATE|rdkafka#producer-4| [thrd:app]: Producer terminating with 3 messages (539 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```

after:

```console
$ pytest -Wonce tests/symbolicator/test_minidump_full.py::SymbolicatorMinidumpIntegrationTest::test_full_minidump
============================= test session starts ==============================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-0.13.1
rootdir: /Users/asottile/workspace/sentry, configfile: pyproject.toml
plugins: forked-1.4.0, rerunfailures-10.2, xdist-2.4.0, sentry-0.1.9, django-4.4.0, cov-3.0.0
collected 1 item                                                               

tests/symbolicator/test_minidump_full.py .                               [100%]

============================== 1 passed in 12.33s ==============================
%4|1663268283.383|TERMINATE|rdkafka#producer-4| [thrd:app]: Producer terminating with 3 messages (539 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
```