### PR TITLE
ref(js): Retain constructed form Model options

### DIFF
--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -218,7 +218,7 @@ class FormModel {
    * Set form options
    */
   setFormOptions(options: FormOptions) {
-    this.options = options || {};
+    this.options = {...this.options, ...options} || {};
   }
 
   /**

--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -124,11 +124,11 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
       ...(this.model.getData() as ExternalActorMapping),
     };
     if (updatedMapping) {
-      const endpointDetails = getExternalActorEndpointDetails(
+      const options = getExternalActorEndpointDetails(
         getBaseFormEndpoint(updatedMapping),
         updatedMapping
       );
-      this.model.setFormOptions({...this.model.options, ...endpointDetails});
+      this.model.setFormOptions(options);
     }
   }
 

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -180,15 +180,9 @@ class NotificationSettings extends AsyncComponent<Props, State> {
 
   onFieldChange = (fieldName: string) => {
     if (SELF_NOTIFICATION_SETTINGS_TYPES.includes(fieldName)) {
-      const endpointDetails = {
-        apiEndpoint: '/users/me/notifications/',
-      };
-      this.model.setFormOptions({...this.model.options, ...endpointDetails});
+      this.model.setFormOptions({apiEndpoint: '/users/me/notifications/'});
     } else {
-      const endpointDetails = {
-        apiEndpoint: '/users/me/notification-settings/',
-      };
-      this.model.setFormOptions({...this.model.options, ...endpointDetails});
+      this.model.setFormOptions({apiEndpoint: '/users/me/notification-settings/'});
     }
   };
 


### PR DESCRIPTION
Any options the model was being constructed with were being overriden when used with a `Form`, which makes a call to this function when the form is mounted.