### PR TITLE
feat(sampling): Add ruby and rails to supported DS SDKs list

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -38,6 +38,8 @@ ALLOWED_SDK_NAMES = frozenset(
         "sentry.python",  # python, django, flask, FastAPI, Starlette, Bottle, Celery, pyramid, rq
         "sentry.python.serverless",  # AWS Lambda
         "sentry.cocoa",  # iOS
+        "sentry.ruby",  # Ruby
+        "sentry.ruby.rails",  # Rails
     )
 )
 # We want sentry.java.android, sentry.java.android.timber, and all others to match


### PR DESCRIPTION
supported from [5.5.0](https://github.com/getsentry/sentry-ruby/releases/tag/5.5.0)