### PR TITLE
deps(ui): Update caniuse database, update browserslist

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5510,9 +5510,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001332:
-  version "1.0.30001341"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz#59590c8ffa8b5939cf4161f00827b8873ad72498"
-  integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
+  version "1.0.30001407"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001407.tgz"
+  integrity sha512-4ydV+t4P7X3zH83fQWNDX/mQEzYomossfpViCOx9zHBSMV+rIe3LFqglHHtVyvNl1FhTNxPxs3jei82iqOW04w==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
It's been a while, update the database so we can target newer browsers and stop targeting old ones. Dropping safari 13 and 14 seem to be the interesting ones. The last update to Safari 14 was about 1 year ago.

Target browser changes:
```diff
- chrome 95
- chrome 94
- chrome 93
- chrome 92
+ chrome 105
+ chrome 104
+ chrome 103
+ chrome 102
- edge 101
- edge 100
+ edge 105
+ edge 104
- firefox 94
- firefox 93
- firefox 92
+ firefox 104
+ firefox 103
+ firefox 102
+ firefox 101
- ios_saf 13.4-13.7
- ios_saf 13.3
- ios_saf 13.2
- ios_saf 13.0-13.1
+ ios_saf 16.0
+ ios_saf 15.6
+ ios_saf 15.5
- safari 14.1
- safari 14
+ safari 16.0
+ safari 15.6
+ safari 15.5
```

Events grouped by user https://sentry.io/organizations/sentry/discover/results/?display=default&field=browser&field=count_unique%28user%29&name=All+Events&project=11276&query=&sort=-count_unique_user&statsPeriod=30d&yAxis=count_unique%28user%29