### PR TITLE
ref(tabs): Remove unnecessary orientation attributes

### DIFF
--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -1,6 +1,7 @@
 import 'intersection-observer'; // polyfill
 
 import {createContext, useState} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {AriaTabListProps} from '@react-aria/tabs';
 import {Item} from '@react-stately/collections';
@@ -67,7 +68,10 @@ export function Tabs({orientation = 'horizontal', className, ...props}: TabsProp
   );
 }
 
-const TabsWrap = styled('div')<{orientation: Orientation}>`
+const TabsWrap = styled('div', {
+  shouldForwardProp: prop =>
+    typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation',
+})<{orientation: Orientation}>`
   display: flex;
   flex-direction: ${p => (p.orientation === 'horizontal' ? 'column' : 'row')};
 

--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -1,7 +1,6 @@
 import 'intersection-observer'; // polyfill
 
 import {createContext, useState} from 'react';
-import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {AriaTabListProps} from '@react-aria/tabs';
 import {Item} from '@react-stately/collections';
@@ -10,6 +9,7 @@ import {ItemProps, Orientation} from '@react-types/shared';
 
 import {TabList} from './tabList';
 import {TabPanels} from './tabPanels';
+import {tabsShouldForwardProp} from './utils';
 
 const _Item = Item as (
   props: ItemProps<any> & {disabled?: boolean; hidden?: boolean}
@@ -68,10 +68,9 @@ export function Tabs({orientation = 'horizontal', className, ...props}: TabsProp
   );
 }
 
-const TabsWrap = styled('div', {
-  shouldForwardProp: prop =>
-    typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation',
-})<{orientation: Orientation}>`
+const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
+  orientation: Orientation;
+}>`
   display: flex;
   flex-direction: ${p => (p.orientation === 'horizontal' ? 'column' : 'row')};
 

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -1,5 +1,4 @@
 import {forwardRef} from 'react';
-import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {useTab} from '@react-aria/tabs';
 import {mergeProps, useObjectRef} from '@react-aria/utils';
@@ -7,6 +6,8 @@ import {TabListState} from '@react-stately/tabs';
 import {Node, Orientation} from '@react-types/shared';
 
 import space from 'sentry/styles/space';
+
+import {tabsShouldForwardProp} from './utils';
 
 interface TabProps {
   item: Node<any>;
@@ -53,10 +54,7 @@ function BaseTab(
 
 export const Tab = forwardRef(BaseTab);
 
-const TabWrap = styled('li', {
-  shouldForwardProp: prop =>
-    typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation',
-})<{
+const TabWrap = styled('li', {shouldForwardProp: tabsShouldForwardProp})<{
   disabled: boolean;
   orientation: Orientation;
   overflowing: boolean;

--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -1,4 +1,5 @@
 import {forwardRef} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {useTab} from '@react-aria/tabs';
 import {mergeProps, useObjectRef} from '@react-aria/utils';
@@ -52,7 +53,10 @@ function BaseTab(
 
 export const Tab = forwardRef(BaseTab);
 
-const TabWrap = styled('li')<{
+const TabWrap = styled('li', {
+  shouldForwardProp: prop =>
+    typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation',
+})<{
   disabled: boolean;
   orientation: Orientation;
   overflowing: boolean;

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -1,4 +1,5 @@
 import {useContext, useEffect, useMemo, useRef, useState} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {AriaTabListProps, useTabList} from '@react-aria/tabs';
 import {Item, useCollection} from '@react-stately/collections';
@@ -200,7 +201,10 @@ const TabListOuterWrap = styled('div')`
   position: relative;
 `;
 
-const TabListWrap = styled('ul')<{orientation: Orientation}>`
+const TabListWrap = styled('ul', {
+  shouldForwardProp: prop =>
+    typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation',
+})<{orientation: Orientation}>`
   position: relative;
   display: grid;
   padding: 0;

--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -1,5 +1,4 @@
 import {useContext, useEffect, useMemo, useRef, useState} from 'react';
-import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {AriaTabListProps, useTabList} from '@react-aria/tabs';
 import {Item, useCollection} from '@react-stately/collections';
@@ -15,6 +14,7 @@ import space from 'sentry/styles/space';
 
 import {TabsContext} from './index';
 import {Tab} from './tab';
+import {tabsShouldForwardProp} from './utils';
 
 /**
  * Uses IntersectionObserver API to detect overflowing tabs. Returns an array
@@ -201,10 +201,9 @@ const TabListOuterWrap = styled('div')`
   position: relative;
 `;
 
-const TabListWrap = styled('ul', {
-  shouldForwardProp: prop =>
-    typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation',
-})<{orientation: Orientation}>`
+const TabListWrap = styled('ul', {shouldForwardProp: tabsShouldForwardProp})<{
+  orientation: Orientation;
+}>`
   position: relative;
   display: grid;
   padding: 0;

--- a/static/app/components/tabs/tabPanels.tsx
+++ b/static/app/components/tabs/tabPanels.tsx
@@ -1,4 +1,5 @@
 import {useContext, useRef} from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {AriaTabPanelProps, useTabPanel} from '@react-aria/tabs';
 import {useCollection} from '@react-stately/collections';
@@ -71,7 +72,10 @@ function TabPanel({state, orientation, className, children, ...props}: TabPanelP
   );
 }
 
-const TabPanelWrap = styled('div')<{orientation: Orientation}>`
+const TabPanelWrap = styled('div', {
+  shouldForwardProp: prop =>
+    typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation',
+})<{orientation: Orientation}>`
   border-radius: ${p => p.theme.borderRadius};
 
   ${p => (p.orientation === 'horizontal' ? `height: 100%;` : `width: 100%;`)};

--- a/static/app/components/tabs/tabPanels.tsx
+++ b/static/app/components/tabs/tabPanels.tsx
@@ -1,5 +1,4 @@
 import {useContext, useRef} from 'react';
-import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {AriaTabPanelProps, useTabPanel} from '@react-aria/tabs';
 import {useCollection} from '@react-stately/collections';
@@ -8,6 +7,7 @@ import {TabListState} from '@react-stately/tabs';
 import {CollectionBase, Node, Orientation} from '@react-types/shared';
 
 import {TabsContext} from './index';
+import {tabsShouldForwardProp} from './utils';
 
 const collectionFactory = (nodes: Iterable<Node<any>>) => new ListCollection(nodes);
 
@@ -72,10 +72,9 @@ function TabPanel({state, orientation, className, children, ...props}: TabPanelP
   );
 }
 
-const TabPanelWrap = styled('div', {
-  shouldForwardProp: prop =>
-    typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation',
-})<{orientation: Orientation}>`
+const TabPanelWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
+  orientation: Orientation;
+}>`
   border-radius: ${p => p.theme.borderRadius};
 
   ${p => (p.orientation === 'horizontal' ? `height: 100%;` : `width: 100%;`)};

--- a/static/app/components/tabs/utils.tsx
+++ b/static/app/components/tabs/utils.tsx
@@ -1,0 +1,4 @@
+import isPropValid from '@emotion/is-prop-valid';
+
+export const tabsShouldForwardProp = prop =>
+  typeof prop === 'string' && isPropValid(prop) && prop !== 'orientation';


### PR DESCRIPTION
`orientation` is a styling prop and should not appear as an attribute in the DOM. Only the tab list element needs an `aria-orientation` attribute.