### PR TITLE
feat(issue-alert): link to last triggered event instead of issue

### DIFF
--- a/static/app/views/alerts/rules/issue/details/issuesList.tsx
+++ b/static/app/views/alerts/rules/issue/details/issuesList.tsx
@@ -18,6 +18,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 
 type GroupHistory = {
   count: number;
+  eventId: string;
   group: Group;
   lastTriggered: string;
 };
@@ -101,7 +102,7 @@ class AlertRuleIssuesList extends AsyncComponent<Props, State> {
             t('Last Triggered'),
           ]}
         >
-          {groupHistory?.map(({group: issue, count, lastTriggered}) => {
+          {groupHistory?.map(({group: issue, count, lastTriggered, eventId}) => {
             const message = getMessage(issue);
             const {title} = getTitle(issue);
 
@@ -110,7 +111,9 @@ class AlertRuleIssuesList extends AsyncComponent<Props, State> {
                 <TitleWrapper>
                   <Link
                     to={{
-                      pathname: `/organizations/${organization.slug}/issues/${issue.id}/`,
+                      pathname:
+                        `/organizations/${organization.slug}/issues/${issue.id}/` +
+                        (eventId ? `events/${eventId}` : ''),
                       query: rule.environment ? {environment: rule.environment} : {},
                     }}
                   >

--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
@@ -58,6 +58,7 @@ describe('AlertRuleDetails', () => {
           count: 1,
           group: TestStubs.Group(),
           lastTriggered: moment('Apr 11, 2019 1:08:59 AM UTC').format(),
+          eventId: 'eventId',
         },
       ],
       headers: {
@@ -92,6 +93,16 @@ describe('AlertRuleDetails', () => {
     expect(await screen.findAllByText('My alert rule')).toHaveLength(2);
     expect(screen.getByText('RequestError:')).toBeInTheDocument();
     expect(screen.getByText('Apr 11, 2019 1:08:59 AM UTC')).toBeInTheDocument();
+    expect(screen.getByText('RequestError:')).toHaveAttribute(
+      'href',
+      expect.stringMatching(
+        RegExp(
+          `/organizations/${organization.slug}/issues/${
+            TestStubs.Group().id
+          }/events/eventId.*`
+        )
+      )
+    );
   });
 
   it('should allow paginating results', async () => {


### PR DESCRIPTION
If backend provides the last triggered `eventId` of an alert issue, link to event page instead of issue page.
[jira](https://getsentry.atlassian.net/browse/FEEDBACK-806)
[backend pr](https://github.com/getsentry/sentry/pull/39363)