### PR TITLE
fix(discover) Added logic to render area graph for size field type in…

### DIFF
--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -6,6 +6,7 @@ import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
 import {Client} from 'sentry/api';
+import {AreaChart} from 'sentry/components/charts/areaChart';
 import {BarChart} from 'sentry/components/charts/barChart';
 import EventsChart from 'sentry/components/charts/eventsChart';
 import {getInterval, getPreviousSeriesName} from 'sentry/components/charts/utils';
@@ -16,9 +17,15 @@ import Placeholder from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
 import {Organization, SelectValue} from 'sentry/types';
 import {valueIsEqual} from 'sentry/utils';
+import {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
+import {CustomMeasurementsContext} from 'sentry/utils/customMeasurements/customMeasurementsContext';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
-import {isEquation, stripEquationPrefix} from 'sentry/utils/discover/fields';
+import {
+  getAggregateArg,
+  isEquation,
+  stripEquationPrefix,
+} from 'sentry/utils/discover/fields';
 import {
   DisplayModes,
   MULTI_Y_AXIS_SUPPORTED_DISPLAY_MODES,
@@ -28,6 +35,8 @@ import {
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {decodeScalar} from 'sentry/utils/queryString';
 import withApi from 'sentry/utils/withApi';
+
+import {isCustomMeasurement} from '../dashboardsV2/utils';
 
 import ChartFooter from './chartFooter';
 
@@ -39,6 +48,7 @@ type ResultsChartProps = {
   organization: Organization;
   router: InjectedRouter;
   yAxisValue: string[];
+  customMeasurements?: CustomMeasurementCollection | undefined;
   processedLineSeries?: LineSeriesOption[];
 };
 
@@ -64,6 +74,7 @@ class ResultsChart extends Component<ResultsChartProps> {
       confirmedQuery,
       yAxisValue,
       processedLineSeries,
+      customMeasurements,
     } = this.props;
 
     const hasPerformanceChartInterpolation = organization.features.includes(
@@ -89,11 +100,19 @@ class ResultsChart extends Component<ResultsChartProps> {
     const isPrevious = display === DisplayModes.PREVIOUS;
     const referrer = `api.discover.${display}-chart`;
     const topEvents = eventView.topEvents ? parseInt(eventView.topEvents, 10) : TOP_N;
+    const aggregateParam = getAggregateArg(yAxisValue[0]) || '';
+    const customPerformanceMetricFieldType = isCustomMeasurement(aggregateParam)
+      ? customMeasurements
+        ? customMeasurements[aggregateParam]?.fieldType
+        : null
+      : null;
     const chartComponent =
       display === DisplayModes.WORLDMAP
         ? WorldMapChart
         : display === DisplayModes.BAR
         ? BarChart
+        : customPerformanceMetricFieldType === 'size' && isTopEvents
+        ? AreaChart
         : undefined;
     const interval =
       display === DisplayModes.BAR
@@ -284,16 +303,21 @@ class ResultsChartContainer extends Component<ContainerProps, ContainerState> {
     return (
       <StyledPanel>
         {(yAxis.length > 0 && (
-          <ResultsChart
-            api={api}
-            eventView={eventView}
-            location={location}
-            organization={organization}
-            router={router}
-            confirmedQuery={confirmedQuery}
-            yAxisValue={yAxis}
-            processedLineSeries={processedLineSeries}
-          />
+          <CustomMeasurementsContext.Consumer>
+            {contextValue => (
+              <ResultsChart
+                api={api}
+                eventView={eventView}
+                location={location}
+                organization={organization}
+                router={router}
+                confirmedQuery={confirmedQuery}
+                yAxisValue={yAxis}
+                processedLineSeries={processedLineSeries}
+                customMeasurements={contextValue?.customMeasurements ?? undefined}
+              />
+            )}
+          </CustomMeasurementsContext.Consumer>
         )) || <NoChartContainer>{t('No Y-Axis selected.')}</NoChartContainer>}
         <ChartFooter
           organization={organization}

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -314,7 +314,7 @@ class ResultsChartContainer extends Component<ContainerProps, ContainerState> {
                 confirmedQuery={confirmedQuery}
                 yAxisValue={yAxis}
                 processedLineSeries={processedLineSeries}
-                customMeasurements={contextValue?.customMeasurements ?? undefined}
+                customMeasurements={contextValue?.customMeasurements}
               />
             )}
           </CustomMeasurementsContext.Consumer>


### PR DESCRIPTION
Renders area chart instead of the default line chart when custom performance metric field type is 'size' and display is Top Period.
