### PR TITLE
fix(metrics): Move mri parsing validation to `MetricField`

### DIFF
--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -36,6 +36,11 @@ class MetricField:
     alias: Optional[str] = None
 
     def __post_init__(self) -> None:
+        # Validate that it is a valid MRI format
+        parsed_mri = parse_mri(self.metric_mri)
+        if parsed_mri is None:
+            raise InvalidParams(f"Invalid Metric MRI: {self.metric_mri}")
+
         # Validates that the MRI requested is an MRI the metrics layer exposes
         metric_name = get_public_name_from_mri(self.metric_mri)
         if not self.alias:
@@ -103,13 +108,11 @@ class MetricsQuery(MetricsQueryValidationRunner):
     def _use_case_id(metric_mri: str) -> UseCaseKey:
         """Find correct use_case_id based on metric_name"""
         parsed_mri = parse_mri(metric_mri)
-        if parsed_mri is not None:
-            if parsed_mri.namespace == "transactions":
-                return UseCaseKey.PERFORMANCE
-            elif parsed_mri.namespace == "sessions":
-                return UseCaseKey.RELEASE_HEALTH
-            raise ValueError("Can't find correct use_case_id based on metric MRI")
-        raise ValueError("Can't parse metric MRI")
+        if parsed_mri.namespace == "transactions":
+            return UseCaseKey.PERFORMANCE
+        elif parsed_mri.namespace == "sessions":
+            return UseCaseKey.RELEASE_HEALTH
+        raise ValueError("Can't find correct use_case_id based on metric MRI")
 
     @staticmethod
     def _validate_field(field: MetricField) -> None:

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -108,6 +108,8 @@ class MetricsQuery(MetricsQueryValidationRunner):
     def _use_case_id(metric_mri: str) -> UseCaseKey:
         """Find correct use_case_id based on metric_name"""
         parsed_mri = parse_mri(metric_mri)
+        assert parsed_mri is not None
+
         if parsed_mri.namespace == "transactions":
             return UseCaseKey.PERFORMANCE
         elif parsed_mri.namespace == "sessions":

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -478,3 +478,32 @@ def test_granularity_validation(stats_period, interval, error_message):
     # that is not present in the select
     with pytest.raises(InvalidParams, match=error_message):
         MetricsQuery(**metrics_query_dict)
+
+
+def test_validate_metric_field_mri():
+    with pytest.raises(InvalidParams, match="Invalid Metric MRI: transaction-metric-duration"):
+        MetricField(
+            op="avg",
+            metric_mri="transaction-metric-duration",
+        )
+
+
+@pytest.mark.parametrize(
+    "alias",
+    [
+        pytest.param(
+            None,
+            id="No alias provided",
+        ),
+        pytest.param(
+            "ahmed_alias",
+            id="alias is provided",
+        ),
+    ],
+)
+def test_validate_metric_field_mri_is_public(alias):
+    with pytest.raises(
+        InvalidParams,
+        match="Unable to find a mri reverse mapping for 'e:sessions/error.preaggr@none'.",
+    ):
+        MetricField(op=None, metric_mri="e:sessions/error.preaggr@none", alias=alias)


### PR DESCRIPTION
Invokes `parse_mri` function on metric mri when instantiating an instance of `MetricField` to ensure it is a valid MRI

