### PR TITLE
fix(ui): Prevent clipped box from expanding only a few pixels

### DIFF
--- a/docs-ui/stories/utilities/clippedBox.stories.js
+++ b/docs-ui/stories/utilities/clippedBox.stories.js
@@ -53,11 +53,11 @@ export const ClipFlex = () => (
     <div>
       With clipFlex off, show more is hardly hiding anything
       <ClippedBox clipHeight={100} clipFlex={0}>
-        <div style={{backgroundColor: 'SeaGreen', height: '105px'}} />
+        <div style={{backgroundColor: 'SeaGreen', height: '80px'}} />
       </ClippedBox>
       With clipFlex on (component should be expanded)
       <ClippedBox clipHeight={100}>
-        <div style={{backgroundColor: 'SeaGreen', height: '105px'}} />
+        <div style={{backgroundColor: 'SeaGreen', height: '80px'}} />
       </ClippedBox>
     </div>
   </div>

--- a/docs-ui/stories/utilities/clippedBox.stories.js
+++ b/docs-ui/stories/utilities/clippedBox.stories.js
@@ -47,3 +47,27 @@ Default.parameters = {
     },
   },
 };
+
+export const ClipFlex = () => (
+  <div>
+    <div>
+      With clipFlex off, show more is hardly hiding anything
+      <ClippedBox clipHeight={100} clipFlex={0}>
+        <div style={{backgroundColor: 'SeaGreen', height: '105px'}} />
+      </ClippedBox>
+      With clipFlex on (component should be expanded)
+      <ClippedBox clipHeight={100}>
+        <div style={{backgroundColor: 'SeaGreen', height: '105px'}} />
+      </ClippedBox>
+    </div>
+  </div>
+);
+
+ClipFlex.storyName = 'Clipped Box Flex';
+ClipFlex.parameters = {
+  docs: {
+    description: {
+      story: 'Demo showing a component that is only slightly larger than the clipHeight',
+    },
+  },
+};

--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -169,6 +169,7 @@ const Wrapper = styled('div', {
     prop !== 'clipHeight' && prop !== 'isClipped' && prop !== 'isRevealed',
 })<State & {clipHeight: number}>`
   position: relative;
+  padding: ${space(1.5)} 0;
 
   /* For "Show More" animation */
   ${p =>

--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -10,11 +10,17 @@ import space from 'sentry/styles/space';
 
 type DefaultProps = {
   btnText?: string;
+  /**
+   * The "show more" button is 20px tall.
+   * Do not clip if there isn't more to hide after the button
+   */
+  clipFlex?: number;
   clipHeight?: number;
   defaultClipped?: boolean;
 };
 
 type Props = {
+  clipFlex: number;
   clipHeight: number;
   className?: string;
   /**
@@ -43,6 +49,7 @@ class ClippedBox extends PureComponent<Props, State> {
   static defaultProps: DefaultProps = {
     defaultClipped: false,
     clipHeight: 200,
+    clipFlex: 20,
     btnText: t('Show More'),
   };
 
@@ -93,7 +100,10 @@ class ClippedBox extends PureComponent<Props, State> {
       return;
     }
 
-    if (!this.state.isClipped && renderedHeight > this.props.clipHeight) {
+    if (
+      !this.state.isClipped &&
+      renderedHeight > this.props.clipHeight + this.props.clipFlex
+    ) {
       /* eslint react/no-did-mount-set-state:0 */
       // okay if this causes re-render; cannot determine until
       // rendered first anyways
@@ -159,7 +169,6 @@ const Wrapper = styled('div', {
     prop !== 'clipHeight' && prop !== 'isClipped' && prop !== 'isRevealed',
 })<State & {clipHeight: number}>`
   position: relative;
-  padding: ${space(1.5)} 0;
 
   /* For "Show More" animation */
   ${p =>

--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -11,7 +11,7 @@ import space from 'sentry/styles/space';
 type DefaultProps = {
   btnText?: string;
   /**
-   * The "show more" button is 20px tall.
+   * The "show more" button is 28px tall.
    * Do not clip if there is only a few more pixels
    */
   clipFlex?: number;
@@ -49,7 +49,7 @@ class ClippedBox extends PureComponent<Props, State> {
   static defaultProps: DefaultProps = {
     defaultClipped: false,
     clipHeight: 200,
-    clipFlex: 20,
+    clipFlex: 28,
     btnText: t('Show More'),
   };
 

--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -12,7 +12,7 @@ type DefaultProps = {
   btnText?: string;
   /**
    * The "show more" button is 20px tall.
-   * Do not clip if there isn't more to hide after the button
+   * Do not clip if there is only a few more pixels
    */
   clipFlex?: number;
   clipHeight?: number;


### PR DESCRIPTION
This attempts to prevent clippedBox from expanding only a few pixels, while keeping the clipHeight the same size.

Example in app

https://user-images.githubusercontent.com/1400464/191142584-b7a348c4-92a0-492d-990b-96cd598ad62f.mp4




Storybook example

https://user-images.githubusercontent.com/1400464/191142387-b4f84fbb-97f6-488c-9cbe-aa5cea545acd.mp4

