### PR TITLE
fix(discover): Added check to render prepend columns along with the o…

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -312,6 +312,7 @@ class GridEditable<
     return (
       <GridRow data-test-id="grid-head-row">
         {prependColumns &&
+          columnOrder?.length > 0 &&
           prependColumns.map((item, i) => (
             <GridHeadCellStatic key={`prepend-${i}`}>{item}</GridHeadCellStatic>
           ))}


### PR DESCRIPTION
Added check to render prepend columns along with the other header columns. This gets rid of the quick flicker when we click into saved queries in discover.

Before: 
<img width="1004" alt="Screen Shot 2022-09-28 at 1 51 07 PM" src="https://user-images.githubusercontent.com/60121741/192853628-6c446328-18f6-4c1c-a90c-a90b4ca54132.png">

<img width="1253" alt="Screen Shot 2022-09-28 at 1 51 27 PM" src="https://user-images.githubusercontent.com/60121741/192853694-71751f6d-4a19-4422-aee4-db287673f634.png">

After:
<img width="1004" alt="Screen Shot 2022-09-28 at 1 49 14 PM" src="https://user-images.githubusercontent.com/60121741/192853253-ace8ce36-8e5b-40f4-9f72-d38b99220680.png">

<img width="1256" alt="Screen Shot 2022-09-28 at 1 49 46 PM" src="https://user-images.githubusercontent.com/60121741/192853343-3d1526af-7754-462f-b4b9-b80a7f511be3.png">

