### PR TITLE
fix(gitlab): Fix AppPlatformEvents hitting Gitlab webhook endpoint

### DIFF
--- a/src/sentry/integrations/gitlab/webhooks.py
+++ b/src/sentry/integrations/gitlab/webhooks.py
@@ -196,7 +196,9 @@ class GitlabWebhookEndpoint(View):
         extra = {
             # This tells us the Gitlab version being used (e.g. current gitlab.com version -> GitLab/15.4.0-pre)
             "user-agent": request.META.get("HTTP_USER_AGENT"),
-            "event-type": request.META["HTTP_X_GITLAB_EVENT"],
+            # Gitlab does not seem to be the only host sending events
+            # AppPlatformEvents also hit this API
+            "event-type": request.META.get("HTTP_X_GITLAB_EVENT"),
         }
         token = "<unknown>"
         try:


### PR DESCRIPTION
It seems that AppPlatformEvents hits the Gitlab webhook [1] and it does not contain the Gitlab headers. This regression was introduced via #39129.

Fixes [SENTRY-W3G](https://sentry.io/organizations/sentry/issues/3624081212/?project=1)

[1] https://github.com/getsentry/sentry/blob/07362b7d8eb6b03acc21aafb91e58a1865c00da3/src/sentry/api/serializers/models/app_platform_event.py#L46-L55