### PR TITLE
chore(ui): Remove storybook exports from vscode autocomplete

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,11 @@
     "editor.formatOnSave": true,
     "editor.tabSize": 2
   },
+  // Exclude Specific Files from Auto-Imports
+  "typescript.preferences.autoImportFileExcludePatterns": [
+    "**/node_modules/@storybook/theming/*",
+    "**/node_modules/@storybook/addons/*"
+  ],
 
   "[typescriptreact]": {
     "editor.formatOnSave": true,


### PR DESCRIPTION
Typescript 4.8 added the ability to exclude files from being auto-imported in vscode. This starts us with two of the most annoying ones. [More info on this feature](https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#exclude-specific-files-from-auto-imports)

useEffect would sometimes import from `@storybook/addons` 
![image](https://user-images.githubusercontent.com/1400464/191363369-f6c65705-bce1-41dc-9151-3743f7ca5140.png)
