### PR TITLE
feat(profiling): Pass sort param to profiling transactions endpoint

### DIFF
--- a/static/app/components/profiling/profileTransactionsTable.tsx
+++ b/static/app/components/profiling/profileTransactionsTable.tsx
@@ -1,11 +1,10 @@
-import {useMemo, useState} from 'react';
+import {useMemo} from 'react';
 
 import Count from 'sentry/components/count';
 import DateTime from 'sentry/components/dateTime';
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
   GridColumnOrder,
-  GridColumnSortBy,
 } from 'sentry/components/gridEditable';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import Link from 'sentry/components/links/link';
@@ -16,6 +15,7 @@ import {defined} from 'sentry/utils';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {generateProfileSummaryRouteWithQuery} from 'sentry/utils/profiling/routes';
 import {renderTableHead} from 'sentry/utils/profiling/tableRenderer';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
@@ -23,6 +23,7 @@ import useProjects from 'sentry/utils/useProjects';
 interface ProfileTransactionsTableProps {
   error: string | null;
   isLoading: boolean;
+  sort: string;
   transactions: ProfileTransaction[];
 }
 
@@ -30,24 +31,28 @@ function ProfileTransactionsTable(props: ProfileTransactionsTableProps) {
   const location = useLocation();
   const organization = useOrganization();
   const {projects} = useProjects();
-  const [currentSort, setCurrentSort] = useState<GridColumnSortBy<string> | null>(() => {
-    if (location.query.orderBy) {
-      const [key, order] = (location.query.orderBy as string).split(',');
-      return {
-        key,
-        order,
-      } as GridColumnSortBy<string>;
-    }
-    return null;
-  });
 
-  const sortableColumns = useMemo(
-    () => new Set(['transaction', 'project', 'lastSeen', 'p75', 'p95', 'count']),
-    []
-  );
+  const sort = useMemo(() => {
+    let column = decodeScalar(props.sort, '-count()');
+    let order: 'asc' | 'desc' = 'asc' as const;
+
+    if (column.startsWith('-')) {
+      column = column.substring(1);
+      order = 'desc' as const;
+    }
+
+    if (!SORTABLE_COLUMNS.has(column as any)) {
+      column = 'count()';
+    }
+
+    return {
+      key: column as TableColumnKey,
+      order,
+    };
+  }, [props.sort]);
 
   const transactions: TableDataRow[] = useMemo(() => {
-    const rows = props.transactions.map(transaction => {
+    return props.transactions.map(transaction => {
       const project = projects.find(proj => proj.id === transaction.project_id);
       return {
         _transactionName: transaction.name,
@@ -65,75 +70,30 @@ function ProfileTransactionsTable(props: ProfileTransactionsTableProps) {
         ) : (
           transaction.name
         ),
-        count: transaction.profiles_count,
+        'count()': transaction.profiles_count,
         project,
-        p50: transaction.duration_ms.p50,
-        p75: transaction.duration_ms.p75,
-        p90: transaction.duration_ms.p90,
-        p95: transaction.duration_ms.p95,
-        p99: transaction.duration_ms.p99,
-        lastSeen: transaction.last_profile_at,
+        'p50()': transaction.duration_ms.p50,
+        'p75()': transaction.duration_ms.p75,
+        'p90()': transaction.duration_ms.p90,
+        'p95()': transaction.duration_ms.p95,
+        'p99()': transaction.duration_ms.p99,
+        'last_seen()': transaction.last_profile_at,
       };
     });
-
-    if (currentSort) {
-      rows.sort((txA, txB) => {
-        const column = currentSort.key;
-        switch (column) {
-          case 'transaction':
-            return txA._transactionName.localeCompare(txB._transactionName);
-          case 'lastSeen':
-            return new Date(txA.lastSeen).getTime() - new Date(txB.lastSeen).getTime();
-          case 'project':
-            if (!txA.project?.slug || !txB.project?.slug) {
-              return 1;
-            }
-            return txA.project.slug.localeCompare(txB.project.slug);
-          case 'count':
-            return txA.count - txB.count;
-          case 'p75':
-            return txA.p75 - txB.p75;
-          case 'p95':
-            return txA.p95 - txB.p95;
-          default:
-            return 1;
-        }
-      });
-
-      if (currentSort.order === 'desc') {
-        rows.reverse();
-      }
-    }
-
-    return rows;
-  }, [props.transactions, location, organization, projects, currentSort]);
+  }, [props.transactions, location, organization, projects]);
 
   const generateSortLink = (column: string) => () => {
-    let dir = 'asc';
-    if (column === currentSort?.key && currentSort.order === 'asc') {
-      dir = 'desc';
+    let dir = 'desc';
+    if (column === sort.key && sort.order === dir) {
+      dir = 'asc';
     }
     return {
       ...location,
       query: {
         ...location.query,
-        orderBy: `${column},${dir}`,
+        sort: `${dir === 'desc' ? '-' : ''}${column}`,
       },
     };
-  };
-
-  const handleHeadCellOnClick = (column: GridColumnOrder<string>) => {
-    if (currentSort?.key === column.key) {
-      setCurrentSort({
-        key: column.key,
-        order: currentSort.order === 'asc' ? 'desc' : 'asc',
-      });
-      return;
-    }
-    setCurrentSort({
-      key: column.key,
-      order: 'asc',
-    });
   };
 
   return (
@@ -142,13 +102,12 @@ function ProfileTransactionsTable(props: ProfileTransactionsTableProps) {
       error={props.error}
       data={transactions}
       columnOrder={COLUMN_ORDER.map(key => COLUMNS[key])}
-      columnSortBy={currentSort ? [currentSort] : []}
+      columnSortBy={[sort]}
       grid={{
         renderHeadCell: renderTableHead<string>({
           generateSortLink,
-          onClick: handleHeadCellOnClick,
-          sortableColumns,
-          currentSort,
+          sortableColumns: SORTABLE_COLUMNS,
+          currentSort: sort,
           rightAlignedColumns: RIGHT_ALIGNED_COLUMNS,
         }),
         renderBodyCell: renderTableBody,
@@ -159,12 +118,24 @@ function ProfileTransactionsTable(props: ProfileTransactionsTableProps) {
 }
 
 const RIGHT_ALIGNED_COLUMNS = new Set<TableColumnKey>([
-  'count',
-  'p50',
-  'p75',
-  'p90',
-  'p95',
-  'p99',
+  'count()',
+  'p50()',
+  'p75()',
+  'p90()',
+  'p95()',
+  'p99()',
+]);
+
+const SORTABLE_COLUMNS = new Set<TableColumnKey>([
+  'project',
+  'transaction',
+  'count()',
+  'p50()',
+  'p75()',
+  'p90()',
+  'p95()',
+  'p99()',
+  'last_seen()',
 ]);
 
 function renderTableBody(
@@ -208,23 +179,23 @@ function ProfilingTransactionsTableCell({
           <ProjectBadge project={value} avatarSize={16} />
         </Container>
       );
-    case 'count':
+    case 'count()':
       return (
         <NumberContainer>
           <Count value={value} />
         </NumberContainer>
       );
-    case 'p50':
-    case 'p75':
-    case 'p90':
-    case 'p95':
-    case 'p99':
+    case 'p50()':
+    case 'p75()':
+    case 'p90()':
+    case 'p95()':
+    case 'p99()':
       return (
         <NumberContainer>
           <PerformanceDuration milliseconds={value} abbreviation />
         </NumberContainer>
       );
-    case 'lastSeen':
+    case 'last_seen()':
       return (
         <Container>
           <DateTime date={value} />
@@ -237,14 +208,14 @@ function ProfilingTransactionsTableCell({
 
 type TableColumnKey =
   | 'transaction'
-  | 'count'
+  | 'count()'
   | 'project'
-  | 'p50'
-  | 'p75'
-  | 'p90'
-  | 'p95'
-  | 'p99'
-  | 'lastSeen';
+  | 'p50()'
+  | 'p75()'
+  | 'p90()'
+  | 'p95()'
+  | 'p99()'
+  | 'last_seen()';
 
 type TableDataRow = Record<TableColumnKey, any>;
 
@@ -253,10 +224,10 @@ type TableColumn = GridColumnOrder<TableColumnKey>;
 const COLUMN_ORDER: TableColumnKey[] = [
   'transaction',
   'project',
-  'lastSeen',
-  'p75',
-  'p95',
-  'count',
+  'last_seen()',
+  'p75()',
+  'p95()',
+  'count()',
 ];
 
 const COLUMNS: Record<TableColumnKey, TableColumn> = {
@@ -265,8 +236,8 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
     name: t('Transaction'),
     width: COL_WIDTH_UNDEFINED,
   },
-  count: {
-    key: 'count',
+  'count()': {
+    key: 'count()',
     name: t('Count'),
     width: COL_WIDTH_UNDEFINED,
   },
@@ -275,33 +246,33 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
     name: t('Project'),
     width: COL_WIDTH_UNDEFINED,
   },
-  p50: {
-    key: 'p50',
+  'p50()': {
+    key: 'p50()',
     name: t('P50'),
     width: COL_WIDTH_UNDEFINED,
   },
-  p75: {
-    key: 'p75',
+  'p75()': {
+    key: 'p75()',
     name: t('P75'),
     width: COL_WIDTH_UNDEFINED,
   },
-  p90: {
-    key: 'p90',
+  'p90()': {
+    key: 'p90()',
     name: t('P90'),
     width: COL_WIDTH_UNDEFINED,
   },
-  p95: {
-    key: 'p95',
+  'p95()': {
+    key: 'p95()',
     name: t('P95'),
     width: COL_WIDTH_UNDEFINED,
   },
-  p99: {
-    key: 'p99',
+  'p99()': {
+    key: 'p99()',
     name: t('P99'),
     width: COL_WIDTH_UNDEFINED,
   },
-  lastSeen: {
-    key: 'lastSeen',
+  'last_seen()': {
+    key: 'last_seen()',
     name: t('Last Seen'),
     width: COL_WIDTH_UNDEFINED,
   },

--- a/static/app/utils/profiling/hooks/useProfileTransactions.tsx
+++ b/static/app/utils/profiling/hooks/useProfileTransactions.tsx
@@ -17,6 +17,7 @@ type ProfileTransactionsResult = {
 
 interface UseProfileTransactionsOptions {
   query: string;
+  sort: string;
   cursor?: string;
   limit?: number;
   selection?: PageFilters;
@@ -24,6 +25,7 @@ interface UseProfileTransactionsOptions {
 
 function useProfileTransactions({
   cursor,
+  sort,
   limit,
   query,
   selection,
@@ -44,7 +46,7 @@ function useProfileTransactions({
 
     setRequestState({type: 'loading'});
 
-    fetchTransactions(api, organization, {cursor, limit, query, selection})
+    fetchTransactions(api, organization, {cursor, limit, query, selection, sort})
       .then(([transactions, , response]) => {
         setRequestState({
           type: 'resolved',
@@ -63,7 +65,7 @@ function useProfileTransactions({
       });
 
     return () => api.clear();
-  }, [api, organization, cursor, limit, query, selection]);
+  }, [api, organization, cursor, limit, query, selection, sort]);
 
   return requestState;
 }
@@ -76,11 +78,13 @@ function fetchTransactions(
     limit,
     query,
     selection,
+    sort,
   }: {
     cursor: string | undefined;
     limit: number | undefined;
     query: string;
     selection: PageFilters;
+    sort: string;
   }
 ) {
   return api.requestPromise(
@@ -90,6 +94,7 @@ function fetchTransactions(
       includeAllArgs: true,
       query: {
         cursor,
+        sort,
         query,
         per_page: limit,
         project: selection.projects,

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -85,8 +85,14 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
   const {selection} = usePageFilters();
   const cursor = decodeScalar(location.query.cursor);
   const query = decodeScalar(location.query.query, '');
+  const transactionsSort = decodeScalar(location.query.sort, '-count()');
   const profileFilters = useProfileFilters({query: '', selection});
-  const transactions = useProfileTransactions({cursor, query, selection});
+  const transactions = useProfileTransactions({
+    cursor,
+    query,
+    selection,
+    sort: transactionsSort,
+  });
   const {projects} = useProjects();
 
   useEffect(() => {
@@ -175,6 +181,7 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                           : null
                       }
                       isLoading={transactions.type === 'loading'}
+                      sort={transactionsSort}
                       transactions={
                         transactions.type === 'resolved'
                           ? transactions.data.transactions


### PR DESCRIPTION
This will pass the sort param to the endpoint in order to allow the backend to do the sorting instead of relying on sorting the data on the frontend.