### PR TITLE
fix(copy): event -> event id on issue details page

### DIFF
--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -119,7 +119,7 @@ class GroupEventToolbar extends Component<Props> {
       <Wrapper>
         <div>
           <Heading>
-            {t('Event')}{' '}
+            {t('Event ID')}{' '}
             <EventIdLink to={`${baseEventsPath}${evt.id}/`}>{evt.eventID}</EventIdLink>
             <LinkContainer>
               <ExternalLink


### PR DESCRIPTION
We should rename `Event` to `Event ID` because everything beneath this text is information related to the Event

## Before

<img width="850" alt="CleanShot 2022-09-27 at 13 19 04@2x" src="https://user-images.githubusercontent.com/1900676/192627747-8e053b78-b30f-4638-873a-59dff7de9f6e.png">

## After

<img width="840" alt="CleanShot 2022-09-27 at 13 18 42@2x" src="https://user-images.githubusercontent.com/1900676/192627787-6140f1ed-96db-433f-b42e-fc6fc180dbb0.png">

