### PR TITLE
fix(issues): Remove padding from checkmark icon

### DIFF
--- a/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
@@ -80,7 +80,7 @@ const SuggestedAssignees = ({
                 </SuggestedOwnerHovercard>
               </ActorMaxWidth>
 
-              <Button
+              <StyledButton
                 role="button"
                 size="zero"
                 borderless
@@ -123,4 +123,8 @@ const SuggestionRow = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
+`;
+
+const StyledButton = styled(Button)`
+  padding-right: 0;
 `;


### PR DESCRIPTION
Moves the checkmark icons slightly

checkmarks had a few pixels of padding on the right
![image](https://user-images.githubusercontent.com/1400464/193675969-7d4347b8-ebca-4177-a038-58ebbb7fbed6.png)
