### PR TITLE
fix(mep): Include the column so its countmerge

### DIFF
--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -143,6 +143,7 @@ class MetricsDatasetConfig(DatasetConfig):
                     snql_distribution=lambda args, alias: Function(
                         "countIf",
                         [
+                            Column("value"),
                             Function(
                                 "and",
                                 [
@@ -161,7 +162,7 @@ class MetricsDatasetConfig(DatasetConfig):
                                         ],
                                     ),
                                 ],
-                            )
+                            ),
                         ],
                         alias,
                     ),
@@ -174,6 +175,7 @@ class MetricsDatasetConfig(DatasetConfig):
                     snql_distribution=lambda args, alias: Function(
                         "countIf",
                         [
+                            Column("value"),
                             Function(
                                 "and",
                                 [
@@ -192,7 +194,7 @@ class MetricsDatasetConfig(DatasetConfig):
                                         ],
                                     ),
                                 ],
-                            )
+                            ),
                         ],
                         alias,
                     ),
@@ -203,6 +205,7 @@ class MetricsDatasetConfig(DatasetConfig):
                     snql_distribution=lambda args, alias: Function(
                         "countIf",
                         [
+                            Column("value"),
                             Function(
                                 "and",
                                 [
@@ -237,7 +240,7 @@ class MetricsDatasetConfig(DatasetConfig):
                                         ],
                                     ),
                                 ],
-                            )
+                            ),
                         ],
                         alias,
                     ),


### PR DESCRIPTION
- This was causing these results to overcount since we werent merging rows correctly. For the purposes of the endpoint we just needed >0 so it wasn't as noticeable
