### PR TITLE
chore(ui): Disable direct autoimport of testing-library libs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,8 @@
   // Exclude Specific Files from Auto-Imports
   "typescript.preferences.autoImportFileExcludePatterns": [
     "**/node_modules/@storybook/theming/*",
-    "**/node_modules/@storybook/addons/*"
+    "**/node_modules/@storybook/addons/*",
+    "**/node_modules/@testing-library/*"
   ],
 
   "[typescriptreact]": {


### PR DESCRIPTION
Things like `fireEvent` and some other imports would appear at the top and we should always import from `sentry-test` instead.

![image](https://user-images.githubusercontent.com/10888943/192584610-3d8e07cb-f949-4041-a019-5955f9c4e90f.png)
