### PR TITLE
chore(ui): Remove codeowners for test folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -124,7 +124,6 @@ yarn.lock           @getsentry/owners-js-deps
 /src/sentry/search/events/                                      @getsentry/visibility
 /tests/snuba/search/test_backend.py                             @getsentry/visibility
 /static/app/utils/discover/                                     @getsentry/visibility
-/tests/js/spec/utils/discover/                                  @getsentry/visibility
 /static/app/components/charts/                                  @getsentry/visibility
 ### Endof Visibility ###
 
@@ -139,9 +138,7 @@ yarn.lock           @getsentry/owners-js-deps
 /src/sentry/api/endpoints/organization_transaction_anomaly_detection.py         @getsentry/data
 
 /static/app/views/performance/                                  @getsentry/performance
-/tests/js/spec/views/performance/                               @getsentry/performance
 /static/app/utils/performance/                                  @getsentry/performance
-/tests/js/spec/utils/performance/                               @getsentry/performance
 /static/app/components/events/interfaces/spans/                 @getsentry/performance
 /static/app/components/performance/                             @getsentry/performance
 /static/app/components/quickTrace/                              @getsentry/performance
@@ -173,11 +170,8 @@ yarn.lock           @getsentry/owners-js-deps
 /tests/sentry/data_export/                                      @getsentry/discover-n-dashboards
 
 /static/app/views/eventsV2/                                     @getsentry/discover-n-dashboards
-/tests/js/spec/views/eventsV2/                                  @getsentry/discover-n-dashboards
 /static/app/views/discover/                                     @getsentry/discover-n-dashboards
-/tests/js/spec/views/discover/                                  @getsentry/discover-n-dashboards
 /static/app/views/dashboardsV2/                                 @getsentry/discover-n-dashboards
-/tests/js/spec/views/dashboardsV2/                              @getsentry/discover-n-dashboards
 /static/app/components/dashboards/                              @getsentry/discover-n-dashboards
 ### Endof Discover/Dashboards ###
 
@@ -188,7 +182,6 @@ yarn.lock           @getsentry/owners-js-deps
 /static/app/types/profiling.d.ts                                    @getsentry/profiling
 /static/app/utils/profiling                                         @getsentry/profiling
 /static/app/views/profiling                                         @getsentry/profiling
-/tests/js/spec/utils/profiling                                      @getsentry/profiling
 /src/sentry/utils/profiling.py                                      @getsentry/profiling
 /src/sentry/api/endpoints/project_profiling_profile.py              @getsentry/profiling
 /src/sentry/api/endpoints/organization_profiling_profiles.py        @getsentry/profiling
@@ -204,9 +197,6 @@ yarn.lock           @getsentry/owners-js-deps
 /static/app/components/replays/    @getsentry/emerging-technology
 /static/app/utils/replays/         @getsentry/emerging-technology
 /static/app/views/replays/         @getsentry/emerging-technology
-/tests/js/spec/components/replays/ @getsentry/emerging-technology
-/tests/js/spec/utils/replays/      @getsentry/emerging-technology
-/tests/js/spec/views/replays/      @getsentry/emerging-technology
 /src/sentry/replays/               @getsentry/emerging-technology
 /tests/sentry/replays/             @getsentry/emerging-technology
 ###### End of Replays #######
@@ -289,7 +279,6 @@ yarn.lock           @getsentry/owners-js-deps
 ### Enterprise ###
 
 /static/app/views/organizationStats                  @getsentry/enterprise
-/tests/js/spec/views/organizationStats/              @getsentry/enterprise
 /src/sentry/api/endpoints/organization_stats*.py     @getsentry/enterprise
 
 /src/sentry/api/endpoints/organization_auditlogs.py  @getsentry/enterprise
@@ -373,13 +362,10 @@ yarn.lock           @getsentry/owners-js-deps
 /tests/snuba/api/endpoints/test_organization_sessions.py             @getsentry/telemetry-experience
 
 /static/app/views/settings/project/sampling/                         @getsentry/telemetry-experience
-/tests/js/spec/views/settings/project/sampling/                      @getsentry/telemetry-experience
 /static/app/views/settings/project/server-side-sampling/             @getsentry/telemetry-experience
-/tests/js/spec/views/settings/project/server-side-sampling/          @getsentry/telemetry-experience
 /static/app/utils/metrics/                                           @getsentry/telemetry-experience
-/tests/js/spec/utils/metrics/                                        @getsentry/telemetry-experience
 /static/app/actionCreators/metrics.tsx                               @getsentry/telemetry-experience
-/tests/js/spec/actionCreators/metrics.spec.tsx                       @getsentry/telemetry-experience
+/static/app/actionCreators/metrics.spec.tsx                          @getsentry/telemetry-experience
 /static/app/types/metrics.tsx                                        @getsentry/telemetry-experience
 
 ### End of Telemetry Experience ###


### PR DESCRIPTION
The frontend tests were consolidated into the frontend files, these folders no longer exist.
