### PR TITLE
Elias/fix/mock api client warn mode

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -66,7 +66,8 @@ afterEach(() => {
         console.warn(err);
         continue;
       }
-      throw err;
+      // eslint-disable-next-line no-console
+      console.error(err);
     }
     Client.errors = {};
   }

--- a/static/app/actionCreators/group.spec.jsx
+++ b/static/app/actionCreators/group.spec.jsx
@@ -86,6 +86,7 @@ describe('group', () => {
     });
 
     it('should use itemIds as query if provided', function () {
+      MockApiClient.warnOnMissingMocks();
       bulkUpdate(api, {
         orgId: '1337',
         projectId: '1337',
@@ -102,6 +103,7 @@ describe('group', () => {
     });
 
     it('should use query as query if itemIds are absent', function () {
+      MockApiClient.warnOnMissingMocks();
       bulkUpdate(api, {
         orgId: '1337',
         projectId: '1337',
@@ -118,6 +120,7 @@ describe('group', () => {
     });
 
     it('should apply project option', function () {
+      MockApiClient.warnOnMissingMocks();
       bulkUpdate(api, {
         orgId: '1337',
         project: [99],
@@ -142,6 +145,7 @@ describe('group', () => {
     });
 
     it('should use itemIds as query if provided', function () {
+      MockApiClient.warnOnMissingMocks();
       mergeGroups(api, {
         orgId: '1337',
         projectId: '1337',
@@ -158,6 +162,7 @@ describe('group', () => {
     });
 
     it('should use query as query if itemIds are absent', function () {
+      MockApiClient.warnOnMissingMocks();
       mergeGroups(api, {
         orgId: '1337',
         projectId: '1337',

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.jsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.jsx
@@ -79,6 +79,7 @@ describe('StacktraceLink', function () {
       query: {file: frame.filename, commitId: 'master', platform},
       body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
     });
+    MockApiClient.warnOnMissingMocks();
     const wrapper = mountWithTheme(
       <StacktraceLink
         frame={frame}
@@ -104,6 +105,7 @@ describe('StacktraceLink', function () {
         attemptedUrl: 'https://something.io/blah',
       },
     });
+    MockApiClient.warnOnMissingMocks();
     const wrapper = mountWithTheme(
       <StacktraceLink
         frame={frame}
@@ -131,6 +133,7 @@ describe('StacktraceLink', function () {
         integrations: [integration],
       },
     });
+    MockApiClient.warnOnMissingMocks();
     const wrapper = mountWithTheme(
       <StacktraceLink
         frame={frame}
@@ -156,6 +159,7 @@ describe('StacktraceLink', function () {
         integrations: [integration],
       },
     });
+    MockApiClient.warnOnMissingMocks();
     const wrapper = mountWithTheme(
       <StacktraceLink
         frame={frame}

--- a/static/app/components/events/interfaces/threadsV2.spec.tsx
+++ b/static/app/components/events/interfaces/threadsV2.spec.tsx
@@ -1079,6 +1079,7 @@ describe('ThreadsV2', function () {
         ).toBeInTheDocument();
 
         // Click on raw stack trace option
+        MockApiClient.warnOnMissingMocks();
         userEvent.click(screen.getByText(displayOptions['raw-stack-trace']));
 
         // Download button is displayed

--- a/static/app/components/forms/teamSelector.spec.jsx
+++ b/static/app/components/forms/teamSelector.spec.jsx
@@ -125,6 +125,7 @@ describe('Team Selector', function () {
     createWrapper({useId: true, onChange: onChangeMock});
     userEvent.type(screen.getByText('Select...'), '{keyDown}');
 
+    MockApiClient.warnOnMissingMocks();
     userEvent.type(screen.getByLabelText('Select a team'), 'team2');
 
     expect(screen.getByText('#team2')).toBeInTheDocument();

--- a/static/app/components/globalSdkUpdateAlert.spec.tsx
+++ b/static/app/components/globalSdkUpdateAlert.spec.tsx
@@ -234,6 +234,7 @@ describe('GlobalSDKUpdateAlert', () => {
       organization: TestStubs.Organization(),
     });
 
+    MockApiClient.warnOnMissingMocks();
     userEvent.click(await screen.findByText(/Remind me later/));
 
     expect(promptsActivityMock).toHaveBeenCalledWith(

--- a/static/app/components/modals/diffModal.spec.jsx
+++ b/static/app/components/modals/diffModal.spec.jsx
@@ -6,6 +6,7 @@ describe('DiffModal', function () {
   it('renders', function () {
     const project = TestStubs.ProjectDetails();
 
+    MockApiClient.warnOnMissingMocks();
     render(
       <DiffModal
         orgId="123"

--- a/static/app/components/modals/emailVerificationModal.spec.tsx
+++ b/static/app/components/modals/emailVerificationModal.spec.tsx
@@ -4,6 +4,7 @@ import EmailVerificationModal from 'sentry/components/modals/emailVerificationMo
 
 describe('Email Verification Modal', function () {
   it('renders', function () {
+    MockApiClient.warnOnMissingMocks();
     render(
       <EmailVerificationModal
         Body={(p => p.children) as any}
@@ -23,6 +24,7 @@ describe('Email Verification Modal', function () {
 
   it('renders with action param', function () {
     const actionMessage = 'accepting the tenet';
+    MockApiClient.warnOnMissingMocks();
     render(
       <EmailVerificationModal
         Body={(p => p.children) as any}

--- a/static/app/components/quickTrace/quickTrace.spec.tsx
+++ b/static/app/components/quickTrace/quickTrace.spec.tsx
@@ -127,6 +127,7 @@ describe('Quick Trace', function () {
     });
 
     it('renders partial trace with no children', function () {
+      MockApiClient.warnOnMissingMocks();
       const quickTrace = mountWithTheme(
         <QuickTrace
           event={makeTransactionEvent(4) as Event}
@@ -169,6 +170,7 @@ describe('Quick Trace', function () {
     });
 
     it('renders partial trace with multiple children', function () {
+      MockApiClient.warnOnMissingMocks();
       const quickTrace = mountWithTheme(
         <QuickTrace
           event={makeTransactionEvent(4) as Event}
@@ -242,6 +244,7 @@ describe('Quick Trace', function () {
     });
 
     it('renders full trace with multiple ancestors', function () {
+      MockApiClient.warnOnMissingMocks();
       const quickTrace = mountWithTheme(
         <QuickTrace
           event={makeTransactionEvent(5) as Event}
@@ -297,6 +300,7 @@ describe('Quick Trace', function () {
     });
 
     it('renders full trace with multiple descendants', function () {
+      MockApiClient.warnOnMissingMocks();
       const quickTrace = mountWithTheme(
         <QuickTrace
           event={makeTransactionEvent(0) as Event}
@@ -325,6 +329,7 @@ describe('Quick Trace', function () {
     });
 
     it('renders full trace', function () {
+      MockApiClient.warnOnMissingMocks();
       const quickTrace = mountWithTheme(
         <QuickTrace
           event={makeTransactionEvent(5) as Event}
@@ -394,6 +399,7 @@ describe('Quick Trace', function () {
     });
 
     it('renders multiple event targets', function () {
+      MockApiClient.warnOnMissingMocks();
       const quickTrace = mountWithTheme(
         <QuickTrace
           event={makeTransactionEvent(0) as Event}

--- a/static/app/views/admin/adminBuffer.spec.jsx
+++ b/static/app/views/admin/adminBuffer.spec.jsx
@@ -7,6 +7,7 @@ import AdminBuffer from 'sentry/views/admin/adminBuffer';
 describe('AdminBuffer', function () {
   describe('render()', function () {
     it('renders', function () {
+      MockApiClient.warnOnMissingMocks();
       const wrapper = render(<AdminBuffer params={{}} />);
 
       expect(screen.getAllByTestId('loading-indicator')).toHaveLength(2);

--- a/static/app/views/admin/adminQueue.spec.jsx
+++ b/static/app/views/admin/adminQueue.spec.jsx
@@ -49,6 +49,7 @@ describe('AdminQueue', function () {
     });
 
     it('renders', function () {
+      MockApiClient.warnOnMissingMocks();
       const wrapper = render(<AdminQueue params={{}} />);
       expect(wrapper.container).toSnapshot();
     });

--- a/static/app/views/admin/adminQuotas.spec.jsx
+++ b/static/app/views/admin/adminQuotas.spec.jsx
@@ -20,6 +20,7 @@ describe('AdminQuotas', function () {
     });
 
     it('renders', function () {
+      MockApiClient.warnOnMissingMocks();
       const wrapper = render(<AdminQuotas params={{}} />);
       expect(wrapper.container).toSnapshot();
     });

--- a/static/app/views/alerts/rules/metric/create.spec.jsx
+++ b/static/app/views/alerts/rules/metric/create.spec.jsx
@@ -39,6 +39,7 @@ describe('Incident Rules Create', function () {
 
   it('renders', function () {
     const {organization, project} = initializeOrg();
+    MockApiClient.warnOnMissingMocks();
     render(
       <MetricRulesCreate
         params={{orgId: organization.slug, projectId: project.slug}}

--- a/static/app/views/dashboardsV2/view.spec.tsx
+++ b/static/app/views/dashboardsV2/view.spec.tsx
@@ -28,6 +28,7 @@ describe('Dashboards > ViewEditDashboard', function () {
         statsPeriod: '7d',
       },
     };
+    MockApiClient.warnOnMissingMocks();
     render(
       <ViewEditDashboard
         location={TestStubs.location(location)}

--- a/static/app/views/eventsV2/resultsChart.spec.tsx
+++ b/static/app/views/eventsV2/resultsChart.spec.tsx
@@ -106,6 +106,7 @@ describe('EventsV2 > ResultsChart', function () {
       {field: 'count_unique(user)'},
       {field: 'equation|count() + 2'},
     ];
+    MockApiClient.warnOnMissingMocks();
     const wrapper = mountWithTheme(
       <ResultsChart
         router={TestStubs.router()}

--- a/static/app/views/issueList/actions.spec.jsx
+++ b/static/app/views/issueList/actions.spec.jsx
@@ -261,7 +261,7 @@ describe('IssueListActions', function () {
           },
         });
       });
-
+      MockApiClient.warnOnMissingMocks();
       render(<WrappedComponent onMarkReviewed={mockOnMarkReviewed} />);
 
       const reviewButton = screen.getByRole('button', {name: 'Mark Reviewed'});
@@ -276,6 +276,7 @@ describe('IssueListActions', function () {
       SelectedGroupStore.toggleSelectAll();
       GroupStore.loadInitialData([TestStubs.Group({id: '1', inbox: null})]);
 
+      MockApiClient.warnOnMissingMocks();
       render(<WrappedComponent {...defaultProps} />);
 
       expect(screen.getByRole('button', {name: 'Mark Reviewed'})).toBeDisabled();
@@ -313,6 +314,7 @@ describe('IssueListActions', function () {
         }
       });
 
+      MockApiClient.warnOnMissingMocks();
       render(<WrappedComponent />);
 
       // Resolve and ignore are supported
@@ -400,6 +402,7 @@ describe('IssueListActions', function () {
           </OrganizationContext.Provider>
         );
 
+        MockApiClient.warnOnMissingMocks();
         userEvent.click(screen.getByRole('checkbox'));
 
         userEvent.click(screen.getByTestId('issue-list-select-all-notice-link'));

--- a/static/app/views/organizationStats/teamInsights/health.spec.jsx
+++ b/static/app/views/organizationStats/teamInsights/health.spec.jsx
@@ -165,7 +165,7 @@ describe('TeamStatsHealth', () => {
     });
     const context = TestStubs.routerContext([{organization}]);
     TeamStore.loadInitialData(teams, false, null);
-
+    MockApiClient.warnOnMissingMocks();
     return render(<TeamStatsHealth router={mockRouter} location={{}} />, {
       context,
       organization,

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.spec.jsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.spec.jsx
@@ -10,6 +10,7 @@ describe('TeamAlertsTriggered', () => {
       url: `/teams/${organization.slug}/${team.slug}/alerts-triggered/`,
       body: TestStubs.TeamAlertsTriggered(),
     });
+    MockApiClient.warnOnMissingMocks();
     render(
       <TeamAlertsTriggered organization={organization} teamSlug={team.slug} period="8w" />
     );

--- a/static/app/views/performance/transactionDetails/index.spec.jsx
+++ b/static/app/views/performance/transactionDetails/index.spec.jsx
@@ -29,6 +29,7 @@ describe('EventDetails', () => {
       },
     });
 
+    MockApiClient.warnOnMissingMocks();
     render(
       <OrganizationContext.Provider value={organization}>
         <EventDetails
@@ -59,6 +60,7 @@ describe('EventDetails', () => {
       },
     });
 
+    MockApiClient.warnOnMissingMocks();
     render(
       <OrganizationContext.Provider value={organization}>
         <EventDetails

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -512,6 +512,7 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
+    MockApiClient.warnOnMissingMocks();
     render(<TestComponent router={newRouter} />, {
       context: routerContext,
       organization: org,
@@ -531,6 +532,7 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
+    MockApiClient.warnOnMissingMocks();
     render(<TestComponent router={newRouter} />, {
       context: routerContext,
       organization: org,

--- a/static/app/views/projectDetail/projectIssues.spec.jsx
+++ b/static/app/views/projectDetail/projectIssues.spec.jsx
@@ -46,6 +46,7 @@ describe('ProjectDetail > ProjectIssues', function () {
   });
 
   it('renders a link to Issues', function () {
+    MockApiClient.warnOnMissingMocks();
     render(<ProjectIssues organization={organization} location={router.location} />, {
       context: routerContext,
     });
@@ -66,6 +67,7 @@ describe('ProjectDetail > ProjectIssues', function () {
   });
 
   it('renders a link to Discover', function () {
+    MockApiClient.warnOnMissingMocks();
     render(<ProjectIssues organization={organization} location={router.location} />, {
       context: routerContext,
     });

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -136,6 +136,7 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
   });
 
   it('does not show expanders if there is no health data', () => {
+    MockApiClient.warnOnMissingMocks();
     render(
       <ReleaseComparisonChart
         release={release}

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -38,6 +38,7 @@ const createWrapper = (
   const {routerContext} = initializeOrg();
   const org = TestStubs.Organization();
   addMockResponses(notificationSettings, identities, organizationIntegrations);
+  MockApiClient.warnOnMissingMocks();
   return mountWithTheme(
     <NotificationSettingsByType notificationType="alerts" organizations={[org]} />,
     routerContext


### PR DESCRIPTION
This is a follow up PR to this: https://github.com/getsentry/sentry/pull/38769

tldr; mock client errors were being gobbled up by a `setTimeout` and in certain scenarios where we had alot of tests we would associate mock client errors with the wrong test. this PR enforces that we error if we are missing a mock response. for existing tests which are missing mocks we've exposed a `warnOnMissingMocks` mode. this method is marked as `@deprecated` and should show up with a strikethrough/message w/ intellisense 
![image](https://user-images.githubusercontent.com/7349258/192304820-eb649a4f-9e1d-484f-aa4f-d932f60d08e3.png)


