### PR TITLE
fix(discover): Flicker due to fallback to stale savedQuery

### DIFF
--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -63,6 +63,7 @@ type Props = {
   organization: Organization;
   router: InjectedRouter;
   selection: PageFilters;
+  setSavedQuery: (savedQuery: SavedQuery) => void;
   savedQuery?: SavedQuery;
 };
 
@@ -511,7 +512,7 @@ class Results extends Component<Props, State> {
   }
 
   render() {
-    const {organization, location, router, selection, api} = this.props;
+    const {organization, location, router, selection, api, setSavedQuery} = this.props;
     const {
       eventView,
       error,
@@ -533,6 +534,7 @@ class Results extends Component<Props, State> {
         <StyledPageContent>
           <NoProjectMessage organization={organization}>
             <ResultsHeader
+              setSavedQuery={setSavedQuery}
               errorCode={errorCode}
               organization={organization}
               location={location}
@@ -678,6 +680,10 @@ class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
     return [];
   }
 
+  setSavedQuery = (newSavedQuery: SavedQuery) => {
+    this.setState({savedQuery: newSavedQuery});
+  };
+
   renderLoading() {
     return this.renderBody();
   }
@@ -685,7 +691,12 @@ class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
   renderBody(): React.ReactNode {
     const {savedQuery, loading} = this.state;
     return (
-      <Results {...this.props} savedQuery={savedQuery ?? undefined} loading={loading} />
+      <Results
+        {...this.props}
+        savedQuery={savedQuery ?? undefined}
+        loading={loading}
+        setSavedQuery={this.setSavedQuery}
+      />
     );
   }
 }

--- a/static/app/views/eventsV2/resultsHeader.tsx
+++ b/static/app/views/eventsV2/resultsHeader.tsx
@@ -24,6 +24,7 @@ type Props = {
   location: Location;
   organization: Organization;
   router: InjectedRouter;
+  setSavedQuery: (savedQuery: SavedQuery) => void;
   yAxis: string[];
 };
 
@@ -85,7 +86,8 @@ class ResultsHeader extends Component<Props, State> {
   }
 
   render() {
-    const {organization, location, errorCode, eventView, yAxis, router} = this.props;
+    const {organization, location, errorCode, eventView, yAxis, router, setSavedQuery} =
+      this.props;
     const {savedQuery, loading} = this.state;
 
     return (
@@ -105,6 +107,7 @@ class ResultsHeader extends Component<Props, State> {
         </StyledHeaderContent>
         <Layout.HeaderActions>
           <SavedQueryButtonGroup
+            setSavedQuery={setSavedQuery}
             location={location}
             organization={organization}
             eventView={eventView}

--- a/static/app/views/eventsV2/savedQuery/index.spec.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.spec.tsx
@@ -37,6 +37,7 @@ function mount(
       yAxis={yAxis}
       router={router}
       savedQueryLoading={false}
+      setSavedQuery={jest.fn()}
     />
   );
 }
@@ -49,19 +50,24 @@ function generateWrappedComponent(
   yAxis,
   disabled = false
 ) {
-  return mountWithTheme(
-    <SavedQueryButtonGroup
-      location={location}
-      organization={organization}
-      eventView={eventView}
-      savedQuery={savedQuery}
-      disabled={disabled}
-      updateCallback={() => {}}
-      yAxis={yAxis}
-      router={router}
-      savedQueryLoading={false}
-    />
-  );
+  const mockSetSavedQuery = jest.fn();
+  return {
+    mockSetSavedQuery,
+    wrapper: mountWithTheme(
+      <SavedQueryButtonGroup
+        location={location}
+        organization={organization}
+        eventView={eventView}
+        savedQuery={savedQuery}
+        disabled={disabled}
+        updateCallback={() => {}}
+        yAxis={yAxis}
+        router={router}
+        savedQueryLoading={false}
+        setSavedQuery={mockSetSavedQuery}
+      />
+    ),
+  };
 }
 
 describe('EventsV2 > SaveQueryButtonGroup', function () {
@@ -114,7 +120,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
     });
 
     it('renders disabled buttons when disabled prop is used', () => {
-      const wrapper = generateWrappedComponent(
+      const {wrapper} = generateWrappedComponent(
         location,
         organization,
         router,
@@ -129,7 +135,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
     });
 
     it('renders the correct set of buttons', () => {
-      const wrapper = generateWrappedComponent(
+      const {wrapper} = generateWrappedComponent(
         location,
         organization,
         router,
@@ -222,7 +228,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
     });
 
     it('renders the correct set of buttons', () => {
-      const wrapper = generateWrappedComponent(
+      const {wrapper} = generateWrappedComponent(
         location,
         organization,
         router,
@@ -243,7 +249,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
     });
 
     it('treats undefined yAxis the same as count() when checking for changes', () => {
-      const wrapper = generateWrappedComponent(
+      const {wrapper} = generateWrappedComponent(
         location,
         organization,
         router,
@@ -264,7 +270,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
     });
 
     it('converts string yAxis values to array when checking for changes', () => {
-      const wrapper = generateWrappedComponent(
+      const {wrapper} = generateWrappedComponent(
         location,
         organization,
         router,
@@ -285,7 +291,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
     });
 
     it('deletes the saved query', async () => {
-      const wrapper = generateWrappedComponent(
+      const {wrapper} = generateWrappedComponent(
         location,
         organization,
         router,
@@ -309,7 +315,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
     let mockUtils;
 
     it('renders the correct set of buttons', () => {
-      const wrapper = generateWrappedComponent(
+      const {wrapper} = generateWrappedComponent(
         location,
         organization,
         router,
@@ -341,7 +347,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
       });
 
       it('accepts a well-formed query', async () => {
-        const wrapper = generateWrappedComponent(
+        const {mockSetSavedQuery, wrapper} = generateWrappedComponent(
           location,
           organization,
           router,
@@ -362,6 +368,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
           }),
           yAxis
         );
+        expect(mockSetSavedQuery).toHaveBeenCalled();
       });
     });
 
@@ -407,7 +414,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
         ...organization,
         features: ['incidents'],
       };
-      const wrapper = generateWrappedComponent(
+      const {wrapper} = generateWrappedComponent(
         location,
         metricAlertOrg,
         router,
@@ -420,7 +427,7 @@ describe('EventsV2 > SaveQueryButtonGroup', function () {
       expect(buttonCreateAlert.exists()).toBe(true);
     });
     it('does not render create alert button without metric alerts', () => {
-      const wrapper = generateWrappedComponent(
+      const {wrapper} = generateWrappedComponent(
         location,
         organization,
         router,

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -108,6 +108,7 @@ type Props = DefaultProps & {
   router: InjectedRouter;
   savedQuery: SavedQuery | undefined;
   savedQueryLoading: boolean;
+  setSavedQuery: (savedQuery: SavedQuery) => void;
   updateCallback: () => void;
   yAxis: string[];
 };
@@ -236,11 +237,13 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
     event.preventDefault();
     event.stopPropagation();
 
-    const {api, organization, eventView, updateCallback, yAxis} = this.props;
+    const {api, organization, eventView, updateCallback, yAxis, setSavedQuery} =
+      this.props;
 
     handleUpdateQuery(api, organization, eventView, yAxis).then(
       (savedQuery: SavedQuery) => {
         const view = EventView.fromSavedQuery(savedQuery);
+        setSavedQuery(savedQuery);
         this.setState({queryName: ''});
         browserHistory.push(view.getResultsViewShortUrlTarget(organization.slug));
         updateCallback();


### PR DESCRIPTION
When the user clicks "Save Changes", we redirect them to a short URL. At this point, savedQuery from the AsyncComponent becomes stale (because we've updated but haven't fetched the new query). The Results component then tries to use this stale query to build an eventView, but since we've redirected to a short URL the changes aren't there to override the values properly.

Instead, when the update happens successfully, save the response so we derive the proper eventView.