### PR TITLE
ref(ui): Hide traceback platform icon on mobile

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -1,6 +1,5 @@
 import {cloneElement, Component} from 'react';
 import styled from '@emotion/styled';
-import {PlatformIcon} from 'platformicons';
 
 import {t} from 'sentry/locale';
 import {Frame, Organization, PlatformType} from 'sentry/types';
@@ -10,6 +9,8 @@ import withOrganization from 'sentry/utils/withOrganization';
 
 import Line from '../../frame/line';
 import {getImageRange, parseAddress, stackTracePlatformIcon} from '../../utils';
+
+import StacktracePlatformIcon from './platformIcon';
 
 const defaultProps = {
   includeSystemFrames: true,
@@ -261,12 +262,7 @@ class Content extends Component<Props, State> {
 
     return (
       <Wrapper className={className} data-test-id="stack-trace-content">
-        <StyledPlatformIcon
-          platform={platformIcon}
-          size="20px"
-          style={{borderRadius: '3px 0 0 3px'}}
-          data-test-id={`platform-icon-${platformIcon}`}
-        />
+        <StacktracePlatformIcon platform={platformIcon} />
         <StyledList data-test-id="frames">{frames}</StyledList>
       </Wrapper>
     );
@@ -277,12 +273,6 @@ export default withOrganization(Content);
 
 const Wrapper = styled('div')`
   position: relative;
-`;
-
-const StyledPlatformIcon = styled(PlatformIcon)`
-  position: absolute;
-  top: -1px;
-  left: -20px;
 `;
 
 const StyledList = styled('ul')`

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
@@ -1,17 +1,17 @@
 import {cloneElement, Fragment, useState} from 'react';
 import styled from '@emotion/styled';
-import {PlatformIcon} from 'platformicons';
 
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
 import {Frame, Group, PlatformType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {StacktraceType} from 'sentry/types/stacktrace';
 
 import Line from '../../frame/lineV2';
 import {getImageRange, parseAddress, stackTracePlatformIcon} from '../../utils';
+
+import StacktracePlatformIcon from './platformIcon';
 
 type Props = {
   data: StacktraceType;
@@ -243,13 +243,11 @@ function Content({
     return [...convertedFrames].reverse();
   }
 
+  const platformIcon = stackTracePlatformIcon(platform, frames);
+
   return (
     <Wrapper className={getClassName()} data-test-id="stack-trace-content-v2">
-      <StyledPlatformIcon
-        platform={stackTracePlatformIcon(platform, frames)}
-        size="20px"
-        style={{borderRadius: '3px 0 0 3px'}}
-      />
+      <StacktracePlatformIcon platform={platformIcon} />
       <StyledList>{renderConvertedFrames()}</StyledList>
     </Wrapper>
   );
@@ -259,12 +257,6 @@ export default Content;
 
 const Wrapper = styled('div')`
   position: relative;
-`;
-
-const StyledPlatformIcon = styled(PlatformIcon)`
-  position: absolute;
-  margin-top: -1px;
-  left: -${space(3)};
 `;
 
 const StyledList = styled(List)`

--- a/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/platformIcon.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import {PlatformIcon} from 'platformicons';
+
+type Props = {
+  platform: string;
+};
+
+const StacktracePlatformIcon = ({platform}: Props) => (
+  <StyledPlatformIcon
+    platform={platform}
+    size="20px"
+    radius={null}
+    data-test-id={`platform-icon-${platform}`}
+  />
+);
+
+const StyledPlatformIcon = styled(PlatformIcon)`
+  position: absolute;
+  top: -1px;
+  left: -20px;
+  border-radius: 3px 0 0 3px;
+
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    display: none;
+  }
+`;
+
+export default StacktracePlatformIcon;


### PR DESCRIPTION
old
<img width="513" alt="image" src="https://user-images.githubusercontent.com/1421724/191128413-879f89df-b70e-422e-8344-f4268068f6a5.png">

new
<img width="477" alt="image" src="https://user-images.githubusercontent.com/1421724/191128375-e8c5220c-1c5b-47a0-97a5-fe1e3a5f0d3c.png">
