### PR TITLE
feat(replays): Event detail Replay navigation button

### DIFF
--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 import moment from 'moment-timezone';
 
+import Button from 'sentry/components/button';
 import DateTime from 'sentry/components/dateTime';
 import {DataSection} from 'sentry/components/events/styles';
 import FileSize from 'sentry/components/fileSize';
@@ -11,7 +12,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
 import NavigationButtonGroup from 'sentry/components/navigationButtonGroup';
 import Tooltip from 'sentry/components/tooltip';
-import {IconWarning} from 'sentry/icons';
+import {IconPlay, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import space from 'sentry/styles/space';
@@ -50,6 +51,7 @@ type Props = {
   location: Location;
   organization: Organization;
   project: Project;
+  hasReplay?: boolean;
 };
 
 class GroupEventToolbar extends Component<Props> {
@@ -101,7 +103,7 @@ class GroupEventToolbar extends Component<Props> {
     const is24Hours = shouldUse24Hours();
     const evt = this.props.event;
 
-    const {group, organization, location, project} = this.props;
+    const {group, organization, location, project, hasReplay} = this.props;
     const groupId = group.id;
 
     const baseEventsPath = `/organizations/${organization.slug}/issues/${groupId}/events/`;
@@ -156,21 +158,31 @@ class GroupEventToolbar extends Component<Props> {
             location={location}
           />
         </div>
-        <NavigationButtonGroup
-          hasPrevious={!!evt.previousEventID}
-          hasNext={!!evt.nextEventID}
-          links={[
-            {pathname: `${baseEventsPath}oldest/`, query: location.query},
-            {pathname: `${baseEventsPath}${evt.previousEventID}/`, query: location.query},
-            {pathname: `${baseEventsPath}${evt.nextEventID}/`, query: location.query},
-            {pathname: `${baseEventsPath}latest/`, query: location.query},
-          ]}
-          onOldestClick={() => this.handleNavigationClick('oldest')}
-          onOlderClick={() => this.handleNavigationClick('older')}
-          onNewerClick={() => this.handleNavigationClick('newer')}
-          onNewestClick={() => this.handleNavigationClick('newest')}
-          size="sm"
-        />
+        <NavigationContainer>
+          {hasReplay ? (
+            <Button href="#breadcrumbs" size="sm" icon={<IconPlay size="xs" />}>
+              Replay
+            </Button>
+          ) : null}
+          <NavigationButtonGroup
+            hasPrevious={!!evt.previousEventID}
+            hasNext={!!evt.nextEventID}
+            links={[
+              {pathname: `${baseEventsPath}oldest/`, query: location.query},
+              {
+                pathname: `${baseEventsPath}${evt.previousEventID}/`,
+                query: location.query,
+              },
+              {pathname: `${baseEventsPath}${evt.nextEventID}/`, query: location.query},
+              {pathname: `${baseEventsPath}latest/`, query: location.query},
+            ]}
+            onOldestClick={() => this.handleNavigationClick('oldest')}
+            onOlderClick={() => this.handleNavigationClick('older')}
+            onNewerClick={() => this.handleNavigationClick('newer')}
+            onNewestClick={() => this.handleNavigationClick('newest')}
+            size="sm"
+          />
+        </NavigationContainer>
       </Wrapper>
     );
   }
@@ -236,6 +248,13 @@ const DescriptionList = styled('dl')`
   gap: ${space(0.75)} ${space(1)};
   text-align: left;
   margin: 0;
+`;
+
+const NavigationContainer = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0 ${space(1)};
 `;
 
 export default GroupEventToolbar;

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -105,6 +105,7 @@ class GroupEventToolbar extends Component<Props> {
 
     const {group, organization, location, project, hasReplay} = this.props;
     const groupId = group.id;
+    const isReplayEnabled = organization.features.includes('session-replay-ui');
 
     const baseEventsPath = `/organizations/${organization.slug}/issues/${groupId}/events/`;
 
@@ -159,7 +160,7 @@ class GroupEventToolbar extends Component<Props> {
           />
         </div>
         <NavigationContainer>
-          {hasReplay ? (
+          {hasReplay && isReplayEnabled ? (
             <Button href="#breadcrumbs" size="sm" icon={<IconPlay size="xs" />}>
               Replay
             </Button>

--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -228,6 +228,8 @@ class GroupEventDetails extends Component<GroupEventDetailsProps, State> {
     const {activity: activities} = group;
     const mostRecentActivity = getGroupMostRecentActivity(activities);
 
+    const hasReplay = Boolean(event?.tags?.find(({key}) => key === 'replayId')?.value);
+
     return (
       <div className={className} data-test-id="group-event-details">
         <StyledLayoutBody>
@@ -258,6 +260,7 @@ class GroupEventDetails extends Component<GroupEventDetailsProps, State> {
                             organization={organization}
                             location={location}
                             project={project}
+                            hasReplay={hasReplay}
                           />
                         )}
                         <Wrapper>


### PR DESCRIPTION
### Changes
- Adds a Replay button that links to the #breadcrumbs anchor if there is a replayId related to the event

### Notes
In my original PR I added an anchor to the replays section because it felt more semantically correct. Based on Ryans comment on the original PR I'm just having it link to breadcrumbs this time.

### Checklist
- [x] New anchor button doesn't cause any styling or other issues with existing event navigation

Closes #38956 

Replay section anchor button

![Screen Shot 2022-09-27 at 11 43 08 AM](https://user-images.githubusercontent.com/3721977/192572692-5d41c435-a94f-4d4b-9362-9d522a6bc3a3.png)

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
