### PR TITLE
feat(discover): Add save actions to update homepage query

### DIFF
--- a/static/app/actionCreators/discoverHomepageQueries.tsx
+++ b/static/app/actionCreators/discoverHomepageQueries.tsx
@@ -1,24 +1,13 @@
 import {Client} from 'sentry/api';
-import {t} from 'sentry/locale';
 import {NewQuery, SavedQuery} from 'sentry/types';
-
-import {addErrorMessage} from './indicator';
 
 export function updateHomepageQuery(
   api: Client,
   orgId: string,
   query: NewQuery
 ): Promise<SavedQuery> {
-  const promise: Promise<SavedQuery> = api.requestPromise(
-    `/organizations/${orgId}/discover/homepage/`,
-    {
-      method: 'PUT',
-      data: query,
-    }
-  );
-
-  promise.catch(() => {
-    addErrorMessage(t('Unable to set query as Discover home'));
+  return api.requestPromise(`/organizations/${orgId}/discover/homepage/`, {
+    method: 'PUT',
+    data: query,
   });
-  return promise;
 }

--- a/static/app/actionCreators/discoverHomepageQueries.tsx
+++ b/static/app/actionCreators/discoverHomepageQueries.tsx
@@ -1,0 +1,24 @@
+import {Client} from 'sentry/api';
+import {t} from 'sentry/locale';
+import {NewQuery, SavedQuery} from 'sentry/types';
+
+import {addErrorMessage} from './indicator';
+
+export function updateHomepageQuery(
+  api: Client,
+  orgId: string,
+  query: NewQuery
+): Promise<SavedQuery> {
+  const promise: Promise<SavedQuery> = api.requestPromise(
+    `/organizations/${orgId}/discover/homepage/`,
+    {
+      method: 'PUT',
+      data: query,
+    }
+  );
+
+  promise.catch(() => {
+    addErrorMessage(t('Unable to set query as Default Discover Query'));
+  });
+  return promise;
+}

--- a/static/app/actionCreators/discoverHomepageQueries.tsx
+++ b/static/app/actionCreators/discoverHomepageQueries.tsx
@@ -18,7 +18,7 @@ export function updateHomepageQuery(
   );
 
   promise.catch(() => {
-    addErrorMessage(t('Unable to set query as Default Discover Query'));
+    addErrorMessage(t('Unable to set query as Discover home'));
   });
   return promise;
 }

--- a/static/app/views/eventsV2/queryList.spec.jsx
+++ b/static/app/views/eventsV2/queryList.spec.jsx
@@ -21,7 +21,8 @@ describe('EventsV2 > QueryList', function () {
     deleteMock,
     duplicateMock,
     queryChangeMock,
-    updateHomepageMock;
+    updateHomepageMock,
+    wrapper;
 
   beforeAll(async function () {
     await import('sentry/components/modals/widgetBuilder/addToDashboardModal');
@@ -78,10 +79,12 @@ describe('EventsV2 > QueryList', function () {
 
   afterEach(() => {
     jest.clearAllMocks();
+    wrapper && wrapper.unmount();
+    wrapper = null;
   });
 
   it('renders an empty list', function () {
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <QueryList
         organization={organization}
         savedQueries={[]}
@@ -98,7 +101,7 @@ describe('EventsV2 > QueryList', function () {
   });
 
   it('renders pre-built queries and saved ones', function () {
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <QueryList
         organization={organization}
         savedQueries={savedQueries}
@@ -115,7 +118,7 @@ describe('EventsV2 > QueryList', function () {
   });
 
   it('can duplicate and trigger change callback', async function () {
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <QueryList
         organization={organization}
         savedQueries={savedQueries}
@@ -138,7 +141,7 @@ describe('EventsV2 > QueryList', function () {
   });
 
   it('can delete and trigger change callback', async function () {
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <QueryList
         organization={organization}
         savedQueries={savedQueries}
@@ -161,7 +164,7 @@ describe('EventsV2 > QueryList', function () {
   });
 
   it('returns short url location for saved query', function () {
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <QueryList
         organization={organization}
         savedQueries={savedQueries}
@@ -180,7 +183,7 @@ describe('EventsV2 > QueryList', function () {
   });
 
   it('can redirect on last query deletion', async function () {
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <QueryList
         organization={organization}
         savedQueries={savedQueries.slice(1)}
@@ -210,7 +213,7 @@ describe('EventsV2 > QueryList', function () {
     const featuredOrganization = TestStubs.Organization({
       features: ['dashboards-edit'],
     });
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <QueryList
         organization={featuredOrganization}
         savedQueries={savedQueries.slice(1)}
@@ -238,7 +241,7 @@ describe('EventsV2 > QueryList', function () {
   });
 
   it('only renders Delete Query and Duplicate Query in context menu', async function () {
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <QueryList
         organization={organization}
         savedQueries={savedQueries.slice(1)}
@@ -274,7 +277,7 @@ describe('EventsV2 > QueryList', function () {
       ...savedQueries.slice(1)[0],
       yAxis,
     };
-    const wrapper = mountWithTheme(
+    wrapper = mountWithTheme(
       <QueryList
         organization={featuredOrganization}
         savedQueries={[savedQueryWithMultiYAxis]}
@@ -314,7 +317,7 @@ describe('EventsV2 > QueryList', function () {
       const featuredOrganization = TestStubs.Organization({
         features: ['dashboards-edit'],
       });
-      const wrapper = mountWithTheme(
+      wrapper = mountWithTheme(
         <QueryList
           organization={featuredOrganization}
           savedQueries={[
@@ -384,7 +387,7 @@ describe('EventsV2 > QueryList', function () {
       const featuredOrganization = TestStubs.Organization({
         features: ['dashboards-edit'],
       });
-      const wrapper = mountWithTheme(
+      wrapper = mountWithTheme(
         <QueryList
           organization={featuredOrganization}
           savedQueries={[

--- a/static/app/views/eventsV2/queryList.spec.jsx
+++ b/static/app/views/eventsV2/queryList.spec.jsx
@@ -260,7 +260,7 @@ describe('EventsV2 > QueryList', function () {
     const menuItems = card.find('MenuItemWrap');
 
     expect(menuItems.length).toEqual(3);
-    expect(menuItems.at(0).text()).toEqual('Use as Discover home');
+    expect(menuItems.at(0).text()).toEqual('Use as Discover Home');
     expect(menuItems.at(1).text()).toEqual('Duplicate Query');
     expect(menuItems.at(2).text()).toEqual('Delete Query');
   });

--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -177,13 +177,17 @@ class QueryList extends Component<Props> {
             }),
         },
 
-        {
-          key: 'set-as-default',
-          label: t('Use as Discover Home'),
-          onAction: () => {
-            handleUpdateHomepageQuery(api, organization, eventView.toNewQuery());
-          },
-        },
+        ...(organization.features.includes('discover-query-builder-as-landing-page')
+          ? [
+              {
+                key: 'set-as-default',
+                label: t('Use as Discover Home'),
+                onAction: () => {
+                  handleUpdateHomepageQuery(api, organization, eventView.toNewQuery());
+                },
+              },
+            ]
+          : []),
       ];
 
       return (

--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -23,7 +23,11 @@ import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {decodeList} from 'sentry/utils/queryString';
 import withApi from 'sentry/utils/withApi';
 
-import {handleCreateQuery, handleDeleteQuery} from './savedQuery/utils';
+import {
+  handleCreateQuery,
+  handleDeleteQuery,
+  handleUpdateHomepageQuery,
+} from './savedQuery/utils';
 import MiniGraph from './miniGraph';
 import QueryCard from './querycard';
 import {getPrebuiltQueries, handleAddQueryToDashboard} from './utils';
@@ -130,7 +134,7 @@ class QueryList extends Component<Props> {
   }
 
   renderPrebuiltQueries() {
-    const {location, organization, savedQuerySearchQuery, router} = this.props;
+    const {api, location, organization, savedQuerySearchQuery, router} = this.props;
     const views = getPrebuiltQueries(organization);
 
     const hasSearchQuery =
@@ -172,6 +176,14 @@ class QueryList extends Component<Props> {
               router,
             }),
         },
+
+        {
+          key: 'set-as-default',
+          label: t('Use as Discover Home'),
+          onAction: () => {
+            handleUpdateHomepageQuery(api, organization, eventView.toNewQuery());
+          },
+        },
       ];
 
       return (
@@ -211,7 +223,7 @@ class QueryList extends Component<Props> {
   }
 
   renderSavedQueries() {
-    const {savedQueries, location, organization, router} = this.props;
+    const {api, savedQueries, location, organization, router} = this.props;
 
     if (!savedQueries || !Array.isArray(savedQueries) || savedQueries.length === 0) {
       return [];
@@ -244,6 +256,17 @@ class QueryList extends Component<Props> {
                     yAxis: savedQuery?.yAxis ?? eventView.yAxis,
                     router,
                   }),
+              },
+            ]
+          : []),
+        ...(organization.features.includes('discover-query-builder-as-landing-page')
+          ? [
+              {
+                key: 'set-as-default',
+                label: t('Use as Discover Home'),
+                onAction: () => {
+                  handleUpdateHomepageQuery(api, organization, eventView.toNewQuery());
+                },
               },
             ]
           : []),

--- a/static/app/views/eventsV2/results.spec.jsx
+++ b/static/app/views/eventsV2/results.spec.jsx
@@ -1803,7 +1803,7 @@ describe('Results', function () {
     expect(mockHomepage).not.toHaveBeenCalled();
   });
 
-  it('updates the homepage query with up to date eventView when Use as Default is clicked', () => {
+  it('updates the homepage query with up to date eventView when Use as Discover Home is clicked', () => {
     const mockHomepageUpdate = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/discover/homepage/',
       method: 'PUT',
@@ -1836,7 +1836,7 @@ describe('Results', function () {
       {context: initialData.routerContext, organization}
     );
 
-    userEvent.click(screen.getByText('Use as Default'));
+    userEvent.click(screen.getByText('Use as Discover Home'));
 
     expect(mockHomepageUpdate).toHaveBeenCalledWith(
       '/organizations/org-slug/discover/homepage/',

--- a/static/app/views/eventsV2/results.spec.jsx
+++ b/static/app/views/eventsV2/results.spec.jsx
@@ -2,7 +2,7 @@ import {browserHistory} from 'react-router';
 
 import {enforceActOnUseLegacyStoreHook, mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {act, render} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {triggerPress} from 'sentry-test/utils';
 
 import * as PageFilterPersistence from 'sentry/components/organizations/pageFilters/persistence';
@@ -1801,5 +1801,50 @@ describe('Results', function () {
 
     expect(mockSaved).toHaveBeenCalled();
     expect(mockHomepage).not.toHaveBeenCalled();
+  });
+
+  it('updates the homepage query with up to date eventView when Use as Default is clicked', () => {
+    const mockHomepageUpdate = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/discover/homepage/',
+      method: 'PUT',
+      statusCode: 204,
+    });
+    const organization = TestStubs.Organization({
+      features: [
+        'discover-basic',
+        'discover-query',
+        'discover-query-builder-as-landing-page',
+      ],
+    });
+
+    const initialData = initializeOrg({
+      organization,
+      router: {
+        // These fields take priority and should be sent in the request
+        location: {query: {field: ['title', 'user']}},
+      },
+    });
+
+    ProjectsStore.loadInitialData([TestStubs.Project()]);
+
+    render(
+      <Results
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+      />,
+      {context: initialData.routerContext, organization}
+    );
+
+    userEvent.click(screen.getByText('Use as Default'));
+
+    expect(mockHomepageUpdate).toHaveBeenCalledWith(
+      '/organizations/org-slug/discover/homepage/',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          fields: ['title', 'user'],
+        }),
+      })
+    );
   });
 });

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -30,7 +30,12 @@ import withApi from 'sentry/utils/withApi';
 import withProjects from 'sentry/utils/withProjects';
 import {handleAddQueryToDashboard} from 'sentry/views/eventsV2/utils';
 
-import {handleCreateQuery, handleDeleteQuery, handleUpdateQuery} from './utils';
+import {
+  handleCreateQuery,
+  handleDeleteQuery,
+  handleUpdateHomepageQuery,
+  handleUpdateQuery,
+} from './utils';
 
 type SaveAsDropdownProps = {
   disabled: boolean;
@@ -383,14 +388,16 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
   }
 
   renderSaveAsHomepage() {
-    const {organization, eventView, savedQuery, yAxis, router, location} = this.props;
+    const {api, organization, eventView} = this.props;
     return (
       <Button
         key="save-query-as-homepage"
         data-test-id="save-query-as-homepage"
-        onClick={() => console.log('saving duuuuude')}
+        onClick={() => {
+          handleUpdateHomepageQuery(api, organization, eventView.toNewQuery());
+        }}
       >
-        {t('Add to Dashboard')}
+        {t('Use as Default')}
       </Button>
     );
   }
@@ -430,7 +437,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
       <ResponsiveButtonBar gap={1}>
         <Feature
           organization={organization}
-          features={['discover-query-builder-as-landing-page']}
+          features={['discover-query', 'discover-query-builder-as-landing-page']}
         >
           {({hasFeature}) => hasFeature && this.renderSaveAsHomepage()}
         </Feature>

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -397,7 +397,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
           handleUpdateHomepageQuery(api, organization, eventView.toNewQuery());
         }}
       >
-        {t('Use as Default')}
+        {t('Use as Discover Home')}
       </Button>
     );
   }

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -382,6 +382,19 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
     );
   }
 
+  renderSaveAsHomepage() {
+    const {organization, eventView, savedQuery, yAxis, router, location} = this.props;
+    return (
+      <Button
+        key="save-query-as-homepage"
+        data-test-id="save-query-as-homepage"
+        onClick={() => console.log('saving duuuuude')}
+      >
+        {t('Add to Dashboard')}
+      </Button>
+    );
+  }
+
   render() {
     const {organization} = this.props;
 
@@ -415,6 +428,12 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
 
     return (
       <ResponsiveButtonBar gap={1}>
+        <Feature
+          organization={organization}
+          features={['discover-query-builder-as-landing-page']}
+        >
+          {({hasFeature}) => hasFeature && this.renderSaveAsHomepage()}
+        </Feature>
         {renderQueryButton(disabled => this.renderButtonSave(disabled))}
         <Feature organization={organization} features={['incidents']}>
           {({hasFeature}) => hasFeature && this.renderButtonCreateAlert()}

--- a/static/app/views/eventsV2/savedQuery/utils.tsx
+++ b/static/app/views/eventsV2/savedQuery/utils.tsx
@@ -1,3 +1,4 @@
+import {updateHomepageQuery} from 'sentry/actionCreators/discoverHomepageQueries';
 import {
   createSavedQuery,
   deleteSavedQuery,
@@ -209,6 +210,22 @@ export function handleDeleteQuery(
     });
 
   return promise;
+}
+
+export function handleUpdateHomepageQuery(
+  api: Client,
+  organization: Organization,
+  query: NewQuery
+) {
+  const promise = updateHomepageQuery(api, organization.slug, query);
+
+  return promise
+    .then(() => {
+      addSuccessMessage(t('Saved as Default Discover Query'));
+    })
+    .catch(() => {
+      addErrorMessage(t('Unable to set query as Default Discover Query'));
+    });
 }
 
 export function getAnalyticsCreateEventKeyName(

--- a/static/app/views/eventsV2/savedQuery/utils.tsx
+++ b/static/app/views/eventsV2/savedQuery/utils.tsx
@@ -221,10 +221,10 @@ export function handleUpdateHomepageQuery(
 
   return promise
     .then(() => {
-      addSuccessMessage(t('Saved as Default Discover Query'));
+      addSuccessMessage(t('Saved as Discover home'));
     })
     .catch(() => {
-      addErrorMessage(t('Unable to set query as Default Discover Query'));
+      addErrorMessage(t('Unable to set query as Discover home'));
     });
 }
 


### PR DESCRIPTION
Adds a button and context menu option (in the manage page) to save the current query as
the Discover homepage. This PR currently only updates the query. Another PR will
handle resetting the query and stopping the user from repeatedly clicking
"Use as Discover Home"