### PR TITLE
ref(codeSnippet): Use adaptive prism colors

### DIFF
--- a/docs-ui/stories/components/codeSnippet.stories.js
+++ b/docs-ui/stories/components/codeSnippet.stories.js
@@ -1,0 +1,41 @@
+import Prism from 'prismjs';
+
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+
+export default {
+  title: 'Components/Code Snippet',
+  component: CodeSnippet,
+};
+
+export const Default = ({...args}) => (
+  <CodeSnippet {...args}>
+    {`import {x, y} as p from 'point';
+const ANSWER = 42;
+
+class Car extends Vehicle {
+  constructor(speed, cost) {
+    super(speed);
+
+    var c = Symbol('cost');
+    this[c] = cost;
+
+    this.intro = \`This is a car runs at
+      \$\{speed\}.\`;
+  }
+}`}
+  </CodeSnippet>
+);
+
+Default.args = {
+  filename: 'sample.js',
+  language: 'javascript',
+  hideCopyButton: false,
+};
+Default.argTypes = {
+  language: {
+    options: Object.keys(Prism.languages),
+    control: {type: 'inline-radio'},
+    description:
+      'This is not a reactive prop. Changes to this prop after the intitial render will not re-trigger the Prism highlighting function.',
+  },
+};

--- a/static/app/components/codeSnippet.tsx
+++ b/static/app/components/codeSnippet.tsx
@@ -42,9 +42,7 @@ export const prismStyles = ({theme}: {theme: Theme}) => css`
     hyphens: none;
   }
   pre[class*='language-']::selection,
-  code[class*='language-']::selection,
-  pre[class*='language-']::mozselection,
-  code[class*='language-']::mozselection {
+  code[class*='language-']::selection {
     text-shadow: none;
     background: ${theme.prism.selectedColor};
   }

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -118,6 +118,42 @@ export const darkColors = {
   pink100: 'rgba(209, 71, 140, 0.13)',
 };
 
+const prismLight = {
+  inlineCodeColor: '#D25F7C',
+  inlineCodeBackground: '#F8F9FB',
+  blockBackground: '#F8F9FB',
+  baseColor: '#332B3B',
+  selectedColor: '#E9E0EB',
+  highlightBackground: '#E8ECF2',
+  highlightAccent: '#C7CBD1',
+  commentColor: '#72697C',
+  punctuationColor: '#70697C',
+  propertyColor: '#7A6229',
+  selectorColor: '#3C774A',
+  operatorColor: '#635D6F',
+  variableColor: '#A8491A',
+  functionColor: '#106A9E',
+  keywordColor: '#A7114A',
+};
+
+const prismDark = {
+  inlineCodeColor: '#D25F7C',
+  inlineCodeBackground: '#F8F9FB',
+  blockBackground: '#251F3D',
+  baseColor: '#F2EDF6',
+  selectedColor: '#865891',
+  highlightBackground: '#382F5C',
+  highlightAccent: '#D25F7C',
+  commentColor: '#8B7A9E',
+  punctuationColor: '#B3ACC1',
+  propertyColor: '#EAB944',
+  selectorColor: '#7EBE8E',
+  operatorColor: '#A470A7',
+  variableColor: '#E58759',
+  functionColor: '#6CC5F9',
+  keywordColor: '#E386AAv',
+};
+
 const lightShadows = {
   dropShadowLightest: '0 0 2px rgba(43, 34, 51, 0.04)',
   dropShadowLight: '0 1px 4px rgba(43, 34, 51, 0.04)',
@@ -689,6 +725,7 @@ const commonTheme = {
   fontSizeLarge: '16px',
   fontSizeExtraLarge: '18px',
   headerFontSize: '22px',
+  codeFontSize: '13px',
 
   settings: {
     // Max-width for settings breadcrumbs
@@ -854,6 +891,7 @@ export const lightTheme = {
     ...darkColors,
     ...darkAliases,
   },
+  prism: prismLight,
   ...generateUtils(lightColors, lightAliases),
   alert: generateAlertTheme(lightColors, lightAliases),
   badge: generateBadgeTheme(lightColors),
@@ -877,6 +915,7 @@ export const darkTheme: Theme = {
     ...lightColors,
     ...lightAliases,
   },
+  prism: prismDark,
   ...generateUtils(darkColors, lightAliases),
   alert: generateAlertTheme(darkColors, darkAliases),
   badge: generateBadgeTheme(darkColors),


### PR DESCRIPTION
2 main updates to `CodeSnippet`:
 - Use adaptive light/dark mode highlighting colors based on `prism-sentry`
 - Simplify the header element: it will now only appear when `filename` is provided.

[--> Storybook](https://storybook-1z1f9h0s9.sentry.dev/?path=/story/components-code-snippet--default)

**Before:**
<img width="566" alt="Screen Shot 2022-09-30 at 12 01 49 PM" src="https://user-images.githubusercontent.com/44172267/193339031-a8639144-00ac-4787-837a-7c6cc17cc167.png">
<img width="566" alt="Screen Shot 2022-09-30 at 12 05 23 PM" src="https://user-images.githubusercontent.com/44172267/193339541-9ff1882e-947d-4aa8-a803-9278579782cd.png">

**After:**
<img width="566" alt="Screen Shot 2022-09-30 at 12 02 07 PM" src="https://user-images.githubusercontent.com/44172267/193339083-1772e50c-f0de-438b-8e2b-3438f9a544da.png">
<img width="566" alt="Screen Shot 2022-09-30 at 12 05 51 PM" src="https://user-images.githubusercontent.com/44172267/193339616-5d00c9a1-a087-498d-a885-df8118be09ce.png">

