### PR TITLE
feat(metrics): Add `team_key_transaction` to metrics layer [TET-325 TET-426]

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -578,7 +578,7 @@ def _get_group_limit_filters(
     # results down before checking for the group by column combinations.
     values_by_column = {
         key: list({row[aliased_key] for row in results})
-        for key, aliased_key in zip(list(key_to_condition_dict.keys()), aliased_group_keys)
+        for key, aliased_key in zip(key_to_condition_dict.keys(), aliased_group_keys)
     }
     conditions += [
         Condition(key_to_condition_dict[col], Op.IN, Function("tuple", col_values))

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -541,9 +541,7 @@ def _get_group_limit_filters(
     if not metrics_query.groupby or not results:
         return None
 
-    # Translate the groupby fields of the query into their tag keys because these fields
-    # will be used to filter down and order the results of the 2nd query.
-    # For example, (project_id, transaction) is translated to (project_id, tags[3])
+    # Creates a mapping of groupBy fields to their equivalent SnQL
     key_to_condition_dict: Dict[Groupable, Any] = OrderedDict()
     for metric_groupby_obj in metrics_query.groupby:
         key_to_condition_dict[

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -43,7 +43,6 @@ from sentry.snuba.metrics.utils import (
     AVAILABLE_GENERIC_OPERATIONS,
     AVAILABLE_OPERATIONS,
     CUSTOM_MEASUREMENT_DATASETS,
-    FIELD_ALIAS_MAPPINGS,
     METRIC_TYPE_TO_ENTITY,
     UNALLOWED_TAGS,
     DerivedMetricParseException,
@@ -545,18 +544,23 @@ def _get_group_limit_filters(
     # Translate the groupby fields of the query into their tag keys because these fields
     # will be used to filter down and order the results of the 2nd query.
     # For example, (project_id, transaction) is translated to (project_id, tags[3])
-    keys = tuple(
-        FIELD_ALIAS_MAPPINGS[metric_groupby_obj.name]
-        if metric_groupby_obj.name in FIELD_ALIAS_MAPPINGS
-        else resolve_tag_key(use_case_id, metrics_query.org_id, metric_groupby_obj.name)
-        if metric_groupby_obj.name not in FIELD_ALIAS_MAPPINGS.values()
-        else metric_groupby_obj.name
-        for metric_groupby_obj in metrics_query.groupby
-    )
-    aliased_group_keys = tuple(
-        metric_groupby_obj.alias for metric_groupby_obj in metrics_query.groupby
-    )
+    key_to_condition_dict: Dict[Groupable, Any] = OrderedDict()
+    for metric_groupby_obj in metrics_query.groupby:
+        key_to_condition_dict[
+            metric_groupby_obj.name
+        ] = SnubaQueryBuilder.generate_snql_for_groupby_field(
+            metric_groupby_obj=metric_groupby_obj,
+            use_case_id=use_case_id,
+            org_id=metrics_query.org_id,
+            projects=Project.objects.get_many_from_cache(metrics_query.project_ids),
+            is_column=True,
+        )
 
+    aliased_group_keys: Tuple[str] = tuple(
+        metric_groupby_obj.alias
+        for metric_groupby_obj in metrics_query.groupby
+        if metric_groupby_obj.alias is not None
+    )
     # Get an ordered list of tuples containing the values of the group keys.
     # This needs to be deduplicated since in timeseries queries the same
     # grouping key will reappear for every time bucket.
@@ -564,24 +568,29 @@ def _get_group_limit_filters(
         OrderedDict((tuple(row[col] for col in aliased_group_keys), None) for row in results).keys()
     )
     conditions = [
-        Condition(Function("tuple", [Column(k) for k in keys]), Op.IN, Function("tuple", values))
+        Condition(
+            Function("tuple", list(key_to_condition_dict.values())),
+            Op.IN,
+            Function("tuple", values),
+        )
     ]
-
     # In addition to filtering down on the tuple combination of the fields in
     # the group by columns, we need a separate condition for each of the columns
     # in the group by with their respective values so Clickhouse can filter the
     # results down before checking for the group by column combinations.
     values_by_column = {
         key: list({row[aliased_key] for row in results})
-        for key, aliased_key in zip(keys, aliased_group_keys)
+        for key, aliased_key in zip(list(key_to_condition_dict.keys()), aliased_group_keys)
     }
     conditions += [
-        Condition(Column(col), Op.IN, Function("tuple", col_values))
+        Condition(key_to_condition_dict[col], Op.IN, Function("tuple", col_values))
         for col, col_values in values_by_column.items()
     ]
-
     return GroupLimitFilters(
-        keys=keys, aliased_keys=aliased_group_keys, values=values, conditions=conditions
+        keys=tuple(key_to_condition_dict.keys()),
+        aliased_keys=aliased_group_keys,
+        values=values,
+        conditions=conditions,
     )
 
 

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -713,7 +713,8 @@ class MetricExpression(MetricExpressionDefinition, MetricExpressionBase):
     ) -> List[Function]:
         if not self.metric_operation.validate_can_groupby():
             raise InvalidParams(
-                f"Operation {self.metric_operation.op} does not support being grouped by"
+                f"Cannot group by metrics expression {self.metric_operation.op}("
+                f"{get_public_name_from_mri(self.metric_object.metric_mri)})"
             )
         return self.generate_select_statements(
             projects=projects,
@@ -949,9 +950,7 @@ class SingularEntityDerivedMetric(DerivedMetricExpression):
         alias: str,
         params: Optional[MetricOperationParams] = None,
     ) -> List[Function]:
-        raise InvalidParams(
-            f"Metric {get_public_name_from_mri(self.metric_mri)} does not support being grouped by"
-        )
+        raise InvalidParams(f"Cannot group by metric {get_public_name_from_mri(self.metric_mri)}")
 
 
 class CompositeEntityDerivedMetric(DerivedMetricExpression):
@@ -1128,9 +1127,7 @@ class CompositeEntityDerivedMetric(DerivedMetricExpression):
         alias: str,
         params: Optional[MetricOperationParams] = None,
     ) -> List[Function]:
-        raise InvalidParams(
-            f"Metric {get_public_name_from_mri(self.metric_mri)} does not support being grouped by"
-        )
+        raise InvalidParams(f"Cannot group by metric {get_public_name_from_mri(self.metric_mri)}")
 
 
 # ToDo(ahmed): Investigate dealing with derived metric keys as Enum objects rather than string

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -429,3 +429,26 @@ def count_transaction_name_snql_factory(aggregate_filter, org_id, transaction_na
         ],
         alias=alias,
     )
+
+
+def team_key_transaction_snql(org_id, team_key_condition_rhs, alias=None):
+    team_key_conditions = set()
+    for elem in team_key_condition_rhs:
+        if len(elem) != 2:
+            raise InvalidParams("Invalid team_key_condition in params")
+
+        team_key_conditions.add(
+            (elem[0], resolve_tag_value(UseCaseKey.PERFORMANCE, org_id, elem[1]))
+        )
+
+    return Function(
+        "in",
+        [
+            (
+                Column("project_id"),
+                Column(resolve_tag_key(UseCaseKey.PERFORMANCE, org_id, "transaction")),
+            ),
+            list(team_key_conditions),
+        ],
+        alias=alias,
+    )

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -437,8 +437,9 @@ def team_key_transaction_snql(org_id, team_key_condition_rhs, alias=None):
         if len(elem) != 2:
             raise InvalidParams("Invalid team_key_condition in params")
 
+        project_id, transaction_name = elem
         team_key_conditions.add(
-            (elem[0], resolve_tag_value(UseCaseKey.PERFORMANCE, org_id, elem[1]))
+            (project_id, resolve_tag_value(UseCaseKey.PERFORMANCE, org_id, transaction_name))
         )
 
     return Function(

--- a/src/sentry/snuba/metrics/naming_layer/mapping.py
+++ b/src/sentry/snuba/metrics/naming_layer/mapping.py
@@ -1,4 +1,10 @@
-__all__ = ("create_name_mapping_layers", "get_mri", "get_public_name_from_mri")
+__all__ = (
+    "create_name_mapping_layers",
+    "get_mri",
+    "get_public_name_from_mri",
+    "parse_expression",
+    "get_operation_with_public_name",
+)
 
 
 from enum import Enum

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -51,7 +51,7 @@ class MetricField:
         metric_name = get_public_name_from_mri(self.metric_mri)
         return f"{self.op}({metric_name})" if self.op else metric_name
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         hashable_list = []
         if self.op is not None:
             hashable_list.append(self.op)
@@ -79,7 +79,12 @@ class MetricGroupByField:
 
     @property
     def name(self) -> str:
-        return self.field if isinstance(self.field, str) else self.field.alias
+        if isinstance(self.field, str):
+            return self.field
+        if isinstance(self.field, MetricField):
+            assert self.field.alias is not None
+            return self.field.alias
+        raise InvalidParams(f"Invalid groupBy field type: {self.field}")
 
 
 Tag = str

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -248,7 +248,7 @@ class MetricsQuery(MetricsQueryValidationRunner):
                 and metric_groupby_obj.field in UNALLOWED_TAGS
             ):
                 raise InvalidParams(
-                    f"Tag name {metric_groupby_obj.field} cannot be used to groupBy query"
+                    f"Tag name {metric_groupby_obj.field} cannot be used in groupBy query"
                 )
 
     def validate_include_totals(self) -> None:

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -3,7 +3,7 @@ import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Dict, Literal, Optional, Sequence, Set, Union
+from typing import Dict, Literal, Optional, Sequence, Set, Tuple, Union
 
 from snuba_sdk import Column, Direction, Granularity, Limit, Offset
 from snuba_sdk.conditions import Condition, ConditionGroup
@@ -32,7 +32,7 @@ from .utils import (
 class MetricField:
     op: Optional[MetricOperationType]
     metric_mri: str
-    params: Optional[Dict[str, Union[str, int, float]]] = None
+    params: Optional[Dict[str, Union[str, int, float, Sequence[Tuple[Union[str, int]]]]]] = None
     alias: Optional[str] = None
 
     def __post_init__(self) -> None:
@@ -51,15 +51,35 @@ class MetricField:
         metric_name = get_public_name_from_mri(self.metric_mri)
         return f"{self.op}({metric_name})" if self.op else metric_name
 
+    def __hash__(self):
+        hashable_list = []
+        if self.op is not None:
+            hashable_list.append(self.op)
+        hashable_list.append(self.metric_mri)
+        if self.params is not None:
+            hashable_list.append(
+                ",".join(sorted(":".join((x, str(y))) for x, y in self.params.items()))
+            )
+        return hash(tuple(hashable_list))
+
 
 @dataclass(frozen=True)
 class MetricGroupByField:
-    name: str
+    field: Union[str, MetricField]
     alias: Optional[str] = None
 
     def __post_init__(self) -> None:
         if not self.alias:
-            object.__setattr__(self, "alias", self.name)
+            if isinstance(self.field, str):
+                alias = self.field
+            else:
+                assert self.field.alias is not None
+                alias = self.field.alias
+            object.__setattr__(self, "alias", alias)
+
+    @property
+    def name(self) -> str:
+        return self.field if isinstance(self.field, str) else self.field.alias
 
 
 Tag = str
@@ -96,7 +116,7 @@ class MetricsQuery(MetricsQueryValidationRunner):
     start: datetime
     end: datetime
     granularity: Granularity
-    where: Optional[ConditionGroup] = None  # TODO: Should restrict
+    where: Optional[ConditionGroup] = None
     groupby: Optional[Sequence[MetricGroupByField]] = None
     orderby: Optional[Sequence[OrderBy]] = None
     limit: Optional[Limit] = None
@@ -218,9 +238,12 @@ class MetricsQuery(MetricsQueryValidationRunner):
         if not self.groupby:
             return
         for metric_groupby_obj in self.groupby:
-            if metric_groupby_obj.name in UNALLOWED_TAGS:
+            if (
+                isinstance(metric_groupby_obj.field, str)
+                and metric_groupby_obj.field in UNALLOWED_TAGS
+            ):
                 raise InvalidParams(
-                    f"Tag name {metric_groupby_obj.name} cannot be used to groupBy query"
+                    f"Tag name {metric_groupby_obj.field} cannot be used to groupBy query"
                 )
 
     def validate_include_totals(self) -> None:

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -458,7 +458,7 @@ class SnubaQueryBuilder:
                     params=metric_groupby_obj.field.params,
                     projects=projects,
                 )[0]
-            except KeyError:
+            except IndexError:
                 raise InvalidParams(f"Cannot resolve {metric_groupby_obj.field} into SnQL")
         else:
             raise NotImplementedError(f"Unsupported groupby field: {metric_groupby_obj.field}")

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -59,6 +59,7 @@ from sentry.snuba.metrics.query import Tag
 from sentry.snuba.metrics.utils import (
     DATASET_COLUMNS,
     FIELD_ALIAS_MAPPINGS,
+    NON_RESOLVABLE_VALUE_OP,
     OPERATIONS_PERCENTILES,
     TS_COL_GROUP,
     TS_COL_QUERY,
@@ -419,6 +420,49 @@ class SnubaQueryBuilder:
 
         self._alias_to_metric_field = {field.alias: field for field in self._metrics_query.select}
 
+    @staticmethod
+    def generate_snql_for_groupby_field(
+        metric_groupby_obj: MetricGroupByField,
+        use_case_id: UseCaseKey,
+        org_id: int,
+        projects: Sequence[Project],
+        is_column: bool = False,
+    ) -> Union[Column, AliasedExpression, Function]:
+        if isinstance(metric_groupby_obj.field, str):
+            # Handles the case when we are trying to group by `project` for example, but we want
+            # to translate it to `project_id` as that is what the metrics dataset understands
+            if metric_groupby_obj.field in FIELD_ALIAS_MAPPINGS:
+                column_name = FIELD_ALIAS_MAPPINGS[metric_groupby_obj.field]
+            elif metric_groupby_obj.field in FIELD_ALIAS_MAPPINGS.values():
+                column_name = metric_groupby_obj.field
+            else:
+                assert isinstance(metric_groupby_obj.field, Tag)
+                column_name = resolve_tag_key(use_case_id, org_id, metric_groupby_obj.field)
+            return (
+                AliasedExpression(
+                    exp=Column(column_name),
+                    alias=metric_groupby_obj.alias,
+                )
+                if not is_column
+                else Column(column_name)
+            )
+
+        elif isinstance(metric_groupby_obj.field, MetricField):
+            try:
+                metric_expression = metric_object_factory(
+                    metric_groupby_obj.field.op, metric_groupby_obj.field.metric_mri
+                )
+                return metric_expression.generate_groupby_statements(
+                    use_case_id=use_case_id,
+                    alias=metric_groupby_obj.field.alias,
+                    params=metric_groupby_obj.field.params,
+                    projects=projects,
+                )[0]
+            except KeyError:
+                raise InvalidParams(f"Cannot resolve {metric_groupby_obj.field} into SnQL")
+        else:
+            raise NotImplementedError(f"Unsupported groupby field: {metric_groupby_obj.field}")
+
     def _build_where(self) -> List[Union[BooleanCondition, Condition]]:
         where: List[Union[BooleanCondition, Condition]] = [
             Condition(Column("org_id"), Op.EQ, self._org_id),
@@ -436,33 +480,14 @@ class SnubaQueryBuilder:
         groupby_cols = []
 
         for metric_groupby_obj in self._metrics_query.groupby or []:
-            # Handles the case when we are trying to group by `project` for example, but we want
-            # to translate it to `project_id` as that is what the metrics dataset understands
-            if metric_groupby_obj.name in FIELD_ALIAS_MAPPINGS:
-                groupby_cols.append(
-                    AliasedExpression(
-                        exp=Column(FIELD_ALIAS_MAPPINGS[metric_groupby_obj.name]),
-                        alias=metric_groupby_obj.alias,
-                    )
+            groupby_cols.append(
+                self.generate_snql_for_groupby_field(
+                    metric_groupby_obj=metric_groupby_obj,
+                    use_case_id=self._use_case_id,
+                    org_id=self._org_id,
+                    projects=self._projects,
                 )
-            elif metric_groupby_obj.name in FIELD_ALIAS_MAPPINGS.values():
-                groupby_cols.append(
-                    AliasedExpression(
-                        exp=Column(metric_groupby_obj.name), alias=metric_groupby_obj.alias
-                    )
-                )
-            else:
-                assert isinstance(metric_groupby_obj.name, Tag)
-                groupby_cols.append(
-                    AliasedExpression(
-                        exp=Column(
-                            resolve_tag_key(
-                                self._use_case_id, self._org_id, metric_groupby_obj.name
-                            )
-                        ),
-                        alias=metric_groupby_obj.alias,
-                    )
-                )
+            )
         return groupby_cols
 
     def _build_orderby(self) -> Optional[List[OrderBy]]:
@@ -755,7 +780,9 @@ class SnubaResultConverter:
 
         groupby_alias_to_groupby_column = (
             {
-                metric_groupby_obj.alias: metric_groupby_obj.name
+                metric_groupby_obj.alias: metric_groupby_obj.field
+                if isinstance(metric_groupby_obj.field, str)
+                else metric_groupby_obj.field.op
                 for metric_groupby_obj in self._metrics_query.groupby
             }
             if self._metrics_query.groupby
@@ -773,6 +800,7 @@ class SnubaResultConverter:
                     )
                     if groupby_alias_to_groupby_column.get(key)
                     not in set(FIELD_ALIAS_MAPPINGS.values()) | set(FIELD_ALIAS_MAPPINGS.keys())
+                    and groupby_alias_to_groupby_column.get(key) not in NON_RESOLVABLE_VALUE_OP
                     else (key, value)
                     for key, value in tags
                 ),

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -9,6 +9,7 @@ __all__ = (
     "MetricType",
     "OP_TO_SNUBA_FUNCTION",
     "AVAILABLE_OPERATIONS",
+    "AVAILABLE_GENERIC_OPERATIONS",
     "OPERATIONS_TO_ENTITY",
     "METRIC_TYPE_TO_ENTITY",
     "FIELD_ALIAS_MAPPINGS",
@@ -175,6 +176,7 @@ METRIC_TYPE_TO_ENTITY: Mapping[MetricType, EntityKey] = {
 }
 
 FIELD_ALIAS_MAPPINGS = {"project": "project_id"}
+NON_RESOLVABLE_VALUE_OP = {"team_key_transaction"}
 
 
 class Tag(TypedDict):
@@ -205,7 +207,13 @@ OPERATIONS_PERCENTILES = (
     "p95",
     "p99",
 )
-DERIVED_OPERATIONS = ("histogram", "rate", "count_web_vitals", "count_transaction_name")
+DERIVED_OPERATIONS = (
+    "histogram",
+    "rate",
+    "count_web_vitals",
+    "count_transaction_name",
+    "team_key_transaction",
+)
 OPERATIONS = (
     (
         "avg",
@@ -232,12 +240,18 @@ DEFAULT_AGGREGATES: Dict[MetricOperationType, Optional[Union[int, List[Tuple[flo
     "p99": None,
     "sum": 0,
     "percentage": None,
+    # ToDo(ahmed): These are probably better off defined on derived ops themselves rather than adding them here.
     "histogram": [],
     "rate": 0,
     "count_web_vitals": 0,
     "count_transaction_name": 0,
+    "team_key_transaction": 0,
 }
-UNIT_TO_TYPE = {"sessions": "count", "percentage": "percentage", "users": "count"}
+UNIT_TO_TYPE = {
+    "sessions": "count",
+    "percentage": "percentage",
+    "users": "count",
+}
 UNALLOWED_TAGS = {"session.status"}
 DATASET_COLUMNS = {"project_id", "metric_id"}
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -34,6 +34,7 @@ __all__ = (
     "OP_REGEX",
     "CUSTOM_MEASUREMENT_DATASETS",
     "DATASET_COLUMNS",
+    "NON_RESOLVABLE_TAG_VALUES",
 )
 
 
@@ -177,7 +178,9 @@ METRIC_TYPE_TO_ENTITY: Mapping[MetricType, EntityKey] = {
 }
 
 FIELD_ALIAS_MAPPINGS = {"project": "project_id"}
-NON_RESOLVABLE_VALUE_OP = {"team_key_transaction"}
+NON_RESOLVABLE_TAG_VALUES = (
+    {"team_key_transaction"} | set(FIELD_ALIAS_MAPPINGS.keys()) | set(FIELD_ALIAS_MAPPINGS.values())
+)
 
 
 class Tag(TypedDict):

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -80,6 +80,7 @@ MetricOperationType = Literal[
     "rate",
     "count_web_vitals",
     "count_transaction_name",
+    "team_key_transaction",
 ]
 MetricUnit = Literal[
     "nanosecond",
@@ -240,12 +241,6 @@ DEFAULT_AGGREGATES: Dict[MetricOperationType, Optional[Union[int, List[Tuple[flo
     "p99": None,
     "sum": 0,
     "percentage": None,
-    # ToDo(ahmed): These are probably better off defined on derived ops themselves rather than adding them here.
-    "histogram": [],
-    "rate": 0,
-    "count_web_vitals": 0,
-    "count_transaction_name": 0,
-    "team_key_transaction": 0,
 }
 UNIT_TO_TYPE = {
     "sessions": "count",

--- a/tests/sentry/api/endpoints/test_organization_metric_data.py
+++ b/tests/sentry/api/endpoints/test_organization_metric_data.py
@@ -105,7 +105,7 @@ class OrganizationMetricDataTest(MetricsAPIBaseTestCase):
             interval="1h",
         )
         assert response.data["detail"] == (
-            "Tag name session.status cannot be used to groupBy query"
+            "Tag name session.status cannot be used in groupBy query"
         )
 
     def test_filter_session_status(self):

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -101,7 +101,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             start=self.now - timedelta(hours=1),
             end=self.now,
             granularity=Granularity(granularity=3600),
-            groupby=[MetricGroupByField(name="transaction", alias="transaction_group")],
+            groupby=[MetricGroupByField(field="transaction", alias="transaction_group")],
             orderby=[
                 OrderBy(
                     MetricField(
@@ -1197,7 +1197,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             start=start,
             groupby=[
                 MetricGroupByField(
-                    name="transaction",
+                    field="transaction",
                 )
             ],
             end=end,
@@ -1233,6 +1233,110 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             ],
             key=lambda elem: elem["name"],
         )
+
+    @freeze_time("2022-09-22 11:07:00")
+    def test_team_key_transactions_my_teams(self):
+        now = timezone.now()
+
+        for idx, (transaction, value) in enumerate(
+            (("foo_transaction", 1), ("bar_transaction", 1), ("baz_transaction", 0.5))
+        ):
+            self.store_metric(
+                org_id=self.organization.id,
+                project_id=self.project.id,
+                type="distribution",
+                name=TransactionMRI.DURATION.value,
+                tags={"transaction": transaction},
+                timestamp=(now - timedelta(minutes=idx)).timestamp(),
+                value=value,
+                use_case_id=UseCaseKey.PERFORMANCE,
+            )
+
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="team_key_transaction",
+                    metric_mri=str(TransactionMRI.DURATION.value),
+                    params={
+                        "team_key_condition_rhs": [
+                            (self.project.id, "foo_transaction"),
+                        ]
+                    },
+                    alias="team_key_transactions",
+                ),
+                MetricField(
+                    op="p95",
+                    metric_mri=str(TransactionMRI.DURATION.value),
+                    alias="p95",
+                ),
+            ],
+            start=now - timedelta(hours=1),
+            end=now,
+            granularity=Granularity(granularity=3600),
+            limit=Limit(limit=50),
+            offset=Offset(offset=0),
+            groupby=[
+                MetricGroupByField(
+                    field=MetricField(
+                        op="team_key_transaction",
+                        metric_mri=str(TransactionMRI.DURATION.value),
+                        params={
+                            "team_key_condition_rhs": [
+                                (self.project.id, "foo_transaction"),
+                            ]
+                        },
+                        alias="team_key_transactions",
+                    )
+                ),
+                MetricGroupByField("transaction"),
+            ],
+            orderby=[
+                OrderBy(
+                    field=MetricField(
+                        op="team_key_transaction",
+                        metric_mri=str(TransactionMRI.DURATION.value),
+                        params={
+                            "team_key_condition_rhs": [
+                                (self.project.id, "foo_transaction"),
+                            ]
+                        },
+                        alias="team_key_transactions",
+                    ),
+                    direction=Direction.DESC,
+                ),
+                OrderBy(
+                    field=MetricField(
+                        op="p95",
+                        metric_mri=str(TransactionMRI.DURATION.value),
+                        alias="p95",
+                    ),
+                    direction=Direction.DESC,
+                ),
+            ],
+            include_series=False,
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=False,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+        assert data["groups"] == [
+            {
+                "by": {"team_key_transactions": 1, "transaction": "foo_transaction"},
+                "totals": {"team_key_transactions": 1, "p95": 1.0},
+            },
+            {
+                "by": {"team_key_transactions": 0, "transaction": "bar_transaction"},
+                "totals": {"team_key_transactions": 0, "p95": 1.0},
+            },
+            {
+                "by": {"team_key_transactions": 0, "transaction": "baz_transaction"},
+                "totals": {"team_key_transactions": 0, "p95": 0.5},
+            },
+        ]
 
 
 class GetCustomMeasurementsTestCase(MetricsEnhancedPerformanceTestCase):

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -389,7 +389,7 @@ def test_validate_where():
 
 def test_validate_groupby():
     with pytest.raises(
-        InvalidParams, match="Tag name session.status cannot be used to groupBy query"
+        InvalidParams, match="Tag name session.status cannot be used in groupBy query"
     ):
         MetricsQuery(
             **MetricsQueryBuilder()

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -23,6 +23,7 @@ from snuba_sdk import (
     Query,
 )
 
+from sentry.api.utils import InvalidParams
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.sentry_metrics.utils import (
@@ -58,7 +59,7 @@ from sentry.snuba.metrics.fields.snql import (
 )
 from sentry.snuba.metrics.naming_layer import SessionMetricKey
 from sentry.snuba.metrics.naming_layer.mapping import get_mri
-from sentry.snuba.metrics.naming_layer.mri import SessionMRI
+from sentry.snuba.metrics.naming_layer.mri import SessionMRI, TransactionMRI
 from sentry.snuba.metrics.query import MetricField, MetricGroupByField
 from sentry.snuba.metrics.query_builder import QueryDefinition
 from sentry.testutils import TestCase
@@ -1011,6 +1012,101 @@ def test_translate_meta_results_with_duplicates():
         ],
         key=lambda elem: elem["name"],
     )
+
+
+@pytest.mark.parametrize(
+    "select,groupby,usecase,error_string",
+    [
+        pytest.param(
+            [
+                MetricField("sum", SessionMRI.SESSION.value),
+                MetricField("count_unique", SessionMRI.USER.value),
+                MetricField("p95", SessionMRI.RAW_DURATION.value),
+            ],
+            [
+                MetricGroupByField(MetricField("sum", SessionMRI.SESSION.value)),
+            ],
+            UseCaseKey.RELEASE_HEALTH,
+            "Operation sum does not support being grouped by",
+            id="invalid grouping by metric expression - release_health",
+        ),
+        pytest.param(
+            [
+                MetricField("count", TransactionMRI.DURATION.value),
+            ],
+            [
+                MetricGroupByField(MetricField("count", TransactionMRI.DURATION.value)),
+            ],
+            UseCaseKey.PERFORMANCE,
+            "Operation count does not support being grouped by",
+            id="invalid grouping by metric expression - performance",
+        ),
+        pytest.param(
+            [
+                MetricField(None, TransactionMRI.FAILURE_RATE.value),
+            ],
+            [
+                MetricGroupByField(MetricField(None, TransactionMRI.FAILURE_RATE.value)),
+            ],
+            UseCaseKey.PERFORMANCE,
+            "Metric transaction.failure_rate does not support being grouped by",
+            id="invalid grouping by derived metric - release_health",
+        ),
+        pytest.param(
+            [
+                MetricField(None, SessionMRI.ERRORED.value),
+            ],
+            [
+                MetricGroupByField(MetricField(None, SessionMRI.ERRORED.value)),
+            ],
+            UseCaseKey.PERFORMANCE,
+            "Metric session.errored does not support being grouped by",
+            id="invalid grouping by composite entity derived metric - release_health",
+        ),
+        pytest.param(
+            [
+                MetricField(
+                    "team_key_transaction",
+                    TransactionMRI.DURATION.value,
+                    params={"team_key_condition_rhs": [(1, "foo")]},
+                ),
+            ],
+            [
+                MetricGroupByField(
+                    MetricField(
+                        "team_key_transaction",
+                        TransactionMRI.DURATION.value,
+                        params={"team_key_condition_rhs": [(1, "foo")]},
+                    )
+                ),
+            ],
+            UseCaseKey.PERFORMANCE,
+            "",
+            id="valid grouping by metrics expression",
+        ),
+    ],
+)
+def test_only_can_groupby_operations_can_be_added_to_groupby(
+    select, groupby, usecase, error_string
+):
+    query_definition = MetricsQuery(
+        org_id=1,
+        project_ids=[1],
+        select=select,
+        start=MOCK_NOW - timedelta(days=90),
+        end=MOCK_NOW,
+        granularity=Granularity(3600),
+        groupby=groupby,
+    )
+    if error_string:
+        with pytest.raises(InvalidParams, match=error_string):
+            snuba_queries, _ = SnubaQueryBuilder(
+                [PseudoProject(1, 1)], query_definition, use_case_id=usecase
+            ).get_snuba_queries()
+    else:
+        snuba_queries, _ = SnubaQueryBuilder(
+            [PseudoProject(1, 1)], query_definition, use_case_id=usecase
+        ).get_snuba_queries()
 
 
 class QueryDefinitionTestCase(TestCase):

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from unittest import mock
@@ -1027,7 +1028,7 @@ def test_translate_meta_results_with_duplicates():
                 MetricGroupByField(MetricField("sum", SessionMRI.SESSION.value)),
             ],
             UseCaseKey.RELEASE_HEALTH,
-            "Operation sum does not support being grouped by",
+            re.escape("Cannot group by metrics expression sum(sentry.sessions.session)"),
             id="invalid grouping by metric expression - release_health",
         ),
         pytest.param(
@@ -1038,7 +1039,7 @@ def test_translate_meta_results_with_duplicates():
                 MetricGroupByField(MetricField("count", TransactionMRI.DURATION.value)),
             ],
             UseCaseKey.PERFORMANCE,
-            "Operation count does not support being grouped by",
+            re.escape("Cannot group by metrics expression count(transaction.duration)"),
             id="invalid grouping by metric expression - performance",
         ),
         pytest.param(
@@ -1049,7 +1050,7 @@ def test_translate_meta_results_with_duplicates():
                 MetricGroupByField(MetricField(None, TransactionMRI.FAILURE_RATE.value)),
             ],
             UseCaseKey.PERFORMANCE,
-            "Metric transaction.failure_rate does not support being grouped by",
+            "Cannot group by metric transaction.failure_rate",
             id="invalid grouping by derived metric - release_health",
         ),
         pytest.param(
@@ -1060,7 +1061,7 @@ def test_translate_meta_results_with_duplicates():
                 MetricGroupByField(MetricField(None, SessionMRI.ERRORED.value)),
             ],
             UseCaseKey.PERFORMANCE,
-            "Metric session.errored does not support being grouped by",
+            "Cannot group by metric session.errored",
             id="invalid grouping by composite entity derived metric - release_health",
         ),
         pytest.param(


### PR DESCRIPTION
Adds support for `team_key_transaction` to be added
to the metrics layer. As of these changes, we should be able to
select, groupBy and orderBy team_key_transaction

This PR achieves the following by
- Adds a new derived operation `team_key_transaction` and accepts transaction.duration MRI as a metric mri
- Modifying `MetricsGroupByField` to also accept an instance of `MetricField`
- Modifying `MetricsExpressionBase` that has a `generate_groupby_statement` that generates SNQL but also validates that the metrics expression supports grouping by
- Refactor shared logic out of `SnubaQueryBuilder._build_groupby` and `_get_group_limit_filters` into a static method `SnubaQueryBuilder.generate_snql_for_groupby_field`