### PR TITLE
fix(project-selector): Fix 'Select All Projects' behavior [UP-173]

### DIFF
--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -393,21 +393,27 @@ function ProjectSelector({
               onApply={() => handleUpdate(actions)}
               onShowAllProjects={() => {
                 handleQuickSelect({id: ALL_ACCESS_PROJECTS.toString()});
-                actions.close();
                 trackAdvancedAnalyticsEvent('projectselector.multi_button_clicked', {
                   button_type: 'all',
                   path: getRouteStringFromRoutes(router.routes),
                   organization,
                 });
+
+                // Close action triggers onClose which needs to run on next render
+                // with updated state to work correctly
+                setTimeout(actions.close);
               }}
               onShowMyProjects={() => {
                 handleClear();
-                actions.close();
                 trackAdvancedAnalyticsEvent('projectselector.multi_button_clicked', {
                   button_type: 'my',
                   path: getRouteStringFromRoutes(router.routes),
                   organization,
                 });
+
+                // Close action triggers onClose which needs to run on next render
+                // with updated state to work correctly
+                setTimeout(actions.close);
               }}
               message={footerMessage}
             />

--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -399,8 +399,10 @@ function ProjectSelector({
                   organization,
                 });
 
-                // Close action triggers onClose which needs to run on next render
-                // with updated state to work correctly
+                // The close action here triggers the onClose() handler which we
+                // use to apply the current selection. We need that to happen on the
+                // next render so that the state will reflect All Projects instead of
+                // the outdated selection that exists when this callback is triggered.
                 setTimeout(actions.close);
               }}
               onShowMyProjects={() => {
@@ -411,8 +413,10 @@ function ProjectSelector({
                   organization,
                 });
 
-                // Close action triggers onClose which needs to run on next render
-                // with updated state to work correctly
+                // The close action here triggers the onClose() handler which we
+                // use to apply the current selection. We need that to happen on the
+                // next render so that the state will reflect My Projects instead of
+                // the outdated selection that exists when this callback is triggered.
                 setTimeout(actions.close);
               }}
               message={footerMessage}

--- a/static/app/components/organizations/projectSelector/projectSelector.spec.jsx
+++ b/static/app/components/organizations/projectSelector/projectSelector.spec.jsx
@@ -1,6 +1,12 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitForElementToBeRemoved,
+} from 'sentry-test/reactTestingLibrary';
 
 import ProjectSelector from 'sentry/components/organizations/projectSelector';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 
 describe('ProjectSelector', function () {
   const testProject = TestStubs.Project({
@@ -356,5 +362,90 @@ describe('ProjectSelector', function () {
     expect(resortedProjectLabels[0]).toHaveTextContent(projectBBookmarked.slug);
     expect(resortedProjectLabels[1]).toHaveTextContent(projectA.slug);
     expect(resortedProjectLabels[2]).toHaveTextContent(projectDSelected.slug);
+  });
+
+  it('can select all projects when role=owner', function () {
+    const mockOnApplyChange = jest.fn();
+    render(
+      <ProjectSelector
+        {...props}
+        nonMemberProjects={[anotherProject]}
+        organization={{...mockOrg, role: 'owner'}}
+        onApplyChange={mockOnApplyChange}
+      />,
+      {context: routerContext}
+    );
+
+    openMenu();
+
+    userEvent.click(screen.getByRole('button', {name: 'Select All Projects'}));
+
+    expect(mockOnApplyChange).toHaveBeenCalledTimes(1);
+    expect(mockOnApplyChange).toHaveBeenCalledWith([ALL_ACCESS_PROJECTS]);
+  });
+
+  it('can select all projects when role=manager', function () {
+    const mockOnApplyChange = jest.fn();
+    render(
+      <ProjectSelector
+        {...props}
+        nonMemberProjects={[anotherProject]}
+        organization={{...mockOrg, role: 'manager'}}
+        onApplyChange={mockOnApplyChange}
+      />,
+      {context: routerContext}
+    );
+
+    openMenu();
+
+    userEvent.click(screen.getByRole('button', {name: 'Select All Projects'}));
+
+    expect(mockOnApplyChange).toHaveBeenCalledTimes(1);
+    expect(mockOnApplyChange).toHaveBeenCalledWith([ALL_ACCESS_PROJECTS]);
+  });
+
+  it('can select all projects when org has open membership', function () {
+    const mockOnApplyChange = jest.fn();
+    render(
+      <ProjectSelector
+        {...props}
+        nonMemberProjects={[anotherProject]}
+        organization={{...mockOrg, features: [...mockOrg.features, 'open-membership']}}
+        onApplyChange={mockOnApplyChange}
+      />,
+      {context: routerContext}
+    );
+
+    openMenu();
+
+    userEvent.click(screen.getByRole('button', {name: 'Select All Projects'}));
+
+    expect(mockOnApplyChange).toHaveBeenCalledTimes(1);
+    expect(mockOnApplyChange).toHaveBeenCalledWith([ALL_ACCESS_PROJECTS]);
+  });
+
+  it('can select all projects after first selecting a project', async function () {
+    const mockOnApplyChange = jest.fn();
+    render(
+      <ProjectSelector
+        {...props}
+        nonMemberProjects={[anotherProject]}
+        organization={{...mockOrg, role: 'manager'}}
+        onApplyChange={mockOnApplyChange}
+      />,
+      {context: routerContext}
+    );
+
+    openMenu();
+
+    // Check the first project
+    userEvent.click(screen.getByRole('checkbox', {name: testProject.slug}));
+
+    userEvent.click(screen.getByRole('button', {name: 'Select All Projects'}));
+
+    // Menu should close and all projects should be selected, not previously selected project
+    await waitForElementToBeRemoved(() => screen.getByRole('listbox'));
+    expect(mockOnApplyChange).toHaveBeenCalledTimes(1);
+    expect(mockOnApplyChange).toHaveBeenCalledWith([ALL_ACCESS_PROJECTS]);
   });
 });


### PR DESCRIPTION
If you select a project, then click "Select All Projects", `actions.close()` triggers the `onClose` handler which has outdated state, reverting the component back to the old selection. 