### PR TITLE
feat(hybrid-cloud): Add DedupeCookiesMiddleware

### DIFF
--- a/src/sentry/middleware/dedupe_cookies.py
+++ b/src/sentry/middleware/dedupe_cookies.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Callable
+
+from django.conf import settings
+from django.http import HttpResponseRedirect
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.auth import superuser
+
+
+def _query_string(request):
+    qs = request.META.get("QUERY_STRING") or ""
+    if qs:
+        qs = f"?{qs}"
+    return qs
+
+
+# List of cookie names to check for duplicates in a raw Cookie header from a Request object.
+COOKIE_NAMES = [settings.SESSION_COOKIE_NAME, settings.CSRF_COOKIE_NAME, superuser.COOKIE_NAME]
+
+
+def count_cookies(raw_cookie):
+    # Adapted from https://github.com/django/django/blob/ce6230aa976e8d963226a3956b45a8919215dbd8/django/http/cookie.py
+    cookie_counter = defaultdict(lambda: 0)
+    for chunk in raw_cookie.split(";"):
+        if "=" in chunk:
+            key, val = chunk.split("=", 1)
+        else:
+            # Assume an empty name per
+            # https://bugzilla.mozilla.org/show_bug.cgi?id=169091
+            key, val = "", chunk
+        key, val = key.strip(), val.strip()
+        if key or val:
+            cookie_counter[key] += 1
+    return cookie_counter
+
+
+def check_duplicate_cookies(request: Request):
+    cookie_counts = count_cookies(request.META.get("HTTP_COOKIE", ""))
+    cookies_to_delete = set()
+    for cookie_name in COOKIE_NAMES:
+        count = cookie_counts.get(cookie_name, 0)
+        if count <= 1:
+            continue
+        cookies_to_delete.add(cookie_name)
+    if len(cookies_to_delete) > 0:
+        return cookies_to_delete
+    return None
+
+
+class DedupeCookiesMiddleware:
+    """
+    De-duplicate some cookies.
+    """
+
+    def __init__(self, get_response: Callable[[Request], Response]):
+        self.get_response = get_response
+
+    def __call__(self, request: Request) -> Response:
+        if request.method != "GET":
+            return self.get_response(request)
+        duplicate_cookies = check_duplicate_cookies(request)
+        if duplicate_cookies is None:
+            return self.get_response(request)
+
+        # Browsers will send two or more cookies with the same name without letting us know the domain in which they
+        # were actually set. In this case, we redirect the browser to the same path, but with a `Set-Cookie` header
+        # to request the browser to delete duplicate cookie.
+        #
+        # We only do this for some cookies. See COOKIE_NAMES above.
+        #
+        # This idea was adapted from https://github.blog/2013-04-09-yummy-cookies-across-domains/
+        qs = _query_string(request)
+        redirect_url = f"{request.path}{qs}"
+        response = HttpResponseRedirect(redirect_url)
+
+        for cookie_name in duplicate_cookies:
+            response.delete_cookie(cookie_name)
+        return response

--- a/src/sentry/middleware/dedupe_cookies.py
+++ b/src/sentry/middleware/dedupe_cookies.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Callable
 
+import sentry_sdk
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from rest_framework.request import Request
@@ -88,4 +89,9 @@ class DedupeCookiesMiddleware:
             # This change will be reverted once domains are configured for session, csrf, su, and sudo cookies for
             # shipping customer domains.
             response.delete_cookie(cookie_name, domain=".sentry.io")
+
+        sentry_sdk.set_tag("has_duplicate_cookies", "yes")
+        sentry_sdk.set_context("duplicate_cookies", {"cookies": list(duplicate_cookies)})
+        sentry_sdk.capture_message("Found duplicate cookies.")
+
         return response

--- a/src/sentry/middleware/dedupe_cookies.py
+++ b/src/sentry/middleware/dedupe_cookies.py
@@ -84,5 +84,8 @@ class DedupeCookiesMiddleware:
         response = HttpResponseRedirect(redirect_url)
 
         for cookie_name in duplicate_cookies:
-            response.delete_cookie(cookie_name)
+            # De-dupe cookies with Domain=.sentry.io that will collide with cookies with Domain=sentry.io
+            # This change will be reverted once domains are configured for session, csrf, su, and sudo cookies for
+            # shipping customer domains.
+            response.delete_cookie(cookie_name, domain=".sentry.io")
         return response

--- a/src/sentry/middleware/dedupe_cookies.py
+++ b/src/sentry/middleware/dedupe_cookies.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.auth import superuser
+from sudo.settings import COOKIE_NAME as SUDO_COOKIE_NAME
 
 
 def _query_string(request):
@@ -19,7 +20,12 @@ def _query_string(request):
 
 
 # List of cookie names to check for duplicates in a raw Cookie header from a Request object.
-COOKIE_NAMES = [settings.SESSION_COOKIE_NAME, settings.CSRF_COOKIE_NAME, superuser.COOKIE_NAME]
+COOKIE_NAMES = [
+    settings.SESSION_COOKIE_NAME,
+    settings.CSRF_COOKIE_NAME,
+    superuser.COOKIE_NAME,
+    SUDO_COOKIE_NAME,
+]
 
 
 def count_cookies(raw_cookie):

--- a/tests/sentry/middleware/test_dedupe_cookies.py
+++ b/tests/sentry/middleware/test_dedupe_cookies.py
@@ -1,0 +1,131 @@
+from django.conf import settings
+from django.conf.urls import url
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.auth import superuser
+from sentry.testutils import APITestCase
+
+
+class OrganizationTestEndpoint(Endpoint):
+    permission_classes = (AllowAny,)
+
+    def get(self, request, organization_slug):
+        return Response(
+            {
+                "organization_slug": organization_slug,
+            }
+        )
+
+
+urlpatterns = [
+    url(
+        r"^api/0/(?P<organization_slug>[^\/]+)/$",
+        OrganizationTestEndpoint.as_view(),
+        name="org-endpoint",
+    ),
+]
+
+
+def provision_middleware():
+    middleware = list(settings.MIDDLEWARE)
+    if "sentry.middleware.dedupe_cookies.DedupeCookiesMiddleware" not in middleware:
+        index = middleware.index("sentry.middleware.stats.ResponseCodeMiddleware")
+        middleware.insert(index + 1, "sentry.middleware.dedupe_cookies.DedupeCookiesMiddleware")
+    return middleware
+
+
+@override_settings(
+    ROOT_URLCONF=__name__,
+    SENTRY_SELF_HOSTED=False,
+)
+class End2EndTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.middleware = provision_middleware()
+
+    def test_relevant_duplicate_cookies(self):
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
+            headers = {
+                "HTTP_COOKIE": f"{settings.SESSION_COOKIE_NAME}=value; foo=bar; {settings.SESSION_COOKIE_NAME}=value2",
+            }
+            response = self.client.get(
+                reverse("org-endpoint", kwargs={"organization_slug": "test"}) + "?foo=bar",
+                **headers,
+            )
+
+            assert response.status_code == 302
+            assert (
+                response["Location"]
+                == reverse("org-endpoint", kwargs={"organization_slug": "test"}) + "?foo=bar"
+            )
+            assert (
+                response.cookies.output()
+                == 'Set-Cookie: sentrysid=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+            )
+
+    def test_multiple_relevant_duplicate_cookies(self):
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
+            HTTP_COOKIE = (
+                f"{settings.SESSION_COOKIE_NAME}=value; "
+                f"{settings.SESSION_COOKIE_NAME}=value2; "
+                f"{settings.CSRF_COOKIE_NAME}=value; "
+                f"{settings.CSRF_COOKIE_NAME}=value2; "
+                f"{superuser.COOKIE_NAME}=value; "
+                f"{superuser.COOKIE_NAME}=value2"
+            )
+            headers = {
+                "HTTP_COOKIE": HTTP_COOKIE,
+            }
+            response = self.client.get(
+                reverse("org-endpoint", kwargs={"organization_slug": "test"}),
+                **headers,
+            )
+
+            assert response.status_code == 302
+            assert response["Location"] == reverse(
+                "org-endpoint", kwargs={"organization_slug": "test"}
+            )
+            set_cookie = response.cookies.output()
+            assert (
+                'Set-Cookie: sc=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                in set_cookie
+            )
+            assert (
+                'Set-Cookie: sentrysid=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                in set_cookie
+            )
+            assert (
+                'Set-Cookie: su=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                in set_cookie
+            )
+
+    def test_irrelevant_duplicate_cookies(self):
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
+            headers = {
+                "HTTP_COOKIE": "bar=value; foo=bar; bar=value2",
+            }
+            response = self.client.get(
+                reverse("org-endpoint", kwargs={"organization_slug": "test"}),
+                **headers,
+            )
+
+            assert response.status_code == 200
+
+    def test_good_cookies(self):
+        with override_settings(MIDDLEWARE=tuple(self.middleware)):
+            HTTP_COOKIE = (
+                f"{settings.SESSION_COOKIE_NAME}=value; "
+                f"{settings.CSRF_COOKIE_NAME}=value; "
+                f"{superuser.COOKIE_NAME}=value"
+            )
+            headers = {"HTTP_COOKIE": HTTP_COOKIE}
+            response = self.client.get(
+                reverse("org-endpoint", kwargs={"organization_slug": "test"}),
+                **headers,
+            )
+
+            assert response.status_code == 200

--- a/tests/sentry/middleware/test_dedupe_cookies.py
+++ b/tests/sentry/middleware/test_dedupe_cookies.py
@@ -65,7 +65,7 @@ class End2EndTest(APITestCase):
             )
             assert (
                 response.cookies.output()
-                == 'Set-Cookie: sentrysid=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                == 'Set-Cookie: sentrysid=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
             )
 
     def test_multiple_relevant_duplicate_cookies(self):
@@ -94,19 +94,19 @@ class End2EndTest(APITestCase):
             )
             set_cookie = response.cookies.output()
             assert (
-                'Set-Cookie: sc=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                'Set-Cookie: sc=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
                 in set_cookie
             )
             assert (
-                'Set-Cookie: sentrysid=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                'Set-Cookie: sentrysid=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
                 in set_cookie
             )
             assert (
-                'Set-Cookie: su=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                'Set-Cookie: su=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
                 in set_cookie
             )
             assert (
-                'Set-Cookie: sudo=""; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                'Set-Cookie: sudo=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
                 in set_cookie
             )
 

--- a/tests/sentry/middleware/test_dedupe_cookies.py
+++ b/tests/sentry/middleware/test_dedupe_cookies.py
@@ -65,7 +65,7 @@ class End2EndTest(APITestCase):
             )
             assert (
                 response.cookies.output()
-                == 'Set-Cookie: sentrysid=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                == 'Set-Cookie: sentrysid=""; Domain=.testserver; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
             )
 
     def test_multiple_relevant_duplicate_cookies(self):
@@ -94,19 +94,19 @@ class End2EndTest(APITestCase):
             )
             set_cookie = response.cookies.output()
             assert (
-                'Set-Cookie: sc=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                'Set-Cookie: sc=""; Domain=.testserver; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
                 in set_cookie
             )
             assert (
-                'Set-Cookie: sentrysid=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                'Set-Cookie: sentrysid=""; Domain=.testserver; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
                 in set_cookie
             )
             assert (
-                'Set-Cookie: su=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                'Set-Cookie: su=""; Domain=.testserver; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
                 in set_cookie
             )
             assert (
-                'Set-Cookie: sudo=""; Domain=.sentry.io; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
+                'Set-Cookie: sudo=""; Domain=.testserver; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/'
                 in set_cookie
             )
 


### PR DESCRIPTION
To be able to ship customer domains, I'd like to update these configuration keys to allow cookies to be shared across subdomains by setting them to be `.sentry.io` (note the leading dot):

- [`SESSION_COOKIE_DOMAIN`](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-SESSION_COOKIE_DOMAIN)
- [`CSRF_COOKIE_DOMAIN `](https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-CSRF_COOKIE_DOMAIN)
- [`SUPERUSER_COOKIE_DOMAIN`](https://github.com/getsentry/sentry/blob/bd166cb6bbd0cbf3801a723f2dfad2521587e38a/src/sentry/auth/superuser.py#L39)

When setting these keys in production, the user's browser will now contain duplicate cookies for each of these cookies. The previous cookie will not have a [`Domain`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) attribute set, but will be attached to `sentry.io` by default.

The second cookie will have a `Domain` attribute set to `.sentry.io`, enabling it to be shared across subdomains of `*.sentry.io`.

The user's browser will send these duplicate cookies in arbitrary order, and Django will arbitrarily only attach only one cookie to the `request` object.

This pull request introduces a middleware to check for any relevant duplicate cookies for `GET` requests. If any duplicate cookies are found, then the browser will be redirected to the same path, but with a `Set-Cookie` header to ask the browser to drop the duplicated cookie. This idea was adapted from here to address cookie tossing attacks: https://github.blog/2013-04-09-yummy-cookies-across-domains/

The middleware should assist in gracefully updating the user's cookies without having to ask them to clear their cookies. 

This middleware is currently not activated in this pull request. I'll activate it in a follow up pull request.