### PR TITLE
tests(replays): Store replay events further in the past for stability

### DIFF
--- a/tests/acceptance/test_replay_detail.py
+++ b/tests/acceptance/test_replay_detail.py
@@ -29,8 +29,8 @@ class ReplayDetailTest(ReplaysAcceptanceTestCase):
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
 
         replay_id = uuid4().hex
-        seq1_timestamp = datetime.now() - timedelta(seconds=52)
-        seq2_timestamp = datetime.now() - timedelta(seconds=35)
+        seq1_timestamp = datetime.now() - timedelta(minutes=10, seconds=52)
+        seq2_timestamp = datetime.now() - timedelta(minutes=10, seconds=35)
         self.store_replays(
             [
                 mock_replay(

--- a/tests/acceptance/test_replay_list.py
+++ b/tests/acceptance/test_replay_list.py
@@ -21,8 +21,8 @@ class ReplayListTest(ReplaysAcceptanceTestCase):
         )
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
 
-        seq1_timestamp = datetime.now() - timedelta(seconds=52)
-        seq2_timestamp = datetime.now() - timedelta(seconds=35)
+        seq1_timestamp = datetime.now() - timedelta(minutes=10, seconds=52)
+        seq2_timestamp = datetime.now() - timedelta(minutes=10, seconds=35)
         for replay_id in [uuid4().hex, uuid4().hex, uuid4().hex]:
             self.store_replays(
                 [


### PR DESCRIPTION
The replay endpoints looks to suffer from the same issues as the discover endpoints. So I'm storing the segments further in the past hoping to decrease flakiness. See #36619 for a detail explanation of the reason.