### PR TITLE
feat(replays): Remove query params from UrlWalker urls and give them more space

### DIFF
--- a/static/app/components/replays/walker/splitCrumbs.tsx
+++ b/static/app/components/replays/walker/splitCrumbs.tsx
@@ -22,9 +22,9 @@ function splitCrumbs({
   onClick: MaybeOnClickHandler;
   startTimestampMs: number;
 }) {
-  const firstUrl = first(crumbs)?.data?.to;
+  const firstUrl = first(crumbs)?.data?.to?.split('?')?.[0];
   const summarizedCrumbs = crumbs.slice(1, -1) as Crumb[];
-  const lastUrl = last(crumbs)?.data?.to;
+  const lastUrl = last(crumbs)?.data?.to?.split('?')?.[0];
 
   if (crumbs.length === 0) {
     // This one shouldn't overflow, but by including the component css stays
@@ -141,7 +141,7 @@ const Span = styled('span')`
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 0;
-  max-width: 120px;
+  max-width: 240px;
 `;
 
 const Link = styled('a')`


### PR DESCRIPTION
In the Replay Details Page header:
<img width="763" alt="Screen Shot 2022-09-30 at 11 30 40 AM" src="https://user-images.githubusercontent.com/187460/193334342-9cc567e2-49ea-4bb4-b339-796d6576b7d0.png">

On the Replay List page (where there's room to expand)
<img width="763" alt="Screen Shot 2022-09-30 at 11 31 10 AM" src="https://user-images.githubusercontent.com/187460/193334344-f39653bb-985c-4944-a874-e9fc5a24a56b.png">

On the Replay List page (when the 1st column is narrow, the UrlWalker segments will line up and truncate more text):
<img width="545" alt="Screen Shot 2022-09-30 at 11 31 56 AM" src="https://user-images.githubusercontent.com/187460/193334582-2786500a-a1c8-4258-82cf-bed7e232807a.png">


Fixes #38406