### PR TITLE
fix(discover): Type measurements for event search

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -514,11 +514,12 @@ class SearchVisitor(NodeVisitor):
         )
 
     def is_duration_key(self, key):
+        duration_types = [*DURATION_UNITS, "duration"]
         return (
             key in self.config.duration_keys
             or is_duration_measurement(key)
             or is_span_op_breakdown(key)
-            or self.builder.get_field_type(key) in [*DURATION_UNITS, "duration"]
+            or self.builder.get_field_type(key) in duration_types
         )
 
     def is_size_key(self, key):
@@ -760,7 +761,9 @@ class SearchVisitor(NodeVisitor):
         try:
             # Even if the search value matches duration format, only act as
             # duration for certain columns
-            if self.is_duration_key(search_key.name):
+            result_type = self.builder.get_function_result_type(search_key.name)
+
+            if result_type == "duration" or result_type in DURATION_UNITS:
                 aggregate_value = parse_duration(*search_value)
             else:
                 # Duration overlaps with numeric values with `m` (million vs

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 from django.test import SimpleTestCase
@@ -221,9 +222,10 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             ),
         ]
 
-    # TODO: add these to the shared frontend tests later
-    def test_size_filter(self):
+    @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
+    def test_size_filter(self, mock_type):
         config = SearchConfig()
+        mock_type.return_value = "size"
 
         assert parse_search_query("measurements.foo:>5gb measurements.bar:<3pb", config=config) == [
             SearchFilter(
@@ -238,8 +240,10 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             ),
         ]
 
-    def test_aggregate_size_filter(self):
+    @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
+    def test_aggregate_size_filter(self, mock_type):
         config = SearchConfig()
+        mock_type.return_value = "size"
 
         assert parse_search_query(
             "p50(measurements.foo):>5gb p100(measurements.bar):<3pb", config=config
@@ -253,6 +257,82 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
                 key=SearchKey(name="p100(measurements.bar)"),
                 operator="<",
                 value=SearchValue(3 * 1000**5),
+            ),
+        ]
+
+    @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
+    def test_duration_measurement_filter(self, mock_type):
+        config = SearchConfig()
+        mock_type.return_value = "duration"
+
+        assert parse_search_query("measurements.foo:>5s measurements.bar:<3m", config=config) == [
+            SearchFilter(
+                key=SearchKey(name="measurements.foo"),
+                operator=">",
+                value=SearchValue(5 * 1000),
+            ),
+            SearchFilter(
+                key=SearchKey(name="measurements.bar"),
+                operator="<",
+                value=SearchValue(3 * 1000 * 60),
+            ),
+        ]
+
+    @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
+    def test_aggregate_duration_measurement_filter(self, mock_type):
+        config = SearchConfig()
+        mock_type.return_value = "duration"
+
+        assert parse_search_query(
+            "p50(measurements.foo):>5s p100(measurements.bar):<3m", config=config
+        ) == [
+            SearchFilter(
+                key=SearchKey(name="p50(measurements.foo)"),
+                operator=">",
+                value=SearchValue(5 * 1000),
+            ),
+            SearchFilter(
+                key=SearchKey(name="p100(measurements.bar)"),
+                operator="<",
+                value=SearchValue(3 * 1000 * 60),
+            ),
+        ]
+
+    @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
+    def test_numeric_measurement_filter(self, mock_type):
+        config = SearchConfig()
+        mock_type.return_value = "number"
+
+        assert parse_search_query("measurements.foo:>5k measurements.bar:<3m", config=config) == [
+            SearchFilter(
+                key=SearchKey(name="measurements.foo"),
+                operator=">",
+                value=SearchValue(5 * 1000),
+            ),
+            SearchFilter(
+                key=SearchKey(name="measurements.bar"),
+                operator="<",
+                value=SearchValue(3 * 1_000_000),
+            ),
+        ]
+
+    @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
+    def test_aggregate_numeric_measurement_filter(self, mock_type):
+        config = SearchConfig()
+        mock_type.return_value = "number"
+
+        assert parse_search_query(
+            "p50(measurements.foo):>5k p100(measurements.bar):<3m", config=config
+        ) == [
+            SearchFilter(
+                key=SearchKey(name="p50(measurements.foo)"),
+                operator=">",
+                value=SearchValue(5 * 1000),
+            ),
+            SearchFilter(
+                key=SearchKey(name="p100(measurements.bar)"),
+                operator="<",
+                value=SearchValue(3 * 1_000_000),
             ),
         ]
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -225,7 +225,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
     @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
     def test_size_filter(self, mock_type):
         config = SearchConfig()
-        mock_type.return_value = "size"
+        mock_type.return_value = "gigabyte"
 
         assert parse_search_query("measurements.foo:>5gb measurements.bar:<3pb", config=config) == [
             SearchFilter(
@@ -243,7 +243,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
     @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
     def test_aggregate_size_filter(self, mock_type):
         config = SearchConfig()
-        mock_type.return_value = "size"
+        mock_type.return_value = "gigabyte"
 
         assert parse_search_query(
             "p50(measurements.foo):>5gb p100(measurements.bar):<3pb", config=config
@@ -263,7 +263,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
     @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
     def test_duration_measurement_filter(self, mock_type):
         config = SearchConfig()
-        mock_type.return_value = "duration"
+        mock_type.return_value = "seconds"
 
         assert parse_search_query("measurements.foo:>5s measurements.bar:<3m", config=config) == [
             SearchFilter(
@@ -281,7 +281,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
     @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
     def test_aggregate_duration_measurement_filter(self, mock_type):
         config = SearchConfig()
-        mock_type.return_value = "duration"
+        mock_type.return_value = "minutes"
 
         assert parse_search_query(
             "p50(measurements.foo):>5s p100(measurements.bar):<3m", config=config

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -263,7 +263,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
     @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
     def test_duration_measurement_filter(self, mock_type):
         config = SearchConfig()
-        mock_type.return_value = "seconds"
+        mock_type.return_value = "second"
 
         assert parse_search_query("measurements.foo:>5s measurements.bar:<3m", config=config) == [
             SearchFilter(
@@ -281,7 +281,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
     @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
     def test_aggregate_duration_measurement_filter(self, mock_type):
         config = SearchConfig()
-        mock_type.return_value = "minutes"
+        mock_type.return_value = "minute"
 
         assert parse_search_query(
             "p50(measurements.foo):>5s p100(measurements.bar):<3m", config=config


### PR DESCRIPTION
- This updates the event_search grammar to use the builder field type function to determine type since its far more accurate than just checking "is this a measurement"