### PR TITLE
Revert "fix(metrics): Add `freeze_time` to metrics layer tests"

### DIFF
--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -33,7 +33,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 pytestmark = pytest.mark.sentry_metrics
 
 
-@freeze_time()
 class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
     def setUp(self):
         super().setUp()
@@ -241,6 +240,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             key=lambda elem: elem["name"],
         )
 
+    @freeze_time()
     def test_alias_on_single_entity_derived_metrics(self):
         for value, tag_value in (
             (3.4, TransactionStatusTagValue.OK.value),

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
@@ -5,7 +5,6 @@ import time
 
 import pytest
 from django.utils.datastructures import MultiValueDict
-from freezegun import freeze_time
 from snuba_sdk import Granularity, Limit, Offset
 
 from sentry.sentry_metrics.configuration import UseCaseKey
@@ -18,7 +17,6 @@ from sentry.testutils import BaseMetricsTestCase, TestCase
 pytestmark = pytest.mark.sentry_metrics
 
 
-@freeze_time()
 class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
     def test_valid_filter_include_meta(self):
         self.create_release(version="foo", project=self.project)


### PR DESCRIPTION
Reverts getsentry/sentry#39143

Because the original PR doesn't actually fix flaky test, so reverting this change