### PR TITLE
fix(slack): Correctly parse channel from Slack Request

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -73,12 +73,12 @@ class SlackEventEndpoint(SlackDMEndpoint):
             channel_id=slack_request.channel_id,
             response_url=slack_request.response_url,
         )
-        if not slack_request.channel_name:
+        if not slack_request.channel_id:
             return
 
         payload = {
             "token": self._get_access_token(slack_request.integration),
-            "channel": slack_request.channel_name,
+            "channel": slack_request.channel_id,
             "user": slack_request.user_id,
             "text": "Link your Slack identity to Sentry to unfurl Discover charts.",
             **SlackPromptLinkMessageBuilder(associate_url).as_payload(),

--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -37,7 +37,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
     def reply(self, slack_request: SlackDMRequest, message: str) -> Response:
         headers = {"Authorization": f"Bearer {self._get_access_token(slack_request.integration)}"}
-        payload = {"channel": slack_request.channel_name, "text": message}
+        payload = {"channel": slack_request.channel_id, "text": message}
         client = SlackClient()
         try:
             client.post("/chat.postMessage", headers=headers, data=payload, json=True)
@@ -97,7 +97,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
 
         headers = {"Authorization": f"Bearer {self._get_access_token(slack_request.integration)}"}
         payload = {
-            "channel": slack_request.channel_name,
+            "channel": slack_request.channel_id,
             **SlackHelpMessageBuilder(command).as_payload(),
         }
         client = SlackClient()
@@ -212,6 +212,7 @@ class SlackEventEndpoint(SlackDMEndpoint):
                 return self.respond()
 
             command, _ = slack_request.get_command_and_args()
+
             if command in COMMANDS:
                 resp = super().post_dispatcher(slack_request)
 

--- a/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
+++ b/tests/sentry/integrations/slack/webhooks/events/test_message_im.py
@@ -55,6 +55,15 @@ class MessageIMEventTest(BaseEventTest):
         return blocks[0]["text"]["text"], blocks[1]["text"]["text"]
 
     @responses.activate
+    def test_identifying_channel_correctly(self):
+        responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
+        event_data = json.loads(MESSAGE_IM_EVENT)
+        self.post_webhook(event_data=event_data)
+        request = responses.calls[0].request
+        data = json.loads(request.body)
+        assert data.get("channel") == event_data["channel"]
+
+    @responses.activate
     def test_user_message_im_notification_platform(self):
         responses.add(responses.POST, "https://slack.com/api/chat.postMessage", json={"ok": True})
         resp = self.post_webhook(event_data=json.loads(MESSAGE_IM_EVENT))


### PR DESCRIPTION
FIxes SENTRY-PG6

We have a feature on the Slack Bot that lets you message it `help`, or `link` or `link team` without any slashes to get a response, since you're DMing the bot. It wasn't working since we were misreading the location of the channel ID.

<img width="652" alt="image" src="https://user-images.githubusercontent.com/35509934/191378617-a6bd7730-5fb2-4626-8163-8e9d67e78818.png">

