### PR TITLE
fix(dashboards): Use localStorage util

### DIFF
--- a/static/app/views/dashboardsV2/manage/utils.tsx
+++ b/static/app/views/dashboardsV2/manage/utils.tsx
@@ -1,3 +1,5 @@
+import localStorage from 'sentry/utils/localStorage';
+
 const SHOW_TEMPLATES_KEY = 'dashboards-show-templates';
 
 export function shouldShowTemplates(): boolean {


### PR DESCRIPTION
Sometimes localStorage is unavailable, in which case it'll be null and accessing getItem causes exceptions. Use the localStorage util that avoids this behaviour.