### PR TITLE
Link to DSN docs in otherSetup

### DIFF
--- a/static/app/views/onboarding/otherSetup.tsx
+++ b/static/app/views/onboarding/otherSetup.tsx
@@ -66,6 +66,10 @@ class OtherSetup extends AsyncComponent<Props, State> {
         </p>
 
         <p>{tct('Here is the DSN: [DSN]', {DSN: <b> {keyList?.[0].dsn.public}</b>})}</p>
+        <p>{tct('For more about DSNs, please check out [DSNDocs]', 
+                {DSNDocs: 
+                   <ExternalLink href="https://docs.sentry.io/product/sentry-basics/dsn-explainer/" />
+                })}</p>
       </Fragment>
     );
 


### PR DESCRIPTION
When I was getting started at Sentry, I found the concept of a DSN a little confusing as its usage isn't quite what I normally associate with the term, so I thought linking to the docs here might be helpful.