### PR TITLE
chore(hybrid-cloud): Swap ApiToken to control mode

### DIFF
--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -5,7 +5,7 @@ from django.db import models, transaction
 from django.utils import timezone
 from django.utils.encoding import force_text
 
-from sentry.db.models import BaseManager, FlexibleForeignKey, Model, region_silo_model, sane_repr
+from sentry.db.models import BaseManager, FlexibleForeignKey, Model, control_silo_model, sane_repr
 from sentry.models.apiscopes import HasApiScopes
 
 DEFAULT_EXPIRATION = timedelta(days=30)
@@ -19,7 +19,7 @@ def generate_token():
     return uuid4().hex + uuid4().hex
 
 
-@region_silo_model
+@control_silo_model
 class ApiToken(Model, HasApiScopes):
     __include_in_export__ = True
 


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/HC-119

It looks like based on https://www.notion.so/sentry/Draft-Resource-Split-to-avoid-bi-direction-replication-8697f70991144e04a07998a208eec149#5476faa7add04ff6bbf6e3617bf03ee9 this model now belongs to the control silo, thus addressing this issue?