### PR TITLE
fix(metrics): Remove generic_metrics_counters support

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -293,5 +293,4 @@ METRIC_FUNCTION_LIST_BY_TYPE = {
         "user_misery",
         "count_unique",
     ],
-    "generic_counter": [],
 }

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -26,4 +26,3 @@ class EntityKey(Enum):
     MetricsDistributions = "metrics_distributions"
     GenericMetricsDistributions = "generic_metrics_distributions"
     GenericMetricsSets = "generic_metrics_sets"
-    GenericMetricsCounters = "generic_metrics_counters"

--- a/src/sentry/snuba/entity_subscription.py
+++ b/src/sentry/snuba/entity_subscription.py
@@ -52,7 +52,6 @@ ENTITY_TIME_COLUMNS: Mapping[EntityKey, str] = {
     EntityKey.Events: "timestamp",
     EntityKey.Sessions: "started",
     EntityKey.Transactions: "finish_ts",
-    EntityKey.GenericMetricsCounters: "timestamp",
     EntityKey.GenericMetricsDistributions: "timestamp",
     EntityKey.GenericMetricsSets: "timestamp",
     EntityKey.MetricsCounters: "timestamp",

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -159,7 +159,6 @@ def _get_known_entity_of_metric_mri(metric_mri: str) -> Optional[EntityKey]:
         TransactionMRI(metric_mri)
         entity_prefix = metric_mri.split(":")[0]
         return {
-            "c": EntityKey.GenericMetricsCounters,
             "d": EntityKey.GenericMetricsDistributions,
             "s": EntityKey.GenericMetricsSets,
         }[entity_prefix]
@@ -185,7 +184,6 @@ def _get_entity_of_metric_mri(
 
     if use_case_id == UseCaseKey.PERFORMANCE:
         metric_types = (
-            "generic_counter",
             "generic_set",
             "generic_distribution",
         )

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -67,7 +67,6 @@ from sentry.snuba.metrics.utils import (
     DEFAULT_AGGREGATES,
     GENERIC_OP_TO_SNUBA_FUNCTION,
     GRANULARITY,
-    METRIC_TYPE_TO_ENTITY,
     OP_TO_SNUBA_FUNCTION,
     TS_COL_QUERY,
     UNIT_TO_TYPE,
@@ -182,18 +181,19 @@ def _get_entity_of_metric_mri(
     if metric_id is None:
         raise InvalidParams
 
+    entity_keys_set: frozenset[EntityKey]
     if use_case_id == UseCaseKey.PERFORMANCE:
-        metric_types = (
-            "generic_set",
-            "generic_distribution",
+        entity_keys_set = frozenset(
+            {EntityKey.GenericMetricsSets, EntityKey.GenericMetricsDistributions}
         )
     elif use_case_id == UseCaseKey.RELEASE_HEALTH:
-        metric_types = ("counter", "set", "distribution")
+        entity_keys_set = frozenset(
+            {EntityKey.MetricsCounters, EntityKey.MetricsSets, EntityKey.MetricsDistributions}
+        )
     else:
         raise InvalidParams
 
-    for metric_type in metric_types:
-        entity_key = METRIC_TYPE_TO_ENTITY[metric_type]
+    for entity_key in entity_keys_set:
         data = run_metrics_query(
             entity_key=entity_key,
             select=[Column("metric_id")],

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -170,7 +170,6 @@ METRIC_TYPE_TO_ENTITY: Mapping[MetricType, EntityKey] = {
     "counter": EntityKey.MetricsCounters,
     "set": EntityKey.MetricsSets,
     "distribution": EntityKey.MetricsDistributions,
-    "generic_counter": EntityKey.GenericMetricsCounters,
     "generic_set": EntityKey.GenericMetricsSets,
     "generic_distribution": EntityKey.GenericMetricsDistributions,
 }


### PR DESCRIPTION
Removes `generic_metrics_counters` entity as it does not exist because performance metrics do not use counters as per https://github.com/getsentry/snuba/blob/master/snuba/datasets/generic_metrics.py


