### PR TITLE
fix(issues): Consistent owned-by sizing

### DIFF
--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -61,10 +61,12 @@ function AssignedTo({group, projectId}: AssignedToProps) {
                     data-test-id="assigned-avatar"
                     actor={assignedTo}
                     hasTooltip={false}
-                    size={20}
+                    size={24}
                   />
                 ) : (
-                  <IconUser size="md" />
+                  <IconWrapper>
+                    <IconUser size="md" />
+                  </IconWrapper>
                 )}
                 <ActorName>{getAssignedToDisplayName(assignedTo)}</ActorName>
               </ActorWrapper>
@@ -91,6 +93,11 @@ const ActorWrapper = styled('div')`
   align-items: center;
   gap: ${space(1)};
   max-width: 85%;
+  line-height: 1;
+`;
+
+const IconWrapper = styled('div')`
+  display: flex;
 `;
 
 const ActorName = styled('div')`

--- a/static/app/components/group/ownedBy.tsx
+++ b/static/app/components/group/ownedBy.tsx
@@ -96,10 +96,12 @@ function OwnedBy({group, project, organization}: OwnedByProps) {
               data-test-id="owner-avatar"
               actor={currentOwner}
               hasTooltip={false}
-              size={20}
+              size={24}
             />
           ) : (
-            <IconUser size="md" />
+            <IconWrapper>
+              <IconUser size="md" />
+            </IconWrapper>
           )}
           <ActorName>
             {currentOwner?.type === 'team'
@@ -119,10 +121,15 @@ const ActorWrapper = styled('div')`
   align-items: center;
   gap: ${space(1)};
   max-width: 85%;
+  line-height: 1;
 `;
 
 const ActorName = styled('div')`
   ${p => p.theme.overflowEllipsis}
+`;
+
+const IconWrapper = styled('div')`
+  display: flex;
 `;
 
 const StyledLink = styled(Link)`


### PR DESCRIPTION
Fixes an issue with the unassigned avatar size, increases both the unassigned avatar and the assigned avatar.

before
![image](https://user-images.githubusercontent.com/1400464/193938009-46002f00-3450-4ee3-8ce2-e8fb53f52ea5.png)

after
![image](https://user-images.githubusercontent.com/1400464/193938042-30efc260-d42f-43c6-8183-0a2afbe7a8db.png)
