### PR TITLE
feat(issues): Collapse issue details tags

### DIFF
--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -1,3 +1,4 @@
+import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import ClippedBox from 'sentry/components/clippedBox';
@@ -32,7 +33,7 @@ export function EventTags({event, organization, projectId, location}: Props) {
   const streamPath = `/organizations/${orgSlug}/issues/`;
 
   return (
-    <ClippedBox clipHeight={150}>
+    <StyledClippedBox clipHeight={150}>
       <Pills>
         {event.tags.map((tag, index) => (
           <EventTagsPill
@@ -46,6 +47,10 @@ export function EventTags({event, organization, projectId, location}: Props) {
           />
         ))}
       </Pills>
-    </ClippedBox>
+    </StyledClippedBox>
   );
 }
+
+const StyledClippedBox = styled(ClippedBox)`
+  padding: 0;
+`;

--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -1,5 +1,6 @@
 import {Location} from 'history';
 
+import ClippedBox from 'sentry/components/clippedBox';
 import Pills from 'sentry/components/pills';
 import {Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
@@ -31,18 +32,20 @@ export function EventTags({event, organization, projectId, location}: Props) {
   const streamPath = `/organizations/${orgSlug}/issues/`;
 
   return (
-    <Pills>
-      {event.tags.map((tag, index) => (
-        <EventTagsPill
-          key={!defined(tag.key) ? `tag-pill-${index}` : tag.key}
-          tag={tag}
-          projectId={projectId}
-          organization={organization}
-          query={generateQueryWithTag(location.query, tag)}
-          streamPath={streamPath}
-          meta={meta?.[index]}
-        />
-      ))}
-    </Pills>
+    <ClippedBox clipHeight={150}>
+      <Pills>
+        {event.tags.map((tag, index) => (
+          <EventTagsPill
+            key={!defined(tag.key) ? `tag-pill-${index}` : tag.key}
+            tag={tag}
+            projectId={projectId}
+            organization={organization}
+            query={generateQueryWithTag(location.query, tag)}
+            streamPath={streamPath}
+            meta={meta?.[index]}
+          />
+        ))}
+      </Pills>
+    </ClippedBox>
   );
 }


### PR DESCRIPTION
Keep tags around 150px tall, some issues have a massive number of tags making them annoying to scroll past
![image](https://user-images.githubusercontent.com/1400464/191137359-e92d879a-24c3-4a75-a7d9-60f1344f22c3.png)

fixes https://getsentry.atlassian.net/browse/WOR-2165