### PR TITLE
fix(profiling): Landing table last seen format

### DIFF
--- a/static/app/components/profiling/profileTransactionsTable.tsx
+++ b/static/app/components/profiling/profileTransactionsTable.tsx
@@ -198,7 +198,7 @@ function ProfilingTransactionsTableCell({
     case 'last_seen()':
       return (
         <Container>
-          <DateTime date={value} />
+          <DateTime date={value} year seconds timeZone />
         </Container>
       );
     default:


### PR DESCRIPTION
Not sure when this changed but this was no longer showing the full time.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/191591353-e0b1942b-a93a-4839-bc58-8324e6a72319.png)

## After

![image](https://user-images.githubusercontent.com/10239353/191591420-92dbe483-bf0a-488d-ae00-5c06219f0fd7.png)
