### PR TITLE
fix(discover): Pagination on discover table

### DIFF
--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -24,6 +24,7 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {CursorHandler} from 'sentry/components/pagination';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {MAX_QUERY_LENGTH} from 'sentry/constants';
@@ -305,6 +306,18 @@ class Results extends Component<Props, State> {
 
     browserHistory.replace(nextEventView.getResultsViewUrlTarget(organization.slug));
   }
+
+  handleCursor: CursorHandler = (cursor, path, query, _direction) => {
+    const {router} = this.props;
+    router.push({
+      pathname: path,
+      query: {...query, cursor},
+    });
+    // Treat pagination like the user already confirmed the query
+    if (!this.state.needConfirmation) {
+      this.handleConfirmed();
+    }
+  };
 
   handleChangeShowTags = () => {
     const {organization} = this.props;
@@ -601,6 +614,7 @@ class Results extends Component<Props, State> {
                     onChangeShowTags={this.handleChangeShowTags}
                     showTags={showTags}
                     confirmedQuery={confirmedQuery}
+                    onCursor={this.handleCursor}
                   />
                 </Layout.Main>
                 {showTags ? this.renderTagsTable() : null}

--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -4,7 +4,7 @@ import {Location} from 'history';
 
 import {EventQuery} from 'sentry/actionCreators/events';
 import {Client} from 'sentry/api';
-import Pagination from 'sentry/components/pagination';
+import Pagination, {CursorHandler} from 'sentry/components/pagination';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {metric, trackAnalyticsEvent} from 'sentry/utils/analytics';
@@ -27,6 +27,7 @@ type TableProps = {
   eventView: EventView;
   location: Location;
   onChangeShowTags: () => void;
+  onCursor: CursorHandler;
   organization: Organization;
   setError: (msg: string, code: number) => void;
   showTags: boolean;
@@ -193,7 +194,7 @@ class Table extends PureComponent<TableProps, TableState> {
   };
 
   render() {
-    const {eventView} = this.props;
+    const {eventView, onCursor} = this.props;
     const {pageLinks, tableData, isLoading, error} = this.state;
 
     const isFirstPage = pageLinks
@@ -225,7 +226,7 @@ class Table extends PureComponent<TableProps, TableState> {
             );
           }}
         </Measurements>
-        <Pagination pageLinks={pageLinks} />
+        <Pagination pageLinks={pageLinks} onCursor={onCursor} />
       </Container>
     );
   }


### PR DESCRIPTION
Pagination wasn't working because we weren't handling the state 
of confirmedQuery properly. Handle pagination as if state
confirmedQuery is true.
