### PR TITLE
fix(perf): Link user ID tag to transaction summary search

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -571,7 +571,7 @@ export const SEMVER_TAGS = {
  * Some tag keys should never be formatted as `tag[...]`
  * when used as a filter because they are predefined.
  */
-const EXCLUDED_TAG_KEYS = new Set(['release']);
+const EXCLUDED_TAG_KEYS = new Set(['release', 'user']);
 
 export function formatTagKey(key: string): string {
   // Some tags may be normalized from context, but not all of them are.

--- a/static/app/views/performance/transactionSummary.spec.tsx
+++ b/static/app/views/performance/transactionSummary.spec.tsx
@@ -315,6 +315,10 @@ describe('Performance > TransactionSummary', function () {
           key: 'foo',
           topValues: [{count: 1, value: 'bar', name: 'bar'}],
         },
+        {
+          key: 'user',
+          topValues: [{count: 1, value: 'id:100', name: '100'}],
+        },
       ],
     });
     MockApiClient.addMockResponse({
@@ -755,8 +759,11 @@ describe('Performance > TransactionSummary', function () {
       userEvent.click(
         screen.getByLabelText('Add the bar segment tag to the search query')
       );
+      userEvent.click(
+        screen.getByLabelText('Add the id:100 segment tag to the search query')
+      );
 
-      expect(router.push).toHaveBeenCalledTimes(2);
+      expect(router.push).toHaveBeenCalledTimes(3);
 
       expect(router.push).toHaveBeenNthCalledWith(1, {
         query: {
@@ -771,6 +778,15 @@ describe('Performance > TransactionSummary', function () {
         query: {
           project: '2',
           query: 'foo:bar',
+          transaction: '/performance',
+          transactionCursor: '1:0:0',
+        },
+      });
+
+      expect(router.push).toHaveBeenNthCalledWith(3, {
+        query: {
+          project: '2',
+          query: 'user:"id:100"',
           transaction: '/performance',
           transactionCursor: '1:0:0',
         },


### PR DESCRIPTION
### Summary
Fixes a bad link from the user id tag on the transaction event detail page. The link would prefill the search on the transaction summary page with an invalid query showing no results.

Bad link:
![image](https://user-images.githubusercontent.com/197916/192007425-9e051ac0-f8e8-4ed6-b581-59b8788fac5c.png)

Query Before:
![Screen Shot 2022-09-23 at 12 24 10 PM](https://user-images.githubusercontent.com/197916/192007996-0549ed3f-4eec-40fc-91fc-68f011cd7fd9.png)


Fixed Query:
![Screen Shot 2022-09-23 at 12 24 53 PM](https://user-images.githubusercontent.com/197916/192008004-8e558a65-9405-4b7f-8687-f9c8b4ca5fe1.png)

