### PR TITLE
feat(replays): Include issue short id in the replays-events-meta response

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -5,6 +7,7 @@ from sentry import features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
+from sentry.models import Organization
 from sentry.snuba import discover
 
 
@@ -22,6 +25,17 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
 
     private = True
 
+    def get_field_list(self, organization: Organization, request: Request) -> Sequence[str]:
+        return [
+            "id",
+            "error.value",
+            "timestamp",
+            "error.type",
+            "issue.id",
+            "issue",
+            "group.id",
+        ]
+
     def get(self, request: Request, organization) -> Response:
         if not features.has("organizations:session-replay", organization, actor=request.user):
             return Response(status=404)
@@ -33,13 +47,7 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
 
         def data_fn(offset, limit):
             query_details = {
-                "selected_columns": [
-                    "id",
-                    "error.value",
-                    "timestamp",
-                    "error.type",
-                    "issue.id",
-                ],
+                "selected_columns": self.get_field_list(organization, request),
                 "query": request.GET.get("query"),
                 "params": params,
                 "equations": self.get_equation_list(organization, request),

--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -27,13 +27,13 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
 
     def get_field_list(self, organization: Organization, request: Request) -> Sequence[str]:
         return [
-            "id",
-            "error.value",
-            "timestamp",
             "error.type",
+            "error.value",
+            "group.id",
+            "id",
             "issue.id",
             "issue",
-            "group.id",
+            "timestamp",
         ]
 
     def get(self, request: Request, organization) -> Response:

--- a/tests/replays/endpoints/test_organization_replay_events_meta.py
+++ b/tests/replays/endpoints/test_organization_replay_events_meta.py
@@ -26,11 +26,11 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
         event_id_a = "a" * 32
         event_id_b = "b" * 32
 
-        self.store_event(
+        event_a = self.store_event(
             data={"event_id": event_id_a, "timestamp": iso_format(self.min_ago)},
             project_id=self.project_1.id,
         )
-        self.store_event(
+        event_b = self.store_event(
             data={"event_id": event_id_b, "timestamp": iso_format(self.min_ago)},
             project_id=self.project_2.id,
         )
@@ -45,16 +45,20 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
             {
                 "error.type": [],
                 "error.value": [],
+                "group.id": "",
                 "id": event_id_a,
                 "issue.id": 1,
+                "issue": event_a.group.qualified_short_id,
                 "project.name": self.project_1.slug,
                 "timestamp": iso_format(self.min_ago) + "+00:00",
             },
             {
                 "error.type": [],
                 "error.value": [],
+                "group.id": "",
                 "id": event_id_b,
                 "issue.id": 2,
+                "issue": event_b.group.qualified_short_id,
                 "project.name": self.project_2.slug,
                 "timestamp": iso_format(self.min_ago) + "+00:00",
             },


### PR DESCRIPTION
Related to #38922

We need to load up the issue shortId so that we can build that hovercard which looks like this:
![190281630-c17ae25b-ff9b-45dc-90eb-1b48f814d7a5](https://user-images.githubusercontent.com/187460/191864401-9129b05d-6ce8-411d-845d-63c297e7bbb8.png)


Test Plan:
```
GET http://127.0.0.1:8000/api/0/organizations/sentry/replays-events-meta/?query=id:[931189a3a0854e31b75a7720dcf280f2]

# Response is: 
{
  "data": [
    {
      "error.type": [
        "Error",
        "NotFoundError"
      ],
      "id": "931189a3a0854e31b75a7720dcf280f2",
      "issue.id": 3,
      "error.value": [
        "API Request Error",
        "GET \"/issues/3/events/latest/\" 404"
      ],
      "group.id": "",
      "timestamp": "2022-09-22T22:43:00+00:00",
      "project.name": "internal",
      "issue": "INTERNAL-3"
    }
  ],
  "meta": {
    "fields": {
      "error.type": "array",
      "id": "string",
      "issue.id": "integer",
      "error.value": "array",
      "group.id": "string",
      "timestamp": "date",
      "project.name": "string"
    },
    "units": {
      "error.type": null,
      "id": null,
      "issue.id": null,
      "error.value": null,
      "group.id": null,
      "timestamp": null,
      "project.name": null
    },
    "isMetricsData": false,
    "tips": {
      "query": null,
      "columns": null
    }
  }
}
```