### PR TITLE
fix(copy): renaming "exception" section to "stack trace"

### DIFF
--- a/static/app/components/events/interfaces/exception.tsx
+++ b/static/app/components/events/interfaces/exception.tsx
@@ -75,7 +75,7 @@ function Exception({
   return (
     <EventDataSection
       type={EntryType.EXCEPTION}
-      title={<CrashTitle title={t('Exception')} {...commonCrashHeaderProps} />}
+      title={<CrashTitle title={t('Stack Trace')} {...commonCrashHeaderProps} />}
       actions={
         <CrashActions
           stackType={stackType}

--- a/static/app/components/events/interfaces/exceptionV2.tsx
+++ b/static/app/components/events/interfaces/exceptionV2.tsx
@@ -61,7 +61,7 @@ function Exception({
 
   return (
     <TraceEventDataSection
-      title={<PermalinkTitle>{t('Exception')}</PermalinkTitle>}
+      title={<PermalinkTitle>{t('Stack Trace')}</PermalinkTitle>}
       type={EntryType.EXCEPTION}
       stackType={STACK_TYPE.ORIGINAL}
       projectId={projectId}


### PR DESCRIPTION
Everything on the left hand side of the issue details page is the exception so it makes much more sense to rename this section correctly: the `Stack Trace`. In some cases it was already called the Stack Trace so this PR makes things more consistent with how we reference this section across platforms. 

## Before 
 
![CleanShot 2022-09-15 at 15 02 31@2x](https://user-images.githubusercontent.com/1900676/190517029-d430780d-fea2-4928-b725-01a720ffd5ae.png)


## After
![CleanShot 2022-09-15 at 15 02 09@2x](https://user-images.githubusercontent.com/1900676/190517043-611f0c6d-1e85-42fb-9049-27f338236deb.png)

