### PR TITLE
chore(auth): Rename INTEGRATION_EXPIRATION_TTL to PIPELINE_STATE_TTL

### DIFF
--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -16,7 +16,7 @@ from sentry.utils.hashlib import md5_text
 from sentry.web.helpers import render_to_response
 
 from . import PipelineProvider
-from .constants import INTEGRATION_EXPIRATION_TTL
+from .constants import PIPELINE_STATE_TTL
 from .store import PipelineSessionStore
 from .types import PipelineAnalyticsEntry, PipelineRequestState
 
@@ -69,7 +69,7 @@ class Pipeline(abc.ABC):
 
     @classmethod
     def unpack_state(cls, request: Request) -> PipelineRequestState | None:
-        state = cls.session_store_cls(request, cls.pipeline_name, ttl=INTEGRATION_EXPIRATION_TTL)
+        state = cls.session_store_cls(request, cls.pipeline_name, ttl=PIPELINE_STATE_TTL)
         if not state.is_valid():
             return None
 
@@ -99,9 +99,7 @@ class Pipeline(abc.ABC):
     ) -> None:
         self.request = request
         self.organization = organization
-        self.state = self.session_store_cls(
-            request, self.pipeline_name, ttl=INTEGRATION_EXPIRATION_TTL
-        )
+        self.state = self.session_store_cls(request, self.pipeline_name, ttl=PIPELINE_STATE_TTL)
         self.provider_model = provider_model
         self.provider = self.get_provider(provider_key)
 

--- a/src/sentry/pipeline/constants.py
+++ b/src/sentry/pipeline/constants.py
@@ -1,2 +1,2 @@
 # Give users an hour to complete.
-INTEGRATION_EXPIRATION_TTL = 60 * 60
+PIPELINE_STATE_TTL = 60 * 60


### PR DESCRIPTION
We use the pipeline abstraction for things other than integrations such as OAuth2 flows. So I'm renaming `INTEGRATION_EXPIRATION_TTL` to `PIPELINE_STATE_TTL` since it's a descriptive name of what it's used for.