### PR TITLE
ref: switch to declarative metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
-include setup.py README.md MANIFEST.in LICENSE AUTHORS
-recursive-include ./ requirements*.txt
+include AUTHORS requirements*.txt
 graft ./config
 graft src/sentry
 graft src/sentry_plugins

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -8,7 +8,7 @@ cd "$SCRIPT_DIR/.."
 OLD_VERSION="$1"
 NEW_VERSION="$2"
 
-sed -i -e "s/^VERSION = "'".*"'"\$/VERSION = "'"'"$NEW_VERSION"'"'"/" setup.py
+sed -i -e 's/^version = .*$/version = '"$NEW_VERSION/" setup.cfg
 sed -i -e "s/\(Change Date:\s*\)[-0-9]\+\$/\\1$(date +'%Y-%m-%d' -d '3 years')/" LICENSE
 
 echo "New version: $NEW_VERSION"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,92 @@
+[metadata]
+name = sentry
+version = 22.10.0.dev0
+description = A realtime logging and aggregation server.
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://sentry.io
+author = Sentry
+author_email = oss@sentry.io
+license = BSL-1.1
+license_file = LICENSE
+classifiers =
+    Framework :: Django
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    License :: Other/Proprietary License
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3 :: Only
+    Topic :: Software Development
+
+[options]
+packages = find:
+python_requires = >=3.8
+include_package_data = True
+package_dir =
+    =src
+zip_safe = False
+
+[options.packages.find]
+where = src
+
+[options.entry_points]
+console_scripts =
+    sentry = sentry.runner:main
+sentry.apps =
+    # TODO: This can be removed once the getsentry tests no longer check for this app
+    auth_activedirectory = sentry.auth.providers.saml2.activedirectory
+    auth_auth0 = sentry.auth.providers.saml2.auth0
+    auth_github = sentry.auth.providers.github
+    auth_jumpcloud = sentry.auth.providers.saml2.jumpcloud
+    auth_okta = sentry.auth.providers.saml2.okta
+    auth_onelogin = sentry.auth.providers.saml2.onelogin
+    auth_rippling = sentry.auth.providers.saml2.rippling
+    auth_saml2 = sentry.auth.providers.saml2.generic
+    freight = sentry_plugins.freight
+    jira = sentry_plugins.jira
+    opsgenie = sentry_plugins.opsgenie
+    redmine = sentry_plugins.redmine
+    sessionstack = sentry_plugins.sessionstack
+    trello = sentry_plugins.trello
+    twilio = sentry_plugins.twilio
+sentry.plugins =
+    amazon_sqs = sentry_plugins.amazon_sqs.plugin:AmazonSQSPlugin
+    asana = sentry_plugins.asana.plugin:AsanaPlugin
+    bitbucket = sentry_plugins.bitbucket.plugin:BitbucketPlugin
+    freight = sentry_plugins.freight.plugin:FreightPlugin
+    github = sentry_plugins.github.plugin:GitHubPlugin
+    gitlab = sentry_plugins.gitlab.plugin:GitLabPlugin
+    heroku = sentry_plugins.heroku.plugin:HerokuPlugin
+    jira = sentry_plugins.jira.plugin:JiraPlugin
+    opsgenie = sentry_plugins.opsgenie.plugin:OpsGeniePlugin
+    pagerduty = sentry_plugins.pagerduty.plugin:PagerDutyPlugin
+    phabricator = sentry_plugins.phabricator.plugin:PhabricatorPlugin
+    pivotal = sentry_plugins.pivotal.plugin:PivotalPlugin
+    pushover = sentry_plugins.pushover.plugin:PushoverPlugin
+    redmine = sentry_plugins.redmine.plugin:RedminePlugin
+    segment = sentry_plugins.segment.plugin:SegmentPlugin
+    sessionstack = sentry_plugins.sessionstack.plugin:SessionStackPlugin
+    slack = sentry_plugins.slack.plugin:SlackPlugin
+    splunk = sentry_plugins.splunk.plugin:SplunkPlugin
+    trello = sentry_plugins.trello.plugin:TrelloPlugin
+    twilio = sentry_plugins.twilio.plugin:TwilioPlugin
+    victorops = sentry_plugins.victorops.plugin:VictorOpsPlugin
+
+[options.package_data]
+sentry =
+    static/sentry/dist/**
+    static/sentry/images/**
+    static/sentry/js/**
+    static/sentry/vendor/**
+
+[options.exclude_package_data]
+sentry =
+    static/sentry/app/**
+    static/sentry/fonts/**
+    static/sentry/less/**
+
 [flake8]
 # File filtering is taken care of in pre-commit.
 # E203 false positive, see https://github.com/PyCQA/pycodestyle/issues/373

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if python_version != (3, 8):
 
 from distutils.command.build import build as BuildCommand
 
-from setuptools import find_packages, setup
+from setuptools import setup
 from setuptools.command.develop import develop as DevelopCommand
 from setuptools.command.sdist import sdist as SDistCommand
 
@@ -32,7 +32,6 @@ from sentry.utils.distutils import (
     BuildJsSdkRegistryCommand,
 )
 
-VERSION = "22.10.0.dev0"
 IS_LIGHT_BUILD = os.environ.get("SENTRY_LIGHT_BUILD") == "1"
 
 
@@ -93,76 +92,7 @@ if not sys.argv[1:][0].startswith("bdist"):
 
 
 setup(
-    name="sentry",
-    version=VERSION,
-    author="Sentry",
-    author_email="oss@sentry.io",
-    url="https://sentry.io",
-    description="A realtime logging and aggregation server.",
-    long_description=open(os.path.join(ROOT, "README.md")).read(),
-    long_description_content_type="text/markdown",
-    package_dir={"": "src"},
-    packages=find_packages("src"),
-    zip_safe=False,
     install_requires=get_requirements("frozen"),
     extras_require=extras_require,
     cmdclass=cmdclass,
-    license="BSL-1.1",
-    include_package_data=True,
-    package_data={"sentry": [f"static/sentry/{d}/**" for d in ("dist", "js", "images", "vendor")]},
-    exclude_package_data={"sentry": [f"static/sentry/{d}/**" for d in ("app", "fonts", "less")]},
-    entry_points={
-        "console_scripts": ["sentry = sentry.runner:main"],
-        "sentry.apps": [
-            # TODO: This can be removed once the getsentry tests no longer check for this app
-            "auth_activedirectory = sentry.auth.providers.saml2.activedirectory",
-            "auth_auth0 = sentry.auth.providers.saml2.auth0",
-            "auth_github = sentry.auth.providers.github",
-            "auth_okta = sentry.auth.providers.saml2.okta",
-            "auth_onelogin = sentry.auth.providers.saml2.onelogin",
-            "auth_rippling = sentry.auth.providers.saml2.rippling",
-            "auth_jumpcloud = sentry.auth.providers.saml2.jumpcloud",
-            "auth_saml2 = sentry.auth.providers.saml2.generic",
-            "jira = sentry_plugins.jira",
-            "freight = sentry_plugins.freight",
-            "opsgenie = sentry_plugins.opsgenie",
-            "redmine = sentry_plugins.redmine",
-            "sessionstack = sentry_plugins.sessionstack",
-            "trello = sentry_plugins.trello",
-            "twilio = sentry_plugins.twilio",
-        ],
-        "sentry.plugins": [
-            "amazon_sqs = sentry_plugins.amazon_sqs.plugin:AmazonSQSPlugin",
-            "asana = sentry_plugins.asana.plugin:AsanaPlugin",
-            "bitbucket = sentry_plugins.bitbucket.plugin:BitbucketPlugin",
-            "freight = sentry_plugins.freight.plugin:FreightPlugin",
-            "github = sentry_plugins.github.plugin:GitHubPlugin",
-            "gitlab = sentry_plugins.gitlab.plugin:GitLabPlugin",
-            "heroku = sentry_plugins.heroku.plugin:HerokuPlugin",
-            "jira = sentry_plugins.jira.plugin:JiraPlugin",
-            "opsgenie = sentry_plugins.opsgenie.plugin:OpsGeniePlugin",
-            "pagerduty = sentry_plugins.pagerduty.plugin:PagerDutyPlugin",
-            "phabricator = sentry_plugins.phabricator.plugin:PhabricatorPlugin",
-            "pivotal = sentry_plugins.pivotal.plugin:PivotalPlugin",
-            "pushover = sentry_plugins.pushover.plugin:PushoverPlugin",
-            "redmine = sentry_plugins.redmine.plugin:RedminePlugin",
-            "segment = sentry_plugins.segment.plugin:SegmentPlugin",
-            "sessionstack = sentry_plugins.sessionstack.plugin:SessionStackPlugin",
-            "slack = sentry_plugins.slack.plugin:SlackPlugin",
-            "splunk = sentry_plugins.splunk.plugin:SplunkPlugin",
-            "trello = sentry_plugins.trello.plugin:TrelloPlugin",
-            "twilio = sentry_plugins.twilio.plugin:TwilioPlugin",
-            "victorops = sentry_plugins.victorops.plugin:VictorOpsPlugin",
-        ],
-    },
-    classifiers=[
-        "Framework :: Django",
-        "Intended Audience :: Developers",
-        "Intended Audience :: System Administrators",
-        "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Topic :: Software Development",
-        "License :: Other/Proprietary License",
-    ],
 )


### PR DESCRIPTION
in an effort to speed up editable installs I'd like to skip setup.py, this is the first step

this was automated using https://github.com/asottile/setup-py-upgrade and https://github.com/asottile/setup-cfg-fmt (with a little bit of handholding and `git checkout -p`)




<!-- Describe your PR here. -->