### PR TITLE
feat(profiling): add discord link to feedback modal

### DIFF
--- a/static/app/components/featureFeedback/feedbackModal.spec.tsx
+++ b/static/app/components/featureFeedback/feedbackModal.spec.tsx
@@ -102,6 +102,28 @@ describe('FeatureFeedback', function () {
       // Close modal
       userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
     });
+
+    it('renders an arbitrary secondary action', function () {
+      render(<GlobalModal />);
+
+      openModal(modalProps => (
+        <ComponentProviders>
+          <FeedbackModal
+            {...modalProps}
+            featureName="test"
+            secondaryAction={<a href="#">Test Secondary Action Link</a>}
+          />
+        </ComponentProviders>
+      ));
+
+      userEvent.click(screen.getByText('Select type of feedback'));
+
+      // Available feedback types
+      expect(screen.getByText('Test Secondary Action Link')).toBeInTheDocument();
+
+      // Close modal
+      userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+    });
   });
 
   describe('custom', function () {

--- a/static/app/components/featureFeedback/feedbackModal.tsx
+++ b/static/app/components/featureFeedback/feedbackModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import React, {Fragment, useCallback, useMemo, useState} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {
@@ -53,6 +53,7 @@ export type ChildrenProps<T> = {
     onBack?: () => void;
     onNext?: () => void;
     primaryDisabledReason?: string;
+    secondaryAction?: React.ReactNode;
     submitEventData?: Event;
   }) => ReturnType<ModalRenderProps['Footer']>;
   Header: (props: {children: React.ReactNode}) => ReturnType<ModalRenderProps['Header']>;
@@ -70,6 +71,7 @@ type DefaultFeedbackModal = {
   featureName: string;
   children?: undefined;
   feedbackTypes?: string[];
+  secondaryAction?: React.ReactNode;
 };
 
 export type FeedbackModalProps<T extends Data> =
@@ -169,9 +171,13 @@ export function FeedbackModal<T extends Data>({
       onNext,
       submitEventData,
       primaryDisabledReason,
+      secondaryAction,
     }: Parameters<ChildrenProps<T>['Footer']>[0]) => {
       return (
         <Footer>
+          {secondaryAction && (
+            <SecondaryActionWrapper>{secondaryAction}</SecondaryActionWrapper>
+          )}
           {onBack && (
             <BackButtonWrapper>
               <Button onClick={onBack}>{t('Back')}</Button>
@@ -278,7 +284,7 @@ export function FeedbackModal<T extends Data>({
             />
           </Field>
         </ModalBody>
-        <ModalFooter />
+        <ModalFooter secondaryAction={props?.secondaryAction} />
       </Fragment>
     );
   }
@@ -304,4 +310,9 @@ export const modalCss = css`
 const BackButtonWrapper = styled('div')`
   margin-right: ${space(1)};
   width: 100%;
+`;
+
+const SecondaryActionWrapper = styled('div')`
+  flex: 1;
+  align-self: center;
 `;

--- a/static/app/components/featureFeedback/index.spec.tsx
+++ b/static/app/components/featureFeedback/index.spec.tsx
@@ -44,6 +44,26 @@ describe('FeatureFeedback', function () {
     expect(screen.getByRole('button', {name: 'Submit Feedback'})).toBeInTheDocument();
   });
 
+  it('shows the modal on click with custom "onClick" handler', async function () {
+    const mockOnClick = jest.fn();
+    render(
+      <ComponentProviders>
+        <FeatureFeedback
+          featureName="test"
+          buttonProps={{
+            onClick: mockOnClick,
+          }}
+        />
+      </ComponentProviders>
+    );
+
+    userEvent.click(screen.getByText('Give Feedback'));
+
+    expect(await screen.findByText('Select type of feedback')).toBeInTheDocument();
+
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+
   it('Close modal on click', async function () {
     render(
       <ComponentProviders>

--- a/static/app/components/featureFeedback/index.tsx
+++ b/static/app/components/featureFeedback/index.tsx
@@ -11,6 +11,7 @@ import {t} from 'sentry/locale';
 
 export type FeatureFeedbackProps<T extends Data> = FeedbackModalProps<T> & {
   buttonProps?: Partial<ButtonProps>;
+  secondaryAction?: React.ReactNode;
 };
 
 // Provides a button that, when clicked, opens a modal with a form that,

--- a/static/app/components/featureFeedback/index.tsx
+++ b/static/app/components/featureFeedback/index.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {openModal} from 'sentry/actionCreators/modal';
 import Button, {ButtonProps} from 'sentry/components/button';
 import {
@@ -20,14 +22,18 @@ export function FeatureFeedback<T extends Data>({
   buttonProps = {},
   ...props
 }: FeatureFeedbackProps<T>) {
-  function handleClick() {
+  const {onClick, ..._buttonProps} = buttonProps;
+  function handleClick(e: React.MouseEvent) {
     openModal(modalProps => <FeedbackModal {...modalProps} {...props} />, {
       modalCss,
     });
+    if (onClick) {
+      onClick(e);
+    }
   }
 
   return (
-    <Button icon={<IconMegaphone />} onClick={handleClick} {...buttonProps}>
+    <Button icon={<IconMegaphone />} onClick={handleClick} {..._buttonProps}>
       {t('Give Feedback')}
     </Button>
   );

--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -10,6 +10,7 @@ export type ProfilingEventParameters = {
   'profiling_views.profile_details': {};
   'profiling_views.profile_flamegraph': {};
   'profiling_views.profile_summary': {};
+  'profiling_views.visit_discord_channel': {};
 };
 
 type EventKey = keyof ProfilingEventParameters;
@@ -24,4 +25,5 @@ export const profilingEventMap: Record<EventKey, string> = {
   'profiling_views.go_to_transaction': 'Profiling Views: Go to Transaction',
   'profiling_views.onboarding_action': 'Profiling Actions: Onboarding Action',
   'profiling_views.give_feedback_action': 'Profiling Actions: Feedback Action',
+  'profiling_views.visit_discord_channel': 'Profiling Actions: Visit Discord Channel',
 };

--- a/static/app/utils/analytics/profilingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/profilingAnalyticsEvents.tsx
@@ -1,4 +1,5 @@
 export type ProfilingEventParameters = {
+  'profiling_views.give_feedback_action': {};
   'profiling_views.go_to_flamegraph': {source: string};
   'profiling_views.go_to_transaction': {source: string};
   'profiling_views.landing': {};
@@ -22,4 +23,5 @@ export const profilingEventMap: Record<EventKey, string> = {
   'profiling_views.go_to_flamegraph': 'Profiling Views: Go to Flamegraph',
   'profiling_views.go_to_transaction': 'Profiling Views: Go to Transaction',
   'profiling_views.onboarding_action': 'Profiling Actions: Onboarding Action',
+  'profiling_views.give_feedback_action': 'Profiling Actions: Feedback Action',
 };

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -146,6 +146,9 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                 <HeadingActions>
                   <Button onClick={onSetupProfilingClick}>{t('Set Up Profiling')}</Button>
                   <FeatureFeedback
+                    buttonProps={{
+                      priority: 'primary',
+                    }}
                     featureName="profiling"
                     secondaryAction={
                       <DiscordLink href="https://discord.gg/zrMjKA4Vnz">

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -9,7 +9,6 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import {FeatureFeedback} from 'sentry/components/featureFeedback';
 import * as Layout from 'sentry/components/layouts/thirds';
-import ExternalLink from 'sentry/components/links/externalLink';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -159,8 +158,10 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                     }}
                     featureName="profiling"
                     secondaryAction={
-                      <ExternalLink
+                      <Button
+                        priority="link"
                         href="https://discord.gg/zrMjKA4Vnz"
+                        external
                         onClick={() => {
                           trackAdvancedAnalyticsEvent(
                             'profiling_views.visit_discord_channel',
@@ -171,7 +172,7 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                         }}
                       >
                         {t('Visit Discord Channel')}
-                      </ExternalLink>
+                      </Button>
                     }
                   />
                 </HeadingActions>

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -151,9 +151,9 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                     }}
                     featureName="profiling"
                     secondaryAction={
-                      <DiscordLink href="https://discord.gg/zrMjKA4Vnz">
+                      <ExternalLink href="https://discord.gg/zrMjKA4Vnz">
                         {t('Visit Discord Channel')}
-                      </DiscordLink>
+                      </ExternalLink>
                     }
                   />
                 </HeadingActions>
@@ -249,13 +249,6 @@ const ActionBar = styled('div')`
   gap: ${space(2)};
   grid-template-columns: min-content auto;
   margin-bottom: ${space(2)};
-`;
-
-const DiscordLink = styled(ExternalLink)`
-  color: ${p => p.theme.red400};
-  &:hover {
-    color: ${p => p.theme.red400};
-  }
 `;
 
 export default ProfilingContent;

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -148,6 +148,14 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                   <FeatureFeedback
                     buttonProps={{
                       priority: 'primary',
+                      onClick: () => {
+                        trackAdvancedAnalyticsEvent(
+                          'profiling_views.give_feedback_action',
+                          {
+                            organization,
+                          }
+                        );
+                      },
                     }}
                     featureName="profiling"
                     secondaryAction={

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -159,7 +159,17 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                     }}
                     featureName="profiling"
                     secondaryAction={
-                      <ExternalLink href="https://discord.gg/zrMjKA4Vnz">
+                      <ExternalLink
+                        href="https://discord.gg/zrMjKA4Vnz"
+                        onClick={() => {
+                          trackAdvancedAnalyticsEvent(
+                            'profiling_views.visit_discord_channel',
+                            {
+                              organization,
+                            }
+                          );
+                        }}
+                      >
                         {t('Visit Discord Channel')}
                       </ExternalLink>
                     }

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -9,6 +9,7 @@ import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import {FeatureFeedback} from 'sentry/components/featureFeedback';
 import * as Layout from 'sentry/components/layouts/thirds';
+import ExternalLink from 'sentry/components/links/externalLink';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -144,7 +145,14 @@ function ProfilingContent({location, router}: ProfilingContentProps) {
                 <StyledHeading>{t('Profiling')}</StyledHeading>
                 <HeadingActions>
                   <Button onClick={onSetupProfilingClick}>{t('Set Up Profiling')}</Button>
-                  <FeatureFeedback featureName="profiling" />
+                  <FeatureFeedback
+                    featureName="profiling"
+                    secondaryAction={
+                      <DiscordLink href="https://discord.gg/zrMjKA4Vnz">
+                        {t('Visit Discord Channel')}
+                      </DiscordLink>
+                    }
+                  />
                 </HeadingActions>
               </StyledLayoutHeaderContent>
             </Layout.Header>
@@ -238,6 +246,13 @@ const ActionBar = styled('div')`
   gap: ${space(2)};
   grid-template-columns: min-content auto;
   margin-bottom: ${space(2)};
+`;
+
+const DiscordLink = styled(ExternalLink)`
+  color: ${p => p.theme.red400};
+  &:hover {
+    color: ${p => p.theme.red400};
+  }
 `;
 
 export default ProfilingContent;


### PR DESCRIPTION
This PR adds the ability to render a `secondaryAction` in the footer of the `FeatureFeedback` modal. In our case we'd like to link out directly to the `#profiling` discord.

![image](https://user-images.githubusercontent.com/7349258/193055617-44d9784c-e250-4605-92b3-a6e57a1cdc7e.png)

![image](https://user-images.githubusercontent.com/7349258/193057291-ef872f6d-1257-41f7-aca5-6fe0fc7ab4c5.png)
