### PR TITLE
fix(discover): Added default label for event title and breadcrums in …

### DIFF
--- a/static/app/views/eventsV2/breadcrumb.tsx
+++ b/static/app/views/eventsV2/breadcrumb.tsx
@@ -16,6 +16,8 @@ type Props = {
   isHomepage?: boolean;
 };
 
+const HOMEPAGE_DEFAULT_LABEL = t('New Query');
+
 function DiscoverBreadcrumb({
   eventView,
   event,
@@ -45,7 +47,7 @@ function DiscoverBreadcrumb({
   if (eventView && eventView.isValid()) {
     crumbs.push({
       to: eventView.getResultsViewUrlTarget(organization.slug, isHomepage),
-      label: eventView.name || '',
+      label: isHomepage ? HOMEPAGE_DEFAULT_LABEL : eventView.name || '',
     });
   }
 

--- a/static/app/views/eventsV2/eventDetails.spec.jsx
+++ b/static/app/views/eventsV2/eventDetails.spec.jsx
@@ -323,7 +323,7 @@ describe('EventsV2 > EventDetails', function () {
       {context: routerContext, organization}
     );
 
-    expect((await screen.findByText('All Events')).pathname).toEqual(
+    expect((await screen.findByText('New Query')).pathname).toEqual(
       '/organizations/org-slug/discover/homepage/'
     );
   });

--- a/static/app/views/eventsV2/eventInputName.tsx
+++ b/static/app/views/eventsV2/eventInputName.tsx
@@ -18,6 +18,7 @@ type Props = {
 };
 
 const NAME_DEFAULT = t('Untitled query');
+const HOMEPAGE_DEFAULT = t('New Query');
 
 /**
  * Allows user to edit the name of the query.
@@ -53,7 +54,7 @@ function EventInputName({organization, eventView, savedQuery, isHomepage}: Props
     );
   }
 
-  const value = eventView.name || NAME_DEFAULT;
+  const value = isHomepage ? HOMEPAGE_DEFAULT : eventView.name || NAME_DEFAULT;
 
   return (
     <StyledTitle data-test-id={`discover2-query-name-${value}`}>

--- a/static/app/views/eventsV2/resultsHeader.tsx
+++ b/static/app/views/eventsV2/resultsHeader.tsx
@@ -106,6 +106,7 @@ class ResultsHeader extends Component<Props, State> {
             eventView={eventView}
             organization={organization}
             location={location}
+            isHomepage={isHomepage}
           />
           <EventInputName
             savedQuery={savedQuery}


### PR DESCRIPTION
For results: 
<img width="709" alt="Screen Shot 2022-10-04 at 12 42 37 PM" src="https://user-images.githubusercontent.com/60121741/193877821-8db99f1f-1f9e-4bfb-9fa2-7fdcba3660a9.png">

For event detailts: 
<img width="607" alt="Screen Shot 2022-10-04 at 12 43 48 PM" src="https://user-images.githubusercontent.com/60121741/193878038-ce9f25a7-f8b6-4bca-942d-486619ed4112.png">


