### PR TITLE
ref(feature-flag): Add feature flag for a DY CTA in the performance page - [TET-430]

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1183,6 +1183,8 @@ SENTRY_FEATURES = {
     "organizations:dynamic-sampling-basic": False,
     # Enable the creation of uniform and conditional sampling rules.
     "organizations:dynamic-sampling-advanced": False,
+    # Enable dynamic sampling call to action in the performance product
+    "organizations:dynamic-sampling-performance": False,
     # Enable the mobile screenshots feature
     "organizations:mobile-screenshots": False,
     # Enable the release details performance section


### PR DESCRIPTION
**What this PR does:**

- Adds a new feature flag for testing the dynamic sampling call to action (CTA) MVP on the performance page 