### PR TITLE
feat(profiling): display public dsn during onboarding

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "files.exclude": {
     "*.egg-info": true,
-    "*.log": true,
+    "*.log": false,
     "**/*.js.map": true,
     "**/*.min.js": true,
     "**/*.pyc": true,

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
@@ -51,6 +51,7 @@ describe('ProfilingOnboarding', function () {
   });
 
   it('goes to next step and previous step if project is supported', async () => {
+    const project = TestStubs.Project({name: 'iOS Project'});
     ProjectsStore.loadInitialData([
       TestStubs.Project({name: 'iOS Project', platform: 'apple-ios'}),
     ]);
@@ -67,7 +68,7 @@ describe('ProfilingOnboarding', function () {
     render(
       <ProfilingOnboardingModal organization={organization} {...MockRenderModalProps} />
     );
-    selectProject(TestStubs.Project({name: 'iOS Project'}));
+    selectProject(project);
     await act(async () => {
       await tick();
       userEvent.click(screen.getAllByText('Next')[0]);

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
@@ -70,7 +70,7 @@ describe('ProfilingOnboarding', function () {
     );
     selectProject(project);
     await act(async () => {
-      await tick();
+      await screen.findByText(/options\.dsn/);
       userEvent.click(screen.getAllByText('Next')[0]);
     });
     expect(screen.getByText(/Step 2 of 2/i)).toBeInTheDocument();

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
@@ -23,6 +23,8 @@ function selectProject(project: Project) {
   userEvent.click(screen.getByText(project.slug));
 }
 
+const organization = TestStubs.Organization();
+
 describe('ProfilingOnboarding', function () {
   beforeEach(() => {
     // @ts-ignore no-console
@@ -37,7 +39,6 @@ describe('ProfilingOnboarding', function () {
   });
 
   it('renders default step', () => {
-    const organization = TestStubs.Organization();
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/sdk-updates/`,
       body: [],
@@ -49,11 +50,14 @@ describe('ProfilingOnboarding', function () {
     expect(screen.getByText(/Select a Project/i)).toBeInTheDocument();
   });
 
-  it('goes to next step and previous step if project is supported', () => {
-    const organization = TestStubs.Organization();
+  it('goes to next step and previous step if project is supported', async () => {
     ProjectsStore.loadInitialData([
       TestStubs.Project({name: 'iOS Project', platform: 'apple-ios'}),
     ]);
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/keys/`,
+      body: [],
+    });
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/sdk-updates/`,
@@ -64,7 +68,8 @@ describe('ProfilingOnboarding', function () {
       <ProfilingOnboardingModal organization={organization} {...MockRenderModalProps} />
     );
     selectProject(TestStubs.Project({name: 'iOS Project'}));
-    act(() => {
+    await act(async () => {
+      await tick();
       userEvent.click(screen.getAllByText('Next')[0]);
     });
     expect(screen.getByText(/Step 2 of 2/i)).toBeInTheDocument();
@@ -76,11 +81,14 @@ describe('ProfilingOnboarding', function () {
   });
 
   it('does not allow going to next step if project is unsupported', () => {
-    const organization = TestStubs.Organization();
     ProjectsStore.loadInitialData([
       TestStubs.Project({name: 'javascript', platform: 'javascript'}),
     ]);
 
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/keys/`,
+      body: [],
+    });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/sdk-updates/`,
       body: [],
@@ -96,10 +104,13 @@ describe('ProfilingOnboarding', function () {
   });
 
   it('shows sdk updates are required if version is lower than required', async () => {
-    const organization = TestStubs.Organization();
     const project = TestStubs.Project({name: 'iOS Project', platform: 'apple-ios'});
     ProjectsStore.loadInitialData([project]);
 
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/keys/`,
+      body: [],
+    });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/sdk-updates/`,
       body: [
@@ -124,10 +135,12 @@ describe('ProfilingOnboarding', function () {
   });
 
   it('shows a sdk update URL when receiving a updateSdk suggestion if a version is lower than required', async () => {
-    const organization = TestStubs.Organization();
     const project = TestStubs.Project({name: 'iOS Project', platform: 'apple-ios'});
     ProjectsStore.loadInitialData([project]);
-
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/keys/`,
+      body: [],
+    });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/sdk-updates/`,
       body: [
@@ -156,5 +169,42 @@ describe('ProfilingOnboarding', function () {
     const link = (await screen.findByText(/sentry-ios@9.0.0/)) as HTMLAnchorElement;
     expect(link).toBeInTheDocument();
     expect(link.href).toBe('http://test/fake-slug');
+  });
+
+  it('shows the public dsn within the codesnippet', async () => {
+    const project = TestStubs.Project({name: 'iOS Project', platform: 'apple-ios'});
+    ProjectsStore.loadInitialData([project]);
+
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/keys/`,
+      body: [
+        {
+          dsn: {
+            public: 'http://fake-public-dsn.ingest.sentry.io',
+          },
+        },
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sdk-updates/`,
+      body: [
+        {
+          projectId: project.id,
+          sdkName: 'sentry ios',
+          sdkVersion: '6.0.0',
+          suggestions: [],
+        },
+      ],
+    });
+
+    render(
+      <ProfilingOnboardingModal organization={organization} {...MockRenderModalProps} />
+    );
+
+    selectProject(project);
+
+    expect(
+      await screen.findByText(/http:\/\/fake-public-dsn.ingest.sentry.io/)
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -259,7 +259,7 @@ function usePublicDSN({
   }
   return {
     ...response,
-    data: response.data?.[0]?.dsn.public ?? null,
+    data: response.data[0]?.dsn.public ?? null,
   };
 }
 

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -234,7 +234,7 @@ function SelectProjectStep({
                 disabled={
                   !(
                     project?.platform && platformToInstructionsMapping[project.platform]
-                  ) || publicDSN.loading
+                  ) || publicDSN.type === 'loading'
                 }
                 type="submit"
               />
@@ -254,17 +254,14 @@ function usePublicDSN({
   project: Project | null | undefined;
 }) {
   const api = useApi();
-  const [response, setResponse] = useState<
-    RequestState<string | null> & {loading: boolean}
-  >({
+  const [response, setResponse] = useState<RequestState<string | null>>({
     type: 'initial',
-    loading: false,
   });
   useEffect(() => {
     if (!organization || !project) {
       return;
     }
-    setResponse(v => ({...v, type: 'initial', data: null, loading: true}));
+    setResponse(v => ({...v, type: 'loading', data: null}));
     const request: Promise<ProjectKey[]> = api.requestPromise(
       `/projects/${organization.slug}/${project.slug}/keys/`
     );
@@ -274,14 +271,12 @@ function usePublicDSN({
         setResponse({
           type: 'resolved',
           data: data[0]?.dsn.public ?? null,
-          loading: false,
         });
       })
       .catch(error =>
         setResponse({
           type: 'errored',
           error,
-          loading: false,
         })
       );
   }, [organization, project, api]);
@@ -374,7 +369,7 @@ const SDKUpdatesContainer = styled('div')`
 interface InstallStepsProps {
   organization: Organization;
   project: Project;
-  publicDSN: RequestState<string | null> & {loading: boolean};
+  publicDSN: RequestState<string | null>;
   sdkUpdates: RequestState<ProjectSdkUpdates | null>;
 }
 
@@ -410,7 +405,7 @@ function AndroidInstallSteps({
       </li>
       <li>
         <StepTitle>{t('Set Up Profiling')}</StepTitle>
-        {publicDSN.loading ? (
+        {publicDSN.type === 'loading' ? (
           <LoadingIndicator />
         ) : (
           <CodeSnippet language="xml" filename="AndroidManifest.xml">
@@ -461,7 +456,7 @@ function IOSInstallSteps({
           {t('Enable profiling in your app by configuring the SDKs like below:')}
         </StepTitle>
 
-        {publicDSN.loading ? (
+        {publicDSN.type === 'loading' ? (
           <LoadingIndicator />
         ) : (
           <CodeSnippet language="swift">{`SentrySDK.start { options in

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -258,7 +258,8 @@ function usePublicDSN({
   if (response.type !== 'resolved') {
     return response;
   }
-  const dsn = response[0]?.dsn.public;
+
+  const dsn = response.data?.[0]?.dsn.public;
   if (!dsn) {
     Sentry.captureException(
       new Error(`public dsn not found for ${organization?.slug}/${project?.slug}`)

--- a/static/app/utils/useProjectKeys.tsx
+++ b/static/app/utils/useProjectKeys.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+import * as Sentry from '@sentry/react';
 
 import {Organization, Project, ProjectKey, RequestState} from 'sentry/types';
 
@@ -31,12 +32,13 @@ export function useProjectKeys({
           data,
         });
       })
-      .catch(error =>
+      .catch(error => {
         setResponse({
           type: 'errored',
           error,
-        })
-      );
+        });
+        Sentry.captureException(error);
+      });
 
     return () => {
       api.clear();

--- a/static/app/utils/useProjectKeys.tsx
+++ b/static/app/utils/useProjectKeys.tsx
@@ -12,7 +12,7 @@ export function useProjectKeys({
   project: Project | null;
 }) {
   const api = useApi();
-  const [response, setResponse] = useState<RequestState<ProjectKey[] | null>>({
+  const [response, setResponse] = useState<RequestState<ProjectKey[]>>({
     type: 'initial',
   });
   useEffect(() => {

--- a/static/app/utils/useProjectKeys.tsx
+++ b/static/app/utils/useProjectKeys.tsx
@@ -1,0 +1,47 @@
+import {useEffect, useState} from 'react';
+
+import {Organization, Project, ProjectKey, RequestState} from 'sentry/types';
+
+import useApi from './useApi';
+
+export function useProjectKeys({
+  organization,
+  project,
+}: {
+  organization: Organization | null;
+  project: Project | null;
+}) {
+  const api = useApi();
+  const [response, setResponse] = useState<RequestState<ProjectKey[] | null>>({
+    type: 'initial',
+  });
+  useEffect(() => {
+    if (!organization || !project) {
+      return;
+    }
+    setResponse({type: 'loading'});
+    const request: Promise<ProjectKey[]> = api.requestPromise(
+      `/projects/${organization.slug}/${project.slug}/keys/`
+    );
+
+    request
+      .then(data => {
+        setResponse({
+          type: 'resolved',
+          data,
+        });
+      })
+      .catch(error =>
+        setResponse({
+          type: 'errored',
+          error,
+        })
+      );
+
+    () => {
+      api.clear();
+    };
+  }, [organization, project, api]);
+
+  return response;
+}

--- a/static/app/utils/useProjectKeys.tsx
+++ b/static/app/utils/useProjectKeys.tsx
@@ -17,7 +17,7 @@ export function useProjectKeys({
   });
   useEffect(() => {
     if (!organization || !project) {
-      return;
+      return () => {};
     }
     setResponse({type: 'loading'});
     const request: Promise<ProjectKey[]> = api.requestPromise(
@@ -38,7 +38,7 @@ export function useProjectKeys({
         })
       );
 
-    () => {
+    return () => {
       api.clear();
     };
   }, [organization, project, api]);


### PR DESCRIPTION
This PR introduces the display of a project's public DSN within the profiling onboarding code snippet.


<img width="630" alt="image" src="https://user-images.githubusercontent.com/7349258/191997077-b7e53316-025d-4a1a-b71b-b33abf5ad258.png">


<img width="650" alt="image" src="https://user-images.githubusercontent.com/7349258/191997139-3ca8a227-be7d-4484-8f75-f5850f389bed.png">
