### PR TITLE
feat(perf-issues): Change truncation check to be dependent on source

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -971,9 +971,9 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
 
         # Track how many N+1-looking problems we found but dropped because we
         # couldn't be sure (maybe the truncated part of the query differs).
-        if not self._contains_complete_query(self.source_span, is_source=True) or not self._contains_complete_query(
-            self.n_spans[0]
-        ):
+        if not self._contains_complete_query(
+            self.source_span, is_source=True
+        ) or not self._contains_complete_query(self.n_spans[0]):
             metrics.incr("performance.performance_issue.truncated_np1_db")
             return
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -898,7 +898,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
     def on_complete(self) -> None:
         self._maybe_store_problem()
 
-    def _contains_complete_query(self, span: Span) -> bool:
+    def _contains_complete_query(self, span: Span, is_source: Optional[bool] = False) -> bool:
         # When SDKs truncate span description, they add a "..." suffix (three
         # full stops, not an ellipsis).
         query = span.get("description", None)
@@ -971,7 +971,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
 
         # Track how many N+1-looking problems we found but dropped because we
         # couldn't be sure (maybe the truncated part of the query differs).
-        if not self._contains_complete_query(self.source_span) or not self._contains_complete_query(
+        if not self._contains_complete_query(self.source_span, is_source=True) or not self._contains_complete_query(
             self.n_spans[0]
         ):
             metrics.incr("performance.performance_issue.truncated_np1_db")
@@ -1027,10 +1027,13 @@ class NPlusOneDBSpanDetectorExtended(NPlusOneDBSpanDetector):
         if root_span:
             self.potential_parents[root_span.get("span_id")] = root_span
 
-    def _contains_complete_query(self, span: Span) -> bool:
+    def _contains_complete_query(self, span: Span, is_source: Optional[bool] = False) -> bool:
         # Remove the truncation check from the n_plus_one db detector.
         query = span.get("description", None)
-        return bool(query)
+        if is_source:
+            return bool(query)
+        else:
+            return query and not query.endswith("...")
 
 
 # Reports metrics and creates spans for detection


### PR DESCRIPTION
### Summary
Source is likely safe to remove from the truncation check, since it's not the actual problem itself (duplicated calls) and is instead related to its actionability. We can check detection for just source no-truncation before deciding if we need to remove the truncation check on the offending spans as well.

