### PR TITLE
feat(perf issues): Optimize issue search based on query

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -201,7 +201,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
 
         conditions = []
         having = []
-        group_categories: Set[int] = set()
+        group_categories: Set[GroupCategory] = set()
         for search_filter in search_filters:
             if search_filter.key.name in ("issue.category", "issue.type"):
                 group_categories.update(

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -201,7 +201,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
 
         conditions = []
         having = []
-        group_categories = set()
+        group_categories: Set[int] = set()
         for search_filter in search_filters:
             if search_filter.key.name in ("issue.category", "issue.type"):
                 group_categories.update(
@@ -286,9 +286,8 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             turbo=get_sample,  # Turn off FINAL when in sampling mode
             sample=1,  # Don't use clickhouse sampling, even when in turbo mode.
         )
-        group_categories = set()
 
-        rows = []
+        rows: List[Dict[str, int]] = []
         total = 0
         row_length = 0
         if not group_categories or GroupCategory.ERROR in group_categories:

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -314,10 +314,8 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             row_length = len(rows)
 
         organization = Organization.objects.get(id=organization_id)
-        if (
-            features.has("organizations:performance-issues", organization)
-            and not group_categories
-            or GroupCategory.PERFORMANCE in group_categories
+        if features.has("organizations:performance-issues", organization) and (
+            not group_categories or GroupCategory.PERFORMANCE in group_categories
         ):
             transaction_conditions = self.update_conditions(
                 "event.type",

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -39,7 +39,7 @@ from sentry.models import Environment, Group, Optional, Organization, Project
 from sentry.search.events.fields import DateArg
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
 from sentry.search.utils import validate_cdc_search_filters
-from sentry.types.issues import GroupCategory
+from sentry.types.issues import GroupCategory, GroupType, get_category_type_mapping
 from sentry.utils import json, metrics, snuba
 from sentry.utils.cursors import Cursor, CursorResult
 
@@ -185,7 +185,6 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         * a sorted list of (group_id, group_score) tuples sorted descending by score,
         * the count of total results (rows) available for this query.
         """
-
         filters = {"project_id": project_ids}
 
         environments = None
@@ -202,7 +201,10 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
 
         conditions = []
         having = []
+        group_types = set()
         for search_filter in search_filters:
+            if search_filter.key.name in ("issue.category", "issue.type"):
+                group_types.update(value for value in search_filter.value.raw_value)
             if (
                 # Don't filter on postgres fields here, they're not available
                 search_filter.key.name in self.postgres_only_fields
@@ -211,6 +213,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                 search_filter.key.name == "date"
             ):
                 continue
+
             converted_filter = convert_search_filter_to_snuba_query(
                 search_filter,
                 params={
@@ -280,32 +283,42 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             turbo=get_sample,  # Turn off FINAL when in sampling mode
             sample=1,  # Don't use clickhouse sampling, even when in turbo mode.
         )
+        group_categories = set()
 
-        error_conditions = self.update_conditions(
-            "event.type",
-            "!=",
-            "transaction",
-            organization_id,
-            project_ids,
-            environments,
-            environment_ids,
-            conditions,
-        )
-        snuba_error_results = query_partial(
-            conditions=error_conditions,
-            aggregations=aggregations,
-            condition_resolver=snuba.get_snuba_column_name,
-        )
+        for group_type in group_types:
+            for category, types in get_category_type_mapping().items():
+                if GroupType(group_type) in types:
+                    group_categories.add(category)
 
-        mod_agg = aggregations.copy() if aggregations else []
-        mod_agg.insert(0, ["arrayJoin", ["group_ids"], "group_id"])
-
-        rows = snuba_error_results["data"]
-        total = snuba_error_results["totals"]["total"]
-        row_length = len(rows)
+        rows = []
+        total = 0
+        row_length = 0
+        if not group_categories or GroupCategory.ERROR in group_categories:
+            error_conditions = self.update_conditions(
+                "event.type",
+                "!=",
+                "transaction",
+                organization_id,
+                project_ids,
+                environments,
+                environment_ids,
+                conditions,
+            )
+            snuba_error_results = query_partial(
+                conditions=error_conditions,
+                aggregations=aggregations,
+                condition_resolver=snuba.get_snuba_column_name,
+            )
+            rows = snuba_error_results["data"]
+            total = snuba_error_results["totals"]["total"]
+            row_length = len(rows)
 
         organization = Organization.objects.get(id=organization_id)
-        if features.has("organizations:performance-issues", organization):
+        if (
+            features.has("organizations:performance-issues", organization)
+            and not group_categories
+            or GroupCategory.PERFORMANCE in group_categories
+        ):
             transaction_conditions = self.update_conditions(
                 "event.type",
                 "=",
@@ -316,6 +329,9 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                 environment_ids,
                 conditions,
             )
+            mod_agg = aggregations.copy() if aggregations else []
+            mod_agg.insert(0, ["arrayJoin", ["group_ids"], "group_id"])
+
             snuba_transaction_results = query_partial(
                 conditions=transaction_conditions,
                 aggregations=mod_agg,
@@ -426,7 +442,6 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         date_to: Optional[datetime],
         max_hits: Optional[int] = None,
     ) -> CursorResult[Group]:
-
         now = timezone.now()
         end = None
         end_params = [_f for _f in [date_to, get_search_filter(search_filters, "date", "<")] if _f]

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -287,7 +287,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             sample=1,  # Don't use clickhouse sampling, even when in turbo mode.
         )
 
-        rows: List[Dict[str, int]] = []
+        rows: Optional[List[Dict[str, int]]] = []
         total = 0
         row_length = 0
         if not group_categories or GroupCategory.ERROR in group_categories:

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2154,11 +2154,37 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
         with self.feature("organizations:performance-issues"):
             results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
         assert list(results) == [self.perf_group_1, self.perf_group_2]
-        assert False
+
+        with self.feature("organizations:performance-issues"):
+            results = self.make_query(
+                search_filter_query="issue.type:[performance_n_plus_one, performance_slow_span] my_tag:1"
+            )
+        assert list(results) == [self.perf_group_1, self.perf_group_2]
 
     def test_error_performance_query(self):
         with self.feature("organizations:performance-issues"):
             results = self.make_query(search_filter_query="my_tag:1")
+        assert list(results) == [
+            self.perf_group_1,
+            self.perf_group_2,
+            self.error_group_2,
+            self.error_group_1,
+        ]
+        with self.feature("organizations:performance-issues"):
+            results = self.make_query(
+                search_filter_query="issue.category:[performance, error] my_tag:1"
+            )
+        assert list(results) == [
+            self.perf_group_1,
+            self.perf_group_2,
+            self.error_group_2,
+            self.error_group_1,
+        ]
+
+        with self.feature("organizations:performance-issues"):
+            results = self.make_query(
+                search_filter_query="issue.type:[performance_slow_span, error] my_tag:1"
+            )
         assert list(results) == [
             self.perf_group_1,
             self.perf_group_2,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2154,6 +2154,7 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
         with self.feature("organizations:performance-issues"):
             results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
         assert list(results) == [self.perf_group_1, self.perf_group_2]
+        assert False
 
     def test_error_performance_query(self):
         with self.feature("organizations:performance-issues"):


### PR DESCRIPTION
If there's a specific query like `issue.category:performance` or `issue.type:performance_n_plus_one`, skip the query for error issues and vice versa for performance issues. If there is no specific query or the queries use both (like for error and performance issue types), we still query for both.  