### PR TITLE
fix(ui): Use a darker gray on QuestionTooltip for better visibility

### DIFF
--- a/static/app/components/questionTooltip.tsx
+++ b/static/app/components/questionTooltip.tsx
@@ -16,7 +16,7 @@ const QuestionIconContainer = styled('span')<ContainerProps>`
 
   & svg {
     transition: 120ms opacity;
-    color: ${p => p.theme.gray200};
+    color: ${p => p.theme.gray300};
     opacity: 0.6;
 
     &:hover {

--- a/static/app/components/questionTooltip.tsx
+++ b/static/app/components/questionTooltip.tsx
@@ -16,7 +16,7 @@ const QuestionIconContainer = styled('span')<ContainerProps>`
 
   & svg {
     transition: 120ms opacity;
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
     opacity: 0.6;
 
     &:hover {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/10888943/190488144-179360cd-3786-4ddd-82c7-9dc3dda38f91.png)


![image](https://user-images.githubusercontent.com/10888943/190488125-52577cec-6bd8-4db4-aa1d-026ce8aac920.png)


After:

![image](https://user-images.githubusercontent.com/10888943/190487992-cc0583c6-d78e-4817-8cb7-b04c1707fe74.png)

![image](https://user-images.githubusercontent.com/10888943/190488016-c79752dc-9f93-4620-8a84-32bca9543eae.png)
