### PR TITLE
fix(issues) fix all events issue id linking to performance

### DIFF
--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -55,6 +55,7 @@ const AllEventsTable = (props: Props) => {
     <EventsTable
       eventView={eventView}
       location={location}
+      issueId={issueId}
       organization={organization}
       excludedTags={excludedTags}
       setError={() => {

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -234,4 +234,43 @@ describe('Performance GridEditable Table', function () {
     expect(wrapper.find('OperationSort')).toHaveLength(0);
     expect(wrapper.find('RelativeOpsBreakdown')).toHaveLength(0);
   });
+
+  it('renders event id and trace id url', async function () {
+    const initialData = initializeData();
+    const eventView = EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        version: 2,
+        name: 'transactionName',
+        fields,
+        query,
+        projects: [],
+        orderby: '-timestamp',
+      },
+      initialData.router.location
+    );
+    const wrapper = mountWithTheme(
+      <EventsTable
+        totalEventCount={totalEventCount}
+        eventView={eventView}
+        organization={organization}
+        location={initialData.router.location}
+        setError={() => {}}
+        columnTitles={transactionsListTitles}
+        transactionName={transactionName}
+      />,
+      initialData.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    const eventIdCell = wrapper.find('a').at(3);
+    const traceIdCell = wrapper.find('a').at(4);
+    expect(eventIdCell.prop('href')).toMatch(
+      '/organizations/org-slug/performance/undefined:deadbeef/'
+    );
+    expect(traceIdCell.prop('href')).toMatch(
+      '/organizations/org-slug/performance/trace/1234/'
+    );
+  });
 });

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -1,7 +1,7 @@
 import {Component, Fragment} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
-import {Location, LocationDescriptorObject} from 'history';
+import {Location, LocationDescriptor, LocationDescriptorObject} from 'history';
 
 import GridEditable, {
   COL_WIDTH_UNDEFINED,
@@ -87,6 +87,7 @@ type Props = {
   columnTitles?: string[];
   disablePagination?: boolean;
   excludedTags?: string[];
+  issueId?: string;
   totalEventCount?: string;
 };
 
@@ -154,8 +155,15 @@ class EventsTable extends Component<Props, State> {
     ];
 
     if (field === 'id' || field === 'trace') {
-      const generateLink = field === 'id' ? generateTransactionLink : generateTraceLink;
-      const target = generateLink(transactionName)(organization, dataRow, location.query);
+      const {issueId} = this.props;
+      const isIssue: boolean = !!issueId;
+      let target: LocationDescriptor = {};
+      if (isIssue && field === 'id') {
+        target.pathname = `/organizations/${organization.slug}/issues/${issueId}/events/${dataRow.id}/`;
+      } else {
+        const generateLink = field === 'id' ? generateTransactionLink : generateTraceLink;
+        target = generateLink(transactionName)(organization, dataRow, location.query);
+      }
 
       return (
         <CellAction


### PR DESCRIPTION
Fixed bug where clicking the event id in the all events tab under an issue linked to performance
![image](https://user-images.githubusercontent.com/44422760/193953659-1bb0d95e-71bf-49e3-8c52-dfcd69639c1d.png)
