### PR TITLE
fix(perf-issues): Normalize more database spans hashes

### DIFF
--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -104,7 +104,7 @@ def raw_description_strategy(span: Span) -> Sequence[str]:
 IN_CONDITION_PATTERN = re.compile(r" IN \(%s(\s*,\s*%s)*\)")
 
 
-@span_op(["db", "db.query", "db.sql.query"])
+@span_op(["db", "db.query", "db.sql.query", "db.sql.active_record"])
 def normalized_db_span_in_condition_strategy(span: Span) -> Optional[Sequence[str]]:
     """For a `db` query span, the `IN` condition contains the same number of
     elements on the right hand side as the raw query. This results in identical

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -104,14 +104,14 @@ def raw_description_strategy(span: Span) -> Sequence[str]:
 IN_CONDITION_PATTERN = re.compile(r" IN \(%s(\s*,\s*%s)*\)")
 
 
-@span_op("db")
+@span_op(["db", "db.query", "db.sql.query"])
 def normalized_db_span_in_condition_strategy(span: Span) -> Optional[Sequence[str]]:
-    """For a `db` span, the `IN` condition contains the same same number of elements
-    on the right hand side as the raw query. This results in identical queries that
-    have different number of elements on the right hand side to be seen as different
-    spans. We want these spans to be seen as similar spans, so we normalize the right
-    hand side of `IN` conditions to `(%s) to use in the fingerprint.
-    """
+    """For a `db` query span, the `IN` condition contains the same number of
+    elements on the right hand side as the raw query. This results in identical
+    queries that have different number of elements on the right hand side to be
+    seen as different spans. We want these spans to be seen as similar spans,
+    so we normalize the right hand side of `IN` conditions to `(%s) to use in
+    the fingerprint."""
     description = span.get("description") or ""
     cleaned, count = IN_CONDITION_PATTERN.subn(" IN (%s)", description)
     if count == 0:

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, Sequence, TypedDict
+from typing import Any, Callable, Dict, Optional, Sequence, TypedDict, Union
 from urllib.parse import urlparse
 
 from sentry.spans.grouping.utils import Hash, parse_fingerprint_var
@@ -84,9 +84,11 @@ class SpanGroupingStrategy:
         return span_group
 
 
-def span_op(op_name: str) -> Callable[[CallableStrategy], CallableStrategy]:
+def span_op(op_name: Union[str, Sequence[str]]) -> Callable[[CallableStrategy], CallableStrategy]:
+    permitted_ops = [op_name] if isinstance(op_name, str) else op_name
+
     def wrapped(fn: CallableStrategy) -> CallableStrategy:
-        return lambda span: fn(span) if span.get("op") == op_name else None
+        return lambda span: fn(span) if span.get("op") in permitted_ops else None
 
     return wrapped
 

--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -59,6 +59,7 @@ def test_raw_description_strategy(span: Span, fingerprint: Optional[List[str]]) 
             SpanBuilder().with_description("SELECT count() FROM table WHERE id IN (%s)").build(),
             None,
         ),
+        # op is db
         (
             SpanBuilder()
             .with_op("db")
@@ -69,6 +70,14 @@ def test_raw_description_strategy(span: Span, fingerprint: Optional[List[str]]) 
         (
             SpanBuilder()
             .with_op("db")
+            .with_description("SELECT count() FROM table WHERE id IN (%s, %s)")
+            .build(),
+            ["SELECT count() FROM table WHERE id IN (%s)"],
+        ),
+        # op has db prefix
+        (
+            SpanBuilder()
+            .with_op("db.sql.query")
             .with_description("SELECT count() FROM table WHERE id IN (%s, %s)")
             .build(),
             ["SELECT count() FROM table WHERE id IN (%s)"],

--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -74,7 +74,7 @@ def test_raw_description_strategy(span: Span, fingerprint: Optional[List[str]]) 
             .build(),
             ["SELECT count() FROM table WHERE id IN (%s)"],
         ),
-        # op has db prefix
+        # op is a db query
         (
             SpanBuilder()
             .with_op("db.sql.query")


### PR DESCRIPTION
While checking performance issues in Laravel projects, we noticed that queries `SELECT ... IN (?, ?)` and `SELECT ... IN (?, ?, ?)` had different hashes, which they're not supposed to. The cause is that `IN` normalization only applies to `db` spans, but queries can also have the ops `db.query` and `db.sql.query`. Expands the normalization to also include those spans.

I opted to let `span_op` accept a list in lieu of accepting a regex or a prefix, because I thought it was the most explicit (i.e., regexes are easy to get wrong, and some ops like `db.connection` and `db.redis` probably don't need this normalization, so prefix is too loose) but you tell me!

This will improve span grouping and performance issue detection, since we rely on the hashes generated from the span grouping code.