### PR TITLE
feat(hybrid-cloud): Activate DedupeCookiesMiddleware

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -283,6 +283,7 @@ MIDDLEWARE = (
     "sentry.middleware.stats.RequestTimingMiddleware",
     "sentry.middleware.access_log.access_log_middleware",
     "sentry.middleware.stats.ResponseCodeMiddleware",
+    "sentry.middleware.dedupe_cookies.DedupeCookiesMiddleware",
     "sentry.middleware.subdomain.SubdomainMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
This pull request activates the `DedupeCookiesMiddleware` middleware added in https://github.com/getsentry/sentry/pull/39136.

This should deduplicate cookies that are set for the following domains: `sentry.io` and `.sentry.io` (note the leading dot). And help alleviate any issues (e.g. login loops) users might be be having due to duplicate cookies.