### PR TITLE
fix(replays): Make sure the url walker scrolls when the list is large

### DIFF
--- a/static/app/components/replays/walker/splitCrumbs.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.tsx
@@ -102,27 +102,40 @@ function SummarySegment({
 }) {
   const {handleMouseEnter, handleMouseLeave} = useCrumbHandlers(startTimestampMs);
 
-  const summaryItems = crumbs.map((crumb, i) => (
-    <BreadcrumbItem
-      key={crumb.id || i}
-      crumb={crumb}
-      startTimestampMs={startTimestampMs}
-      isHovered={false}
-      isSelected={false}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
-      onClick={handleOnClick}
-    />
-  ));
+  const summaryItems = (
+    <ScrollingList>
+      {crumbs.map((crumb, i) => (
+        <li key={crumb.id || i}>
+          <BreadcrumbItem
+            crumb={crumb}
+            startTimestampMs={startTimestampMs}
+            isHovered={false}
+            isSelected={false}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+            onClick={handleOnClick}
+          />
+        </li>
+      ))}
+    </ScrollingList>
+  );
 
   return (
     <Span>
       <HalfPaddingHovercard body={summaryItems} position="right">
-        <TextOverflow>{tn('%s Page', '%s Pages', summaryItems.length)}</TextOverflow>
+        <TextOverflow>{tn('%s Page', '%s Pages', crumbs.length)}</TextOverflow>
       </HalfPaddingHovercard>
     </Span>
   );
 }
+
+const ScrollingList = styled('ul')`
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  max-height: calc(100vh - 32px);
+  overflow: scroll;
+`;
 
 const Span = styled('span')`
   color: ${p => p.theme.subText};


### PR DESCRIPTION
Checked that scrolling on both the Replay Detail Page and List pages work, and for smaller lists everything looks good too.

<img width="341" alt="Screen Shot 2022-09-25 at 11 36 18 AM" src="https://user-images.githubusercontent.com/187460/192159821-001a1523-b151-4dad-b630-7c9ed4d60c82.png">
<img width="391" alt="Screen Shot 2022-09-25 at 11 37 28 AM" src="https://user-images.githubusercontent.com/187460/192159822-f332c698-2e63-4280-ad92-3633be245754.png">
