### PR TITLE
ref(perf-issues): Add metric for extra spans

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1003,6 +1003,8 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
             self.n_spans[0].get("hash", None),
         )
         if fingerprint not in self.stored_problems:
+            self._metrics_for_extra_matching_spans()
+
             self.stored_problems[fingerprint] = PerformanceProblem(
                 fingerprint=fingerprint,
                 op="db",
@@ -1012,6 +1014,17 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
                 cause_span_ids=[self.source_span.get("span_id", None)],
                 offender_span_ids=[span.get("span_id", None) for span in self.n_spans],
             )
+
+    def _metrics_for_extra_matching_spans(self):
+        # Checks for any extra spans that match the detected problem but are not part of affected spans.
+        # Temporary check since we eventually want to capture extra perf problems on the initial pass while walking spans.
+        n_count = len(self.n_spans)
+        all_matching_spans = [
+            span for span in self.spans if span.get("span_id", None) == self.n_hash
+        ]
+        all_count = len(all_matching_spans)
+        if n_count > 0 and n_count != all_count:
+            metrics.incr("performance.performance_issue.np1_db.extra_spans")
 
     def _reset_detection(self):
         self.source_span = None

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -1020,7 +1020,9 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
         # Temporary check since we eventually want to capture extra perf problems on the initial pass while walking spans.
         n_count = len(self.n_spans)
         all_matching_spans = [
-            span for span in self.spans if span.get("span_id", None) == self.n_hash
+            span
+            for span in self._event.get("spans", [])
+            if span.get("span_id", None) == self.n_hash
         ]
         all_count = len(all_matching_spans)
         if n_count > 0 and n_count != all_count:


### PR DESCRIPTION
We can potentially have unrelated spans or another n+1 db recurring within the same transaction. We should check how often the n+1 detector affected spans does not fully cover all spans with the same hash, which will let us know how accurate it would be if we were to use the hash against span groups on the transaction dataset to determine aggregate impact.

Might add more metrics related to this later, for now this should give us a rough indication of how often it happens.