### PR TITLE
fix(issueDetails): Highlight Tags tab in Tag Details page

### DIFF
--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -198,8 +198,16 @@ class GroupDetails extends Component<Props, State> {
     const {event} = this.state;
 
     const currentRoute = routes[routes.length - 1];
-    const currentTab =
-      Object.values(Tab).find(tab => currentRoute.path === TabPaths[tab]) ?? Tab.DETAILS;
+
+    let currentTab: Tab;
+    // If we're in the tag details page ("/tags/:tagKey/")
+    if (router.params.tagKey) {
+      currentTab = Tab.TAGS;
+    } else {
+      currentTab =
+        Object.values(Tab).find(tab => currentRoute.path === TabPaths[tab]) ??
+        Tab.DETAILS;
+    }
 
     const baseUrl = `/organizations/${organization.slug}/issues/${group.id}/${
       router.params.eventId && event ? `events/${event.id}/` : ''


### PR DESCRIPTION
**Before:** we're in the Tag Details page, but the "Details" tab is highlighted
<img width="833" alt="Screen Shot 2022-09-27 at 10 49 16 AM" src="https://user-images.githubusercontent.com/44172267/192599880-60c859f9-49d5-422e-adf6-7223ea2b2739.png">

**After:** the "Tags" tab is correctly highlighted
<img width="833" alt="Screen Shot 2022-09-27 at 10 49 01 AM" src="https://user-images.githubusercontent.com/44172267/192599832-9e7134eb-53ed-4e6b-8342-28d62fcd6109.png">

