### PR TITLE
Add `replays.delete_replay` queue

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -678,6 +678,7 @@ CELERY_QUEUES = [
     Queue("release_health.duplex", routing_key="release_health.duplex"),
     Queue("get_suspect_resolutions", routing_key="get_suspect_resolutions"),
     Queue("get_suspect_resolutions_releases", routing_key="get_suspect_resolutions_releases"),
+    Queue("replays.delete_replay", routing_key="replays.delete_replay"),
 ]
 
 for queue in CELERY_QUEUES:


### PR DESCRIPTION
Before switching the task (https://github.com/getsentry/sentry/pull/39520), we need to create the queue.