### PR TITLE
feat(commit-context): Create analytic event groupowner.assignment

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -13,6 +13,7 @@ from .first_release_tag_sent import *  # noqa: F401,F403
 from .first_sourcemaps_sent import *  # noqa: F401,F403
 from .first_transaction_sent import *  # noqa: F401,F403
 from .first_user_context_sent import *  # noqa: F401,F403
+from .groupowner_assignment import *  # noqa: F401,F403
 from .inapp_request import *  # noqa: F401,F403
 from .inbox_in import *  # noqa: F401,F403
 from .inbox_out import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/groupowner_assignment.py
+++ b/src/sentry/analytics/events/groupowner_assignment.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class GroupOwnerAssignment(analytics.Event):
+    type = "groupowner.assignment"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("group_id"),
+        analytics.Attribute("new_assignment", type=bool),
+    )
+
+
+analytics.register(GroupOwnerAssignment)

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from django.utils import timezone
 
+from sentry import analytics
 from sentry.api.serializers.models.release import get_users_for_authors
 from sentry.integrations.utils.commit_context import find_commit_context_for_event
 from sentry.locks import locks
@@ -137,5 +138,12 @@ def process_commit_context(
                     else:
                         owner.delete()
 
+            analytics.record(
+                "groupowner.assignment",
+                organization_id=project.organization_id,
+                project_id=project.id,
+                group_id=group_id,
+                new_assignment=created,
+            )
     except UnableToAcquireLock:
         pass


### PR DESCRIPTION
## Objective:
We want to track how many times the Commit Context groupowner assignment got changed for the same group. This should indicate that the stacktrace had changed between the events and should be proof that our assumption that the grouping algorithm is accurate is false. The caveat for this metric is that it will only be created if a new event occurs 7 days after the original assignment