### PR TITLE
fix(monitors): Correct chart series timestamp values

### DIFF
--- a/static/app/views/monitors/monitorStats.tsx
+++ b/static/app/views/monitors/monitorStats.tsx
@@ -15,7 +15,7 @@ type State = AsyncComponent['state'] & {
   stats: MonitorStat[] | null;
 };
 
-type Stat = {name: string; value: number};
+type Stat = {name: number; value: number};
 
 export default class MonitorStats extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
@@ -52,8 +52,8 @@ export default class MonitorStats extends AsyncComponent<Props, State> {
         emptyStats = false;
       }
       const timestamp = p.ts * 1000;
-      success.data.push({name: timestamp.toString(), value: p.ok});
-      failed.data.push({name: timestamp.toString(), value: p.error});
+      success.data.push({name: timestamp, value: p.ok});
+      failed.data.push({name: timestamp, value: p.error});
     });
     const colors = [theme.green300, theme.red300];
 

--- a/static/app/views/monitors/monitorStats.tsx
+++ b/static/app/views/monitors/monitorStats.tsx
@@ -3,6 +3,7 @@ import MiniBarChart from 'sentry/components/charts/miniBarChart';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
+import {SeriesDataUnit} from 'sentry/types/echarts';
 import theme from 'sentry/utils/theme';
 
 import {Monitor, MonitorStat} from './types';
@@ -14,8 +15,6 @@ type Props = AsyncComponent['props'] & {
 type State = AsyncComponent['state'] & {
   stats: MonitorStat[] | null;
 };
-
-type Stat = {name: number; value: number};
 
 export default class MonitorStats extends AsyncComponent<Props, State> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
@@ -41,11 +40,11 @@ export default class MonitorStats extends AsyncComponent<Props, State> {
     let emptyStats = true;
     const success = {
       seriesName: t('Successful'),
-      data: [] as Stat[],
+      data: [] as SeriesDataUnit[],
     };
     const failed = {
       seriesName: t('Failed'),
-      data: [] as Stat[],
+      data: [] as SeriesDataUnit[],
     };
     this.state.stats?.forEach(p => {
       if (p.ok || p.error) {


### PR DESCRIPTION
Don't need to `.toString` the timestamp values, in fact the chart doesn't seem to work if they are `.toString`'ed

Before:
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/9372512/192858985-02b8ef88-d7c8-4b74-a31e-43ea0aa3a21a.png">


After:
<img width="1188" alt="image" src="https://user-images.githubusercontent.com/9372512/192858937-9dfeccca-e246-454f-9ae8-b5e7569ca2f1.png">
