### PR TITLE
fix(types): Convert string literal to actual string type

### DIFF
--- a/static/app/types/release.tsx
+++ b/static/app/types/release.tsx
@@ -83,7 +83,7 @@ interface ReleaseData {
   newGroups: number;
   versionInfo: VersionInfo;
   adoptionStages?: Record<
-    'string',
+    string,
     {
       adopted: string | null;
       stage: string | null;

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -224,7 +224,7 @@ function ReleaseAdoption({
   });
 
   const adoptionStage = release.adoptionStages?.[project.slug]?.stage;
-  const adoptionStageLabel = ADOPTION_STAGE_LABELS[adoptionStage];
+  const adoptionStageLabel = adoptionStage ? ADOPTION_STAGE_LABELS[adoptionStage] : null;
   const multipleEnvironments = environment.length === 0 || environment.length > 1;
 
   return (

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -104,8 +104,9 @@ function ReleaseCardProjectRow({
     adoptionStages?.[project.slug].stage;
 
   const adoptionStageLabel =
-    Boolean(get24hCountByProject && adoptionStage && isMobileRelease(project.platform)) &&
-    ADOPTION_STAGE_LABELS[adoptionStage];
+    get24hCountByProject && adoptionStage && isMobileRelease(project.platform)
+      ? ADOPTION_STAGE_LABELS[adoptionStage]
+      : null;
 
   return (
     <ProjectRow data-test-id="release-card-project-row">


### PR DESCRIPTION
Noticed there was a `Record<'string', {...}>` which was causing uses of the type to resolve to `any`.  Changed to `string` and fixed any type issues stemming from that change.