### PR TITLE
fix(ui): Make sure correct project object is passed to issue actions

### DIFF
--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -588,6 +588,7 @@ class GroupDetails extends Component<Props, State> {
           replaysCount={replayIds?.length}
           currentTab={currentTab}
           baseUrl={baseUrl}
+          project={project as Project}
         />
         {isValidElement(children) ? cloneElement(children, childProps) : children}
       </Fragment>

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -28,7 +28,7 @@ import Tooltip from 'sentry/components/tooltip';
 import {IconChat} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Event, Group, IssueCategory, Organization, User} from 'sentry/types';
+import {Event, Group, IssueCategory, Organization, Project, User} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {getMessage} from 'sentry/utils/events';
@@ -46,6 +46,7 @@ type Props = {
   group: Group;
   groupReprocessingStatus: ReprocessingStatus;
   organization: Organization;
+  project: Project;
   replaysCount: number | undefined;
   event?: Event;
 };
@@ -79,9 +80,9 @@ function GroupHeader({
   organization,
   replaysCount,
   event,
+  project,
 }: Props) {
   const location = useLocation();
-  const {project} = group;
 
   const trackAssign: React.ComponentProps<typeof AssigneeSelector>['onAssign'] =
     useCallback(() => {


### PR DESCRIPTION
group.project was being passed to the group details actions which was causing actions like "resolve in next release" to be disabled when they shouldn't have been, because `group.project` did not have the `features` array.

It appears there are some serious typing issues here which allowed this bug to slip through. Will take a look into this once this fix has landed.

The issue looked like this, which can be found on any issue details page:

![image](https://user-images.githubusercontent.com/10888943/191563720-3273494e-49ae-4092-9ba5-70550af80cee.png)
