### PR TITLE
refs(tests): Remove `USE_SNUBA` env variable from test configs.

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -176,7 +176,6 @@ jobs:
           make run-acceptance
         env:
           PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
-          USE_SNUBA: 1
 
       - name: Save snapshots
         uses: getsentry/action-visual-snapshot@e832d70549c14886ddc2ab809b436ba72e30e19b  # main

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -102,8 +102,6 @@ jobs:
 
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ steps.setup.outputs.matrix-instance-total }})
         run: |
-          # Note: `USE_SNUBA` is not used for backend tests because there are a few failing tests with Snuba enabled.
-          unset USE_SNUBA
           make test-python-ci
 
       - name: Handle artifacts
@@ -373,7 +371,6 @@ jobs:
     env:
       # XXX: MATRIX_INSTANCE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
       MATRIX_INSTANCE_TOTAL: 2
-      USE_SNUBA: 1
       MIGRATIONS_TEST_MIGRATE: 1
 
     steps:


### PR DESCRIPTION
This is unused since we merged https://github.com/getsentry/sentry/pull/39297. So both the backend and snuba tests are running on almost the same config now. The main difference is that snuba tests run kafka, while backend don't.

We could probably look into unifying these jobs in the near future.