### PR TITLE
feat(replays): Fetch error title when querying for issues related to a replay

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -29,11 +29,11 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
         return [
             "error.type",
             "error.value",
-            "group.id",
             "id",
             "issue.id",
             "issue",
             "timestamp",
+            "title",
         ]
 
     def get(self, request: Request, organization) -> Response:

--- a/src/sentry/replays/endpoints/organization_replay_events_meta.py
+++ b/src/sentry/replays/endpoints/organization_replay_events_meta.py
@@ -28,7 +28,7 @@ class OrganizationReplayEventsMetaEndpoint(OrganizationEventsV2EndpointBase):
     def get_field_list(self, organization: Organization, request: Request) -> Sequence[str]:
         return [
             "error.type",
-            "error.value",
+            "error.value",  # Deprecated, use title instead. See replayDataUtils.tsx
             "id",
             "issue.id",
             "issue",

--- a/tests/replays/endpoints/test_organization_replay_events_meta.py
+++ b/tests/replays/endpoints/test_organization_replay_events_meta.py
@@ -45,22 +45,22 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
             {
                 "error.type": [],
                 "error.value": [],
-                "group.id": "",
                 "id": event_id_a,
                 "issue.id": 1,
                 "issue": event_a.group.qualified_short_id,
                 "project.name": self.project_1.slug,
                 "timestamp": iso_format(self.min_ago) + "+00:00",
+                "title": "<unlabeled event>",
             },
             {
                 "error.type": [],
                 "error.value": [],
-                "group.id": "",
                 "id": event_id_b,
                 "issue.id": 2,
                 "issue": event_b.group.qualified_short_id,
                 "project.name": self.project_2.slug,
                 "timestamp": iso_format(self.min_ago) + "+00:00",
+                "title": "<unlabeled event>",
             },
         ]
 


### PR DESCRIPTION
Fetch the error title because captured replay error breadcrumbs might not have the message field set, and we'll need something to show

With the title field added (and group.id wasn't ever returning anything -> removed now):
![Screen Shot 2022-09-29 at 3 15 54 PM](https://user-images.githubusercontent.com/187460/193152418-322c35f6-481b-4a50-adc2-2af243c13b6c.png)

Required by #39489
See #39339