### PR TITLE
ref(gitlab): Capture Sentry errors for Gitlab webhook

### DIFF
--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -35,6 +35,17 @@ class WebhookTest(GitLabTestCase):
     def test_get(self):
         response = self.client.get(self.url)
         assert response.status_code == 405
+        assert response.reason_phrase == "HTTP method not supported."
+
+    def test_missing_x_gitlab_token(self):
+        response = self.client.post(
+            self.url,
+            data=PUSH_EVENT,
+            content_type="application/json",
+            HTTP_X_GITLAB_EVENT="lol",
+        )
+        assert response.status_code == 400
+        assert response.reason_phrase == "Gitlab sent us a payload without HTTP_X_GITLAB_TOKEN."
 
     def test_unknown_event(self):
         response = self.client.post(
@@ -45,6 +56,7 @@ class WebhookTest(GitLabTestCase):
             HTTP_X_GITLAB_EVENT="lol",
         )
         assert response.status_code == 400
+        assert response.reason_phrase == "Invalid Gitlab event sent."
 
     def test_invalid_token(self):
         response = self.client.post(
@@ -55,6 +67,7 @@ class WebhookTest(GitLabTestCase):
             HTTP_X_GITLAB_EVENT="Push Hook",
         )
         assert response.status_code == 400
+        assert response.reason_phrase == "Gitlab sent us a malformed HTTP_X_GITLAB_TOKEN."
 
     def test_valid_id_invalid_secret(self):
         response = self.client.post(
@@ -65,6 +78,10 @@ class WebhookTest(GitLabTestCase):
             HTTP_X_GITLAB_EVENT="Push Hook",
         )
         assert response.status_code == 400
+        assert (
+            response.reason_phrase
+            == "Gitlab's webhook secret does not match. Refresh token (or re-install the integration) by following this https://docs.sentry.io/product/integrations/integration-platform/public-integration/#refreshing-tokens."
+        )
 
     def test_invalid_payload(self):
         response = self.client.post(
@@ -75,6 +92,7 @@ class WebhookTest(GitLabTestCase):
             HTTP_X_GITLAB_EVENT="Push Hook",
         )
         assert response.status_code == 400
+        assert response.reason_phrase == "Data received is not JSON."
 
     def test_push_event_missing_repo(self):
         response = self.client.post(


### PR DESCRIPTION
There's various 400 error responses from the webhook where we do not create errors for, thus, being unable to see know what's happening.

These changes will allow investigating customer issues more easily. Including seeing the body and headers.

I managed to create [a sample event](https://sentry.io/organizations/sentry-test/issues/3609536054/?query=is%3Aunresolved&statsPeriod=24h) from my localhost:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/44410/191566859-beda4ea0-30e3-4dc1-bf7b-54bd07b524b9.png">
<img width="392" alt="image" src="https://user-images.githubusercontent.com/44410/191566919-8135e82a-eb92-4796-bec4-743f1374d794.png">
<img width="773" alt="image" src="https://user-images.githubusercontent.com/44410/191567086-64bf0dc6-8b4d-4bba-ba24-6450f30adefa.png">

Fixes WOR-2208