### PR TITLE
feat(debug): Add send button to email previews

### DIFF
--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -1,7 +1,7 @@
 {% load sentry_assets %}
 
 <div style="padding: 20px; border-bottom: 1px solid #ddd; background: #fff; margin-bottom: 20px;">
-  <div style="width: 500; margin: 0 auto">
+  <div style="width: 600; margin: 0 auto; display: flex;">
     {% if preview.subject %}<h1>{{ preview.subject }}</h1>{% endif %}
     <label for="event" style="margin-right: 10px">Selection:</label>
     <select id="event" style="width: 200px; margin-right: 20px;">
@@ -63,6 +63,9 @@
       <option value="html">HTML</option>
       <option value="txt" {% if format == 'txt' %} selected="selected"{% endif %}>Plaintext</option>
     </select>
+    <form action="" method="post" style="margin-left: auto; margin-block-end: 0;">
+      <button type="submit">Send</button>
+    </form>
   </div>
 </div>
 

--- a/src/sentry/web/frontend/debug/debug_release_summary_email.py
+++ b/src/sentry/web/frontend/debug/debug_release_summary_email.py
@@ -2,20 +2,26 @@ import datetime
 from urllib.parse import quote
 
 import pytz
-from django.views.generic import View
 from rest_framework.request import Request
-from rest_framework.response import Response
 from sentry_relay import parse_release
 
 from sentry.models import Deploy, Organization, Project, Release
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.utils.http import absolute_uri
 
-from .mail import MailPreview
+from .mail import MailPreviewView
 
 
-class DebugReleaseSummaryEmailView(View):
-    def get(self, request: Request) -> Response:
+class DebugReleaseSummaryEmailView(MailPreviewView):
+    @property
+    def text_template(self):
+        return "sentry/emails/activity/release_summary.txt"
+
+    @property
+    def html_template(self):
+        return "sentry/emails/activity/release_summary.html"
+
+    def get_context(self, request: Request):
         org = Organization(id=1, slug="organization", name="My Company")
         projects = [
             Project(id=1, organization=org, slug="project", name="My Project"),
@@ -49,19 +55,15 @@ class DebugReleaseSummaryEmailView(View):
             for p in projects
         ]
 
-        return MailPreview(
-            html_template="sentry/emails/activity/release_summary.html",
-            text_template="sentry/emails/activity/release_summary.txt",
-            context={
-                "author_count": 1,
-                "commit_count": 4,
-                "deploy": deploy,
-                "environment": "production",
-                "file_count": 5,
-                "project_count": len(projects),
-                "projects": list(zip(projects, release_links, issue_links, [6, 1, 0])),
-                "reason": GroupSubscriptionReason.descriptions[GroupSubscriptionReason.committed],
-                "release": release,
-                "version_parsed": version_parsed,
-            },
-        ).render(request)
+        return {
+            "author_count": 1,
+            "commit_count": 4,
+            "deploy": deploy,
+            "environment": "production",
+            "file_count": 5,
+            "project_count": len(projects),
+            "projects": list(zip(projects, release_links, issue_links, [6, 1, 0])),
+            "reason": GroupSubscriptionReason.descriptions[GroupSubscriptionReason.committed],
+            "release": release,
+            "version_parsed": version_parsed,
+        }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8980455/191379141-d869824f-3954-481c-aa13-265a8f32cb66.png)

Added a button to email debug views. Once clicked it'll send the email using the default backend.

Note that as of right now email debug views are somewhat messy. some debug views are functional while others are classes. This feature requires inheriting from `MailPreviewView` on a per-view basis. This will be addressed in a future PR.