### PR TITLE
feat(profiles): store transactionId on profileGroup

### DIFF
--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -285,6 +285,7 @@ export function parseTypescriptChromeTraceArrayFormat(
   return {
     name: 'chrometrace',
     traceID: profileID,
+    transactionID: null,
     activeProfileIndex: 0,
     profiles,
     metadata: {} as Profiling.Schema['metadata'],
@@ -535,6 +536,7 @@ export function parseChromeTraceFormat(
     activeProfileIndex: 0,
     profiles: [],
     traceID: profileID,
+    transactionID: null,
     metadata: {} as Profiling.Schema['metadata'],
   };
 }

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -29,6 +29,7 @@ export interface ProfileGroup {
   name: string;
   profiles: Profile[];
   traceID: string;
+  transactionID: string | null;
 }
 
 export function importProfile(
@@ -102,6 +103,7 @@ function importJSSelfProfile(
   return {
     traceID,
     name: traceID,
+    transactionID: null,
     activeProfileIndex: 0,
     profiles: [profile],
     metadata: {
@@ -136,6 +138,7 @@ function importSchema(
 
   return {
     traceID,
+    transactionID: input.metadata.transactionID ?? null,
     name: input.metadata?.transactionName ?? traceID,
     activeProfileIndex: input.activeProfileIndex ?? 0,
     metadata: input.metadata ?? {},
@@ -154,6 +157,7 @@ function importNodeProfile(
 
   return {
     traceID,
+    transactionID: null,
     name: input.name,
     activeProfileIndex: 0,
     metadata: {},

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -32,6 +32,7 @@ import {useProfileGroup} from './profileGroupProvider';
 const LoadingGroup: ProfileGroup = {
   name: 'Loading',
   activeProfileIndex: 0,
+  transactionID: null,
   metadata: {},
   traceID: '',
   profiles: [Profile.Empty],


### PR DESCRIPTION
If transactionID is present, store it so that we can fetch the underlying transaction. We will need this info to try and enrich flamecharts with span data