### PR TITLE
feat(metrics): Make metrics layer accept MRI directly [TET-321]

### DIFF
--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -18,7 +18,7 @@ from sentry.utils.dates import to_timestamp
 # TODO: Add __all__ to be consistent with sibling modules
 from ...models import ONE_DAY
 from ...release_health.base import AllowedResolution
-from .naming_layer.mapping import get_mri
+from .naming_layer.mapping import get_public_name_from_mri
 from .utils import (
     MAX_POINTS,
     OPERATIONS,
@@ -31,7 +31,7 @@ from .utils import (
 @dataclass(frozen=True)
 class MetricField:
     op: Optional[MetricOperationType]
-    metric_name: str
+    metric_mri: str
     params: Optional[Dict[str, Union[str, int, float]]] = None
     alias: Optional[str] = None
 
@@ -39,11 +39,13 @@ class MetricField:
         # ToDo(ahmed): Once we allow MetricField to accept MRI, we should set the alias to the operation and public
         #  facing name
         if not self.alias:
-            key = f"{self.op}({self.metric_name})" if self.op is not None else self.metric_name
+            metric_name = get_public_name_from_mri(self.metric_mri)
+            key = f"{self.op}({metric_name})" if self.op is not None else metric_name
             object.__setattr__(self, "alias", key)
 
     def __str__(self) -> str:
-        return f"{self.op}({self.metric_name})" if self.op else self.metric_name
+        metric_name = get_public_name_from_mri(self.metric_mri)
+        return f"{self.op}({metric_name})" if self.op else metric_name
 
 
 @dataclass(frozen=True)
@@ -113,16 +115,15 @@ class MetricsQuery(MetricsQueryValidationRunner):
     @staticmethod
     def _validate_field(field: MetricField) -> None:
         derived_metrics_mri = get_derived_metrics(exclude_private=True)
-        metric_mri = get_mri(field.metric_name)
 
         if field.op:
             if field.op not in OPERATIONS:
                 raise InvalidParams(
                     f"Invalid operation '{field.op}'. Must be one of {', '.join(OPERATIONS)}"
                 )
-            if metric_mri in derived_metrics_mri:
+            if field.metric_mri in derived_metrics_mri:
                 raise DerivedMetricParseException(
-                    f"Failed to parse {field.op}({field.metric_name}). No operations can be "
+                    f"Failed to parse {field.op}({get_public_name_from_mri(field.metric_mri)}). No operations can be "
                     f"applied on this field as it is already a derived metric with an "
                     f"aggregation applied to it."
                 )
@@ -132,8 +133,7 @@ class MetricsQuery(MetricsQueryValidationRunner):
             raise InvalidParams('Request is missing a "field"')
         use_case_ids = set()
         for field in self.select:
-            metric_mri = get_mri(field.metric_name)
-            use_case_ids.add(self._use_case_id(metric_mri))
+            use_case_ids.add(self._use_case_id(field.metric_mri))
             self._validate_field(field)
         if len(use_case_ids) > 1:
             raise InvalidParams("All select fields should have the same use_case_id")
@@ -161,11 +161,10 @@ class MetricsQuery(MetricsQueryValidationRunner):
         for f in self.orderby:
             orderby_fields.add(f.field)
 
-            metric_mri = get_mri(f.field.metric_name)
             # Construct a metrics expression
-            metric_field_obj = metric_object_factory(f.field.op, metric_mri)
+            metric_field_obj = metric_object_factory(f.field.op, f.field.metric_mri)
 
-            use_case_id = self._use_case_id(metric_mri)
+            use_case_id = self._use_case_id(f.field.metric_mri)
             entity = metric_field_obj.get_entity(self.project_ids, use_case_id)
 
             if isinstance(entity, Mapping):

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -1629,11 +1629,15 @@ class DerivedMetricsDataTest(MetricsAPIBaseTestCase):
     @patch("sentry.snuba.metrics.query.parse_mri")
     @patch("sentry.snuba.metrics.fields.base.get_public_name_from_mri")
     @patch("sentry.snuba.metrics.query_builder.get_mri")
-    @patch("sentry.snuba.metrics.query.get_mri")
+    @patch("sentry.snuba.metrics.query.get_public_name_from_mri")
     def test_derived_metric_incorrectly_defined_as_singular_entity(
-        self, mocked_get_mri, mocked_get_mri_query, mocked_reverse_mri, mocked_parse_mri
+        self,
+        mocked_get_public_name_from_mri,
+        mocked_get_mri_query,
+        mocked_reverse_mri,
+        mocked_parse_mri,
     ):
-        mocked_get_mri.return_value = "crash_free_fake"
+        mocked_get_public_name_from_mri.return_value = "crash_free_fake"
         mocked_get_mri_query.return_value = "crash_free_fake"
         mocked_reverse_mri.return_value = "crash_free_fake"
         mocked_parse_mri.return_value = ParsedMRI("e", "sessions", "crash_free_fake", "none")

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -89,12 +89,12 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="count",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                     alias="count_lcp",
                 ),
                 MetricField(
                     op="count",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_FCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_FCP.value,
                     alias="count_fcp",
                 ),
             ],
@@ -106,7 +106,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 OrderBy(
                     MetricField(
                         op="count",
-                        metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                        metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                         alias="count_lcp",
                     ),
                     Direction.DESC,
@@ -114,7 +114,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 OrderBy(
                     MetricField(
                         op="count",
-                        metric_name=TransactionMetricKey.MEASUREMENTS_FCP.value,
+                        metric_mri=TransactionMRI.MEASUREMENTS_FCP.value,
                         alias="count_fcp",
                     ),
                     Direction.DESC,
@@ -174,12 +174,12 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="count",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                     alias="count_lcp",
                 ),
                 MetricField(
                     op="count",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                     alias="count_lcp_2",
                 ),
             ],
@@ -193,7 +193,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 OrderBy(
                     MetricField(
                         op="count",
-                        metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                        metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                         alias="count_lcp",
                     ),
                     Direction.DESC,
@@ -201,7 +201,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 OrderBy(
                     MetricField(
                         op="count",
-                        metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                        metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                         alias="count_lcp_2",
                     ),
                     Direction.DESC,
@@ -265,7 +265,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op=None,
-                    metric_name=TransactionMetricKey.FAILURE_RATE.value,
+                    metric_mri=TransactionMRI.FAILURE_RATE.value,
                     alias="failure_rate_alias",
                 ),
             ],
@@ -333,12 +333,12 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="p50",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                     alias="p50_lcp",
                 ),
                 MetricField(
                     op="p50",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_FCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_FCP.value,
                     alias="p50_fcp",
                 ),
             ],
@@ -353,7 +353,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 OrderBy(
                     MetricField(
                         op="p50",
-                        metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                        metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                         alias="p50_lcp",
                     ),
                     direction=Direction.ASC,
@@ -430,7 +430,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 MetricField(
                     op="histogram",
                     # ToDo(ahmed): Replace this with MRI once we make MetricsQuery accept MRI
-                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                     params={
                         "histogram_from": 2,
                         "histogram_to": None,
@@ -440,7 +440,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 ),
                 MetricField(
                     op="histogram",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                     params={
                         "histogram_from": None,
                         "histogram_to": 9,
@@ -500,12 +500,12 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="rate",
-                    metric_name=TransactionMetricKey.DURATION.value,
+                    metric_mri=TransactionMRI.DURATION.value,
                     params={"numerator": 3600, "denominator": 60},
                 ),
                 MetricField(
                     op="count",
-                    metric_name=TransactionMetricKey.DURATION.value,
+                    metric_mri=TransactionMRI.DURATION.value,
                 ),
             ],
             start=start,
@@ -562,7 +562,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="rate",
-                    metric_name=TransactionMetricKey.DURATION.value,
+                    metric_mri=TransactionMRI.DURATION.value,
                     params={"numerator": 86400, "denominator": 60},
                 ),
             ],
@@ -629,12 +629,12 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="rate",
-                    metric_name=TransactionMetricKey.DURATION.value,
+                    metric_mri=TransactionMRI.DURATION.value,
                     params={"numerator": 3600, "denominator": 60},
                 ),
                 MetricField(
                     op="count",
-                    metric_name=TransactionMetricKey.DURATION.value,
+                    metric_mri=TransactionMRI.DURATION.value,
                 ),
             ],
             start=day_ago + timedelta(minutes=30),
@@ -687,12 +687,12 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="rate",
-                    metric_name=TransactionMetricKey.DURATION.value,
+                    metric_mri=TransactionMRI.DURATION.value,
                     params={"numerator": 60},
                 ),
                 MetricField(
                     op="count",
-                    metric_name=TransactionMetricKey.DURATION.value,
+                    metric_mri=TransactionMRI.DURATION.value,
                 ),
             ],
             start=start,
@@ -750,7 +750,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="rate",
-                    metric_name=TransactionMetricKey.DURATION.value,
+                    metric_mri=TransactionMRI.DURATION.value,
                 ),
             ],
             start=start,
@@ -832,31 +832,31 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="count_web_vitals",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_LCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
                     params={"measurement_rating": "good"},
                     alias="count_web_vitals_measurements_lcp_good",
                 ),
                 MetricField(
                     op="count_web_vitals",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_FP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_FP.value,
                     params={"measurement_rating": "good"},
                     alias="count_web_vitals_measurements_fp_good",
                 ),
                 MetricField(
                     op="count_web_vitals",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_FCP.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_FCP.value,
                     params={"measurement_rating": "meh"},
                     alias="count_web_vitals_measurements_fcp_meh",
                 ),
                 MetricField(
                     op="count_web_vitals",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_FID.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_FID.value,
                     params={"measurement_rating": "meh"},
                     alias="count_web_vitals_measurements_fid_meh",
                 ),
                 MetricField(
                     op="count_web_vitals",
-                    metric_name=TransactionMetricKey.MEASUREMENTS_CLS.value,
+                    metric_mri=TransactionMRI.MEASUREMENTS_CLS.value,
                     params={"measurement_rating": "good"},
                     alias="count_web_vitals_measurements_cls_good",
                 ),

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
@@ -10,7 +10,7 @@ from snuba_sdk import Granularity, Limit, Offset
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.snuba.metrics import MetricField, MetricsQuery
 from sentry.snuba.metrics.datasource import get_series
-from sentry.snuba.metrics.naming_layer import SessionMetricKey, SessionMRI
+from sentry.snuba.metrics.naming_layer import SessionMRI
 from sentry.snuba.metrics.query_builder import QueryDefinition, get_date_range
 from sentry.testutils import BaseMetricsTestCase, TestCase
 
@@ -121,7 +121,7 @@ class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op=None,
-                    metric_name=str(SessionMetricKey.ERRORED.value),
+                    metric_mri=str(SessionMRI.ERRORED.value),
                     alias="errored_sessions_alias",
                 ),
             ],
@@ -179,7 +179,7 @@ class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="histogram",
-                    metric_name="sentry.sessions.session.duration",
+                    metric_mri=SessionMRI.RAW_DURATION.value,
                     params={
                         "histogram_from": 2,
                         "histogram_buckets": 2,
@@ -215,7 +215,7 @@ class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             select=[
                 MetricField(
                     op="histogram",
-                    metric_name=SessionMetricKey.DURATION.value,
+                    metric_mri=SessionMRI.DURATION.value,
                     params={
                         "histogram_from": 2,
                         "histogram_buckets": 2,

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -17,13 +17,12 @@ from sentry.snuba.metrics import (
     OrderBy,
     parse_query,
 )
-from sentry.snuba.metrics.naming_layer import SessionMetricKey
-from sentry.snuba.metrics.naming_layer.public import TransactionMetricKey
+from sentry.snuba.metrics.naming_layer import SessionMRI, TransactionMRI
 from sentry.utils.dates import parse_stats_period
 
 
 class MetricsQueryBuilder:
-    AVG_DURATION_METRIC = MetricField(op="avg", metric_name=SessionMetricKey.DURATION.value)
+    AVG_DURATION_METRIC = MetricField(op="avg", metric_mri=SessionMRI.DURATION.value)
 
     def __init__(self):
         now = datetime.now()
@@ -109,7 +108,7 @@ def test_validate_select():
     ):
         MetricsQuery(
             **MetricsQueryBuilder()
-            .with_select([MetricField(op="foo", metric_name=SessionMetricKey.DURATION.value)])
+            .with_select([MetricField(op="foo", metric_mri=SessionMRI.DURATION.value)])
             .to_metrics_query_dict()
         )
     with pytest.raises(
@@ -124,17 +123,15 @@ def test_validate_select():
     ):
         MetricsQuery(
             **MetricsQueryBuilder()
-            .with_select(
-                [MetricField(op="sum", metric_name=SessionMetricKey.CRASH_FREE_RATE.value)]
-            )
+            .with_select([MetricField(op="sum", metric_mri=SessionMRI.CRASH_FREE_RATE.value)])
             .to_metrics_query_dict()
         )
 
 
 def test_validate_select_invalid_use_case_ids():
     with pytest.raises(InvalidParams, match="All select fields should have the same use_case_id"):
-        metric_field_1 = MetricField(op=None, metric_name=SessionMetricKey.CRASH_FREE_RATE.value)
-        metric_field_2 = MetricField(op="p50", metric_name=TransactionMetricKey.DURATION.value)
+        metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.CRASH_FREE_RATE.value)
+        metric_field_2 = MetricField(op="p50", metric_mri=TransactionMRI.DURATION.value)
         MetricsQuery(
             **MetricsQueryBuilder()
             .with_select([metric_field_1, metric_field_2])
@@ -152,7 +149,7 @@ def test_validate_order_by():
             .with_orderby(
                 [
                     OrderBy(
-                        field=MetricField(op="foo", metric_name=SessionMetricKey.DURATION.value),
+                        field=MetricField(op="foo", metric_mri=SessionMRI.DURATION.value),
                         direction=Direction.ASC,
                     )
                 ]
@@ -174,9 +171,7 @@ def test_validate_order_by():
             .with_orderby(
                 [
                     OrderBy(
-                        field=MetricField(
-                            op="sum", metric_name=SessionMetricKey.CRASH_FREE_RATE.value
-                        ),
+                        field=MetricField(op="sum", metric_mri=SessionMRI.CRASH_FREE_RATE.value),
                         direction=Direction.ASC,
                     )
                 ]
@@ -186,7 +181,7 @@ def test_validate_order_by():
 
 
 def test_validate_order_by_field_in_select():
-    metric_field_2 = MetricField(op=None, metric_name=SessionMetricKey.ALL.value)
+    metric_field_2 = MetricField(op=None, metric_mri=SessionMRI.ALL.value)
     metrics_query_dict = (
         MetricsQueryBuilder()
         .with_orderby([OrderBy(field=metric_field_2, direction=Direction.ASC)])
@@ -208,8 +203,8 @@ def test_validate_order_by_field_in_select():
 
 
 def test_validate_multiple_orderby_columns_not_specified_in_select():
-    metric_field_1 = MetricField(op=None, metric_name=SessionMetricKey.ABNORMAL.value)
-    metric_field_2 = MetricField(op=None, metric_name=SessionMetricKey.ALL.value)
+    metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.ABNORMAL.value)
+    metric_field_2 = MetricField(op=None, metric_mri=SessionMRI.ALL.value)
     metrics_query_dict = (
         MetricsQueryBuilder()
         .with_select([MetricsQueryBuilder.AVG_DURATION_METRIC, metric_field_1])
@@ -233,9 +228,9 @@ def test_validate_multiple_order_by_fields_from_multiple_entities():
     The example should fail because session crash free rate is generated from
     counters entity while p50 of duration will go to distribution
     """
-    metric_field_1 = MetricField(op=None, metric_name=SessionMetricKey.CRASH_FREE_RATE.value)
-    metric_field_2 = MetricField(op=None, metric_name=SessionMetricKey.CRASH_FREE_USER_RATE.value)
-    metric_field_3 = MetricField(op="p50", metric_name=TransactionMetricKey.DURATION.value)
+    metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.CRASH_FREE_RATE.value)
+    metric_field_2 = MetricField(op=None, metric_mri=SessionMRI.CRASH_FREE_USER_RATE.value)
+    metric_field_3 = MetricField(op="p50", metric_mri=TransactionMRI.DURATION.value)
     metrics_query_dict = (
         MetricsQueryBuilder()
         .with_select([metric_field_1, metric_field_2])
@@ -261,8 +256,8 @@ def test_validate_multiple_orderby_derived_metrics_from_different_entities():
     This example should fail because session crash free rate is generated from
     counters while session user crash free rate is generated from sets
     """
-    metric_field_1 = MetricField(op=None, metric_name=SessionMetricKey.CRASH_FREE_RATE.value)
-    metric_field_2 = MetricField(op=None, metric_name=SessionMetricKey.CRASH_FREE_USER_RATE.value)
+    metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.CRASH_FREE_RATE.value)
+    metric_field_2 = MetricField(op=None, metric_mri=SessionMRI.CRASH_FREE_USER_RATE.value)
     metrics_query_dict = (
         MetricsQueryBuilder()
         .with_select([metric_field_1, metric_field_2])
@@ -287,8 +282,8 @@ def test_validate_many_order_by_fields_are_in_select():
     """
     Validate no exception is raised when all orderBy fields are presented the select
     """
-    metric_field_1 = MetricField(op=None, metric_name=SessionMetricKey.ABNORMAL.value)
-    metric_field_2 = MetricField(op=None, metric_name=SessionMetricKey.ALL.value)
+    metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.ABNORMAL.value)
+    metric_field_2 = MetricField(op=None, metric_mri=SessionMRI.ALL.value)
 
     metrics_query_dict = (
         MetricsQueryBuilder()
@@ -318,8 +313,8 @@ def test_validate_many_order_by_fields_are_in_select():
 
     # This example should pass because both session crash free rate
     # and sum(session) both go to the entity counters
-    metric_field_1 = MetricField(op=None, metric_name=SessionMetricKey.CRASH_FREE_RATE.value)
-    metric_field_2 = MetricField(op="sum", metric_name="sentry.sessions.session")
+    metric_field_1 = MetricField(op=None, metric_mri=SessionMRI.CRASH_FREE_RATE.value)
+    metric_field_2 = MetricField(op="sum", metric_mri=SessionMRI.SESSION.value)
     metrics_query_dict = (
         MetricsQueryBuilder()
         .with_select([metric_field_1, metric_field_2])
@@ -341,8 +336,8 @@ def test_validate_functions_from_multiple_entities_in_orderby():
     # `avg` are in OP_TO_SNUBA_FUNCTION["metrics_distributions"].keys()
     # but
     # `count_unique` are in OP_TO_SNUBA_FUNCTION["metrics_sets"].keys()
-    metric_field_1 = MetricField(op="avg", metric_name=TransactionMetricKey.DURATION.value)
-    metric_field_2 = MetricField(op="count_unique", metric_name=TransactionMetricKey.USER.value)
+    metric_field_1 = MetricField(op="avg", metric_mri=TransactionMRI.DURATION.value)
+    metric_field_2 = MetricField(op="count_unique", metric_mri=TransactionMRI.USER.value)
 
     metrics_query_dict = (
         MetricsQueryBuilder()
@@ -367,8 +362,8 @@ def test_validate_functions_from_multiple_entities_in_orderby():
 
 def test_validate_distribution_functions_in_orderby():
     # Validate no exception is raised when all orderBy fields are presented the select
-    metric_field_1 = MetricField(op="avg", metric_name=TransactionMetricKey.DURATION.value)
-    metric_field_2 = MetricField(op="p50", metric_name=TransactionMetricKey.DURATION.value)
+    metric_field_1 = MetricField(op="avg", metric_mri=TransactionMRI.DURATION.value)
+    metric_field_2 = MetricField(op="p50", metric_mri=TransactionMRI.DURATION.value)
 
     metrics_query_dict = (
         MetricsQueryBuilder()

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -289,9 +289,9 @@ def test_build_snuba_query(mock_now, mock_now2):
         org_id=1,
         project_ids=[1],
         select=[
-            MetricField("sum", "sentry.sessions.session"),
-            MetricField("count_unique", "sentry.sessions.user"),
-            MetricField("p95", "sentry.sessions.session.duration"),
+            MetricField("sum", SessionMRI.SESSION.value),
+            MetricField("count_unique", SessionMRI.USER.value),
+            MetricField("p95", SessionMRI.RAW_DURATION.value),
         ],
         start=MOCK_NOW - timedelta(days=90),
         end=MOCK_NOW,


### PR DESCRIPTION
The metrics layer entrypoint which is the `MetricsQuery` object used to accept public names. As public names is not the naming contract we guarantee not to change, this PR allows `MetricQuery` object to directly accept MRI as that is the naming contract we guarantee

