### PR TITLE
feat(perf-issue): introduce multiple groups to post process forwarder

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1090,15 +1090,16 @@ def _eventstream_insert_many(jobs):
             is_new_group_environment = group_info.is_new_group_environment
 
             # performance issues with potentially multiple groups to a transaction
-            group_states = {
-                gi.group.id: {
+            group_states = [
+                {
+                    "id": gi.group.id,
                     "is_new": gi.is_new,
                     "is_regression": gi.is_regression,
                     "is_new_group_environment": gi.is_new_group_environment,
                 }
                 for gi in job["groups"]
                 if gi is not None
-            }
+            ]
 
         eventstream.insert(
             event=job["event"],

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1083,14 +1083,21 @@ def _eventstream_insert_many(jobs):
             is_regression = False
             is_new_group_environment = False
         else:
+            # error issues
+            group_info = job["groups"][0]
+            is_new = group_info.is_new
+            is_regression = group_info.is_regression
+            is_new_group_environment = group_info.is_new_group_environment
+
+            # performance issues with potentially multiple groups to a transaction
             group_states = {
-                g.id: {
-                    "is_new": g.is_new,
-                    "is_regression": g.is_regression,
-                    "is_new_group_environment": g.is_new_group_environment,
+                gi.group.id: {
+                    "is_new": gi.is_new,
+                    "is_regression": gi.is_regression,
+                    "is_new_group_environment": gi.is_new_group_environment,
                 }
-                for g in job["groups"]
-                if g is not None
+                for gi in job["groups"]
+                if gi is not None
             }
 
         eventstream.insert(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1078,14 +1078,20 @@ def _eventstream_insert_many(jobs):
         # XXX: Temporary hack so that we keep this group info working for error issues. We'll need
         # to change the format of eventstream to be able to handle data for multiple groups
         if not job["groups"]:
+            group_states = None
             is_new = False
             is_regression = False
             is_new_group_environment = False
         else:
-            group_info = job["groups"][0]
-            is_new = group_info.is_new
-            is_regression = group_info.is_regression
-            is_new_group_environment = group_info.is_new_group_environment
+            group_states = {
+                g.id: {
+                    "is_new": g.is_new,
+                    "is_regression": g.is_regression,
+                    "is_new_group_environment": g.is_new_group_environment,
+                }
+                for g in job["groups"]
+                if g is not None
+            }
 
         eventstream.insert(
             event=job["event"],
@@ -1100,6 +1106,7 @@ def _eventstream_insert_many(jobs):
             # through the event stream, but we don't care
             # about post processing and handling the commit.
             skip_consume=job.get("raw", False),
+            group_states=group_states,
         )
 
 

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -38,8 +38,7 @@ class GroupState(TypedDict):
     is_new_group_environment: bool
 
 
-class GroupsState(TypedDict):
-    groups: Mapping[int, GroupState]
+GroupStates = Mapping[int, GroupState]
 
 
 class EventStream(Service):
@@ -70,7 +69,7 @@ class EventStream(Service):
         is_new_group_environment: bool,
         primary_hash: Optional[str],
         skip_consume: bool = False,
-        groups_state: Optional[GroupsState] = None,
+        group_states: Optional[GroupStates] = None,
     ) -> None:
         if skip_consume:
             logger.info("post_process.skip.raw_event", extra={"event_id": event_id})
@@ -95,7 +94,7 @@ class EventStream(Service):
         primary_hash: Optional[str],
         received_timestamp: float,
         skip_consume: bool = False,
-        groups_state: GroupsState | None = None,
+        group_states: GroupStates | None = None,
     ) -> None:
         self._dispatch_post_process_group_task(
             event.event_id,
@@ -106,7 +105,7 @@ class EventStream(Service):
             is_new_group_environment,
             primary_hash,
             skip_consume,
-            groups_state,
+            group_states,
         )
 
     def start_delete_groups(

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -2,7 +2,17 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Collection, Literal, Mapping, Optional, Sequence, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Collection,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    TypedDict,
+    Union,
+)
 
 from sentry.tasks.post_process import post_process_group
 from sentry.utils.cache import cache_key_for_event
@@ -20,6 +30,16 @@ class ForwarderNotRequired(NotImplementedError):
     Exception raised if this backend does not require a forwarder process to
     enqueue post-processing tasks.
     """
+
+
+class GroupState(TypedDict):
+    is_new: bool
+    is_regression: bool
+    is_new_group_environment: bool
+
+
+class GroupsState(TypedDict):
+    groups: Mapping[int, GroupState]
 
 
 class EventStream(Service):
@@ -50,6 +70,7 @@ class EventStream(Service):
         is_new_group_environment: bool,
         primary_hash: Optional[str],
         skip_consume: bool = False,
+        groups_state: Optional[GroupsState] = None,
     ) -> None:
         if skip_consume:
             logger.info("post_process.skip.raw_event", extra={"event_id": event_id})
@@ -74,6 +95,7 @@ class EventStream(Service):
         primary_hash: Optional[str],
         received_timestamp: float,
         skip_consume: bool = False,
+        groups_state: GroupsState | None = None,
     ) -> None:
         self._dispatch_post_process_group_task(
             event.event_id,
@@ -84,6 +106,7 @@ class EventStream(Service):
             is_new_group_environment,
             primary_hash,
             skip_consume,
+            groups_state,
         )
 
     def start_delete_groups(

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -36,6 +36,7 @@ class GroupState(TypedDict):
     is_new: bool
     is_regression: bool
     is_new_group_environment: bool
+    primary_hash: Optional[str]
 
 
 GroupStates = Mapping[int, GroupState]

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -36,7 +36,6 @@ class GroupState(TypedDict):
     is_new: bool
     is_regression: bool
     is_new_group_environment: bool
-    primary_hash: Optional[str]
 
 
 GroupStates = Mapping[int, GroupState]

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -33,12 +33,13 @@ class ForwarderNotRequired(NotImplementedError):
 
 
 class GroupState(TypedDict):
+    id: int
     is_new: bool
     is_regression: bool
     is_new_group_environment: bool
 
 
-GroupStates = Mapping[int, GroupState]
+GroupStates = Sequence[GroupState]
 
 
 class EventStream(Service):
@@ -94,7 +95,7 @@ class EventStream(Service):
         primary_hash: Optional[str],
         received_timestamp: float,
         skip_consume: bool = False,
-        group_states: GroupStates | None = None,
+        group_states: Optional[GroupStates] = None,
     ) -> None:
         self._dispatch_post_process_group_task(
             event.event_id,

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -6,7 +6,7 @@ from confluent_kafka import Producer
 from django.conf import settings
 
 from sentry import options
-from sentry.eventstream.base import GroupsState
+from sentry.eventstream.base import GroupStates
 from sentry.eventstream.kafka.consumer import SynchronizedConsumer
 from sentry.eventstream.kafka.postprocessworker import (
     ErrorsPostProcessForwarderWorker,
@@ -58,7 +58,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
         primary_hash,
         received_timestamp: float,
         skip_consume,
-        groups_state: Optional[GroupsState] = None,
+        group_states: Optional[GroupStates] = None,
     ) -> Mapping[str, str]:
 
         # HACK: We are putting all this extra information that is required by the
@@ -98,7 +98,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
                     "is_regression": encode_bool(is_regression),
                     "skip_consume": encode_bool(skip_consume),
                     "transaction_forwarder": encode_bool(transaction_forwarder),
-                    "groups_state": encode_dict(groups_state) if groups_state is not None else None,
+                    "group_states": encode_dict(group_states) if group_states is not None else None,
                 }
             )
         else:
@@ -123,7 +123,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
         primary_hash,
         received_timestamp: float,
         skip_consume=False,
-        groups_state: Optional[GroupsState] = None,
+        group_states: Optional[GroupStates] = None,
         **kwargs,
     ):
         message_type = "transaction" if self._is_transaction_event(event) else "error"
@@ -147,7 +147,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
             primary_hash,
             received_timestamp,
             skip_consume,
-            groups_state,
+            group_states,
             **kwargs,
         )
 

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -1,6 +1,6 @@
 import logging
 import signal
-from typing import Any, Literal, Mapping, MutableMapping, Optional, Tuple, Union
+from typing import Any, Literal, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
 
 from confluent_kafka import Producer
 from django.conf import settings
@@ -71,7 +71,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
                 value = False
             return str(int(value))
 
-        def encode_dict(value: Mapping[Any, Any]) -> str:
+        def encode_list(value: Sequence[Any]) -> str:
             return json.dumps(value)
 
         # we strip `None` values here so later in the pipeline they can be
@@ -98,7 +98,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
                     "is_regression": encode_bool(is_regression),
                     "skip_consume": encode_bool(skip_consume),
                     "transaction_forwarder": encode_bool(transaction_forwarder),
-                    "group_states": encode_dict(group_states) if group_states is not None else None,
+                    "group_states": encode_list(group_states) if group_states is not None else None,
                 }
             )
         else:

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -5,6 +5,7 @@ from typing import Any, Literal, Mapping, MutableMapping, Optional, Tuple, Union
 from confluent_kafka import Producer
 from django.conf import settings
 
+from sentry import options
 from sentry.eventstream.base import GroupStates
 from sentry.eventstream.kafka.consumer import SynchronizedConsumer
 from sentry.eventstream.kafka.postprocessworker import (
@@ -78,21 +79,40 @@ class KafkaEventStream(SnubaProtocolEventStream):
         def strip_none_values(value: Mapping[str, Optional[str]]) -> Mapping[str, str]:
             return {key: value for key, value in value.items() if value is not None}
 
-        return strip_none_values(
-            {
-                "Received-Timestamp": str(received_timestamp),
-                "event_id": str(event.event_id),
-                "project_id": str(event.project_id),
-                "group_id": str(event.group_id) if event.group_id is not None else None,
-                "primary_hash": str(primary_hash) if primary_hash is not None else None,
-                "is_new": encode_bool(is_new),
-                "is_new_group_environment": encode_bool(is_new_group_environment),
-                "is_regression": encode_bool(is_regression),
-                "skip_consume": encode_bool(skip_consume),
-                "transaction_forwarder": encode_bool(self._is_transaction_event(event)),
-                "group_states": encode_dict(group_states) if group_states is not None else None,
+        # transaction_forwarder header is not sent if option "eventstream:kafka-headers"
+        # is not set to avoid increasing consumer lag on shared events topic.
+        transaction_forwarder = self._is_transaction_event(event)
+
+        send_new_headers = options.get("eventstream:kafka-headers")
+
+        if send_new_headers is True:
+            return strip_none_values(
+                {
+                    "Received-Timestamp": str(received_timestamp),
+                    "event_id": str(event.event_id),
+                    "project_id": str(event.project_id),
+                    "group_id": str(event.group_id) if event.group_id is not None else None,
+                    "primary_hash": str(primary_hash) if primary_hash is not None else None,
+                    "is_new": encode_bool(is_new),
+                    "is_new_group_environment": encode_bool(is_new_group_environment),
+                    "is_regression": encode_bool(is_regression),
+                    "skip_consume": encode_bool(skip_consume),
+                    "transaction_forwarder": encode_bool(transaction_forwarder),
+                    "group_states": encode_dict(group_states) if group_states is not None else None,
+                }
+            )
+        else:
+            return {
+                **super()._get_headers_for_insert(
+                    event,
+                    is_new,
+                    is_regression,
+                    is_new_group_environment,
+                    primary_hash,
+                    received_timestamp,
+                    skip_consume,
+                ),
             }
-        )
 
     def insert(
         self,

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -71,7 +71,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
                 value = False
             return str(int(value))
 
-        def encode_dict(value: Mapping) -> str:
+        def encode_dict(value: Mapping[Any, Any]) -> str:
             return json.dumps(value)
 
         # we strip `None` values here so later in the pipeline they can be

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -191,18 +191,13 @@ def get_task_kwargs_for_message_from_headers(
                 "is_new_group_environment": is_new_group_environment,
             }
 
-            if "group_states" not in header_data:
-                header_data["group_states"] = None
-
-            group_states_str = None
+            group_states_str = decode_optional_str(header_data.get("group_states"))
+            group_states = None
             try:
-                group_states_str = decode_optional_str(header_data["group_states"])
                 group_states = decode_optional_dict_str(group_states_str)
             except ValueError:
-                group_states = None
                 logger.error(f"Received event with malformed group_states: '{group_states_str}'")
             except Exception:
-                group_states = None
                 logger.error(
                     f"Uncaught exception thrown when trying to parse group_states: '{group_states_str}'"
                 )

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -1,5 +1,15 @@
 import logging
-from typing import Any, Callable, FrozenSet, Mapping, Optional, Sequence, Tuple, cast
+from typing import (
+    Any,
+    Callable,
+    FrozenSet,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    cast,
+)
 
 from sentry.utils import json, metrics
 
@@ -182,7 +192,7 @@ def get_task_kwargs_for_message_from_headers(
                 cast(bytes, header_data["is_new_group_environment"])
             )
 
-            task_state = {
+            task_state: MutableMapping[str, Any] = {
                 "skip_consume": skip_consume,
                 "is_new": is_new,
                 "is_regression": is_regression,

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -147,7 +147,7 @@ def decode_optional_dict_str(value: Optional[bytes]) -> Optional[Mapping[Any, An
     if not isinstance(parsed, dict):
         raise ValueError(f"'{dict_str}' could not be parsed into an instance of dict.")
 
-    return json.loads(dict_str)
+    return cast(Mapping[Any, Any], json.loads(dict_str))
 
 
 def get_task_kwargs_for_message_from_headers(

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -136,6 +136,20 @@ def decode_bool(value: bytes) -> bool:
     return bool(int(decode_str(value)))
 
 
+def decode_optional_dict_str(value: Optional[bytes]) -> Optional[Mapping[Any, Any]]:
+    if value is None:
+        return None
+    dict_str = decode_optional_str(value)
+    if dict_str is None:
+        return None
+
+    parsed = json.loads(dict_str)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"'{dict_str}' could not be parsed into an instance of dict.")
+
+    return json.loads(dict_str)
+
+
 def get_task_kwargs_for_message_from_headers(
     headers: Sequence[Tuple[str, Optional[bytes]]]
 ) -> Optional[Mapping[str, Any]]:
@@ -182,8 +196,11 @@ def get_task_kwargs_for_message_from_headers(
 
             if "group_states" not in header_data:
                 header_data["group_states"] = None
-            group_states_str = decode_optional_str(header_data["group_states"])
-            group_states = json.loads(group_states_str) if group_states_str else None
+            try:
+                group_states = decode_optional_dict_str(header_data["group_states"])
+            except ValueError:
+                group_states = None
+
         else:
             event_data = {}
             task_state = {}

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -44,7 +44,7 @@ def basic_protocol_handler(
         for name in ("is_new", "is_regression", "is_new_group_environment"):
             kwargs[name] = task_state[name]
 
-        if task_state and task_state.get("group_states"):
+        if task_state:
             kwargs["group_states"] = task_state.get("group_states")
 
         return kwargs

--- a/src/sentry/eventstream/kafka/protocol.py
+++ b/src/sentry/eventstream/kafka/protocol.py
@@ -136,15 +136,15 @@ def decode_bool(value: bytes) -> bool:
     return bool(int(decode_str(value)))
 
 
-def decode_optional_dict_str(value: Optional[str]) -> Optional[Mapping[Any, Any]]:
+def decode_optional_list_str(value: Optional[str]) -> Optional[Sequence[Any]]:
     if value is None:
         return None
 
     parsed = json.loads(value)
-    if not isinstance(parsed, dict):
-        raise ValueError(f"'{value}' could not be parsed into an instance of dict.")
+    if not isinstance(parsed, list):
+        raise ValueError(f"'{value}' could not be parsed into an instance of list.")
 
-    return cast(Mapping[Any, Any], json.loads(value))
+    return cast(Sequence[Any], json.loads(value))
 
 
 def get_task_kwargs_for_message_from_headers(
@@ -193,8 +193,9 @@ def get_task_kwargs_for_message_from_headers(
 
             group_states_str = decode_optional_str(header_data.get("group_states"))
             group_states = None
+            # TODO: remove this try/except once rollout is complete and don't observe any errors in logs
             try:
-                group_states = decode_optional_dict_str(group_states_str)
+                group_states = decode_optional_list_str(group_states_str)
             except ValueError:
                 logger.error(f"Received event with malformed group_states: '{group_states_str}'")
             except Exception:

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Collection,
+    List,
     Mapping,
     MutableMapping,
     Optional,
@@ -160,7 +161,7 @@ class SnubaProtocolEventStream(EventStream):
 
         is_transaction_event = self._is_transaction_event(event)
 
-        extra_data = [
+        extra_data: List[Mapping[Any, Any]] = [
             {
                 "group_id": event.group_id,
                 "group_ids": [group.id for group in event.groups],

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -185,7 +185,7 @@ class SnubaProtocolEventStream(EventStream):
         ]
 
         if groups_state is not None:
-            extra_data.append(groups_state)
+            extra_data.append({**groups_state})
 
         self._send(
             project.id,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -6,7 +6,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Collection,
-    List,
     Mapping,
     MutableMapping,
     Optional,
@@ -161,37 +160,32 @@ class SnubaProtocolEventStream(EventStream):
 
         is_transaction_event = self._is_transaction_event(event)
 
-        extra_data: List[Mapping[Any, Any]] = [
-            {
-                "group_id": event.group_id,
-                "group_ids": [group.id for group in event.groups],
-                "event_id": event.event_id,
-                "organization_id": project.organization_id,
-                "project_id": event.project_id,
-                # TODO(mitsuhiko): We do not want to send this incorrect
-                # message but this is what snuba needs at the moment.
-                "message": event.search_message,
-                "platform": event.platform,
-                "datetime": event.datetime,
-                "data": event_data,
-                "primary_hash": primary_hash,
-                "retention_days": retention_days,
-            },
-            {
-                "is_new": is_new,
-                "is_regression": is_regression,
-                "is_new_group_environment": is_new_group_environment,
-                "skip_consume": skip_consume,
-            },
-        ]
-
-        if group_states is not None:
-            extra_data.append({**group_states})
-
         self._send(
             project.id,
             "insert",
-            extra_data=tuple(extra_data),
+            extra_data=(
+                {
+                    "group_id": event.group_id,
+                    "group_ids": [group.id for group in event.groups],
+                    "event_id": event.event_id,
+                    "organization_id": project.organization_id,
+                    "project_id": event.project_id,
+                    # TODO(mitsuhiko): We do not want to send this incorrect
+                    # message but this is what snuba needs at the moment.
+                    "message": event.search_message,
+                    "platform": event.platform,
+                    "datetime": event.datetime,
+                    "data": event_data,
+                    "primary_hash": primary_hash,
+                    "retention_days": retention_days,
+                },
+                {
+                    "is_new": is_new,
+                    "is_regression": is_regression,
+                    "is_new_group_environment": is_new_group_environment,
+                    "skip_consume": skip_consume,
+                },
+            ),
             headers=headers,
             skip_semantic_partitioning=skip_semantic_partitioning,
             is_transaction_event=is_transaction_event,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -184,6 +184,7 @@ class SnubaProtocolEventStream(EventStream):
                     "is_regression": is_regression,
                     "is_new_group_environment": is_new_group_environment,
                     "skip_consume": skip_consume,
+                    "group_states": group_states,
                 },
             ),
             headers=headers,

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -20,7 +20,7 @@ import urllib3
 
 from sentry import quotas
 from sentry.eventstore.models import GroupEvent
-from sentry.eventstream.base import EventStream, GroupsState
+from sentry.eventstream.base import EventStream, GroupStates
 from sentry.utils import json, snuba
 from sentry.utils.safe import get_path
 from sentry.utils.sdk import set_current_event_project
@@ -101,7 +101,7 @@ class SnubaProtocolEventStream(EventStream):
         primary_hash: Optional[str],
         received_timestamp: float,
         skip_consume: bool,
-        groups_state: Optional[GroupsState] = None,
+        group_states: Optional[GroupStates] = None,
     ) -> Mapping[str, str]:
         return {"Received-Timestamp": str(received_timestamp)}
 
@@ -118,7 +118,7 @@ class SnubaProtocolEventStream(EventStream):
         primary_hash: Optional[str],
         received_timestamp: float,
         skip_consume: bool = False,
-        groups_state: Optional[GroupsState] = None,
+        group_states: Optional[GroupStates] = None,
         **kwargs: Any,
     ) -> None:
         if isinstance(event, GroupEvent):
@@ -149,7 +149,7 @@ class SnubaProtocolEventStream(EventStream):
             primary_hash,
             received_timestamp,
             skip_consume,
-            groups_state,
+            group_states,
         )
 
         skip_semantic_partitioning = (
@@ -184,8 +184,8 @@ class SnubaProtocolEventStream(EventStream):
             },
         ]
 
-        if groups_state is not None:
-            extra_data.append({**groups_state})
+        if group_states is not None:
+            extra_data.append({**group_states})
 
         self._send(
             project.id,
@@ -428,7 +428,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
         primary_hash: Optional[str],
         received_timestamp: float,
         skip_consume: bool = False,
-        groups_state: Optional[GroupsState] = None,
+        group_states: Optional[GroupStates] = None,
         **kwargs: Any,
     ) -> None:
         super().insert(
@@ -439,7 +439,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
             primary_hash,
             received_timestamp,
             skip_consume,
-            groups_state,
+            group_states,
             **kwargs,
         )
         self._dispatch_post_process_group_task(
@@ -451,5 +451,5 @@ class SnubaEventStream(SnubaProtocolEventStream):
             is_new_group_environment,
             primary_hash,
             skip_consume,
-            groups_state,
+            group_states,
         )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -416,6 +416,8 @@ register("relay.transaction-metrics-org-sample-rate", default=0.0)
 # new behavior: Treat transactions from old SDKs as low-cardinality, except for browser JS.
 register("relay.transaction-names-client-based", default=0.0)
 
+# Write new kafka headers in eventstream
+register("eventstream:kafka-headers", default=True)
 
 # Post process forwarder options
 # Gets data from Kafka headers

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -416,8 +416,6 @@ register("relay.transaction-metrics-org-sample-rate", default=0.0)
 # new behavior: Treat transactions from old SDKs as low-cardinality, except for browser JS.
 register("relay.transaction-names-client-based", default=0.0)
 
-# Write new kafka headers in eventstream
-register("eventstream:kafka-headers", default=True)
 
 # Post process forwarder options
 # Gets data from Kafka headers

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1322,7 +1322,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             primary_hash="acbd18db4cc2f85cedef654fccc4a4d8",
             skip_consume=False,
             received_timestamp=event.data["received"],
-            group_states={"id": event.groups[0].id, **group_states1},
+            group_states=[{"id": event.groups[0].id, **group_states1}],
         )
 
         event = save_event()
@@ -1341,7 +1341,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             primary_hash="acbd18db4cc2f85cedef654fccc4a4d8",
             skip_consume=False,
             received_timestamp=event.data["received"],
-            group_states={"id": event.groups[0].id, **group_states2},
+            group_states=[{"id": event.groups[0].id, **group_states2}],
         )
 
     def test_default_fingerprint(self):

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1322,7 +1322,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             primary_hash="acbd18db4cc2f85cedef654fccc4a4d8",
             skip_consume=False,
             received_timestamp=event.data["received"],
-            group_states={event.groups[0].id: group_states1},
+            group_states={"id": event.groups[0].id, **group_states1},
         )
 
         event = save_event()
@@ -1341,7 +1341,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             primary_hash="acbd18db4cc2f85cedef654fccc4a4d8",
             skip_consume=False,
             received_timestamp=event.data["received"],
-            group_states={event.groups[0].id: group_states2},
+            group_states={"id": event.groups[0].id, **group_states2},
         )
 
     def test_default_fingerprint(self):

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1309,30 +1309,39 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
 
         assert Release.objects.get(id=instance.first_release_id).version == release_version
 
+        group_states1 = {
+            "is_new": True,
+            "is_regression": False,
+            "is_new_group_environment": True,
+        }
         # Ensure that the first event in the (group, environment) pair is
         # marked as being part of a new environment.
         eventstream_insert.assert_called_with(
             event=event,
-            is_new=True,
-            is_regression=False,
-            is_new_group_environment=True,
+            **group_states1,
             primary_hash="acbd18db4cc2f85cedef654fccc4a4d8",
             skip_consume=False,
             received_timestamp=event.data["received"],
+            group_states={event.groups[0].id: group_states1},
         )
 
         event = save_event()
+
+        group_states2 = {
+            "is_new": False,
+            "is_regression": None,  # XXX: wut
+            "is_new_group_environment": False,
+        }
 
         # Ensure that the next event in the (group, environment) pair is *not*
         # marked as being part of a new environment.
         eventstream_insert.assert_called_with(
             event=event,
-            is_new=False,
-            is_regression=None,  # XXX: wut
-            is_new_group_environment=False,
+            **group_states2,
             primary_hash="acbd18db4cc2f85cedef654fccc4a4d8",
             skip_consume=False,
             received_timestamp=event.data["received"],
+            group_states={event.groups[0].id: group_states2},
         )
 
     def test_default_fingerprint(self):

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -631,6 +631,7 @@ def kafka_message_payload():
             "is_regression": None,
             "is_new_group_environment": False,
             "skip_consume": False,
+            "group_states": None,
         },
     ]
 

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -719,4 +719,5 @@ class BatchedConsumerTest(TestCase):
             is_new=False,
             is_regression=None,
             is_new_group_environment=False,
+            group_states=None,
         )

--- a/tests/sentry/eventstream/kafka/test_postprocessworker.py
+++ b/tests/sentry/eventstream/kafka/test_postprocessworker.py
@@ -29,6 +29,14 @@ def kafka_message_payload():
             "is_regression": None,
             "is_new_group_environment": False,
             "skip_consume": False,
+            "group_states": [
+                {
+                    "id": 43,
+                    "is_new": False,
+                    "is_regression": None,
+                    "is_new_group_environment": False,
+                }
+            ],
         },
     ]
 
@@ -84,6 +92,9 @@ def test_post_process_forwarder(
         is_new=False,
         is_regression=None,
         is_new_group_environment=False,
+        group_states=[
+            {"id": 43, "is_new": False, "is_regression": None, "is_new_group_environment": False}
+        ],
     )
 
     forwarder.shutdown()
@@ -117,6 +128,9 @@ def test_post_process_forwarder_bad_message_headers(
         is_new=False,
         is_regression=None,
         is_new_group_environment=False,
+        group_states=[
+            {"id": 43, "is_new": False, "is_regression": None, "is_new_group_environment": False}
+        ],
     )
 
     forwarder.shutdown()
@@ -165,6 +179,9 @@ def test_errors_post_process_forwarder_missing_headers(
         is_new=False,
         is_regression=None,
         is_new_group_environment=False,
+        group_states=[
+            {"id": 43, "is_new": False, "is_regression": None, "is_new_group_environment": False}
+        ],
     )
 
     forwarder.shutdown()
@@ -193,6 +210,9 @@ def test_errors_post_process_forwarder_false_headers(
         is_new=False,
         is_regression=None,
         is_new_group_environment=False,
+        group_states=[
+            {"id": 43, "is_new": False, "is_regression": None, "is_new_group_environment": False}
+        ],
     )
 
     forwarder.shutdown()
@@ -265,6 +285,9 @@ def test_transactions_post_process_forwarder_true_headers(
         is_new=False,
         is_regression=None,
         is_new_group_environment=False,
+        group_states=[
+            {"id": 43, "is_new": False, "is_regression": None, "is_new_group_environment": False}
+        ],
     )
 
     forwarder.shutdown()

--- a/tests/sentry/eventstream/kafka/test_protocol.py
+++ b/tests/sentry/eventstream/kafka/test_protocol.py
@@ -52,6 +52,7 @@ def test_get_task_kwargs_for_message_version_1():
     assert kwargs.pop("is_new") is True
     assert kwargs.pop("is_regression") is False
     assert kwargs.pop("is_new_group_environment") is True
+    assert kwargs.pop("group_states") is None
 
     assert not kwargs, f"unexpected values remaining: {kwargs!r}"
 

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -91,7 +91,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
             "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
             "skip_consume": False,
             "received_timestamp": event.data["received"],
-            "group_states": {"id": event.groups[0].id, **group_state},
+            "group_states": [{"id": event.groups[0].id, **group_state}],
         }
 
         self.__produce_event(*insert_args, **insert_kwargs)
@@ -150,7 +150,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
             "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
             "skip_consume": False,
             "received_timestamp": event.data["received"],
-            "group_states": {"id": event.groups[0].id, **group_state},
+            "group_states": [{"id": event.groups[0].id, **group_state}],
         }
 
         self.__produce_event(*insert_args, **insert_kwargs)

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -78,14 +78,20 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         # verify eventstream was called by EventManager
         insert_args, insert_kwargs = list(mock_eventstream_insert.call_args)
         assert not insert_args
-        assert insert_kwargs == {
-            "event": event,
+
+        group_state = {
             "is_new_group_environment": True,
             "is_new": True,
             "is_regression": False,
+        }
+
+        assert insert_kwargs == {
+            "event": event,
+            **group_state,
             "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
             "skip_consume": False,
             "received_timestamp": event.data["received"],
+            "group_states": {event.groups[0].id: group_state},
         }
 
         self.__produce_event(*insert_args, **insert_kwargs)
@@ -133,14 +139,18 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         event.group_id = None
         event.groups = [self.group]
         insert_args = ()
-        insert_kwargs = {
-            "event": event,
+        group_state = {
             "is_new_group_environment": True,
             "is_new": True,
             "is_regression": False,
+        }
+        insert_kwargs = {
+            "event": event,
+            **group_state,
             "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
             "skip_consume": False,
             "received_timestamp": event.data["received"],
+            "group_states": {event.groups[0].id: group_state},
         }
 
         self.__produce_event(*insert_args, **insert_kwargs)

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -91,7 +91,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
             "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
             "skip_consume": False,
             "received_timestamp": event.data["received"],
-            "group_states": {event.groups[0].id: group_state},
+            "group_states": {"id": event.groups[0].id, **group_state},
         }
 
         self.__produce_event(*insert_args, **insert_kwargs)
@@ -150,7 +150,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
             "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
             "skip_consume": False,
             "received_timestamp": event.data["received"],
-            "group_states": {event.groups[0].id: group_state},
+            "group_states": {"id": event.groups[0].id, **group_state},
         }
 
         self.__produce_event(*insert_args, **insert_kwargs)


### PR DESCRIPTION
With the introduction of Performance issues, the assumption that an event will create at most one Group must change. Errors will always correspond to a single Group, but transactions can support up to 10 different types of Groups being created to accommodate for the different detection methods for a single transaction.

To support `post_process_group` working for transactions that result in multiple Groups being created, we need to modify the `EventStream.insert` and `PostProcessForwarderWorker` to accept a datastructure like:
```
{
  1: {
    "is_new": False,
    "is_new_group_environment": False,
    "is_regression": False,
  },
  2: {
    "is_new": True,
    "is_new_group_environment": False,
    "is_regression": False,
  }
}
```
that describes the groups that were created and its associated task state.


Fixes ISP-13