### PR TITLE
chore(replays): add replay deletion to sampled tasks

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -111,6 +111,7 @@ SAMPLED_TASKS = {
     "sentry.tasks.reports.prepare_organization_report": 0.1,
     "sentry.tasks.reports.deliver_organization_user_report": 0.01,
     "sentry.tasks.process_buffer.process_incr": 0.01,
+    "sentry.replays.tasks.delete_recording_segments": settings.SAMPLED_DEFAULT_RATE,
 }
 
 if settings.ADDITIONAL_SAMPLED_TASKS:


### PR DESCRIPTION
sample APM data for the replay deletion celery task (this is low throughput so default should be fine).