### PR TITLE
fix(tests): User report test clear django cache

### DIFF
--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -15,6 +15,7 @@ from datetime import datetime
 import pytest
 import requests
 import yaml
+from django.core.cache import cache
 
 import sentry
 
@@ -442,3 +443,8 @@ def set_sentry_option(request):
         request.addfinalizer(lambda: ctx_mgr.__exit__(None, None, None))
 
     return inner
+
+
+@pytest.fixture
+def django_cache():
+    cache.clear()

--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -447,4 +447,5 @@ def set_sentry_option(request):
 
 @pytest.fixture
 def django_cache():
+    yield cache
     cache.clear()

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -304,7 +304,7 @@ def test_userreport(default_project, monkeypatch):
 
 
 @pytest.mark.django_db
-def test_userreport_reverse_order(default_project, monkeypatch):
+def test_userreport_reverse_order(django_cache, default_project, monkeypatch):
     """
     Test that ingesting a userreport before the event works. This is relevant
     for unreal crashes where the userreport is processed immediately in the


### PR DESCRIPTION
EventUser is stored in postgres but EventManager will not recreate the EventUser if the cache key exists. Make sure to clear the cache before running this test or we may hit a situation where the event user exists in the cache but not in postgres.