### PR TITLE
feat(perf-vitals): Add INP to the backend

### DIFF
--- a/src/sentry/api/endpoints/organization_events_has_measurements.py
+++ b/src/sentry/api/endpoints/organization_events_has_measurements.py
@@ -18,6 +18,7 @@ MEASUREMENT_TYPES = {
         "measurements.fcp",
         "measurements.lcp",
         "measurements.fid",
+        "measurements.inp",
         "measurements.cls",
     ],
     "mobile": [

--- a/src/sentry/api/endpoints/organization_events_vitals.py
+++ b/src/sentry/api/endpoints/organization_events_vitals.py
@@ -15,6 +15,7 @@ class OrganizationEventsVitalsEndpoint(OrganizationEventsV2EndpointBase):
     VITALS = {
         "measurements.lcp": {"thresholds": [0, 2500, 4000]},
         "measurements.fid": {"thresholds": [0, 100, 300]},
+        "measurements.inp": {"thresholds": [0, 200, 500]},
         "measurements.cls": {"thresholds": [0, 0.1, 0.25]},
         "measurements.fcp": {"thresholds": [0, 1000, 3000]},
         "measurements.fp": {"thresholds": [0, 1000, 3000]},

--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -157,6 +157,7 @@ class ArithmeticVisitor(NodeVisitor):
         "measurements.fcp",
         "measurements.lcp",
         "measurements.fid",
+        "measurements.inp",
         "measurements.ttfb",
         "measurements.ttfb.requesttime",
     }

--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -63,6 +63,10 @@ VITAL_THRESHOLDS: Dict[str, ThresholdDict] = {
         "poor": 300,
         "meh": 100,
     },
+    "inp": {
+        "poor": 500,
+        "meh": 200,
+    },
     "cls": {
         "poor": 0.25,
         "meh": 0.1,
@@ -209,6 +213,7 @@ METRICS_MAP = {
     "measurements.cls": "d:transactions/measurements.cls@none",
     "measurements.fcp": "d:transactions/measurements.fcp@millisecond",
     "measurements.fid": "d:transactions/measurements.fid@millisecond",
+    "measurements.inp": "d:transactions/measurements.inp@millisecond",
     "measurements.fp": "d:transactions/measurements.fp@millisecond",
     "measurements.frames_frozen": "d:transactions/measurements.frames_frozen@none",
     "measurements.frames_slow": "d:transactions/measurements.frames_slow@none",

--- a/src/sentry/search/events/datasets/metrics.py
+++ b/src/sentry/search/events/datasets/metrics.py
@@ -521,6 +521,7 @@ class MetricsDatasetConfig(DatasetConfig):
                                 "measurements.fcp",
                                 "measurements.lcp",
                                 "measurements.fid",
+                                "measurements.inp",
                                 "measurements.cls",
                             ],
                             allow_custom_measurements=False,
@@ -1149,6 +1150,7 @@ class MetricsDatasetConfig(DatasetConfig):
             "measurements.fcp",
             "measurements.fp",
             "measurements.fid",
+            "measurements.inp",
             "measurements.cls",
         ]:
             raise InvalidSearchQuery("count_web_vitals only supports measurements")

--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -71,6 +71,7 @@ TRANSACTION_METRICS_NAMES = {
     "d:transactions/breakdowns.span_ops.ops.browser@millisecond": PREFIX + 122,
     "d:transactions/breakdowns.span_ops.ops.resource@millisecond": PREFIX + 123,
     "d:transactions/breakdowns.span_ops.ops.ui@millisecond": PREFIX + 124,
+    "d:transactions/measurements.inp@millisecond": PREFIX + 125,
 }
 
 # 200 - 299

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -77,6 +77,7 @@ class TransactionMRI(Enum):
     MEASUREMENTS_APP_START_WARM = "d:transactions/measurements.app_start_warm@millisecond"
     MEASUREMENTS_CLS = "d:transactions/measurements.cls@none"
     MEASUREMENTS_FID = "d:transactions/measurements.fid@millisecond"
+    MEASUREMENTS_INP = "d:transactions/measurements.inp@millisecond"
     MEASUREMENTS_FP = "d:transactions/measurements.fp@millisecond"
     MEASUREMENTS_FRAMES_FROZEN = "d:transactions/measurements.frames_frozen@none"
     MEASUREMENTS_FRAMES_FROZEN_RATE = "d:transactions/measurements.frames_frozen_rate@ratio"

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -65,6 +65,7 @@ class TransactionMetricKey(Enum):
     MEASUREMENTS_APP_START_WARM = "transaction.measurements.app_start_warm"
     MEASUREMENTS_CLS = "transaction.measurements.cls"
     MEASUREMENTS_FID = "transaction.measurements.fid"
+    MEASUREMENTS_INP = "transaction.measurements.inp"
     MEASUREMENTS_FP = "transaction.measurements.fp"
     MEASUREMENTS_FRAMES_FROZEN = "transaction.measurements.frames_frozen"
     MEASUREMENTS_FRAMES_FROZEN_RATE = "transaction.measurements.frames_frozen_rate"

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1235,6 +1235,7 @@ class MetricsEnhancedPerformanceTestCase(BaseMetricsTestCase, TestCase):
         "measurements.fp": "metrics_distributions",
         "measurements.fcp": "metrics_distributions",
         "measurements.fid": "metrics_distributions",
+        "measurements.inp": "metrics_distributions",
         "measurements.cls": "metrics_distributions",
         "measurements.frames_frozen_rate": "metrics_distributions",
         "spans.http": "metrics_distributions",

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1448,6 +1448,7 @@ def is_duration_measurement(key):
         "measurements.fcp",
         "measurements.lcp",
         "measurements.fid",
+        "measurements.inp",
         "measurements.ttfb",
         "measurements.ttfb.requesttime",
         "measurements.app_start_cold",

--- a/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_project_config_with_breakdown/with_metrics.pysnap
@@ -926,6 +926,7 @@ transactionMetrics:
   - d:transactions/measurements.cls@none
   - d:transactions/measurements.fcp@millisecond
   - d:transactions/measurements.fid@millisecond
+  - d:transactions/measurements.inp@millisecond
   - d:transactions/measurements.fp@millisecond
   - d:transactions/measurements.frames_frozen@none
   - d:transactions/measurements.frames_frozen_rate@ratio

--- a/tests/sentry/search/events/test_builder.py
+++ b/tests/sentry/search/events/test_builder.py
@@ -898,6 +898,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
                 "p90(measurements.fcp)",
                 "p95(measurements.cls)",
                 "p99(measurements.fid)",
+                "p99(measurements.inp)",
             ],
         )
         self.assertCountEqual(
@@ -912,6 +913,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
                         "measurements.fcp",
                         "measurements.cls",
                         "measurements.fid",
+                        "measurements.inp",
                     ],
                 ),
             ],
@@ -924,6 +926,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
                 _metric_percentile_definition(self.organization.id, "90", "measurements.fcp"),
                 _metric_percentile_definition(self.organization.id, "95", "measurements.cls"),
                 _metric_percentile_definition(self.organization.id, "99", "measurements.fid"),
+                _metric_percentile_definition(self.organization.id, "99", "measurements.inp"),
             ],
         )
 

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -802,6 +802,12 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 125,
             ),
             (
+                {"measurement_rating": "meh", "transaction": "foo_transaction"},
+                TransactionMetricKey.MEASUREMENTS_INP.value,
+                TransactionMRI.MEASUREMENTS_INP.value,
+                300,
+            ),
+            (
                 {"measurement_rating": "good", "transaction": "foo_transaction"},
                 TransactionMetricKey.MEASUREMENTS_CLS.value,
                 TransactionMRI.MEASUREMENTS_CLS.value,
@@ -856,6 +862,12 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 ),
                 MetricField(
                     op="count_web_vitals",
+                    metric_mri=TransactionMRI.MEASUREMENTS_INP.value,
+                    params={"measurement_rating": "meh"},
+                    alias="count_web_vitals_measurements_inp_meh",
+                ),
+                MetricField(
+                    op="count_web_vitals",
                     metric_mri=TransactionMRI.MEASUREMENTS_CLS.value,
                     params={"measurement_rating": "good"},
                     alias="count_web_vitals_measurements_cls_good",
@@ -888,12 +900,14 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
         assert group_totals["count_web_vitals_measurements_fcp_meh"] == 1
         assert group_totals["count_web_vitals_measurements_cls_good"] == 1
         assert group_totals["count_web_vitals_measurements_fid_meh"] == 1
+        assert group_totals["count_web_vitals_measurements_inp_meh"] == 1
 
         assert data["meta"] == sorted(
             [
                 {"name": "count_web_vitals_measurements_cls_good", "type": "UInt64"},
                 {"name": "count_web_vitals_measurements_fcp_meh", "type": "UInt64"},
                 {"name": "count_web_vitals_measurements_fid_meh", "type": "UInt64"},
+                {"name": "count_web_vitals_measurements_inp_meh", "type": "UInt64"},
                 {"name": "count_web_vitals_measurements_fp_good", "type": "UInt64"},
                 {"name": "count_web_vitals_measurements_lcp_good", "type": "UInt64"},
                 {"name": "transaction", "type": "string"},

--- a/tests/sentry/snuba/test_discover_query.py
+++ b/tests/sentry/snuba/test_discover_query.py
@@ -2972,6 +2972,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
                 "measurements.fcp",
                 "measurements.lcp",
                 "measurements.fid",
+                "measurements.inp",
                 "measurements.cls",
                 "measurements.does_not_exist",
             ],
@@ -2985,6 +2986,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         assert data[0]["measurements.fcp"] == event_data["measurements"]["fcp"]["value"]
         assert data[0]["measurements.lcp"] == event_data["measurements"]["lcp"]["value"]
         assert data[0]["measurements.fid"] == event_data["measurements"]["fid"]["value"]
+        assert data[0]["measurements.inp"] == event_data["measurements"]["inp"]["value"]
         assert data[0]["measurements.cls"] == event_data["measurements"]["cls"]["value"]
         assert data[0]["measurements.does_not_exist"] is None
 


### PR DESCRIPTION
This adds INP as a web vital queryable to the backend, as well as adding it in the vitals endpoints, and adding it to the metrics layer since it should also be fetched as a metric as well.

Note: This is a draft for now since we don't necessarily want to turn this on until the js sdk is setup to send it. It will be a bit before this graduates into a real PR.
