### PR TITLE
ref(urls): Remove unnecessary `onboarding/` route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -324,8 +324,6 @@ urlpatterns += [
             ]
         ),
     ),
-    # Onboarding
-    url(r"^onboarding/", generic_react_page_view),
     # Admin
     url(r"^manage/", react_page_view, name="sentry-admin-overview"),
     # Legacy Redirects


### PR DESCRIPTION
This is handled by the fallthrough route