### PR TITLE
fix(commit-context): Frames start from the bottom of the error stack

### DIFF
--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -77,7 +77,7 @@ def process_commit_context(
                 frames = munged[1]
 
             # First frame in the stacktrace that is "in_app"
-            frame = next(filter(lambda frame: frame.get("in_app", False), frames), None)
+            frame = next(filter(lambda frame: frame.get("in_app", False), frames[::-1]), None)
 
             if not frame:
                 metrics.incr(


### PR DESCRIPTION
## Objective:
Frames start from the bottom of the error stack. So currently the Commit Context is matching on frames of base libraries. Whereas the value of Commit Context is in the top-level frame that cause the exception.