### PR TITLE
feat(dashboards): Adds release health search bar validation

### DIFF
--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -659,6 +659,7 @@ export class TokenConverter {
    */
   checkInvalidTextFilter = (key: TextFilter['key'], value: TextFilter['value']) => {
     if (
+      this.config.validateKeys &&
       this.config.supportedTags &&
       !Object.keys(this.config.supportedTags).includes(key.text)
     ) {
@@ -824,7 +825,14 @@ export type SearchConfig = {
    * Text filter keys we allow to have operators
    */
   textOperatorKeys: Set<string>;
+  /**
+   * If validateKeys is set to true, tag keys that don't exist in supportedTags will be consider invalid
+   */
   supportedTags?: TagCollection;
+  /**
+   * If set to true, tag keys that don't exist in supportedTags will be consider invalid
+   */
+  validateKeys?: boolean;
 };
 
 const defaultConfig: SearchConfig = {

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -787,12 +787,6 @@ export type ParseResult = Array<
   | TokenResult<Token.Spaces>
 >;
 
-export type SearchValidationFunction = <T extends FilterType>(
-  filter: T,
-  key: FilterMap[T]['key'],
-  value: FilterMap[T]['value']
-) => InvalidFilter | null;
-
 /**
  * Configures behavior of search parsing
  */

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -661,7 +661,7 @@ export class TokenConverter {
     if (
       this.config.validateKeys &&
       this.config.supportedTags &&
-      !Object.keys(this.config.supportedTags).includes(key.text)
+      !this.config.supportedTags[key.text]
     ) {
       return {reason: t(`Invalid key. "${key.text}" is not a supported search key.`)};
     }

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -18,7 +18,6 @@ import {
   ParseResult,
   parseSearch,
   SearchConfig,
-  SearchValidationFunction,
   TermOperator,
   Token,
   TokenResult,
@@ -248,10 +247,6 @@ type Props = WithRouterProps & {
    */
   searchSource?: string;
   /**
-   * Custom SearchValidationFunction for additional search validation needed not provided by default
-   */
-  searchValidator?: SearchValidationFunction;
-  /**
    * Type of supported tags
    */
   supportedTagType?: ItemType;
@@ -328,7 +323,7 @@ class SmartSearchBar extends Component<Props, State> {
     showDropdown: false,
     parsedQuery: parseSearch(this.initialQuery, {
       ...getSearchConfigFromCustomPerformanceMetrics(this.props.customPerformanceMetrics),
-      additionalSearchValidator: this.props.searchValidator,
+      supportedTags: this.props.supportedTags,
     }),
     searchTerm: '',
     searchGroups: [],
@@ -380,7 +375,7 @@ class SmartSearchBar extends Component<Props, State> {
   makeQueryState(query: string) {
     const additionalConfig: Partial<SearchConfig> = {
       ...getSearchConfigFromCustomPerformanceMetrics(this.props.customPerformanceMetrics),
-      additionalSearchValidator: this.props.searchValidator,
+      supportedTags: this.props.supportedTags,
     };
     return {
       query,
@@ -1731,7 +1726,7 @@ class SmartSearchBar extends Component<Props, State> {
       maxQueryLength,
       maxMenuHeight,
       customPerformanceMetrics,
-      searchValidator,
+      supportedTags,
     } = this.props;
 
     const {
@@ -1869,7 +1864,7 @@ class SmartSearchBar extends Component<Props, State> {
             visibleShortcuts={visibleShortcuts}
             maxMenuHeight={maxMenuHeight}
             customPerformanceMetrics={customPerformanceMetrics}
-            searchValidator={searchValidator}
+            supportedTags={supportedTags}
           />
         )}
       </Container>

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -172,6 +172,10 @@ type Props = WithRouterProps & {
    */
   hasRecentSearches?: boolean;
   /**
+   * Whether or not to highlight unsupported tags red
+   */
+  highlightUnsupportedTags?: boolean;
+  /**
    * Allows additional content to be played before the search bar and icon
    */
   inlineLabel?: React.ReactNode;
@@ -246,10 +250,6 @@ type Props = WithRouterProps & {
    * Indicates the usage of the search bar for analytics
    */
   searchSource?: string;
-  /**
-   * Whether or not to highlight unsupported tags red
-   */
-  showUnsupportedTags?: boolean;
   /**
    * Type of supported tags
    */
@@ -328,7 +328,7 @@ class SmartSearchBar extends Component<Props, State> {
     parsedQuery: parseSearch(this.initialQuery, {
       ...getSearchConfigFromCustomPerformanceMetrics(this.props.customPerformanceMetrics),
       supportedTags: this.props.supportedTags,
-      validateKeys: this.props.showUnsupportedTags,
+      validateKeys: this.props.highlightUnsupportedTags,
     }),
     searchTerm: '',
     searchGroups: [],
@@ -381,7 +381,7 @@ class SmartSearchBar extends Component<Props, State> {
     const additionalConfig: Partial<SearchConfig> = {
       ...getSearchConfigFromCustomPerformanceMetrics(this.props.customPerformanceMetrics),
       supportedTags: this.props.supportedTags,
-      validateKeys: this.props.showUnsupportedTags,
+      validateKeys: this.props.highlightUnsupportedTags,
     };
     return {
       query,

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -247,6 +247,10 @@ type Props = WithRouterProps & {
    */
   searchSource?: string;
   /**
+   * Whether or not to highlight unsupported tags red
+   */
+  showUnsupportedTags?: boolean;
+  /**
    * Type of supported tags
    */
   supportedTagType?: ItemType;
@@ -324,6 +328,7 @@ class SmartSearchBar extends Component<Props, State> {
     parsedQuery: parseSearch(this.initialQuery, {
       ...getSearchConfigFromCustomPerformanceMetrics(this.props.customPerformanceMetrics),
       supportedTags: this.props.supportedTags,
+      validateKeys: this.props.showUnsupportedTags,
     }),
     searchTerm: '',
     searchGroups: [],
@@ -376,6 +381,7 @@ class SmartSearchBar extends Component<Props, State> {
     const additionalConfig: Partial<SearchConfig> = {
       ...getSearchConfigFromCustomPerformanceMetrics(this.props.customPerformanceMetrics),
       supportedTags: this.props.supportedTags,
+      validateKeys: this.props.showUnsupportedTags,
     };
     return {
       query,

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -6,11 +6,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import HotkeysLabel from 'sentry/components/hotkeysLabel';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Overlay} from 'sentry/components/overlay';
-import {
-  parseSearch,
-  SearchConfig,
-  SearchValidationFunction,
-} from 'sentry/components/searchSyntax/parser';
+import {parseSearch, SearchConfig} from 'sentry/components/searchSyntax/parser';
 import HighlightQuery from 'sentry/components/searchSyntax/renderer';
 import Tag from 'sentry/components/tag';
 import {IconOpen} from 'sentry/icons';
@@ -38,7 +34,6 @@ type Props = {
   maxMenuHeight?: number;
   onIconClick?: (value: string) => void;
   runShortcut?: (shortcut: Shortcut) => void;
-  searchValidator?: SearchValidationFunction;
   supportedTags?: TagCollection;
   visibleShortcuts?: Shortcut[];
 };

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -16,6 +16,7 @@ import Tag from 'sentry/components/tag';
 import {IconOpen} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import {TagCollection} from 'sentry/types';
 import {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 import {FieldKind} from 'sentry/utils/fields';
 
@@ -38,6 +39,7 @@ type Props = {
   onIconClick?: (value: string) => void;
   runShortcut?: (shortcut: Shortcut) => void;
   searchValidator?: SearchValidationFunction;
+  supportedTags?: TagCollection;
   visibleShortcuts?: Shortcut[];
 };
 
@@ -52,7 +54,7 @@ const SearchDropdown = ({
   searchSubstring = '',
   onClick = () => {},
   customPerformanceMetrics,
-  searchValidator,
+  supportedTags,
 }: Props) => (
   <SearchDropdownOverlay className={className} data-test-id="smart-search-dropdown">
     {loading ? (
@@ -80,7 +82,7 @@ const SearchDropdown = ({
                       ...getSearchConfigFromCustomPerformanceMetrics(
                         customPerformanceMetrics
                       ),
-                      additionalSearchValidator: searchValidator,
+                      supportedTags,
                     }}
                   />
                 ))}

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -2,6 +2,7 @@
 import {
   filterTypeConfig,
   interchangeableFilterOperators,
+  SearchConfig,
   TermOperator,
   Token,
   TokenResult,
@@ -28,6 +29,7 @@ import {
 } from './types';
 import {TagCollection} from 'sentry/types';
 import {FieldKind, FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
+import {CustomMeasurementCollection} from 'sentry/utils/customMeasurements/customMeasurements';
 
 export function addSpace(query = '') {
   if (query.length !== 0 && query[query.length - 1] !== ' ') {
@@ -586,4 +588,40 @@ export const getDateTagAutocompleteGroups = (tagName: string): AutocompleteGroup
       type: ItemType.TAG_VALUE,
     },
   ];
+};
+
+export const getSearchConfigFromCustomPerformanceMetrics = (
+  customPerformanceMetrics?: CustomMeasurementCollection
+): Partial<SearchConfig> => {
+  const searchConfigMap: Record<string, string[]> = {
+    sizeKeys: [],
+    durationKeys: [],
+    percentageKeys: [],
+    numericKeys: [],
+  };
+  if (customPerformanceMetrics) {
+    Object.keys(customPerformanceMetrics).forEach(metricName => {
+      const {fieldType} = customPerformanceMetrics[metricName];
+      switch (fieldType) {
+        case 'size':
+          searchConfigMap.sizeKeys.push(metricName);
+          break;
+        case 'duration':
+          searchConfigMap.durationKeys.push(metricName);
+          break;
+        case 'percentage':
+          searchConfigMap.percentageKeys.push(metricName);
+          break;
+        default:
+          searchConfigMap.numericKeys.push(metricName);
+      }
+    });
+  }
+  const searchConfig = {
+    sizeKeys: new Set(searchConfigMap.sizeKeys),
+    durationKeys: new Set(searchConfigMap.durationKeys),
+    percentageKeys: new Set(searchConfigMap.percentageKeys),
+    numericKeys: new Set(searchConfigMap.numericKeys),
+  };
+  return searchConfig;
 };

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.spec.tsx
@@ -1,0 +1,53 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {ReleaseSearchBar} from './releaseSearchBar';
+
+describe('Release Search Bar', function () {
+  const {organization} = initializeOrg();
+  const pageFilters = {
+    datetime: {
+      period: '14d',
+      utc: null,
+      start: null,
+      end: null,
+    },
+    environments: [],
+    projects: [],
+  };
+
+  beforeEach(function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  it('does not allow search conditions with keys not equal to release, project, or environment', function () {
+    render(
+      <ReleaseSearchBar
+        onClose={undefined}
+        organization={organization}
+        pageFilters={pageFilters}
+        widgetQuery={{
+          aggregates: [],
+          columns: [],
+          conditions: '',
+          name: '',
+          orderby: '',
+          fieldAliases: undefined,
+          fields: undefined,
+        }}
+      />
+    );
+    const textbox = screen.getByRole('textbox');
+    userEvent.click(textbox);
+    userEvent.type(textbox, 'test-key:10 ');
+    userEvent.keyboard('{arrowleft}');
+
+    expect(
+      screen.getByText('Search key must be release, project, or environment.')
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.spec.tsx
@@ -47,7 +47,7 @@ describe('Release Search Bar', function () {
     userEvent.keyboard('{arrowleft}');
 
     expect(
-      screen.getByText('Search key must be release, project, or environment.')
+      screen.getByText('Invalid key. "test-key" is not a supported search key.')
     ).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -94,6 +94,7 @@ export function ReleaseSearchBar({
           query={widgetQuery.conditions}
           savedSearchType={SavedSearchType.SESSION}
           hasRecentSearches
+          showUnsupportedTags
         />
       )}
     </ClassNames>

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -4,7 +4,6 @@ import memoize from 'lodash/memoize';
 
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {SearchBarProps} from 'sentry/components/events/searchBar';
-import {SearchValidationFunction} from 'sentry/components/searchSyntax/parser';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {MAX_QUERY_LENGTH, NEGATION_OPERATOR, SEARCH_WILDCARD} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -68,13 +67,6 @@ export function ReleaseSearchBar({
     );
   }
 
-  const releaseSearchValidator: SearchValidationFunction = (_filter, key, _value) => {
-    if (!['release', 'project', 'environment'].includes(key.text)) {
-      return {reason: 'Search key must be release, project, or environment.'};
-    }
-    return null;
-  };
-
   const supportedTags = Object.values(SESSIONS_FILTER_TAGS).reduce((acc, key) => {
     acc[key] = {key, name: key};
     return acc;
@@ -102,7 +94,6 @@ export function ReleaseSearchBar({
           query={widgetQuery.conditions}
           savedSearchType={SavedSearchType.SESSION}
           hasRecentSearches
-          searchValidator={releaseSearchValidator}
         />
       )}
     </ClassNames>

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -4,6 +4,7 @@ import memoize from 'lodash/memoize';
 
 import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {SearchBarProps} from 'sentry/components/events/searchBar';
+import {SearchValidationFunction} from 'sentry/components/searchSyntax/parser';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {MAX_QUERY_LENGTH, NEGATION_OPERATOR, SEARCH_WILDCARD} from 'sentry/constants';
 import {t} from 'sentry/locale';
@@ -67,6 +68,13 @@ export function ReleaseSearchBar({
     );
   }
 
+  const releaseSearchValidator: SearchValidationFunction = (_filter, key, _value) => {
+    if (!['release', 'project', 'environment'].includes(key.text)) {
+      return {reason: 'Search key must be release, project, or environment.'};
+    }
+    return null;
+  };
+
   const supportedTags = Object.values(SESSIONS_FILTER_TAGS).reduce((acc, key) => {
     acc[key] = {key, name: key};
     return acc;
@@ -94,6 +102,7 @@ export function ReleaseSearchBar({
           query={widgetQuery.conditions}
           savedSearchType={SavedSearchType.SESSION}
           hasRecentSearches
+          searchValidator={releaseSearchValidator}
         />
       )}
     </ClassNames>

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/releaseSearchBar.tsx
@@ -94,7 +94,7 @@ export function ReleaseSearchBar({
           query={widgetQuery.conditions}
           savedSearchType={SavedSearchType.SESSION}
           hasRecentSearches
-          showUnsupportedTags
+          highlightUnsupportedTags
         />
       )}
     </ClassNames>


### PR DESCRIPTION
Adds release health specific search syntax validator to enforce only release, project, or environment key searches.
Also cleans up and fixes some typos for custom measurement config in search parser.

![image](https://user-images.githubusercontent.com/83961295/192320450-5180bc3b-58b6-42b4-bd89-c05c8da88a1f.png)
