### PR TITLE
Added chart type for bar display.

### DIFF
--- a/src/sentry/integrations/slack/unfurl/discover.py
+++ b/src/sentry/integrations/slack/unfurl/discover.py
@@ -29,6 +29,7 @@ display_modes: Mapping[str, ChartType] = {
     "dailytop5": ChartType.SLACK_DISCOVER_TOP5_DAILY,
     "previous": ChartType.SLACK_DISCOVER_PREVIOUS_PERIOD,
     "worldmap": ChartType.SLACK_DISCOVER_WORLDMAP,
+    "bar": ChartType.SLACK_DISCOVER_TOTAL_DAILY,
 }
 
 # All `multiPlotType: line` fields in /static/app/utils/discover/fields.tsx

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -912,7 +912,7 @@ class UnfurlTest(TestCase):
     )
     @patch("sentry.integrations.slack.unfurl.discover.generate_chart", return_value="chart-url")
     def test_bar_chart_display_renders_bar_chart(self, mock_generate_chart, _):
-        url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?display=bar&field=title&[…]event.type%3Aerror&sort=-count&statsPeriod=24h&yAxis=count%28%29"
+        url = f"https://sentry.io/organizations/{self.organization.slug}/discover/results/?display=bar&field=title&event.type%3Aerror&sort=-count&statsPeriod=24h&yAxis=count%28%29"
 
         link_type, args = match_link(url)
 


### PR DESCRIPTION
Initially the default chart type of "total period" was being assigned to displays of type 'bar'. 