### PR TITLE
feat(issues): Tracks tab changes in issue group details page

### DIFF
--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -29,6 +29,13 @@ export type IssueEventParameters = {
     group?: string;
     platform?: string;
   };
+  'issue_group_details.tab.clicked': {
+    tab: string;
+    browser?: string;
+    device?: string;
+    os?: string;
+    platform?: string;
+  };
   'issue_search.empty': {
     query: string;
     search_source: string;
@@ -120,6 +127,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'quick_trace.connected_services': 'Quick Trace: Connected Services',
   'span_view.embedded_child.hide': 'Span View: Hide Embedded Transaction',
   'span_view.embedded_child.show': 'Span View: Show Embedded Transaction',
+  'issue_group_details.tab.clicked': 'Issue Group Details: Header Tab Clicked',
 
   // Performance Issue specific events here
   'issue_details.performance.autogrouped_siblings_toggle':

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 
@@ -21,7 +21,7 @@ import Link from 'sentry/components/links/link';
 import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import SeenByList from 'sentry/components/seenByList';
 import ShortId from 'sentry/components/shortId';
-import {Item, TabList} from 'sentry/components/tabs';
+import {Item, TabList, TabsContext} from 'sentry/components/tabs';
 import Tooltip from 'sentry/components/tooltip';
 import {IconChat} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -144,6 +144,10 @@ function GroupHeader({
     return [];
   }, [organization, groupReprocessingStatus]);
 
+  const {
+    rootProps: {onChange},
+  } = useContext(TabsContext);
+
   const errorIssueTabs = useMemo(() => {
     const projectFeatures = new Set(project ? project.features : []);
     const organizationFeatures = new Set(organization ? organization.features : []);
@@ -153,8 +157,27 @@ function GroupHeader({
     const hasEventAttachments = organizationFeatures.has('event-attachments');
     const hasSessionReplay = organizationFeatures.has('session-replay-ui');
 
+    const analyticsData = event
+      ? event.tags
+          .filter(({key}) => ['device', 'os', 'browser'].includes(key))
+          .reduce((acc, {key, value}) => {
+            acc[key] = value;
+            return acc;
+          }, {})
+      : {};
+
     return (
-      <StyledTabList>
+      <StyledTabList
+        onSelectionChange={key => {
+          trackAdvancedAnalyticsEvent('issue_group_details.tab.clicked', {
+            organization,
+            tab: key.toString(),
+            platform: project.platform,
+            ...analyticsData,
+          });
+          return onChange?.(key);
+        }}
+      >
         <Item key={Tab.DETAILS} disabled={disabledTabs.includes(Tab.DETAILS)}>
           {t('Details')}
         </Item>
@@ -220,6 +243,8 @@ function GroupHeader({
     organization,
     project,
     replaysCount,
+    onChange,
+    event,
   ]);
 
   const performanceIssueTabs = useMemo(() => {


### PR DESCRIPTION
Tracks when a user changes tabs in the Issue Group Detail page. Record the tab, browser, device, os, and platform.
![image](https://user-images.githubusercontent.com/83961295/193687586-8b2f9c39-06ca-4899-8865-17e581d7153b.png)
