### PR TITLE
feat(dashboards): Prevent widget builder preview from firing request if widget query condition is invalid

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.tsx
@@ -24,6 +24,7 @@ import {BuildStep} from './buildStep';
 
 interface Props {
   displayType: DisplayType;
+  isWidgetValid: boolean;
   location: Location;
   onChange: (displayType: DisplayType) => void;
   organization: Organization;
@@ -44,6 +45,7 @@ export function VisualizationStep({
   noDashboardsMEPProvider,
   dashboardFilters,
   location,
+  isWidgetValid,
 }: Props) {
   const [debouncedWidget, setDebouncedWidget] = useState(widget);
 
@@ -121,6 +123,7 @@ export function VisualizationStep({
           noLazyLoad
           showStoredAlert
           noDashboardsMEPProvider={noDashboardsMEPProvider}
+          isWidgetValid={isWidgetValid}
         />
       </VisualizationWrapper>
     </BuildStep>

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.tsx
@@ -24,7 +24,7 @@ import {BuildStep} from './buildStep';
 
 interface Props {
   displayType: DisplayType;
-  isWidgetValid: boolean;
+  isWidgetInvalid: boolean;
   location: Location;
   onChange: (displayType: DisplayType) => void;
   organization: Organization;
@@ -45,7 +45,7 @@ export function VisualizationStep({
   noDashboardsMEPProvider,
   dashboardFilters,
   location,
-  isWidgetValid,
+  isWidgetInvalid,
 }: Props) {
   const [debouncedWidget, setDebouncedWidget] = useState(widget);
 
@@ -123,7 +123,7 @@ export function VisualizationStep({
           noLazyLoad
           showStoredAlert
           noDashboardsMEPProvider={noDashboardsMEPProvider}
-          isWidgetValid={isWidgetValid}
+          isWidgetInvalid={isWidgetInvalid}
         />
       </VisualizationWrapper>
     </BuildStep>

--- a/static/app/views/dashboardsV2/widgetBuilder/footer.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/footer.tsx
@@ -39,7 +39,11 @@ export function Footer({
           priority="primary"
           onClick={onSave}
           disabled={invalidForm}
-          title={invalidForm ? t('Required fields must be filled out') : undefined}
+          title={
+            invalidForm
+              ? t('Required fields must be filled out and contain valid inputs')
+              : undefined
+          }
         >
           {isEditing ? t('Update Widget') : t('Add Widget')}
         </Button>

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -1666,10 +1666,13 @@ describe('WidgetBuilder', function () {
       );
     });
 
-    it('disables add widget button if widget query condition is invalid', async function () {
+    it('disables add widget button and prevents widget previewing from firing widget query if widget query condition is invalid', async function () {
       renderTestComponent({
         orgFeatures: [...defaultOrgFeatures],
       });
+      userEvent.click(await screen.findByText('Table'));
+      userEvent.click(screen.getByText('Line Chart'));
+      expect(eventsStatsMock).toHaveBeenCalledTimes(1);
 
       userEvent.type(
         screen.getByTestId('smart-search-input'),
@@ -1682,6 +1685,8 @@ describe('WidgetBuilder', function () {
       await waitFor(() =>
         expect(screen.getByText('Add Widget').closest('button')).toBeDisabled()
       );
+      expect(screen.getByText('Widget query condition is invalid.')).toBeInTheDocument();
+      expect(eventsStatsMock).toHaveBeenCalledTimes(1);
     });
 
     describe('Widget Library', function () {

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -1082,6 +1082,7 @@ function WidgetBuilder({
                                   );
                                 }}
                                 noDashboardsMEPProvider
+                                isWidgetValid={state.queryConditionsValid}
                               />
                               <DataSetStep
                                 dataSet={state.dataSet}

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -1082,7 +1082,7 @@ function WidgetBuilder({
                                   );
                                 }}
                                 noDashboardsMEPProvider
-                                isWidgetValid={state.queryConditionsValid}
+                                isWidgetInvalid={!state.queryConditionsValid}
                               />
                               <DataSetStep
                                 dataSet={state.dataSet}

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -1,4 +1,4 @@
-import React, {Component} from 'react';
+import React, {Component, Fragment} from 'react';
 import LazyLoad from 'react-lazyload';
 // eslint-disable-next-line no-restricted-imports
 import {withRouter, WithRouterProps} from 'react-router';
@@ -9,6 +9,7 @@ import {Location} from 'history';
 import {Client} from 'sentry/api';
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
+import ErrorPanel from 'sentry/components/charts/errorPanel';
 import {HeaderTitle} from 'sentry/components/charts/styles';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import FeatureBadge from 'sentry/components/featureBadge';
@@ -17,7 +18,7 @@ import {Panel} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {parseSearch} from 'sentry/components/searchSyntax/parser';
 import Tooltip from 'sentry/components/tooltip';
-import {IconCopy, IconDelete, IconEdit, IconGrabbable} from 'sentry/icons';
+import {IconCopy, IconDelete, IconEdit, IconGrabbable, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, PageFilters} from 'sentry/types';
@@ -58,6 +59,7 @@ type Props = WithRouterProps & {
   index?: string;
   isMobile?: boolean;
   isPreview?: boolean;
+  isWidgetValid?: boolean;
   noDashboardsMEPProvider?: boolean;
   noLazyLoad?: boolean;
   onDelete?: () => void;
@@ -233,6 +235,7 @@ class WidgetCard extends Component<Props, State> {
       showStoredAlert,
       noDashboardsMEPProvider,
       dashboardFilters,
+      isWidgetValid,
     } = this.props;
 
     if (widget.displayType === DisplayType.TOP_N) {
@@ -283,21 +286,8 @@ class WidgetCard extends Component<Props, State> {
                 </Tooltip>
                 {this.renderContextMenu()}
               </WidgetHeader>
-              {noLazyLoad ? (
-                <WidgetCardChartContainer
-                  api={api}
-                  organization={organization}
-                  selection={selection}
-                  widget={widget}
-                  isMobile={isMobile}
-                  renderErrorMessage={renderErrorMessage}
-                  tableItemLimit={tableItemLimit}
-                  windowWidth={windowWidth}
-                  onDataFetched={this.setData}
-                  dashboardFilters={dashboardFilters}
-                />
-              ) : (
-                <LazyLoad once resize height={200}>
+              {isWidgetValid ? (
+                noLazyLoad ? (
                   <WidgetCardChartContainer
                     api={api}
                     organization={organization}
@@ -310,7 +300,29 @@ class WidgetCard extends Component<Props, State> {
                     onDataFetched={this.setData}
                     dashboardFilters={dashboardFilters}
                   />
-                </LazyLoad>
+                ) : (
+                  <LazyLoad once resize height={200}>
+                    <WidgetCardChartContainer
+                      api={api}
+                      organization={organization}
+                      selection={selection}
+                      widget={widget}
+                      isMobile={isMobile}
+                      renderErrorMessage={renderErrorMessage}
+                      tableItemLimit={tableItemLimit}
+                      windowWidth={windowWidth}
+                      onDataFetched={this.setData}
+                      dashboardFilters={dashboardFilters}
+                    />
+                  </LazyLoad>
+                )
+              ) : (
+                <Fragment>
+                  {renderErrorMessage?.('Widget query condition is invalid.')}
+                  <StyledErrorPanel>
+                    <IconWarning color="gray500" size="lg" />
+                  </StyledErrorPanel>
+                </Fragment>
               )}
               {this.renderToolbar()}
             </WidgetCardPanel>
@@ -430,4 +442,8 @@ const WidgetHeader = styled('div')`
 const StoredDataAlert = styled(Alert)`
   margin-top: ${space(1)};
   margin-bottom: 0;
+`;
+
+const StyledErrorPanel = styled(ErrorPanel)`
+  padding: ${space(2)};
 `;

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -287,7 +287,27 @@ class WidgetCard extends Component<Props, State> {
                 {this.renderContextMenu()}
               </WidgetHeader>
               {isWidgetInvalid ? (
-                noLazyLoad ? (
+                <Fragment>
+                  {renderErrorMessage?.('Widget query condition is invalid.')}
+                  <StyledErrorPanel>
+                    <IconWarning color="gray500" size="lg" />
+                  </StyledErrorPanel>
+                </Fragment>
+              ) : noLazyLoad ? (
+                <WidgetCardChartContainer
+                  api={api}
+                  organization={organization}
+                  selection={selection}
+                  widget={widget}
+                  isMobile={isMobile}
+                  renderErrorMessage={renderErrorMessage}
+                  tableItemLimit={tableItemLimit}
+                  windowWidth={windowWidth}
+                  onDataFetched={this.setData}
+                  dashboardFilters={dashboardFilters}
+                />
+              ) : (
+                <LazyLoad once resize height={200}>
                   <WidgetCardChartContainer
                     api={api}
                     organization={organization}
@@ -300,29 +320,7 @@ class WidgetCard extends Component<Props, State> {
                     onDataFetched={this.setData}
                     dashboardFilters={dashboardFilters}
                   />
-                ) : (
-                  <LazyLoad once resize height={200}>
-                    <WidgetCardChartContainer
-                      api={api}
-                      organization={organization}
-                      selection={selection}
-                      widget={widget}
-                      isMobile={isMobile}
-                      renderErrorMessage={renderErrorMessage}
-                      tableItemLimit={tableItemLimit}
-                      windowWidth={windowWidth}
-                      onDataFetched={this.setData}
-                      dashboardFilters={dashboardFilters}
-                    />
-                  </LazyLoad>
-                )
-              ) : (
-                <Fragment>
-                  {renderErrorMessage?.('Widget query condition is invalid.')}
-                  <StyledErrorPanel>
-                    <IconWarning color="gray500" size="lg" />
-                  </StyledErrorPanel>
-                </Fragment>
+                </LazyLoad>
               )}
               {this.renderToolbar()}
             </WidgetCardPanel>

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -59,7 +59,7 @@ type Props = WithRouterProps & {
   index?: string;
   isMobile?: boolean;
   isPreview?: boolean;
-  isWidgetValid?: boolean;
+  isWidgetInvalid?: boolean;
   noDashboardsMEPProvider?: boolean;
   noLazyLoad?: boolean;
   onDelete?: () => void;
@@ -235,7 +235,7 @@ class WidgetCard extends Component<Props, State> {
       showStoredAlert,
       noDashboardsMEPProvider,
       dashboardFilters,
-      isWidgetValid,
+      isWidgetInvalid,
     } = this.props;
 
     if (widget.displayType === DisplayType.TOP_N) {
@@ -286,7 +286,7 @@ class WidgetCard extends Component<Props, State> {
                 </Tooltip>
                 {this.renderContextMenu()}
               </WidgetHeader>
-              {isWidgetValid ? (
+              {isWidgetInvalid ? (
                 noLazyLoad ? (
                   <WidgetCardChartContainer
                     api={api}


### PR DESCRIPTION
Updates the widget builder preview to not send widget query requests if the widget query condition is invalid.
This is to mitigate the amount of invalid requests we send to backend apis since we already know that they will fail.
Displays the following message:
<img width="1008" alt="image" src="https://user-images.githubusercontent.com/83961295/192822546-520cf00e-c740-4eaa-8f1b-6493622c2dba.png">
