### PR TITLE
ref(Snowflake): Deprecated feature flag for snowflake ids

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1193,8 +1193,6 @@ SENTRY_FEATURES = {
     "organizations:u2f-superuser-form": False,
     # Enable setting team-level roles and receiving permissions from them
     "organizations:team-roles": False,
-    # Enable snowflake ids
-    "organizations:enable-snowflake-id": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -155,7 +155,6 @@ default_manager.add("organizations:widget-library", OrganizationFeature, True)
 default_manager.add("organizations:widget-viewer-modal", OrganizationFeature, True)
 default_manager.add("organizations:widget-viewer-modal-minimap", OrganizationFeature, True)
 default_manager.add("organizations:u2f-superuser-form", OrganizationFeature, True)
-default_manager.add("organizations:enable-snowflake-id", OrganizationFeature, True)
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -17,7 +17,7 @@ from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 
 from bitfield import BitField
-from sentry import features, projectoptions
+from sentry import projectoptions
 from sentry.constants import RESERVED_PROJECT_SLUGS, ObjectStatus
 from sentry.db.mixin import PendingDeletionMixin, delete_pending_deletion_option
 from sentry.db.models import (
@@ -182,9 +182,7 @@ class Project(Model, PendingDeletionMixin, SnowflakeIdMixin):
                     max_length=50,
                 )
 
-        if SENTRY_USE_SNOWFLAKE or features.has(
-            "organizations:enable-snowflake-id", self.organization
-        ):
+        if SENTRY_USE_SNOWFLAKE:
             snowflake_redis_key = "project_snowflake_key"
             self.save_with_snowflake_id(
                 snowflake_redis_key, lambda: super(Project, self).save(*args, **kwargs)


### PR DESCRIPTION
With the setting `SENTRY_USE_SNOWFLAKE` set, the feature flag will now be useless. Removing to allow `SENTRY_USE_SNOWFLAKE` control usage of snowflake ids

https://github.com/getsentry/sentry/pull/39474