### PR TITLE
ref(ui): Match spacing on other pages in Replays overview

### DIFF
--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -37,9 +37,9 @@ function ReplaysFilters({organization, handleSearchQuery, query}: Props) {
 const FilterContainer = styled('div')`
   display: inline-grid;
   grid-template-columns: minmax(0, max-content) minmax(20rem, 1fr);
-  gap: ${space(1)};
+  gap: ${space(2)};
   width: 100%;
-  margin-bottom: ${space(1)};
+  margin-bottom: ${space(2)};
 
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
Before
<img width="1806" alt="image" src="https://user-images.githubusercontent.com/1421724/191133777-81ecdc9d-1d43-4d5d-9bb7-838dc911f00b.png">

After
<img width="1806" alt="image" src="https://user-images.githubusercontent.com/1421724/191133790-7d32fbd8-8162-434a-8257-c51290679975.png">
