### PR TITLE
chore(auth): Update login redirect to support customer domains

### DIFF
--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -17,6 +17,7 @@ from rest_framework.request import Request
 
 from sentry.models import Authenticator, User
 from sentry.utils import metrics
+from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.auth")
 
@@ -149,7 +150,7 @@ def get_org_redirect_url(request, active_organization):
     return "/organizations/new/"
 
 
-def get_login_redirect(request, default=None):
+def _get_login_redirect(request, default=None):
     if default is None:
         default = get_login_url()
 
@@ -172,6 +173,17 @@ def get_login_redirect(request, default=None):
         login_url = default
 
     return login_url
+
+
+def get_login_redirect(request, default=None):
+    from sentry.api.utils import generate_organization_url
+
+    login_redirect = _get_login_redirect(request, default)
+    url_prefix = None
+    if "subdomain" in request and request.subdomain:
+        url_prefix = generate_organization_url(request.subdomain)
+        return absolute_uri(login_redirect, url_prefix=url_prefix)
+    return login_redirect
 
 
 def is_valid_redirect(url: str, allowed_hosts: Optional[Container] = None) -> bool:

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -180,7 +180,7 @@ def get_login_redirect(request, default=None):
 
     login_redirect = _get_login_redirect(request, default)
     url_prefix = None
-    if "subdomain" in request and request.subdomain:
+    if hasattr(request, "subdomain") and request.subdomain:
         url_prefix = generate_organization_url(request.subdomain)
         return absolute_uri(login_redirect, url_prefix=url_prefix)
     return login_redirect

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -14,6 +14,9 @@ def absolute_uri(url: Optional[str] = None, url_prefix=None) -> str:
         url_prefix = options.get("system.url-prefix")
     if not url:
         return url_prefix
+    parsed = urlparse(url)
+    if parsed.hostname is not None:
+        url_prefix = origin_from_url(url)
     return urljoin(url_prefix.rstrip("/") + "/", url.lstrip("/"))
 
 

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from django.urls import reverse
-from requests import request
 
 import sentry.utils.auth
 from sentry.models import User

--- a/tests/sentry/utils/test_auth.py
+++ b/tests/sentry/utils/test_auth.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from django.urls import reverse
+from requests import request
 
 import sentry.utils.auth
 from sentry.models import User
@@ -52,6 +53,55 @@ class GetLoginRedirectTest(TestCase):
         result = get_login_redirect(self.make_request("http://example.com"))
         assert result == reverse("sentry-login")
 
+        result = get_login_redirect(self.make_request("ftp://testserver"))
+        assert result == reverse("sentry-login")
+
+    def test_next(self):
+        result = get_login_redirect(self.make_request("http://testserver/foobar/"))
+        assert result == "http://testserver/foobar/"
+
+        result = get_login_redirect(self.make_request("ftp://testserver/foobar/"))
+        assert result == reverse("sentry-login")
+
+        request = self.make_request("/foobar/")
+        request.subdomain = "orgslug"
+        result = get_login_redirect(request)
+        assert result == "http://orgslug.testserver/foobar/"
+
+        request = self.make_request("http://testserver/foobar/")
+        request.subdomain = "orgslug"
+        result = get_login_redirect(request)
+        assert result == "http://testserver/foobar/"
+
+        request = self.make_request("ftp://testserver/foobar/")
+        request.subdomain = "orgslug"
+        result = get_login_redirect(request)
+        assert result == f"http://orgslug.testserver{reverse('sentry-login')}"
+
+    def test_after_2fa(self):
+        request = self.make_request()
+        request.session["_after_2fa"] = "http://testserver/foobar/"
+        result = get_login_redirect(request)
+        assert result == "http://testserver/foobar/"
+
+        request = self.make_request()
+        request.subdomain = "orgslug"
+        request.session["_after_2fa"] = "/foobar/"
+        result = get_login_redirect(request)
+        assert result == "http://orgslug.testserver/foobar/"
+
+    def test_pending_2fa(self):
+        request = self.make_request()
+        request.session["_pending_2fa"] = [1234, 1234, 1234]
+        result = get_login_redirect(request)
+        assert result == reverse("sentry-2fa-dialog")
+
+        request = self.make_request()
+        request.subdomain = "orgslug"
+        request.session["_pending_2fa"] = [1234, 1234, 1234]
+        result = get_login_redirect(request)
+        assert result == f"http://orgslug.testserver{reverse('sentry-2fa-dialog')}"
+
     def test_login_uses_default(self):
         result = get_login_redirect(self.make_request(reverse("sentry-login")))
         assert result == reverse("sentry-login")
@@ -59,6 +109,11 @@ class GetLoginRedirectTest(TestCase):
     def test_no_value_uses_default(self):
         result = get_login_redirect(self.make_request())
         assert result == reverse("sentry-login")
+
+        request = self.make_request()
+        request.subdomain = "orgslug"
+        result = get_login_redirect(request)
+        assert result == f"http://orgslug.testserver{reverse('sentry-login')}"
 
 
 class LoginTest(TestCase):

--- a/tests/sentry/utils/test_http.py
+++ b/tests/sentry/utils/test_http.py
@@ -13,8 +13,20 @@ class AbsoluteUriTest(unittest.TestCase):
     def test_without_path(self):
         assert absolute_uri() == options.get("system.url-prefix")
 
+    def test_override_url_prefix(self):
+        assert absolute_uri("/foo/bar", url_prefix="http://foobar/") == "http://foobar/foo/bar"
+
     def test_with_path(self):
         assert absolute_uri("/foo/bar") == "{}/foo/bar".format(options.get("system.url-prefix"))
+
+    def test_hostname_present(self):
+        assert (
+            absolute_uri("https://orgslug.sentry.io/foo/bar") == "https://orgslug.sentry.io/foo/bar"
+        )
+        assert (
+            absolute_uri("https://orgslug.sentry.io/foo/bar", url_prefix="http://foobar/")
+            == "https://orgslug.sentry.io/foo/bar"
+        )
 
 
 class GetOriginsTestCase(TestCase):

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -531,6 +531,6 @@ class AuthLoginCustomerDomainTest(TestCase):
 
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (reverse("sentry-login"), 302),
+                (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
                 ("http://testserver/organizations/new/", 302),
             ]

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -425,7 +425,7 @@ class AuthLoginCustomerDomainTest(TestCase):
         )
         assert resp.status_code == 200
         assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
+            (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
             ("http://testserver/organizations/new/", 302),
         ]
 
@@ -442,7 +442,7 @@ class AuthLoginCustomerDomainTest(TestCase):
         )
         assert resp.status_code == 200
         assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
+            (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
             ("/organizations/albertos-apples/issues/", 302),
         ]
 
@@ -463,7 +463,7 @@ class AuthLoginCustomerDomainTest(TestCase):
 
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (reverse("sentry-login"), 302),
+                (f"http://invalid.testserver{reverse('sentry-login')}", 302),
                 ("http://albertos-apples.testserver/auth/login/", 302),
                 ("/organizations/albertos-apples/issues/", 302),
             ]
@@ -486,7 +486,7 @@ class AuthLoginCustomerDomainTest(TestCase):
             )
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (reverse("sentry-login"), 302),
+                (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
                 # Non-sentry staff should be kicked out of using customer domain
                 ("http://testserver/auth/login/", 302),
                 ("/organizations/albertos-apples/issues/", 302),
@@ -509,7 +509,7 @@ class AuthLoginCustomerDomainTest(TestCase):
 
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (reverse("sentry-login"), 302),
+                (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
                 (f"/organizations/{self.organization.slug}/issues/", 302),
                 ("/organizations/albertos-apples/issues/", 302),
                 ("/auth/login/albertos-apples/", 302),


### PR DESCRIPTION
Update append `request.subdomain` (i.e. customer domain) to the login redirect URL only whenever the login redirect URL is not absolute.