### PR TITLE
fix(metrics): Make calls to snql func more explicit

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -1065,7 +1065,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=SessionMRI.ALL.value,
             metrics=[SessionMRI.SESSION.value],
             unit="sessions",
-            snql=lambda *_, org_id, metric_ids, alias=None: all_sessions(
+            snql=lambda org_id, metric_ids, alias=None: all_sessions(
                 org_id, metric_ids, alias=alias
             ),
         ),
@@ -1073,15 +1073,13 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=SessionMRI.ALL_USER.value,
             metrics=[SessionMRI.USER.value],
             unit="users",
-            snql=lambda *_, org_id, metric_ids, alias=None: all_users(
-                org_id, metric_ids, alias=alias
-            ),
+            snql=lambda org_id, metric_ids, alias=None: all_users(org_id, metric_ids, alias=alias),
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ABNORMAL.value,
             metrics=[SessionMRI.SESSION.value],
             unit="sessions",
-            snql=lambda *_, org_id, metric_ids, alias=None: abnormal_sessions(
+            snql=lambda org_id, metric_ids, alias=None: abnormal_sessions(
                 org_id, metric_ids, alias=alias
             ),
         ),
@@ -1089,7 +1087,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=SessionMRI.ABNORMAL_USER.value,
             metrics=[SessionMRI.USER.value],
             unit="users",
-            snql=lambda *_, org_id, metric_ids, alias=None: abnormal_users(
+            snql=lambda org_id, metric_ids, alias=None: abnormal_users(
                 org_id, metric_ids, alias=alias
             ),
         ),
@@ -1097,7 +1095,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=SessionMRI.CRASHED.value,
             metrics=[SessionMRI.SESSION.value],
             unit="sessions",
-            snql=lambda *_, org_id, metric_ids, alias=None: crashed_sessions(
+            snql=lambda org_id, metric_ids, alias=None: crashed_sessions(
                 org_id, metric_ids, alias=alias
             ),
         ),
@@ -1105,7 +1103,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=SessionMRI.CRASHED_USER.value,
             metrics=[SessionMRI.USER.value],
             unit="users",
-            snql=lambda *_, org_id, metric_ids, alias=None: crashed_users(
+            snql=lambda org_id, metric_ids, alias=None: crashed_users(
                 org_id, metric_ids, alias=alias
             ),
         ),
@@ -1113,7 +1111,9 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=SessionMRI.CRASH_RATE.value,
             metrics=[SessionMRI.CRASHED.value, SessionMRI.ALL.value],
             unit="percentage",
-            snql=lambda *args, org_id, metric_ids, alias=None: division_float(*args, alias=alias),
+            snql=lambda crashed_count, all_count, org_id, metric_ids, alias=None: division_float(
+                crashed_count, all_count, alias=alias
+            ),
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.CRASH_USER_RATE.value,
@@ -1122,25 +1122,31 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
                 SessionMRI.ALL_USER.value,
             ],
             unit="percentage",
-            snql=lambda *args, org_id, metric_ids, alias=None: division_float(*args, alias=alias),
+            snql=lambda crashed_user_count, all_user_count, org_id, metric_ids, alias=None: division_float(
+                crashed_user_count, all_user_count, alias=alias
+            ),
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.CRASH_FREE_RATE.value,
             metrics=[SessionMRI.CRASH_RATE.value],
             unit="percentage",
-            snql=lambda *args, org_id, metric_ids, alias=None: complement(*args, alias=alias),
+            snql=lambda crash_rate_value, org_id, metric_ids, alias=None: complement(
+                crash_rate_value, alias=alias
+            ),
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.CRASH_FREE_USER_RATE.value,
             metrics=[SessionMRI.CRASH_USER_RATE.value],
             unit="percentage",
-            snql=lambda *args, org_id, metric_ids, alias=None: complement(*args, alias=alias),
+            snql=lambda crash_user_rate_value, org_id, metric_ids, alias=None: complement(
+                crash_user_rate_value, alias=alias
+            ),
         ),
         SingularEntityDerivedMetric(
             metric_mri=SessionMRI.ERRORED_PREAGGREGATED.value,
             metrics=[SessionMRI.SESSION.value],
             unit="sessions",
-            snql=lambda *_, org_id, metric_ids, alias=None: errored_preaggr_sessions(
+            snql=lambda org_id, metric_ids, alias=None: errored_preaggr_sessions(
                 org_id, metric_ids, alias=alias
             ),
             is_private=True,
@@ -1149,7 +1155,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=SessionMRI.ERRORED_SET.value,
             metrics=[SessionMRI.ERROR.value],
             unit="sessions",
-            snql=lambda *_, org_id, metric_ids, alias=None: uniq_aggregation_on_metric(
+            snql=lambda org_id, metric_ids, alias=None: uniq_aggregation_on_metric(
                 metric_ids, alias=alias
             ),
             is_private=True,
@@ -1161,7 +1167,9 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
                 SessionMRI.ABNORMAL.value,
             ],
             unit="sessions",
-            snql=lambda *args, org_id, metric_ids, alias=None: addition(*args, alias=alias),
+            snql=lambda crashed_count, abnormal_count, org_id, metric_ids, alias=None: addition(
+                crashed_count, abnormal_count, alias=alias
+            ),
             is_private=True,
         ),
         CompositeEntityDerivedMetric(
@@ -1189,7 +1197,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=SessionMRI.ERRORED_USER_ALL.value,
             metrics=[SessionMRI.USER.value],
             unit="users",
-            snql=lambda *_, org_id, metric_ids, alias=None: errored_all_users(
+            snql=lambda org_id, metric_ids, alias=None: errored_all_users(
                 org_id, metric_ids, alias=alias
             ),
             is_private=True,
@@ -1201,7 +1209,9 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
                 SessionMRI.ABNORMAL_USER.value,
             ],
             unit="users",
-            snql=lambda *args, org_id, metric_ids, alias=None: addition(*args, alias=alias),
+            snql=lambda crashed_user_count, abnormal_user_count, org_id, metric_ids, alias=None: addition(
+                crashed_user_count, abnormal_user_count, alias=alias
+            ),
             is_private=True,
         ),
         SingularEntityDerivedMetric(
@@ -1211,7 +1221,9 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
                 SessionMRI.CRASHED_AND_ABNORMAL_USER.value,
             ],
             unit="users",
-            snql=lambda *args, org_id, metric_ids, alias=None: subtraction(*args, alias=alias),
+            snql=lambda errored_user_all_count, crashed_and_abnormal_user_count, org_id, metric_ids, alias=None: subtraction(
+                errored_user_all_count, crashed_and_abnormal_user_count, alias=alias
+            ),
             post_query_func=lambda *args: max(0, *args),
         ),
         CompositeEntityDerivedMetric(
@@ -1230,14 +1242,16 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
                 SessionMRI.ERRORED_USER_ALL.value,
             ],
             unit="users",
-            snql=lambda *args, org_id, metric_ids, alias=None: subtraction(*args, alias=alias),
+            snql=lambda all_user_count, errored_user_all_count, org_id, metric_ids, alias=None: subtraction(
+                all_user_count, errored_user_all_count, alias=alias
+            ),
             post_query_func=lambda *args: max(0, *args),
         ),
         SingularEntityDerivedMetric(
             metric_mri=TransactionMRI.ALL.value,
             metrics=[TransactionMRI.DURATION.value],
             unit="transactions",
-            snql=lambda *_, org_id, metric_ids, alias=None: all_transactions(
+            snql=lambda org_id, metric_ids, alias=None: all_transactions(
                 org_id, metric_ids=metric_ids, alias=alias
             ),
             is_private=True,
@@ -1246,7 +1260,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=TransactionMRI.FAILURE_COUNT.value,
             metrics=[TransactionMRI.DURATION.value],
             unit="transactions",
-            snql=lambda *_, org_id, metric_ids, alias=None: failure_count_transaction(
+            snql=lambda org_id, metric_ids, alias=None: failure_count_transaction(
                 org_id, metric_ids=metric_ids, alias=alias
             ),
             is_private=True,
@@ -1266,7 +1280,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=TransactionMRI.SATISFIED.value,
             metrics=[TransactionMRI.DURATION.value],
             unit="transactions",
-            snql=lambda *_, org_id, metric_ids, alias=None: satisfaction_count_transaction(
+            snql=lambda org_id, metric_ids, alias=None: satisfaction_count_transaction(
                 org_id=org_id, metric_ids=metric_ids, alias=alias
             ),
             is_private=True,
@@ -1275,7 +1289,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=TransactionMRI.TOLERATED.value,
             metrics=[TransactionMRI.DURATION.value],
             unit="transactions",
-            snql=lambda *_, org_id, metric_ids, alias=None: tolerated_count_transaction(
+            snql=lambda org_id, metric_ids, alias=None: tolerated_count_transaction(
                 org_id=org_id, metric_ids=metric_ids, alias=alias
             ),
             is_private=True,
@@ -1298,7 +1312,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
                 TransactionMRI.USER.value,
             ],
             unit="users",
-            snql=lambda *_, org_id, metric_ids, alias=None: miserable_users(
+            snql=lambda org_id, metric_ids, alias=None: miserable_users(
                 org_id=org_id, metric_ids=metric_ids, alias=alias
             ),
         ),
@@ -1306,7 +1320,7 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             metric_mri=TransactionMRI.ALL_USER.value,
             metrics=[TransactionMRI.USER.value],
             unit="percentage",
-            snql=lambda *_, org_id, metric_ids, alias=None: uniq_aggregation_on_metric(
+            snql=lambda org_id, metric_ids, alias=None: uniq_aggregation_on_metric(
                 metric_ids, alias=alias
             ),
             is_private=True,


### PR DESCRIPTION
Improves calls to snql attr of `SingularEntityDerivedMetric` by passing explicit arg names of the snql arguments expected by these functions

