### PR TITLE
feat(issues): Allow expanding owners on issue details

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -23,6 +23,7 @@ from sentry.api.serializers import GroupSerializer, GroupSerializerSnuba, serial
 from sentry.api.serializers.models.plugin import PluginSerializer, is_plugin_deprecated
 from sentry.models import Activity, Group, GroupSeen, GroupSubscriptionManager, UserReport
 from sentry.models.groupinbox import get_inbox_details
+from sentry.models.groupowner import get_owner_details
 from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
 from sentry.types.issues import GroupCategory
@@ -202,6 +203,11 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 inbox_map = get_inbox_details([group])
                 inbox_reason = inbox_map.get(group.id)
                 data.update({"inbox": inbox_reason})
+
+            if "owners" in expand:
+                owner_details = get_owner_details([group], request.user)
+                owners = owner_details.get(group.id)
+                data.update({"owners": owners})
 
             action_list = self._get_actions(request, group)
             data.update(


### PR DESCRIPTION
Similar to the group index route, adds the ability to get the group's owners

required for https://getsentry.atlassian.net/browse/WOR-2168