### PR TITLE
ref(ui): Use monospace for Activity note textarea

### DIFF
--- a/static/app/components/activity/note/mentionStyle.tsx
+++ b/static/app/components/activity/note/mentionStyle.tsx
@@ -20,6 +20,7 @@ export default function mentionStyle({theme, minHeight}: Options) {
 
     input: {
       margin: 0,
+      fontFamily: theme.text.familyMono,
     },
 
     '&singleLine': {


### PR DESCRIPTION
Github does this and it's nice to write code blocks with

<img width="355" alt="image" src="https://user-images.githubusercontent.com/1421724/193117990-864a5ac5-3fff-4ad3-aa90-0f60cd04eca7.png">
