### PR TITLE
fix(discover): fixes bug where previous series would not format tooltip value

### DIFF
--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -305,7 +305,11 @@ class Chart extends React.Component<ChartProps, State> {
         trigger: 'axis' as const,
         truncate: 80,
         valueFormatter: (value: number, label?: string) => {
-          const aggregateName = label?.split(':').pop()?.trim();
+          const aggregateName = label
+            ?.replace(/^previous /, '')
+            .split(':')
+            .pop()
+            ?.trim();
           if (aggregateName) {
             return timeseriesResultsTypes
               ? tooltipFormatter(value, timeseriesResultsTypes[aggregateName])


### PR DESCRIPTION
Fixes an issue where previous series in discover would not format the tooltip value correctly
<img width="365" alt="image" src="https://user-images.githubusercontent.com/83961295/192833479-ba52e9d1-dc43-4e58-adc5-5ccb3b80ceab.png">
