### PR TITLE
fix(discover): Fixes custom perf metric cell action not using correct values

### DIFF
--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -132,6 +132,17 @@ function EventCustomPerformanceMetric({
         return eventView.getResultsViewUrlTarget(organization.slug);
     }
   }
+
+  // Some custom perf metrics have units.
+  // These custom perf metrics need to be adjusted to the correct value.
+  let customMetricValue = value;
+  if (typeof value === 'number' && unit && customMetricValue) {
+    if (Object.keys(SIZE_UNITS).includes(unit)) {
+      customMetricValue *= SIZE_UNITS[unit];
+    } else if (Object.keys(DURATION_UNITS).includes(unit)) {
+      customMetricValue *= DURATION_UNITS[unit];
+    }
+  }
   return (
     <StyledPanel>
       <div>
@@ -145,22 +156,22 @@ function EventCustomPerformanceMetric({
           {
             key: 'includeEvents',
             label: t('Show events with this value'),
-            to: generateLinkWithQuery(`measurements.${name}:${value}`),
+            to: generateLinkWithQuery(`measurements.${name}:${customMetricValue}`),
           },
           {
             key: 'excludeEvents',
             label: t('Hide events with this value'),
-            to: generateLinkWithQuery(`!measurements.${name}:${value}`),
+            to: generateLinkWithQuery(`!measurements.${name}:${customMetricValue}`),
           },
           {
             key: 'includeGreaterThanEvents',
             label: t('Show events with values greater than'),
-            to: generateLinkWithQuery(`measurements.${name}:>${value}`),
+            to: generateLinkWithQuery(`measurements.${name}:>${customMetricValue}`),
           },
           {
             key: 'includeLessThanEvents',
             label: t('Show events with values less than'),
-            to: generateLinkWithQuery(`measurements.${name}:<${value}`),
+            to: generateLinkWithQuery(`measurements.${name}:<${customMetricValue}`),
           },
         ]}
         triggerProps={{

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -24,7 +24,11 @@ import EventView, {
   isFieldSortable,
   pickRelevantLocationQueryStrings,
 } from 'sentry/utils/discover/eventView';
-import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
+import {
+  DURATION_UNITS,
+  getFieldRenderer,
+  SIZE_UNITS,
+} from 'sentry/utils/discover/fieldRenderers';
 import {
   Column,
   fieldAlignment,
@@ -364,7 +368,7 @@ class TableView extends Component<TableViewProps> {
 
   handleCellAction = (dataRow: TableDataRow, column: TableColumn<keyof TableDataRow>) => {
     return (action: Actions, value: React.ReactText) => {
-      const {eventView, organization, projects, location} = this.props;
+      const {eventView, organization, projects, location, tableData} = this.props;
 
       const query = new MutableSearch(eventView.query);
 
@@ -434,7 +438,18 @@ class TableView extends Component<TableViewProps> {
           return;
         }
         default: {
-          updateQuery(query, action, column, value);
+          // Some custom perf metrics have units.
+          // These custom perf metrics need to be adjusted to the correct value.
+          let cellValue = value;
+          const unit = tableData?.meta?.units?.[column.name];
+          if (typeof cellValue === 'number' && unit) {
+            if (Object.keys(SIZE_UNITS).includes(unit)) {
+              cellValue *= SIZE_UNITS[unit];
+            } else if (Object.keys(DURATION_UNITS).includes(unit)) {
+              cellValue *= DURATION_UNITS[unit];
+            }
+          }
+          updateQuery(query, action, column, cellValue);
         }
       }
       nextView.query = query.formatString();


### PR DESCRIPTION
Fixes an issue where the cell actions for custom perf metrics in discover tables would use incorrect values when applying filters