### PR TITLE
ref: remove unused sentry.utils.http.safe_urlencode

### DIFF
--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from typing import Optional
-from urllib.parse import quote, urlencode, urljoin, urlparse
+from urllib.parse import quote, urljoin, urlparse
 
 from django.conf import settings
 
@@ -25,33 +25,6 @@ def origin_from_url(url):
         return url
     url = urlparse(url)
     return f"{url.scheme}://{url.netloc}"
-
-
-def safe_urlencode(params, doseq=0):
-    """
-    UTF-8-safe version of safe_urlencode
-
-    The stdlib safe_urlencode prior to Python 3.x chokes on UTF-8 values
-    which can't fail down to ascii.
-    """
-    # Snippet originally from pysolr: https://github.com/toastdriven/pysolr
-
-    if hasattr(params, "items"):
-        params = params.items()
-
-    new_params = list()
-
-    for k, v in params:
-        k = k.encode("utf-8")
-
-        if isinstance(v, str):
-            new_params.append((k, v.encode("utf-8")))
-        elif isinstance(v, (list, tuple)):
-            new_params.append((k, [i.encode("utf-8") for i in v]))
-        else:
-            new_params.append((k, str(v)))
-
-    return urlencode(new_params, doseq)
 
 
 def get_origins(project=None):


### PR DESCRIPTION
there's another `safe_urlencode` which is actually used (but I suspect that one should get nuked too)