### PR TITLE
fix(js): Set useApiRequests initial isLoading state to true

### DIFF
--- a/static/app/utils/useApiRequests.tsx
+++ b/static/app/utils/useApiRequests.tsx
@@ -152,7 +152,7 @@ function useApiRequests<T extends Record<string, any>>({
   const initialState = useMemo<State<T>>(
     () => ({
       data: {} as T,
-      isLoading: false,
+      isLoading: true,
       hasError: false,
       isReloading: false,
       errors: {},


### PR DESCRIPTION
This matches the behavior of AsyncComponent: https://github.com/getsentry/sentry/blob/9197dc513ae80b621898b922a9d59c85affb3649/static/app/components/asyncComponent.tsx#L194

Right now `renderComponent` is returning the success view on first render because of this.