### PR TITLE
feat(alert-email): convert alert email datetimes to local timezones

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -4,6 +4,7 @@ import abc
 import logging
 from typing import Sequence, Set, Tuple
 
+from django.conf import settings
 from django.template.defaultfilters import pluralize
 from django.urls import reverse
 
@@ -20,6 +21,8 @@ from sentry.incidents.models import (
     TriggerStatus,
 )
 from sentry.models.notificationsetting import NotificationSetting
+from sentry.models.options.user_option import UserOption
+from sentry.models.user import User
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.email import MessageBuilder, get_email_addresses
@@ -88,14 +91,16 @@ class EmailActionHandler(ActionHandler):
         self.email_users(TriggerStatus.RESOLVED, new_status)
 
     def email_users(self, trigger_status: TriggerStatus, incident_status: IncidentStatus) -> None:
-        email_context = generate_incident_trigger_email_context(
-            self.project,
-            self.incident,
-            self.action.alert_rule_trigger,
-            trigger_status,
-            incident_status,
-        )
         for user_id, email in self.get_targets():
+            user = User.objects.get(id=user_id)
+            email_context = generate_incident_trigger_email_context(
+                self.project,
+                self.incident,
+                self.action.alert_rule_trigger,
+                trigger_status,
+                incident_status,
+                user,
+            )
             self.build_message(email_context, trigger_status, user_id).send_async(to=[email])
 
     def build_message(self, context, status, user_id):
@@ -185,7 +190,12 @@ def format_duration(minutes):
 
 
 def generate_incident_trigger_email_context(
-    project, incident, alert_rule_trigger, trigger_status, incident_status
+    project,
+    incident,
+    alert_rule_trigger,
+    trigger_status,
+    incident_status,
+    user=None,
 ):
     trigger = alert_rule_trigger
     incident_trigger = IncidentTrigger.objects.get(incident=incident, alert_rule_trigger=trigger)
@@ -225,6 +235,12 @@ def generate_incident_trigger_email_context(
         except Exception:
             logging.exception("Error while attempting to build_metric_alert_chart")
 
+    tz = settings.SENTRY_DEFAULT_TIME_ZONE
+    if user is not None:
+        user_option_tz = UserOption.objects.get_value(user=user, key="timezone")
+        if user_option_tz is not None:
+            tz = user_option_tz
+
     return {
         "link": absolute_uri(
             reverse(
@@ -263,4 +279,5 @@ def generate_incident_trigger_email_context(
         "is_warning": incident_status == IncidentStatus.WARNING,
         "unsubscribe_link": None,
         "chart_url": chart_url,
+        "timezone": tz,
     }

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -92,7 +92,7 @@ class EmailActionHandler(ActionHandler):
 
     def email_users(self, trigger_status: TriggerStatus, incident_status: IncidentStatus) -> None:
         for user_id, email in self.get_targets():
-            user = User.objects.get(id=user_id)
+            user = User.objects.get_from_cache(id=user_id)
             email_context = generate_incident_trigger_email_context(
                 self.project,
                 self.incident,

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -1,9 +1,11 @@
 import logging
 
+import pytz
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
 from django.template import loader
+from django.utils import timezone
 
 from sentry.auth import access
 from sentry.models import Team
@@ -84,7 +86,13 @@ def render_to_string(template, context=None, request=None):
         context = dict(context)
         context.update(default_context)
 
-    return loader.render_to_string(template, context=context, request=request)
+    if "timezone" in context and context["timezone"] in pytz.all_timezones_set:
+        timezone.activate(context["timezone"])
+
+    rendered = loader.render_to_string(template, context=context, request=request)
+    timezone.deactivate()
+
+    return rendered
 
 
 def render_to_response(template, context=None, request=None, status=200, content_type="text/html"):


### PR DESCRIPTION


<!-- Describe your PR here. -->


Converts datetimes in alert trigger email to the timezone set in user options.  Adds timezone to email context.