### PR TITLE
feat(discover): Allow events api queries to filter by ibyte sizes

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -167,7 +167,7 @@ tz_format   = ~r"[+-]\d{2}:\d{2}"
 iso_8601_date_format = date_format time_format? ("Z" / tz_format)? &end_value
 rel_date_format      = ~r"[+-][0-9]+[wdhm]" &end_value
 duration_format      = numeric ("ms"/"s"/"min"/"m"/"hr"/"h"/"day"/"d"/"wk"/"w") &end_value
-size_format          = numeric ("bit"/"nb"/"bytes"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb"/"zb"/"yb") &end_value
+size_format          = numeric ("bit"/"nb"/"bytes"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb"/"zb"/"yb"/"kib"/"mib"/"gib"/"tib"/"pib"/"eib"/"zib"/"yib") &end_value
 percentage_format    = numeric "%"
 
 # NOTE: the order in which these operators are listed matters because for

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -114,9 +114,25 @@ def parse_size(value, size):
         byte = size_value * 1000**7
     elif size == "yb":
         byte = size_value * 1000**8
+    elif size == "kib":
+        byte = size_value * 1024
+    elif size == "mib":
+        byte = size_value * 1024**2
+    elif size == "gib":
+        byte = size_value * 1024**3
+    elif size == "tib":
+        byte = size_value * 1024**4
+    elif size == "pib":
+        byte = size_value * 1024**5
+    elif size == "eib":
+        byte = size_value * 1024**6
+    elif size == "zib":
+        byte = size_value * 1024**7
+    elif size == "yib":
+        byte = size_value * 1024**8
     else:
         raise InvalidQuery(
-            f"{size} is not a valid size type, must be bit, bytes, kb, mb, gb, tb, pb, eb, zb, yb"
+            f"{size} is not a valid size type, must be bit, bytes, kb, mb, gb, tb, pb, eb, zb, yb, kib, mib, gib, tib, pib, eib, zib, yib"
         )
 
     return byte

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -241,6 +241,26 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
         ]
 
     @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
+    def test_ibyte_size_filter(self, mock_type):
+        config = SearchConfig()
+        mock_type.return_value = "gigabyte"
+
+        assert parse_search_query(
+            "measurements.foo:>5gib measurements.bar:<3pib", config=config
+        ) == [
+            SearchFilter(
+                key=SearchKey(name="measurements.foo"),
+                operator=">",
+                value=SearchValue(5 * 1024**3),
+            ),
+            SearchFilter(
+                key=SearchKey(name="measurements.bar"),
+                operator="<",
+                value=SearchValue(3 * 1024**5),
+            ),
+        ]
+
+    @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
     def test_aggregate_size_filter(self, mock_type):
         config = SearchConfig()
         mock_type.return_value = "gigabyte"
@@ -257,6 +277,26 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
                 key=SearchKey(name="p100(measurements.bar)"),
                 operator="<",
                 value=SearchValue(3 * 1000**5),
+            ),
+        ]
+
+    @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
+    def test_aggregate_ibyte_size_filter(self, mock_type):
+        config = SearchConfig()
+        mock_type.return_value = "gigabyte"
+
+        assert parse_search_query(
+            "p50(measurements.foo):>5gib p100(measurements.bar):<3pib", config=config
+        ) == [
+            SearchFilter(
+                key=SearchKey(name="p50(measurements.foo)"),
+                operator=">",
+                value=SearchValue(5 * 1024**3),
+            ),
+            SearchFilter(
+                key=SearchKey(name="p100(measurements.bar)"),
+                operator="<",
+                value=SearchValue(3 * 1024**5),
             ),
         ]
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -243,7 +243,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
     @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
     def test_ibyte_size_filter(self, mock_type):
         config = SearchConfig()
-        mock_type.return_value = "gigabyte"
+        mock_type.return_value = "gibibyte"
 
         assert parse_search_query(
             "measurements.foo:>5gib measurements.bar:<3pib", config=config
@@ -283,7 +283,7 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
     @patch("sentry.search.events.builder.QueryBuilder.get_field_type")
     def test_aggregate_ibyte_size_filter(self, mock_type):
         config = SearchConfig()
-        mock_type.return_value = "gigabyte"
+        mock_type.return_value = "gibibyte"
 
         assert parse_search_query(
             "p50(measurements.foo):>5gib p100(measurements.bar):<3pib", config=config


### PR DESCRIPTION
We currently allow filtering on discover with abyte sizes.
ie measurements.custom:>10kb
This adds capability to filter by ibyte sizes as well.
ie measurements.custom:>10kib