### PR TITLE
ref(js): Modify renderComponent in useApiRequests accept a render function

### DIFF
--- a/static/app/utils/useApiRequests.spec.tsx
+++ b/static/app/utils/useApiRequests.spec.tsx
@@ -13,11 +13,11 @@ describe('useApiRequests', () => {
 
   describe('error handling', () => {
     function HomePage() {
-      const {renderComponent} = useApiRequests<{message: {value?: string}}>({
+      const {renderComponent} = useApiRequests<{message: {value: string}}>({
         endpoints: [['message', '/some/path/to/something/']],
         shouldRenderBadRequests: true,
       });
-      return renderComponent(({data}) => <div>{data.message?.value}</div>);
+      return renderComponent(({data}) => <div>{data.message.value}</div>);
     }
 
     function UniqueErrorsAsyncComponent() {
@@ -31,7 +31,7 @@ describe('useApiRequests', () => {
       });
 
       // @ts-expect-error
-      return renderComponent(({data}) => <div>{data.message?.value}</div>);
+      return renderComponent(({data}) => <div>{data.message.value}</div>);
     }
 
     const memoryHistory = createMemoryHistory();

--- a/static/app/utils/useApiRequests.spec.tsx
+++ b/static/app/utils/useApiRequests.spec.tsx
@@ -13,15 +13,15 @@ describe('useApiRequests', () => {
 
   describe('error handling', () => {
     function HomePage() {
-      const {renderComponent, data} = useApiRequests<{message: {value?: string}}>({
+      const {renderComponent} = useApiRequests<{message: {value?: string}}>({
         endpoints: [['message', '/some/path/to/something/']],
         shouldRenderBadRequests: true,
       });
-      return renderComponent(<div>{data.message?.value}</div>);
+      return renderComponent(({data}) => <div>{data.message?.value}</div>);
     }
 
     function UniqueErrorsAsyncComponent() {
-      const {renderComponent, data} = useApiRequests({
+      const {renderComponent} = useApiRequests({
         endpoints: [
           ['first', '/first/path/'],
           ['second', '/second/path/'],
@@ -31,7 +31,7 @@ describe('useApiRequests', () => {
       });
 
       // @ts-expect-error
-      return renderComponent(<div>{data.message?.value}</div>);
+      return renderComponent(({data}) => <div>{data.message?.value}</div>);
     }
 
     const memoryHistory = createMemoryHistory();

--- a/static/app/views/monitors/monitorStats.tsx
+++ b/static/app/views/monitors/monitorStats.tsx
@@ -13,28 +13,10 @@ type Props = {
 };
 
 type State = {
-  stats: MonitorStat[] | null;
+  stats: MonitorStat[];
 };
 
-const MonitorStats = ({monitor}: Props) => {
-  const until = Math.floor(new Date().getTime() / 1000);
-  const since = until - 3600 * 24 * 30;
-  const {data, renderComponent} = useApiRequests<State>({
-    endpoints: [
-      [
-        'stats',
-        `/monitors/${monitor.id}/stats/`,
-        {
-          query: {
-            since: since.toString(),
-            until: until.toString(),
-            resolution: '1d',
-          },
-        },
-      ],
-    ],
-  });
-
+const MonitorStatsSuccess = ({data}: {data: State}) => {
   let emptyStats = true;
   const success = {
     seriesName: t('Successful'),
@@ -45,7 +27,7 @@ const MonitorStats = ({monitor}: Props) => {
     data: [] as SeriesDataUnit[],
   };
 
-  data.stats?.forEach(p => {
+  data.stats.forEach(p => {
     if (p.ok || p.error) {
       emptyStats = false;
     }
@@ -55,7 +37,7 @@ const MonitorStats = ({monitor}: Props) => {
   });
   const colors = [theme.green300, theme.red300];
 
-  return renderComponent(
+  return (
     <Panel>
       <PanelBody withPadding>
         {!emptyStats ? (
@@ -77,6 +59,28 @@ const MonitorStats = ({monitor}: Props) => {
       </PanelBody>
     </Panel>
   );
+};
+
+const MonitorStats = ({monitor}: Props) => {
+  const until = Math.floor(new Date().getTime() / 1000);
+  const since = until - 3600 * 24 * 30;
+  const {renderComponent} = useApiRequests<State>({
+    endpoints: [
+      [
+        'stats',
+        `/monitors/${monitor.id}/stats/`,
+        {
+          query: {
+            since: since.toString(),
+            until: until.toString(),
+            resolution: '1d',
+          },
+        },
+      ],
+    ],
+  });
+
+  return renderComponent(MonitorStatsSuccess);
 };
 
 export default MonitorStats;

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -448,7 +448,7 @@ class ReleasesList extends AsyncView<Props, State> {
     }
 
     if (this.shouldShowQuickstart) {
-      return <ReleasesPromo organization={organization} project={selectedProject!} />;
+      return <ReleasesPromo project={selectedProject!} />;
     }
 
     return (

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -243,7 +243,7 @@ const ReleasesPromoSuccess = ({
                 {
                   label: <GroupHeader>{t('Available Integrations')}</GroupHeader>,
                   id: 'available-integrations',
-                  items: (integrations || []).map(renderIntegrationNode),
+                  items: integrations.map(renderIntegrationNode),
                 },
               ]}
               alignMenu="left"


### PR DESCRIPTION
The current API of `renderComponent` in `useApiRequests` means that you need to render the success data before the request actually succeeds. This causes you to either check for null all over the place, or mistype the response (by not adding `| null`). By passing a function into `renderComponent`, we can pass a `data` parameter that is non-null. React also doesn't have to render the subtree until the request actually succeeds.

Old usage:

```tsx
type ResponseData = { numbers: number[] | null }

const {renderComponent, data} = useApiRequests<ResponseData>;

return renderComponent(
  <div>
   {/* Note that you have to check for data.key to be null here */}
   {data.key && data.key.map(num => <span>{num}</span>}
  </div>
)
```

New usage:

```tsx
type ResponseData = { numbers: number[] }

const {renderComponent} = useApiRequests<ResponseData>;

return renderComponent(({data}) => (
  <div>
    {data.key.map(num => <span>{num}</span>}
  </div>
))
```

or even better, extract the success view out to its own component:

```tsx
type ResponseData = { numbers: number[] }

const {renderComponent} = useApiRequests<ResponseData>;

return renderComponent(SuccessView)
```

