### PR TITLE
feat(Snowflake): Enable snowflake id for CI 

### DIFF
--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -182,6 +182,7 @@ def pytest_configure(config):
 
     settings.VALIDATE_SUPERUSER_ACCESS_CATEGORY_AND_REASON = False
     settings.SENTRY_USE_BIG_INTS = True
+    settings.SENTRY_USE_SNOWFLAKE = True
 
     settings.SENTRY_SNOWFLAKE_EPOCH_START = datetime(1999, 12, 31, 0, 0).timestamp()
 


### PR DESCRIPTION
Fixed our models in CI for https://github.com/getsentry/getsentry/pull/8327.

Renabling the SENTRY_USE_SNOWFLAKE flag for all tests. Now snowflake ids will be used in our tests again. 