### PR TITLE
fix(discover): Ensure dropdown indexes are unique

### DIFF
--- a/static/app/components/charts/intervalSelector.tsx
+++ b/static/app/components/charts/intervalSelector.tsx
@@ -178,7 +178,8 @@ export default function IntervalSelector({
     const results = _timeRangeAutoCompleteFilter(items, filterValue, {
       supportedPeriods: SUPPORTED_RELATIVE_PERIOD_UNITS,
       supportedUnits: SUPPORTED_RELATIVE_UNITS_LIST,
-    }).filter(item => {
+    });
+    const filteredResults = results.filter(item => {
       const itemHours = parsePeriodToHours(item.value);
       if (itemHours < intervalOption.min) {
         newItem = intervalOption.min;
@@ -191,7 +192,7 @@ export default function IntervalSelector({
     });
     if (newItem) {
       const [amount, unit] = formatHoursToInterval(newItem);
-      results.push(
+      filteredResults.push(
         makeItem(
           amount,
           unit,
@@ -200,7 +201,7 @@ export default function IntervalSelector({
         )
       );
     }
-    return results;
+    return filteredResults;
   };
 
   return (


### PR DESCRIPTION
- This fixes a bug where results.length would be reduced by 2 since we remove numbers out of the min&max bounds, so results.length + 1 would be a used index for makeItem