### PR TITLE
chore(hybrid-cloud): Turn off customer domain middleware by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1883,6 +1883,9 @@ SENTRY_USE_CDC_DEV = False
 # This flag activates profiling backend in the development environment
 SENTRY_USE_PROFILING = False
 
+# This flag activates code paths that are specific for customer domains
+SENTRY_USE_CUSTOMER_DOMAINS = False
+
 # SENTRY_DEVSERVICES = {
 #     "service-name": lambda settings, options: (
 #         {

--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -77,6 +77,8 @@ class CustomerDomainMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: Request) -> Response:
+        if not getattr(settings, "SENTRY_USE_CUSTOMER_DOMAINS", False):
+            return self.get_response(request)
         if not hasattr(request, "subdomain"):
             return self.get_response(request)
         subdomain = request.subdomain

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -396,6 +396,9 @@ def provision_middleware():
 
 
 @control_silo_test
+@override_settings(
+    SENTRY_USE_CUSTOMER_DOMAINS=True,
+)
 class AuthLoginCustomerDomainTest(TestCase):
     @fixture
     def path(self):


### PR DESCRIPTION
Turn off the customer domain middleware by default.

This ensures no issues arise for self-hosted installations and single tenant instances.