### PR TITLE
ref(ui): Remove circle from sidebar collapse icon

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -407,13 +407,7 @@ function Sidebar({location, organization}: Props) {
                 id="collapse"
                 data-test-id="sidebar-collapse"
                 {...sidebarItemProps}
-                icon={
-                  <IconChevron
-                    isCircled
-                    direction={collapsed ? 'right' : 'left'}
-                    size="md"
-                  />
-                }
+                icon={<IconChevron direction={collapsed ? 'right' : 'left'} size="sm" />}
                 label={collapsed ? t('Expand') : t('Collapse')}
                 onClick={toggleCollapse}
               />


### PR DESCRIPTION
To me this makes the collapse feel less like a 'menu item' and more like a separate thing I can do to the sidebar

Before
<img width="1806" alt="image" src="https://user-images.githubusercontent.com/1421724/191132654-b2c5d909-fd9c-433f-93e9-e775d11077c2.png">

<img width="1806" alt="image" src="https://user-images.githubusercontent.com/1421724/191132775-efcaf812-2dc2-4961-944c-c500746ce365.png">


After
<img width="1806" alt="image" src="https://user-images.githubusercontent.com/1421724/191132638-22201775-e2e4-4847-9cc4-4c37a1de24d3.png">

<img width="1806" alt="image" src="https://user-images.githubusercontent.com/1421724/191132750-79269709-c681-428d-a5cb-4b222e96d5f3.png">
