### PR TITLE
ref(ui): Allow custom usage chart colors

### DIFF
--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -73,6 +73,15 @@ export enum DataCategory {
 
 export type EventType = 'error' | 'transaction' | 'attachment';
 
+export enum Outcome {
+  ACCEPTED = 'accepted',
+  FILTERED = 'filtered',
+  INVALID = 'invalid',
+  DROPPED = 'dropped', // this is not a real outcome coming from the server
+  RATE_LIMITED = 'rate_limited',
+  CLIENT_DISCARD = 'client_discard',
+}
+
 export type IntervalPeriod = ReturnType<typeof getInterval>;
 
 /**

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -351,7 +351,7 @@ const dataCategory = {
  */
 const outcome = {
   [Outcome.ACCEPTED]: CHART_PALETTE[0][0],
-  [Outcome.FILTERED]: CHART_PALETTE[0][0],
+  [Outcome.FILTERED]: CHART_PALETTE[1][1],
   [Outcome.DROPPED]: CHART_PALETTE[5][3],
 };
 

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -2,7 +2,7 @@ import {css} from '@emotion/react';
 import color from 'color';
 
 import CHART_PALETTE from 'sentry/constants/chartPalette';
-import {DataCategory} from 'sentry/types';
+import {DataCategory, Outcome} from 'sentry/types';
 
 /**
  * Exporting for use in Storybook only. Do not import this
@@ -344,6 +344,15 @@ const dataCategory = {
   [DataCategory.TRANSACTIONS]: CHART_PALETTE[4][2],
   [DataCategory.ATTACHMENTS]: CHART_PALETTE[4][1],
   [DataCategory.DEFAULT]: CHART_PALETTE[4][0],
+};
+
+/**
+ * Default colors for data usage outcomes
+ */
+const outcome = {
+  [Outcome.ACCEPTED]: CHART_PALETTE[0][0],
+  [Outcome.FILTERED]: CHART_PALETTE[0][0],
+  [Outcome.DROPPED]: CHART_PALETTE[5][3],
 };
 
 const generateAlertTheme = (colors: BaseColors, alias: Aliases) => ({
@@ -795,6 +804,7 @@ const commonTheme = {
   },
 
   dataCategory,
+  outcome,
 
   tag: generateTagTheme(lightColors),
 

--- a/static/app/views/organizationStats/types.tsx
+++ b/static/app/views/organizationStats/types.tsx
@@ -1,14 +1,5 @@
 import {SeriesApi} from 'sentry/types';
 
-export enum Outcome {
-  ACCEPTED = 'accepted',
-  FILTERED = 'filtered',
-  INVALID = 'invalid',
-  DROPPED = 'dropped', // this is not a real outcome coming from the server
-  RATE_LIMITED = 'rate_limited',
-  CLIENT_DISCARD = 'client_discard',
-}
-
 /**
  * Raw response from API endpoint
  */

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -132,6 +132,11 @@ type Props = DefaultProps & {
   usageStats: ChartStats;
 
   /**
+   * Override chart colors for each outcome
+   */
+  categoryColors?: string[];
+
+  /**
    * Additional data to draw on the chart alongside usage
    */
   chartSeries?: SeriesOption[];
@@ -394,7 +399,7 @@ export class UsageChart extends Component<Props, State> {
   }
 
   renderChart() {
-    const {theme, title, isLoading, isError, errors} = this.props;
+    const {categoryColors, theme, title, isLoading, isError, errors} = this.props;
     if (isLoading) {
       return (
         <Placeholder height="200px">
@@ -423,13 +428,15 @@ export class UsageChart extends Component<Props, State> {
       yAxisFormatter,
     } = this.chartMetadata;
 
+    const colors = categoryColors?.length ? categoryColors : this.chartColors;
+
     return (
       <Fragment>
         <HeaderTitleLegend>{title || t('Current Usage Period')}</HeaderTitleLegend>
         {getDynamicText({
           value: (
             <BaseChart
-              colors={this.chartColors}
+              colors={colors}
               grid={{bottom: '3px', left: '0px', right: '10px', top: '40px'}}
               xAxis={xAxis({
                 show: true,

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -12,7 +12,7 @@ import ScoreCard from 'sentry/components/scoreCard';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {DataCategory, IntervalPeriod, Organization} from 'sentry/types';
+import {DataCategory, IntervalPeriod, Organization, Outcome} from 'sentry/types';
 import {parsePeriodToHours} from 'sentry/utils/dates';
 
 import {
@@ -20,7 +20,7 @@ import {
   FORMAT_DATETIME_HOURLY,
   getDateFromMoment,
 } from './usageChart/utils';
-import {Outcome, UsageSeries, UsageStat} from './types';
+import {UsageSeries, UsageStat} from './types';
 import UsageChart, {
   CHART_OPTIONS_DATA_TRANSFORM,
   ChartDataTransform,

--- a/static/app/views/organizationStats/usageStatsPerMin.tsx
+++ b/static/app/views/organizationStats/usageStatsPerMin.tsx
@@ -2,9 +2,9 @@ import styled from '@emotion/styled';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
 import {t} from 'sentry/locale';
-import {DataCategory, Organization} from 'sentry/types';
+import {DataCategory, Organization, Outcome} from 'sentry/types';
 
-import {Outcome, UsageSeries} from './types';
+import {UsageSeries} from './types';
 import {formatUsageWithUnits, getFormatUsageOptions} from './utils';
 
 type Props = {

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -11,10 +11,10 @@ import SearchBar from 'sentry/components/searchBar';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {DataCategory, Organization, Project} from 'sentry/types';
+import {DataCategory, Organization, Outcome, Project} from 'sentry/types';
 import withProjects from 'sentry/utils/withProjects';
 
-import {Outcome, UsageSeries} from './types';
+import {UsageSeries} from './types';
 import UsageTable, {CellProject, CellStat, TableStat} from './usageTable';
 
 type Props = {

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -21,13 +21,12 @@ import {t, tct} from 'sentry/locale';
 import ModalStore from 'sentry/stores/modalStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
-import {Project} from 'sentry/types';
+import {Outcome, Project} from 'sentry/types';
 import {SamplingRule, UniformModalsSubmit} from 'sentry/types/sampling';
 import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {formatPercentage} from 'sentry/utils/formatters';
 import useApi from 'sentry/utils/useApi';
-import {Outcome} from 'sentry/views/organizationStats/types';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 import {

--- a/static/app/views/settings/project/server-side-sampling/testUtils.tsx
+++ b/static/app/views/settings/project/server-side-sampling/testUtils.tsx
@@ -3,7 +3,7 @@ import {InjectedRouter} from 'react-router';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import GlobalModal from 'sentry/components/globalModal';
-import {Organization, Project} from 'sentry/types';
+import {Organization, Outcome, Project} from 'sentry/types';
 import {
   RecommendedSdkUpgrade,
   SamplingConditionOperator,
@@ -15,7 +15,6 @@ import {
   SamplingSdkVersion,
 } from 'sentry/types/sampling';
 import {OrganizationContext} from 'sentry/views/organizationContext';
-import {Outcome} from 'sentry/views/organizationStats/types';
 import {RouteContext} from 'sentry/views/routeContext';
 import ServerSideSampling from 'sentry/views/settings/project/server-side-sampling';
 

--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.tsx
@@ -1,11 +1,10 @@
 import moment from 'moment';
 
 import {t} from 'sentry/locale';
-import {SeriesApi} from 'sentry/types';
+import {Outcome, SeriesApi} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import commonTheme from 'sentry/utils/theme';
-import {Outcome} from 'sentry/views/organizationStats/types';
 
 import {quantityField} from '.';
 

--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.tsx
@@ -1,8 +1,7 @@
 import round from 'lodash/round';
 
-import {SeriesApi} from 'sentry/types';
+import {Outcome, SeriesApi} from 'sentry/types';
 import {findClosestNumber} from 'sentry/utils/findClosestNumber';
-import {Outcome} from 'sentry/views/organizationStats/types';
 
 import {quantityField} from '.';
 

--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSeries.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSeries.tsx
@@ -2,11 +2,10 @@ import cloneDeep from 'lodash/cloneDeep';
 import moment from 'moment';
 
 import {t} from 'sentry/locale';
-import {SeriesApi} from 'sentry/types';
+import {Outcome, SeriesApi} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {defined} from 'sentry/utils';
 import commonTheme from 'sentry/utils/theme';
-import {Outcome} from 'sentry/views/organizationStats/types';
 
 import {quantityField} from '.';
 


### PR DESCRIPTION
Allow for custom usage chart colors to support processed transactions and help scale for additional data categories. Chart colors will be the same for all data categories and differ by usage outcome (accepted, filtered, dropped, etc.).

![Screen Shot 2022-09-22 at 3 33 18 PM](https://user-images.githubusercontent.com/16394317/191864236-abfcace1-287d-4ea8-bcae-ec701e9bdd53.png)
