### PR TITLE
chore(auth): Update sentry.auth.providers.oauth2 to support customer domains

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from urllib.parse import urlparse
 
 from django.utils import timezone
+from rest_framework.request import Request
 
 from sentry import options
 from sentry.auth.access import get_cached_organization_member
@@ -182,3 +183,10 @@ def generate_region_url() -> str:
     if not region_url_template or not region:
         return options.get("system.url-prefix")
     return region_url_template.replace("{region}", region)
+
+
+def generate_url_prefix(request: Request) -> str:
+    url_prefix = options.get("system.url-prefix")
+    if request.subdomain:
+        url_prefix = generate_organization_url(request.subdomain)
+    return url_prefix

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -679,8 +679,8 @@ class AuthHelper(Pipeline):
         state.update({"flow": self.flow})
         return state
 
-    def get_redirect_url(self):
-        return absolute_uri(reverse("sentry-auth-sso"))
+    def get_redirect_url(self, url_prefix=None):
+        return absolute_uri(reverse("sentry-auth-sso"), url_prefix=url_prefix)
 
     def dispatch_to(self, step: View):
         return step.dispatch(request=self.request, helper=self)

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -9,11 +9,12 @@ from sentry import options
 ParsedUriMatch = namedtuple("ParsedUriMatch", ["scheme", "domain", "path"])
 
 
-def absolute_uri(url: Optional[str] = None) -> str:
-    prefix = options.get("system.url-prefix")
+def absolute_uri(url: Optional[str] = None, url_prefix=None) -> str:
+    if url_prefix is None:
+        url_prefix = options.get("system.url-prefix")
     if not url:
-        return prefix
-    return urljoin(prefix.rstrip("/") + "/", url.lstrip("/"))
+        return url_prefix
+    return urljoin(url_prefix.rstrip("/") + "/", url.lstrip("/"))
 
 
 def origin_from_url(url):


### PR DESCRIPTION
This is a first pass in updating [`sentry.auth.providers.oauth2`](https://github.com/getsentry/sentry/blob/master/src/sentry/auth/providers/oauth2.py) to support customer domains. 

The motivation is to add SSO support for customer domains by dynamically update `redirect_uri` attributes with the appropriate hostname.