### PR TITLE
feat(replays): Auto-scroll the Console and Network tables in Replay Details

### DIFF
--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -1,3 +1,4 @@
+import {ForwardedRef, forwardRef} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
@@ -71,52 +72,58 @@ export type PanelTableProps = {
  *       with `headers`. Then we can get rid of that gross `> *` selector
  * - [ ] Allow customization of wrappers (Header and body cells if added)
  */
-const PanelTable = ({
-  headers,
-  children,
-  isLoading,
-  isEmpty,
-  disablePadding,
-  className,
-  emptyMessage = t('There are no items to display'),
-  emptyAction,
-  loader,
-  stickyHeaders = false,
-  ...props
-}: PanelTableProps) => {
-  const shouldShowLoading = isLoading === true;
-  const shouldShowEmptyMessage = !shouldShowLoading && isEmpty;
-  const shouldShowContent = !shouldShowLoading && !shouldShowEmptyMessage;
+const PanelTable = forwardRef(
+  (
+    {
+      headers,
+      children,
+      isLoading,
+      isEmpty,
+      disablePadding,
+      className,
+      emptyMessage = t('There are no items to display'),
+      emptyAction,
+      loader,
+      stickyHeaders = false,
+      ...props
+    }: PanelTableProps,
+    ref: ForwardedRef<HTMLDivElement>
+  ) => {
+    const shouldShowLoading = isLoading === true;
+    const shouldShowEmptyMessage = !shouldShowLoading && isEmpty;
+    const shouldShowContent = !shouldShowLoading && !shouldShowEmptyMessage;
 
-  return (
-    <Wrapper
-      columns={headers.length}
-      disablePadding={disablePadding}
-      className={className}
-      hasRows={shouldShowContent}
-      {...props}
-    >
-      {headers.map((header, i) => (
-        <PanelTableHeader key={i} sticky={stickyHeaders}>
-          {header}
-        </PanelTableHeader>
-      ))}
+    return (
+      <Wrapper
+        ref={ref}
+        columns={headers.length}
+        disablePadding={disablePadding}
+        className={className}
+        hasRows={shouldShowContent}
+        {...props}
+      >
+        {headers.map((header, i) => (
+          <PanelTableHeader key={i} sticky={stickyHeaders}>
+            {header}
+          </PanelTableHeader>
+        ))}
 
-      {shouldShowLoading && (
-        <LoadingWrapper>{loader || <LoadingIndicator />}</LoadingWrapper>
-      )}
+        {shouldShowLoading && (
+          <LoadingWrapper>{loader || <LoadingIndicator />}</LoadingWrapper>
+        )}
 
-      {shouldShowEmptyMessage && (
-        <TableEmptyStateWarning>
-          <p>{emptyMessage}</p>
-          {emptyAction}
-        </TableEmptyStateWarning>
-      )}
+        {shouldShowEmptyMessage && (
+          <TableEmptyStateWarning>
+            <p>{emptyMessage}</p>
+            {emptyAction}
+          </TableEmptyStateWarning>
+        )}
 
-      {shouldShowContent && getContent(children)}
-    </Wrapper>
-  );
-};
+        {shouldShowContent && getContent(children)}
+      </Wrapper>
+    );
+  }
+);
 
 function getContent(children: PanelTableProps['children']) {
   if (typeof children === 'function') {

--- a/static/app/utils/replays/hooks/useCurrentItemScroller.tsx
+++ b/static/app/utils/replays/hooks/useCurrentItemScroller.tsx
@@ -3,7 +3,7 @@ import {useEffect, useState} from 'react';
 
 const defer = (fn: () => void) => setTimeout(fn, 0);
 
-export function useCurrentItemScroller(containerRef: RefObject<HTMLElement>) {
+export default function useCurrentItemScroller(containerRef: RefObject<HTMLElement>) {
   const [isAutoScrollDisabled, setIsAutoScrollDisabled] = useState(false);
 
   useEffect(() => {

--- a/static/app/views/replays/detail/breadcrumbs/index.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/index.tsx
@@ -1,4 +1,4 @@
-import {useRef} from 'react';
+import {Fragment, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {
@@ -11,17 +11,17 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
 import useCrumbHandlers from 'sentry/utils/replays/hooks/useCrumbHandlers';
-import {useCurrentItemScroller} from 'sentry/utils/replays/hooks/useCurrentItemScroller';
+import useCurrentItemScroller from 'sentry/utils/replays/hooks/useCurrentItemScroller';
 import BreadcrumbItem from 'sentry/views/replays/detail/breadcrumbs/breadcrumbItem';
 import FluidPanel from 'sentry/views/replays/detail/layout/fluidPanel';
 
 function CrumbPlaceholder({number}: {number: number}) {
   return (
-    <BreadcrumbContainer>
+    <Fragment>
       {[...Array(number)].map((_, i) => (
         <PlaceholderMargin key={i} height="53px" />
       ))}
-    </BreadcrumbContainer>
+    </Fragment>
   );
 }
 
@@ -63,7 +63,7 @@ function Breadcrumbs({showTitle = true}: Props) {
       : undefined;
 
   const content = isLoaded ? (
-    <BreadcrumbContainer>
+    <Fragment>
       {crumbs.map(crumb => (
         <BreadcrumbItem
           key={crumb.id}
@@ -78,7 +78,7 @@ function Breadcrumbs({showTitle = true}: Props) {
           allowHover={false}
         />
       ))}
-    </BreadcrumbContainer>
+    </Fragment>
   ) : (
     <CrumbPlaceholder number={4} />
   );
@@ -89,7 +89,7 @@ function Breadcrumbs({showTitle = true}: Props) {
         bodyRef={crumbListContainerRef}
         title={showTitle ? <PanelHeader>{t('Breadcrumbs')}</PanelHeader> : undefined}
       >
-        {content}
+        <BreadcrumbContainer>{content}</BreadcrumbContainer>
       </FluidPanel>
     </Panel>
   );


### PR DESCRIPTION
Enables scroll-to-item inside the Console and Network tables inside the Replay Details page
Previously the only section that scrolled was the Breadcrumbs.

Test Plan:
1. Open a long-ish replay that has errors, something where there are enough console messages to scroll
2. Click (in the Timeline) on an error near the end of the replay

Notice that the breadcrumbs scrolls to show that Error
Notice that the console tab opens (since #39296) and scrolls to the error message

Right now this only works when the current timestamp is not the same as the timestamp of the thing you're clicking on. So if you click on an event and go to it... but then scroll around the table a little... well if you click that same event in the Timeline again, it won't scroll you to that spot :(

Repeat for Errors at the start of the replay
Repeat for Navigation events at the start/end of the replay (they will open the network tab and scroll)