### PR TITLE
fix(perf-issues): Fix error with config selector

### DIFF
--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -411,7 +411,9 @@ const EventEntries = ({
         <EventGroupingInfo
           projectId={projectSlug}
           event={event}
-          showGroupingConfig={orgFeatures.includes('set-grouping-config')}
+          showGroupingConfig={
+            orgFeatures.includes('set-grouping-config') && 'groupingConfig' in event
+          }
         />
       )}
       {!isShare && (

--- a/static/app/components/events/groupingInfo/index.tsx
+++ b/static/app/components/events/groupingInfo/index.tsx
@@ -84,7 +84,11 @@ class EventGroupingInfo extends AsyncComponent<Props, State> {
     const {configOverride} = this.state;
     const {event} = this.props;
 
-    const configId = configOverride ?? event.groupingConfig.id;
+    if (!event.groupingConfig) {
+      return null;
+    }
+
+    const configId = configOverride ?? event.groupingConfig?.id;
 
     return (
       <GroupingConfigSelect

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -421,10 +421,6 @@ interface EventBase {
   errors: any[];
   eventID: string;
   fingerprints: string[];
-  groupingConfig: {
-    enhancements: string;
-    id: string;
-  };
   id: string;
   location: string | null;
   message: string;
@@ -446,6 +442,10 @@ interface EventBase {
   device?: Record<string, any>;
   endTimestamp?: number;
   groupID?: string;
+  groupingConfig?: {
+    enhancements: string;
+    id: string;
+  };
   issueCategory?: IssueCategory;
   latestEventID?: string | null;
   measurements?: Record<string, Measurement>;


### PR DESCRIPTION
Closes JAVASCRIPT-2A6X. If the `"organizations:set-grouping-config"` flag is on, the UI tries to show a config selector. Since transaction events don't have grouping configs, the data is missing, and this feature fails. To fix, do not attempt to show the dropdown unless there is known config info.

![Screen Shot 2022-09-23 at 12 58 24 PM](https://user-images.githubusercontent.com/989898/192014353-290be800-66a7-488d-8ca2-c0e0196ee874.png)
