### PR TITLE
fix(replays): Fix the Replay Network table so it highlights error status codes in red at all times

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -333,11 +333,11 @@ const Item = styled('div')<{
   ${p => p.numeric && 'font-variant-numeric: tabular-nums;'};
 
   ${EmptyText} {
-    color: ${({hasOccurred = true, timestampSortDir, ...p}) => {
-      if (hasOccurred || !timestampSortDir) {
-        return p.theme.gray400;
+    color: ${p => {
+      if (p.isStatusError) {
+        return p.hasOccurred || !p.timestampSortDir ? p.theme.red400 : p.theme.red200;
       }
-      return p.theme.gray300;
+      return p.hasOccurred || !p.timestampSortDir ? p.theme.gray400 : p.theme.gray300;
     }};
   }
 `;

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -294,6 +294,13 @@ const EmptyText = styled(Text)`
   color: ${p => p.theme.subText};
 `;
 
+const fontColor = p => {
+  if (p.isStatusError) {
+    return p.hasOccurred || !p.timestampSortDir ? p.theme.red400 : p.theme.red200;
+  }
+  return p.hasOccurred || !p.timestampSortDir ? p.theme.gray400 : p.theme.gray300;
+};
+
 const Item = styled('div')<{
   hasOccurred: boolean;
   isCurrent: boolean;
@@ -307,12 +314,7 @@ const Item = styled('div')<{
   align-items: center;
   ${p => p.center && 'justify-content: center;'}
   max-height: 28px;
-  color: ${p => {
-    if (p.isStatusError) {
-      return p.hasOccurred || !p.timestampSortDir ? p.theme.red400 : p.theme.red200;
-    }
-    return p.hasOccurred || !p.timestampSortDir ? p.theme.gray400 : p.theme.gray300;
-  }};
+  color: ${fontColor};
   padding: ${space(0.75)} ${space(1.5)};
   background-color: ${p => p.theme.background};
   border-bottom: ${p => {
@@ -333,12 +335,7 @@ const Item = styled('div')<{
   ${p => p.numeric && 'font-variant-numeric: tabular-nums;'};
 
   ${EmptyText} {
-    color: ${p => {
-      if (p.isStatusError) {
-        return p.hasOccurred || !p.timestampSortDir ? p.theme.red400 : p.theme.red200;
-      }
-      return p.hasOccurred || !p.timestampSortDir ? p.theme.gray400 : p.theme.gray300;
-    }};
+    color: ${fontColor};
   }
 `;
 

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -13,7 +13,6 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
-import {ColorOrAlias} from 'sentry/utils/theme';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import useNetworkFilters from 'sentry/views/replays/detail/network/useNetworkFilters';
 import {
@@ -175,7 +174,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
       isCurrent: currentNetworkSpan?.id === spanId,
       hasOccurred:
         currentTime >= relativeTimeInMs(networkStartTimestamp, startTimestampMs),
-      timestampSort:
+      timestampSortDir:
         sortConfig.by === 'startTimestamp'
           ? ((sortConfig.asc ? 'asc' : 'desc') as SortDirection)
           : undefined,
@@ -296,48 +295,46 @@ const EmptyText = styled(Text)`
 `;
 
 const Item = styled('div')<{
+  hasOccurred: boolean;
+  isCurrent: boolean;
+  isStatusError: boolean;
+  timestampSortDir: SortDirection | undefined;
   center?: boolean;
-  color?: ColorOrAlias;
-  hasOccurred?: boolean;
-  isCurrent?: boolean;
   isStatusCode?: boolean;
-  isStatusError?: boolean;
   numeric?: boolean;
-  timestampSort?: SortDirection;
 }>`
   display: flex;
   align-items: center;
   ${p => p.center && 'justify-content: center;'}
   max-height: 28px;
-  color: ${({hasOccurred = true, isStatusError, timestampSort, ...p}) => {
-    if (hasOccurred || !timestampSort) {
-      return isStatusError ? p.theme.red400 : p.theme.gray400;
+  color: ${p => {
+    if (p.isStatusError) {
+      return p.hasOccurred || !p.timestampSortDir ? p.theme.red400 : p.theme.red200;
     }
-    return p.theme.gray300;
+    return p.hasOccurred || !p.timestampSortDir ? p.theme.gray400 : p.theme.gray300;
   }};
   padding: ${space(0.75)} ${space(1.5)};
   background-color: ${p => p.theme.background};
-  border-bottom: ${({isCurrent = false, isStatusError, timestampSort, ...p}) => {
-    if (isCurrent && timestampSort === 'asc') {
+  border-bottom: ${p => {
+    if (p.isCurrent && p.timestampSortDir === 'asc') {
       return `1px solid ${p.theme.purple300} !important`;
     }
-    return isStatusError
+    return p.isStatusError
       ? `1px solid ${p.theme.red100}`
       : `1px solid ${p.theme.innerBorder}`;
   }};
 
-  border-top: ${({isCurrent = false, timestampSort, ...p}) => {
-    if (isCurrent && timestampSort === 'desc') {
-      return `1px solid ${p.theme.purple300} !important`;
-    }
-    return 0;
+  border-top: ${p => {
+    return p.isCurrent && p.timestampSortDir === 'desc'
+      ? `1px solid ${p.theme.purple300} !important`
+      : 0;
   }};
 
   ${p => p.numeric && 'font-variant-numeric: tabular-nums;'};
 
   ${EmptyText} {
-    color: ${({hasOccurred = true, timestampSort, ...p}) => {
-      if (hasOccurred || !timestampSort) {
+    color: ${({hasOccurred = true, timestampSortDir, ...p}) => {
+      if (hasOccurred || !timestampSortDir) {
         return p.theme.gray400;
       }
       return p.theme.gray300;


### PR DESCRIPTION
Tested all the combos (see table). Not shown but also checked that if the table is sorted by another column we always go with the red.

| | Normal Sort order (first event at top)  | Reverse sort order |
| --- | ------------- | ------------- |
| 404 not yet happened | ![normal sort, not yet at the 404](https://user-images.githubusercontent.com/187460/191830123-fd338575-e36a-4f82-9e76-b99e2dab3898.png)  | ![reverse sort, not yet at the 404](https://user-images.githubusercontent.com/187460/191830140-0bcbbdae-2bf3-4120-9031-42ffaaf371d5.png)  |
| 404 has occurred | ![normal sort, after 404](https://user-images.githubusercontent.com/187460/191830124-ff3a9aaa-1d84-45ce-9304-cbae201b8083.png)  | ![reverse sort, after the 404](https://user-images.githubusercontent.com/187460/191830142-1320c12b-179d-4762-9f95-dc7e0b99fcde.png)  |

Also fixing a bug where the "Missing" text wasn't highlighted:
Before:
![Screen Shot 2022-09-22 at 12 07 36 PM](https://user-images.githubusercontent.com/187460/191831070-7bf87472-04b2-426b-9c81-eff89de3e1cd.png)



Fixes #39154