### PR TITLE
fix(ui): Better tooltip for event timestamps

### DIFF
--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -74,7 +74,7 @@ class GroupEventToolbar extends Component<Props> {
     const dateReceived = evt.dateReceived ? moment(evt.dateReceived) : null;
 
     return (
-      <DescriptionList className="flat">
+      <DescriptionList>
         <dt>Occurred</dt>
         <dd>
           {dateCreated.format('ll')}
@@ -234,10 +234,11 @@ const LinkContainer = styled('span')`
 `;
 
 const DescriptionList = styled('dl')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: ${space(0.75)} ${space(1)};
   text-align: left;
   margin: 0;
-  min-width: 200px;
-  max-width: 250px;
 `;
 
 export default GroupEventToolbar;


### PR DESCRIPTION
Before
<img width="274" alt="image" src="https://user-images.githubusercontent.com/1421724/191096400-65bffadf-141e-4020-9e61-8e0b9de6a066.png">

After
<img width="247" alt="image" src="https://user-images.githubusercontent.com/1421724/191096498-b6c8562f-63aa-4e32-87e5-a73a5ff81368.png">

