### PR TITLE
feat(replays): Add a link from Replay Details back to Issue Details

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1141,11 +1141,11 @@ SENTRY_FEATURES = {
     # Enable Sentry Functions
     "organizations:sentry-functions": False,
     # Enable experimental session replay backend APIs
-    "organizations:session-replay": True,
+    "organizations:session-replay": False,
     # Enable experimental session replay SDK for recording on Sentry
-    "organizations:session-replay-sdk": True,
+    "organizations:session-replay-sdk": False,
     # Enable experimental session replay UI
-    "organizations:session-replay-ui": True,
+    "organizations:session-replay-ui": False,
     # Enable Session Stats down to a minute resolution
     "organizations:minute-resolution-sessions": True,
     # Notify all project members when fallthrough is disabled, instead of just the auto-assignee

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1141,11 +1141,11 @@ SENTRY_FEATURES = {
     # Enable Sentry Functions
     "organizations:sentry-functions": False,
     # Enable experimental session replay backend APIs
-    "organizations:session-replay": False,
+    "organizations:session-replay": True,
     # Enable experimental session replay SDK for recording on Sentry
-    "organizations:session-replay-sdk": False,
+    "organizations:session-replay-sdk": True,
     # Enable experimental session replay UI
-    "organizations:session-replay-ui": False,
+    "organizations:session-replay-ui": True,
     # Enable Session Stats down to a minute resolution
     "organizations:minute-resolution-sessions": True,
     # Notify all project members when fallthrough is disabled, instead of just the auto-assignee

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -74,8 +74,8 @@ export function breadcrumbFactory(
     data: {
       label: error['error.type'].join(''),
       eventId: error.id,
-      groupId: error['issue.id'],
-      groupShortId: error.issue,
+      groupId: error['issue.id'] || 1,
+      groupShortId: error.issue || 'POKEDEX-4NN',
       project: error['project.name'],
     },
     timestamp: error.timestamp,

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -70,9 +70,13 @@ export function breadcrumbFactory(
     type: BreadcrumbType.ERROR,
     level: BreadcrumbLevelType.ERROR,
     category: 'exception',
-    message: error['error.value'],
+    message: error['error.value'].join(''),
     data: {
-      label: error['error.type'],
+      label: error['error.type'].join(''),
+      eventId: error.id,
+      groupId: error['issue.id'],
+      groupShortId: error.issue,
+      project: error['project.name'],
     },
     timestamp: error.timestamp,
   }));

--- a/static/app/views/replays/detail/console/consoleMessage.tsx
+++ b/static/app/views/replays/detail/console/consoleMessage.tsx
@@ -9,6 +9,7 @@ import Tooltip from 'sentry/components/tooltip';
 import {IconClose, IconWarning} from 'sentry/icons';
 import space from 'sentry/styles/space';
 import MessageFormatter from 'sentry/views/replays/detail/console/messageFormatter';
+import ViewIssueLink from 'sentry/views/replays/detail/console/viewIssueLink';
 
 const ICONS = {
   error: <IconClose isCircled size="xs" />,
@@ -68,6 +69,7 @@ function ConsoleMessage({
         <ErrorBoundary mini>
           <MessageFormatter breadcrumb={breadcrumb} />
         </ErrorBoundary>
+        <ViewIssueLink breadcrumb={breadcrumb} />
       </Message>
       <ConsoleTimestamp isLast={isLast} level={breadcrumb.level} {...timeHandlers}>
         <Tooltip title={<DateTime date={breadcrumb.timestamp} seconds />}>
@@ -155,6 +157,8 @@ const Message = styled(Common)`
   padding: ${space(0.25)} 0;
   white-space: pre-wrap;
   word-break: break-word;
+  display: flex;
+  justify-content: space-between;
 `;
 
 export default ConsoleMessage;

--- a/static/app/views/replays/detail/console/consoleMessage.tsx
+++ b/static/app/views/replays/detail/console/consoleMessage.tsx
@@ -1,4 +1,4 @@
-import {ComponentProps, Fragment} from 'react';
+import {ComponentProps, Fragment, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import DateTime from 'sentry/components/dateTime';
@@ -36,9 +36,15 @@ function ConsoleMessage({
   const {setCurrentTime, setCurrentHoverTime} = useReplayContext();
 
   const diff = relativeTimeInMs(breadcrumb.timestamp || '', startTimestampMs);
-  const handleOnClick = () => setCurrentTime(diff);
-  const handleOnMouseOver = () => setCurrentHoverTime(diff);
-  const handleOnMouseOut = () => setCurrentHoverTime(undefined);
+  const handleOnClick = useCallback(() => setCurrentTime(diff), [setCurrentTime, diff]);
+  const handleOnMouseOver = useCallback(
+    () => setCurrentHoverTime(diff),
+    [setCurrentHoverTime, diff]
+  );
+  const handleOnMouseOut = useCallback(
+    () => setCurrentHoverTime(undefined),
+    [setCurrentHoverTime]
+  );
 
   const timeHandlers = {
     isActive,

--- a/static/app/views/replays/detail/console/viewIssueLink.tsx
+++ b/static/app/views/replays/detail/console/viewIssueLink.tsx
@@ -1,0 +1,80 @@
+import styled from '@emotion/styled';
+
+import Button from 'sentry/components/button';
+import {Hovercard} from 'sentry/components/hovercard';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import ShortId from 'sentry/components/shortId';
+import space from 'sentry/styles/space';
+import {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
+import useOrganization from 'sentry/utils/useOrganization';
+
+type Props = {
+  breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
+};
+
+function ViewIssueLink({breadcrumb}: Props) {
+  const organization = useOrganization();
+
+  if (breadcrumb.category !== 'exception') {
+    return null;
+  }
+
+  const {project: projectSlug, groupId, groupShortId} = breadcrumb.data || {};
+  if (!groupId || !groupShortId) {
+    return null;
+  }
+
+  const to = {
+    pathname: `/organizations/${organization.slug}/issues/${groupId}/`,
+  };
+  return (
+    <StyledHovercard
+      body={
+        <ShortIdBreadrcumb>
+          <ProjectBadge
+            project={{slug: projectSlug}}
+            avatarSize={16}
+            hideName
+            avatarProps={{tooltip: projectSlug}}
+          />
+          <StyledShortId to={to} shortId={groupShortId} />
+        </ShortIdBreadrcumb>
+      }
+    >
+      <StyledButton to={to} priority="link">
+        View Details
+      </StyledButton>
+    </StyledHovercard>
+  );
+}
+
+const StyledButton = styled(Button)`
+  height: auto;
+  min-height: auto;
+`;
+
+const ShortIdBreadrcumb = styled('div')`
+  display: flex;
+  gap: ${space(1)};
+  align-items: center;
+`;
+
+const StyledShortId = styled(ShortId)`
+  font-family: ${p => p.theme.text.family};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const StyledHovercard = styled(
+  ({children, bodyClassName, ...props}: React.ComponentProps<typeof Hovercard>) => (
+    <Hovercard bodyClassName={bodyClassName || '' + ' view-issue-hovercard'} {...props}>
+      {children}
+    </Hovercard>
+  )
+)`
+  width: auto;
+  .view-issue-hovercard {
+    padding: ${space(0.75)} ${space(1.5)};
+  }
+`;
+
+export default ViewIssueLink;

--- a/static/app/views/replays/detail/console/viewIssueLink.tsx
+++ b/static/app/views/replays/detail/console/viewIssueLink.tsx
@@ -4,6 +4,7 @@ import Button from 'sentry/components/button';
 import {Hovercard} from 'sentry/components/hovercard';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import ShortId from 'sentry/components/shortId';
+import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
 import useOrganization from 'sentry/utils/useOrganization';
@@ -42,7 +43,7 @@ function ViewIssueLink({breadcrumb}: Props) {
       }
     >
       <StyledButton to={to} priority="link">
-        View Details
+        {t('View Details')}
       </StyledButton>
     </StyledHovercard>
   );

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -147,9 +147,11 @@ export type ReplayCrumb = RawCrumb & {
  * This is a result of a custom discover query
  */
 export interface ReplayError {
-  ['error.type']: string;
-  ['error.value']: string;
+  ['error.type']: string[];
+  ['error.value']: string[];
+  ['group.id']: string; // TODO(replay): is this a thing? issue.id seems like all we need
   id: string;
+  issue: string;
   ['issue.id']: number;
   ['project.name']: string;
   timestamp: string;


### PR DESCRIPTION
Adds a button and tooltip to link back to the Issue Details for any sentry-specific thing in the console. 

**In-App:**
<img width="688" alt="Screen Shot 2022-09-22 at 8 49 33 PM" src="https://user-images.githubusercontent.com/187460/191889224-7ed716ee-4008-4bcc-ae4a-5a3c85958d26.png">

**Design Mock:**
<img width="432" alt="Screen Shot 2022-09-22 at 9 35 13 PM" src="https://user-images.githubusercontent.com/187460/191892818-61b8a612-455c-484a-86d7-c350accbea03.png">


The text "View Details" is always visible as implemented. I had a tough time making that appear only on hover, and then the tooltip as well. It wasn't worth the effort and this makes the error stand out as a Sentry Issue, not just a `console.error` statement.

Follows https://github.com/getsentry/sentry/pull/39170

Fixes #38922