### PR TITLE
feat(replays): Update useReplayData to call the new replays_events_meta endpoint

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -170,16 +170,16 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
         return [];
       }
 
-      const response = await api.requestPromise(`/organizations/${orgSlug}/events/`, {
-        query: {
-          field: ['id', 'error.value', 'timestamp', 'error.type', 'issue.id'],
-          projects: [-1],
-          start: replayRecord.startedAt.toISOString(),
-          end: replayRecord.finishedAt.toISOString(),
-          query: `id:[${String(replayRecord.errorIds)}]`,
-          referrer: 'api.replay.details-page',
-        },
-      });
+      const response = await api.requestPromise(
+        `/organizations/${orgSlug}/replays_events_meta/`,
+        {
+          query: {
+            start: replayRecord.startedAt.toISOString(),
+            end: replayRecord.finishedAt.toISOString(),
+            query: `id:[${String(replayRecord.errorIds)}]`,
+          },
+        }
+      );
       return response.data;
     },
     [api, orgSlug]

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -171,7 +171,7 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
       }
 
       const response = await api.requestPromise(
-        `/organizations/${orgSlug}/replays_events_meta/`,
+        `/organizations/${orgSlug}/replays-events-meta/`,
         {
           query: {
             start: replayRecord.startedAt.toISOString(),


### PR DESCRIPTION
Frontend changes that make use of the new endpoint added in #38933

Depends on https://github.com/getsentry/sentry/pull/38933


Fixes #38812