### PR TITLE
fix(discover): Check for discover-query before requesting homepage

### DIFF
--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -683,6 +683,7 @@ class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
 
     if (
       organization.features.includes('discover-query-builder-as-landing-page') &&
+      organization.features.includes('discover-query') &&
       isEmpty(location.query)
     ) {
       endpoints.push([


### PR DESCRIPTION
`discover-query` is the feature flag that allows users to save queries, so the
endpoint is also feature flagged with this. Don't fetch this resource in the frontend
if the user doesn't have `discover-query`.