### PR TITLE
ref(sampling): Make 'give feedback' button primary - [TET-435]

### DIFF
--- a/static/app/components/featureFeedback/index.tsx
+++ b/static/app/components/featureFeedback/index.tsx
@@ -22,18 +22,16 @@ export function FeatureFeedback<T extends Data>({
   buttonProps = {},
   ...props
 }: FeatureFeedbackProps<T>) {
-  const {onClick, ..._buttonProps} = buttonProps;
   function handleClick(e: React.MouseEvent) {
     openModal(modalProps => <FeedbackModal {...modalProps} {...props} />, {
       modalCss,
     });
-    if (onClick) {
-      onClick(e);
-    }
+
+    buttonProps.onClick?.(e);
   }
 
   return (
-    <Button icon={<IconMegaphone />} onClick={handleClick} {..._buttonProps}>
+    <Button {...buttonProps} icon={<IconMegaphone />} onClick={handleClick}>
       {t('Give Feedback')}
     </Button>
   );

--- a/static/app/views/settings/project/server-side-sampling/samplingFeedback.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingFeedback.tsx
@@ -148,7 +148,13 @@ function MultipleCheckboxField({
 
 export function SamplingFeedback() {
   return (
-    <FeatureFeedback featureName="dynamic-sampling" initialData={initialData}>
+    <FeatureFeedback
+      featureName="dynamic-sampling"
+      initialData={initialData}
+      buttonProps={{
+        priority: 'primary',
+      }}
+    >
       {({Header, Body, Footer, state, onFieldChange}) => {
         if (state.step === 0) {
           return (


### PR DESCRIPTION
**What this PR does:**

- FeatureFeedback code cleanup
- Make the 'give feedback' button in sampling purple (primary)


**Preview:**

![Screenshot 2022-10-04 at 18 30 45](https://user-images.githubusercontent.com/29228205/193874912-47c9df9b-9cdb-4492-895f-513cd7a06a85.png)
