### PR TITLE
fix(grouping): Exception matcher with no frames [INGEST-1577]

### DIFF
--- a/src/sentry/grouping/enhancer/__init__.py
+++ b/src/sentry/grouping/enhancer/__init__.py
@@ -321,7 +321,7 @@ class Rule:
 
         # 1 - Check if exception matchers match
         for m in self._exception_matchers:
-            if not m.matches_frame(frames, -1, platform, exception_data, cache):
+            if not m.matches_frame(frames, None, platform, exception_data, cache):
                 return []
 
         rv = []

--- a/src/sentry/grouping/enhancer/matchers.py
+++ b/src/sentry/grouping/enhancer/matchers.py
@@ -268,6 +268,13 @@ class CategoryMatch(FrameFieldMatch):
 
 
 class ExceptionFieldMatch(FrameMatch):
+    def matches_frame(self, frames, idx, platform, exception_data, cache):
+        match_frame = None
+        rv = self._positive_frame_match(match_frame, platform, exception_data, cache)
+        if self.negated:
+            rv = not rv
+        return rv
+
     def _positive_frame_match(self, frame_data, platform, exception_data, cache):
         field = get_path(exception_data, *self.field_path) or "<unknown>"
         return cached(cache, glob_match, field, self._encoded_pattern)

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -333,6 +333,16 @@ def test_mechanism_matching():
     )
 
 
+def test_mechanism_matching_no_frames():
+    enhancement = Enhancements.from_config_string(
+        """
+        error.mechanism:NSError -app
+    """
+    )
+    (rule,) = enhancement.rules
+    assert _get_matching_frame_actions(rule, [], "python", {"mechanism": {"type": "NSError"}})
+
+
 def test_range_matching():
     enhancement = Enhancements.from_config_string(
         """

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -340,7 +340,14 @@ def test_mechanism_matching_no_frames():
     """
     )
     (rule,) = enhancement.rules
-    assert _get_matching_frame_actions(rule, [], "python", {"mechanism": {"type": "NSError"}})
+    exception_data = {"mechanism": {"type": "NSError"}}
+
+    # Does not crash:
+    assert [] == _get_matching_frame_actions(rule, [], "python", exception_data)
+
+    # Matcher matches:
+    (matcher,) = rule._exception_matchers
+    assert matcher.matches_frame([], None, "python", exception_data, {})
 
 
 def test_range_matching():


### PR DESCRIPTION
We used to pass `-1` as a frame index for exception matchers, which worked by accident because `-1` is a valid list index in Python, except when the list of frames was empty.

Replace `-1` by `None` and make sure we do not attempt to access the list of frames in the exception matcher, by giving it its own `matches_frame` override.

Fixes SENTRY-VWW