### PR TITLE
ref(replay): Make `NetworkSpan` be a sub-type of `ReplaySpan`

### DIFF
--- a/static/app/utils/replays/getReplayEvent.tsx
+++ b/static/app/utils/replays/getReplayEvent.tsx
@@ -1,4 +1,7 @@
-export function getPrevReplayEvent<T extends {timestamp?: string | number}>({
+import type {Crumb} from 'sentry/types/breadcrumbs';
+import type {ReplaySpan} from 'sentry/views/replays/types';
+
+export function getPrevReplayEvent<T extends ReplaySpan | Crumb>({
   items,
   targetTimestampMs,
   allowExact = false,
@@ -30,7 +33,7 @@ export function getPrevReplayEvent<T extends {timestamp?: string | number}>({
   }, undefined);
 }
 
-export function getNextReplayEvent<T extends {timestamp?: string}>({
+export function getNextReplayEvent<T extends ReplaySpan | Crumb>({
   items,
   targetTimestampMs,
   allowExact = false,

--- a/static/app/utils/replays/replayDataUtils.spec.tsx
+++ b/static/app/utils/replays/replayDataUtils.spec.tsx
@@ -15,9 +15,11 @@ function createSpan(extra: {
   description?: string;
 }): ReplaySpan<Record<string, any>> {
   return {
-    startTimestamp: 1,
-    endTimestamp: 2,
     data: {},
+    endTimestamp: 2,
+    id: '0',
+    startTimestamp: 1,
+    timestamp: 1,
     ...extra,
   };
 }

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -157,7 +157,13 @@ export function breadcrumbFactory(
 }
 
 export function spansFactory(spans: ReplaySpan[]) {
-  return spans.sort((a, b) => a.startTimestamp - b.startTimestamp);
+  return spans
+    .sort((a, b) => a.startTimestamp - b.startTimestamp)
+    .map(span => ({
+      ...span,
+      id: `${span.description ?? span.op}-${span.startTimestamp}-${span.endTimestamp}`,
+      timestamp: span.startTimestamp * 1000,
+    }));
 }
 
 /**

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -20,10 +20,9 @@ import {
   getResourceTypes,
   getStatusTypes,
   ISortConfig,
-  NetworkSpan,
   sortNetwork,
 } from 'sentry/views/replays/detail/network/utils';
-import type {ReplayRecord} from 'sentry/views/replays/types';
+import type {NetworkSpan, ReplayRecord} from 'sentry/views/replays/types';
 
 type Props = {
   networkSpans: NetworkSpan[];
@@ -31,9 +30,6 @@ type Props = {
 };
 
 type SortDirection = 'asc' | 'desc';
-
-const createSpanId = (span: NetworkSpan) =>
-  `${span.description ?? span.op}-${span.startTimestamp}-${span.endTimestamp}`;
 
 function NetworkList({replayRecord, networkSpans}: Props) {
   const startTimestampMs = replayRecord.startedAt.getTime();
@@ -57,11 +53,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
   const networkData = useMemo(() => sortNetwork(items, sortConfig), [items, sortConfig]);
 
   const currentNetworkSpan = getPrevReplayEvent({
-    items: networkData.map(span => ({
-      ...span,
-      id: createSpanId(span),
-      timestamp: span.startTimestamp * 1000,
-    })),
+    items: networkData,
     targetTimestampMs: startTimestampMs + currentTime,
     allowEqual: true,
     allowExact: true,
@@ -164,7 +156,6 @@ function NetworkList({replayRecord, networkSpans}: Props) {
   ];
 
   const renderTableRow = (network: NetworkSpan) => {
-    const spanId = createSpanId(network);
     const networkStartTimestamp = network.startTimestamp * 1000;
     const networkEndTimestamp = network.endTimestamp * 1000;
     const statusCode = network.data.statusCode;
@@ -172,7 +163,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
     const columnHandlers = getColumnHandlers(networkStartTimestamp);
     const columnProps = {
       isStatusError: typeof statusCode === 'number' && statusCode >= 400,
-      isCurrent: currentNetworkSpan?.id === spanId,
+      isCurrent: currentNetworkSpan?.id === network.id,
       hasOccurred:
         currentTime >= relativeTimeInMs(networkStartTimestamp, startTimestampMs),
       timestampSortDir:
@@ -182,7 +173,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
     };
 
     return (
-      <Fragment key={spanId}>
+      <Fragment key={network.id}>
         <Item {...columnHandlers} {...columnProps} isStatusCode>
           {statusCode ? statusCode : <EmptyText>---</EmptyText>}
         </Item>

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -254,7 +254,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
         disablePadding
         stickyHeaders
       >
-        {networkData.map(renderTableRow) || null}
+        {networkData.map(renderTableRow)}
       </StyledPanelTable>
     </NetworkContainer>
   );

--- a/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
+++ b/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
@@ -4,7 +4,7 @@ import type {Location} from 'history';
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
 import {useLocation} from 'sentry/utils/useLocation';
-import {NetworkSpan} from 'sentry/views/replays/detail/network/utils';
+import type {NetworkSpan} from 'sentry/views/replays/types';
 
 import useDomFilters, {FilterFields} from './useNetworkFilters';
 
@@ -18,6 +18,8 @@ const mockBrowserHistoryPush = browserHistory.push as jest.MockedFunction<
 
 const networkSpans: NetworkSpan[] = [
   {
+    id: '0',
+    timestamp: 1663131080555.4,
     op: 'navigation.navigate',
     description: 'http://localhost:3000/',
     startTimestamp: 1663131080.5554,
@@ -27,6 +29,8 @@ const networkSpans: NetworkSpan[] = [
     },
   },
   {
+    id: '1',
+    timestamp: 1663131080576.7,
     op: 'resource.link',
     description: 'http://localhost:3000/static/css/main.1856e8e3.chunk.css',
     startTimestamp: 1663131080.5767,
@@ -36,6 +40,8 @@ const networkSpans: NetworkSpan[] = [
     },
   },
   {
+    id: '2',
+    timestamp: 1663131080577.0998,
     op: 'resource.script',
     description: 'http://localhost:3000/static/js/2.3b866bed.chunk.js',
     startTimestamp: 1663131080.5770998,
@@ -45,6 +51,8 @@ const networkSpans: NetworkSpan[] = [
     },
   },
   {
+    id: '3',
+    timestamp: 1663131080641,
     op: 'resource.fetch',
     description: 'https://pokeapi.co/api/v2/pokemon',
     startTimestamp: 1663131080.641,
@@ -55,6 +63,8 @@ const networkSpans: NetworkSpan[] = [
     },
   },
   {
+    id: '4',
+    timestamp: 1663131080642.2,
     op: 'resource.img',
     description: 'http://localhost:3000/static/media/logo.ddd5084d.png',
     startTimestamp: 1663131080.6422,
@@ -64,6 +74,8 @@ const networkSpans: NetworkSpan[] = [
     },
   },
   {
+    id: '5',
+    timestamp: 1663131080644.7997,
     op: 'resource.css',
     description:
       'http://localhost:3000/static/media/glyphicons-halflings-regular.448c34a5.woff2',
@@ -74,6 +86,8 @@ const networkSpans: NetworkSpan[] = [
     },
   },
   {
+    id: '6',
+    timestamp: 1663131082346,
     op: 'navigation.push',
     description: '/mypokemon',
     startTimestamp: 1663131082.346,
@@ -81,6 +95,8 @@ const networkSpans: NetworkSpan[] = [
     data: {},
   },
   {
+    id: '7',
+    timestamp: 1663131092471,
     op: 'resource.fetch',
     description: 'https://pokeapi.co/api/v2/pokemon/pikachu',
     startTimestamp: 1663131092.471,
@@ -91,6 +107,8 @@ const networkSpans: NetworkSpan[] = [
     },
   },
   {
+    id: '8',
+    timestamp: 1663131120198,
     op: 'resource.fetch',
     description: 'https://pokeapi.co/api/v2/pokemon/mewtu',
     startTimestamp: 1663131120.198,

--- a/static/app/views/replays/detail/network/useNetworkFilters.tsx
+++ b/static/app/views/replays/detail/network/useNetworkFilters.tsx
@@ -2,8 +2,9 @@ import {useCallback, useMemo} from 'react';
 
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useFiltersInLocationQuery from 'sentry/utils/replays/hooks/useFiltersInLocationQuery';
-import {NetworkSpan, UNKNOWN_STATUS} from 'sentry/views/replays/detail/network/utils';
+import {UNKNOWN_STATUS} from 'sentry/views/replays/detail/network/utils';
 import {filterItems} from 'sentry/views/replays/detail/utils';
+import type {NetworkSpan} from 'sentry/views/replays/types';
 
 export type FilterFields = {
   f_n_search: string;

--- a/static/app/views/replays/detail/network/utils.spec.tsx
+++ b/static/app/views/replays/detail/network/utils.spec.tsx
@@ -1,4 +1,6 @@
-import {getResourceTypes, getStatusTypes, NetworkSpan} from './utils';
+import type {NetworkSpan} from 'sentry/views/replays/types';
+
+import {getResourceTypes, getStatusTypes} from './utils';
 
 describe('getResourceTypes', () => {
   const SPAN_NAVIGATE = {op: 'navigation.navigate'} as NetworkSpan;

--- a/static/app/views/replays/detail/network/utils.tsx
+++ b/static/app/views/replays/detail/network/utils.tsx
@@ -1,12 +1,5 @@
 import {defined} from 'sentry/utils';
-
-export type NetworkSpan = {
-  data: Record<string, any>;
-  endTimestamp: number;
-  op: string;
-  startTimestamp: number;
-  description?: string;
-};
+import type {NetworkSpan} from 'sentry/views/replays/types';
 
 export interface ISortConfig {
   asc: boolean;

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -123,8 +123,10 @@ export type RecordingEvent = eventWithTime;
 export interface ReplaySpan<T = Record<string, any>> {
   data: T;
   endTimestamp: number;
+  id: string;
   op: string;
   startTimestamp: number;
+  timestamp: number;
   description?: string;
 }
 
@@ -135,6 +137,8 @@ export type MemorySpanType = ReplaySpan<{
     usedJSHeapSize: number;
   };
 }>;
+
+export type NetworkSpan = ReplaySpan;
 
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
 


### PR DESCRIPTION
`NetworkSpan` should be based on `ReplaySpan`, the benefit being that we can share more utils functions if they have the same shape. 

Also, we were previously converting network spans to be breadcrumbs in order to call `getPrevReplayEvent()`, it's better to just do that one time inside replayDataUtils.tsx going forward.

Related to https://github.com/getsentry/sentry/pull/39354