### PR TITLE
feat(perf-issues): Add extended n+1 db detector

### DIFF
--- a/src/sentry/testutils/perfomance_issues/events/n-plus-one-db-root-parent-span.json
+++ b/src/sentry/testutils/perfomance_issues/events/n-plus-one-db-root-parent-span.json
@@ -1,0 +1,151 @@
+{
+  "event_id": "47829ecde95d42ac843f24592b7b7e46",
+  "datetime": "2022-08-31T14:53:43.393462+00:00",
+  "environment": "production",
+  "spans": [
+    {
+      "timestamp": 1661957621.286672,
+      "start_timestamp": 1661957620.963648,
+      "exclusive_time": 323.024035,
+      "description": "SELECT `books_book`.`id`, `books_book`.`title`, `books_book`.`author_id` FROM `books_book` ORDER BY `books_book`.`id` DESC LIMIT 10",
+      "op": "db",
+      "span_id": "bc1f71fd71c8f594",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "858fea692d4d93e8",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957621.453721,
+      "start_timestamp": 1661957621.289976,
+      "exclusive_time": 163.745165,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "b150bdaa43ddec7c",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957621.679301,
+      "start_timestamp": 1661957621.456593,
+      "exclusive_time": 222.707987,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "968fdbd8bca7f2f6",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957621.849921,
+      "start_timestamp": 1661957621.682341,
+      "exclusive_time": 167.57989,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "b2d1eddd591d84ba",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.020631,
+      "start_timestamp": 1661957621.852634,
+      "exclusive_time": 167.997121,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "ae40cc8427bd68d2",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.337579,
+      "start_timestamp": 1661957622.023377,
+      "exclusive_time": 314.20207,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "9e902554055d3477",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.509795,
+      "start_timestamp": 1661957622.342078,
+      "exclusive_time": 167.71698,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "90302ecea560be76",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.733698,
+      "start_timestamp": 1661957622.513375,
+      "exclusive_time": 220.322848,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "a75f1cec8d07106f",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957622.903231,
+      "start_timestamp": 1661957622.73603,
+      "exclusive_time": 167.200804,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "8af15a555f92701e",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.072045,
+      "start_timestamp": 1661957622.906652,
+      "exclusive_time": 165.393114,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "9c3a569621230f03",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    },
+    {
+      "timestamp": 1661957623.391001,
+      "start_timestamp": 1661957623.074995,
+      "exclusive_time": 316.005946,
+      "description": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+      "op": "db",
+      "span_id": "8788fb3fc43ad948",
+      "parent_span_id": "86d3f8a7e85d7324",
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "hash": "63f1e89e6a073441",
+      "same_process_as_parent": true
+    }
+  ],
+  "start_timestamp": 1661957619.181783,
+  "timestamp": 1661957623.393462,
+  "title": "GET /books/new",
+  "trace": {
+    "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+    "span_id": "86d3f8a7e85d7324",
+    "op": "http.server",
+    "status": "ok",
+    "hash": "aa6df963e9081e3a"
+  },
+  "transaction": "GET /books/new",
+  "type": "transaction"
+}

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -35,6 +35,7 @@ class DetectorType(Enum):
     RENDER_BLOCKING_ASSET_SPAN = "render_blocking_assets"
     N_PLUS_ONE_SPANS = "n_plus_one"
     N_PLUS_ONE_DB_QUERIES = "n_plus_one_db"
+    N_PLUS_ONE_DB_QUERIES_EXTENDED = "n_plus_one_db_ext"
 
 
 DETECTOR_TYPE_TO_GROUP_TYPE = {
@@ -47,6 +48,7 @@ DETECTOR_TYPE_TO_GROUP_TYPE = {
     DetectorType.RENDER_BLOCKING_ASSET_SPAN: GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN,
     DetectorType.N_PLUS_ONE_SPANS: GroupType.PERFORMANCE_N_PLUS_ONE,
     DetectorType.N_PLUS_ONE_DB_QUERIES: GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+    DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
 }
 
 # Detector and the corresponding system option must be added to this list to have issues created.
@@ -230,6 +232,10 @@ def get_detection_settings(project_id: str):
             "count": settings["n_plus_one_db_count"],
             "duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
         },
+        DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: {
+            "count": settings["n_plus_one_db_count"],
+            "duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
+        },
     }
 
 
@@ -250,6 +256,9 @@ def _detect_performance_problems(data: Event, sdk_span: Any) -> List[Performance
         ),
         DetectorType.N_PLUS_ONE_SPANS: NPlusOneSpanDetector(detection_settings, data),
         DetectorType.N_PLUS_ONE_DB_QUERIES: NPlusOneDBSpanDetector(detection_settings, data),
+        DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: NPlusOneDBSpanDetectorExtended(
+            detection_settings, data
+        ),
     }
 
     for span in spans:
@@ -818,6 +827,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
     def init(self):
         self.stored_problems = {}
         self.potential_parents = {}
+        self.n_hash = None
         self.n_spans = []
         self.source_span = None
 
@@ -969,6 +979,27 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
             (str(parent_op) + str(parent_hash) + str(source_hash) + str(n_hash)).encode("utf8"),
         ).hexdigest()
         return f"1-{problem_class}-{full_fingerprint}"
+
+
+class NPlusOneDBSpanDetectorExtended(NPlusOneDBSpanDetector):
+    """
+    Detector goals:
+    - Extend N+1 DB Detector to make it compatible with more frameworks.
+    """
+
+    __slots__ = (
+        "stored_problems",
+        "potential_parents",
+        "source_span",
+        "n_hash",
+        "n_spans",
+    )
+
+    def init(self):
+        super().init()
+        root_span = self._event.get("trace", None)
+        if root_span:
+            self.potential_parents[root_span.get("span_id")] = root_span
 
 
 # Reports metrics and creates spans for detection

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -109,7 +109,7 @@ class PerformanceDetectionTest(unittest.TestCase):
         "sentry.utils.performance_issues.performance_detection.get_allowed_issue_creation_detectors"
     )
     def test_n_plus_one_extended_detection_no_parent_span(self, mock):
-        allowed_detectors = set([DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED])
+        allowed_detectors = {DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED}
         mock.return_value = allowed_detectors
         n_plus_one_event = EVENTS["n-plus-one-db-root-parent-span"]
         sdk_span_mock = Mock()
@@ -146,12 +146,12 @@ class PerformanceDetectionTest(unittest.TestCase):
         n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
         sdk_span_mock = Mock()
 
-        allowed_detectors = set([DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED])
+        allowed_detectors = {DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED}
         mock.return_value = allowed_detectors
 
         n_plus_one_extended_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
 
-        allowed_detectors = set([DetectorType.N_PLUS_ONE_DB_QUERIES])
+        allowed_detectors = {DetectorType.N_PLUS_ONE_DB_QUERIES}
         mock.return_value = allowed_detectors
 
         n_plus_one_original_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -105,6 +105,60 @@ class PerformanceDetectionTest(unittest.TestCase):
         assert perf_problems == []
 
     @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
+    @patch(
+        "sentry.utils.performance_issues.performance_detection.get_allowed_issue_creation_detectors"
+    )
+    def test_n_plus_one_extended_detection_no_parent_span(self, mock):
+        allowed_detectors = set([DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED])
+        mock.return_value = allowed_detectors
+        n_plus_one_event = EVENTS["n-plus-one-db-root-parent-span"]
+        sdk_span_mock = Mock()
+
+        perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
+        assert perf_problems == [
+            PerformanceProblem(
+                fingerprint="1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-25f4aa547724c350ef3abdaef2cf78e62399f96e",
+                op="db",
+                desc="SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
+                type=GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+                parent_span_ids=["86d3f8a7e85d7324"],
+                cause_span_ids=["bc1f71fd71c8f594"],
+                offender_span_ids=[
+                    "b150bdaa43ddec7c",
+                    "968fdbd8bca7f2f6",
+                    "b2d1eddd591d84ba",
+                    "ae40cc8427bd68d2",
+                    "9e902554055d3477",
+                    "90302ecea560be76",
+                    "a75f1cec8d07106f",
+                    "8af15a555f92701e",
+                    "9c3a569621230f03",
+                    "8788fb3fc43ad948",
+                ],
+            )
+        ]
+
+    @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
+    @patch(
+        "sentry.utils.performance_issues.performance_detection.get_allowed_issue_creation_detectors"
+    )
+    def test_n_plus_one_extended_detection_matches_previous_group(self, mock):
+        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
+        sdk_span_mock = Mock()
+
+        allowed_detectors = set([DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED])
+        mock.return_value = allowed_detectors
+
+        n_plus_one_extended_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
+
+        allowed_detectors = set([DetectorType.N_PLUS_ONE_DB_QUERIES])
+        mock.return_value = allowed_detectors
+
+        n_plus_one_original_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
+
+        assert n_plus_one_original_problems == n_plus_one_extended_problems
+
+    @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
     def test_no_feature_flag_disables_creation(self):
         self.features = []
         n_plus_one_event = EVENTS["n-plus-one-in-django-index-view"]
@@ -527,12 +581,12 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 7
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 9
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
                     "_pi_all_issue_count",
-                    4,
+                    5,
                 ),
                 call(
                     "_pi_transaction",
@@ -552,6 +606,11 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
                 ),
                 call("_pi_n_plus_one_db", "b8be6138369491dd"),
+                call(
+                    "_pi_n_plus_one_db_ext_fp",
+                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
+                ),
+                call("_pi_n_plus_one_db_ext", "b8be6138369491dd"),
             ]
         )
         assert_n_plus_one_db_problem(perf_problems)


### PR DESCRIPTION
### Summary
This extends our existing n+1 db detector so we can try to improve detection without creating more issues (for the moment). For the time being this is detection-only, and for the first change we'll get rid of the 'parent' requirement not allowing for the root span. A lot of our DB integrations don't have parent information, or don't have extra spans to put under the root of the transaction that would act as the parent.

This new detector should work for `nodejs (mongo / pg / more)` and `ruby` without needing to fix the db-spans-without parents issue. 

#### Rollout
- This is currently detection only, but I've diverged from the original behaviour of a 1:1 detector to group type relation. This new detector still related to the n+1 db group, since eventually it will replace it. 
- We should (in an upcoming PR) add a duplicate check for performance problems before passing off to be grouped.
- We can have a separate system option for the creation rate on this detector and turn down the original and turn up this extended detector. Since the fingerprint should be the same, as well as the perf-type for existing issues, there shouldn't be more created groups. Alternatively we can just put a PR to switch the class for detectors.
