### PR TITLE
fix(copy): modal header and events tab

### DIFF
--- a/static/app/components/modals/createOwnershipRuleModal.tsx
+++ b/static/app/components/modals/createOwnershipRuleModal.tsx
@@ -28,7 +28,9 @@ const CreateOwnershipRuleModal = ({Body, Header, closeModal, ...props}: Props) =
 
   return (
     <Fragment>
-      <Header closeButton>{t('Create Ownership Rule')}</Header>
+      <Header closeButton>
+        <h4>{t('Create Ownership Rule')}</h4>
+      </Header>
       <Body>
         <ProjectOwnershipModal {...props} onSave={handleSuccess} />
       </Body>

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -187,7 +187,7 @@ function GroupHeader({
           {t('Tags')}
         </Item>
         <Item key={Tab.EVENTS} disabled={disabledTabs.includes(Tab.EVENTS)}>
-          {t('Events')}
+          {t('All Events')}
         </Item>
         <Item key={Tab.MERGED} disabled={disabledTabs.includes(Tab.MERGED)}>
           {t('Merged Issues')}


### PR DESCRIPTION
1. Changing `Events` tab to `All Events` on the Issue Details page for consistency
2. Updated the Ownership modal with the correct heading size