### PR TITLE
fix(ui): Fix overflowing release details filters on mobile

### DIFF
--- a/static/app/components/organizations/headerItem.tsx
+++ b/static/app/components/organizations/headerItem.tsx
@@ -129,6 +129,7 @@ const StyledHeaderItem = styled('div', {
 const Content = styled('div')`
   display: flex;
   flex: 1;
+  width: 0;
   white-space: nowrap;
   overflow: hidden;
   margin-right: ${space(1.5)};

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -716,6 +716,10 @@ const ReleaseDetailsPageFilters = styled('div')`
   grid-template-columns: minmax(0, max-content) 1fr;
   gap: ${space(2)};
   margin-bottom: ${space(2)};
+
+  @media (max-width: ${p => p.theme.breakpoints.small}) {
+    grid-template-columns: auto;
+  }
 `;
 
 const StyledPageTimeRangeSelector = styled(PageTimeRangeSelector)`


### PR DESCRIPTION
Before:

<img width="424" alt="image" src="https://user-images.githubusercontent.com/10888943/192647843-f050bb33-97f5-4269-8b6a-954e5ac3acba.png">

After:

<img width="410" alt="image" src="https://user-images.githubusercontent.com/10888943/192647762-8b378b9a-8771-44cd-93b1-a7b5f51f49ec.png">
