### PR TITLE
fix(perf-issues): Fix spans being too far out of view horizontally

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -210,7 +210,7 @@ class SpanTree extends Component<PropType> {
       }
     }, 0);
 
-    const isEmbeddedSpanTree = !!waterfallModel.focusedSpanIds;
+    const isEmbeddedSpanTree = waterfallModel.isEmbeddedSpanTree;
 
     const {spanTree, numOfSpansOutOfViewAbove, filteredSpansAbove} = spans.reduce(
       (acc: AccType, payload: EnhancedProcessedSpanType) => {
@@ -364,7 +364,11 @@ class SpanTree extends Component<PropType> {
         // This is necessary because generally these spans are dependant on intersection observers which will
         // mark them in view, but these observers are not reliable when the span tree is in a condensed state.
         // Marking them here will ensure that the horizontally positioning is correctly set when the tree is loaded.
-        if (!('type' in span) && isEmbeddedSpanTree) {
+        if (
+          !('type' in span) &&
+          isEmbeddedSpanTree &&
+          waterfallModel.focusedSpanIds?.has(span.span_id)
+        ) {
           markSpanInView(span.span_id, treeDepth);
         }
 

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -367,7 +367,8 @@ class SpanTree extends Component<PropType> {
         if (
           !('type' in span) &&
           isEmbeddedSpanTree &&
-          waterfallModel.focusedSpanIds?.has(span.span_id)
+          // We only do this for affected spans, since we don't want to always manually add every single span
+          waterfallModel.affectedSpanIds?.includes(span.span_id)
         ) {
           markSpanInView(span.span_id, treeDepth);
         }

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -210,6 +210,8 @@ class SpanTree extends Component<PropType> {
       }
     }, 0);
 
+    const isEmbeddedSpanTree = !!waterfallModel.focusedSpanIds;
+
     const {spanTree, numOfSpansOutOfViewAbove, filteredSpansAbove} = spans.reduce(
       (acc: AccType, payload: EnhancedProcessedSpanType) => {
         const {type} = payload;
@@ -284,7 +286,7 @@ class SpanTree extends Component<PropType> {
               occurrence={payload.occurrence}
               onWheel={onWheel}
               generateContentSpanBarRef={generateContentSpanBarRef}
-              isEmbeddedSpanTree={!!waterfallModel.focusedSpanIds}
+              isEmbeddedSpanTree={isEmbeddedSpanTree}
             />
           );
           acc.spanNumber = spanNumber + 1;
@@ -357,6 +359,14 @@ class SpanTree extends Component<PropType> {
             storeSpanBar={storeSpanBar}
           />
         );
+
+        // If this is an embedded span tree, we will manually mark these spans as in view.
+        // This is necessary because generally these spans are dependant on intersection observers which will
+        // mark them in view, but these observers are not reliable when the span tree is in a condensed state.
+        // Marking them here will ensure that the horizontally positioning is correctly set when the tree is loaded.
+        if (!('type' in span) && isEmbeddedSpanTree) {
+          markSpanInView(span.span_id, treeDepth);
+        }
 
         acc.spanNumber = spanNumber + 1;
         return acc;

--- a/static/app/components/events/interfaces/spans/waterfallModel.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.tsx
@@ -26,6 +26,7 @@ class WaterfallModel {
   rootSpan: SpanTreeModel;
   parsedTrace: ParsedTraceType;
   fuse: Fuse<IndexedFusedSpan> | undefined = undefined;
+  affectedSpanIds: string[] | undefined = undefined;
   isEmbeddedSpanTree: boolean;
 
   // readable/writable state
@@ -59,6 +60,7 @@ class WaterfallModel {
     this.hiddenSpanSubTrees = new Set();
 
     // When viewing the span waterfall from a Performance Issue, a set of span IDs may be provided
+    this.affectedSpanIds = affectedSpanIds;
     this.focusedSpanIds = affectedSpanIds ? new Set(affectedSpanIds) : undefined;
     // If the set of span IDs is provided, this waterfall is for an embedded span tree
     this.isEmbeddedSpanTree = !!this.focusedSpanIds;

--- a/static/app/components/events/interfaces/spans/waterfallModel.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.tsx
@@ -26,6 +26,7 @@ class WaterfallModel {
   rootSpan: SpanTreeModel;
   parsedTrace: ParsedTraceType;
   fuse: Fuse<IndexedFusedSpan> | undefined = undefined;
+  isEmbeddedSpanTree: boolean;
 
   // readable/writable state
   operationNameFilters: ActiveOperationFilter = noFilter;
@@ -59,6 +60,8 @@ class WaterfallModel {
 
     // When viewing the span waterfall from a Performance Issue, a set of span IDs may be provided
     this.focusedSpanIds = affectedSpanIds ? new Set(affectedSpanIds) : undefined;
+    // If the set of span IDs is provided, this waterfall is for an embedded span tree
+    this.isEmbeddedSpanTree = !!this.focusedSpanIds;
 
     makeObservable(this, {
       parsedTrace: observable,


### PR DESCRIPTION
When loading a performance issue, the spans in the embedded span tree would often be shifted too far horizontally, such that they would not even be visible. This is especially noticeable to users with smaller screens, since there is less screen real estate available.

This was happening because the IntersectionObserver responsible for marking the spans in view is unreliable when the span tree is not at its max height. I addressed this in this fix by manually marking the spans in view during the construction of the span tree, if it is an embedded span tree.

### Before
![image](https://user-images.githubusercontent.com/16740047/191833473-9f9e36ac-5a3c-4e53-b88f-f3cd4d3393fb.png)

### After
![image](https://user-images.githubusercontent.com/16740047/191833517-1fe8327c-8f20-47d6-b9c9-70a5529eb9c0.png)
