### PR TITLE
wip(spike-protections): Add options to ProjectSerializer

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -159,10 +159,13 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
             )
         else:
             expand = set()
+            expand_context = {"options": request.GET.getlist("options") or []}
             if request.GET.get("transactionStats"):
                 expand.add("transaction_stats")
             if request.GET.get("sessionStats"):
                 expand.add("session_stats")
+            if request.GET.get("options"):
+                expand.add("options")
 
             def serialize_on_result(result):
                 environment_id = self._get_environment_id_from_request(request, organization.id)
@@ -170,6 +173,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     environment_id=environment_id,
                     stats_period=stats_period,
                     expand=expand,
+                    expand_context=expand_context,
                     collapse=collapse,
                 )
                 return serialize(result, request.user, serializer)


### PR DESCRIPTION
This PR is a proof of concept for expanding on options for the Project Serializer. The `expand_context` dict lets us provide a list of options which we want to see in the serialized result, instead of just serializing every option in the project.

cc @cathyteng17 