### PR TITLE
feat(spike protection): organization project options endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_projectoptions.py
+++ b/src/sentry/api/endpoints/organization_projectoptions.py
@@ -1,0 +1,29 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import pending_silo_endpoint
+from sentry.api.bases.organization import Organization, OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.project import Project
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models import ProjectOptionsSerializer
+
+
+@pending_silo_endpoint
+class OrganizationProjectOptionsEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationPermission,)
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        """
+        For each Project in an Organization, list its project options and values,
+        or a singular project option and value if specified.
+
+        :pparam string organization_slug: the slug of the organization.
+        :qparam string option: an optional project option name
+
+        """
+        projects = Project.objects.filter(organization=organization)
+        option = request.GET.get("option")
+
+        serializer = ProjectOptionsSerializer(option=option)
+
+        return Response(serialize(list(projects), serializer=serializer))

--- a/src/sentry/api/endpoints/organization_projectoptions.py
+++ b/src/sentry/api/endpoints/organization_projectoptions.py
@@ -2,7 +2,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.base import pending_silo_endpoint
-from sentry.api.bases.organization import Organization, OrganizationEndpoint, OrganizationPermission
+from sentry.api.bases.organization import Organization, OrganizationEndpoint
 from sentry.api.bases.project import Project
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import ProjectOptionsSerializer
@@ -10,7 +10,7 @@ from sentry.api.serializers.models import ProjectOptionsSerializer
 
 @pending_silo_endpoint
 class OrganizationProjectOptionsEndpoint(OrganizationEndpoint):
-    permission_classes = (OrganizationPermission,)
+    private = True
 
     def get(self, request: Request, organization: Organization) -> Response:
         """

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -321,6 +321,7 @@ from .endpoints.organization_onboarding_continuation_email import (
 from .endpoints.organization_onboarding_tasks import OrganizationOnboardingTaskEndpoint
 from .endpoints.organization_pinned_searches import OrganizationPinnedSearchEndpoint
 from .endpoints.organization_processingissues import OrganizationProcessingIssuesEndpoint
+from .endpoints.organization_projectoptions import OrganizationProjectOptionsEndpoint
 from .endpoints.organization_projects import (
     OrganizationProjectsCountEndpoint,
     OrganizationProjectsEndpoint,
@@ -1385,6 +1386,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/projects/$",
                     OrganizationProjectsEndpoint.as_view(),
                     name="sentry-api-0-organization-projects",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/project-options/$",
+                    OrganizationProjectOptionsEndpoint.as_view(),
+                    name="sentry-api-0-organization-project-options",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/projects-count/$",

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -14,6 +14,52 @@ from sentry.utils.cache import cache
 if TYPE_CHECKING:
     from sentry.models import Project
 
+OPTION_KEYS = frozenset(
+    [
+        # we need the epoch to fill in the defaults correctly
+        "sentry:option-epoch",
+        "sentry:origins",
+        "sentry:resolve_age",
+        "sentry:scrub_data",
+        "sentry:scrub_defaults",
+        "sentry:safe_fields",
+        "sentry:store_crash_reports",
+        "sentry:builtin_symbol_sources",
+        "sentry:symbol_sources",
+        "sentry:sensitive_fields",
+        "sentry:csp_ignored_sources_defaults",
+        "sentry:csp_ignored_sources",
+        "sentry:default_environment",
+        "sentry:reprocessing_active",
+        "sentry:blacklisted_ips",
+        "sentry:releases",
+        "sentry:error_messages",
+        "sentry:scrape_javascript",
+        "sentry:token",
+        "sentry:token_header",
+        "sentry:verify_ssl",
+        "sentry:scrub_ip_address",
+        "sentry:grouping_config",
+        "sentry:grouping_enhancements",
+        "sentry:grouping_enhancements_base",
+        "sentry:secondary_grouping_config",
+        "sentry:secondary_grouping_expiry",
+        "sentry:grouping_auto_update",
+        "sentry:fingerprinting_rules",
+        "sentry:relay_pii_config",
+        "sentry:dynamic_sampling",
+        "sentry:breakdowns",
+        "sentry:span_attributes",
+        "sentry:performance_issue_creation_rate",
+        "sentry:spike_projection_config",
+        "feedback:branding",
+        "digests:mail:minimum_delay",
+        "digests:mail:maximum_delay",
+        "mail:subject_prefix",
+        "mail:subject_template",
+    ]
+)
+
 
 class ProjectOptionManager(OptionManager["Project"]):
     def get_value_bulk(self, instances: Sequence[Project], key: str) -> Mapping[Project, Any]:

--- a/tests/sentry/api/endpoints/test_organization_projectoptions.py
+++ b/tests/sentry/api/endpoints/test_organization_projectoptions.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+
+from django.urls import reverse
+from django.utils import timezone
+from freezegun import freeze_time
+
+from sentry.testutils import APITestCase
+
+
+class OrganizationProjectOptionsTest(APITestCase):
+    CURRENT_TIME = datetime(2022, 9, 29, 0, 0, tzinfo=timezone.utc)
+
+    @freeze_time(CURRENT_TIME)
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.project1 = self.create_project(
+            organization=self.organization, slug="project1", name="Project 1"
+        )
+        self.project1.update_option("sentry:spike_projection_config", True)
+        self.project1.update_option("option2", "hello")
+        self.project2 = self.create_project(
+            organization=self.organization, slug="project2", name="Project 2"
+        )
+        self.project2.update_option("option3", 123)
+        self.organization2 = self.create_organization(slug="org2", owner=self.user)
+        self.project3 = self.create_project(organization=self.organization2)
+        self.path = reverse(
+            "sentry-api-0-organization-project-options",
+            args=[self.organization.slug],
+        )
+        self.now = datetime(2022, 9, 29, 0, 0, tzinfo=timezone.utc)
+        self.options_list = [
+            "sentry:option-epoch",
+            "sentry:csp_ignored_sources_defaults",
+            "sentry:csp_ignored_sources",
+            "sentry:reprocessing_active",
+            "sentry:performance_issue_creation_rate",
+            "filters:blacklisted_ips",
+            "filters:releases",
+            "filters:error_messages",
+            "feedback:branding",
+        ]
+
+    def test_organization_projectoptions_get_all(self):
+        response = self.client.get(self.path)
+
+        assert response.status_code == 200
+
+        project1_options = response.data[1]["options"]
+        project2_options = response.data[0]["options"]
+
+        assert project1_options["sentry:spike_projection_config"]
+        assert not project1_options.get("option2")
+        assert not project2_options.get("option3")
+
+        for option in self.options_list:
+            assert option in project1_options
+            assert option in project2_options
+
+        assert response.data[1]["id"] == str(self.project1.id)
+        assert response.data[1]["slug"] == self.project1.slug
+        assert response.data[1]["name"] == self.project1.name
+        assert response.data[0]["id"] == str(self.project2.id)
+        assert response.data[0]["slug"] == self.project2.slug
+        assert response.data[0]["name"] == self.project2.name
+
+    def test_organization_projectoptions_get_option(self):
+        query = {"option": "sentry:spike_projection_config"}
+        response = self.client.get(self.path, query)
+
+        assert response.status_code == 200
+
+        project1_options = response.data[1]["options"]
+        project2_options = response.data[0]["options"]
+
+        assert project1_options == {"sentry:spike_projection_config": True}
+        assert project2_options == {}
+
+        assert response.data[1]["id"] == str(self.project1.id)
+        assert response.data[1]["slug"] == self.project1.slug
+        assert response.data[1]["name"] == self.project1.name
+        assert response.data[0]["id"] == str(self.project2.id)
+        assert response.data[0]["slug"] == self.project2.slug
+        assert response.data[0]["name"] == self.project2.name


### PR DESCRIPTION
For Spike Protection, we are planning on having a page featuring a bunch of toggles so users can toggle on and off spike protection (a project option) for the projects of their choosing. The existing `OrganizationProjectsEndpoint` doesn't return the options for each project, and adding an additional query into a separate database to retrieve the options in this endpoint will slow down the initial response.

Instead of modifying `OrganizationProjectsEndpoint`, which already returns a lot of information, most of which is unnecessary to initialize the toggles for the spike protection page, here we are creating a new endpoint that returns the options for each project along with the most basic information in order to show the list of projects on the page. It will return all of the non-sensitive project options for each project unless an option query parameter is specified, and in that case will return that option and value for each project if it exists for each project.

The response body is as follows:
```
{
  {
    "id": "id",
    "slug": "slug"
    "name": "name"
    "options": {"key": value}
  }
}
```

Addresses ER-1198