### PR TITLE
fix(tests): Use `RedisSnubaTSDB` by default in all tests

### DIFF
--- a/docker/sentry.conf.py
+++ b/docker/sentry.conf.py
@@ -185,7 +185,7 @@ SENTRY_QUOTAS = "sentry.quotas.redis.RedisQuota"
 # The TSDB is used for building charts as well as making things like per-rate
 # alerts possible.
 
-SENTRY_TSDB = "sentry.tsdb.redis.RedisTSDB"
+SENTRY_TSDB = "sentry.tsdb.redis.RedisSnubaTSDB"
 
 ###########
 # Digests #

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -172,7 +172,12 @@ def clean_series(start: datetime, stop: datetime, rollup: int, series: Iterable[
 
     result = []
     for i, (timestamp, value) in enumerate(series):
-        assert timestamp == start_timestamp + rollup * i
+        assert timestamp == start_timestamp + rollup * i, (
+            timestamp,
+            start_timestamp + rollup * i,
+            to_datetime(timestamp),
+            to_datetime(start_timestamp + rollup * i),
+        )
         if timestamp >= stop_timestamp:
             break
 

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -172,12 +172,7 @@ def clean_series(start: datetime, stop: datetime, rollup: int, series: Iterable[
 
     result = []
     for i, (timestamp, value) in enumerate(series):
-        assert timestamp == start_timestamp + rollup * i, (
-            timestamp,
-            start_timestamp + rollup * i,
-            to_datetime(timestamp),
-            to_datetime(start_timestamp + rollup * i),
-        )
+        assert timestamp == start_timestamp + rollup * i
         if timestamp >= stop_timestamp:
             break
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -261,11 +261,9 @@ def register_extensions():
 
 
 def pytest_runtest_teardown(item):
-    if not os.environ.get("USE_SNUBA", False):
-        from sentry import tsdb
-
-        # TODO(dcramer): this only works if this is the correct tsdb backend
-        tsdb.flush()
+    # if not os.environ.get("USE_SNUBA", False):
+    #     TODO(dcramer): this only works if this is the correct tsdb backend
+    # tsdb.flush()
 
     # XXX(dcramer): only works with DummyNewsletter
     from sentry import newsletter

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -261,10 +261,6 @@ def register_extensions():
 
 
 def pytest_runtest_teardown(item):
-    # if not os.environ.get("USE_SNUBA", False):
-    #     TODO(dcramer): this only works if this is the correct tsdb backend
-    # tsdb.flush()
-
     # XXX(dcramer): only works with DummyNewsletter
     from sentry import newsletter
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -105,7 +105,7 @@ def pytest_configure(config):
 
     settings.SENTRY_ALLOW_ORIGIN = "*"
 
-    settings.SENTRY_TSDB = "sentry.tsdb.inmemory.InMemoryTSDB"
+    settings.SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"
     settings.SENTRY_TSDB_OPTIONS = {}
 
     settings.SENTRY_NEWSLETTER = "sentry.newsletter.dummy.DummyNewsletter"
@@ -134,11 +134,6 @@ def pytest_configure(config):
 
     settings.SENTRY_RATELIMITER = "sentry.ratelimits.redis.RedisRateLimiter"
     settings.SENTRY_RATELIMITER_OPTIONS = {}
-
-    if os.environ.get("USE_SNUBA", False):
-        settings.SENTRY_SEARCH = "sentry.search.snuba.EventsDatasetSnubaSearchBackend"
-        settings.SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"
-        settings.SENTRY_EVENTSTREAM = "sentry.eventstream.snuba.SnubaEventStream"
 
     if not hasattr(settings, "SENTRY_OPTIONS"):
         settings.SENTRY_OPTIONS = {}

--- a/tests/sentry/api/endpoints/test_group_stats.py
+++ b/tests/sentry/api/endpoints/test_group_stats.py
@@ -1,5 +1,5 @@
-from sentry import tsdb
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 
 
@@ -7,23 +7,27 @@ from sentry.testutils.silo import region_silo_test
 class GroupStatsTest(APITestCase):
     def test_simple(self):
         self.login_as(user=self.user)
-
-        group1 = self.create_group()
-        group2 = self.create_group()
+        group1 = self.store_event(
+            data={
+                "fingerprint": ["group1"],
+                "timestamp": iso_format(before_now(minutes=5)),
+            },
+            project_id=self.project.id,
+        ).group
 
         url = f"/api/0/issues/{group1.id}/stats/"
+
+        for fingerprint, count in (("group1", 2), ("group2", 5)):
+            for _ in range(count):
+                self.store_event(
+                    data={
+                        "fingerprint": [fingerprint],
+                        "timestamp": iso_format(before_now(minutes=5)),
+                    },
+                    project_id=self.project.id,
+                )
+
         response = self.client.get(url, format="json")
-
-        assert response.status_code == 200, response.content
-        for point in response.data:
-            assert point[1] == 0
-        assert len(response.data) == 24
-
-        tsdb.incr(tsdb.models.group, group1.id, count=3)
-        tsdb.incr(tsdb.models.group, group2.id, count=5)
-
-        response = self.client.get(url, format="json")
-
         assert response.status_code == 200, response.content
         assert response.data[-1][1] == 3, response.data
         for point in response.data[:-1]:

--- a/tests/sentry/api/endpoints/test_organization_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_stats.py
@@ -3,19 +3,35 @@ import sys
 
 from django.urls import reverse
 
-from sentry import tsdb
+from sentry.constants import DataCategory
 from sentry.testutils import APITestCase
+from sentry.testutils.cases import OutcomesSnubaTest
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.outcomes import Outcome
 
 
 @region_silo_test
-class OrganizationStatsTest(APITestCase):
+class OrganizationStatsTest(APITestCase, OutcomesSnubaTest):
     def test_simple(self):
         self.login_as(user=self.user)
 
         org = self.create_organization(owner=self.user)
-
-        tsdb.incr(tsdb.models.organization_total_received, org.id, count=3)
+        project = self.create_project(organization=org)
+        project_key = self.create_project_key(project=project)
+        self.store_outcomes(
+            {
+                "org_id": org.id,
+                "timestamp": before_now(minutes=1),
+                "project_id": project.id,
+                "key_id": project_key.id,
+                "outcome": Outcome.ACCEPTED,
+                "reason": "none",
+                "category": DataCategory.ERROR,
+                "quantity": 1,
+            },
+            3,
+        )
 
         url = reverse("sentry-api-0-organization-stats", args=[org.slug])
         response = self.client.get(url)
@@ -30,8 +46,21 @@ class OrganizationStatsTest(APITestCase):
         self.login_as(user=self.user)
 
         org = self.create_organization(owner=self.user)
-
-        tsdb.incr(tsdb.models.organization_total_received, org.id, count=3)
+        project = self.create_project(organization=org)
+        project_key = self.create_project_key(project=project)
+        self.store_outcomes(
+            {
+                "org_id": org.id,
+                "timestamp": before_now(hours=1),
+                "project_id": project.id,
+                "key_id": project_key.id,
+                "outcome": Outcome.ACCEPTED,
+                "reason": "none",
+                "category": DataCategory.ERROR,
+                "quantity": 1,
+            },
+            3,
+        )
 
         url = reverse("sentry-api-0-organization-stats", args=[org.slug])
         response = self.client.get(f"{url}?resolution=1d")

--- a/tests/sentry/api/endpoints/test_project_group_stats.py
+++ b/tests/sentry/api/endpoints/test_project_group_stats.py
@@ -1,5 +1,5 @@
-from sentry import tsdb
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 
 
@@ -8,14 +8,32 @@ class ProjectGroupStatsTest(APITestCase):
     def test_simple(self):
         self.login_as(user=self.user)
 
-        project = self.create_project()
-        group1 = self.create_group(project=project)
-        group2 = self.create_group(project=project)
+        group1 = self.store_event(
+            data={
+                "fingerprint": ["group1"],
+                "timestamp": iso_format(before_now(minutes=5)),
+            },
+            project_id=self.project.id,
+        ).group
+        group2 = self.store_event(
+            data={
+                "fingerprint": ["group2"],
+                "timestamp": iso_format(before_now(minutes=5)),
+            },
+            project_id=self.project.id,
+        ).group
 
-        url = f"/api/0/projects/{project.organization.slug}/{project.slug}/issues/stats/"
-        response = self.client.get(f"{url}?id={group1.id}&id={group2.id}", format="json")
+        for fingerprint, count in (("group1", 2), ("group2", 4)):
+            for _ in range(count):
+                self.store_event(
+                    data={
+                        "fingerprint": [fingerprint],
+                        "timestamp": iso_format(before_now(minutes=5)),
+                    },
+                    project_id=self.project.id,
+                )
 
-        tsdb.incr(tsdb.models.group, group1.id, count=3)
+        url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/issues/stats/"
 
         response = self.client.get(f"{url}?id={group1.id}&id={group2.id}", format="json")
 

--- a/tests/sentry/api/endpoints/test_project_stats.py
+++ b/tests/sentry/api/endpoints/test_project_stats.py
@@ -1,20 +1,49 @@
 from django.urls import reverse
 
-from sentry import tsdb
+from sentry.constants import DataCategory
 from sentry.testutils import APITestCase
+from sentry.testutils.cases import OutcomesSnubaTest
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import region_silo_test
+from sentry.utils.outcomes import Outcome
 
 
 @region_silo_test
-class ProjectStatsTest(APITestCase):
+class ProjectStatsTest(APITestCase, OutcomesSnubaTest):
     def test_simple(self):
         self.login_as(user=self.user)
 
         project1 = self.create_project(name="foo")
         project2 = self.create_project(name="bar")
 
-        tsdb.incr(tsdb.models.project_total_received, project1.id, count=3)
-        tsdb.incr(tsdb.models.project_total_received, project2.id, count=5)
+        project_key1 = self.create_project_key(project=project1)
+        self.store_outcomes(
+            {
+                "org_id": project1.organization.id,
+                "timestamp": before_now(minutes=1),
+                "project_id": project1.id,
+                "key_id": project_key1.id,
+                "outcome": Outcome.ACCEPTED,
+                "reason": "none",
+                "category": DataCategory.ERROR,
+                "quantity": 3,
+            },
+            1,
+        )
+        project_key2 = self.create_project_key(project=project2)
+        self.store_outcomes(
+            {
+                "org_id": project2.organization.id,
+                "timestamp": before_now(minutes=1),
+                "project_id": project2.id,
+                "key_id": project_key2.id,
+                "outcome": Outcome.ACCEPTED,
+                "reason": "none",
+                "category": DataCategory.ERROR,
+                "quantity": 5,
+            },
+            1,
+        )
 
         url = reverse(
             "sentry-api-0-project-stats",
@@ -31,7 +60,7 @@ class ProjectStatsTest(APITestCase):
     def test_get_error_message_stats(self):
         self.login_as(user=self.user)
 
-        project1 = self.create_project(name="foo")
+        project = self.create_project(name="foo")
 
         STAT_OPTS = {
             "ip-address": 1,
@@ -43,52 +72,28 @@ class ProjectStatsTest(APITestCase):
             "web-crawlers": 7,
             "invalid-csp": 8,
         }
-
-        tsdb.incr(
-            tsdb.models.project_total_received_ip_address,
-            project1.id,
-            count=STAT_OPTS["ip-address"],
-        )
-        tsdb.incr(
-            tsdb.models.project_total_received_release_version,
-            project1.id,
-            count=STAT_OPTS["release-version"],
-        )
-        tsdb.incr(
-            tsdb.models.project_total_received_error_message,
-            project1.id,
-            count=STAT_OPTS["error-message"],
-        )
-        tsdb.incr(
-            tsdb.models.project_total_received_browser_extensions,
-            project1.id,
-            count=STAT_OPTS["browser-extensions"],
-        )
-        tsdb.incr(
-            tsdb.models.project_total_received_legacy_browsers,
-            project1.id,
-            count=STAT_OPTS["legacy-browsers"],
-        )
-        tsdb.incr(
-            tsdb.models.project_total_received_localhost, project1.id, count=STAT_OPTS["localhost"]
-        )
-        tsdb.incr(
-            tsdb.models.project_total_received_web_crawlers,
-            project1.id,
-            count=STAT_OPTS["web-crawlers"],
-        )
-        tsdb.incr(
-            tsdb.models.project_total_received_invalid_csp,
-            project1.id,
-            count=STAT_OPTS["invalid-csp"],
-        )
+        project_key = self.create_project_key(project=project)
+        for reason, count in STAT_OPTS.items():
+            self.store_outcomes(
+                {
+                    "org_id": project.organization.id,
+                    "timestamp": before_now(minutes=1),
+                    "project_id": project.id,
+                    "key_id": project_key.id,
+                    "outcome": Outcome.FILTERED,
+                    "reason": reason,
+                    "category": DataCategory.ERROR,
+                    "quantity": count,
+                },
+                1,
+            )
 
         url = reverse(
             "sentry-api-0-project-stats",
-            kwargs={"organization_slug": project1.organization.slug, "project_slug": project1.slug},
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
         )
         for stat in STAT_OPTS.keys():
             response = self.client.get(url, {"stat": stat}, format="json")
             assert response.status_code == 200, response.content
             assert len(response.data) == 24
-            assert response.data[-1][1] == STAT_OPTS[stat], response.data
+            assert response.data[-1][1] == STAT_OPTS[stat], (stat, response.data)

--- a/tests/sentry/api/endpoints/test_project_user_stats.py
+++ b/tests/sentry/api/endpoints/test_project_user_stats.py
@@ -28,21 +28,21 @@ class ProjectUserDetailsTest(APITestCase):
                 "tags": {"sentry:user": "user_1"},
             },
             project_id=self.project.id,
-        ).group
+        )
         self.store_event(
             data={
                 "timestamp": iso_format(before_now(minutes=5)),
                 "tags": {"sentry:user": "user_1"},
             },
             project_id=self.project.id,
-        ).group
+        )
         self.store_event(
             data={
                 "timestamp": iso_format(before_now(minutes=5)),
                 "tags": {"sentry:user": "user_2"},
             },
             project_id=self.project.id,
-        ).group
+        )
 
         response = self.client.get(self.path)
 

--- a/tests/sentry/api/endpoints/test_project_user_stats.py
+++ b/tests/sentry/api/endpoints/test_project_user_stats.py
@@ -1,9 +1,7 @@
 from django.urls import reverse
-from django.utils import timezone
 
-from sentry import tsdb
-from sentry.models import EventUser
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 
 
@@ -24,15 +22,27 @@ class ProjectUserDetailsTest(APITestCase):
         )
 
     def test_simple(self):
-        euser1 = EventUser.objects.create(email="foo@example.com", project_id=self.project.id)
-        euser2 = EventUser.objects.create(email="bar@example.com", project_id=self.project.id)
-        tsdb.record_multi(
-            (
-                (tsdb.models.users_affected_by_project, self.project.id, (euser2.tag_value,)),
-                (tsdb.models.users_affected_by_project, self.project.id, (euser1.tag_value,)),
-            ),
-            timestamp=timezone.now(),
-        )
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=5)),
+                "tags": {"sentry:user": "user_1"},
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=5)),
+                "tags": {"sentry:user": "user_1"},
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(minutes=5)),
+                "tags": {"sentry:user": "user_2"},
+            },
+            project_id=self.project.id,
+        ).group
 
         response = self.client.get(self.path)
 

--- a/tests/sentry/api/endpoints/test_team_stats.py
+++ b/tests/sentry/api/endpoints/test_team_stats.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 
-from sentry import tsdb
 from sentry.testutils import APITestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 
 
@@ -16,18 +16,22 @@ class TeamStatsTest(APITestCase):
         team_2 = self.create_team(members=[self.user])
         project_3 = self.create_project(teams=[team_2], name="c")
 
-        tsdb.incr(tsdb.models.project, project_1.id, count=3)
-        tsdb.incr(tsdb.models.project, project_2.id, count=5)
-        tsdb.incr(tsdb.models.project, project_3.id, count=10)
+        for project, count in ((project_1, 2), (project_2, 1), (project_3, 4)):
+            for _ in range(count):
+                self.store_event(
+                    data={
+                        "timestamp": iso_format(before_now(minutes=5)),
+                    },
+                    project_id=project.id,
+                )
 
         url = reverse(
             "sentry-api-0-team-stats",
             kwargs={"organization_slug": team.organization.slug, "team_slug": team.slug},
         )
         response = self.client.get(url)
-
         assert response.status_code == 200, response.content
-        assert response.data[-1][1] == 8, response.data
+        assert response.data[-1][1] == 3, response.data
         for point in response.data[:-1]:
             assert point[1] == 0
         assert len(response.data) == 24

--- a/tests/sentry/models/test_groupsnooze.py
+++ b/tests/sentry/models/test_groupsnooze.py
@@ -1,11 +1,10 @@
 import itertools
-from datetime import datetime, timedelta
-from unittest import mock
+from datetime import timedelta
 
 import pytest
 from django.utils import timezone
+from freezegun import freeze_time
 
-from sentry import tsdb
 from sentry.models import Group, GroupSnooze
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -77,56 +76,50 @@ class GroupSnoozeTest(TestCase, SnubaTestCase):
         snooze = GroupSnooze.objects.create(group=group, user_count=100, state={"users_seen": 0})
         assert not snooze.is_valid(test_rates=True)
 
-    @mock.patch("django.utils.timezone.now")
-    def test_user_rate_reached(self, mock_now):
-        mock_now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
+    @freeze_time()
+    def test_user_rate_reached(self):
+        for i in range(5):
+            group = self.store_event(
+                data={
+                    "fingerprint": ["group1"],
+                    "timestamp": iso_format(before_now(minutes=5 + i)),
+                    "tags": {"sentry:user": i},
+                },
+                project_id=self.project.id,
+            ).group
 
-        snooze = GroupSnooze.objects.create(group=self.group, user_count=100, user_window=60)
-        tsdb.record(
-            tsdb.models.users_affected_by_group,
-            self.group.id,
-            [next(self.sequence) for _ in range(0, 101)],
-        )
+        snooze = GroupSnooze.objects.create(group=group, user_count=5, user_window=60)
         assert not snooze.is_valid(test_rates=True)
 
-    @mock.patch("django.utils.timezone.now")
-    def test_user_rate_not_reached(self, mock_now):
-        mock_now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
-
+    @freeze_time()
+    def test_user_rate_not_reached(self):
         snooze = GroupSnooze.objects.create(group=self.group, user_count=100, user_window=60)
         assert snooze.is_valid(test_rates=True)
 
-    @mock.patch("django.utils.timezone.now")
-    def test_user_rate_without_test(self, mock_now):
-        mock_now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
-
+    @freeze_time()
+    def test_user_rate_without_test(self):
         snooze = GroupSnooze.objects.create(group=self.group, count=100, window=60)
         assert snooze.is_valid(test_rates=False)
 
-    @mock.patch("django.utils.timezone.now")
-    def test_rate_not_reached(self, mock_now):
-        mock_now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
-
+    @freeze_time()
+    def test_rate_not_reached(self):
         snooze = GroupSnooze.objects.create(group=self.group, count=100, window=60)
         assert snooze.is_valid(test_rates=True)
 
-    @mock.patch("django.utils.timezone.now")
-    def test_rate_reached(self, mock_now):
-        mock_now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
-
-        snooze = GroupSnooze.objects.create(group=self.group, count=100, window=24 * 60)
-        for n in range(6):
-            tsdb.incr(
-                tsdb.models.group,
-                self.group.id,
-                count=20,
-                timestamp=mock_now() - timedelta(minutes=n),
-            )
+    @freeze_time()
+    def test_rate_reached(self):
+        for i in range(5):
+            group = self.store_event(
+                data={
+                    "fingerprint": ["group1"],
+                    "timestamp": iso_format(before_now(minutes=5 + i)),
+                },
+                project_id=self.project.id,
+            ).group
+        snooze = GroupSnooze.objects.create(group=group, count=5, window=24 * 60)
         assert not snooze.is_valid(test_rates=True)
 
-    @mock.patch("django.utils.timezone.now")
-    def test_rate_without_test(self, mock_now):
-        mock_now.return_value = datetime(2016, 8, 1, 0, 0, 0, 0, tzinfo=timezone.utc)
-
+    @freeze_time()
+    def test_rate_without_test(self):
         snooze = GroupSnooze.objects.create(group=self.group, count=100, window=60)
         assert snooze.is_valid(test_rates=False)


### PR DESCRIPTION
`RedisSnubaTSDB` has been the default in productions. To make our tests reflect production we should use 
it there as well.

Removed most uses of `tsdb.incr` from the tests. The only ones left are places that are actually still using
`tsdb.incr`.

