### PR TITLE
fix(releases): fix release version not validating none value

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -605,6 +605,9 @@ class Release(Model):
 
     @staticmethod
     def is_valid_version(value):
+        if value is None:
+            return False
+
         if any(c in value for c in BAD_RELEASE_CHARS):
             return False
 

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -677,6 +677,9 @@ class SetRefsTest(SetRefsTestCase):
 
         assert len(mock_fetch_commit.method_calls) == 0
 
+    def test_invalid_version_none_value(self):
+        assert not Release.is_valid_version(None)
+
     def test_invalid_version(self):
         cases = ["", "latest", ".", "..", "\t", "\n", "  "]
 


### PR DESCRIPTION
Missed a spot when validating the release version value.

Fixes SENTRY-VMK