### PR TITLE
fix: capture current ref outseide of useEffect

### DIFF
--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -5,6 +5,7 @@ import {useEffect, useState} from 'react';
  */
 const useKeyPress = (targetKey: string, targetRef?: React.RefObject<HTMLElement>) => {
   const [keyPressed, setKeyPressed] = useState(false);
+  const current = targetRef?.current ?? document.body;
 
   useEffect(() => {
     const downHandler = ({key}: KeyboardEvent) => {
@@ -19,7 +20,6 @@ const useKeyPress = (targetKey: string, targetRef?: React.RefObject<HTMLElement>
       }
     };
 
-    const current = targetRef?.current ?? document.body;
     current.addEventListener('keydown', downHandler);
     current.addEventListener('keyup', upHandler);
 
@@ -27,7 +27,7 @@ const useKeyPress = (targetKey: string, targetRef?: React.RefObject<HTMLElement>
       current.removeEventListener('keydown', downHandler);
       current.removeEventListener('keyup', upHandler);
     };
-  }, [targetKey, targetRef]);
+  }, [targetKey, current]);
 
   return keyPressed;
 };


### PR DESCRIPTION


<!-- Describe your PR here. -->
updateUseKeyPress to capture current ref in case ref target has changed


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
