### PR TITLE
fix(profiling): Send debug_images to vroom so they can be stored in the profile

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -389,4 +389,4 @@ def _insert_vroom_profile(profile: Profile) -> bool:
         profile["profile"] = ""
 
         # remove debug information we don't need anymore
-        profile.pop("debug_meta")
+        profile.pop("debug_meta", None)

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -205,9 +205,6 @@ def _symbolicate(profile: Profile, project: Project) -> None:
             sentry_sdk.capture_exception(e)
             break
 
-    # remove debug information we don't need anymore
-    profile.pop("debug_meta")
-
     # rename the profile key to suggest it has been processed
     profile["profile"] = profile.pop("sampled_profile")
 
@@ -390,3 +387,6 @@ def _insert_vroom_profile(profile: Profile) -> bool:
     finally:
         profile["received"] = original_timestamp
         profile["profile"] = ""
+
+        # remove debug information we don't need anymore
+        profile.pop("debug_meta")


### PR DESCRIPTION
`debug_images` can be useful to debug why symbols are missing for a given profile. We were not sending them as part of the request to `vroom`, the profiling service. With this PR we'll keep the key on the `profile` object until we send it to `vroom` and then we'll discard it.