### PR TITLE
fix(perf_issues): Fix `sentry.event_manager.create_performance_group_transaction.count` to be unsampled

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2059,7 +2059,8 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
                     with sentry_sdk.start_span(
                         op="event_manager.create_performance_group_transaction"
                     ) as span, metrics.timer(
-                        "event_manager.create_performance_group_transaction"
+                        "event_manager.create_performance_group_transaction",
+                        sample_rate=1.0,
                     ) as metric_tags, transaction.atomic():
                         span.set_tag("create_group_transaction.outcome", "no_group")
                         metric_tags["create_group_transaction.outcome"] = "no_group"


### PR DESCRIPTION
This stat also is better off with a 1.0 sample rate, since data volume is low.