### PR TITLE
feat(sampling): Add gatsby and svelte to supported sdks

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -33,6 +33,8 @@ ALLOWED_SDK_NAMES = frozenset(
         "sentry.javascript.node",  # Node, Express, koa
         "sentry.javascript.react-native",  # React Native
         "sentry.javascript.serverless",  # AWS Lambda Node
+        "sentry.javascript.gatsby",  # Gatsby
+        "sentry.javascript.svelte",  # Svelte
         "sentry.python",  # python, django, flask, FastAPI, Starlette, Bottle, Celery, pyramid, rq
         "sentry.python.serverless",  # AWS Lambda
         "sentry.cocoa",  # iOS


### PR DESCRIPTION
Gatsby and Svelte already support dynamic sampling.
We were missing them in the list of supported SDKs.