### PR TITLE
test(flakey):  fix flakey test

### DIFF
--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -626,10 +626,10 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
         self.one_alert_rule = self.create_alert_rule(
             projects=self.projects, date_added=date_added.replace(tzinfo=pytz.UTC)
         )
+        self.three_alert_rule = self.create_alert_rule(projects=self.projects)
         self.two_alert_rule = self.create_alert_rule(
             projects=self.projects, date_added=date_added.replace(tzinfo=pytz.UTC)
         )
-        self.three_alert_rule = self.create_alert_rule(projects=self.projects)
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             request_data = {"per_page": "2"}

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -626,13 +626,13 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
         self.one_alert_rule = self.create_alert_rule(
             projects=self.projects, date_added=date_added.replace(tzinfo=pytz.UTC)
         )
-        self.three_alert_rule = self.create_alert_rule(projects=self.projects)
         self.two_alert_rule = self.create_alert_rule(
             projects=self.projects, date_added=date_added.replace(tzinfo=pytz.UTC)
         )
+        self.three_alert_rule = self.create_alert_rule(projects=self.projects)
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
-            request_data = {"per_page": "2"}
+            request_data = {"per_page": "2", "sort": ["date_added", "id"]}
             response = self.client.get(
                 path=self.combined_rules_url, data=request_data, content_type="application/json"
             )


### PR DESCRIPTION
Creation of `one_alert_rule` and `two_alert_rule` may be in a race where the primary keys generated could be non-sequential. 

Adding a small delay between creations of these two alert rules should resolve the flip-flopping of Ids between the two rows which might be causing `test_offset_pagination` to flake.