### PR TITLE
fix(discover): Fixes has filter for custom performance metrics not working

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1097,9 +1097,10 @@ class QueryBuilder:
         search_filter: SearchFilter,
     ) -> Optional[WhereType]:
         name = search_filter.key.name
-        if search_filter.value.value and (measurement_meta := self.get_measument_by_name(name)):
+        value = search_filter.value.value
+        if value and (measurement_meta := self.get_measument_by_name(name)):
             unit = measurement_meta.get("unit")
-            value = self.resolve_measurement_value(unit, search_filter.value.value)
+            value = self.resolve_measurement_value(unit, value)
             search_filter = SearchFilter(
                 search_filter.key, search_filter.operator, SearchValue(value)
             )

--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1097,7 +1097,7 @@ class QueryBuilder:
         search_filter: SearchFilter,
     ) -> Optional[WhereType]:
         name = search_filter.key.name
-        if measurement_meta := self.get_measument_by_name(name):
+        if search_filter.value.value and (measurement_meta := self.get_measument_by_name(name)):
             unit = measurement_meta.get("unit")
             value = self.resolve_measurement_value(unit, search_filter.value.value)
             search_filter = SearchFilter(


### PR DESCRIPTION
Fixes `has` operator not working for custom performance metrics, ie `has:measurements.custom.kibibyte`