### PR TITLE
fix(tests): Attachments test use unique event id

### DIFF
--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -203,7 +203,7 @@ def test_individual_attachments(
 ):
     monkeypatch.setattr("sentry.features.has", lambda *a, **kw: event_attachments)
 
-    event_id = "515539018c9b4260a6f999572f1661ee"
+    event_id = uuid.uuid4().hex
     attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
     project_id = default_project.id
     group_id = None


### PR DESCRIPTION
This test was sharing event_ids across runs without clearing the attachments cache resulting in the group id from a previous run being attached to a run of the test where there shouldn't be a group id.