### PR TITLE
chore(sudo): Update SUDO_COOKIE_DOMAIN fallback

### DIFF
--- a/src/sudo/settings.py
+++ b/src/sudo/settings.py
@@ -17,7 +17,7 @@ REDIRECT_FIELD_NAME = getattr(settings, "SUDO_REDIRECT_FIELD_NAME", "next")
 COOKIE_AGE = getattr(settings, "SUDO_COOKIE_AGE", 10800)
 
 # The domain to bind the sudo cookie to. Default to the current domain.
-COOKIE_DOMAIN = getattr(settings, "SUDO_COOKIE_DOMAIN", None)
+COOKIE_DOMAIN = getattr(settings, "SUDO_COOKIE_DOMAIN", settings.SESSION_COOKIE_DOMAIN)
 
 # Should the cookie only be accessible via http requests?
 # Note: If this is set to False, any JavaScript files have the ability to access


### PR DESCRIPTION
Update fallback of `SUDO_COOKIE_DOMAIN` to be `SESSION_COOKIE_DOMAIN `.

This matches to how we set the fallback for `SUPERUSER_COOKIE_DOMAIN ` here: https://github.com/getsentry/sentry/blob/4182b6777aa21ba1943499c10d4e9744302cda33/src/sentry/auth/superuser.py#L39

and when we run the dev server here:

https://github.com/getsentry/sentry/blob/4182b6777aa21ba1943499c10d4e9744302cda33/src/sentry/runner/initializer.py#L336-L337

