### PR TITLE
feat: add optional ref to useKeyPress

### DIFF
--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -3,7 +3,7 @@ import {RefObject, useEffect, useState} from 'react';
 /**
  * Hook to detect when a specific key is being pressed
  */
-const useKeyPress = function (targetKey: string, ref?: RefObject<HTMLInputElement>) {
+const useKeyPress = (targetKey: string, ref?: RefObject<HTMLInputElement>) => {
   const [keyPressed, setKeyPressed] = useState(false);
 
   const downHandler = ({key}: KeyboardEvent) => {

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -22,18 +22,15 @@ const useKeyPress = (
       }
     };
 
-    let current: any = window;
-    if (targetRef?.current) {
-      current = targetRef?.current;
-    }
-    current.addEventListener('keydown', downHandler);
-    current.addEventListener('keyup', upHandler);
+    const current: any = targetRef?.current ?? window;
+    current?.addEventListener('keydown', downHandler);
+    current?.addEventListener('keyup', upHandler);
 
     return () => {
-      current.removeEventListener('keydown', downHandler);
-      current.removeEventListener('keyup', upHandler);
+      current?.removeEventListener('keydown', downHandler);
+      current?.removeEventListener('keyup', upHandler);
     };
-  })[targetKey];
+  }, [targetKey, targetRef]);
 
   return keyPressed;
 };

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -20,12 +20,12 @@ const useKeyPress = (targetKey: string, targetRef?: React.RefObject<HTMLElement>
     };
 
     const current = targetRef?.current ?? document.body;
-    current?.addEventListener('keydown', downHandler);
-    current?.addEventListener('keyup', upHandler);
+    current.addEventListener('keydown', downHandler);
+    current.addEventListener('keyup', upHandler);
 
     return () => {
-      current?.removeEventListener('keydown', downHandler);
-      current?.removeEventListener('keyup', upHandler);
+      current.removeEventListener('keydown', downHandler);
+      current.removeEventListener('keyup', upHandler);
     };
   }, [targetKey, targetRef]);
 

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -1,33 +1,39 @@
-import {useEffect, useState} from 'react';
+import {RefObject, useEffect, useState} from 'react';
 
 /**
  * Hook to detect when a specific key is being pressed
  */
-function useKeyPress(targetKey: React.KeyboardEvent['key']) {
+const useKeyPress = function (targetKey: string, ref?: RefObject<HTMLInputElement>) {
   const [keyPressed, setKeyPressed] = useState(false);
 
-  useEffect(() => {
-    function downHandler({key}: KeyboardEvent) {
-      if (key === targetKey) {
-        setKeyPressed(true);
-      }
+  const downHandler = ({key}: KeyboardEvent) => {
+    if (key === targetKey) {
+      setKeyPressed(true);
     }
+  };
 
-    function upHandler({key}: KeyboardEvent) {
-      if (key === targetKey) {
-        setKeyPressed(false);
-      }
+  const upHandler = ({key}: KeyboardEvent) => {
+    if (key === targetKey) {
+      setKeyPressed(false);
     }
-    window.addEventListener('keydown', downHandler);
-    window.addEventListener('keyup', upHandler);
+  };
+
+  useEffect(() => {
+    const current = ref?.current || window;
+    // @ts-ignore
+    current?.addEventListener('keydown', downHandler);
+    // @ts-ignore
+    current?.addEventListener('keyup', upHandler);
 
     return () => {
-      window.removeEventListener('keydown', downHandler);
-      window.removeEventListener('keyup', upHandler);
+      // @ts-ignore
+      current?.removeEventListener('keydown', downHandler);
+      // @ts-ignore
+      current?.removeEventListener('keyup', upHandler);
     };
-  }, [targetKey]);
+  });
 
   return keyPressed;
-}
+};
 
 export default useKeyPress;

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -3,10 +3,7 @@ import {useEffect, useState} from 'react';
 /**
  * Hook to detect when a specific key is being pressed
  */
-const useKeyPress = (
-  targetKey: string,
-  targetRef?: React.RefObject<HTMLInputElement>
-) => {
+const useKeyPress = (targetKey: string, targetRef?: React.RefObject<HTMLElement>) => {
   const [keyPressed, setKeyPressed] = useState(false);
 
   useEffect(() => {
@@ -22,13 +19,13 @@ const useKeyPress = (
       }
     };
 
-    const current: any = targetRef?.current ?? window;
-    current?.addEventListener('keydown', downHandler);
-    current?.addEventListener('keyup', upHandler);
+    const current = targetRef?.current ?? window;
+    (current as HTMLElement)?.addEventListener('keydown', downHandler);
+    (current as HTMLElement)?.addEventListener('keyup', upHandler);
 
     return () => {
-      current?.removeEventListener('keydown', downHandler);
-      current?.removeEventListener('keyup', upHandler);
+      (current as HTMLElement)?.removeEventListener('keydown', downHandler);
+      (current as HTMLElement)?.removeEventListener('keyup', upHandler);
     };
   }, [targetKey, targetRef]);
 

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -1,37 +1,39 @@
-import {RefObject, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 /**
  * Hook to detect when a specific key is being pressed
  */
-const useKeyPress = (targetKey: string, ref?: RefObject<HTMLInputElement>) => {
+const useKeyPress = (
+  targetKey: string,
+  targetRef?: React.RefObject<HTMLInputElement>
+) => {
   const [keyPressed, setKeyPressed] = useState(false);
 
-  const downHandler = ({key}: KeyboardEvent) => {
-    if (key === targetKey) {
-      setKeyPressed(true);
-    }
-  };
-
-  const upHandler = ({key}: KeyboardEvent) => {
-    if (key === targetKey) {
-      setKeyPressed(false);
-    }
-  };
-
   useEffect(() => {
-    const current = ref?.current || window;
-    // @ts-ignore
-    current?.addEventListener('keydown', downHandler);
-    // @ts-ignore
-    current?.addEventListener('keyup', upHandler);
+    const downHandler = ({key}: KeyboardEvent) => {
+      if (key === targetKey) {
+        setKeyPressed(true);
+      }
+    };
+
+    const upHandler = ({key}: KeyboardEvent) => {
+      if (key === targetKey) {
+        setKeyPressed(false);
+      }
+    };
+
+    let current: any = window;
+    if (targetRef?.current) {
+      current = targetRef?.current;
+    }
+    current.addEventListener('keydown', downHandler);
+    current.addEventListener('keyup', upHandler);
 
     return () => {
-      // @ts-ignore
-      current?.removeEventListener('keydown', downHandler);
-      // @ts-ignore
-      current?.removeEventListener('keyup', upHandler);
+      current.removeEventListener('keydown', downHandler);
+      current.removeEventListener('keyup', upHandler);
     };
-  });
+  })[targetKey];
 
   return keyPressed;
 };

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -19,13 +19,13 @@ const useKeyPress = (targetKey: string, targetRef?: React.RefObject<HTMLElement>
       }
     };
 
-    const current = targetRef?.current ?? window;
-    (current as HTMLElement)?.addEventListener('keydown', downHandler);
-    (current as HTMLElement)?.addEventListener('keyup', upHandler);
+    const current = targetRef?.current ?? document.body;
+    current?.addEventListener('keydown', downHandler);
+    current?.addEventListener('keyup', upHandler);
 
     return () => {
-      (current as HTMLElement)?.removeEventListener('keydown', downHandler);
-      (current as HTMLElement)?.removeEventListener('keyup', upHandler);
+      current?.removeEventListener('keydown', downHandler);
+      current?.removeEventListener('keyup', upHandler);
     };
   }, [targetKey, targetRef]);
 


### PR DESCRIPTION

<!-- Describe your PR here. -->

Adds optional ref object to the useKeyPress util method (as opposed to just window)

This allows us to attach keypress events to multiple components within the same window.

Mainly borrowed from [here](https://newdevzone.com/posts/react-how-to-navigate-through-list-by-arrow-keys)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
