### PR TITLE
feat(perf-issues): Show grouping information on issue details page

### DIFF
--- a/static/app/components/events/eventEntries.spec.tsx
+++ b/static/app/components/events/eventEntries.spec.tsx
@@ -43,7 +43,7 @@ async function renderComponent(event: Event, errors?: Array<Error>) {
   return {alertSummaryInfo, errorItem: errorItems};
 }
 
-describe('GroupEventEntries', function () {
+describe('EventEntries', function () {
   const event = TestStubs.Event();
 
   beforeEach(() => {

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -407,15 +407,13 @@ const EventEntries = ({
       {!isShare && event?.sdkUpdates && event.sdkUpdates.length > 0 && (
         <EventSdkUpdates event={{sdkUpdates: event.sdkUpdates, ...event}} />
       )}
-      {!isShare &&
-        event.groupID &&
-        group?.issueCategory !== IssueCategory.PERFORMANCE && (
-          <EventGroupingInfo
-            projectId={projectSlug}
-            event={event}
-            showGroupingConfig={orgFeatures.includes('set-grouping-config')}
-          />
-        )}
+      {!isShare && event.groupID && (
+        <EventGroupingInfo
+          projectId={projectSlug}
+          event={event}
+          showGroupingConfig={orgFeatures.includes('set-grouping-config')}
+        />
+      )}
       {!isShare && (
         <MiniReplayView
           event={event}

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -161,6 +161,29 @@ class GroupVariant extends Component<Props, State> {
           data.push([t('Grouping Config'), variant.config.id]);
         }
         break;
+      case EventGroupVariantType.PERFORMANCE_PROBLEM:
+        data.push([
+          t('Type'),
+          <TextWithQuestionTooltip key="type">
+            {variant.type}
+            <QuestionTooltip
+              size="xs"
+              position="top"
+              title={t(
+                'Uses the evidence from performance issue detection to generate a fingerprint.'
+              )}
+            />
+          </TextWithQuestionTooltip>,
+        ]);
+
+        data.push(['Span Operation', variant.evidence.op]);
+        data.push(['Parent Span Hashes', variant.evidence.parent_span_hashes]);
+        data.push(['Source Span Hashes', variant.evidence.cause_span_hashes]);
+        data.push([
+          'Offender Span Hashes',
+          [...new Set(variant.evidence.offender_span_hashes)],
+        ]);
+        break;
       default:
         break;
     }

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -176,6 +176,7 @@ class GroupVariant extends Component<Props, State> {
           </TextWithQuestionTooltip>,
         ]);
 
+        data.push(['Performance Issue Type', variant.key]);
         data.push(['Span Operation', variant.evidence.op]);
         data.push(['Parent Span Hashes', variant.evidence.parent_span_hashes]);
         data.push(['Source Span Hashes', variant.evidence.cause_span_hashes]);

--- a/static/app/components/events/groupingInfo/utils.tsx
+++ b/static/app/components/events/groupingInfo/utils.tsx
@@ -3,9 +3,14 @@ import isObject from 'lodash/isObject';
 import {EventGroupComponent} from 'sentry/types';
 
 export function hasNonContributingComponent(component: EventGroupComponent | undefined) {
-  if (!component?.contributes) {
+  if (component === undefined) {
+    return false;
+  }
+
+  if (!component.contributes) {
     return true;
   }
+
   for (const value of component.values) {
     if (isObject(value) && hasNonContributingComponent(value)) {
       return true;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -33,6 +33,15 @@ export type EventGroupingConfig = {
   strategies: string[];
 };
 
+export type VariantEvidence = {
+  desc: string;
+  fingerprint: string;
+  cause_span_hashes?: string[];
+  offender_span_hashes?: string[];
+  op?: string;
+  parent_span_hashes?: string[];
+};
+
 type EventGroupVariantKey = 'custom-fingerprint' | 'app' | 'default' | 'system';
 
 export enum EventGroupVariantType {
@@ -41,6 +50,7 @@ export enum EventGroupVariantType {
   CUSTOM_FINGERPRINT = 'custom-fingerprint',
   COMPONENT = 'component',
   SALTED_COMPONENT = 'salted-component',
+  PERFORMANCE_PROBLEM = 'performance-problem',
 }
 
 interface BaseVariant {
@@ -79,12 +89,18 @@ interface SaltedComponentVariant extends BaseVariant, HasComponentGrouping {
   type: EventGroupVariantType.SALTED_COMPONENT;
 }
 
+interface PerformanceProblemVariant extends BaseVariant {
+  evidence: VariantEvidence;
+  type: EventGroupVariantType.PERFORMANCE_PROBLEM;
+}
+
 export type EventGroupVariant =
   | FallbackVariant
   | ChecksumVariant
   | ComponentVariant
   | SaltedComponentVariant
-  | CustomFingerprintVariant;
+  | CustomFingerprintVariant
+  | PerformanceProblemVariant;
 
 export type EventGroupInfo = Record<EventGroupVariantKey, EventGroupVariant>;
 


### PR DESCRIPTION
Closes PERF-1758 and ISP-33. Adds the "Grouping Information" section to the issue details page for performance issues. This is a frontend follow-up to #39119.

**e.g.,**
![Screen Shot 2022-09-23 at 10 37 17 AM](https://user-images.githubusercontent.com/989898/191986563-fa99c7dd-cba5-4441-b8f6-df4a3a8239d4.png)


## Changes

- Fix misnamed spec file. The file didn't match the component name
- Enable grouping info for performance issues, they are now eligible
- Add typing for performance issue grouping variant
- Show performance issue grouping info. Show the evidence span hashes and some issue info
- Fix component-less grouping handling
