### PR TITLE
ref(settings): Fix breadcrumbs focus ring in Settings

### DIFF
--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -72,11 +72,6 @@ export default SettingsBreadcrumb;
 const CrumbLink = styled(Link)`
   display: block;
 
-  &.focus-visible {
-    outline: none;
-    box-shadow: ${p => p.theme.blue300} 0 2px 0;
-  }
-
   color: ${p => p.theme.subText};
   &:hover {
     color: ${p => p.theme.textColor};


### PR DESCRIPTION
**Before:**
<img width="194" alt="Screen Shot 2022-09-15 at 2 35 44 PM" src="https://user-images.githubusercontent.com/44172267/190513037-78956521-6fd2-427b-92e4-9629129b34e1.png">

**After:**
<img width="194" alt="Screen Shot 2022-09-15 at 2 36 00 PM" src="https://user-images.githubusercontent.com/44172267/190513074-27f8d9c7-e6af-48ed-92f3-4af3223b650b.png">
