### PR TITLE
feat(billing): Add processed transactions to orgstats in anticipation of AM2 plans

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -212,7 +212,7 @@ export const DEFAULT_RELATIVE_PERIODS_PAGE_FILTER = {
 
 export const DATA_CATEGORY_NAMES = {
   [DataCategory.ERRORS]: t('Errors'),
-  [DataCategory.TRANSACTIONS]: t('Transactions'),
+  [DataCategory.TRANSACTIONS]: t('Indexed Transactions'),
   [DataCategory.ATTACHMENTS]: t('Attachments'),
   [DataCategory.TRANSACTIONS_PROCESSED]: t('Processed Transactions'),
 };

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -60,6 +60,7 @@ export class OrganizationStats extends Component<Props> {
     switch (dataCategory) {
       case DataCategory.ERRORS:
       case DataCategory.TRANSACTIONS:
+      case DataCategory.TRANSACTIONS_PROCESSED:
       case DataCategory.ATTACHMENTS:
         return dataCategory as DataCategory;
       default:
@@ -283,7 +284,7 @@ export class OrganizationStats extends Component<Props> {
                   </PageHeader>
                   <p>
                     {t(
-                      'We collect usage metrics on three categories: errors, transactions, and attachments. The charts below reflect data that Sentry has received across your entire organization. You can also find them broken down by project in the table.'
+                      'We collect usage metrics for errors, processed transactions, indexed transactions, and attachments. The charts below reflect data that Sentry has received across your entire organization. You can also find them broken down by project in the table.'
                     )}
                   </p>
                 </Fragment>

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -59,6 +59,12 @@ export const CHART_OPTIONS_DATACATEGORY: CategoryOption[] = [
     yAxisMinInterval: 100,
   },
   {
+    label: DATA_CATEGORY_NAMES[DataCategory.TRANSACTIONS_PROCESSED],
+    value: DataCategory.TRANSACTIONS_PROCESSED,
+    disabled: false,
+    yAxisMinInterval: 100,
+  },
+  {
     label: DATA_CATEGORY_NAMES[DataCategory.ATTACHMENTS],
     value: DataCategory.ATTACHMENTS,
     disabled: false,


### PR DESCRIPTION
Currently blocked by outcomes from processed transactions.
