### PR TITLE
feat(integrations): Avoid SSRF vulnerability when working with JS fetchFile

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1584,6 +1584,9 @@ SENTRY_CACHE_MAX_VALUE_SIZE = None
 # 'name' in SENTRY_MANAGED_USER_FIELDS.
 SENTRY_MANAGED_USER_FIELDS = ()
 
+# Set this variable to your whitelisted domains to avoid SSRF vulnerability e.g. "*.example.com, api.google.com, "
+SENTRY_FETCH_FILE_WHITELIST = ""
+
 SENTRY_SCOPES = {
     "org:read",
     "org:write",

--- a/src/sentry/models/eventerror.py
+++ b/src/sentry/models/eventerror.py
@@ -28,6 +28,7 @@ class EventError:
     JS_INVALID_CONTENT = "js_invalid_content"
     JS_NO_COLUMN = "js_no_column"
     JS_MISSING_SOURCE = "js_no_source"
+    JS_FETCH_FILE_NOT_ALLOWED = "js_fetch_file_not_allowed"
     JS_INVALID_SOURCEMAP = "js_invalid_source"
     JS_TOO_MANY_REMOTE_SOURCES = "js_too_many_sources"
     JS_INVALID_SOURCE_ENCODING = "js_invalid_source_encoding"
@@ -74,6 +75,7 @@ class EventError:
         JS_INVALID_CONTENT: "Source file was not JavaScript",
         JS_NO_COLUMN: "Cannot expand sourcemap due to missing column information",
         JS_MISSING_SOURCE: "Source code was not found",
+        JS_FETCH_FILE_NOT_ALLOWED: "Domain not allowed for download",
         JS_INVALID_SOURCEMAP: "Sourcemap was invalid or not parseable",
         JS_TOO_MANY_REMOTE_SOURCES: "The maximum number of remote source requests was made",
         JS_INVALID_SOURCE_ENCODING: "Source file was not encoded properly",


### PR DESCRIPTION
feat(integrations): Avoid SSRF vulnerability when working with JS fetchFile

Add possibility to avoid SSRF vulnerability when, in case of JS, Sentry try to fetch file from some URI. Add new SENTRY_FETCH_FILE_WHITELIST option which grants you possibility to set domains from where Sentry must download files, for all other domains result will be error.
You can set a list of domains like "api.example.com, gw.example.com, [www.example.com](http://www.example.com/)" or use just ".example.com, example.com" to add any subdomains in "example.com" domain. If you are using 4th level domain names, then you need to add for example ".api.example.com"

FIXES #39102

Legal Boilerplate
Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.