### PR TITLE
feat(discover): Allow saving interval on the frontend

### DIFF
--- a/static/app/components/charts/intervalSelector.spec.jsx
+++ b/static/app/components/charts/intervalSelector.spec.jsx
@@ -25,7 +25,7 @@ describe('IntervalSelector', function () {
       />
     );
     render(intervalSelector);
-    expect(interval).toEqual(undefined);
+    expect(interval).toEqual('4h');
   });
   it('resets large interval', function () {
     eventView.interval = '1h';
@@ -38,7 +38,7 @@ describe('IntervalSelector', function () {
       />
     );
     render(intervalSelector);
-    expect(eventView.interval).toEqual(undefined);
+    expect(eventView.interval).toEqual('1m');
   });
   it('leaves default interval alone', function () {
     eventView.interval = undefined;

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -188,28 +188,22 @@ export interface NewQuery {
   fields: Readonly<string[]>;
   id: string | undefined;
   name: string;
-  // GlobalSelectionHeader
   projects: Readonly<number[]>;
-
   version: SavedQueryVersions;
   createdBy?: User;
   display?: string;
   end?: string;
   environment?: Readonly<string[]>;
-
   expired?: boolean;
+  interval?: string;
   orderby?: string;
-  // Query and Table
   query?: string;
   range?: string;
   start?: string;
-
   teams?: Readonly<('myteams' | number)[]>;
   topEvents?: string;
   utc?: boolean | string;
   widths?: Readonly<string[]>;
-
-  // Graph
   yAxis?: string[];
 }
 

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -457,6 +457,7 @@ class EventView {
       yAxis: Array.isArray(saved.yAxis) ? saved.yAxis[0] : saved.yAxis,
       display: saved.display,
       topEvents: saved.topEvents ? saved.topEvents.toString() : undefined,
+      interval: saved.interval,
       createdBy: saved.createdBy,
       expired: saved.expired,
       additionalConditions: new MutableSearch([]),
@@ -498,7 +499,7 @@ class EventView {
           saved.topEvents ||
           TOP_N
         ).toString(),
-        interval: decodeScalar(location.query.interval),
+        interval: decodeScalar(location.query.interval) || saved.interval,
         createdBy: saved.createdBy,
         expired: saved.expired,
         additionalConditions: new MutableSearch([]),
@@ -528,6 +529,7 @@ class EventView {
       sorts: undefined,
       project: undefined,
       environment: undefined,
+      interval: undefined,
       yAxis: 'count()',
       display: DisplayModes.DEFAULT,
       topEvents: '5',
@@ -582,6 +584,7 @@ class EventView {
       yAxis: this.yAxis ? [this.yAxis] : undefined,
       display: this.display,
       topEvents: this.topEvents,
+      interval: this.interval,
     };
 
     if (!newQuery.query) {

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -399,14 +399,16 @@ class Results extends Component<Props, State> {
       interval: value,
     };
 
-    router.push({
-      pathname: location.pathname,
-      query: newQuery,
-    });
+    if (location.query.interval !== value) {
+      router.push({
+        pathname: location.pathname,
+        query: newQuery,
+      });
 
-    // Treat display changing like the user already confirmed the query
-    if (!this.state.needConfirmation) {
-      this.handleConfirmed();
+      // Treat display changing like the user already confirmed the query
+      if (!this.state.needConfirmation) {
+        this.handleConfirmed();
+      }
     }
   };
 


### PR DESCRIPTION
- This adds interval to the frontend correctly so its saveable and read from the saved query
- The saved interval is overwritten when the timerange is changed, and lost until leaving and returning
- This adds a check that the interval did indeed change before pushing to the router so we don't loop