### PR TITLE
feat(replays): Replay error crumbs should open Console, not Issues tab

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -114,8 +114,6 @@ function Event({
           setActiveTab('dom');
           break;
         case 'error':
-          setActiveTab('issues');
-          break;
         default:
           setActiveTab('console');
           break;

--- a/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/breadcrumbItem.tsx
@@ -47,6 +47,7 @@ function BreadcrumbItem({
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
       onClick?.(crumb, e);
+
       switch (crumb.type) {
         case 'navigation':
         case 'debug':
@@ -56,8 +57,6 @@ function BreadcrumbItem({
           setActiveTab('dom');
           break;
         case 'error':
-          setActiveTab('issues');
-          break;
         default:
           setActiveTab('console');
           break;


### PR DESCRIPTION
Clicking on Errors that are in the Breadcrumbs list, or Timeline should open up the Console tab, no longer the Issues tab.