### PR TITLE
ref(perf-issues): Add 'sdk' to metrics

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -990,7 +990,7 @@ def report_metrics_for_detectors(
         metrics.incr(
             "performance.performance_issue.aggregate",
             len(all_detected_problems),
-            tags={"sdk_name": sdk_name}
+            tags={"sdk_name": sdk_name},
         )
         if event_id:
             set_tag("_pi_transaction", event_id)

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -259,7 +259,7 @@ def _detect_performance_problems(data: Event, sdk_span: Any) -> List[Performance
         detector.on_complete()
 
     # Metrics reporting only for detection, not created issues.
-    report_metrics_for_detectors(event_id, detectors, sdk_span)
+    report_metrics_for_detectors(data, event_id, detectors, sdk_span)
 
     # Get list of detectors that are allowed to create issues.
     allowed_perf_issue_detectors = get_allowed_issue_creation_detectors(project_id)
@@ -973,10 +973,11 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
 
 # Reports metrics and creates spans for detection
 def report_metrics_for_detectors(
-    event_id: Optional[str], detectors: Dict[str, PerformanceDetector], sdk_span: Any
+    event: Event, event_id: Optional[str], detectors: Dict[str, PerformanceDetector], sdk_span: Any
 ):
     all_detected_problems = [i for _, d in detectors.items() for i in d.stored_problems]
     has_detected_problems = bool(all_detected_problems)
+    sdk_name = event.get("sdk", {}).get("name", "")
 
     try:
         # Setting a tag isn't critical, the transaction doesn't exist sometimes, if it's called outside prod code (eg. load-mocks / tests)
@@ -989,11 +990,12 @@ def report_metrics_for_detectors(
         metrics.incr(
             "performance.performance_issue.aggregate",
             len(all_detected_problems),
+            tags={"sdk_name": sdk_name}
         )
         if event_id:
             set_tag("_pi_transaction", event_id)
 
-    detected_tags = {}
+    detected_tags = {"sdk_name": sdk_name}
     for detector_enum, detector in detectors.items():
         detector_key = detector_enum.value
         detected_problems = detector.stored_problems


### PR DESCRIPTION
### Summary
This adds the sdk in use for an event to metrics. This will allow us to determine how the detectors work for different sdk families.`sdk.name` is fairly low card.
