### PR TITLE
types(compact-select): Ensure that onChange type is inferred properly [UP-141]

### DIFF
--- a/static/app/components/charts/optionSelector.tsx
+++ b/static/app/components/charts/optionSelector.tsx
@@ -13,18 +13,16 @@ type BaseProps = React.ComponentProps<typeof CompactSelect> & {
   featureType?: 'alpha' | 'beta' | 'new';
 };
 
-type SingleProps = BaseProps & {
+interface SingleProps extends Omit<BaseProps, 'onChange'> {
   onChange: (value: string) => void;
   selected: string;
-  multiple?: false;
-};
-type MultipleProps = BaseProps & {
-  multiple: true;
+}
+interface MultipleProps extends Omit<BaseProps, 'onChange'> {
   onChange: (value: string[]) => void;
   selected: string[];
-};
+}
 
-function OptionSelector({
+function OptionSelector<MultipleType extends boolean>({
   options,
   onChange,
   selected,
@@ -32,17 +30,13 @@ function OptionSelector({
   featureType,
   multiple,
   ...rest
-}: SingleProps | MultipleProps) {
+}: MultipleType extends true ? MultipleProps : SingleProps) {
   const mappedOptions = useMemo(() => {
     return options.map(opt => ({
       ...opt,
       label: <Truncate value={String(opt.label)} maxLength={60} expandDirection="left" />,
     }));
   }, [options]);
-
-  function onValueChange(option) {
-    onChange(multiple ? option.map(o => o.value) : option.value);
-  }
 
   function isOptionDisabled(option) {
     return (
@@ -60,7 +54,9 @@ function OptionSelector({
       size="sm"
       options={mappedOptions}
       value={selected}
-      onChange={onValueChange}
+      onChange={option => {
+        onChange(multiple ? option.map(o => o.value) : option.value);
+      }}
       isOptionDisabled={isOptionDisabled}
       multiple={multiple}
       triggerProps={{

--- a/static/app/components/events/traceEventDataSection.tsx
+++ b/static/app/components/events/traceEventDataSection.tsx
@@ -259,7 +259,7 @@ export function TraceEventDataSection({
                   value={state.sortBy}
                   options={Object.entries(sortByOptions).map(([value, label]) => ({
                     label,
-                    value,
+                    value: value as keyof typeof sortByOptions,
                   }))}
                 />
                 <CompositeSelect

--- a/static/app/components/forms/compositeSelect.tsx
+++ b/static/app/components/forms/compositeSelect.tsx
@@ -144,7 +144,7 @@ function CompositeSelect<OptionType extends GeneralSelectValue = GeneralSelectVa
   }
 
   return (
-    <CompactSelect<ExtendedOptionType>
+    <CompactSelect
       {...props}
       multiple
       options={options}

--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -2,7 +2,6 @@ import {useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import CompactSelect from 'sentry/components/forms/compactSelect';
-import {ControlProps, GeneralSelectValue} from 'sentry/components/forms/selectControl';
 import {IconList} from 'sentry/icons';
 import {tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -19,7 +18,7 @@ interface ThreadSelectorProps {
   threadId: FlamegraphState['profiles']['threadId'];
 }
 
-function ThreadMenuSelector<OptionType extends GeneralSelectValue = GeneralSelectValue>({
+function ThreadMenuSelector({
   threadId,
   onThreadIdChange,
   profileGroup,
@@ -42,7 +41,7 @@ function ThreadMenuSelector<OptionType extends GeneralSelectValue = GeneralSelec
     });
   }, [profileGroup]);
 
-  const handleChange: NonNullable<ControlProps<OptionType>['onChange']> = useCallback(
+  const handleChange: (opt: SelectValue<number>) => void = useCallback(
     opt => {
       if (defined(opt)) {
         onThreadIdChange(opt.value);

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -157,7 +157,7 @@ function Search(props: Props) {
         value={eventsDisplayFilterName}
         onChange={opt => onChangeEventsDisplayFilter(opt.value)}
         options={Object.entries(eventsFilterOptions).map(([name, filter]) => ({
-          value: name,
+          value: name as EventsDisplayFilterName,
           label: filter.label,
         }))}
       />

--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -102,15 +102,15 @@ function ProfileSummaryContent(props: ProfileSummaryContentProps) {
           options={[
             {
               label: t('All'),
-              value: 'all',
+              value: 'all' as const,
             },
             {
               label: t('Application'),
-              value: 'application',
+              value: 'application' as const,
             },
             {
               label: t('System'),
-              value: 'system',
+              value: 'system' as const,
             },
           ]}
           onChange={({value}) => setFunctionType(value)}

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -28,7 +28,9 @@ interface Props {
 }
 
 const getDistinctLogLevels = (breadcrumbs: Crumb[]) =>
-  Array.from(new Set<string>(breadcrumbs.map(breadcrumb => breadcrumb.level)));
+  Array.from(
+    new Set<BreadcrumbLevelType>(breadcrumbs.map(breadcrumb => breadcrumb.level))
+  );
 
 function Console({breadcrumbs, startTimestampMs = 0}: Props) {
   const {currentHoverTime, currentTime} = useReplayContext();


### PR DESCRIPTION
The types in `<CompactSelect />` are such that `onChange` always gets inferred as `(value: any) => void`. These changes make sure that the typings are correct.

To do this, I also had to use conditional typing for the `multiple` prop since that changes the type of the `onChange` argument to an array.

Other file changes are to fix consumers of `CompactSelect` that weren't typed narrowly enough.

Before:

![image](https://user-images.githubusercontent.com/10888943/191138099-2311ac21-66f0-430b-b84f-bd1d0ae16772.png)

After:

![image](https://user-images.githubusercontent.com/10888943/191137670-3fe2ffc6-2bfd-40da-a510-51872dac684d.png)

w/ `multiple`

![image](https://user-images.githubusercontent.com/10888943/191137897-5ff17ba1-9603-4faa-83dc-1ccd8754d9c4.png)
