### PR TITLE
Add Java SDK to supported SDKs for DS

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -40,9 +40,10 @@ ALLOWED_SDK_NAMES = frozenset(
         "sentry.cocoa",  # iOS
     )
 )
-# We want sentry.java.android, sentry.java.android.timber, and all others to match
+# We want sentry.java, sentry.java.spring, sentry.java.android, sentry.java.android.timber,
+# and all others to match
 # Same for sentry.dart, sentry.dart.browser, and sentry.dart.flutter
-ALLOWED_SDK_NAMES_PREFIXES = frozenset(("sentry.java.android", "sentry.dart"))
+ALLOWED_SDK_NAMES_PREFIXES = frozenset(("sentry.java", "sentry.dart"))
 
 
 class QueryBoundsException(Exception):

--- a/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
+++ b/tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py
@@ -175,6 +175,17 @@ def mocked_discover_query():
                 'count_if(transaction.source, notEquals, "")': 0,
                 "count()": 1,
             },
+            # project: spring
+            {
+                "sdk.version": "6.5.0-beta.2",
+                "sdk.name": "sentry.java.spring",
+                "project": "spring",
+                'equation|count_if(trace.client_sample_rate, notEquals, "") / count()': 1.0,
+                'count_if(trace.client_sample_rate, notEquals, "")': 6,
+                'equation|count_if(transaction.source, notEquals, "") / count()': 1.0,
+                'count_if(transaction.source, notEquals, "")': 4,
+                "count()": 21,
+            },
             # project: timber
             {
                 "sdk.version": "6.4.1",
@@ -336,6 +347,14 @@ class OrganizationDynamicSamplingSDKVersionsTest(APITestCase):
                     "latestSDKVersion": "7.1.4",
                     "isSendingSampleRate": False,
                     "isSendingSource": False,
+                    "isSupportedPlatform": True,
+                },
+                {
+                    "project": "spring",
+                    "latestSDKName": "sentry.java.spring",
+                    "latestSDKVersion": "6.5.0-beta.2",
+                    "isSendingSampleRate": True,
+                    "isSendingSource": True,
                     "isSupportedPlatform": True,
                 },
                 {


### PR DESCRIPTION
Version [6.5.0-beta.2](https://github.com/getsentry/sentry-java/releases/tag/6.5.0-beta.2) of the Java SDK has just been released. This marks the Java SDK as one of the SDKs supporting Dynamic Sampling.
