### PR TITLE
fix(discover): Use prev location when calculating prev API payload

### DIFF
--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -37,7 +37,7 @@ type TableState = {
   error: null | string;
   isLoading: boolean;
   pageLinks: null | string;
-  prevView: null | EventView;
+  prevView: null | [EventView, Location];
   tableData: TableData | null | undefined;
   tableFetchID: symbol | undefined;
 };
@@ -83,7 +83,9 @@ class Table extends PureComponent<TableProps, TableState> {
     if (prevView === null) {
       return true;
     }
-    const otherAPIPayload = prevView.getEventsAPIPayload(this.props.location);
+
+    const [prevEventView, prevLocation] = prevView;
+    const otherAPIPayload = prevEventView.getEventsAPIPayload(prevLocation);
 
     return !isAPIPayloadSimilar(thisAPIPayload, otherAPIPayload);
   };
@@ -101,7 +103,7 @@ class Table extends PureComponent<TableProps, TableState> {
     if (!eventView.isValid() || !confirmedQuery) {
       return;
     }
-    this.setState({prevView: eventView});
+    this.setState({prevView: [eventView, location]});
 
     // note: If the eventView has no aggregates, the endpoint will automatically add the event id in
     // the API payload response


### PR DESCRIPTION
By the time the check for a confirmed query runs, prevProps.location is the new location. Instead, store the location when a query was last valid and fetched and use that to calculate the API payload.

Fixes an issue raised where the pagination on the Discover table doesn't work.