### PR TITLE
fix(profiling): Make sure the profile gets inserted in ClickHouse before we aggregate

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -381,12 +381,11 @@ def _insert_vroom_profile(profile: Profile) -> bool:
             )
             return False
         return True
-    except RecursionError:
+    except RecursionError as e:
         profile["call_trees"] = {}
-        metrics.incr(
-            "profiling.insert_vroom_profile.error.recursion",
-            tags={"platform": profile["platform"], "profile_id": profile["profile_id"]},
-        )
+        with sentry_sdk.push_scope() as scope:
+            scope.set_tag("profile_id", profile["profile_id"])
+            sentry_sdk.capture_exception(e)
         return True
     except Exception as e:
         sentry_sdk.capture_exception(e)

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -382,7 +382,6 @@ def _insert_vroom_profile(profile: Profile) -> bool:
             return False
         return True
     except RecursionError as e:
-        profile["call_trees"] = {}
         sentry_sdk.set_context(
             "profile", {"profile_id": profile["profile_id"], "platform": profile["platform"]}
         )

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -369,7 +369,7 @@ def _insert_vroom_profile(profile: Profile) -> bool:
         if response.status == 204:
             profile["call_trees"] = {}
         elif response.status == 200:
-            profile["call_trees"] = json.loads(response.data)["call_trees"]
+            profile["call_trees"] = json.loads(response.data, use_rapid_json=True)["call_trees"]
         else:
             metrics.incr(
                 "profiling.insert_vroom_profile.error",

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -383,6 +383,10 @@ def _insert_vroom_profile(profile: Profile) -> bool:
         return True
     except RecursionError:
         profile["call_trees"] = {}
+        metrics.incr(
+            "profiling.insert_vroom_profile.error.recursion",
+            tags={"platform": profile["platform"], "profile_id": profile["profile_id"]},
+        )
         return True
     except Exception as e:
         sentry_sdk.capture_exception(e)

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -383,9 +383,10 @@ def _insert_vroom_profile(profile: Profile) -> bool:
         return True
     except RecursionError as e:
         profile["call_trees"] = {}
-        with sentry_sdk.push_scope() as scope:
-            scope.set_tag("profile_id", profile["profile_id"])
-            sentry_sdk.capture_exception(e)
+        sentry_sdk.set_context(
+            "profile", {"profile_id": profile["profile_id"], "platform": profile["platform"]}
+        )
+        sentry_sdk.capture_exception(e)
         return True
     except Exception as e:
         sentry_sdk.capture_exception(e)

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -86,8 +86,8 @@ def process_profile(
         return
 
     _initialize_publisher()
-    _insert_eventstream_call_tree(profile=profile)
     _insert_eventstream_profile(profile=profile)
+    _insert_eventstream_call_tree(profile=profile)
 
     _track_outcome(profile=profile, project=project, outcome=Outcome.ACCEPTED, key_id=key_id)
 


### PR DESCRIPTION
When a profile is stored on GCS (when sent to `vroom`), we should send it to Snuba for insertion right away as it could be useful already. Now, we also want to aggregate it, but it that fails, it's less of an issue.