### PR TITLE
feat(perf-issues): Re-enable ignore options by time window for all issue types [UP-172]

### DIFF
--- a/static/app/components/actions/ignore.spec.jsx
+++ b/static/app/components/actions/ignore.spec.jsx
@@ -6,7 +6,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import IgnoreActions from 'sentry/components/actions/ignore';
-import {IssueCategory} from 'sentry/types';
 
 describe('IgnoreActions', function () {
   const spy = jest.fn();
@@ -16,9 +15,7 @@ describe('IgnoreActions', function () {
 
   describe('disabled', function () {
     it('does not call onUpdate when clicked', function () {
-      render(
-        <IgnoreActions issueCategory={IssueCategory.ERROR} onUpdate={spy} disabled />
-      );
+      render(<IgnoreActions onUpdate={spy} disabled />);
       const button = screen.getByRole('button', {name: 'Ignore'});
       expect(button).toBeDisabled();
       userEvent.click(button);
@@ -28,9 +25,7 @@ describe('IgnoreActions', function () {
 
   describe('ignored', function () {
     it('displays ignored view', function () {
-      render(
-        <IgnoreActions issueCategory={IssueCategory.ERROR} onUpdate={spy} isIgnored />
-      );
+      render(<IgnoreActions onUpdate={spy} isIgnored />);
       const button = screen.getByRole('button', {name: 'Unignore'});
       expect(button).toBeInTheDocument();
       // Shows icon only
@@ -43,7 +38,7 @@ describe('IgnoreActions', function () {
 
   describe('without confirmation', function () {
     it('calls spy with ignore details when clicked', function () {
-      render(<IgnoreActions issueCategory={IssueCategory.ERROR} onUpdate={spy} />);
+      render(<IgnoreActions onUpdate={spy} />);
       const button = screen.getByRole('button', {name: 'Ignore'});
       userEvent.click(button);
       expect(spy).toHaveBeenCalledTimes(1);
@@ -54,12 +49,7 @@ describe('IgnoreActions', function () {
   describe('with confirmation step', function () {
     it('displays confirmation modal with message provided', function () {
       render(
-        <IgnoreActions
-          issueCategory={IssueCategory.ERROR}
-          onUpdate={spy}
-          shouldConfirm
-          confirmMessage={() => 'confirm me'}
-        />
+        <IgnoreActions onUpdate={spy} shouldConfirm confirmMessage={() => 'confirm me'} />
       );
       renderGlobalModal();
       const button = screen.getByRole('button', {name: 'Ignore'});

--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -13,12 +13,10 @@ import {IconChevron, IconMute} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {
   GroupStatusResolution,
-  IssueCategory,
   ResolutionStatus,
   ResolutionStatusDetails,
   SelectValue,
 } from 'sentry/types';
-import {getIssueCapability} from 'sentry/utils/groupCapabilities';
 
 const ONE_HOUR = 60;
 
@@ -42,7 +40,6 @@ const IGNORE_WINDOWS: SelectValue<number>[] = [
 ];
 
 type Props = {
-  issueCategory: IssueCategory;
   onUpdate: (params: GroupStatusResolution) => void;
   confirmLabel?: string;
   confirmMessage?: (
@@ -54,7 +51,6 @@ type Props = {
 };
 
 const IgnoreActions = ({
-  issueCategory,
   onUpdate,
   disabled,
   shouldConfirm,
@@ -103,7 +99,7 @@ const IgnoreActions = ({
       />
     ));
 
-  const openCustomIgnoreCount = (isPerformanceIssue: boolean) =>
+  const openCustomIgnoreCount = () =>
     openModal(deps => (
       <CustomIgnoreCountModal
         {...deps}
@@ -113,11 +109,10 @@ const IgnoreActions = ({
         countName="ignoreCount"
         windowName="ignoreWindow"
         windowOptions={IGNORE_WINDOWS}
-        isPerformanceIssue={isPerformanceIssue}
       />
     ));
 
-  const openCustomIgnoreUserCount = (isPerformanceIssue: boolean) =>
+  const openCustomIgnoreUserCount = () =>
     openModal(deps => (
       <CustomIgnoreCountModal
         {...deps}
@@ -127,195 +122,100 @@ const IgnoreActions = ({
         countName="ignoreUserCount"
         windowName="ignoreUserWindow"
         windowOptions={IGNORE_WINDOWS}
-        isPerformanceIssue={isPerformanceIssue}
       />
     ));
 
-  // TODO: This function is only here since some of the dropdown options do not currently work for Performance issues.
-  // In the future, all options will be enabled and so we can revert this to what it was before (a single constant array of dropdown items)
-  const getDropdownItems = () => {
-    if (issueCategory === IssueCategory.PERFORMANCE) {
-      const disabledReason = getIssueCapability(issueCategory, 'ignore').disabledReason;
-
-      return [
+  const dropdownItems = [
+    {
+      key: 'for',
+      label: t('For\u2026'),
+      isSubmenu: true,
+      children: [
+        ...IGNORE_DURATIONS.map(duration => ({
+          key: `for-${duration}`,
+          label: <Duration seconds={duration * 60} />,
+          onAction: () => onIgnore({ignoreDuration: duration}),
+        })),
         {
-          key: 'for',
-          label: t('For\u2026'),
+          key: 'for-custom',
+          label: t('Custom'),
+          onAction: () => openCustomIgnoreDuration(),
+        },
+      ],
+    },
+    {
+      key: 'until-reoccur',
+      label: t('Until this occurs again\u2026'),
+      isSubmenu: true,
+      children: [
+        ...IGNORE_COUNTS.map(count => ({
+          key: `until-reoccur-${count}-times`,
+          label:
+            count === 1
+              ? t('one time\u2026') // This is intentional as unbalanced string formatters are problematic
+              : tn('%s time\u2026', '%s times\u2026', count),
           isSubmenu: true,
           children: [
-            ...IGNORE_DURATIONS.map(duration => ({
-              key: `for-${duration}`,
-              label: <Duration seconds={duration * 60} />,
-              onAction: () => onIgnore({ignoreDuration: duration}),
-            })),
             {
-              key: 'for-custom',
-              label: t('Custom'),
-              onAction: () => openCustomIgnoreDuration(),
+              key: `until-reoccur-${count}-times-from-now`,
+              label: t('from now'),
+              onAction: () => onIgnore({ignoreCount: count}),
             },
+            ...IGNORE_WINDOWS.map(({value, label}) => ({
+              key: `until-reoccur-${count}-times-from-${label}`,
+              label,
+              onAction: () =>
+                onIgnore({
+                  ignoreCount: count,
+                  ignoreWindow: value,
+                }),
+            })),
           ],
-        },
+        })),
         {
-          key: 'until-reoccur',
-          label: t('Until this occurs again\u2026'),
+          key: 'until-reoccur-custom',
+          label: t('Custom'),
+          onAction: () => openCustomIgnoreCount(),
+        },
+      ],
+    },
+    {
+      key: 'until-affect',
+      label: t('Until this affects an additional\u2026'),
+      isSubmenu: true,
+      children: [
+        ...IGNORE_COUNTS.map(count => ({
+          key: `until-affect-${count}-users`,
+          label:
+            count === 1
+              ? t('one user\u2026') // This is intentional as unbalanced string formatters are problematic
+              : tn('%s user\u2026', '%s users\u2026', count),
           isSubmenu: true,
           children: [
-            ...IGNORE_COUNTS.map(count => ({
-              key: `until-reoccur-${count}-times`,
-              label:
-                count === 1
-                  ? t('one time\u2026') // This is intentional as unbalanced string formatters are problematic
-                  : tn('%s time\u2026', '%s times\u2026', count),
-              isSubmenu: true,
-              children: [
-                {
-                  key: `until-reoccur-${count}-times-from-now`,
-                  label: t('from now'),
-                  onAction: () => onIgnore({ignoreCount: count}),
-                },
-                ...IGNORE_WINDOWS.map(({label}) => ({
-                  key: `until-reoccur-${count}-times-from-${label}`,
-                  label,
-                  details: disabledReason,
-                  disabled: true,
-                })),
-              ],
-            })),
             {
-              key: 'until-reoccur-custom',
-              label: t('Custom'),
-              onAction: () => openCustomIgnoreCount(true), // TODO: Disable time window in the modal
+              key: `until-affect-${count}-users-from-now`,
+              label: t('from now'),
+              onAction: () => onIgnore({ignoreUserCount: count}),
             },
+            ...IGNORE_WINDOWS.map(({value, label}) => ({
+              key: `until-affect-${count}-users-from-${label}`,
+              label,
+              onAction: () =>
+                onIgnore({
+                  ignoreUserCount: count,
+                  ignoreUserWindow: value,
+                }),
+            })),
           ],
-        },
+        })),
         {
-          key: 'until-affect',
-          label: t('Until this affects an additional\u2026'),
-          isSubmenu: true,
-          children: [
-            ...IGNORE_COUNTS.map(count => ({
-              key: `until-affect-${count}-users`,
-              label:
-                count === 1
-                  ? t('one user\u2026') // This is intentional as unbalanced string formatters are problematic
-                  : tn('%s user\u2026', '%s users\u2026', count),
-              isSubmenu: true,
-              children: [
-                {
-                  key: `until-affect-${count}-users-from-now`,
-                  label: t('from now'),
-                  onAction: () => onIgnore({ignoreUserCount: count}),
-                },
-                ...IGNORE_WINDOWS.map(({label}) => ({
-                  key: `until-affect-${count}-users-from-${label}`,
-                  label,
-                  details: disabledReason,
-                  disabled: true,
-                })),
-              ],
-            })),
-            {
-              key: 'until-affect-custom',
-              label: t('Custom'),
-              onAction: () => openCustomIgnoreUserCount(true), // TODO: Edit modal to disable time window
-            },
-          ],
+          key: 'until-affect-custom',
+          label: t('Custom'),
+          onAction: () => openCustomIgnoreUserCount(),
         },
-      ];
-    }
-
-    return [
-      {
-        key: 'for',
-        label: t('For\u2026'),
-        isSubmenu: true,
-        children: [
-          ...IGNORE_DURATIONS.map(duration => ({
-            key: `for-${duration}`,
-            label: <Duration seconds={duration * 60} />,
-            onAction: () => onIgnore({ignoreDuration: duration}),
-          })),
-          {
-            key: 'for-custom',
-            label: t('Custom'),
-            onAction: () => openCustomIgnoreDuration(),
-          },
-        ],
-      },
-      {
-        key: 'until-reoccur',
-        label: t('Until this occurs again\u2026'),
-        isSubmenu: true,
-        children: [
-          ...IGNORE_COUNTS.map(count => ({
-            key: `until-reoccur-${count}-times`,
-            label:
-              count === 1
-                ? t('one time\u2026') // This is intentional as unbalanced string formatters are problematic
-                : tn('%s time\u2026', '%s times\u2026', count),
-            isSubmenu: true,
-            children: [
-              {
-                key: `until-reoccur-${count}-times-from-now`,
-                label: t('from now'),
-                onAction: () => onIgnore({ignoreCount: count}),
-              },
-              ...IGNORE_WINDOWS.map(({value, label}) => ({
-                key: `until-reoccur-${count}-times-from-${label}`,
-                label,
-                onAction: () =>
-                  onIgnore({
-                    ignoreCount: count,
-                    ignoreWindow: value,
-                  }),
-              })),
-            ],
-          })),
-          {
-            key: 'until-reoccur-custom',
-            label: t('Custom'),
-            onAction: () => openCustomIgnoreCount(false),
-          },
-        ],
-      },
-      {
-        key: 'until-affect',
-        label: t('Until this affects an additional\u2026'),
-        isSubmenu: true,
-        children: [
-          ...IGNORE_COUNTS.map(count => ({
-            key: `until-affect-${count}-users`,
-            label:
-              count === 1
-                ? t('one user\u2026') // This is intentional as unbalanced string formatters are problematic
-                : tn('%s user\u2026', '%s users\u2026', count),
-            isSubmenu: true,
-            children: [
-              {
-                key: `until-affect-${count}-users-from-now`,
-                label: t('from now'),
-                onAction: () => onIgnore({ignoreUserCount: count}),
-              },
-              ...IGNORE_WINDOWS.map(({value, label}) => ({
-                key: `until-affect-${count}-users-from-${label}`,
-                label,
-                onAction: () =>
-                  onIgnore({
-                    ignoreUserCount: count,
-                    ignoreUserWindow: value,
-                  }),
-              })),
-            ],
-          })),
-          {
-            key: 'until-affect-custom',
-            label: t('Custom'),
-            onAction: () => openCustomIgnoreUserCount(false),
-          },
-        ],
-      },
-    ];
-  };
+      ],
+    },
+  ];
 
   return (
     <ButtonBar merged>
@@ -344,7 +244,7 @@ const IgnoreActions = ({
           />
         )}
         menuTitle={t('Ignore')}
-        items={getDropdownItems()}
+        items={dropdownItems}
         isDisabled={disabled}
       />
     </ButtonBar>

--- a/static/app/components/customIgnoreCountModal.tsx
+++ b/static/app/components/customIgnoreCountModal.tsx
@@ -14,7 +14,6 @@ type WindowNames = 'ignoreWindow' | 'ignoreUserWindow';
 type Props = ModalRenderProps & {
   countLabel: string;
   countName: CountNames;
-  isPerformanceIssue: boolean;
   label: string;
   onSelected: (statusDetails: ResolutionStatusDetails) => void;
   windowName: WindowNames;
@@ -49,22 +48,9 @@ class CustomIgnoreCountModal extends Component<Props, State> {
   };
 
   render() {
-    const {
-      Header,
-      Footer,
-      Body,
-      countLabel,
-      label,
-      closeModal,
-      windowOptions,
-      isPerformanceIssue,
-    } = this.props;
+    const {Header, Footer, Body, countLabel, label, closeModal, windowOptions} =
+      this.props;
     const {count, window} = this.state;
-
-    // TODO: Revert this when this option becomes available for Performance Issues
-    const helpSubtext = isPerformanceIssue
-      ? t('This option is currently not available for Performance issues.')
-      : t('(Optional) If supplied, this rule will apply as a rate of change.');
 
     return (
       <Fragment>
@@ -95,8 +81,7 @@ class CustomIgnoreCountModal extends Component<Props, State> {
             options={windowOptions}
             placeholder={t('e.g. per hour')}
             allowClear
-            help={helpSubtext}
-            disabled={isPerformanceIssue}
+            help={t('(Optional) If supplied, this rule will apply as a rate of change.')}
           />
         </Body>
         <Footer>

--- a/static/app/utils/groupCapabilities.tsx
+++ b/static/app/utils/groupCapabilities.tsx
@@ -26,13 +26,7 @@ const ISSUE_CATEGORY_CAPABILITIES: Record<IssueCategory, IssueCategoryCapabiliti
       enabled: false,
       disabledReason: t('Not yet supported for performance issues'),
     },
-    // NOTE: The enabled flag is not being used by the ignore dropdown, since
-    // only specific suboptions are disabled. I am leaving the disabledReason
-    // here so it can be used in tooltips for each disabled dropdown option
-    ignore: {
-      enabled: false,
-      disabledReason: t('This ignore option is not yet supported for performance issues'),
-    },
+    ignore: {enabled: true},
     share: {
       enabled: false,
       disabledReason: t('Sharing is not yet supported for performance issues'),

--- a/static/app/views/issueList/actions.spec.jsx
+++ b/static/app/views/issueList/actions.spec.jsx
@@ -426,48 +426,6 @@ describe('IssueListActions', function () {
           })
         );
       });
-
-      it('silently filters out performance issues when bulk ignoring by time window', function () {
-        const bulkMergeMock = MockApiClient.addMockResponse({
-          url: '/organizations/org-slug/issues/',
-          method: 'PUT',
-        });
-
-        render(
-          <OrganizationContext.Provider value={orgWithPerformanceIssues}>
-            <GlobalModal />
-            <IssueListActions {...defaultProps} query="is:unresolved" queryCount={100} />
-          </OrganizationContext.Provider>
-        );
-
-        userEvent.click(screen.getByRole('checkbox'));
-
-        userEvent.click(screen.getByTestId('issue-list-select-all-notice-link'));
-
-        userEvent.click(screen.getByRole('button', {name: 'Ignore options'}));
-        fireEvent.click(screen.getByTestId('until-affect'));
-        fireEvent.click(screen.getByTestId('until-affect-10-users'));
-        userEvent.click(screen.getByTestId('until-affect-10-users-from-per hour'));
-
-        const modal = screen.getByRole('dialog');
-
-        expect(
-          within(modal).getByText(
-            /ignoring performance issues by time window is not yet supported/i
-          )
-        ).toBeInTheDocument();
-
-        userEvent.click(within(modal).getByRole('button', {name: 'Bulk ignore issues'}));
-
-        expect(bulkMergeMock).toHaveBeenCalledWith(
-          expect.anything(),
-          expect.objectContaining({
-            query: expect.objectContaining({
-              query: 'is:unresolved !issue.category:performance',
-            }),
-          })
-        );
-      });
     });
   });
 });

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -243,9 +243,7 @@ function ActionSet({
       <IgnoreActions
         onUpdate={onUpdate}
         shouldConfirm={onShouldConfirm(ConfirmAction.IGNORE)}
-        confirmMessage={statusDetails =>
-          confirm({action: ConfirmAction.IGNORE, canBeUndone: true, statusDetails})
-        }
+        confirmMessage={() => confirm({action: ConfirmAction.IGNORE, canBeUndone: true})}
         confirmLabel={label('ignore')}
         issueCategory={issueCategory}
         disabled={ignoreDisabled}

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -11,7 +11,6 @@ import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {
   BaseGroup,
-  IssueCategory,
   IssueCategoryCapabilities,
   Project,
   ResolutionStatus,
@@ -105,13 +104,6 @@ function ActionSet({
   // the dropdown menu based on the current screen size
   const theme = useTheme();
   const nestMergeAndReview = useMedia(`(max-width: ${theme.breakpoints.xlarge})`);
-
-  // If at least one Performance Issue is selected, some of the ignore dropdown options must be disabled.
-  const issueCategory: IssueCategory = selectedIssues.some(
-    issue => issue?.issueCategory === IssueCategory.PERFORMANCE
-  )
-    ? IssueCategory.PERFORMANCE
-    : IssueCategory.ERROR;
 
   const menuItems: MenuItemProps[] = [
     {
@@ -245,7 +237,6 @@ function ActionSet({
         shouldConfirm={onShouldConfirm(ConfirmAction.IGNORE)}
         confirmMessage={() => confirm({action: ConfirmAction.IGNORE, canBeUndone: true})}
         confirmLabel={label('ignore')}
-        issueCategory={issueCategory}
         disabled={ignoreDisabled}
       />
       {!nestMergeAndReview && (

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -11,7 +11,7 @@ import GroupStore from 'sentry/stores/groupStore';
 import SelectedGroupStore from 'sentry/stores/selectedGroupStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
-import {Group, PageFilters, ResolutionStatusDetails} from 'sentry/types';
+import {Group, PageFilters} from 'sentry/types';
 import theme from 'sentry/utils/theme';
 import useApi from 'sentry/utils/useApi';
 import useMedia from 'sentry/utils/useMedia';
@@ -20,12 +20,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import ActionSet from './actionSet';
 import Headers from './headers';
 import IssueListSortOptions from './sortOptions';
-import {
-  BULK_LIMIT,
-  BULK_LIMIT_STR,
-  ConfirmAction,
-  performanceIssuesSupportsIgnoreAction,
-} from './utils';
+import {BULK_LIMIT, BULK_LIMIT_STR, ConfirmAction} from './utils';
 
 type IssueListActionsProps = {
   allResultsVisible: boolean;
@@ -136,16 +131,6 @@ function IssueListActions({
       'issue-list-removal-action'
     );
 
-    // TODO: Remove this check when performance issues supports ignoring by time window
-    const ignoreStatusDetails = data?.statusDetails as
-      | ResolutionStatusDetails
-      | undefined;
-    const unsupportedByPerformanceIssues =
-      ignoreStatusDetails && !performanceIssuesSupportsIgnoreAction(ignoreStatusDetails);
-    const bulkUpdateQuery = unsupportedByPerformanceIssues
-      ? queryExcludingPerformanceIssues
-      : query;
-
     actionSelectedGroups(itemIds => {
       // TODO(Kelly): remove once issue-list-removal-action feature is stable
       if (!hasIssueListRemovalAction) {
@@ -172,7 +157,7 @@ function IssueListActions({
           orgId: organization.slug,
           itemIds,
           data,
-          query: bulkUpdateQuery,
+          query,
           environment: selection.environments,
           ...projectConstraints,
           ...selection.datetime,

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -78,12 +78,10 @@ export function getConfirm({
     action,
     canBeUndone,
     append = '',
-    statusDetails,
   }: {
     action: ConfirmAction | string;
     canBeUndone: boolean;
     append?: string;
-    statusDetails?: ResolutionStatusDetails;
   }) {
     const question = allInQuerySelected
       ? getBulkConfirmMessage(`${action}${append}`, queryCount)
@@ -123,17 +121,6 @@ export function getConfirm({
             </PerformanceIssueAlert>
           </Fragment>
         );
-        break;
-      case ConfirmAction.IGNORE:
-        if (statusDetails && !performanceIssuesSupportsIgnoreAction(statusDetails)) {
-          message = (
-            <PerformanceIssueAlert {...{organization, allInQuerySelected}}>
-              {t(
-                'Ignoring performance issues by time window is not yet supported. Any encountered in this query will be skipped.'
-              )}
-            </PerformanceIssueAlert>
-          );
-        }
         break;
       default:
         message = !canBeUndone ? <p>{t('This action cannot be undone.')}</p> : null;

--- a/static/app/views/organizationGroupDetails/actions/index.tsx
+++ b/static/app/views/organizationGroupDetails/actions/index.tsx
@@ -391,7 +391,6 @@ class Actions extends Component<Props, State> {
         </GuideAnchor>
         <GuideAnchor target="ignore_delete_discard" position="bottom" offset={20}>
           <IgnoreActions
-            issueCategory={group.issueCategory}
             isIgnored={isIgnored}
             onUpdate={this.onUpdate}
             disabled={disabled}


### PR DESCRIPTION
Performance issues supports these options now (https://github.com/getsentry/sentry/pull/39120)

So this reverts the work done in these PRs:

https://github.com/getsentry/sentry/pull/38756 

https://github.com/getsentry/sentry/pull/38540