### PR TITLE
ref(ui): Better settings layout padding on small screens

### DIFF
--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -167,6 +167,10 @@ const Content = styled('div')`
   padding: ${space(4)};
   min-width: 0; /* keep children from stretching container */
 
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    padding: ${space(2)};
+  }
+
   /**
    * PageContent is not normally used in settings but <PermissionDenied /> uses it under the hood.
    * This prevents double padding.


### PR DESCRIPTION
old
<img width="466" alt="image" src="https://user-images.githubusercontent.com/1421724/191127981-6260197f-388d-40a1-8021-21e7511a23b1.png">

new
<img width="467" alt="image" src="https://user-images.githubusercontent.com/1421724/191127994-90598224-7e51-4583-854c-4637809fe9a8.png">
