### PR TITLE
Add unknown log level for performance issues

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -177,6 +177,7 @@ RESERVED_PROJECT_SLUGS = frozenset(
     )
 )
 
+UNKNOWN_LOG_LEVEL = 100
 LOG_LEVELS = {
     logging.NOTSET: "sample",
     logging.DEBUG: "debug",
@@ -184,6 +185,7 @@ LOG_LEVELS = {
     logging.WARNING: "warning",
     logging.ERROR: "error",
     logging.FATAL: "fatal",
+    UNKNOWN_LOG_LEVEL: "unknown",
 }
 DEFAULT_LOG_LEVEL = "error"
 DEFAULT_LOGGER_NAME = ""

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -106,9 +106,8 @@ from sentry.utils.performance_issues.performance_detection import (
 )
 from sentry.utils.safe import get_path, safe_execute, setdefault_path, trim
 
-logger = logging.getLogger("sentry.events")
 logging.addLevelName(UNKNOWN_LOG_LEVEL, "UNKNOWN")  # used for performance issues
-
+logger = logging.getLogger("sentry.events")
 
 SECURITY_REPORT_INTERFACES = ("csp", "hpkp", "expectct", "expectstaple")
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2138,7 +2138,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
                 "value": description,
             }
             assert group.location() == "/books/"
-            assert group.level == 40
+            assert group.level == 100
             assert group.issue_category == GroupCategory.PERFORMANCE
             assert group.issue_type == GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES
             assert EventPerformanceProblem.fetch(


### PR DESCRIPTION
https://github.com/getsentry/relay/pull/1489 is blocking

will add tests to `event_manager/test_validate_data.py` once merged