### PR TITLE
fix(perf-issues): Fix errors with integration tags on save event

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1062,7 +1062,9 @@ def report_metrics_for_detectors(
     event_integrations = event.get("sdk", {}).get("integrations", []) or []
 
     for integration_name in INTEGRATIONS_OF_INTEREST:
-        detected_tags["integration_" + integration_name] = integration_name in event_integrations
+        detected_tags["integration_" + integration_name.lower()] = (
+            integration_name in event_integrations
+        )
 
     for detector_enum, detector in detectors.items():
         detector_key = detector_enum.value

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1059,7 +1059,7 @@ def report_metrics_for_detectors(
             set_tag("_pi_transaction", event_id)
 
     detected_tags = {"sdk_name": sdk_name}
-    event_integrations = event.get("sdk", {}).get("integrations", [])
+    event_integrations = event.get("sdk", {}).get("integrations", []) or []
 
     for integration_name in INTEGRATIONS_OF_INTEREST:
         detected_tags["integration_" + integration_name] = integration_name in event_integrations


### PR DESCRIPTION
- Fall back to empty integration list if the SDKs returns `None`
- Lowercase integration names, so the tag is `integration_mongo` and not `integration_Mongo`
