### PR TITLE
ref(js): Use `js-cookie` for our CSRF cookie value

### DIFF
--- a/static/app/utils/getCsrfToken.tsx
+++ b/static/app/utils/getCsrfToken.tsx
@@ -1,5 +1,5 @@
-import getCookie from 'sentry/utils/getCookie';
+import Cookies from 'js-cookie';
 
 export default function getCsrfToken() {
-  return getCookie(window.csrfCookieName ?? 'sc') ?? '';
+  return Cookies.get(window.csrfCookieName ?? 'sc') ?? '';
 }


### PR DESCRIPTION
We broke everything with #39185 and fixed it with #39244. 

Let's just not even use this because literally this was the only place this janky code was used.

I plan to follow up with a fix of acceptance tests later.