### PR TITLE
fix(issue-stream): Ensure that custom ingore modal works when full page is selected

### DIFF
--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -58,9 +58,12 @@ const IgnoreActions = ({
   confirmLabel = t('Ignore'),
   isIgnored = false,
 }: Props) => {
-  const onIgnore = (statusDetails: ResolutionStatusDetails | undefined = {}) => {
+  const onIgnore = (
+    statusDetails: ResolutionStatusDetails | undefined = {},
+    {bypassConfirm} = {bypassConfirm: false}
+  ) => {
     openConfirmModal({
-      bypass: !shouldConfirm,
+      bypass: bypassConfirm || !shouldConfirm,
       onConfirm: () =>
         onUpdate({
           status: ResolutionStatus.IGNORED,
@@ -72,7 +75,7 @@ const IgnoreActions = ({
   };
 
   const onCustomIgnore = (statusDetails: ResolutionStatusDetails) => {
-    onIgnore(statusDetails);
+    onIgnore(statusDetails, {bypassConfirm: true});
   };
 
   if (isIgnored) {


### PR DESCRIPTION
Custom ignore modals were not properly ignoring issues when the full page was selected. This is because `shouldConfirm` was true in that scenario which tried to open a subsequent confirmation modal. This makes sure that the confirmation modal is bypassed when you have a custom ignore option (because those options already have a modal).