### PR TITLE
fix(perf-issues): sdk name on metrics (again)

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -995,7 +995,7 @@ def report_metrics_for_detectors(
 ):
     all_detected_problems = [i for _, d in detectors.items() for i in d.stored_problems]
     has_detected_problems = bool(all_detected_problems)
-    sdk_name = get_sdk_name(event.data) if "data" in event else ""
+    sdk_name = get_sdk_name(event)
 
     try:
         # Setting a tag isn't critical, the transaction doesn't exist sometimes, if it's called outside prod code (eg. load-mocks / tests)


### PR DESCRIPTION
### Summary
The event we receive for this function is actually the event data already, checked locally with a real event, this should work this time.


