### PR TITLE
fix(discover): Fix flaky redirects to homepage

### DIFF
--- a/static/app/utils/discover/urls.tsx
+++ b/static/app/utils/discover/urls.tsx
@@ -60,7 +60,7 @@ export function getDiscoverLandingUrl(organization: OrganizationSummary): string
   ) {
     return getDiscoverQueriesUrl(organization);
   }
-  return `/organizations/${organization.slug}/discover/results/`;
+  return `/organizations/${organization.slug}/discover/results/id=homepage`;
 }
 
 export function getDiscoverQueriesUrl(organization: OrganizationSummary): string {

--- a/static/app/utils/discover/urls.tsx
+++ b/static/app/utils/discover/urls.tsx
@@ -60,7 +60,7 @@ export function getDiscoverLandingUrl(organization: OrganizationSummary): string
   ) {
     return getDiscoverQueriesUrl(organization);
   }
-  return `/organizations/${organization.slug}/discover/results/id=homepage`;
+  return `/organizations/${organization.slug}/discover/results/?homepage=true`;
 }
 
 export function getDiscoverQueriesUrl(organization: OrganizationSummary): string {

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -293,10 +293,7 @@ class Results extends Component<Props, State> {
 
     // If the view is not valid, redirect to a known valid state.
     const {location, organization, selection} = this.props;
-    if (homepageQuery) {
-      homepageQuery.id = 'homepage';
-    }
-    const query = homepageQuery ?? DEFAULT_EVENT_VIEW;
+    const query = homepageQuery ? omit(homepageQuery, 'id') : DEFAULT_EVENT_VIEW;
     const nextEventView = EventView.fromNewQueryWithLocation(query, location);
     if (nextEventView.project.length === 0 && selection.projects) {
       nextEventView.project = selection.projects;
@@ -675,7 +672,7 @@ class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
     const {organization, location} = this.props;
 
     const endpoints: ReturnType<AsyncComponent['getEndpoints']> = [];
-    if (location.query.id && location.query.id !== 'homepage') {
+    if (location.query.id) {
       endpoints.push([
         'savedQuery',
         `/organizations/${organization.slug}/discover/saved/${location.query.id}/`,
@@ -685,9 +682,7 @@ class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
 
     if (
       organization.features.includes('discover-query-builder-as-landing-page') &&
-      organization.features.includes('discover-query') &&
-      location.query.id &&
-      location.query.id === 'homepage'
+      organization.features.includes('discover-query')
     ) {
       endpoints.push([
         'homepageQuery',

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -3,7 +3,6 @@ import {browserHistory, InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {Location} from 'history';
-import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 
@@ -294,7 +293,10 @@ class Results extends Component<Props, State> {
 
     // If the view is not valid, redirect to a known valid state.
     const {location, organization, selection} = this.props;
-    const query = homepageQuery ? omit(homepageQuery, 'id') : DEFAULT_EVENT_VIEW;
+    if (homepageQuery) {
+      homepageQuery.id = 'homepage';
+    }
+    const query = homepageQuery ?? DEFAULT_EVENT_VIEW;
     const nextEventView = EventView.fromNewQueryWithLocation(query, location);
     if (nextEventView.project.length === 0 && selection.projects) {
       nextEventView.project = selection.projects;
@@ -673,7 +675,7 @@ class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
     const {organization, location} = this.props;
 
     const endpoints: ReturnType<AsyncComponent['getEndpoints']> = [];
-    if (location.query.id) {
+    if (location.query.id && location.query.id !== 'homepage') {
       endpoints.push([
         'savedQuery',
         `/organizations/${organization.slug}/discover/saved/${location.query.id}/`,
@@ -683,7 +685,8 @@ class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
 
     if (
       organization.features.includes('discover-query-builder-as-landing-page') &&
-      isEmpty(location.query)
+      location.query.id &&
+      location.query.id === 'homepage'
     ) {
       endpoints.push([
         'homepageQuery',


### PR DESCRIPTION
Using `isEmpty(location.query)` to determine
if we should load homepage can be flaky if
the API request isn't fulfilled before pagefilters
append query params to the URL.

Add a param `homepage=true` so we're not
relying on the check to see if `query` is empty
in `location`. 