### PR TITLE
chore(csrf): Restrict emitting Sentry events for only staff or superusers

### DIFF
--- a/src/sentry/web/frontend/csrf_failure.py
+++ b/src/sentry/web/frontend/csrf_failure.py
@@ -15,7 +15,6 @@ class CsrfFailureView(View):
         context = {"no_referer": reason == REASON_NO_REFERER}
         with sentry_sdk.configure_scope() as scope:
             # Emit a sentry request that the incoming request is rejected by the CSRF protection.
-            scope.set_tag("csrf_failure", "yes")
             if hasattr(request, "user") and request.user.is_authenticated:
                 is_staff = request.user.is_staff
                 is_superuser = request.user.is_superuser
@@ -24,11 +23,8 @@ class CsrfFailureView(View):
                 if is_superuser:
                     scope.set_tag("is_superuser", "yes")
                 if is_staff or is_superuser:
+                    scope.set_tag("csrf_failure", "yes")
                     sentry_sdk.capture_exception("CSRF failure for staff or superuser")
-                else:
-                    sentry_sdk.capture_message("CSRF failure")
-            else:
-                sentry_sdk.capture_message("CSRF failure")
         return render_to_response("sentry/403-csrf-failure.html", context, request, status=403)
 
 


### PR DESCRIPTION
Emitting Sentry events for all CSRF failure resulted in too many false positives.

I'm restricting this for only staff or superusers, since that'll be a more notable to pay attention to.