### PR TITLE
feat(spans): Add pageload span <meta> tags

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -16,6 +16,10 @@
   <meta name="robots" content="none, noarchive">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
+  {% autoescape off %}
+  {% generate_pageload_span_meta %}
+  {% endautoescape %}
+
   <link rel="icon" type="image/png" href="{% absolute_asset_url "sentry" "images/favicon.png" %}">
 
   <link rel="apple-touch-icon" href="{% absolute_asset_url "sentry" "images/logos/apple-touch-icon.png" %}">

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -1,5 +1,6 @@
 import re
 
+import sentry_sdk
 from django import template
 from django.conf import settings
 from django.template.base import token_kwargs
@@ -107,3 +108,8 @@ class ScriptNode(template.Node):
         if matches:
             return matches.group(1).strip()
         return text
+
+
+@register.simple_tag
+def generate_pageload_span_meta():
+    return sentry_sdk.Hub.current.trace_propagation_meta()


### PR DESCRIPTION
On pageload, let the backend span (i.e. python) be the first span of the trace.