### PR TITLE
feat(profiling): enhance onboarding codeblock

### DIFF
--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -7,41 +7,7 @@ import Prism from 'prismjs';
 import Tooltip from 'sentry/components/tooltip';
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
-
-const PreContainer = styled('pre')<{unsetBorderRadiusTop?: boolean}>`
-  overflow-x: scroll;
-  ${p =>
-    p.unsetBorderRadiusTop
-      ? `
-  border-top-left-radius: 0px;
-  border-top-right-radius: 0px;
-  `
-      : null}
-
-  word-break: break-all;
-  white-space: pre-wrap;
-
-  code {
-    white-space: pre;
-  }
-`;
-const UnstyledButton = styled('button')`
-  all: unset;
-  cursor: pointer;
-`;
-
-const CodeContainerActionBar = styled('div')`
-  display: flex;
-  justify-content: end;
-  gap: 10px;
-  padding: 10px;
-
-  color: ${p => p.theme.white};
-  font-size: ${p => p.theme.fontSizeSmall};
-  border-bottom: 1px solid ${p => p.theme.purple200};
-  background: #251f3d;
-  border-radius: ${p => p.theme.borderRadiusTop};
-`;
+import space from 'sentry/styles/space';
 
 interface CodeSnippetProps {
   children: string;
@@ -95,10 +61,54 @@ export function CodeSnippet({
       )}
 
       <PreContainer unsetBorderRadiusTop={!hideActionBar}>
-        <code className={`language-${language}`} ref={ref}>
+        <code ref={ref} className={`language-${language}`}>
           {children}
         </code>
       </PreContainer>
     </Fragment>
   );
 }
+
+const PreContainer = styled('pre')<{unsetBorderRadiusTop?: boolean}>`
+  overflow-x: scroll;
+  ${p =>
+    p.unsetBorderRadiusTop
+      ? `
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  `
+      : null}
+
+  word-break: break-all;
+  white-space: pre-wrap;
+
+  code {
+    white-space: pre;
+  }
+`;
+
+const UnstyledButton = styled('button')`
+  all: unset;
+  cursor: pointer;
+`;
+
+// code blocks are globally styled by `prism-sentry`
+// its design tokens are slightly different than the app
+// so we've left it in charge of colors while overriding
+// css that breaks the experience
+const CodeContainerActionBar = styled(({children, ...props}) => (
+  <div {...props}>
+    <pre className="language-">{children}</pre>
+  </div>
+))`
+  pre.language- {
+    display: flex;
+    justify-content: end;
+    gap: ${space(1)};
+    padding: ${space(1.5)};
+    margin-bottom: 0px;
+    border-bottom: 1px solid ${p => p.theme.purple200};
+    border-radius: ${p => p.theme.borderRadiusTop};
+    font-size: ${p => p.theme.fontSizeSmall};
+  }
+`;

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -8,10 +8,19 @@ import Tooltip from 'sentry/components/tooltip';
 import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
-const PreContainer = styled('pre')`
+const PreContainer = styled('pre')<{unsetBorderRadiusTop?: boolean}>`
   overflow-x: scroll;
+  ${p =>
+    p.unsetBorderRadiusTop
+      ? `
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
+  `
+      : null}
+
+  word-break: break-all;
+  white-space: pre-wrap;
+
   code {
     white-space: pre;
   }
@@ -34,13 +43,19 @@ const CodeContainerActionBar = styled('div')`
   border-radius: ${p => p.theme.borderRadiusTop};
 `;
 
-interface CodeContainerProps {
+interface CodeSnippetProps {
   children: string;
   language: string;
   filename?: string;
+  hideActionBar?: boolean;
 }
 
-export function CodeSnippet({children, language, filename}: CodeContainerProps) {
+export function CodeSnippet({
+  children,
+  language,
+  filename,
+  hideActionBar,
+}: CodeSnippetProps) {
   const ref = useRef<HTMLModElement | null>(null);
 
   useEffect(() => Prism.highlightElement(ref.current, false), [children]);
@@ -64,19 +79,22 @@ export function CodeSnippet({children, language, filename}: CodeContainerProps) 
 
   return (
     <Fragment>
-      <CodeContainerActionBar>
-        {filename && <span>{filename}</span>}
-        <Tooltip delay={0} isHoverable={false} title={tooltipTitle} position="bottom">
-          <UnstyledButton
-            type="button"
-            onClick={handleCopy}
-            onMouseLeave={() => setTooltipState('copy')}
-          >
-            <IconCopy />
-          </UnstyledButton>
-        </Tooltip>
-      </CodeContainerActionBar>
-      <PreContainer>
+      {!hideActionBar && (
+        <CodeContainerActionBar>
+          {filename && <span>{filename}</span>}
+          <Tooltip delay={0} isHoverable={false} title={tooltipTitle} position="bottom">
+            <UnstyledButton
+              type="button"
+              onClick={handleCopy}
+              onMouseLeave={() => setTooltipState('copy')}
+            >
+              <IconCopy />
+            </UnstyledButton>
+          </Tooltip>
+        </CodeContainerActionBar>
+      )}
+
+      <PreContainer unsetBorderRadiusTop={!hideActionBar}>
         <code className={`language-${language}`} ref={ref}>
           {children}
         </code>

--- a/static/app/components/profiling/ProfilingOnboarding/codeSnippet.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/codeSnippet.tsx
@@ -1,0 +1,86 @@
+import 'prism-sentry/index.css';
+
+import {Fragment, useEffect, useRef, useState} from 'react';
+import styled from '@emotion/styled';
+import Prism from 'prismjs';
+
+import Tooltip from 'sentry/components/tooltip';
+import {IconCopy} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+const PreContainer = styled('pre')`
+  overflow-x: scroll;
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  code {
+    white-space: pre;
+  }
+`;
+const UnstyledButton = styled('button')`
+  all: unset;
+  cursor: pointer;
+`;
+
+const CodeContainerActionBar = styled('div')`
+  display: flex;
+  justify-content: end;
+  gap: 10px;
+  padding: 10px;
+
+  color: ${p => p.theme.white};
+  font-size: ${p => p.theme.fontSizeSmall};
+  border-bottom: 1px solid ${p => p.theme.purple200};
+  background: #251f3d;
+  border-radius: ${p => p.theme.borderRadiusTop};
+`;
+
+interface CodeContainerProps {
+  children: string;
+  language: string;
+  filename?: string;
+}
+
+export function CodeSnippet({children, language, filename}: CodeContainerProps) {
+  const ref = useRef<HTMLModElement | null>(null);
+
+  useEffect(() => Prism.highlightElement(ref.current, false), [children]);
+  const [tooltipState, setTooltipState] = useState<'copy' | 'copied' | 'error'>('copy');
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(children);
+      setTooltipState('copied');
+    } catch (err) {
+      setTooltipState('error');
+    }
+  };
+
+  const tooltipTitle =
+    tooltipState === 'copy'
+      ? t('Copy')
+      : tooltipState === 'copied'
+      ? t('Copied')
+      : t('Unable to copy');
+
+  return (
+    <Fragment>
+      <CodeContainerActionBar>
+        {filename && <span>{filename}</span>}
+        <Tooltip delay={0} isHoverable={false} title={tooltipTitle} position="bottom">
+          <UnstyledButton
+            type="button"
+            onClick={handleCopy}
+            onMouseLeave={() => setTooltipState('copy')}
+          >
+            <IconCopy />
+          </UnstyledButton>
+        </Tooltip>
+      </CodeContainerActionBar>
+      <PreContainer>
+        <code className={`language-${language}`} ref={ref}>
+          {children}
+        </code>
+      </PreContainer>
+    </Fragment>
+  );
+}

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -19,6 +19,8 @@ import {semverCompare} from 'sentry/utils/profiling/units/versions';
 import useProjects from 'sentry/utils/useProjects';
 import {useProjectSdkUpdates} from 'sentry/utils/useProjectSdkUpdates';
 
+import {CodeSnippet} from './codeSnippet';
+
 // This is just a doubly linked list of steps
 interface OnboardingStep {
   current: React.ComponentType<OnboardingStepProps>;
@@ -324,13 +326,13 @@ function AndroidInstallSteps({
       </li>
       <li>
         <StepTitle>{t('Set Up Profiling')}</StepTitle>
-        <CodeContainer>
+        <CodeSnippet language="xml" filename="AndroidManifest.xml">
           {`<application>
   <meta-data android:name="io.sentry.dsn" android:value="..." />
   <meta-data android:name="io.sentry.traces.sample-rate" android:value="1.0" />
   <meta-data android:name="io.sentry.traces.profiling.enable" android:value="true" />
 </application>`}
-        </CodeContainer>
+        </CodeSnippet>
       </li>
     </Fragment>
   );
@@ -367,11 +369,11 @@ function IOSInstallSteps({
         <StepTitle>
           {t('Enable profiling in your app by configuring the SDKs like below:')}
         </StepTitle>
-        <CodeContainer>{`SentrySDK.start { options in
+        <CodeSnippet language="swift">{`SentrySDK.start { options in
     options.dsn = "..."
     options.tracesSampleRate = 1.0 // Make sure transactions are enabled
     options.profilesSampleRate = 1.0
-}`}</CodeContainer>
+}`}</CodeSnippet>
       </li>
     </Fragment>
   );
@@ -610,18 +612,3 @@ const StepIndicator = styled('span')`
   color: ${p => p.theme.subText};
   margin-right: ${space(2)};
 `;
-
-const PreContainer = styled('pre')`
-  overflow-x: scroll;
-
-  code {
-    white-space: pre;
-  }
-`;
-function CodeContainer({children}: {children: React.ReactNode}) {
-  return (
-    <PreContainer>
-      <code>{children}</code>
-    </PreContainer>
-  );
-}

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -4,6 +4,7 @@ import {PlatformIcon} from 'platformicons';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
 import Button, {ButtonPropsWithoutAriaLabel} from 'sentry/components/button';
+import {CodeSnippet} from 'sentry/components/codeSnippet';
 import {SelectField} from 'sentry/components/forms';
 import {SelectFieldProps} from 'sentry/components/forms/selectField';
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -18,8 +19,6 @@ import {Project, ProjectSdkUpdates} from 'sentry/types/project';
 import {semverCompare} from 'sentry/utils/profiling/units/versions';
 import useProjects from 'sentry/utils/useProjects';
 import {useProjectSdkUpdates} from 'sentry/utils/useProjectSdkUpdates';
-
-import {CodeSnippet} from './codeSnippet';
 
 // This is just a doubly linked list of steps
 interface OnboardingStep {


### PR DESCRIPTION
This PR adds a `CodeSnippet` component for profile onboarding. The `CodeSnippet` aligns better to the one found in our docs and enables copy to clipboard functionality.

Note: swift syntax highlighting doesn't work, gotta investigate `prism-sentry`

https://user-images.githubusercontent.com/7349258/191118455-66e46c99-9016-4fa6-b654-659675d1c07d.mov

dark theme for ref:
<img width="589" alt="image" src="https://user-images.githubusercontent.com/7349258/191118936-bc11bceb-28bc-46a0-8224-08d43878f908.png">


