### PR TITLE
fix(discover): Filter for falsy is_homepage in discover endpoints

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -31,7 +31,9 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
             return self.respond(status=404)
 
         try:
-            query = DiscoverSavedQuery.objects.get(id=query_id, organization=organization)
+            query = DiscoverSavedQuery.objects.get(
+                id=query_id, organization=organization, is_homepage=False
+            )
         except DiscoverSavedQuery.DoesNotExist:
             raise ResourceDoesNotExist
 
@@ -45,7 +47,9 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
             return self.respond(status=404)
 
         try:
-            model = DiscoverSavedQuery.objects.get(id=query_id, organization=organization)
+            model = DiscoverSavedQuery.objects.get(
+                id=query_id, organization=organization, is_homepage=False
+            )
         except DiscoverSavedQuery.DoesNotExist:
             raise ResourceDoesNotExist
 
@@ -83,7 +87,9 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
             return self.respond(status=404)
 
         try:
-            model = DiscoverSavedQuery.objects.get(id=query_id, organization=organization)
+            model = DiscoverSavedQuery.objects.get(
+                id=query_id, organization=organization, is_homepage=False
+            )
         except DiscoverSavedQuery.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -1,4 +1,4 @@
-from django.db.models import F
+from django.db.models import F, Q
 from django.utils import timezone
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -32,7 +32,9 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
 
         try:
             query = DiscoverSavedQuery.objects.get(
-                id=query_id, organization=organization, is_homepage=False
+                Q(is_homepage=False) | Q(is_homepage__isnull=True),
+                id=query_id,
+                organization=organization,
             )
         except DiscoverSavedQuery.DoesNotExist:
             raise ResourceDoesNotExist
@@ -48,7 +50,9 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
 
         try:
             model = DiscoverSavedQuery.objects.get(
-                id=query_id, organization=organization, is_homepage=False
+                Q(is_homepage=False) | Q(is_homepage__isnull=True),
+                id=query_id,
+                organization=organization,
             )
         except DiscoverSavedQuery.DoesNotExist:
             raise ResourceDoesNotExist
@@ -88,7 +92,9 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
 
         try:
             model = DiscoverSavedQuery.objects.get(
-                id=query_id, organization=organization, is_homepage=False
+                Q(is_homepage=False) | Q(is_homepage__isnull=True),
+                id=query_id,
+                organization=organization,
             )
         except DiscoverSavedQuery.DoesNotExist:
             raise ResourceDoesNotExist
@@ -117,7 +123,11 @@ class DiscoverSavedQueryVisitEndpoint(OrganizationEndpoint):
             return self.respond(status=404)
 
         try:
-            model = DiscoverSavedQuery.objects.get(id=query_id, organization=organization)
+            model = DiscoverSavedQuery.objects.get(
+                Q(is_homepage=False) | Q(is_homepage__isnull=True),
+                id=query_id,
+                organization=organization,
+            )
         except DiscoverSavedQuery.DoesNotExist:
             raise ResourceDoesNotExist
 

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -98,6 +98,25 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 403, response.content
 
+    def test_get_homepage_query(self):
+        query = {"fields": ["event_id"], "query": "event.type:error", "limit": 10, "version": 2}
+        model = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by=self.user,
+            name="v2 query",
+            query=query,
+            is_homepage=True,
+        )
+
+        model.set_projects(self.project_ids)
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-discover-saved-query-detail", args=[self.org.slug, model.id]
+            )
+            response = self.client.get(url)
+
+        assert response.status_code == 404, response.content
+
     def test_put(self):
         with self.feature(self.feature_name):
             url = reverse(
@@ -204,6 +223,28 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
             assert response.status_code == 400
             assert "No Projects found, join a Team" == response.data["detail"]
 
+    def test_put_homepage_query(self):
+        query = {"fields": ["event_id"], "query": "event.type:error", "limit": 10, "version": 2}
+        model = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by=self.user,
+            name="v2 query",
+            query=query,
+            is_homepage=True,
+        )
+
+        model.set_projects(self.project_ids)
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-discover-saved-query-detail",
+                args=[self.org.slug, model.id],
+            )
+            response = self.client.put(
+                url, {"name": "New query", "projects": [], "range": "24h", "fields": []}
+            )
+
+        assert response.status_code == 404, response.content
+
     def test_put_org_without_access(self):
         with self.feature(self.feature_name):
             url = reverse(
@@ -262,6 +303,26 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
             response = self.client.delete(url)
 
         assert response.status_code == 403, response.content
+
+    def test_delete_homepage_query(self):
+        query = {"fields": ["event_id"], "query": "event.type:error", "limit": 10, "version": 2}
+        model = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by=self.user,
+            name="v2 query",
+            query=query,
+            is_homepage=True,
+        )
+
+        model.set_projects(self.project_ids)
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-discover-saved-query-detail",
+                args=[self.org.slug, model.id],
+            )
+            response = self.client.delete(url)
+
+        assert response.status_code == 404, response.content
 
 
 @region_silo_test


### PR DESCRIPTION
A user shouldn't be able to interact with a homepage query outside of the homepage endpoint. This adds filtering so we can differentiate the two.

I needed to use `Q` objects to select False or NULL because we didn't provide a default for the value