### PR TITLE
fix(trends): Keep period consistent

### DIFF
--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -4,6 +4,7 @@ import {withRouter} from 'react-router';
 
 import Button from 'sentry/components/button';
 import Truncate from 'sentry/components/truncate';
+import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import TrendsDiscoverQuery from 'sentry/utils/performance/trends/trendsDiscoverQuery';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -161,6 +162,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
                   initialConditions,
                   additionalQuery: {
                     trendFunction: trendFunctionField,
+                    statsPeriod: eventView.statsPeriod || DEFAULT_STATS_PERIOD,
                   },
                 });
                 return (


### PR DESCRIPTION
### Summary
When on the default period for landing, clicking into trends doesn't keep the default period, which causes odd results in the trends view. Whether we should link directly to transaction summary is a separate discussion, for now we can just fix this part.


