### PR TITLE
feat(empty-stacktraces): Add the empty_stacktrace.js_console tag to Issue Search frontend

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -142,7 +142,13 @@ def convert_query_values(search_filters, projects, user, environments):
     :return: New collection of `SearchFilters`, which may have converted values.
     """
 
-    def convert_search_filter(search_filter):
+    def convert_search_filter(search_filter, organization):
+        if search_filter.key.name == "empty_stacktrace.js_console":
+            if not features.has("organizations:filter-empty-console-errors", organization):
+                raise InvalidSearchQuery(
+                    "The empty_stacktrace.js_console filter is not supported for this organization"
+                )
+
         if search_filter.key.name in value_converters:
             converter = value_converters[search_filter.key.name]
             new_value = converter(
@@ -162,4 +168,5 @@ def convert_query_values(search_filters, projects, user, environments):
             )
         return search_filter
 
-    return [convert_search_filter(search_filter) for search_filter in search_filters]
+    organization = projects[0].organization
+    return [convert_search_filter(search_filter, organization) for search_filter in search_filters]

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -82,6 +82,7 @@ default_manager.add("organizations:discover-frontend-use-events-endpoint", Organ
 default_manager.add("organizations:discover-interval-selector", OrganizationFeature, True)
 default_manager.add("organizations:discover-query-builder-as-landing-page", OrganizationFeature, True)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)
+default_manager.add("organizations:filter-empty-console-errors", OrganizationFeature, True)
 default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-title-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-tree-ui", OrganizationFeature, True)

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from sentry.models import Project, Release
 from sentry.stacktraces.functions import set_in_app, trim_function_name
+from sentry.stacktraces.platform import JAVASCRIPT_PLATFORMS
 from sentry.utils.cache import cache
 from sentry.utils.hashlib import hash_values
 from sentry.utils.safe import get_path, safe_execute
@@ -489,6 +490,35 @@ def dedup_errors(errors):
     return rv
 
 
+def suspected_console_errors(mechanism, error_type, frames):
+    def is_suspicious_frame(frame) -> bool:
+        function = frame.get("function", None)
+        filename = frame.get("filename", None)
+        return function == "?" and filename == "<anonymous>"
+
+    def has_suspicious_frames(frames) -> bool:
+        if len(frames) == 2 and is_suspicious_frame(frames[0]):
+            return True
+        return all(is_suspicious_frame(frame) for frame in frames)
+
+    if (
+        not frames
+        or not mechanism
+        or mechanism.get("type") != "onerror"
+        or mechanism.get("handled")
+    ):
+        return False
+
+    has_short_stacktrace = len(frames) <= 2
+    is_suspicious_error = error_type.lower() in [
+        "syntaxerror",
+        "referenceerror",
+        "typeerror",
+    ]
+
+    return has_short_stacktrace and is_suspicious_error and has_suspicious_frames(frames)
+
+
 def process_stacktraces(data, make_processors=None, set_raw_stacktrace=True):
     infos = find_stacktraces_in_data(data, with_exceptions=True)
     if make_processors is None:
@@ -520,7 +550,8 @@ def process_stacktraces(data, make_processors=None, set_raw_stacktrace=True):
         # Process all stacktraces
         for stacktrace_info, processable_frames in processing_task.iter_processable_stacktraces():
             # Let the stacktrace processors touch the exception
-            if stacktrace_info.is_exception and stacktrace_info.container:
+            is_exception = stacktrace_info.is_exception and stacktrace_info.container
+            if is_exception:
                 for processor in processing_task.iter_processors():
                     with sentry_sdk.start_span(
                         op="stacktraces.processing.process_stacktraces.process_exception"
@@ -543,6 +574,15 @@ def process_stacktraces(data, make_processors=None, set_raw_stacktrace=True):
                     stacktrace_info.stacktrace["frames"] = new_frames
                     changed = True
                     span.set_data("data_changed", True)
+
+                mechanism = stacktrace_info.container.get("mechanism") if is_exception else None
+                error_type = stacktrace_info.container.get("type") if is_exception else None
+                with sentry_sdk.configure_scope() as scope:
+                    if JAVASCRIPT_PLATFORMS in stacktrace_info.platforms:
+                        scope.set_tag(
+                            "empty_stacktrace.js_console",
+                            suspected_console_errors(mechanism, error_type, new_frames),
+                        )
             if (
                 set_raw_stacktrace
                 and new_raw_frames is not None

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -80,6 +80,7 @@ export enum FieldKey {
   STACK_PACKAGE = 'stack.package',
   STACK_RESOURCE = 'stack.resource',
   STACK_STACK_LEVEL = 'stack.stack_level',
+  EMPTY_STACKTRACE_JS_CONSOLE = 'empty_stacktrace.js_console',
   TIMESTAMP = 'timestamp',
   TIMESTAMP_TO_DAY = 'timestamp.to_day',
   TIMESTAMP_TO_HOUR = 'timestamp.to_hour',
@@ -786,6 +787,11 @@ const FIELD_DEFINITIONS: Record<AllFieldKeys, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.NUMBER,
   },
+  [FieldKey.EMPTY_STACKTRACE_JS_CONSOLE]: {
+    desc: t('Errors from Javascript browser console'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.BOOLEAN,
+  },
   [FieldKey.TIMES_SEEN]: {
     desc: t('Total number of events'),
     kind: FieldKind.FIELD,
@@ -932,6 +938,7 @@ export const ISSUE_FIELDS = [
   FieldKey.STACK_MODULE,
   FieldKey.STACK_PACKAGE,
   FieldKey.STACK_STACK_LEVEL,
+  FieldKey.EMPTY_STACKTRACE_JS_CONSOLE,
   FieldKey.TIMESTAMP,
   FieldKey.TIMES_SEEN,
   FieldKey.TITLE,

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -158,6 +158,22 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
 
+class ConvertJavaScriptConsoleTagTest(TestCase):
+    def test_valid(self):
+        filters = [SearchFilter(SearchKey("empty_stacktrace.js_console"), "=", SearchValue(True))]
+        with self.feature("organizations:filter-empty-console-errors"):
+            result = convert_query_values(filters, [self.project], self.user, None)
+            assert result[0].value.raw_value is True
+
+    def test_invalid(self):
+        filters = [SearchFilter(SearchKey("empty_stacktrace.js_console"), "=", SearchValue(True))]
+        with pytest.raises(
+            InvalidSearchQuery,
+            match="The empty_stacktrace.js_console filter is not supported for this organization",
+        ):
+            convert_query_values(filters, [self.project], self.user, None)
+
+
 class ConvertQueryValuesTest(TestCase):
     def test_valid_converter(self):
         filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("me"))]


### PR DESCRIPTION
Add the empty_stacktrace.js_console tag to be searchable on the Issue Stream, with a feature flag.

The feature flag will make this available within Sentry.

#39375 and WOR-2187.