### PR TITLE
fix(tests): Fix another flakey test caused by using `RedisSnubaTSDB`

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_stats.py
@@ -13,7 +13,7 @@ from sentry.utils.outcomes import Outcome
 
 
 @region_silo_test
-@freeze_time(before_now(days=1).replace(minute=10))
+@freeze_time(before_now(days=1).replace(hour=1, minute=10))
 class OrganizationStatsTest(APITestCase, OutcomesSnubaTest):
     def test_simple(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Need to freeze the hour on this test as well