### PR TITLE
feat(metrics): Add ability to specify result meta type [TET-325 TET-439]

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -842,13 +842,13 @@ def get_series(
     if len(result_groups) > metrics_query.limit.limit:
         result_groups = result_groups[0 : metrics_query.limit.limit]
 
-    metrics_query_fields = {
-        str(metric_field) for metric_field in converter._alias_to_metric_field.keys()
-    }
     groupby_aliases = (
-        {metric_groupby_obj.alias for metric_groupby_obj in metrics_query.groupby}
+        {
+            metric_groupby_obj.alias: metric_groupby_obj
+            for metric_groupby_obj in metrics_query.groupby
+        }
         if metrics_query.groupby
-        else set()
+        else {}
     )
 
     return {
@@ -856,7 +856,11 @@ def get_series(
         "end": metrics_query.end,
         "intervals": intervals,
         "groups": result_groups,
-        "meta": translate_meta_results(meta, metrics_query_fields, groupby_aliases)
+        "meta": translate_meta_results(
+            meta=meta,
+            alias_to_metric_field=converter._alias_to_metric_field,
+            alias_to_metric_group_by_field=groupby_aliases,
+        )
         if include_meta
         else [],
     }

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -365,7 +365,7 @@ def translate_meta_results(
 
         # Column name could be either a mri, ["bucketed_time"] or a tag or a dataset col like
         # "project_id" or "metric_id"
-        is_tag = column_name in set(alias_to_metric_group_by_field.keys())
+        is_tag = column_name in alias_to_metric_group_by_field.keys()
         is_time_col = column_name in [TS_COL_GROUP]
         is_dataset_col = column_name in DATASET_COLUMNS
 
@@ -397,7 +397,7 @@ def translate_meta_results(
                             }
                         )
                     continue
-                if record["name"] not in set(alias_to_metric_field.keys()):
+                if record["name"] not in alias_to_metric_field.keys():
                     raise InvalidParams(f"Field {record['name']} was not in the select clause")
 
                 defined_parent_meta_type = get_metric_object_from_metric_field(

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -9,7 +9,7 @@ __all__ = (
     "translate_meta_results",
 )
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 from snuba_sdk import (
     AliasedExpression,
@@ -44,6 +44,7 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.metrics.fields import metric_object_factory
 from sentry.snuba.metrics.fields.base import (
     COMPOSITE_ENTITY_CONSTITUENT_ALIAS,
+    MetricExpressionBase,
     generate_bottom_up_dependency_tree_for_metrics,
     org_id_from_projects,
 )
@@ -341,10 +342,15 @@ def parse_tag(use_case_id: UseCaseKey, org_id: int, tag_string: str) -> str:
     return reverse_resolve(use_case_id, org_id, tag_key)
 
 
+def get_metric_object_from_metric_field(metric_field: MetricField) -> MetricExpressionBase:
+    """Get the metric object from a metric field"""
+    return metric_object_factory(op=metric_field.op, metric_mri=metric_field.metric_mri)
+
+
 def translate_meta_results(
     meta: Sequence[Dict[str, str]],
-    query_metric_fields: Set[str],
-    groupby_aliases: Set[str],
+    alias_to_metric_field: Dict[str, MetricField],
+    alias_to_metric_group_by_field: Dict[str, MetricGroupByField],
 ) -> Sequence[Dict[str, str]]:
     """
     Translate meta results:
@@ -359,7 +365,7 @@ def translate_meta_results(
 
         # Column name could be either a mri, ["bucketed_time"] or a tag or a dataset col like
         # "project_id" or "metric_id"
-        is_tag = column_name in groupby_aliases
+        is_tag = column_name in set(alias_to_metric_group_by_field.keys())
         is_time_col = column_name in [TS_COL_GROUP]
         is_dataset_col = column_name in DATASET_COLUMNS
 
@@ -375,10 +381,31 @@ def translate_meta_results(
                     # it is a safe assumption to make.
                     parent_alias = record["name"].split(COMPOSITE_ENTITY_CONSTITUENT_ALIAS)[1]
                     if parent_alias not in {elem["name"] for elem in results}:
-                        results.append({"name": parent_alias, "type": record["type"]})
+                        try:
+                            defined_parent_meta_type = get_metric_object_from_metric_field(
+                                alias_to_metric_field[parent_alias]
+                            ).get_meta_type()
+                        except KeyError:
+                            defined_parent_meta_type = None
+
+                        results.append(
+                            {
+                                "name": parent_alias,
+                                "type": record["type"]
+                                if defined_parent_meta_type is None
+                                else defined_parent_meta_type,
+                            }
+                        )
                     continue
-                if record["name"] not in query_metric_fields:
+                if record["name"] not in set(alias_to_metric_field.keys()):
                     raise InvalidParams(f"Field {record['name']} was not in the select clause")
+
+                defined_parent_meta_type = get_metric_object_from_metric_field(
+                    alias_to_metric_field[record["name"]]
+                ).get_meta_type()
+                record["type"] = (
+                    record["type"] if defined_parent_meta_type is None else defined_parent_meta_type
+                )
             except InvalidParams:
                 # XXX(ahmed): We get into this branch when we are tying to generate inferred types
                 # for instances of `CompositeEntityDerivedMetric` as type needs to be inferred from
@@ -394,7 +421,17 @@ def translate_meta_results(
             if is_tag:
                 # since we changed value from int to str we need
                 # also want to change type
-                record["type"] = "string"
+                metric_groupby_field = alias_to_metric_group_by_field[record["name"]]
+                if isinstance(metric_groupby_field.field, MetricField):
+                    defined_parent_meta_type = get_metric_object_from_metric_field(
+                        metric_groupby_field.field
+                    ).get_meta_type()
+                else:
+                    defined_parent_meta_type = None
+
+                record["type"] = (
+                    "string" if defined_parent_meta_type is None else defined_parent_meta_type
+                )
             elif is_time_col or is_dataset_col:
                 record["name"] = column_name
 

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -1321,7 +1321,7 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
         data = get_series(
             [self.project],
             metrics_query=metrics_query,
-            include_meta=False,
+            include_meta=True,
             use_case_id=UseCaseKey.PERFORMANCE,
         )
         assert data["groups"] == [
@@ -1338,6 +1338,14 @@ class PerformanceMetricsLayerTestCase(TestCase, BaseMetricsTestCase):
                 "totals": {"team_key_transactions": 0, "p95": 0.5},
             },
         ]
+        assert data["meta"] == sorted(
+            [
+                {"name": "p95", "type": "Array(Float64)"},
+                {"name": "team_key_transactions", "type": "boolean"},
+                {"name": "transaction", "type": "string"},
+            ],
+            key=lambda elem: elem["name"],
+        )
 
     @freeze_time("2022-09-22 11:07:00")
     def test_team_key_transaction_as_condition(self):

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -47,7 +47,11 @@ from sentry.snuba.metrics import (
     resolve_tags,
     translate_meta_results,
 )
-from sentry.snuba.metrics.fields.base import COMPOSITE_ENTITY_CONSTITUENT_ALIAS
+from sentry.snuba.metrics.fields.base import (
+    COMPOSITE_ENTITY_CONSTITUENT_ALIAS,
+    CompositeEntityDerivedMetric,
+    SingularEntityDerivedMetric,
+)
 from sentry.snuba.metrics.fields.snql import (
     abnormal_sessions,
     addition,
@@ -975,15 +979,34 @@ def test_get_intervals():
 def test_translate_meta_results():
     meta = [
         {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Array(Float64)"},
+        {"name": "team_key_transaction", "type": "UInt8"},
         {"name": "transaction", "type": "UInt64"},
         {"name": "project_id", "type": "UInt64"},
         {"name": "metric_id", "type": "UInt64"},
     ]
     assert translate_meta_results(
-        meta, {"p50(transaction.measurements.lcp)"}, {"transaction"}
+        meta,
+        {
+            "p50(transaction.measurements.lcp)": MetricField(
+                op="p50",
+                metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
+                alias="p50(transaction.measurements.lcp)",
+            ),
+        },
+        {
+            "transaction": MetricGroupByField("transaction"),
+            "team_key_transaction": MetricGroupByField(
+                field=MetricField(
+                    op="team_key_transaction",
+                    metric_mri=TransactionMRI.DURATION.value,
+                    alias="team_key_transaction",
+                )
+            ),
+        },
     ) == sorted(
         [
             {"name": "p50(transaction.measurements.lcp)", "type": "Array(Float64)"},
+            {"name": "team_key_transaction", "type": "boolean"},
             {"name": "transaction", "type": "string"},
             {"name": "project_id", "type": "UInt64"},
             {"name": "metric_id", "type": "UInt64"},
@@ -1003,13 +1026,100 @@ def test_translate_meta_results_with_duplicates():
     ]
     assert translate_meta_results(
         meta,
-        {"p50(transaction.measurements.lcp)"},
-        {"transaction"},
+        {
+            "p50(transaction.measurements.lcp)": MetricField(
+                op="p50",
+                metric_mri=TransactionMRI.MEASUREMENTS_LCP.value,
+                alias="p50(transaction.measurements.lcp)",
+            )
+        },
+        {"transaction": MetricGroupByField("transaction")},
     ) == sorted(
         [
             {"name": "p50(transaction.measurements.lcp)", "type": "Array(Float64)"},
             {"name": "transaction", "type": "string"},
             {"name": "project_id", "type": "UInt64"},
+        ],
+        key=lambda elem: elem["name"],
+    )
+
+
+@mock.patch(
+    "sentry.snuba.metrics.query_builder.get_metric_object_from_metric_field",
+    return_value=SingularEntityDerivedMetric(
+        metric_mri=TransactionMRI.FAILURE_RATE.value,
+        metrics=[
+            TransactionMRI.FAILURE_COUNT.value,
+            TransactionMRI.ALL.value,
+        ],
+        unit="transactions",
+        snql=lambda failure_count, tx_count, org_id, metric_ids, alias=None: division_float(
+            failure_count, tx_count, alias=alias
+        ),
+        meta_type="ratio",
+    ),
+)
+def test_translate_meta_result_type_singular_entity_derived_metric(_):
+    meta = [
+        {"name": "transaction.failure_rate", "type": "Array(Float64)"},
+        {"name": "transaction", "type": "UInt64"},
+        {"name": "project_id", "type": "UInt64"},
+    ]
+    assert translate_meta_results(
+        meta,
+        {
+            "transaction.failure_rate": MetricField(
+                op=None,
+                metric_mri=TransactionMRI.FAILURE_RATE.value,
+                alias="transaction.failure_rate",
+            )
+        },
+        {"transaction": MetricGroupByField("transaction")},
+    ) == sorted(
+        [
+            {"name": "transaction.failure_rate", "type": "ratio"},
+            {"name": "transaction", "type": "string"},
+            {"name": "project_id", "type": "UInt64"},
+        ],
+        key=lambda elem: elem["name"],
+    )
+
+
+@mock.patch(
+    "sentry.snuba.metrics.query_builder.get_metric_object_from_metric_field",
+    return_value=CompositeEntityDerivedMetric(
+        metric_mri=SessionMRI.ERRORED.value,
+        metrics=[
+            SessionMRI.ERRORED_ALL.value,
+            SessionMRI.CRASHED_AND_ABNORMAL.value,
+        ],
+        meta_type="sessions",
+        unit="sessions",
+        post_query_func=lambda errored_all, crashed_abnormal: max(
+            0, errored_all - crashed_abnormal
+        ),
+    ),
+)
+def test_translate_meta_result_type_composite_entity_derived_metric(_):
+    meta = [
+        {
+            "name": "e:sessions/all_errored@none__CHILD_OF__session.errored",
+            "type": "Array(Float64)",
+        },
+    ]
+    assert translate_meta_results(
+        meta,
+        {
+            "session.errored": MetricField(
+                op=None,
+                metric_mri=SessionMRI.ERRORED.value,
+                alias="session.errored",
+            )
+        },
+        {},
+    ) == sorted(
+        [
+            {"name": "session.errored", "type": "sessions"},
         ],
         key=lambda elem: elem["name"],
     )


### PR DESCRIPTION
Adds ability to specify result meta type on
all children of MetricsExpressionBase meaning
MetricsExpression, SingularEntityDerivedMetric, and CompositeEntityDerivedMetric. This change was required to add a meta type on `team_key_transaction` of
boolean


