### PR TITLE
feat(discover): Discover frontend allow ibyte filters

### DIFF
--- a/static/app/components/searchSyntax/grammar.pegjs
+++ b/static/app/components/searchSyntax/grammar.pegjs
@@ -352,7 +352,7 @@ duration_format
 
 size_format
   = value:numeric
-    unit:("bit"/"nb"/"bytes"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb"/"zb"/"yb")
+    unit:("bit"/"nb"/"bytes"/"kb"/"mb"/"gb"/"tb"/"pb"/"eb"/"zb"/"yb"/"kib"/"mib"/"gib"/"tib"/"pib"/"eib"/"zib"/"yib")
     &end_value {
       return tc.tokenValueSize(value, unit);
     }

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -491,7 +491,26 @@ export class TokenConverter {
 
   tokenValueSize = (
     value: string,
-    unit: 'bit' | 'nb' | 'bytes' | 'kb' | 'mb' | 'gb' | 'tb' | 'pb' | 'eb' | 'zb' | 'yb'
+    unit:
+      | 'bit'
+      | 'nb'
+      | 'bytes'
+      | 'kb'
+      | 'mb'
+      | 'gb'
+      | 'tb'
+      | 'pb'
+      | 'eb'
+      | 'zb'
+      | 'yb'
+      | 'kib'
+      | 'mib'
+      | 'gib'
+      | 'tib'
+      | 'pib'
+      | 'eib'
+      | 'zib'
+      | 'yib'
   ) => ({
     ...this.defaultTokenFields,
 
@@ -678,7 +697,7 @@ export class TokenConverter {
     if (this.keyValidation.isSize(keyName)) {
       return {
         reason: t('Invalid file size. Expected number followed by file size unit suffix'),
-        expectedType: [FilterType.Duration],
+        expectedType: [FilterType.Size],
       };
     }
 


### PR DESCRIPTION
Updates frontend discover search syntax to allow filtering by ibyte sizes
<img width="377" alt="image" src="https://user-images.githubusercontent.com/83961295/191363036-f7a4a947-10a4-4002-ac98-7e61646f5b31.png">

Depends on https://github.com/getsentry/sentry/pull/39081