### PR TITLE
feat(dev): Use SENTRY_DEV_DSN to report local dev events

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2151,12 +2151,12 @@ SENTRY_SDK_CONFIG = {
         "custom_measurements": True,
     },
 }
-SENTRY_SDK_DSN = os.environ.get("SENTRY_SDK")
-if SENTRY_SDK_DSN:
-    # In production, this value is *not* set via SENTRY_SDK
+SENTRY_DEV_DSN = os.environ.get("SENTRY_DEV_DSN")
+if SENTRY_DEV_DSN:
+    # In production, this value is *not* set via an env variable
     # https://github.com/getsentry/getsentry/blob/16a07f72853104b911a368cc8ae2b4b49dbf7408/getsentry/conf/settings/prod.py#L604-L606
     # This is used in case you want to report traces of your development set up to a project of your choice
-    SENTRY_SDK_CONFIG["dsn"] = SENTRY_SDK_DSN
+    SENTRY_SDK_CONFIG["dsn"] = SENTRY_DEV_DSN
 
 # Callable to bind additional context for the Sentry SDK
 #

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2151,6 +2151,13 @@ SENTRY_SDK_CONFIG = {
         "custom_measurements": True,
     },
 }
+SENTRY_SDK_DSN = os.environ.get("SENTRY_SDK")
+if SENTRY_SDK_DSN:
+    # In production, this value is *not* set via SENTRY_SDK
+    # https://github.com/getsentry/getsentry/blob/16a07f72853104b911a368cc8ae2b4b49dbf7408/getsentry/conf/settings/prod.py#L604-L606
+    # This is used in case you want to report traces of your development set up to a project of your choice
+    SENTRY_SDK_CONFIG["dsn"] = SENTRY_SDK_DSN
+
 # Callable to bind additional context for the Sentry SDK
 #
 # def get_org_context(scope, organization, **kwargs):


### PR DESCRIPTION
In #38561 I enabled tracing for a Celery task which I could only make it work locally with a trick like this.