### PR TITLE
fix(ts): Numeric data type in discover fields

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -44,7 +44,10 @@ export type ParsedFunction = {
   name: string;
 };
 
-type ValidateColumnValueFunction = ({name: string, dataType: ColumnType}) => boolean;
+type ValidateColumnValueFunction = (data: {
+  dataType: ColumnType;
+  name: string;
+}) => boolean;
 
 export type ValidateColumnTypes =
   | ColumnType[]

--- a/static/app/views/eventsV2/table/types.tsx
+++ b/static/app/views/eventsV2/table/types.tsx
@@ -89,7 +89,7 @@ export type FieldValueColumns =
   | {
       kind: FieldValueKind.NUMERIC_METRICS;
       meta: {
-        dataType: 'numeric';
+        dataType: 'number';
         name: string;
       };
     };


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/pull/38883

Removing one of the last 4 instances where we still get errors in typescript 4.8