### PR TITLE
feat(replays): Show the absolute timestamp when hovering Replay Network table

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import DateTime from 'sentry/components/dateTime';
 import FileSize from 'sentry/components/fileSize';
 import CompactSelect from 'sentry/components/forms/compactSelect';
 import {PanelTable, PanelTableHeader} from 'sentry/components/panels';
@@ -216,9 +217,11 @@ function NetworkList({replayRecord, networkSpans}: Props) {
           {`${(networkEndTimestamp - networkStartTimestamp).toFixed(2)}ms`}
         </Item>
         <Item {...columnHandlers} {...columnProps} numeric>
-          <UnstyledButton onClick={() => handleClick(networkStartTimestamp)}>
-            {showPlayerTime(networkStartTimestamp, startTimestampMs, true)}
-          </UnstyledButton>
+          <Tooltip title={<DateTime date={networkStartTimestamp} seconds />}>
+            <UnstyledButton onClick={() => handleClick(networkStartTimestamp)}>
+              {showPlayerTime(networkStartTimestamp, startTimestampMs, true)}
+            </UnstyledButton>
+          </Tooltip>
         </Item>
       </Fragment>
     );


### PR DESCRIPTION
Uses the same components that are employed in the Replay Breadcrumbs, Console, Dom Tab, etc. 

Absolute date in Network table:
<img width="231" alt="Screen Shot 2022-09-26 at 11 38 46 AM" src="https://user-images.githubusercontent.com/187460/192355040-fd6c3f5f-3db9-4407-aa8d-f0f30ebf016b.png">

Absolute date in Console (not changed, for reference):
<img width="171" alt="Screen Shot 2022-09-26 at 11 38 52 AM" src="https://user-images.githubusercontent.com/187460/192355043-ea67637d-b72c-442b-9c86-7606e123c851.png">

