### PR TITLE
feat(perf-issues): Remove trunc check for n+1-db-ext detector

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1019,6 +1019,11 @@ class NPlusOneDBSpanDetectorExtended(NPlusOneDBSpanDetector):
         if root_span:
             self.potential_parents[root_span.get("span_id")] = root_span
 
+    def _contains_complete_query(self, span: Span) -> bool:
+        # Remove the truncation check from the n_plus_one db detector.
+        query = span.get("description", None)
+        return bool(query)
+
 
 # Reports metrics and creates spans for detection
 def report_metrics_for_detectors(


### PR DESCRIPTION
### Summary
Truncation is somewhat limiting, we can try removing it in this detector. We already have a metric for how often we encounter this, so we'll see.
