### PR TITLE
fix(discover): Fix discover add to dashboard modal dashboard selector disabled

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -241,7 +241,6 @@ function AddToDashboardModal({
                 forceTransactions={metricsDataSide.forceTransactionsOnly}
               >
                 <WidgetCard
-                  api={api}
                   organization={organization}
                   currentWidgetDragging={false}
                   isEditing={false}


### PR DESCRIPTION
Fixes an issue where the dashboards fetch request in the add to dashboard modal gets cancelled and the dropdown selector is disabled indefinitely. Sharing the same api object with the WidgetCard tends to cancel the inflight dashboards request. Stop passing api prop so WidgetCard can get its own from withApi HoC

<img width="770" alt="image" src="https://user-images.githubusercontent.com/83961295/191542986-c117e20f-2ed2-41c9-9a7e-eaa16589f692.png">
