### PR TITLE
perf(replay): Improve Replay Details pageload speed by fetching errors in parallel with replay segments

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -189,12 +189,22 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
     setState(INITIAL_STATE);
 
     try {
-      const [record, attachments] = await Promise.all([
-        fetchReplay(),
+      // const [record, attachments] = await Promise.all([
+      //   fetchReplay(),
+      //   fetchAllRRwebEvents(),
+      // ]);
+      // const replayRecord = mapResponseToReplayRecord(record);
+      // const errors = await fetchErrors(replayRecord);
+
+      const [[replayRecord, errors], attachments] = await Promise.all([
+        (async (): Promise<[ReplayRecord, any]> => {
+          const fetchedRecord = await fetchReplay();
+          const mappedRecord = mapResponseToReplayRecord(fetchedRecord);
+          const fetchedErrors = await fetchErrors(mappedRecord);
+          return [mappedRecord, fetchedErrors];
+        })(),
         fetchAllRRwebEvents(),
       ]);
-      const replayRecord = mapResponseToReplayRecord(record);
-      const errors = await fetchErrors(replayRecord);
 
       setState(prev => ({
         ...prev,

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -189,13 +189,6 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
     setState(INITIAL_STATE);
 
     try {
-      // const [record, attachments] = await Promise.all([
-      //   fetchReplay(),
-      //   fetchAllRRwebEvents(),
-      // ]);
-      // const replayRecord = mapResponseToReplayRecord(record);
-      // const errors = await fetchErrors(replayRecord);
-
       const [[replayRecord, errors], attachments] = await Promise.all([
         (async (): Promise<[ReplayRecord, any]> => {
           const fetchedRecord = await fetchReplay();


### PR DESCRIPTION
Before we can see that the 3rd request is blocked on the first two:
![before](https://user-images.githubusercontent.com/187460/191842210-b780c2b3-06c9-42b0-b2d6-68877a40661e.png)

After this change the 3rd request is only waiting for the 1st to complete. The segment data download is still happening.
![after](https://user-images.githubusercontent.com/187460/191842223-8e6f0a92-84c9-4340-b719-2387a0439fad.png)

Note: In these screen shots from google chrome the green horizontal bar represents the server-wait time (the time that the server spends getting the data ready) and the blue bars represent the content download time.

Fixes #38341
