### PR TITLE
feat(metrics): Allow `team_key_transaction` to be used as a condition [TET-427 TET-325]

### DIFF
--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -489,7 +489,7 @@ class SnubaQueryBuilder:
                 try:
                     metric_condition_filters.append(
                         Condition(
-                            lhs=metric_expression.generate_select_statements(
+                            lhs=metric_expression.generate_where_statements(
                                 use_case_id=self._use_case_id,
                                 params=condition.lhs.params,
                                 projects=self._projects,

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -16,6 +16,7 @@ from sentry.api.utils import InvalidParams
 from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.snuba.metrics import (
+    MetricConditionField,
     MetricField,
     MetricGroupByField,
     MetricsQuery,
@@ -1335,6 +1336,118 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
             {
                 "by": {"team_key_transactions": 0, "transaction": "baz_transaction"},
                 "totals": {"team_key_transactions": 0, "p95": 0.5},
+            },
+        ]
+
+    @freeze_time("2022-09-22 11:07:00")
+    def test_team_key_transaction_as_condition(self):
+        now = timezone.now()
+
+        for idx, (transaction, value) in enumerate(
+            (("foo_transaction", 1), ("bar_transaction", 1), ("baz_transaction", 0.5))
+        ):
+            self.store_metric(
+                org_id=self.organization.id,
+                project_id=self.project.id,
+                type="distribution",
+                name=TransactionMRI.DURATION.value,
+                tags={"transaction": transaction},
+                timestamp=(now - timedelta(minutes=idx)).timestamp(),
+                value=value,
+                use_case_id=UseCaseKey.PERFORMANCE,
+            )
+
+        metrics_query = MetricsQuery(
+            org_id=self.organization.id,
+            project_ids=[self.project.id],
+            select=[
+                MetricField(
+                    op="team_key_transaction",
+                    metric_mri=str(TransactionMRI.DURATION.value),
+                    params={
+                        "team_key_condition_rhs": [
+                            (self.project.id, "foo_transaction"),
+                        ]
+                    },
+                    alias="team_key_transactions",
+                ),
+                MetricField(
+                    op="p95",
+                    metric_mri=str(TransactionMRI.DURATION.value),
+                    alias="p95",
+                ),
+            ],
+            start=now - timedelta(hours=1),
+            end=now,
+            granularity=Granularity(granularity=3600),
+            limit=Limit(limit=50),
+            offset=Offset(offset=0),
+            groupby=[
+                MetricGroupByField(
+                    field=MetricField(
+                        op="team_key_transaction",
+                        metric_mri=str(TransactionMRI.DURATION.value),
+                        params={
+                            "team_key_condition_rhs": [
+                                (self.project.id, "foo_transaction"),
+                            ]
+                        },
+                        alias="team_key_transactions",
+                    )
+                ),
+                MetricGroupByField("transaction"),
+            ],
+            orderby=[
+                OrderBy(
+                    field=MetricField(
+                        op="team_key_transaction",
+                        metric_mri=str(TransactionMRI.DURATION.value),
+                        params={
+                            "team_key_condition_rhs": [
+                                (self.project.id, "foo_transaction"),
+                            ]
+                        },
+                        alias="team_key_transactions",
+                    ),
+                    direction=Direction.DESC,
+                ),
+                OrderBy(
+                    field=MetricField(
+                        op="p95",
+                        metric_mri=str(TransactionMRI.DURATION.value),
+                        alias="p95",
+                    ),
+                    direction=Direction.DESC,
+                ),
+            ],
+            where=[
+                MetricConditionField(
+                    lhs=MetricField(
+                        op="team_key_transaction",
+                        metric_mri=str(TransactionMRI.DURATION.value),
+                        params={
+                            "team_key_condition_rhs": [
+                                (self.project.id, "foo_transaction"),
+                            ]
+                        },
+                        alias="team_key_transactions",
+                    ),
+                    op=Op.EQ,
+                    rhs=1,
+                )
+            ],
+            include_series=False,
+        )
+        data = get_series(
+            [self.project],
+            metrics_query=metrics_query,
+            include_meta=False,
+            use_case_id=UseCaseKey.PERFORMANCE,
+        )
+        assert data["groups"] == [
+            {
+                "by": {"team_key_transactions": 1, "transaction": "foo_transaction"},
+                "totals": {"team_key_transactions": 1, "p95": 1.0},
             },
         ]
 


### PR DESCRIPTION
Adds capability to use `team_key_transaction` as a condition in the query. It achieves this by introducing `ConditionMetricField` which in the future should replace the `MetricQuery` accepting snuba conditions

