### PR TITLE
feat(profiling): Send compressed payloads to the profiling service

### DIFF
--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 from urllib.parse import urlencode, urlparse
 
+import brotli
 import urllib3
 from django.conf import settings
 from django.http import StreamingHttpResponse
@@ -73,8 +74,13 @@ def get_from_profiling_service(
     if headers:
         kwargs["headers"].update(headers)
     if json_data:
-        kwargs["headers"]["Content-Type"] = "application/json"
-        kwargs["body"] = json.dumps(json_data)
+        kwargs["headers"].update(
+            {
+                "Content-Encoding": "br",
+                "Content-Type": "application/json",
+            }
+        )
+        kwargs["body"] = brotli.compress(json.dumps(json_data).encode("ascii"))
     return _profiling_pool.urlopen(  # type: ignore
         method,
         path,

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional
 from urllib.parse import urlencode, urlparse
 
-import brotli
+import brotli  # type: ignore
 import urllib3
 from django.conf import settings
 from django.http import StreamingHttpResponse

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -80,7 +80,7 @@ def get_from_profiling_service(
                 "Content-Type": "application/json",
             }
         )
-        kwargs["body"] = brotli.compress(json.dumps(json_data).encode("ascii"))
+        kwargs["body"] = brotli.compress(json.dumps(json_data).encode("utf-8"))
     return _profiling_pool.urlopen(  # type: ignore
         method,
         path,


### PR DESCRIPTION
In order to reduce request time, we'd want to start compressing profiles between Sentry and the profiling service.

This would need to be deployed first: https://github.com/getsentry/vroom/pull/75.