### PR TITLE
fix(perf-issues) remove source span from span evidence

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -41,7 +41,6 @@ export function SpanEvidenceSection({event, organization}: Props) {
   const spansById = keyBy(spans, 'span_id');
 
   const parentSpan = spansById[event.perfProblem.parentSpanIds[0]];
-  const sourceSpan = spansById[event.perfProblem.causeSpanIds[0]];
   const repeatingSpan = spansById[event.perfProblem.offenderSpanIds[0]];
 
   const data: KeyValueListData = [
@@ -57,21 +56,12 @@ export function SpanEvidenceSection({event, organization}: Props) {
     },
     {
       key: '2',
-      subject: t('Source Span'),
-      value: getSpanEvidenceValue(sourceSpan),
-    },
-    {
-      key: '3',
       subject: t('Repeating Span'),
       value: getSpanEvidenceValue(repeatingSpan),
     },
   ];
 
-  const affectedSpanIds = [
-    parentSpan.span_id,
-    sourceSpan.span_id,
-    ...event.perfProblem.offenderSpanIds,
-  ];
+  const affectedSpanIds = [parentSpan.span_id, ...event.perfProblem.offenderSpanIds];
 
   return (
     <DataSection

--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -67,7 +67,7 @@ export function SpanEvidenceSection({event, organization}: Props) {
     <DataSection
       title={t('Span Evidence')}
       description={t(
-        'Span Evidence identifies the parent span where the N+1 occurs, the source span that occurs immediately before the repeating spans, and the repeating span itself.'
+        'Span Evidence identifies the parent span where the N+1 occurs, and the repeating spans.'
       )}
     >
       <KeyValueList data={data} />


### PR DESCRIPTION
Source span was decided to be potentially confusing and inaccurate, we are removing it for now

<img width="911" alt="image" src="https://user-images.githubusercontent.com/44422760/191785272-b905c875-ac45-4cc2-97a3-feea15e6f20a.png">
