### PR TITLE
fix(metrics): Ensures validation for public mris is applied [TET-412]

### DIFF
--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -16,7 +16,7 @@ and so it is a private metric, whereas `SessionMRI.CRASH_FREE_RATE` has a corres
 `SessionMetricKey` with the same name i.e. `SessionMetricKey.CRASH_FREE_RATE` and hence is a public
 metric that is queryable by the API.
 """
-__all__ = ("SessionMRI", "TransactionMRI", "MRI_SCHEMA_REGEX", "MRI_EXPRESSION_REGEX")
+__all__ = ("SessionMRI", "TransactionMRI", "MRI_SCHEMA_REGEX", "MRI_EXPRESSION_REGEX", "parse_mri")
 
 import re
 from dataclasses import dataclass

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -36,10 +36,9 @@ class MetricField:
     alias: Optional[str] = None
 
     def __post_init__(self) -> None:
-        # ToDo(ahmed): Once we allow MetricField to accept MRI, we should set the alias to the operation and public
-        #  facing name
+        # Validates that the MRI requested is an MRI the metrics layer exposes
+        metric_name = get_public_name_from_mri(self.metric_mri)
         if not self.alias:
-            metric_name = get_public_name_from_mri(self.metric_mri)
             key = f"{self.op}({metric_name})" if self.op is not None else metric_name
             object.__setattr__(self, "alias", key)
 
@@ -116,6 +115,8 @@ class MetricsQuery(MetricsQueryValidationRunner):
     def _validate_field(field: MetricField) -> None:
         derived_metrics_mri = get_derived_metrics(exclude_private=True)
 
+        # Validate the validity of the expression meaning that if an operation is present, then it needs to be one of
+        # of the supported operations and that the metric mri should be one of the aggregated derived metrics
         if field.op:
             if field.op not in OPERATIONS:
                 raise InvalidParams(

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_release_health.py
@@ -7,6 +7,7 @@ import pytest
 from django.utils.datastructures import MultiValueDict
 from snuba_sdk import Granularity, Limit, Offset
 
+from sentry.api.utils import InvalidParams
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.snuba.metrics import MetricField, MetricsQuery
 from sentry.snuba.metrics.datasource import get_series
@@ -244,3 +245,41 @@ class ReleaseHealthMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 "totals": {"histogram_duration": hist},
             }
         ]
+
+    def test_query_private_metrics_raise_exception(self):
+        self.store_metric(
+            org_id=self.organization.id,
+            project_id=self.project.id,
+            type="counter",
+            name=str(SessionMRI.SESSION.value),
+            tags={"session.status": "errored_preaggr"},
+            timestamp=time.time(),
+            value=2,
+            use_case_id=UseCaseKey.RELEASE_HEALTH,
+        )
+        start, end, rollup = get_date_range(
+            {
+                "statsPeriod": "1h",
+                "interval": "1h",
+            }
+        )
+        with pytest.raises(
+            InvalidParams,
+            match="Unable to find a mri reverse mapping for 'e:sessions/error.preaggr@none'.",
+        ):
+            MetricsQuery(
+                org_id=self.organization.id,
+                project_ids=[self.project.id],
+                select=[
+                    MetricField(
+                        op=None,
+                        metric_mri=str(SessionMRI.ERRORED_PREAGGREGATED.value),
+                        alias="errored_preaggregated_sessions_alias",
+                    ),
+                ],
+                start=start,
+                end=end,
+                granularity=Granularity(granularity=rollup),
+                limit=Limit(limit=51),
+                offset=Offset(offset=0),
+            )


### PR DESCRIPTION
Fixes a bug that skips validation for public metric if an alias is provided
