### PR TITLE
fix(replays): Replay referrer event property cleanup

### DIFF
--- a/static/app/utils/replays/hooks/useReplayPageview.tsx
+++ b/static/app/utils/replays/hooks/useReplayPageview.tsx
@@ -15,7 +15,7 @@ function useReplayPageview() {
   useEffect(() => {
     trackAdvancedAnalyticsEvent('replay.details-viewed', {
       organization,
-      referrer: decodeScalar(location.query.referrer),
+      referrer_slug: decodeScalar(location.query.referrer),
       user_email: config.user.email,
     });
   }, [organization, location.query.referrer, config.user.email]);


### PR DESCRIPTION
### Changes
- renames `referrer` field to `referrer_slug`

### Notes
Talked to Ryan about it and based on the code the referrer field should only be getting route slugs ie: `/organization/:orgId/replays` and not full referrer urls from different places like in the issue screenshot. He mentioned maybe it's some sort of default field so this PR just renames it and hopefully this will make it more clear.

Tagged issue #38555 



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
