### PR TITLE
fix(perf-issues): Fix bug with span evidence and parent span

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -23,7 +23,7 @@ interface Props {
 }
 
 export type TraceContextSpanProxy = Omit<TraceContextType, 'span_id'> & {
-  span_id: string;
+  span_id: string; // TODO: Remove this temporary type.
 };
 
 export function SpanEvidenceSection({event, organization}: Props) {
@@ -42,7 +42,9 @@ export function SpanEvidenceSection({event, organization}: Props) {
     return entry.type === EntryType.SPANS;
   });
   const spans: Array<RawSpanType | TraceContextSpanProxy> = spanEntry?.data ?? [];
-  if (event.contexts.trace && event.contexts.trace?.span_id) {
+
+  if (event?.contexts?.trace && event?.contexts?.trace?.span_id) {
+    // TODO: Fix this conditional and check if span_id is ever actually undefined.
     spans.push(event.contexts.trace as TraceContextSpanProxy);
   }
   const spansById = keyBy(spans, 'span_id');

--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -14,13 +14,17 @@ import {
 import DataSection from '../../eventTagsAndScreenshot/dataSection';
 import KeyValueList from '../keyValueList';
 import TraceView from '../spans/traceView';
-import {RawSpanType, SpanEntry} from '../spans/types';
+import {RawSpanType, SpanEntry, TraceContextType} from '../spans/types';
 import WaterfallModel from '../spans/waterfallModel';
 
 interface Props {
   event: EventTransaction;
   organization: Organization;
 }
+
+export type TraceContextSpanProxy = Omit<TraceContextType, 'span_id'> & {
+  span_id: string;
+};
 
 export function SpanEvidenceSection({event, organization}: Props) {
   if (!event.perfProblem) {
@@ -37,7 +41,10 @@ export function SpanEvidenceSection({event, organization}: Props) {
   const spanEntry = event.entries.find((entry: SpanEntry | any): entry is SpanEntry => {
     return entry.type === EntryType.SPANS;
   });
-  const spans: Array<RawSpanType> = spanEntry?.data ?? [];
+  const spans: Array<RawSpanType | TraceContextSpanProxy> = spanEntry?.data ?? [];
+  if (event.contexts.trace && event.contexts.trace?.span_id) {
+    spans.push(event.contexts.trace as TraceContextSpanProxy);
+  }
   const spansById = keyBy(spans, 'span_id');
 
   const parentSpan = spansById[event.perfProblem.parentSpanIds[0]];
@@ -83,7 +90,7 @@ export function SpanEvidenceSection({event, organization}: Props) {
   );
 }
 
-function getSpanEvidenceValue(span: RawSpanType) {
+function getSpanEvidenceValue(span: RawSpanType | TraceContextSpanProxy) {
   if (!span.op && !span.description) {
     return t('(no value)');
   }


### PR DESCRIPTION
When the parent span is the root span for the transaction, it's not in the spans list, and causes an error since the span doesn't appear.

Fixes JAVASCRIPT-2ANQ
