### PR TITLE
ref(tests): Replace usages of mock django timezone with freezegun

### DIFF
--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -1,8 +1,5 @@
-from datetime import datetime
-from unittest import mock
-
-import pytz
 from exam import fixture
+from freezegun import freeze_time
 
 from sentry.api.serializers import serialize
 from sentry.incidents.models import Incident, IncidentActivity, IncidentStatus
@@ -44,10 +41,8 @@ class BaseIncidentDetailsTest:
 
 @region_silo_test
 class OrganizationIncidentDetailsTest(BaseIncidentDetailsTest, APITestCase):
-    @mock.patch("django.utils.timezone.now")
-    def test_simple(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_simple(self):
         incident = self.create_incident(seen_by=[self.user])
         with self.feature("organizations:incidents"):
             resp = self.get_success_response(incident.organization.slug, incident.identifier)

--- a/tests/sentry/rules/filters/test_age_comparison.py
+++ b/tests/sentry/rules/filters/test_age_comparison.py
@@ -1,8 +1,7 @@
-from datetime import datetime, timedelta
-from unittest import mock
+from datetime import timedelta
 
-import pytz
 from django.utils import timezone
+from freezegun import freeze_time
 
 from sentry.rules.filters.age_comparison import AgeComparisonFilter
 from sentry.testutils.cases import RuleTestCase
@@ -11,10 +10,8 @@ from sentry.testutils.cases import RuleTestCase
 class AgeComparisonFilterTest(RuleTestCase):
     rule_cls = AgeComparisonFilter
 
-    @mock.patch("django.utils.timezone.now")
-    def test_older_applies_correctly(self, now):
-        now.return_value = datetime(2020, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_older_applies_correctly(self):
         event = self.get_event()
         value = 10
         data = {"comparison_type": "older", "value": str(value), "time": "hour"}
@@ -27,10 +24,8 @@ class AgeComparisonFilterTest(RuleTestCase):
         event.group.first_seen = timezone.now() - timedelta(hours=11)
         self.assertPasses(rule, event)
 
-    @mock.patch("django.utils.timezone.now")
-    def test_newer_applies_correctly(self, now):
-        now.return_value = datetime(2020, 8, 1, 0, 0, 0, 0, tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_newer_applies_correctly(self):
         event = self.get_event()
         value = 10
         data = {"comparison_type": "newer", "value": str(value), "time": "hour"}

--- a/tests/sentry/rules/filters/test_age_comparison.py
+++ b/tests/sentry/rules/filters/test_age_comparison.py
@@ -10,7 +10,7 @@ from sentry.testutils.cases import RuleTestCase
 class AgeComparisonFilterTest(RuleTestCase):
     rule_cls = AgeComparisonFilter
 
-    @freeze_time(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.utc))
+    @freeze_time(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0))
     def test_older_applies_correctly(self):
         event = self.get_event()
         value = 10
@@ -25,7 +25,7 @@ class AgeComparisonFilterTest(RuleTestCase):
         # this needs to be offset by 1ms otherwise it's exactly the same time as "now" and won't pass
         self.assertPasses(rule, event)
 
-    @freeze_time(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.utc))
+    @freeze_time(datetime.now().replace(hour=0, minute=0, second=0, microsecond=0))
     def test_newer_applies_correctly(self):
         event = self.get_event()
         value = 10

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta
-from unittest import mock
 
 import pytest
 from django.utils import timezone
+from freezegun import freeze_time
 
 from sentry.models import EventUser, GroupStatus, Release, Team, User
 from sentry.search.base import ANY
@@ -163,58 +163,51 @@ class ParseQueryTest(TestCase):
         assert result == {"tags": {"foo-bar": "foobar"}, "query": ""}
 
     # TODO: update docs to include minutes, days, and weeks suffixes
-    @mock.patch("django.utils.timezone.now")
-    def test_age_tag_negative_value(self, now):
-        start = datetime(2016, 1, 1, tzinfo=timezone.utc)
-        now.return_value = start
+    @freeze_time("2016-01-01")
+    def test_age_tag_negative_value(self):
+        start = datetime.now(timezone.utc)
         expected = start - timedelta(hours=12)
         result = self.parse_query("age:-12h")
         assert result == {"tags": {}, "query": "", "age_from": expected, "age_from_inclusive": True}
 
-    @mock.patch("django.utils.timezone.now")
-    def test_age_tag_positive_value(self, now):
-        start = datetime(2016, 1, 1, tzinfo=timezone.utc)
-        now.return_value = start
+    @freeze_time("2016-01-01")
+    def test_age_tag_positive_value(self):
+        start = datetime.now(timezone.utc)
         expected = start - timedelta(hours=12)
         result = self.parse_query("age:+12h")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
-    @mock.patch("django.utils.timezone.now")
-    def test_age_tag_weeks(self, now):
-        start = datetime(2016, 1, 1, tzinfo=timezone.utc)
-        now.return_value = start
+    @freeze_time("2016-01-01")
+    def test_age_tag_weeks(self):
+        start = datetime.now(timezone.utc)
         expected = start - timedelta(days=35)
         result = self.parse_query("age:+5w")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
-    @mock.patch("django.utils.timezone.now")
-    def test_age_tag_days(self, now):
-        start = datetime(2016, 1, 1, tzinfo=timezone.utc)
-        now.return_value = start
+    @freeze_time("2016-01-01")
+    def test_age_tag_days(self):
+        start = datetime.now(timezone.utc)
         expected = start - timedelta(days=10)
         result = self.parse_query("age:+10d")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
-    @mock.patch("django.utils.timezone.now")
-    def test_age_tag_hours(self, now):
-        start = datetime(2016, 1, 1, tzinfo=timezone.utc)
-        now.return_value = start
+    @freeze_time("2016-01-01")
+    def test_age_tag_hours(self):
+        start = datetime.now(timezone.utc)
         expected = start - timedelta(hours=10)
         result = self.parse_query("age:+10h")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
-    @mock.patch("django.utils.timezone.now")
-    def test_age_tag_minutes(self, now):
-        start = datetime(2016, 1, 1, tzinfo=timezone.utc)
-        now.return_value = start
+    @freeze_time("2016-01-01")
+    def test_age_tag_minutes(self):
+        start = datetime.now(timezone.utc)
         expected = start - timedelta(minutes=30)
         result = self.parse_query("age:+30m")
         assert result == {"tags": {}, "query": "", "age_to": expected, "age_to_inclusive": True}
 
-    @mock.patch("django.utils.timezone.now")
-    def test_two_age_tags(self, now):
-        start = datetime(2016, 1, 1, tzinfo=timezone.utc)
-        now.return_value = start
+    @freeze_time("2016-01-01")
+    def test_two_age_tags(self):
+        start = datetime.now(timezone.utc)
         expected_to = start - timedelta(hours=12)
         expected_from = start - timedelta(hours=24)
         result = self.parse_query("age:+12h age:-24h")

--- a/tests/sentry/tsdb/test_base.py
+++ b/tests/sentry/tsdb/test_base.py
@@ -1,8 +1,9 @@
 import itertools
-from datetime import datetime, timedelta
-from unittest import TestCase, mock
+from datetime import datetime, timedelta, timezone
+from unittest import TestCase
 
 import pytz
+from freezegun import freeze_time
 
 from sentry.tsdb.base import ONE_DAY, ONE_HOUR, ONE_MINUTE, BaseTSDB
 from sentry.utils.dates import to_timestamp
@@ -44,36 +45,36 @@ class BaseTSDBTest(TestCase):
         result = self.tsdb.calculate_expiry(10, 30, timestamp)
         assert result == 1368890330
 
-    @mock.patch("django.utils.timezone.now")
-    def test_get_optimal_rollup_series_aligned_intervals(self, now):
-        now.return_value = datetime(2016, 8, 1, tzinfo=pytz.utc)
+    @freeze_time("2016-08-01")
+    def test_get_optimal_rollup_series_aligned_intervals(self):
 
-        start = now() - timedelta(seconds=30)
+        start = datetime.now(timezone.utc) - timedelta(seconds=30)
+
         assert self.tsdb.get_optimal_rollup_series(start) == (
             10,
             [to_timestamp(start + timedelta(seconds=10) * i) for i in range(4)],
         )
 
-        start = now() - timedelta(minutes=30)
+        start = datetime.now(timezone.utc) - timedelta(minutes=30)
         assert self.tsdb.get_optimal_rollup_series(start) == (
             ONE_MINUTE,
             [to_timestamp(start + timedelta(minutes=1) * i) for i in range(31)],
         )
 
-        start = now() - timedelta(hours=5)
+        start = datetime.now(timezone.utc) - timedelta(hours=5)
         assert self.tsdb.get_optimal_rollup_series(start) == (
             ONE_HOUR,
             [to_timestamp(start + timedelta(hours=1) * i) for i in range(6)],
         )
 
-        start = now() - timedelta(days=7)
+        start = datetime.now(timezone.utc) - timedelta(days=7)
         assert self.tsdb.get_optimal_rollup_series(start) == (
             ONE_DAY,
             [to_timestamp(start + timedelta(hours=24) * i) for i in range(8)],
         )
 
-    @mock.patch("django.utils.timezone.now")
-    def test_get_optimal_rollup_series_offset_intervals(self, now):
+    @freeze_time("2016-08-01 00:00:15")
+    def test_get_optimal_rollup_series_offset_intervals(self):
         # This test is a funny one (notice it doesn't return a range that
         # includes the start position.) This occurs because the algorithm for
         # determining the series to be returned will attempt to return the same
@@ -81,8 +82,7 @@ class BaseTSDBTest(TestCase):
         # doesn't necessarily return data *from that specific interval* (the
         # end timestamp is always included.)
 
-        now.return_value = datetime(2016, 8, 1, 0, 0, 15, tzinfo=pytz.utc)
-        start = now() - timedelta(seconds=19)
+        start = datetime.now(timezone.utc) - timedelta(seconds=19)
         assert self.tsdb.get_optimal_rollup_series(start, rollup=10) == (
             10,
             [
@@ -91,41 +91,40 @@ class BaseTSDBTest(TestCase):
             ],
         )
 
-        now.return_value = datetime(2016, 8, 1, 0, 0, 30, tzinfo=pytz.utc)
-        start = now() - timedelta(seconds=ONE_MINUTE - 1)
+        now = datetime.now(timezone.utc) + timedelta(seconds=15)
+        start = now - timedelta(seconds=ONE_MINUTE - 1)
         assert self.tsdb.get_optimal_rollup_series(start, rollup=ONE_MINUTE) == (
             ONE_MINUTE,
             [to_timestamp(datetime(2016, 8, 1, 0, 0, 0, tzinfo=pytz.utc))],
         )
 
-        now.return_value = datetime(2016, 8, 1, 12, tzinfo=pytz.utc)
-        start = now() - timedelta(seconds=ONE_DAY - 1)
+        now = datetime.now(timezone.utc) + timedelta(hours=11, seconds=45)
+        start = now - timedelta(seconds=ONE_DAY - 1)
         assert self.tsdb.get_optimal_rollup_series(start, rollup=ONE_DAY) == (
             ONE_DAY,
             [to_timestamp(datetime(2016, 8, 1, 0, tzinfo=pytz.utc))],
         )
 
-    @mock.patch("django.utils.timezone.now")
-    def test_make_series_aligned_intervals(self, now):
-        now.return_value = datetime(2016, 8, 1, tzinfo=pytz.utc)
+    @freeze_time("2016-08-01")
+    def test_make_series_aligned_intervals(self):
 
-        start = now() - timedelta(seconds=30)
+        start = datetime.now(timezone.utc) - timedelta(seconds=30)
         assert self.tsdb.make_series(0, start) == [
             (to_timestamp(start + timedelta(seconds=10) * i), 0) for i in range(4)
         ]
 
-        start = now() - timedelta(minutes=30)
+        start = datetime.now(timezone.utc) - timedelta(minutes=30)
         assert self.tsdb.make_series(lambda timestamp: 1, start) == [
             (to_timestamp(start + timedelta(minutes=1) * i), 1) for i in range(31)
         ]
 
         counter = itertools.count()
-        start = now() - timedelta(hours=5)
+        start = datetime.now(timezone.utc) - timedelta(hours=5)
         assert self.tsdb.make_series(lambda timestamp: next(counter), start) == [
             (to_timestamp(start + timedelta(hours=1) * i), i) for i in range(6)
         ]
 
-        start = now() - timedelta(days=7)
+        start = datetime.now(timezone.utc) - timedelta(days=7)
         assert self.tsdb.make_series(0, start) == [
             (to_timestamp(start + timedelta(hours=24) * i), 0) for i in range(8)
         ]


### PR DESCRIPTION
Use freezegun everywhere for consistency 🧊 🔫  we use this in many more places than `@mock.patch("django.utils.timezone.now")` already so this is just replacing the remaining usages so every test is using the same thing and it's not confusing when you see both and wonder which one to use. 