### PR TITLE
test(acceptance): Set an extra garbage cookie

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -509,6 +509,15 @@ def browser(request, live_server):
 
     browser.set_emulated_media([{"name": "prefers-reduced-motion", "value": "reduce"}])
 
+    # XXX: We explicitly set an extra garbage cookie, just so like in
+    # production, there are more than one cookies set.
+    #
+    # This is the outcome of an incident where the acceptance tests failed to
+    # capture an issue where cookie lookup in the frontend failed, but did NOT
+    # fail in the acceptance tests because the code worked fine when
+    # document.cookie only had one cookie in it.
+    browser.save_cookie("acceptance_test_cookie", "1")
+
     if hasattr(request, "cls"):
         request.cls.browser = browser
     request.node.browser = browser


### PR DESCRIPTION
In INC-211 we broke production POST and PUT's because the CSRF cookie couldn't be looked up (#39248).

**The acceptance tests DID NOT catch this becuase there was only a single cookie set.**

While we do indeed test that we're passing the CSRF cookie in acceptance tests, this particular change broke the way the CSRF cookie was looked up when there *are multiple cookies*

This helps with that