### PR TITLE
chore(integration): Update GitHub integration for customer domains

### DIFF
--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -247,6 +247,8 @@ class OAuth2LoginView(PipelineView):
         redirect_uri = f"{self.get_authorize_url()}?{urlencode(params)}"
 
         pipeline.bind_state("state", state)
+        if request.subdomain:
+            pipeline.bind_state("subdomain", request.subdomain)
 
         return self.redirect(redirect_uri)
 

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -3,6 +3,7 @@ from typing import Optional
 from urllib.parse import quote, urlencode, urljoin, urlparse
 
 from django.conf import settings
+from rest_framework.request import Request
 
 from sentry import options
 
@@ -15,6 +16,13 @@ def absolute_uri(url: Optional[str] = None, url_prefix=None) -> str:
     if not url:
         return url_prefix
     return urljoin(url_prefix.rstrip("/") + "/", url.lstrip("/"))
+
+
+def create_redirect_url(request: Request, redirect_url: str) -> str:
+    qs = request.META.get("QUERY_STRING") or ""
+    if qs:
+        qs = "?" + qs
+    return f"{redirect_url}{qs}"
 
 
 def origin_from_url(url):

--- a/src/sentry/web/frontend/organization_integration_setup.py
+++ b/src/sentry/web/frontend/organization_integration_setup.py
@@ -41,5 +41,8 @@ class OrganizationIntegrationSetupView(OrganizationView):
 
             pipeline.initialize()
 
+            if request.subdomain is not None:
+                pipeline.bind_state("subdomain", request.subdomain)
+
             response = pipeline.current_step()
         return response

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -1,9 +1,12 @@
 from django.contrib import messages
+from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
+from sentry.api.utils import generate_organization_url
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.utils.http import absolute_uri, create_redirect_url
 from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
 
@@ -31,7 +34,7 @@ class PipelineAdvancerView(BaseView):
     csrf_protect = False
 
     @transaction_start("PipelineAdvancerView")
-    def handle(self, request: Request, provider_id) -> Response:
+    def handle(self, request: Request, provider_id: str) -> Response:
         pipeline = None
 
         for pipeline_cls in PIPELINE_CLASSES:
@@ -53,4 +56,14 @@ class PipelineAdvancerView(BaseView):
             messages.add_message(request, messages.ERROR, _("Invalid request."))
             return self.redirect("/")
 
-        return pipeline.current_step()
+        subdomain = pipeline.fetch_state("subdomain")
+        if subdomain is not None and request.subdomain != subdomain:
+            url_prefix = generate_organization_url(subdomain)
+            redirect_url = absolute_uri(
+                reverse("sentry-extension-setup", kwargs={"provider_id": provider_id}),
+                url_prefix=url_prefix,
+            )
+            return HttpResponseRedirect(create_redirect_url(request, redirect_url))
+
+        response = pipeline.current_step()
+        return response

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -1,15 +1,21 @@
-from unittest.mock import Mock
+from collections import namedtuple
+from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 import responses
+from django.test import Client, RequestFactory
 from exam import fixture
 from requests.exceptions import SSLError
 
 import sentry.identity
-from sentry.identity.oauth2 import OAuth2CallbackView
+from sentry.identity.oauth2 import OAuth2CallbackView, OAuth2LoginView
 from sentry.identity.pipeline import IdentityProviderPipeline
 from sentry.identity.providers.dummy import DummyProvider
 from sentry.testutils import TestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.utils import json
+
+MockResponse = namedtuple("MockResponse", ["headers", "content"])
 
 
 @control_silo_test
@@ -17,6 +23,8 @@ class OAuth2CallbackViewTest(TestCase):
     def setUp(self):
         sentry.identity.register(DummyProvider)
         super().setUp()
+        self.request = RequestFactory().get("/")
+        self.request.subdomain = None
 
     def tearDown(self):
         super().tearDown()
@@ -30,16 +38,48 @@ class OAuth2CallbackViewTest(TestCase):
             client_secret="secret-value",
         )
 
-    @responses.activate
-    def test_exchange_token_success(self):
-        responses.add(
-            responses.POST, "https://example.org/oauth/token", json={"token": "a-fake-token"}
-        )
-        pipeline = IdentityProviderPipeline(request=Mock(), provider_key="dummy")
+    @mock.patch("sentry.identity.oauth2.safe_urlopen")
+    def test_exchange_token_success(self, safe_urlopen):
+        headers = {"Content-Type": "application/json"}
+        safe_urlopen.return_value = MockResponse(headers, json.dumps({"token": "a-fake-token"}))
+
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
         code = "auth-code"
-        result = self.view.exchange_token(None, pipeline, code)
+        result = self.view.exchange_token(self.request, pipeline, code)
         assert "token" in result
         assert "a-fake-token" == result["token"]
+
+        assert safe_urlopen.called
+        data = safe_urlopen.call_args[1]["data"]
+        assert data == {
+            "client_id": 123456,
+            "client_secret": "secret-value",
+            "code": "auth-code",
+            "grant_type": "authorization_code",
+            "redirect_uri": "http://testserver/extensions/default/setup/",
+        }
+
+    @mock.patch("sentry.identity.oauth2.safe_urlopen")
+    def test_exchange_token_success_customer_domains(self, safe_urlopen):
+        headers = {"Content-Type": "application/json"}
+        safe_urlopen.return_value = MockResponse(headers, json.dumps({"token": "a-fake-token"}))
+
+        self.request.subdomain = "albertos-apples"
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
+        code = "auth-code"
+        result = self.view.exchange_token(self.request, pipeline, code)
+        assert "token" in result
+        assert "a-fake-token" == result["token"]
+
+        assert safe_urlopen.called
+        data = safe_urlopen.call_args[1]["data"]
+        assert data == {
+            "client_id": 123456,
+            "client_secret": "secret-value",
+            "code": "auth-code",
+            "grant_type": "authorization_code",
+            "redirect_uri": "http://testserver/extensions/default/setup/",
+        }
 
     @responses.activate
     def test_exchange_token_ssl_error(self):
@@ -49,9 +89,9 @@ class OAuth2CallbackViewTest(TestCase):
         responses.add_callback(
             responses.POST, "https://example.org/oauth/token", callback=ssl_error
         )
-        pipeline = IdentityProviderPipeline(request=Mock(), provider_key="dummy")
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
         code = "auth-code"
-        result = self.view.exchange_token(None, pipeline, code)
+        result = self.view.exchange_token(self.request, pipeline, code)
         assert "token" not in result
         assert "error" in result
         assert "error_description" in result
@@ -60,10 +100,63 @@ class OAuth2CallbackViewTest(TestCase):
     @responses.activate
     def test_exchange_token_no_json(self):
         responses.add(responses.POST, "https://example.org/oauth/token", body="")
-        pipeline = IdentityProviderPipeline(request=Mock(), provider_key="dummy")
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
         code = "auth-code"
-        result = self.view.exchange_token(None, pipeline, code)
+        result = self.view.exchange_token(self.request, pipeline, code)
         assert "token" not in result
         assert "error" in result
         assert "error_description" in result
         assert "JSON" in result["error_description"]
+
+
+@control_silo_test
+class OAuth2LoginViewTest(TestCase):
+    def setUp(self):
+        sentry.identity.register(DummyProvider)
+        super().setUp()
+        self.request = RequestFactory().get("/")
+        self.request.session = Client().session
+        self.request.subdomain = None
+
+    def tearDown(self):
+        super().tearDown()
+        sentry.identity.unregister(DummyProvider)
+
+    @fixture
+    def view(self):
+        return OAuth2LoginView(
+            authorize_url="https://example.org/oauth2/authorize",
+            client_id=123456,
+            scope="all-the-things",
+        )
+
+    def test_simple(self):
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
+        response = self.view.dispatch(self.request, pipeline)
+
+        assert response.status_code == 302
+        assert response["Location"].startswith("https://example.org/oauth2/authorize")
+        redirect_url = urlparse(response["Location"])
+        query = parse_qs(redirect_url.query)
+
+        assert query["client_id"][0] == "123456"
+        assert query["redirect_uri"][0] == "http://testserver/extensions/default/setup/"
+        assert query["response_type"][0] == "code"
+        assert query["scope"][0] == "all-the-things"
+        assert "state" in query
+
+    def test_customer_domains(self):
+        self.request.subdomain = "albertos-apples"
+        pipeline = IdentityProviderPipeline(request=self.request, provider_key="dummy")
+        response = self.view.dispatch(self.request, pipeline)
+
+        assert response.status_code == 302
+        assert response["Location"].startswith("https://example.org/oauth2/authorize")
+        redirect_url = urlparse(response["Location"])
+        query = parse_qs(redirect_url.query)
+
+        assert query["client_id"][0] == "123456"
+        assert query["redirect_uri"][0] == "http://testserver/extensions/default/setup/"
+        assert query["response_type"][0] == "code"
+        assert query["scope"][0] == "all-the-things"
+        assert "state" in query

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -26,10 +26,15 @@ class SlackIntegrationTest(IntegrationTestCase):
         authorizing_user_id="UXXXXXXX1",
         expected_client_id="slack-client-id",
         expected_client_secret="slack-client-secret",
+        customer_domain=None,
     ):
         responses.reset()
 
-        resp = self.client.get(self.init_path)
+        kwargs = {}
+        if customer_domain:
+            kwargs["HTTP_HOST"] = customer_domain
+
+        resp = self.client.get(self.init_path, **kwargs)
         assert resp.status_code == 302
         redirect = urlparse(resp["Location"])
         assert redirect.scheme == "https"
@@ -94,6 +99,11 @@ class SlackIntegrationTest(IntegrationTestCase):
             )
         )
 
+        if customer_domain:
+            assert resp.status_code == 302
+            assert resp["Location"].startswith(f"http://{customer_domain}/extensions/slack/setup/")
+            resp = self.client.get(resp["Location"], **kwargs)
+
         mock_request = responses.calls[0].request
         req_params = parse_qs(mock_request.body)
         assert req_params["grant_type"] == ["authorization_code"]
@@ -109,6 +119,34 @@ class SlackIntegrationTest(IntegrationTestCase):
     def test_bot_flow(self):
         with self.tasks():
             self.assert_setup_flow()
+
+        integration = Integration.objects.get(provider=self.provider.key)
+        assert integration.external_id == "TXXXXXXX1"
+        assert integration.name == "Example"
+        assert integration.metadata == {
+            "access_token": "xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+            "scopes": sorted(self.provider.identity_oauth_scopes),
+            "icon": "http://example.com/ws_icon.jpg",
+            "domain_name": "test-slack-workspace.slack.com",
+            "installation_type": "born_as_bot",
+        }
+        oi = OrganizationIntegration.objects.get(
+            integration=integration, organization=self.organization
+        )
+        assert oi.config == {}
+
+        idp = IdentityProvider.objects.get(type="slack", external_id="TXXXXXXX1")
+        identity = Identity.objects.get(idp=idp, user=self.user, external_id="UXXXXXXX1")
+        assert identity.status == IdentityStatus.VALID
+
+        audit_entry = AuditLogEntry.objects.get(event=audit_log.get_event_id("INTEGRATION_ADD"))
+        audit_log_event = audit_log.get(audit_entry.event)
+        assert audit_log_event.render(audit_entry) == "installed Example for the slack integration"
+
+    @responses.activate
+    def test_bot_flow_customer_domains(self):
+        with self.tasks():
+            self.assert_setup_flow(customer_domain=f"{self.organization.slug}.testserver")
 
         integration = Integration.objects.get(provider=self.provider.key)
         assert integration.external_id == "TXXXXXXX1"


### PR DESCRIPTION
Branches from https://github.com/getsentry/sentry/pull/39052.

When redirecting back to `sentry.io` from github.com, we'll redirect the user back to the customer domain hostname, if the initial github app installation came from a customer domain. 

Updates to other integrations will follow.