### PR TITLE
chore(auth): Update sentry.identity.oauth2 to support customer domains

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from urllib.parse import urlparse
 
 from django.utils import timezone
+from rest_framework.request import Request
 
 from sentry import options
 from sentry.auth.access import get_cached_organization_member
@@ -182,3 +183,10 @@ def generate_region_url() -> str:
     if not region_url_template or not region:
         return options.get("system.url-prefix")
     return region_url_template.replace("{region}", region)
+
+
+def generate_url_prefix(request: Request) -> str:
+    url_prefix = options.get("system.url-prefix")
+    if request.subdomain:
+        url_prefix = generate_organization_url(request.subdomain)
+    return url_prefix

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -679,8 +679,8 @@ class AuthHelper(Pipeline):
         state.update({"flow": self.flow})
         return state
 
-    def get_redirect_url(self):
-        return absolute_uri(reverse("sentry-auth-sso"))
+    def get_redirect_url(self, url_prefix=None):
+        return absolute_uri(reverse("sentry-auth-sso"), url_prefix=url_prefix)
 
     def dispatch_to(self, step: View):
         return step.dispatch(request=self.request, helper=self)

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -9,11 +9,12 @@ from sentry import options
 ParsedUriMatch = namedtuple("ParsedUriMatch", ["scheme", "domain", "path"])
 
 
-def absolute_uri(url: Optional[str] = None) -> str:
-    prefix = options.get("system.url-prefix")
+def absolute_uri(url: Optional[str] = None, url_prefix=None) -> str:
+    if url_prefix is None:
+        url_prefix = options.get("system.url-prefix")
     if not url:
-        return prefix
-    return urljoin(prefix.rstrip("/") + "/", url.lstrip("/"))
+        return url_prefix
+    return urljoin(url_prefix.rstrip("/") + "/", url.lstrip("/"))
 
 
 def origin_from_url(url):

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -135,6 +135,7 @@ class OAuth2LoginViewTest(TestCase):
         response = self.view.dispatch(self.request, pipeline)
 
         assert response.status_code == 302
+        assert response["Location"].startswith("https://example.org/oauth2/authorize")
         redirect_url = urlparse(response["Location"])
         query = parse_qs(redirect_url.query)
 
@@ -150,6 +151,7 @@ class OAuth2LoginViewTest(TestCase):
         response = self.view.dispatch(self.request, pipeline)
 
         assert response.status_code == 302
+        assert response["Location"].startswith("https://example.org/oauth2/authorize")
         redirect_url = urlparse(response["Location"])
         query = parse_qs(redirect_url.query)
 

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -1,15 +1,21 @@
-from unittest.mock import Mock
+from collections import namedtuple
+from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 import responses
+from django.test import Client, RequestFactory
 from exam import fixture
 from requests.exceptions import SSLError
 
 import sentry.identity
-from sentry.identity.oauth2 import OAuth2CallbackView
+from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.identity.providers.dummy import DummyProvider
 from sentry.testutils import TestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.utils import json
+
+MockResponse = namedtuple("MockResponse", ["headers", "content"])
 
 
 @control_silo_test
@@ -17,6 +23,8 @@ class OAuth2CallbackViewTest(TestCase):
     def setUp(self):
         sentry.identity.register(DummyProvider)
         super().setUp()
+        self.request = RequestFactory().get("/")
+        self.request.subdomain = None
 
     def tearDown(self):
         super().tearDown()
@@ -30,16 +38,48 @@ class OAuth2CallbackViewTest(TestCase):
             client_secret="secret-value",
         )
 
-    @responses.activate
-    def test_exchange_token_success(self):
-        responses.add(
-            responses.POST, "https://example.org/oauth/token", json={"token": "a-fake-token"}
-        )
-        pipeline = IdentityProviderPipeline(request=Mock(), provider_key="dummy")
+    @mock.patch("sentry.identity.oauth2.safe_urlopen")
+    def test_exchange_token_success(self, safe_urlopen):
+        headers = {"Content-Type": "application/json"}
+        safe_urlopen.return_value = MockResponse(headers, json.dumps({"token": "a-fake-token"}))
+
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
         code = "auth-code"
-        result = self.view.exchange_token(None, pipeline, code)
+        result = self.view.exchange_token(self.request, pipeline, code)
         assert "token" in result
         assert "a-fake-token" == result["token"]
+
+        assert safe_urlopen.called
+        data = safe_urlopen.call_args[1]["data"]
+        assert data == {
+            "client_id": 123456,
+            "client_secret": "secret-value",
+            "code": "auth-code",
+            "grant_type": "authorization_code",
+            "redirect_uri": "http://testserver/extensions/default/setup/",
+        }
+
+    @mock.patch("sentry.identity.oauth2.safe_urlopen")
+    def test_exchange_token_success_customer_domains(self, safe_urlopen):
+        headers = {"Content-Type": "application/json"}
+        safe_urlopen.return_value = MockResponse(headers, json.dumps({"token": "a-fake-token"}))
+
+        self.request.subdomain = "albertos-apples"
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
+        code = "auth-code"
+        result = self.view.exchange_token(self.request, pipeline, code)
+        assert "token" in result
+        assert "a-fake-token" == result["token"]
+
+        assert safe_urlopen.called
+        data = safe_urlopen.call_args[1]["data"]
+        assert data == {
+            "client_id": 123456,
+            "client_secret": "secret-value",
+            "code": "auth-code",
+            "grant_type": "authorization_code",
+            "redirect_uri": "http://albertos-apples.testserver/extensions/default/setup/",
+        }
 
     @responses.activate
     def test_exchange_token_ssl_error(self):
@@ -49,9 +89,9 @@ class OAuth2CallbackViewTest(TestCase):
         responses.add_callback(
             responses.POST, "https://example.org/oauth/token", callback=ssl_error
         )
-        pipeline = IdentityProviderPipeline(request=Mock(), provider_key="dummy")
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
         code = "auth-code"
-        result = self.view.exchange_token(None, pipeline, code)
+        result = self.view.exchange_token(self.request, pipeline, code)
         assert "token" not in result
         assert "error" in result
         assert "error_description" in result
@@ -60,10 +100,64 @@ class OAuth2CallbackViewTest(TestCase):
     @responses.activate
     def test_exchange_token_no_json(self):
         responses.add(responses.POST, "https://example.org/oauth/token", body="")
-        pipeline = IdentityProviderPipeline(request=Mock(), provider_key="dummy")
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
         code = "auth-code"
-        result = self.view.exchange_token(None, pipeline, code)
+        result = self.view.exchange_token(self.request, pipeline, code)
         assert "token" not in result
         assert "error" in result
         assert "error_description" in result
         assert "JSON" in result["error_description"]
+
+
+@control_silo_test
+class OAuth2LoginViewTest(TestCase):
+    def setUp(self):
+        sentry.identity.register(DummyProvider)
+        super().setUp()
+        self.request = RequestFactory().get("/")
+        self.request.session = Client().session
+        self.request.subdomain = None
+
+    def tearDown(self):
+        super().tearDown()
+        sentry.identity.unregister(DummyProvider)
+
+    @fixture
+    def view(self):
+        return OAuth2LoginView(
+            authorize_url="https://example.org/oauth2/authorize",
+            client_id=123456,
+            scope="all-the-things",
+        )
+
+    def test_simple(self):
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
+        response = self.view.dispatch(self.request, pipeline)
+
+        assert response.status_code == 302
+        redirect_url = urlparse(response["Location"])
+        query = parse_qs(redirect_url.query)
+
+        assert query["client_id"][0] == "123456"
+        assert query["redirect_uri"][0] == "http://testserver/extensions/default/setup/"
+        assert query["response_type"][0] == "code"
+        assert query["scope"][0] == "all-the-things"
+        assert "state" in query
+
+    def test_customer_domains(self):
+        self.request.subdomain = "albertos-apples"
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
+        response = self.view.dispatch(self.request, pipeline)
+
+        assert response.status_code == 302
+        redirect_url = urlparse(response["Location"])
+        query = parse_qs(redirect_url.query)
+
+        assert query["client_id"][0] == "123456"
+        assert (
+            query["redirect_uri"][0]
+            == "http://albertos-apples.testserver/extensions/default/setup/"
+        )
+        assert query["response_type"][0] == "code"
+        assert query["scope"][0] == "all-the-things"
+        assert "state" in query


### PR DESCRIPTION
Branched from https://github.com/getsentry/sentry/pull/38970

This is a first pass in updating [`sentry.identity.oauth2`](https://github.com/getsentry/sentry/blob/master/src/sentry/identity/oauth2.py) to support customer domains. 

The motivation is to add SSO support for customer domains by dynamically update `redirect_uri` attributes with the appropriate hostname.

This is not to be confused with https://github.com/getsentry/sentry/pull/38970, I intentionally separated out the changes so that it's easier to review.