### PR TITLE
fix(releases): Increase size of release adoption tooltip

### DIFF
--- a/static/app/views/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/releases/list/releasesAdoptionChart.tsx
@@ -268,7 +268,7 @@ class ReleasesAdoptionChart extends Component<Props> {
                                       s.marker
                                     }<strong>${
                                       s.seriesName &&
-                                      truncationFormatter(s.seriesName, 12)
+                                      truncationFormatter(s.seriesName, 32)
                                     }</strong></span>${s.data[1].toFixed(2)}%</div>`
                                 )
                                 .join(''),


### PR DESCRIPTION
Show more of each release name preventing them from looking the same
![image](https://user-images.githubusercontent.com/1400464/193946081-f31db13d-ce21-4703-a119-1eafaf6cb6a3.png)
