### PR TITLE
fix(page-filter): Remove seconds from time range

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/index.spec.jsx
+++ b/static/app/components/organizations/timeRangeSelector/index.spec.jsx
@@ -423,7 +423,6 @@ describe('TimeRangeSelector', function () {
     userEvent.type(input, '5');
 
     // With just the number "5", all unit options should be present
-    expect(screen.getByText('Last 5 seconds')).toBeInTheDocument();
     expect(screen.getByText('Last 5 minutes')).toBeInTheDocument();
     expect(screen.getByText('Last 5 hours')).toBeInTheDocument();
     expect(screen.getByText('Last 5 days')).toBeInTheDocument();
@@ -433,7 +432,6 @@ describe('TimeRangeSelector', function () {
 
     // With "5d", only "Last 5 days" should be shown
     expect(screen.getByText('Last 5 days')).toBeInTheDocument();
-    expect(screen.queryByText('Last 5 seconds')).not.toBeInTheDocument();
     expect(screen.queryByText('Last 5 minutes')).not.toBeInTheDocument();
     expect(screen.queryByText('Last 5 hours')).not.toBeInTheDocument();
     expect(screen.queryByText('Last 5 weeks')).not.toBeInTheDocument();

--- a/static/app/components/organizations/timeRangeSelector/utils.tsx
+++ b/static/app/components/organizations/timeRangeSelector/utils.tsx
@@ -6,7 +6,8 @@ import {t, tn} from 'sentry/locale';
 
 import TimeRangeItemLabel from './timeRangeItemLabel';
 
-type RelativePeriodUnit = 's' | 'm' | 'h' | 'd' | 'w';
+type PeriodUnit = 's' | 'm' | 'h' | 'd' | 'w';
+type RelativePeriodUnit = Exclude<PeriodUnit, 's'>;
 
 type RelativeUnitsMapping = {
   [unit in RelativePeriodUnit]: {
@@ -21,11 +22,6 @@ const DATE_TIME_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 const STATS_PERIOD_REGEX = /^(\d+)([smhdw]{1})$/;
 
 const SUPPORTED_RELATIVE_PERIOD_UNITS: RelativeUnitsMapping = {
-  s: {
-    label: (num: number) => tn('Last second', 'Last %s seconds', num),
-    searchKey: t('seconds'),
-    momentUnit: 'seconds',
-  },
   m: {
     label: (num: number) => tn('Last minute', 'Last %s minutes', num),
     searchKey: t('minutes'),
@@ -124,7 +120,7 @@ export function getRelativeSummary(
 
 export function makeItem(
   amount: number,
-  unit: keyof typeof SUPPORTED_RELATIVE_PERIOD_UNITS,
+  unit: PeriodUnit,
   label: (num: number) => string,
   index: number
 ) {


### PR DESCRIPTION
- This removes seconds from the timerange autocomplete, as far as I know there aren't any reasons to use seconds that minutes or another period could accomplish better
- This also prevents some strange discover bugs when such small periods are selected