### PR TITLE
fix(ecosystem): Do not say "synced" on ownership rules

### DIFF
--- a/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
+++ b/static/app/views/settings/project/projectOwnership/rulesPanel.tsx
@@ -1,9 +1,10 @@
 import styled from '@emotion/styled';
-import moment from 'moment';
 
 import TextArea from 'sentry/components/forms/controls/textarea';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
+import TimeSince from 'sentry/components/timeSince';
 import {IconGithub, IconGitlab, IconSentry} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 
 type Props = {
@@ -52,23 +53,20 @@ function RulesPanel({
   return (
     <Panel data-test-id={dataTestId}>
       <PanelHeader>
-        {[
-          <Container key="title">
-            {renderIcon()}
-            <Title>{renderTitle()}</Title>
-            {repoName && <Repository>{`- ${repoName}`}</Repository>}
-          </Container>,
-          <Container key="control">
+        <Container>
+          {renderIcon()}
+          <Title>{renderTitle()}</Title>
+          {repoName && <Repository>{`- ${repoName}`}</Repository>}
+        </Container>
+        <Container>
+          {dateUpdated && (
             <SyncDate>
-              {dateUpdated && `Last synced ${moment(dateUpdated).fromNow()}`}
+              {t('Last %s', type === 'codeowners' ? t('synced') : t('edited'))}{' '}
+              <TimeSince date={dateUpdated} />
             </SyncDate>
-            <Controls>
-              {(controls || []).map((c, n) => (
-                <span key={n}> {c}</span>
-              ))}
-            </Controls>
-          </Container>,
-        ]}
+          )}
+          <Controls>{controls}</Controls>
+        </Container>
       </PanelHeader>
 
       <PanelBody>
@@ -136,9 +134,7 @@ const SyncDate = styled('div')`
   font-weight: normal;
 `;
 const Controls = styled('div')`
-  display: grid;
+  display: flex;
   align-items: center;
   gap: ${space(1)};
-  grid-auto-flow: column;
-  justify-content: flex-end;
 `;


### PR DESCRIPTION
Ownership rules are manually edited. Codeowners sync.

Also remove some grid.

before
![image](https://user-images.githubusercontent.com/1400464/192398014-2921e3d9-318b-4cd5-9758-1c95da573e5c.png)

after
![image](https://user-images.githubusercontent.com/1400464/192398062-9e3d795f-55d5-4e2e-88d7-2eb452791ca6.png)
