### PR TITLE
fix(api): instruct client browser not to cache API token endpoints

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.views.decorators.cache import never_cache
 from rest_framework import serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -20,6 +21,7 @@ class ApiTokensEndpoint(Endpoint):
     authentication_classes = (SessionAuthentication,)
     permission_classes = (IsAuthenticated,)
 
+    @never_cache
     def get(self, request: Request) -> Response:
         token_list = list(
             ApiToken.objects.filter(application__isnull=True, user=request.user).select_related(
@@ -29,6 +31,7 @@ class ApiTokensEndpoint(Endpoint):
 
         return Response(serialize(token_list, request.user))
 
+    @never_cache
     def post(self, request: Request) -> Response:
         serializer = ApiTokenSerializer(data=request.data)
 
@@ -51,6 +54,7 @@ class ApiTokensEndpoint(Endpoint):
             return Response(serialize(token, request.user), status=201)
         return Response(serializer.errors, status=400)
 
+    @never_cache
     def delete(self, request: Request):
         token = request.data.get("token")
         if not token:

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -15,6 +15,16 @@ class ApiTokensListTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
 
+    def test_never_cache(self):
+        ApiToken.objects.create(user=self.user)
+        ApiToken.objects.create(user=self.user)
+
+        self.login_as(self.user)
+        url = reverse("sentry-api-0-api-tokens")
+        response = self.client.get(url)
+        assert response.status_code == 200, response.content
+        assert response.get("cache-control") == "max-age=0, no-cache, no-store, must-revalidate"
+
 
 class ApiTokensCreateTest(APITestCase):
     def test_no_scopes(self):
@@ -33,6 +43,13 @@ class ApiTokensCreateTest(APITestCase):
         assert not token.refresh_token
         assert token.get_scopes() == ["event:read"]
 
+    def test_never_cache(self):
+        self.login_as(self.user)
+        url = reverse("sentry-api-0-api-tokens")
+        response = self.client.post(url, data={"scopes": ["event:read"]})
+        assert response.status_code == 201
+        assert response.get("cache-control") == "max-age=0, no-cache, no-store, must-revalidate"
+
 
 class ApiTokensDeleteTest(APITestCase):
     def test_simple(self):
@@ -42,3 +59,11 @@ class ApiTokensDeleteTest(APITestCase):
         response = self.client.delete(url, data={"token": token.token})
         assert response.status_code == 204
         assert not ApiToken.objects.filter(id=token.id).exists()
+
+    def test_never_cache(self):
+        token = ApiToken.objects.create(user=self.user)
+        self.login_as(self.user)
+        url = reverse("sentry-api-0-api-tokens")
+        response = self.client.delete(url, data={"token": token.token})
+        assert response.status_code == 204
+        assert response.get("cache-control") == "max-age=0, no-cache, no-store, must-revalidate"


### PR DESCRIPTION
The endpoint for managing user API tokens currently caches data in a user's browser.
These endpoints could contain sensitive values (ie. user API tokens), we should not cache these on the user's endpoint.