### PR TITLE
fix(perf-issues): Fix context-trace in n+1 (db) extended

### DIFF
--- a/src/sentry/testutils/performance_issues/events/n-plus-one-db-root-parent-span.json
+++ b/src/sentry/testutils/performance_issues/events/n-plus-one-db-root-parent-span.json
@@ -139,12 +139,14 @@
   "start_timestamp": 1661957619.181783,
   "timestamp": 1661957623.393462,
   "title": "GET /books/new",
-  "trace": {
-    "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
-    "span_id": "86d3f8a7e85d7324",
-    "op": "http.server",
-    "status": "ok",
-    "hash": "aa6df963e9081e3a"
+  "contexts": {
+    "trace": {
+      "trace_id": "a5c94c91f0a248d19e5068ca6acc8afe",
+      "span_id": "86d3f8a7e85d7324",
+      "op": "http.server",
+      "status": "ok",
+      "hash": "aa6df963e9081e3a"
+    }
   },
   "transaction": "GET /books/new",
   "type": "transaction"

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -17,6 +17,7 @@ from sentry.models import Organization, Project, ProjectOption
 from sentry.types.issues import GroupType
 from sentry.utils import metrics
 from sentry.utils.event_frames import get_sdk_name
+from sentry.utils.safe import get_path
 
 from .performance_span_issue import PerformanceSpanProblem
 
@@ -1015,7 +1016,7 @@ class NPlusOneDBSpanDetectorExtended(NPlusOneDBSpanDetector):
 
     def init(self):
         super().init()
-        root_span = self._event.get("trace", None)
+        root_span = get_path(self._event, "contexts", "trace")
         if root_span:
             self.potential_parents[root_span.get("span_id")] = root_span
 


### PR DESCRIPTION
### Summary
Fix the n+1-db extended detector since I missed the contexts block when building the fixture, which causes it to not find the trace properly on prod.
