### PR TITLE
chore(hybrid-cloud): Delegate pipeline redis store to propagate customer domain

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from urllib.parse import urlparse
 
 from django.utils import timezone
-from rest_framework.request import Request
 
 from sentry import options
 from sentry.auth.access import get_cached_organization_member
@@ -183,10 +182,3 @@ def generate_region_url() -> str:
     if not region_url_template or not region:
         return options.get("system.url-prefix")
     return region_url_template.replace("{region}", region)
-
-
-def generate_url_prefix(request: Request) -> str:
-    url_prefix = options.get("system.url-prefix")
-    if request.subdomain:
-        url_prefix = generate_organization_url(request.subdomain)
-    return url_prefix

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -20,6 +20,7 @@ from django.views import View
 
 from sentry import audit_log, features
 from sentry.api.invite_helper import ApiInviteHelper, remove_invite_cookie
+from sentry.api.utils import generate_organization_url
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.idpmigration import (
@@ -190,17 +191,26 @@ class AuthIdentityHandler:
         user = auth_identity.user
         user.backend = settings.AUTHENTICATION_BACKENDS[0]
 
+        data = state.data
+        subdomain = None
+        if data:
+            subdomain = data.get("subdomain") or None
+        login_redirect_url = auth.get_login_redirect(self.request)
+        if subdomain is not None:
+            url_prefix = generate_organization_url(subdomain)
+            login_redirect_url = absolute_uri(login_redirect_url, url_prefix=url_prefix)
+
         try:
             self._login(user)
         except self._NotCompletedSecurityChecks:
-            return HttpResponseRedirect(auth.get_login_redirect(self.request))
+            return HttpResponseRedirect(login_redirect_url)
 
         state.clear()
 
         if not is_active_superuser(self.request):
             # set activeorg to ensure correct redirect upon logging in
             auth.set_active_org(self.request, self.organization.slug)
-        return HttpResponseRedirect(auth.get_login_redirect(self.request))
+        return HttpResponseRedirect(login_redirect_url)
 
     def _handle_new_membership(self, auth_identity: AuthIdentity) -> Optional[OrganizationMember]:
         user = auth_identity.user
@@ -679,8 +689,8 @@ class AuthHelper(Pipeline):
         state.update({"flow": self.flow})
         return state
 
-    def get_redirect_url(self, url_prefix=None):
-        return absolute_uri(reverse("sentry-auth-sso"), url_prefix=url_prefix)
+    def get_redirect_url(self):
+        return absolute_uri(reverse("sentry-auth-sso"))
 
     def dispatch_to(self, step: View):
         return step.dispatch(request=self.request, helper=self)

--- a/src/sentry/auth/providers/oauth2.py
+++ b/src/sentry/auth/providers/oauth2.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.utils import generate_url_prefix
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.auth.provider import Provider
 from sentry.auth.view import AuthView
@@ -53,15 +52,14 @@ class OAuth2Login(AuthView):
 
         state = uuid4().hex
 
-        url_prefix = generate_url_prefix(request)
-        params = self.get_authorize_params(
-            state=state, redirect_uri=helper.get_redirect_url(url_prefix)
-        )
-        redirect_uri = f"{self.get_authorize_url()}?{urlencode(params)}"
+        params = self.get_authorize_params(state=state, redirect_uri=helper.get_redirect_url())
+        authorization_url = f"{self.get_authorize_url()}?{urlencode(params)}"
 
         helper.bind_state("state", state)
+        if request.subdomain:
+            helper.bind_state("subdomain", request.subdomain)
 
-        return self.redirect(redirect_uri)
+        return self.redirect(authorization_url)
 
 
 class OAuth2Callback(AuthView):
@@ -88,9 +86,8 @@ class OAuth2Callback(AuthView):
         }
 
     def exchange_token(self, request: Request, helper, code):
-        url_prefix = generate_url_prefix(request)
         # TODO: this needs the auth yet
-        data = self.get_token_params(code=code, redirect_uri=helper.get_redirect_url(url_prefix))
+        data = self.get_token_params(code=code, redirect_uri=helper.get_redirect_url())
         req = safe_urlopen(self.access_token_url, data=data)
         body = safe_urlread(req)
         if req.headers["Content-Type"].startswith("application/x-www-form-urlencoded"):

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from exam import fixture
 
 from sentry.auth.providers.oauth2 import OAuth2Callback, OAuth2Login, OAuth2Provider
-from sentry.models import AuthProvider
+from sentry.models import AuthIdentity, AuthProvider
 from sentry.testutils import AuthProviderTestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
@@ -53,6 +53,11 @@ class AuthOAuth2Test(AuthProviderTestCase):
         self.auth_provider = AuthProvider.objects.create(
             provider=self.provider_name, organization=self.organization
         )
+        AuthIdentity.objects.create(
+            auth_provider=self.auth_provider,
+            user=self.user,
+            ident="oauth_external_id_1234",
+        )
 
     @fixture
     def login_path(self):
@@ -72,18 +77,22 @@ class AuthOAuth2Test(AuthProviderTestCase):
         resp = self.client.post(self.login_path, {"init": True}, **kwargs)
 
         assert resp.status_code == 302
-        redirect = urlparse(resp.get("Location", ""))
+        redirect_dest = resp.get("Location", "")
+        assert redirect_dest.startswith("http://example.com/authorize_url")
+        redirect = urlparse(redirect_dest)
         query = parse_qs(redirect.query)
 
         assert redirect.path == "/authorize_url"
-        assert query["redirect_uri"][0] == f"http://{http_host}/auth/sso/"
+        assert query["redirect_uri"][0] == "http://testserver/auth/sso/"
         assert query["client_id"][0] == "my_client_id"
         assert "state" in query
 
         return query["state"][0]
 
     @mock.patch("sentry.auth.providers.oauth2.safe_urlopen")
-    def initiate_callback(self, state, auth_data, urlopen, expect_success=True, **kwargs):
+    def initiate_callback(
+        self, state, auth_data, urlopen, expect_success=True, customer_domain="", **kwargs
+    ):
         headers = {"Content-Type": "application/json"}
         urlopen.return_value = MockResponse(headers, json.dumps(auth_data))
 
@@ -91,40 +100,64 @@ class AuthOAuth2Test(AuthProviderTestCase):
         resp = self.client.get(f"{self.sso_path}?{query}", **kwargs)
 
         if expect_success:
-            assert resp.status_code == 200
+            assert resp.status_code == 302
+            assert resp["Location"] == f"{customer_domain}/auth/login/"
             assert urlopen.called
             data = urlopen.call_args[1]["data"]
-
-            http_host = "testserver"
-            if "HTTP_HOST" in kwargs:
-                http_host = kwargs["HTTP_HOST"]
 
             assert data == {
                 "grant_type": "authorization_code",
                 "code": "1234",
-                "redirect_uri": f"http://{http_host}/auth/sso/",
+                "redirect_uri": "http://testserver/auth/sso/",
                 "client_id": "my_client_id",
                 "client_secret": "my_client_secret",
             }
 
+            resp = self.client.get(resp["Location"], follow=True)
+            assert resp.status_code == 200
+            assert resp.redirect_chain == [("/organizations/baz/issues/", 302)]
+            assert resp.context["user"] == self.user
         return resp
 
     def test_oauth2_flow(self):
         auth_data = {"id": "oauth_external_id_1234", "email": self.user.email}
 
         state = self.initiate_oauth_flow()
-        auth_resp = self.initiate_callback(state, auth_data)
-
-        assert auth_resp.context["existing_user"] == self.user
+        self.initiate_callback(state, auth_data)
 
     def test_oauth2_flow_customer_domain(self):
         HTTP_HOST = "albertos-apples.testserver"
         auth_data = {"id": "oauth_external_id_1234", "email": self.user.email}
 
         state = self.initiate_oauth_flow(http_host=HTTP_HOST)
-        auth_resp = self.initiate_callback(state, auth_data, HTTP_HOST=HTTP_HOST)
+        self.initiate_callback(
+            state,
+            auth_data,
+            customer_domain="http://albertos-apples.testserver",
+        )
 
-        assert auth_resp.context["existing_user"] == self.user
+    @mock.patch("sentry.utils.auth.login")
+    def test_oauth2_flow_incomplete_security_checks(self, mock_login):
+        mock_login.return_value = False
+        auth_data = {"id": "oauth_external_id_1234", "email": self.user.email}
+
+        state = self.initiate_oauth_flow()
+        response = self.initiate_callback(state, auth_data, expect_success=False, follow=True)
+        assert response.status_code == 200
+        assert response.redirect_chain == [("/auth/login/", 302)]
+        assert response.context["user"] != self.user
+
+    @mock.patch("sentry.utils.auth.login")
+    def test_oauth2_flow_customer_domain_incomplete_security_checks(self, mock_login):
+        HTTP_HOST = "albertos-apples.testserver"
+        mock_login.return_value = False
+        auth_data = {"id": "oauth_external_id_1234", "email": self.user.email}
+
+        state = self.initiate_oauth_flow(http_host=HTTP_HOST)
+        response = self.initiate_callback(state, auth_data, expect_success=False, follow=True)
+        assert response.status_code == 200
+        assert response.redirect_chain == [("http://albertos-apples.testserver/auth/login/", 302)]
+        assert response.context["user"] != self.user
 
     def test_state_mismatch(self):
         auth_data = {"id": "oauth_external_id_1234", "email": self.user.email}
@@ -135,6 +168,7 @@ class AuthOAuth2Test(AuthProviderTestCase):
         messages = list(auth_resp.context["messages"])
         assert len(messages) == 1
         assert str(messages[0]).startswith("Authentication error")
+        assert auth_resp.context["user"] != self.user
 
     def test_response_errors(self):
         auth_data = {"error_description": "Mock failure"}
@@ -154,3 +188,4 @@ class AuthOAuth2Test(AuthProviderTestCase):
         messages = list(auth_resp.context["messages"])
         assert len(messages) == 1
         assert str(messages[0]).startswith("Authentication error")
+        assert auth_resp.context["user"] != self.user


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/38970, I had updated an OAuth2 provider implementation such that we do per-request customization by dynamically update the callback URL based on if a subdomain is present (e.g. `sentry.sentry.io`)

The [OAuth2 spec on redirect URIs](https://www.oauth.com/oauth2-servers/redirect-uris/redirect-uri-registration/) suggests that request-specific data in the callback URL be delegated to the "state" parameter. 

I've undid the per-request callback URL changes added in https://github.com/getsentry/sentry/pull/38970, and instead delegated to the  pipeline redis store (using "state" parameter) to propagate any customer domain information.

The request flow for customer domains should look like this:

1. Go to https://orgslug.sentry.io
2. Click on social media button: https://sentry.io/identity/login/google/?referrer=login
3. Create unique `state` parameter and store `orgslug` customer domain in pipeline redis store.
4. Redirect to https://accounts.google.com/o/oauth2/auth
5. Perform OAuth2 authorization flow.
6. Redirect back to https://sentry.io/auth/sso/
7. Authorization code token exchange.
8. Retrieve `orgslug` customer domain from pipeline redis store, and  redirect user to https://orgslug.sentry.io/auth/login
9. Redirect to  https://orgslug.sentry.o/organizations/orgslug/issues/ (this will be an orgless slug in the future)

