### PR TITLE
fix(tests): Fix flaky stats tests

### DIFF
--- a/tests/sentry/api/endpoints/test_group_stats.py
+++ b/tests/sentry/api/endpoints/test_group_stats.py
@@ -1,3 +1,5 @@
+from freezegun import freeze_time
+
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -5,6 +7,7 @@ from sentry.testutils.silo import region_silo_test
 
 @region_silo_test
 class GroupStatsTest(APITestCase):
+    @freeze_time(before_now(days=1).replace(minute=10))
     def test_simple(self):
         self.login_as(user=self.user)
         group1 = self.store_event(

--- a/tests/sentry/api/endpoints/test_organization_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_stats.py
@@ -2,6 +2,7 @@ import functools
 import sys
 
 from django.urls import reverse
+from freezegun import freeze_time
 
 from sentry.constants import DataCategory
 from sentry.testutils import APITestCase
@@ -12,6 +13,7 @@ from sentry.utils.outcomes import Outcome
 
 
 @region_silo_test
+@freeze_time(before_now(days=1).replace(minute=10))
 class OrganizationStatsTest(APITestCase, OutcomesSnubaTest):
     def test_simple(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_group_stats.py
+++ b/tests/sentry/api/endpoints/test_project_group_stats.py
@@ -1,3 +1,5 @@
+from freezegun import freeze_time
+
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -5,6 +7,7 @@ from sentry.testutils.silo import region_silo_test
 
 @region_silo_test
 class ProjectGroupStatsTest(APITestCase):
+    @freeze_time(before_now(days=1).replace(minute=10))
     def test_simple(self):
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_project_stats.py
+++ b/tests/sentry/api/endpoints/test_project_stats.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from freezegun import freeze_time
 
 from sentry.constants import DataCategory
 from sentry.testutils import APITestCase
@@ -9,6 +10,7 @@ from sentry.utils.outcomes import Outcome
 
 
 @region_silo_test
+@freeze_time(before_now(days=1).replace(minute=10))
 class ProjectStatsTest(APITestCase, OutcomesSnubaTest):
     def test_simple(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_team_stats.py
+++ b/tests/sentry/api/endpoints/test_team_stats.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from freezegun import freeze_time
 
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -6,6 +7,7 @@ from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test
+@freeze_time(before_now(days=1).replace(minute=10))
 class TeamStatsTest(APITestCase):
     def test_simple(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
These tests all fail if run in the first minute of the hour. Tested this with `@freeze_time(before_now(days=1).replace(minute=0))`. For tests that fail at that time I've hardcoded them to run at a specific minute of the hour.