### PR TITLE
feat(replays): Add missing tags to replay record object

### DIFF
--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -42,6 +42,9 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
     ...(apiResponse.device?.model ? {'device.model': [apiResponse.device.model]} : {}),
     ...(apiResponse.sdk?.name ? {'sdk.name': [apiResponse.sdk.name]} : {}),
     ...(apiResponse.sdk?.version ? {'sdk.version': [apiResponse.sdk.version]} : {}),
+    ...(apiResponse.user?.ip_address
+      ? {'user.ip_address': [apiResponse.user.ip_address]}
+      : {}),
   };
 
   // Sort the tags by key

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -27,10 +27,36 @@ export const isNetworkSpan = (span: ReplaySpan) => {
 };
 
 export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
+  // Add missing tags to the response
+  const unorderedTags: ReplayRecord['tags'] = {
+    ...apiResponse.tags,
+    ...(apiResponse.os?.name ? {'os.name': [apiResponse.os.name]} : {}),
+    ...(apiResponse.os?.version ? {'os.version': [apiResponse.os.version]} : {}),
+    ...(apiResponse.browser?.name ? {'browser.name': [apiResponse.browser.name]} : {}),
+    ...(apiResponse.browser?.version
+      ? {'browser.version': [apiResponse.browser.version]}
+      : {}),
+    ...(apiResponse.device?.name ? {'device.name': [apiResponse.device.name]} : {}),
+    ...(apiResponse.device?.family ? {'device.family': [apiResponse.device.family]} : {}),
+    ...(apiResponse.device?.brand ? {'device.brand': [apiResponse.device.brand]} : {}),
+    ...(apiResponse.device?.model ? {'device.model': [apiResponse.device.model]} : {}),
+    ...(apiResponse.sdk?.name ? {'sdk.name': [apiResponse.sdk.name]} : {}),
+    ...(apiResponse.sdk?.version ? {'sdk.version': [apiResponse.sdk.version]} : {}),
+  };
+
+  // Sort the tags by key
+  const tags = Object.keys(unorderedTags)
+    .sort()
+    .reduce((acc, key) => {
+      acc[key] = unorderedTags[key];
+      return acc;
+    }, {});
+
   return {
     ...apiResponse,
     ...(apiResponse.startedAt ? {startedAt: new Date(apiResponse.startedAt)} : {}),
     ...(apiResponse.finishedAt ? {finishedAt: new Date(apiResponse.finishedAt)} : {}),
+    tags,
   };
 }
 


### PR DESCRIPTION

<!-- Describe your PR here. -->
### Changes
- Added the following missing fields to the tags object:

  - `os.name`
  - `os.version`
  - `browser.name`
  - `browser.version`
  - `device.name`
  - `device.brand`
  - `device.family`
  - `device.model`
  - `sdk.name`
  - `sdk.version`
  - `user.ip_address`

Closes #38597 

![image](https://user-images.githubusercontent.com/39612839/193939123-b0a5d617-a309-47d5-82fe-d6417769a5e5.png)

### Tests notes

- Made sure the tags panel was working and showing the data as expected
- Made sure that the components using the `mapResponseToReplayRecord` were working as expected

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
