### PR TITLE
ref(monitors): Replace IssueList with GroupList

### DIFF
--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -51,11 +51,7 @@ class MonitorDetails extends AsyncView<Props, State> {
 
         <MonitorStats monitor={monitor} />
 
-        <Panel style={{paddingBottom: 0}}>
-          <PanelHeader>{t('Related Issues')}</PanelHeader>
-
-          <MonitorIssues monitor={monitor} orgId={this.props.params.orgId} />
-        </Panel>
+        <MonitorIssues monitor={monitor} orgId={this.props.params.orgId} />
 
         <Panel>
           <PanelHeader>{t('Recent Check-ins')}</PanelHeader>

--- a/static/app/views/monitors/monitorIssues.tsx
+++ b/static/app/views/monitors/monitorIssues.tsx
@@ -10,17 +10,17 @@ type Props = {
   orgId: string;
 };
 
-const MonitorIssues = ({orgId, monitor}: Props) => {
-  const renderEmptyMessage = () => (
-    <Panel>
-      <PanelBody>
-        <EmptyStateWarning>
-          <p>{t('No issues founds relating to this monitor')}</p>
-        </EmptyStateWarning>
-      </PanelBody>
-    </Panel>
-  );
+const MonitorIssuesEmptyMessage = () => (
+  <Panel>
+    <PanelBody>
+      <EmptyStateWarning>
+        <p>{t('No issues founds relating to this monitor')}</p>
+      </EmptyStateWarning>
+    </PanelBody>
+  </Panel>
+);
 
+const MonitorIssues = ({orgId, monitor}: Props) => {
   return (
     <GroupList
       orgId={orgId}
@@ -31,7 +31,7 @@ const MonitorIssues = ({orgId, monitor}: Props) => {
         limit: 5,
       }}
       query=""
-      renderEmptyMessage={renderEmptyMessage}
+      renderEmptyMessage={MonitorIssuesEmptyMessage}
       canSelectGroups={false}
       withPagination={false}
       withChart={false}

--- a/static/app/views/monitors/monitorIssues.tsx
+++ b/static/app/views/monitors/monitorIssues.tsx
@@ -1,4 +1,6 @@
-import IssueList from 'sentry/components/issueList';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import GroupList from 'sentry/components/issues/groupList';
+import {Panel, PanelBody} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
 
 import {Monitor} from './types';
@@ -8,19 +10,34 @@ type Props = {
   orgId: string;
 };
 
-const MonitorIssues = ({orgId, monitor}: Props) => (
-  <IssueList
-    endpoint={`/organizations/${orgId}/issues/`}
-    query={{
-      query: 'monitor.id:"' + monitor.id + '"',
-      project: monitor.project.id,
-      limit: 5,
-    }}
-    pagination={false}
-    emptyText={t('No issues found')}
-    noBorder
-    noMargin
-  />
-);
+const MonitorIssues = ({orgId, monitor}: Props) => {
+  const renderEmptyMessage = () => (
+    <Panel>
+      <PanelBody>
+        <EmptyStateWarning>
+          <p>{t('No issues founds relating to this monitor')}</p>
+        </EmptyStateWarning>
+      </PanelBody>
+    </Panel>
+  );
+
+  return (
+    <GroupList
+      orgId={orgId}
+      endpointPath={`/organizations/${orgId}/issues/`}
+      queryParams={{
+        query: `monitor.id:"${monitor.id}"`,
+        project: monitor.project.id,
+        limit: 5,
+      }}
+      query=""
+      renderEmptyMessage={renderEmptyMessage}
+      canSelectGroups={false}
+      withPagination={false}
+      withChart={false}
+      useTintRow={false}
+    />
+  );
+};
 
 export default MonitorIssues;


### PR DESCRIPTION
Monitors was the only page using the `IssueList` component which is very redundant with the existing `GroupList` component, so we should unify and then get rid of `IssueList` (https://github.com/getsentry/sentry/pull/39324)

Before:
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/9372512/192406567-871c920d-80e1-44d3-9521-34202aad7f39.png">

After:
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/9372512/192406532-b7040bb2-9f5d-4399-a118-a63f864b8d9b.png">
