### PR TITLE
feat(commit-context): Update EventFileCommitters endpoint to use GroupOwner assignments

### DIFF
--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -4,7 +4,10 @@ from rest_framework.response import Response
 from sentry import eventstore, features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.commit import CommitSerializer
 from sentry.models import Commit, Group, Release
+from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.utils.committers import (
     get_serialized_event_file_committers,
     get_serialized_release_committers_for_group,
@@ -30,24 +33,51 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
         if event is None:
             return Response({"detail": "Event not found"}, status=404)
 
-        try:
-            committers = get_serialized_event_file_committers(
-                project, event, frame_limit=int(request.GET.get("frameLimit", 25))
+        if features.has("organizations:commit-context", project.organization, actor=request.user):
+            group_owners = GroupOwner.objects.filter(
+                group_id=event.group_id,
+                project=project,
+                organization_id=project.organization_id,
+                type=GroupOwnerType.SUSPECT_COMMIT.value,
+            ).order_by("-date_added")
+            owner = next(filter(lambda go: go.context.get("commitId"), group_owners), None)
+            if not owner:
+                return Response({"committers": []})
+            commit = Commit.objects.get(id=owner.context.get("commitId"))
+
+            return Response(
+                {
+                    "committers": [
+                        {
+                            "author": serialize(owner.user),
+                            "commits": [
+                                serialize(commit, serializer=CommitSerializer(exclude=["author"]))
+                            ],
+                        }
+                    ]
+                }
             )
-        except Group.DoesNotExist:
-            return Response({"detail": "Issue not found"}, status=404)
-        except Release.DoesNotExist:
-            return Response({"detail": "Release not found"}, status=404)
-        except Commit.DoesNotExist:
-            return Response({"detail": "No Commits found for Release"}, status=404)
+        else:
+            try:
+                committers = get_serialized_event_file_committers(
+                    project, event, frame_limit=int(request.GET.get("frameLimit", 25))
+                )
+            except Group.DoesNotExist:
+                return Response({"detail": "Issue not found"}, status=404)
+            except Release.DoesNotExist:
+                return Response({"detail": "Release not found"}, status=404)
+            except Commit.DoesNotExist:
+                return Response({"detail": "No Commits found for Release"}, status=404)
 
-        data = {
-            "committers": committers,
-        }
+            data = {
+                "committers": committers,
+            }
 
-        if features.has(
-            "organizations:release-committer-assignees", project.organization, actor=request.user
-        ):
-            data["releaseCommitters"] = get_serialized_release_committers_for_group(event.group)
+            if features.has(
+                "organizations:release-committer-assignees",
+                project.organization,
+                actor=request.user,
+            ):
+                data["releaseCommitters"] = get_serialized_release_committers_for_group(event.group)
 
-        return Response(data)
+            return Response(data)

--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -1,3 +1,4 @@
+from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -31,7 +32,7 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
         """
         event = eventstore.get_event_by_id(project.id, event_id)
         if event is None:
-            return Response({"detail": "Event not found"}, status=404)
+            raise NotFound(detail="Event not found")
 
         if features.has("organizations:commit-context", project.organization, actor=request.user):
             group_owners = GroupOwner.objects.filter(
@@ -63,11 +64,11 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
                     project, event, frame_limit=int(request.GET.get("frameLimit", 25))
                 )
             except Group.DoesNotExist:
-                return Response({"detail": "Issue not found"}, status=404)
+                raise NotFound(detail="Issue not found")
             except Release.DoesNotExist:
-                return Response({"detail": "Release not found"}, status=404)
+                raise NotFound(detail="Release not found")
             except Commit.DoesNotExist:
-                return Response({"detail": "No Commits found for Release"}, status=404)
+                raise NotFound(detail="No Commits found for Release")
 
             data = {
                 "committers": committers,

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
+from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.releasecommit import ReleaseCommit
 from sentry.models.repository import Repository
 from sentry.testutils import APITestCase
@@ -217,3 +218,55 @@ class EventCommittersTest(APITestCase):
         assert commits[0]["id"] == "a" * 40
 
         assert releaseCommitters[0]["release"]["id"] == release.id
+
+    def test_with_commit_context_feature_flag(self):
+        with self.feature({"organizations:commit-context": True}):
+            self.login_as(user=self.user)
+            self.repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="example",
+                integration_id=self.integration.id,
+            )
+            self.commit = self.create_commit(
+                project=self.project,
+                repo=self.repo,
+                author=self.create_commit_author(project=self.project, user=self.user),
+                key="asdfwreqr",
+                message="placeholder commit message",
+            )
+            event = self.store_event(
+                data={
+                    "fingerprint": ["group1"],
+                    "timestamp": iso_format(before_now(minutes=1)),
+                    "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+                },
+                project_id=self.project.id,
+            )
+
+            GroupOwner.objects.create(
+                group=event.group,
+                user=self.user,
+                project=self.project,
+                organization=self.organization,
+                type=GroupOwnerType.SUSPECT_COMMIT.value,
+                context={"commitId": self.commit.id},
+            )
+
+            url = reverse(
+                "sentry-api-0-event-file-committers",
+                kwargs={
+                    "event_id": event.event_id,
+                    "project_slug": event.project.slug,
+                    "organization_slug": event.project.organization.slug,
+                },
+            )
+
+            response = self.client.get(url, format="json")
+            assert response.status_code == 200, response.content
+            assert len(response.data["committers"]) == 1
+            assert response.data["committers"][0]["author"]["username"] == "admin@localhost"
+            assert len(response.data["committers"][0]["commits"]) == 1
+            assert (
+                response.data["committers"][0]["commits"][0]["message"]
+                == "placeholder commit message"
+            )


### PR DESCRIPTION
## Objective:
If org has the commit-context feature flag, we should send the GroupOwner Suspect Commit assignments. It should match the existing API response.