### PR TITLE
feat(perf-issues): Add option to ux for n+1 ext 

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -21,6 +21,7 @@ const optionsAvailable = [
   'performance.issues.all.problem-creation',
   'performance.issues.all.early-adopter-rollout',
   'performance.issues.n_plus_one_db.problem-creation',
+  'performance.issues.n_plus_one_db_ext.problem-creation',
   'performance.issues.n_plus_one_db.count_threshold',
   'performance.issues.n_plus_one_db.duration_threshold',
 ];
@@ -105,6 +106,7 @@ export default class AdminSettings extends AsyncView<{}, State> {
             <Panel>
               <PanelHeader>Performance Issues - Detectors</PanelHeader>
               {fields['performance.issues.n_plus_one_db.problem-creation']}
+              {fields['performance.issues.n_plus_one_db_ext.problem-creation']}
               {fields['performance.issues.n_plus_one_db.count_threshold']}
               {fields['performance.issues.n_plus_one_db.duration_threshold']}
             </Panel>

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -119,6 +119,14 @@ const performanceOptionDefinitions: Field[] = [
     ...HIGH_THROUGHPUT_RATE_OPTION,
   },
   {
+    key: 'performance.issues.n_plus_one_db_ext.problem-creation',
+    label: t('N+1 (DB) (Extended) creation rate'),
+    help: t(
+      'Controls the rate at which performance issues are created specifically for N+1 detection (extended). Value of 0 will disable creation, a value of 1.0 fully enables it.'
+    ),
+    ...HIGH_THROUGHPUT_RATE_OPTION,
+  },
+  {
     key: 'performance.issues.n_plus_one_db.count_threshold',
     label: t('N+1 (DB) count threshold'),
     help: t(


### PR DESCRIPTION
### Summary
This adds the option to rollout the extended n+1 detector.