### PR TITLE
ref(pageFilters): Update desync alert

### DIFF
--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -30,6 +30,14 @@ type Props = WithRouterProps &
   InitializeUrlStateProps & {
     children?: React.ReactNode;
     /**
+     * Custom alert message for the desynced filter state.
+     */
+    desyncedAlertMessage?: string;
+    /**
+     * Whether to hide the revert button in the desynced filter alert.
+     */
+    hideDesyncRevertButton?: boolean;
+    /**
      * Slugs of projects to display in project selector
      */
     specificProjectSlugs?: string[];
@@ -50,6 +58,8 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     shouldForceProject,
     specificProjectSlugs,
     skipInitializeUrlParams,
+    desyncedAlertMessage,
+    hideDesyncRevertButton,
   } = props;
 
   const {isReady} = usePageFilters();
@@ -163,7 +173,11 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
 
   return (
     <Fragment>
-      <DesyncedFilterAlert router={router} />
+      <DesyncedFilterAlert
+        router={router}
+        message={desyncedAlertMessage}
+        hideRevertButton={hideDesyncRevertButton}
+      />
       {children}
     </Fragment>
   );

--- a/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
@@ -8,6 +8,7 @@ import Button from 'sentry/components/button';
 import {IconClose} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import {PinnedPageFilter} from 'sentry/types';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
@@ -17,13 +18,13 @@ type Props = {
   message?: string;
 };
 
-const filterNameMap = {
-  projects: 'project',
-  environments: 'environment',
-  date: 'date',
+const filterNameMap: Record<PinnedPageFilter, string> = {
+  projects: t('project'),
+  environments: t('environment'),
+  datetime: t('date'),
 };
 
-function getReadableDesyncedFilterList(desyncedFilters) {
+function getReadableDesyncedFilterList(desyncedFilters: Set<PinnedPageFilter>) {
   const filters = [...desyncedFilters];
 
   if (filters.length === 1) {

--- a/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
@@ -6,16 +6,41 @@ import {revertToPinnedFilters} from 'sentry/actionCreators/pageFilters';
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import {IconClose} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 
 type Props = {
   router: InjectedRouter;
+  hideRevertButton?: boolean;
+  message?: string;
 };
 
-export default function DesyncedFilterAlert({router}: Props) {
+const filterNameMap = {
+  projects: 'project',
+  environments: 'environment',
+  date: 'date',
+};
+
+function getReadableDesyncedFilterList(desyncedFilters) {
+  const filters = [...desyncedFilters];
+
+  if (filters.length === 1) {
+    return `${filterNameMap[filters[0]]} filter`;
+  }
+
+  return `${filters
+    .slice(0, -1)
+    .map(value => filterNameMap[value])
+    .join(', ')} and ${filterNameMap[filters[filters.length - 1]]} filters`;
+}
+
+export default function DesyncedFilterAlert({
+  router,
+  message,
+  hideRevertButton = false,
+}: Props) {
   const {desyncedFilters} = usePageFilters();
   const organization = useOrganization();
   const [hideAlert, setHideAlert] = useState(false);
@@ -29,15 +54,17 @@ export default function DesyncedFilterAlert({router}: Props) {
   }
 
   return (
-    <Alert
+    <DesyncedAlert
       type="info"
       showIcon
       system
       trailingItems={
         <Fragment>
-          <RevertButton priority="link" size="zero" onClick={onRevertClick} borderless>
-            {t('Revert')}
-          </RevertButton>
+          {!hideRevertButton && (
+            <RevertButton priority="link" size="zero" onClick={onRevertClick} borderless>
+              {t('Restore old values')}
+            </RevertButton>
+          )}
           <Button
             priority="link"
             size="zero"
@@ -48,12 +75,21 @@ export default function DesyncedFilterAlert({router}: Props) {
         </Fragment>
       }
     >
-      {t(
-        "You're viewing a shared link. Certain queries and filters have been automatically filled from URL parameters."
+      {tct(
+        message ??
+          'The [filter] [has] been overwritten. This can happen when you open sentry.io links with filter parameters that are different from your current filter values.',
+        {
+          filter: getReadableDesyncedFilterList(desyncedFilters),
+          has: desyncedFilters.size > 1 ? t('have') : t('has'),
+        }
       )}
-    </Alert>
+    </DesyncedAlert>
   );
 }
+
+const DesyncedAlert = styled(Alert)`
+  margin-bottom: 0;
+`;
 
 const RevertButton = styled(Button)`
   display: flex;

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -606,6 +606,8 @@ class DashboardDetail extends Component<Props, State> {
 
     return (
       <PageFiltersContainer
+        desyncedAlertMessage='Using filter values saved to this dashboard. To edit saved filters, click "Edit Dashboard".'
+        hideDesyncRevertButton
         defaultSelection={{
           datetime: {
             start: null,
@@ -723,6 +725,8 @@ class DashboardDetail extends Component<Props, State> {
     return (
       <SentryDocumentTitle title={dashboard.title} orgSlug={organization.slug}>
         <PageFiltersContainer
+          desyncedAlertMessage='Using filter values saved to this dashboard. To edit saved filters, click "Edit Dashboard".'
+          hideDesyncRevertButton
           defaultSelection={{
             datetime: {
               start: null,


### PR DESCRIPTION
A few improvements to the desynced filter alert:
* An updated default message that mentions which filters are desynced
* Ability to add custom, page-specific desync messages. These custom messages are useful for pages where there might be a different reason why the filters are desynced, including Dashboards and, at some point in the future, Discover.

**Before:**
<img width="1199" alt="Screen Shot 2022-09-27 at 5 19 03 PM" src="https://user-images.githubusercontent.com/44172267/192659790-111c1b43-fa80-4429-8358-eb291f33a78b.png">

**After, default message:**
<img width="1199" alt="Screen Shot 2022-09-27 at 5 13 37 PM" src="https://user-images.githubusercontent.com/44172267/192659701-9453c8d2-f209-4708-b456-920f43925515.png">

**After, custom message in Dashboards:**
<img width="1199" alt="Screen Shot 2022-09-27 at 5 13 45 PM" src="https://user-images.githubusercontent.com/44172267/192659706-68dd5038-6d65-4abf-aaeb-dd29853fbf38.png">
