### PR TITLE
Improve span grouping for Laravel and Rails

### DIFF
--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -101,7 +101,7 @@ def raw_description_strategy(span: Span) -> Sequence[str]:
     return [span.get("description") or ""]
 
 
-IN_CONDITION_PATTERN = re.compile(r" IN \(%s(\s*,\s*%s)*\)")
+IN_CONDITION_PATTERN = re.compile(r" IN \(((%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)")
 
 
 @span_op(["db", "db.query", "db.sql.query", "db.sql.active_record"])

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -101,7 +101,7 @@ def raw_description_strategy(span: Span) -> Sequence[str]:
     return [span.get("description") or ""]
 
 
-IN_CONDITION_PATTERN = re.compile(r" IN \(((%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)")
+IN_CONDITION_PATTERN = re.compile(r" IN \(((%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)", re.I)
 
 
 @span_op(["db", "db.query", "db.sql.query", "db.sql.active_record"])

--- a/src/sentry/spans/grouping/strategy/base.py
+++ b/src/sentry/spans/grouping/strategy/base.py
@@ -101,6 +101,7 @@ def raw_description_strategy(span: Span) -> Sequence[str]:
     return [span.get("description") or ""]
 
 
+# Catches sequences like (?, ?, ?), ($1, $2, $3), and (%s, %s, %s)
 IN_CONDITION_PATTERN = re.compile(r" IN \(((%s|\$?\d+|\?)(\s*,\s*(%s|\$?\d+|\?))*)\)", re.I)
 
 

--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -82,6 +82,48 @@ def test_raw_description_strategy(span: Span, fingerprint: Optional[List[str]]) 
             .build(),
             ["SELECT count() FROM table WHERE id IN (%s)"],
         ),
+        # description has multiple IN statements
+        (
+            SpanBuilder()
+            .with_op("db.sql.query")
+            .with_description(
+                "SELECT count() FROM table WHERE id IN (%s, %s) AND id IN (%s, %s, %s)"
+            )
+            .build(),
+            ["SELECT count() FROM table WHERE id IN (%s) AND id IN (%s)"],
+        ),
+        # supports unparametrized queries
+        (
+            SpanBuilder()
+            .with_op("db.sql.query")
+            .with_description("SELECT count() FROM table WHERE id IN (100, 101, 102)")
+            .build(),
+            ["SELECT count() FROM table WHERE id IN (%s)"],
+        ),
+        # supports lowercase IN
+        (
+            SpanBuilder()
+            .with_op("db.sql.query")
+            .with_description("select count() from table where id in (100, 101, 102)")
+            .build(),
+            ["select count() from table where id IN (%s)"],
+        ),
+        # op is an ActiveRecord query
+        (
+            SpanBuilder()
+            .with_op("db.sql.active_record")
+            .with_description("SELECT count() FROM table WHERE id IN ($1, $2, $3)")
+            .build(),
+            ["SELECT count() FROM table WHERE id IN (%s)"],
+        ),
+        # op is a Laravel query
+        (
+            SpanBuilder()
+            .with_op("db.sql.query")
+            .with_description("SELECT count() FROM table WHERE id IN (?, ?, ?)")
+            .build(),
+            ["SELECT count() FROM table WHERE id IN (%s)"],
+        ),
         # the number of %s is relevant
         (
             SpanBuilder()


### PR DESCRIPTION
Follow-up to #39473. That PR helped, but did not do the job.

Our span grouping code takes queries like `SELECT * FROM table WHERE id IN (%s, %s, %s)` and collapses them into `SELECT * FROM table WHERE id IN (%s)` before hashing. However, this only works for Django! Django uses `... IN (%s, %s, %s)` for `IN` query span descriptions, but Laravel does `... IN (?, ?, ?)`, while Rails does `... IN ($1, $2, $3)`. Also, sometimes people make custom `IN` queries like this: `... in (433, 434, 454...etc`.

- Expands the regular expression to allow for Rails and Laravel styles of parameters
- Makes the regular expression case-insensitive

This'll be a big help with fingerprinting N+1 issues, since right now every length of `(%s, %s...` sequence gets its own fingerprint.

Is it weird that the sequence `IN (?, ?, ?, ?)` collapses into `IN (%s)` and not `IN (?)`? This is not user-facing in any way so I figured it's fine