### PR TITLE
ref(perf-issues): Add platform to group metric

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1294,8 +1294,7 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
         with sentry_sdk.start_span(
             op="event_manager.create_group_transaction"
         ) as span, metrics.timer(
-            "event_manager.create_group_transaction",
-            tags={"platform": event.platform or "unknown"}
+            "event_manager.create_group_transaction", tags={"platform": event.platform or "unknown"}
         ) as metric_tags, transaction.atomic():
             span.set_tag("create_group_transaction.outcome", "no_group")
             metric_tags["create_group_transaction.outcome"] = "no_group"

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1294,7 +1294,8 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
         with sentry_sdk.start_span(
             op="event_manager.create_group_transaction"
         ) as span, metrics.timer(
-            "event_manager.create_group_transaction"
+            "event_manager.create_group_transaction",
+            tags={"platform": event.platform or "unknown"}
         ) as metric_tags, transaction.atomic():
             span.set_tag("create_group_transaction.outcome", "no_group")
             metric_tags["create_group_transaction.outcome"] = "no_group"

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1294,7 +1294,7 @@ def _save_aggregate(event, hashes, release, metadata, received_timestamp, **kwar
         with sentry_sdk.start_span(
             op="event_manager.create_group_transaction"
         ) as span, metrics.timer(
-            "event_manager.create_group_transaction", tags={"platform": event.platform or "unknown"}
+            "event_manager.create_group_transaction"
         ) as metric_tags, transaction.atomic():
             span.set_tag("create_group_transaction.outcome", "no_group")
             metric_tags["create_group_transaction.outcome"] = "no_group"
@@ -2084,6 +2084,7 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
                         op="event_manager.create_performance_group_transaction"
                     ) as span, metrics.timer(
                         "event_manager.create_performance_group_transaction",
+                        tags={"platform": event.platform or "unknown"},
                         sample_rate=1.0,
                     ) as metric_tags, transaction.atomic():
                         span.set_tag("create_group_transaction.outcome", "no_group")


### PR DESCRIPTION
### Summary
We're using `event_manager.create_performance_group_transaction.count` to check created perf-issue groups at the moment, we could alternatively add a bool to `group.created`, but either way I think we should have a breakdown of create perf issue groups by platform.
