### PR TITLE
fix(perf-issue): fix merging results with None data returned

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -283,8 +283,10 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         mapped_results: Sequence[Tuple[Iterable[MergeableRow], int, int]] = list(
             map(
                 lambda bulk_result: (
-                    bulk_result["data"],
-                    bulk_result["totals"]["total"],
+                    bulk_result["data"] if bulk_result["data"] is not None else [],
+                    bulk_result["totals"]["total"]
+                    if bulk_result["totals"]["total"] is not None
+                    else 0,
                     len(bulk_result),
                 ),
                 filter(lambda bulk_result: bool(bulk_result), bulk_query_results),

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1375,6 +1375,38 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             **common_args,
         )
 
+    @mock.patch("sentry.search.snuba.executors.bulk_raw_query")
+    def test_reduce_bulk_results_none_total(self, bulk_raw_query_mock):
+        bulk_raw_query_mock.return_value = [
+            {"data": [], "totals": {"total": None}},
+            {"data": [], "totals": {"total": None}},
+        ]
+
+        assert (
+            self.make_query(
+                search_filter_query="last_seen:>%s" % date_to_query_format(timezone.now()),
+                sort_by="date",
+            ).results
+            == []
+        )
+        assert bulk_raw_query_mock.called
+
+    @mock.patch("sentry.search.snuba.executors.bulk_raw_query")
+    def test_reduce_bulk_results_none_data(self, bulk_raw_query_mock):
+        bulk_raw_query_mock.return_value = [
+            {"data": None, "totals": {"total": 0}},
+            {"data": None, "totals": {"total": 0}},
+        ]
+
+        assert (
+            self.make_query(
+                search_filter_query="last_seen:>%s" % date_to_query_format(timezone.now()),
+                sort_by="date",
+            ).results
+            == []
+        )
+        assert bulk_raw_query_mock.called
+
     def test_pre_and_post_filtering(self):
         prev_max_pre = options.get("snuba.search.max-pre-snuba-candidates")
         options.set("snuba.search.max-pre-snuba-candidates", 1)


### PR DESCRIPTION
Missed a scenario when the bulk results returns None data causing some merging issues.

Fixes SENTRY-W3V