### PR TITLE
fix(discover): Interval dropdown wrong side

### DIFF
--- a/static/app/components/charts/intervalSelector.tsx
+++ b/static/app/components/charts/intervalSelector.tsx
@@ -215,7 +215,6 @@ export default function IntervalSelector({
       autoCompleteFilter={(items, filterValue) =>
         intervalAutoComplete(items, filterValue)
       }
-      alignMenu="right"
     >
       {({isOpen}) => (
         <DropdownButton borderless prefix={t('Interval')} isOpen={isOpen}>


### PR DESCRIPTION
- Remove alignMenu right, which was causing the dropdown to render on the right even when the screen width was very narrow


### Preview

#### Before
![image](https://user-images.githubusercontent.com/4205004/192623356-01e2071a-f0df-47f8-90e9-87586e3913dd.png)

#### After
![image](https://user-images.githubusercontent.com/4205004/192623393-3d96ffbe-f3cc-40bc-8c5c-a93686da9db8.png)
