### PR TITLE
useKeyPress takes an html element rather than ref

### DIFF
--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -3,9 +3,9 @@ import {useEffect, useState} from 'react';
 /**
  * Hook to detect when a specific key is being pressed
  */
-const useKeyPress = (targetKey: string, targetRef?: React.RefObject<HTMLElement>) => {
+const useKeyPress = (targetKey: string, target?: HTMLElement) => {
   const [keyPressed, setKeyPressed] = useState(false);
-  const current = targetRef?.current ?? document.body;
+  const current = target ?? document.body;
 
   useEffect(() => {
     const downHandler = ({key}: KeyboardEvent) => {


### PR DESCRIPTION

<!-- Describe your PR here. -->

rather than passing a ref - lets just pass an html element and rely on the implementation to keep track of dom mounting changes

RE: https://github.com/getsentry/sentry/pull/39370#discussion_r983923968

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
