### PR TITLE
test(ui): Convert SmartSearchBar tests to RTL

### DIFF
--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -134,7 +134,12 @@ const FilterToken = ({
       forceVisible
       skipWrapper
     >
-      <Filter ref={filterElementRef} active={isActive} invalid={showInvalid}>
+      <Filter
+        ref={filterElementRef}
+        active={isActive}
+        invalid={showInvalid}
+        data-test-id={showInvalid ? 'filter-token-invalid' : 'filter-token'}
+      >
         {filter.negated && <Negation>!</Negation>}
         <KeyToken token={filter.key} negated={filter.negated} />
         {filter.operator && <Operator>{filter.operator}</Operator>}

--- a/static/app/components/smartSearchBar/index.spec.jsx
+++ b/static/app/components/smartSearchBar/index.spec.jsx
@@ -1,5 +1,5 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -7,31 +7,17 @@ import {
   waitFor,
 } from 'sentry-test/reactTestingLibrary';
 
-import {Client} from 'sentry/api';
 import {SmartSearchBar} from 'sentry/components/smartSearchBar';
-import {ShortcutType} from 'sentry/components/smartSearchBar/types';
-import {shortcuts} from 'sentry/components/smartSearchBar/utils';
 import TagStore from 'sentry/stores/tagStore';
 import {FieldKey} from 'sentry/utils/fields';
 
 describe('SmartSearchBar', function () {
-  let defaultProps, location, options, organization, supportedTags;
-  let environmentTagValuesMock;
-  const tagValuesMock = jest.fn(() => Promise.resolve([]));
-
-  const mockCursorPosition = (component, pos) => {
-    delete component.cursorPosition;
-    Object.defineProperty(component, 'cursorPosition', {
-      get: jest.fn().mockReturnValue(pos),
-      configurable: true,
-    });
-  };
+  let defaultProps;
 
   beforeEach(function () {
     TagStore.reset();
     TagStore.loadTagsSuccess(TestStubs.Tags());
-    tagValuesMock.mockClear();
-    supportedTags = TagStore.getState();
+    const supportedTags = TagStore.getState();
     supportedTags.firstRelease = {
       key: 'firstRelease',
       name: 'firstRelease',
@@ -41,30 +27,18 @@ describe('SmartSearchBar', function () {
       name: 'is',
     };
 
-    organization = TestStubs.Organization({id: '123'});
+    const organization = TestStubs.Organization({id: '123'});
 
-    location = {
+    const location = {
       pathname: '/organizations/org-slug/recent-searches/',
       query: {
         projectId: '0',
       },
     };
 
-    options = TestStubs.routerContext([
-      {
-        organization,
-        location,
-        router: {location},
-      },
-    ]);
-
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/recent-searches/',
-      body: [],
-    });
-    environmentTagValuesMock = MockApiClient.addMockResponse({
-      url: '/projects/123/456/tags/environment/values/',
       body: [],
     });
 
@@ -137,7 +111,9 @@ describe('SmartSearchBar', function () {
     const textbox = screen.getByRole('textbox');
     userEvent.type(textbox, 'bro');
 
-    expect(await screen.findByTestId('search-autocomplete-item')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('option', {name: 'bro wser - field'})
+    ).toBeInTheDocument();
 
     // down once to 'browser' dropdown item
     userEvent.keyboard('{ArrowDown}{Tab}');
@@ -160,7 +136,9 @@ describe('SmartSearchBar', function () {
     const textbox = screen.getByRole('textbox');
     userEvent.type(textbox, 'bro');
 
-    expect(await screen.findByTestId('search-autocomplete-item')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('option', {name: 'bro wser - field'})
+    ).toBeInTheDocument();
 
     // down once to 'browser' dropdown item
     userEvent.keyboard('{ArrowDown}{Enter}');
@@ -173,6 +151,19 @@ describe('SmartSearchBar', function () {
 
     // Should not have executed the search
     expect(onSearchMock).not.toHaveBeenCalled();
+  });
+
+  it('searches and completes tags with negation operator', async function () {
+    render(<SmartSearchBar {...defaultProps} />);
+
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, '!bro');
+
+    const field = await screen.findByRole('option', {name: 'bro wser - field'});
+
+    userEvent.click(field);
+
+    expect(textbox).toHaveValue('!browser:');
   });
 
   describe('componentWillReceiveProps()', function () {
@@ -319,299 +310,154 @@ describe('SmartSearchBar', function () {
     expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
-  describe('updateAutoCompleteItems()', function () {
-    beforeEach(function () {
-      jest.useFakeTimers();
-    });
-    it('sets state when empty', function () {
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      searchBar.updateAutoCompleteItems();
-      expect(searchBar.state.searchTerm).toEqual('');
-      expect(searchBar.state.searchGroups).toEqual([]);
-      expect(searchBar.state.activeSearchItem).toEqual(-1);
-    });
+  it('does not fetch tag values with environment tag and excludeEnvironment', function () {
+    jest.useFakeTimers('modern');
 
-    it('sets state when incomplete tag', async function () {
-      const props = {
-        query: 'fu',
-        organization,
-        location,
-        supportedTags,
-      };
-      jest.useRealTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = wrapper.instance();
-      wrapper.find('textarea').simulate('focus');
-      searchBar.updateAutoCompleteItems();
-      await tick();
-      wrapper.update();
-      expect(searchBar.state.searchTerm).toEqual('fu');
-      expect(searchBar.state.searchGroups).toEqual([
-        expect.objectContaining({children: []}),
-      ]);
-      expect(searchBar.state.activeSearchItem).toEqual(-1);
+    const getTagValuesMock = jest.fn().mockResolvedValue([]);
+
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        onGetTagValues={getTagValuesMock}
+        excludeEnvironment
+      />
+    );
+
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'environment:');
+
+    act(() => {
+      jest.runOnlyPendingTimers();
     });
 
-    it('sets state when incomplete tag has negation operator', async function () {
-      const props = {
-        query: '!fu',
-        organization,
-        location,
-        supportedTags,
-      };
-      jest.useRealTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = wrapper.instance();
-      wrapper.find('textarea').simulate('focus');
-      searchBar.updateAutoCompleteItems();
-      await tick();
-      wrapper.update();
-      expect(searchBar.state.searchTerm).toEqual('fu');
-      expect(searchBar.state.searchGroups).toEqual([
-        expect.objectContaining({children: []}),
-      ]);
-      expect(searchBar.state.activeSearchItem).toEqual(-1);
+    expect(getTagValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch tag values with timesSeen tag', function () {
+    jest.useFakeTimers('modern');
+
+    const getTagValuesMock = jest.fn().mockResolvedValue([]);
+
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        onGetTagValues={getTagValuesMock}
+        excludeEnvironment
+      />
+    );
+
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'timesSeen:');
+
+    act(() => {
+      jest.runOnlyPendingTimers();
     });
 
-    it('sets state when incomplete tag as second textarea', async function () {
-      const props = {
-        query: 'is:unresolved fu',
-        organization,
-        location,
-        supportedTags,
-      };
-      jest.useRealTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = wrapper.instance();
-      // Cursor is at end of line
-      mockCursorPosition(searchBar, 15);
-      searchBar.updateAutoCompleteItems();
-      await tick();
-      wrapper.update();
-      expect(searchBar.state.searchTerm).toEqual('fu');
-      // 2 items because of headers ("Tags")
-      expect(searchBar.state.searchGroups).toHaveLength(1);
-      expect(searchBar.state.activeSearchItem).toEqual(-1);
+    expect(getTagValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches and displays tag values with other tags', function () {
+    jest.useFakeTimers();
+
+    const getTagValuesMock = jest.fn().mockResolvedValue([]);
+
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        onGetTagValues={getTagValuesMock}
+        excludeEnvironment
+      />
+    );
+
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'browser:');
+
+    act(() => {
+      jest.runOnlyPendingTimers();
     });
 
-    it('does not request values when tag is environments', function () {
-      const props = {
-        query: 'environment:production',
-        excludeEnvironment: true,
-        location,
-        organization,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      searchBar.updateAutoCompleteItems();
-      jest.advanceTimersByTime(301);
-      expect(environmentTagValuesMock).not.toHaveBeenCalled();
+    expect(getTagValuesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows correct options on cursor changes for keys and values', async function () {
+    jest.useFakeTimers();
+
+    const getTagValuesMock = jest.fn().mockResolvedValue([]);
+
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        query="is:unresolved"
+        onGetTagValues={getTagValuesMock}
+        onGetRecentSearches={jest.fn().mockReturnValue([])}
+      />
+    );
+
+    const textbox = screen.getByRole('textbox');
+
+    // Set cursor to beginning of "is" tag
+    textbox.setSelectionRange(0, 0);
+    userEvent.click(textbox);
+    act(() => {
+      jest.runAllTimers();
     });
+    // Should show "Keys" section
+    expect(await screen.findByText('Keys')).toBeInTheDocument();
 
-    it('does not request values when tag is `timesSeen`', function () {
-      // This should never get called
-      const mock = MockApiClient.addMockResponse({
-        url: '/projects/123/456/tags/timesSeen/values/',
-        body: [],
-      });
-      const props = {
-        query: 'timesSeen:',
-        organization,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(
-        <SmartSearchBar {...props} api={new Client()} />,
-        options
-      ).instance();
-      searchBar.updateAutoCompleteItems();
-      jest.advanceTimersByTime(301);
-      expect(mock).not.toHaveBeenCalled();
+    // Set cursor to middle of "is" tag
+    userEvent.keyboard('{ArrowRight}');
+    act(() => {
+      jest.runAllTimers();
     });
+    // Should show "Keys" and NOT "Operator Helpers" or "Values"
+    expect(await screen.findByText('Keys')).toBeInTheDocument();
+    expect(screen.queryByText('Operator Helpers')).not.toBeInTheDocument();
+    expect(screen.queryByText('Values')).not.toBeInTheDocument();
 
-    it('requests values when tag is `firstRelease`', function () {
-      const mock = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/releases/',
-        body: [],
-      });
-      const props = {
-        orgId: 'org-slug',
-        projectId: '0',
-        query: 'firstRelease:',
-        location,
-        organization,
-        supportedTags,
-      };
-
-      const searchBar = mountWithTheme(
-        <SmartSearchBar {...props} api={new Client()} />,
-        options
-      ).instance();
-      mockCursorPosition(searchBar, 13);
-      searchBar.updateAutoCompleteItems();
-
-      jest.advanceTimersByTime(301);
-      expect(mock).toHaveBeenCalledWith(
-        '/organizations/org-slug/releases/',
-        expect.objectContaining({
-          method: 'GET',
-          query: {
-            project: '0',
-            per_page: 5, // Limit results to 5 for autocomplete
-          },
-        })
-      );
+    // Set cursor to end of "is" tag
+    userEvent.keyboard('{ArrowRight}');
+    act(() => {
+      jest.runAllTimers();
     });
+    // Should show "Tags" and "Operator Helpers" but NOT "Values"
+    expect(await screen.findByText('Keys')).toBeInTheDocument();
+    expect(screen.getByText('Operator Helpers')).toBeInTheDocument();
+    expect(screen.queryByText('Values')).not.toBeInTheDocument();
 
-    it('shows operator autocompletion', async function () {
-      const props = {
-        query: 'is:unresolved',
-        organization,
-        location,
-        supportedTags,
-      };
-      jest.useRealTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = wrapper.instance();
-      // Cursor is on ':'
-      mockCursorPosition(searchBar, 3);
-      searchBar.updateAutoCompleteItems();
-      await tick();
-      wrapper.update();
-      // two search groups because of operator suggestions
-      expect(searchBar.state.searchGroups).toHaveLength(2);
-      expect(searchBar.state.activeSearchItem).toEqual(-1);
+    // Set cursor after the ":"
+    userEvent.keyboard('{ArrowRight}');
+    act(() => {
+      jest.runAllTimers();
     });
+    // Should show "Values" and "Operator Helpers" but NOT "Keys"
+    expect(await screen.findByText('Values')).toBeInTheDocument();
+    expect(await screen.findByText('Operator Helpers')).toBeInTheDocument();
+    expect(screen.queryByText('Keys')).not.toBeInTheDocument();
 
-    it('responds to cursor changes', async function () {
-      const props = {
-        query: 'is:unresolved',
-        organization,
-        location,
-        supportedTags,
-      };
-      jest.useRealTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = wrapper.instance();
-      // Cursor is on ':'
-      mockCursorPosition(searchBar, 3);
-      searchBar.updateAutoCompleteItems();
-      await tick();
-      wrapper.update();
-      // two search groups tags and values
-      expect(searchBar.state.searchGroups).toHaveLength(2);
-      expect(searchBar.state.activeSearchItem).toEqual(-1);
-      mockCursorPosition(searchBar, 1);
-      searchBar.updateAutoCompleteItems();
-      await tick();
-      wrapper.update();
-      // one search group because showing tags
-      expect(searchBar.state.searchGroups).toHaveLength(1);
-      expect(searchBar.state.activeSearchItem).toEqual(-1);
+    // Set cursor inside value
+    userEvent.keyboard('{ArrowRight}');
+    act(() => {
+      jest.runAllTimers();
     });
+    // Should show "Values" and NOT "Operator Helpers" or "Keys"
+    expect(await screen.findByText('Values')).toBeInTheDocument();
+    expect(screen.queryByText('Operator Helpers')).not.toBeInTheDocument();
+    expect(screen.queryByText('Keys')).not.toBeInTheDocument();
+  });
 
-    it('shows errors on incorrect tokens', function () {
-      const props = {
-        query: 'tag: is: has: ',
-        organization,
-        location,
-        supportedTags,
-      };
-      jest.useRealTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      wrapper.find('Filter').forEach(filter => {
-        expect(filter.prop('invalid')).toBe(true);
-      });
-    });
+  it('shows syntax error for incorrect tokens', function () {
+    render(<SmartSearchBar {...defaultProps} query="tag: is: has:" />);
 
-    it('handles autocomplete race conditions when cursor position changed', async function () {
-      const props = {
-        query: 'is:',
-        organization,
-        location,
-        supportedTags,
-      };
+    // Should have three invalid tokens (tag:, is:, and has:)
+    expect(screen.getAllByTestId('filter-token-invalid')).toHaveLength(3);
+  });
 
-      jest.useFakeTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = wrapper.instance();
-      // Cursor is on ':'
-      searchBar.generateValueAutocompleteGroup = jest.fn(
-        () =>
-          new Promise(resolve => {
-            setTimeout(() => {
-              resolve({
-                searchItems: [],
-                recentSearchItems: [],
-                tagName: 'test',
-                type: 'value',
-              });
-            }, [300]);
-          })
-      );
-      mockCursorPosition(searchBar, 3);
-      searchBar.updateAutoCompleteItems();
-      jest.advanceTimersByTime(200);
-
-      // Move cursor off of the place the update was called before it's done at 300ms
-      mockCursorPosition(searchBar, 0);
-
-      jest.advanceTimersByTime(101);
-
-      // Get the pending promises to resolve
-      await Promise.resolve();
-      wrapper.update();
-
-      expect(searchBar.state.searchGroups).toHaveLength(0);
-    });
-
-    it('handles race conditions when query changes from default state', async function () {
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-
-      jest.useFakeTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = wrapper.instance();
-      // Cursor is on ':'
-      searchBar.getRecentSearches = jest.fn(
-        () =>
-          new Promise(resolve => {
-            setTimeout(() => {
-              resolve([]);
-            }, [300]);
-          })
-      );
-      mockCursorPosition(searchBar, 0);
-      searchBar.updateAutoCompleteItems();
-      jest.advanceTimersByTime(200);
-
-      // Change query before it's done at 300ms
-      searchBar.updateQuery('is:');
-
-      jest.advanceTimersByTime(101);
-
-      // Get the pending promises to resolve
-      await Promise.resolve();
-      wrapper.update();
-
-      expect(searchBar.state.searchGroups).toHaveLength(0);
-    });
-
-    it('correctly groups nested keys', async function () {
-      const props = {
-        query: 'nest',
-        organization,
-        location,
-        supportedTags: {
+  it('renders nested keys correctly', async function () {
+    const {container} = render(
+      <SmartSearchBar
+        {...defaultProps}
+        query=""
+        supportedTags={{
           nested: {
             key: 'nested',
             name: 'nested',
@@ -620,200 +466,28 @@ describe('SmartSearchBar', function () {
             key: 'nested.child',
             name: 'nested.child',
           },
-        },
-      };
-      jest.useRealTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = wrapper.instance();
-      // Cursor is at end of line
-      mockCursorPosition(searchBar, 4);
-      searchBar.updateAutoCompleteItems();
-      await tick();
-      wrapper.update();
-
-      expect(searchBar.state.searchGroups).toHaveLength(1);
-      expect(searchBar.state.searchGroups[0].children).toHaveLength(1);
-      expect(searchBar.state.searchGroups[0].children[0].title).toBe('nested');
-      expect(searchBar.state.searchGroups[0].children[0].children).toHaveLength(1);
-      expect(searchBar.state.searchGroups[0].children[0].children[0].title).toBe(
-        'nested.child'
-      );
-    });
-
-    it('correctly groups nested keys without a parent', async function () {
-      const props = {
-        query: 'nest',
-        organization,
-        location,
-        supportedTags: {
-          'nested.child1': {
-            key: 'nested.child1',
-            name: 'nested.child1',
+          'nestednoparent.child': {
+            key: 'nestednoparent.child',
+            name: 'nestednoparent.child',
           },
-          'nested.child2': {
-            key: 'nested.child2',
-            name: 'nested.child2',
-          },
-        },
-      };
-      jest.useRealTimers();
-      const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = wrapper.instance();
-      // Cursor is at end of line
-      mockCursorPosition(searchBar, 4);
-      searchBar.updateAutoCompleteItems();
-      await tick();
-      wrapper.update();
+        }}
+      />
+    );
 
-      expect(searchBar.state.searchGroups).toHaveLength(1);
-      expect(searchBar.state.searchGroups[0].children).toHaveLength(1);
-      expect(searchBar.state.searchGroups[0].children[0].title).toBe('nested');
-      expect(searchBar.state.searchGroups[0].children[0].children).toHaveLength(2);
-      expect(searchBar.state.searchGroups[0].children[0].children[0].title).toBe(
-        'nested.child1'
-      );
-      expect(searchBar.state.searchGroups[0].children[0].children[1].title).toBe(
-        'nested.child2'
-      );
-    });
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'nest');
+
+    await screen.findByText('Keys');
+
+    expect(container).toSnapshot();
   });
 
-  describe('cursorSearchTerm', function () {
-    it('selects the correct free text word', async function () {
-      jest.useRealTimers();
-
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-      const textarea = smartSearchBar.find('textarea');
-
-      textarea.simulate('focus');
-      mockCursorPosition(searchBar, 6);
-      textarea.simulate('change', {target: {value: 'typ testest    err'}});
-      await tick();
-
-      // Expect the correct search term to be selected
-      const cursorSearchTerm = searchBar.cursorSearchTerm;
-      expect(cursorSearchTerm.searchTerm).toEqual('testest');
-      expect(cursorSearchTerm.start).toBe(4);
-      expect(cursorSearchTerm.end).toBe(11);
-    });
-
-    it('selects the correct free text word (last word)', async function () {
-      jest.useRealTimers();
-
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-      const textarea = smartSearchBar.find('textarea');
-
-      textarea.simulate('focus');
-      mockCursorPosition(searchBar, 15);
-      textarea.simulate('change', {target: {value: 'typ testest    err'}});
-      await tick();
-
-      // Expect the correct search term to be selected
-      const cursorSearchTerm = searchBar.cursorSearchTerm;
-      expect(cursorSearchTerm.searchTerm).toEqual('err');
-      expect(cursorSearchTerm.start).toBe(15);
-      expect(cursorSearchTerm.end).toBe(18);
-    });
-
-    it('selects the correct free text word (first word)', async function () {
-      jest.useRealTimers();
-
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-      const textarea = smartSearchBar.find('textarea');
-
-      textarea.simulate('focus');
-      mockCursorPosition(searchBar, 1);
-      textarea.simulate('change', {target: {value: 'typ testest    err'}});
-      await tick();
-
-      // Expect the correct search term to be selected
-      const cursorSearchTerm = searchBar.cursorSearchTerm;
-      expect(cursorSearchTerm.searchTerm).toEqual('typ');
-      expect(cursorSearchTerm.start).toBe(0);
-      expect(cursorSearchTerm.end).toBe(3);
-    });
-
-    it('search term location correctly selects key of filter token', async function () {
-      jest.useRealTimers();
-
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-      const textarea = smartSearchBar.find('textarea');
-
-      textarea.simulate('focus');
-      mockCursorPosition(searchBar, 6);
-      textarea.simulate('change', {target: {value: 'typ device:123'}});
-      await tick();
-
-      // Expect the correct search term to be selected
-      const cursorSearchTerm = searchBar.cursorSearchTerm;
-      expect(cursorSearchTerm.searchTerm).toEqual('device');
-      expect(cursorSearchTerm.start).toBe(4);
-      expect(cursorSearchTerm.end).toBe(10);
-    });
-
-    it('search term location correctly selects value of filter token', async function () {
-      jest.useRealTimers();
-
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-      const textarea = smartSearchBar.find('textarea');
-
-      textarea.simulate('focus');
-      mockCursorPosition(searchBar, 11);
-      textarea.simulate('change', {target: {value: 'typ device:123'}});
-      await tick();
-
-      // Expect the correct search term to be selected
-      const cursorSearchTerm = searchBar.cursorSearchTerm;
-      expect(cursorSearchTerm.searchTerm).toEqual('123');
-      expect(cursorSearchTerm.start).toBe(11);
-      expect(cursorSearchTerm.end).toBe(14);
-    });
-  });
-
-  describe('getTagKeys()', function () {
-    it('filters both keys and descriptions', async function () {
-      jest.useRealTimers();
-
-      const props = {
-        query: 'event',
-        organization,
-        location,
-        supportedTags: {
+  it('filters keys on name and description', async function () {
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        query=""
+        supportedTags={{
           [FieldKey.DEVICE_CHARGING]: {
             key: FieldKey.DEVICE_CHARGING,
           },
@@ -823,447 +497,342 @@ describe('SmartSearchBar', function () {
           [FieldKey.DEVICE_ARCH]: {
             key: FieldKey.DEVICE_ARCH,
           },
-        },
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
+        }}
+      />
+    );
 
-      mockCursorPosition(searchBar, 3);
-      searchBar.updateAutoCompleteItems();
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'event');
 
-      await tick();
+    await screen.findByText('Keys');
 
-      expect(searchBar.state.flatSearchItems).toHaveLength(2);
-      expect(searchBar.state.flatSearchItems[0].title).toBe(FieldKey.EVENT_TYPE);
-      expect(searchBar.state.flatSearchItems[1].title).toBe(FieldKey.DEVICE_CHARGING);
-    });
+    // Should show event.type (has event in key) and device.charging (has event in description)
+    expect(screen.getByRole('option', {name: /event . type/})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: /charging/})).toBeInTheDocument();
 
-    it('filters only keys', async function () {
-      jest.useRealTimers();
-
-      const props = {
-        query: 'device',
-        organization,
-        location,
-        supportedTags: {
-          [FieldKey.DEVICE_CHARGING]: {
-            key: FieldKey.DEVICE_CHARGING,
-          },
-          [FieldKey.EVENT_TYPE]: {
-            key: FieldKey.EVENT_TYPE,
-          },
-          [FieldKey.DEVICE_ARCH]: {
-            key: FieldKey.DEVICE_ARCH,
-          },
-        },
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-
-      mockCursorPosition(searchBar, 2);
-      searchBar.updateAutoCompleteItems();
-
-      await tick();
-
-      expect(searchBar.state.flatSearchItems).toHaveLength(2);
-      expect(searchBar.state.flatSearchItems[0].title).toBe(FieldKey.DEVICE_ARCH);
-      expect(searchBar.state.flatSearchItems[1].title).toBe(FieldKey.DEVICE_CHARGING);
-    });
-
-    it('filters only descriptions', async function () {
-      jest.useRealTimers();
-
-      const props = {
-        query: 'time',
-        organization,
-        location,
-        supportedTags: {
-          [FieldKey.DEVICE_CHARGING]: {
-            key: FieldKey.DEVICE_CHARGING,
-          },
-          [FieldKey.EVENT_TYPE]: {
-            key: FieldKey.EVENT_TYPE,
-          },
-          [FieldKey.DEVICE_ARCH]: {
-            key: FieldKey.DEVICE_ARCH,
-          },
-        },
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-
-      mockCursorPosition(searchBar, 4);
-      searchBar.updateAutoCompleteItems();
-
-      await tick();
-
-      expect(searchBar.state.flatSearchItems).toHaveLength(1);
-      expect(searchBar.state.flatSearchItems[0].title).toBe(FieldKey.DEVICE_CHARGING);
-    });
+    // But not device.arch (not in key or description)
+    expect(screen.queryByRole('option', {name: /arch/})).not.toBeInTheDocument();
   });
 
-  describe('onAutoComplete()', function () {
-    it('completes terms from the list', function () {
-      const props = {
-        query: 'event.type:error ',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      mockCursorPosition(searchBar, 'event.type:error '.length);
-      searchBar.onAutoComplete('myTag:', {type: 'tag'});
-      expect(searchBar.state.query).toEqual('event.type:error myTag:');
+  it('handles autocomplete race conditions when cursor position changed', async function () {
+    jest.useFakeTimers();
+    const mockOnGetTagValues = jest.fn().mockImplementation(
+      () =>
+        new Promise(resolve => {
+          setTimeout(() => {
+            resolve(['value']);
+          }, [300]);
+        })
+    );
+
+    render(
+      <SmartSearchBar {...defaultProps} onGetTagValues={mockOnGetTagValues} query="" />
+    );
+
+    const textbox = screen.getByRole('textbox');
+
+    // Type key and start searching values
+    userEvent.type(textbox, 'is:');
+
+    act(() => {
+      jest.advanceTimersByTime(200);
     });
 
-    it('completes values if cursor is not at the end', function () {
-      const props = {
-        query: 'id: event.type:error ',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      mockCursorPosition(searchBar, 3);
-      searchBar.onAutoComplete('12345', {type: 'tag-value'});
-      expect(searchBar.state.query).toEqual('id:12345 event.type:error ');
+    // Before values have finished searching, clear the textbox
+    userEvent.clear(textbox);
+
+    act(() => {
+      jest.runAllTimers();
     });
 
-    it('completes values if cursor is at the end', function () {
-      const props = {
-        query: 'event.type:error id:',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      mockCursorPosition(searchBar, 20);
-      searchBar.onAutoComplete('12345', {type: 'tag-value'});
-      expect(searchBar.state.query).toEqual('event.type:error id:12345 ');
+    // Should show keys, not values in dropdown
+    expect(await screen.findByText('Keys')).toBeInTheDocument();
+    expect(screen.queryByText('Values')).not.toBeInTheDocument();
+  });
+
+  it('autocompletes tag values', async function () {
+    jest.useFakeTimers();
+    const mockOnChange = jest.fn();
+
+    const getTagValuesMock = jest.fn().mockResolvedValue(['Chrome', 'Firefox']);
+
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        onGetTagValues={getTagValuesMock}
+        query=""
+        onChange={mockOnChange}
+      />
+    );
+
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'browser:');
+
+    act(() => {
+      jest.runOnlyPendingTimers();
     });
 
-    it('triggers onChange', function () {
-      const onChange = jest.fn();
-      const props = {
-        query: 'event.type:error id:',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(
-        <SmartSearchBar {...props} onChange={onChange} />,
-        options
-      ).instance();
-      mockCursorPosition(searchBar, 20);
-      searchBar.onAutoComplete('12345', {type: 'tag-value'});
-      expect(onChange).toHaveBeenCalledWith(
-        'event.type:error id:12345 ',
+    const option = await screen.findByRole('option', {name: /Firefox/});
+
+    userEvent.click(option);
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenLastCalledWith(
+        'browser:Firefox ',
         expect.anything()
       );
     });
+  });
 
-    it('keeps the negation operator present', async function () {
-      jest.useRealTimers();
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-      const textarea = smartSearchBar.find('textarea');
-      // start typing part of the tag prefixed by the negation operator!
-      textarea.simulate('focus');
-      textarea.simulate('change', {target: {value: 'event.type:error !ti'}});
-      mockCursorPosition(searchBar, 20);
-      await tick();
-      // Expect the correct search term to be selected
-      const cursorSearchTerm = searchBar.cursorSearchTerm;
-      expect(cursorSearchTerm.searchTerm).toEqual('ti');
-      expect(cursorSearchTerm.start).toBe(18);
-      expect(cursorSearchTerm.end).toBe(20);
-      // use autocompletion to do the rest
-      searchBar.onAutoComplete('title:', {});
-      expect(searchBar.state.query).toEqual('event.type:error !title:');
+  it('autocompletes tag values when there are other tags', async function () {
+    jest.useFakeTimers();
+    const mockOnChange = jest.fn();
+
+    const getTagValuesMock = jest.fn().mockResolvedValue(['Chrome', 'Firefox']);
+
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        onGetTagValues={getTagValuesMock}
+        excludeEnvironment
+        query="is:unresolved error.handled:true"
+        onChange={mockOnChange}
+      />
+    );
+
+    // Type "browser:" in between existing key/values
+    const textbox = screen.getByRole('textbox');
+    fireEvent.change(textbox, {
+      target: {value: 'is:unresolved browser: error.handled:true'},
     });
 
-    it('handles special case for user tag', function () {
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-      const textarea = smartSearchBar.find('textarea');
+    // Make sure cursor is at end of "browser:""
+    textbox.setSelectionRange(
+      'is:unresolved browser:'.length,
+      'is:unresolved browser:'.length
+    );
+    userEvent.click(textbox);
 
-      textarea.simulate('change', {target: {value: 'user:'}});
-      mockCursorPosition(searchBar, 5);
-      searchBar.onAutoComplete('id:1', {});
-      expect(searchBar.state.query).toEqual('user:"id:1" ');
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    const option = await screen.findByRole('option', {name: /Firefox/});
+
+    userEvent.click(option);
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenLastCalledWith(
+        'is:unresolved browser:Firefox error.handled:true',
+        expect.anything()
+      );
     });
   });
 
-  it('quotes in predefined values with spaces when autocompleting', async function () {
-    jest.useRealTimers();
-    const onSearch = jest.fn();
-    supportedTags.predefined = {
-      key: 'predefined',
-      name: 'predefined',
-      predefined: true,
-      values: ['predefined tag with spaces'],
-    };
-    const props = {
-      orgId: 'org-slug',
-      projectId: '0',
-      query: '',
-      location,
-      organization,
-      supportedTags,
-      onSearch,
-    };
-    const searchBar = mountWithTheme(
-      <SmartSearchBar {...props} api={new Client()} />,
+  it('autocompletes tag values (user tag)', async function () {
+    jest.useFakeTimers();
+    const mockOnChange = jest.fn();
+    const getTagValuesMock = jest.fn().mockResolvedValue(['id:1']);
 
-      options
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        onGetTagValues={getTagValuesMock}
+        query=""
+        onChange={mockOnChange}
+      />
     );
-    searchBar.find('textarea').simulate('focus');
-    searchBar
-      .find('textarea')
-      .simulate('change', {target: {value: 'predefined:predefined'}});
-    await tick();
 
-    const preventDefault = jest.fn();
-    searchBar.find('textarea').simulate('keyDown', {key: 'ArrowDown'});
-    searchBar.find('textarea').simulate('keyDown', {key: 'Enter', preventDefault});
-    await tick();
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'user:');
 
-    expect(searchBar.find('textarea').props().value).toEqual(
-      'predefined:"predefined tag with spaces" '
-    );
-  });
-
-  it('escapes quotes in predefined values properly when autocompleting', async function () {
-    jest.useRealTimers();
-    const onSearch = jest.fn();
-    supportedTags.predefined = {
-      key: 'predefined',
-      name: 'predefined',
-      predefined: true,
-      values: ['"predefined" "tag" "with" "quotes"'],
-    };
-    const props = {
-      orgId: 'org-slug',
-      projectId: '0',
-      query: '',
-      location,
-      organization,
-      supportedTags,
-      onSearch,
-    };
-    const searchBar = mountWithTheme(
-      <SmartSearchBar {...props} api={new Client()} />,
-
-      options
-    );
-    searchBar.find('textarea').simulate('focus');
-    searchBar
-      .find('textarea')
-      .simulate('change', {target: {value: 'predefined:predefined'}});
-    await tick();
-
-    const preventDefault = jest.fn();
-    searchBar.find('textarea').simulate('keyDown', {key: 'ArrowDown'});
-    searchBar.find('textarea').simulate('keyDown', {key: 'Enter', preventDefault});
-    await tick();
-
-    expect(searchBar.find('textarea').props().value).toEqual(
-      'predefined:"\\"predefined\\" \\"tag\\" \\"with\\" \\"quotes\\"" '
-    );
-  });
-
-  describe('quick actions', () => {
-    it('delete first token', async () => {
-      const props = {
-        query: 'is:unresolved sdk.name:sentry-cocoa has:key',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      searchBar.updateAutoCompleteItems();
-
-      mockCursorPosition(searchBar, 1);
-
-      await tick();
-
-      const deleteAction = shortcuts.find(a => a.shortcutType === ShortcutType.Delete);
-
-      expect(deleteAction).toBeDefined();
-      if (deleteAction) {
-        searchBar.runShortcut(deleteAction);
-
-        await tick();
-
-        expect(searchBar.state.query).toEqual('sdk.name:sentry-cocoa has:key');
-      }
+    act(() => {
+      jest.runOnlyPendingTimers();
     });
 
-    it('delete middle token', async () => {
-      const props = {
-        query: 'is:unresolved sdk.name:sentry-cocoa has:key',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      searchBar.updateAutoCompleteItems();
+    const option = await screen.findByRole('option', {name: /id:1/});
 
-      mockCursorPosition(searchBar, 18);
+    userEvent.click(option);
 
-      await tick();
-
-      const deleteAction = shortcuts.find(a => a.shortcutType === ShortcutType.Delete);
-
-      expect(deleteAction).toBeDefined();
-      if (deleteAction) {
-        searchBar.runShortcut(deleteAction);
-
-        await tick();
-
-        expect(searchBar.state.query).toEqual('is:unresolved has:key');
-      }
-    });
-
-    it('exclude token', async () => {
-      const props = {
-        query: 'is:unresolved sdk.name:sentry-cocoa has:key',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      searchBar.updateAutoCompleteItems();
-
-      mockCursorPosition(searchBar, 18);
-
-      await tick();
-
-      const excludeAction = shortcuts.find(shortcut => shortcut.text === 'Exclude');
-
-      expect(excludeAction).toBeDefined();
-      if (excludeAction) {
-        searchBar.runShortcut(excludeAction);
-
-        await tick();
-
-        expect(searchBar.state.query).toEqual(
-          'is:unresolved !sdk.name:sentry-cocoa has:key '
-        );
-      }
-    });
-
-    it('include token', async () => {
-      const props = {
-        query: 'is:unresolved !sdk.name:sentry-cocoa has:key',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
-      searchBar.updateAutoCompleteItems();
-
-      mockCursorPosition(searchBar, 18);
-
-      await tick();
-
-      const includeAction = shortcuts.find(shortcut => shortcut.text === 'Include');
-
-      expect(includeAction).toBeDefined();
-      if (includeAction) {
-        searchBar.runShortcut(includeAction);
-
-        await tick();
-
-        expect(searchBar.state.query).toEqual(
-          'is:unresolved sdk.name:sentry-cocoa has:key '
-        );
-      }
-    });
-
-    it('replaces the correct word', async function () {
-      const props = {
-        query: '',
-        organization,
-        location,
-        supportedTags,
-      };
-      const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBar = smartSearchBar.instance();
-      const textarea = smartSearchBar.find('textarea');
-
-      textarea.simulate('focus');
-      mockCursorPosition(searchBar, 4);
-      textarea.simulate('change', {target: {value: 'typ ti err'}});
-
-      await tick();
-
-      // Expect the correct search term to be selected
-      const cursorSearchTerm = searchBar.cursorSearchTerm;
-      expect(cursorSearchTerm.searchTerm).toEqual('ti');
-      expect(cursorSearchTerm.start).toBe(4);
-      expect(cursorSearchTerm.end).toBe(6);
-      // use autocompletion to do the rest
-      searchBar.onAutoComplete('title:', {});
-      expect(searchBar.state.query).toEqual('typ title: err');
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenLastCalledWith('user:"id:1" ', expect.anything());
     });
   });
 
-  describe('Invalid field state', () => {
-    it('Shows invalid field state when invalid field is used', async () => {
-      const props = {
-        query: 'invalid:',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBarInst = searchBar.instance();
+  it('autocompletes tag values (predefined values with spaces)', async function () {
+    jest.useFakeTimers();
+    const mockOnChange = jest.fn();
 
-      mockCursorPosition(searchBarInst, 8);
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        query=""
+        onChange={mockOnChange}
+        supportedTags={{
+          predefined: {
+            key: 'predefined',
+            name: 'predefined',
+            predefined: true,
+            values: ['predefined tag with spaces'],
+          },
+        }}
+      />
+    );
 
-      searchBar.find('textarea').simulate('focus');
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'predefined:');
 
-      searchBarInst.updateAutoCompleteItems();
-
-      await tick();
-
-      expect(searchBarInst.state.searchGroups).toHaveLength(1);
-      expect(searchBarInst.state.searchGroups[0].title).toEqual('Keys');
-      expect(searchBarInst.state.searchGroups[0].type).toEqual('invalid-tag');
-      expect(searchBar.text()).toContain("The field invalid isn't supported here");
+    act(() => {
+      jest.runOnlyPendingTimers();
     });
 
-    it('Does not show invalid field state when valid field is used', async () => {
-      const props = {
-        query: 'is:',
-        organization,
-        location,
-        supportedTags,
-      };
-      const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
-      const searchBarInst = searchBar.instance();
-
-      mockCursorPosition(searchBarInst, 3);
-
-      searchBarInst.updateAutoCompleteItems();
-
-      await tick();
-
-      expect(searchBar.text()).not.toContain("isn't supported here");
+    const option = await screen.findByRole('option', {
+      name: /predefined tag with spaces/,
     });
+
+    userEvent.click(option);
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenLastCalledWith(
+        'predefined:"predefined tag with spaces" ',
+        expect.anything()
+      );
+    });
+  });
+
+  it('autocompletes tag values (predefined values with quotes)', async function () {
+    jest.useFakeTimers();
+    const mockOnChange = jest.fn();
+
+    render(
+      <SmartSearchBar
+        {...defaultProps}
+        query=""
+        onChange={mockOnChange}
+        supportedTags={{
+          predefined: {
+            key: 'predefined',
+            name: 'predefined',
+            predefined: true,
+            values: ['"predefined" "tag" "with" "quotes"'],
+          },
+        }}
+      />
+    );
+
+    const textbox = screen.getByRole('textbox');
+    userEvent.type(textbox, 'predefined:');
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    const option = await screen.findByRole('option', {
+      name: /quotes/,
+    });
+
+    userEvent.click(option);
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenLastCalledWith(
+        'predefined:"\\"predefined\\" \\"tag\\" \\"with\\" \\"quotes\\"" ',
+        expect.anything()
+      );
+    });
+  });
+
+  describe('quick actions', function () {
+    it('can delete tokens', function () {
+      render(
+        <SmartSearchBar
+          {...defaultProps}
+          query="is:unresolved sdk.name:sentry-cocoa has:key"
+        />
+      );
+
+      const textbox = screen.getByRole('textbox');
+      userEvent.click(textbox);
+
+      // Put cursor inside is:resolved
+      textbox.setSelectionRange(1, 1);
+
+      userEvent.click(screen.getByRole('button', {name: /Delete/}));
+
+      expect(textbox).toHaveValue('sdk.name:sentry-cocoa has:key');
+    });
+
+    it('can delete a middle token', function () {
+      render(
+        <SmartSearchBar
+          {...defaultProps}
+          query="is:unresolved sdk.name:sentry-cocoa has:key"
+        />
+      );
+
+      const textbox = screen.getByRole('textbox');
+      // Put cursor inside sdk.name
+      textbox.setSelectionRange('is:unresolved s'.length, 'is:unresolved s'.length);
+      userEvent.click(textbox);
+
+      userEvent.click(screen.getByRole('button', {name: /Delete/}));
+
+      expect(textbox).toHaveValue('is:unresolved has:key');
+    });
+
+    it('can exclude a token', function () {
+      render(
+        <SmartSearchBar
+          {...defaultProps}
+          query="is:unresolved sdk.name:sentry-cocoa has:key"
+        />
+      );
+
+      const textbox = screen.getByRole('textbox');
+      // Put cursor inside sdk.name
+      textbox.setSelectionRange('is:unresolved sd'.length, 'is:unresolved sd'.length);
+      userEvent.click(textbox);
+
+      userEvent.click(screen.getByRole('button', {name: /Exclude/}));
+
+      expect(textbox).toHaveValue('is:unresolved !sdk.name:sentry-cocoa has:key ');
+    });
+
+    it('can include a token', async function () {
+      render(
+        <SmartSearchBar
+          {...defaultProps}
+          query="is:unresolved !sdk.name:sentry-cocoa has:key"
+        />
+      );
+
+      const textbox = screen.getByRole('textbox');
+      // Put cursor inside sdk.name
+      textbox.setSelectionRange('is:unresolved !s'.length, 'is:unresolved !s'.length);
+      userEvent.click(textbox);
+
+      expect(textbox).toHaveValue('is:unresolved !sdk.name:sentry-cocoa has:key ');
+
+      await screen.findByRole('button', {name: /Include/});
+      userEvent.click(screen.getByRole('button', {name: /Include/}));
+
+      expect(textbox).toHaveValue('is:unresolved sdk.name:sentry-cocoa has:key ');
+    });
+  });
+
+  it('displays invalid field message', async function () {
+    render(<SmartSearchBar {...defaultProps} query="" />);
+
+    const textbox = screen.getByRole('textbox');
+
+    userEvent.type(textbox, 'invalid:');
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(
+      await screen.findByRole('option', {name: /the field invalid isn't supported here/i})
+    ).toBeInTheDocument();
   });
 
   describe('date fields', () => {
@@ -1272,15 +841,8 @@ describe('SmartSearchBar', function () {
       await import('sentry/components/calendar/datePicker');
     });
 
-    const props = {
-      query: '',
-      organization,
-      location,
-      supportedTags,
-    };
-
     it('displays date picker dropdown when appropriate', () => {
-      render(<SmartSearchBar {...props} />);
+      render(<SmartSearchBar {...defaultProps} query="" />);
 
       const textbox = screen.getByRole('textbox');
       userEvent.click(textbox);
@@ -1315,7 +877,7 @@ describe('SmartSearchBar', function () {
     });
 
     it('can select a suggested relative time value', () => {
-      render(<SmartSearchBar {...props} />);
+      render(<SmartSearchBar {...defaultProps} query="" />);
 
       userEvent.type(screen.getByRole('textbox'), 'lastSeen:');
 
@@ -1325,7 +887,7 @@ describe('SmartSearchBar', function () {
     });
 
     it('can select a specific date/time', async () => {
-      render(<SmartSearchBar {...props} />);
+      render(<SmartSearchBar {...defaultProps} query="" />);
 
       userEvent.type(screen.getByRole('textbox'), 'lastSeen:');
 
@@ -1365,7 +927,7 @@ describe('SmartSearchBar', function () {
     });
 
     it('can change an existing datetime', async () => {
-      render(<SmartSearchBar {...props} />);
+      render(<SmartSearchBar {...defaultProps} query="" />);
 
       const textbox = screen.getByRole('textbox');
       fireEvent.change(textbox, {
@@ -1392,7 +954,7 @@ describe('SmartSearchBar', function () {
     });
 
     it('populates the date picker correctly for date without time', async () => {
-      render(<SmartSearchBar {...props} query="lastSeen:2022-01-01" />);
+      render(<SmartSearchBar {...defaultProps} query="lastSeen:2022-01-01" />);
 
       const textbox = screen.getByRole('textbox');
       // Move cursor to the timestamp
@@ -1412,7 +974,7 @@ describe('SmartSearchBar', function () {
     });
 
     it('populates the date picker correctly for date with time and no timezone', async () => {
-      render(<SmartSearchBar {...props} query="lastSeen:2022-01-01T09:45:12" />);
+      render(<SmartSearchBar {...defaultProps} query="lastSeen:2022-01-01T09:45:12" />);
 
       const textbox = screen.getByRole('textbox');
       // Move cursor to the timestamp
@@ -1428,7 +990,9 @@ describe('SmartSearchBar', function () {
     });
 
     it('populates the date picker correctly for date with time and timezone', async () => {
-      render(<SmartSearchBar {...props} query="lastSeen:2022-01-01T09:45:12-05:00" />);
+      render(
+        <SmartSearchBar {...defaultProps} query="lastSeen:2022-01-01T09:45:12-05:00" />
+      );
 
       const textbox = screen.getByRole('textbox');
       // Move cursor to the timestamp
@@ -1446,18 +1010,16 @@ describe('SmartSearchBar', function () {
 
   describe('custom performance metric filters', () => {
     it('raises Invalid file size when parsed filter unit is not a valid size unit', () => {
-      const props = {
-        organization,
-        location,
-        supportedTags,
-        customPerformanceMetrics: {
-          'measurements.custom.kibibyte': {
-            fieldType: 'size',
-          },
-        },
-      };
-
-      render(<SmartSearchBar {...props} />);
+      render(
+        <SmartSearchBar
+          {...defaultProps}
+          customPerformanceMetrics={{
+            'measurements.custom.kibibyte': {
+              fieldType: 'size',
+            },
+          }}
+        />
+      );
 
       const textbox = screen.getByRole('textbox');
       userEvent.click(textbox);
@@ -1472,18 +1034,16 @@ describe('SmartSearchBar', function () {
     });
 
     it('raises Invalid duration when parsed filter unit is not a valid duration unit', () => {
-      const props = {
-        organization,
-        location,
-        supportedTags,
-        customPerformanceMetrics: {
-          'measurements.custom.minute': {
-            fieldType: 'duration',
-          },
-        },
-      };
-
-      render(<SmartSearchBar {...props} />);
+      render(
+        <SmartSearchBar
+          {...defaultProps}
+          customPerformanceMetrics={{
+            'measurements.custom.minute': {
+              fieldType: 'duration',
+            },
+          }}
+        />
+      );
 
       const textbox = screen.getByRole('textbox');
       userEvent.click(textbox);

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1487,6 +1487,7 @@ class SmartSearchBar extends Component<Props, State> {
           this.setState({
             searchTerm: tagName,
           });
+
           this.updateAutoCompleteStateMultiHeader(autocompleteGroups);
         }
         return;

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -316,6 +316,7 @@ const DropdownItem = ({
   return (
     <Fragment>
       <SearchListItem
+        role="option"
         className={`${isChild ? 'group-child' : ''} ${item.active ? 'active' : ''}`}
         data-test-id="search-autocomplete-item"
         onClick={


### PR DESCRIPTION
Converted the rest of the SmartSearchBar tests to RTL.

There were a lot of these, and many were testing implementation details so they didn't map perfectly to RTL tests. I reduced the total number of tests since a single RTL often covered multiple of the existing enzyme test cases. This does make the diff quite difficult to follow though - sorry about that!