### PR TITLE
feat(empty-stacktraces): Tag events with stack traces from JS console errors

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -957,6 +957,8 @@ SENTRY_FEATURES = {
     "organizations:active-release-monitor-alpha": False,
     # Workflow 2.0 Active Release Notifications
     "organizations:active-release-notifications-enable": False,
+    # Enables tagging javascript errors from the browser console.
+    "organizations:javascript-console-error-tag": False,
     # Enable advanced search features, like negation and wildcard matching.
     "organizations:advanced-search": True,
     # Use metrics as the dataset for crash free metric alerts

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -62,6 +62,7 @@ default_manager.add("organizations:create")
 # Organization scoped features that are in development or in customer trials.
 default_manager.add("organizations:active-release-monitor-alpha", OrganizationFeature, True)
 default_manager.add("organizations:active-release-notifications-enable", OrganizationFeature)
+default_manager.add("organizations:javascript-console-error-tag", OrganizationFeature)
 default_manager.add("organizations:alert-crash-free-metrics", OrganizationFeature, True)
 default_manager.add("organizations:alert-filters", OrganizationFeature)
 default_manager.add("organizations:api-keys", OrganizationFeature)

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -1197,34 +1197,36 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             new_frames = [new_frame]
             raw_frames = [raw_frame] if changed_raw else None
 
-            try:
-                if features.has(
-                    "organizations:javascript-console-error-tag", self.organization, actor=None
-                ):
-                    self.tag_suspected_console_errors(new_frames)
-            except Exception as exc:
-                logger.exception("Failed to tag suspected console errors", exc_info=exc)
-
+            self.tag_suspected_console_errors(new_frames)
             return new_frames, raw_frames, all_errors
 
     def tag_suspected_console_errors(self, new_frames):
-        suspected_console_errors = None
-        try:
-            suspected_console_errors = self.suspected_console_errors(new_frames)
-        except Exception as exc:
-            logger.error(
-                "Failed to evaluate event for suspected JavaScript browser console error",
-                exc_info=exc,
-            )
+        def tag_error(new_frames):
+            suspected_console_errors = None
+            try:
+                suspected_console_errors = self.suspected_console_errors(new_frames)
+            except Exception as exc:
+                logger.error(
+                    "Failed to evaluate event for suspected JavaScript browser console error",
+                    exc_info=exc,
+                )
+
+            try:
+                set_tag(self.data, "empty_stacktrace.js_console", suspected_console_errors)
+            except Exception as exc:
+                logger.error(
+                    "Failed to tag event with empty_stacktrace.js_console=%s for suspected JavaScript browser console error",
+                    suspected_console_errors,
+                    exc_info=exc,
+                )
 
         try:
-            set_tag(self.data, "empty_stacktrace.js_console", suspected_console_errors)
+            if features.has(
+                "organizations:javascript-console-error-tag", self.organization, actor=None
+            ):
+                tag_error(new_frames)
         except Exception as exc:
-            logger.error(
-                "Failed to tag event with empty_stacktrace.js_console=%s for suspected JavaScript browser console error",
-                suspected_console_errors,
-                exc_info=exc,
-            )
+            logger.exception("Failed to tag suspected console errors", exc_info=exc)
 
     def expand_frame(self, frame, source=None):
         """

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -20,6 +20,7 @@ from symbolic import SourceMapCache as SmCache
 from symbolic import SourceMapView
 
 from sentry import features, http, options
+from sentry.event_manager import set_tag
 from sentry.models import EventError, Organization, ReleaseFile
 from sentry.models.releasefile import ARTIFACT_INDEX_FILENAME, ReleaseArchive, read_artifact_index
 from sentry.stacktraces.processing import StacktraceProcessor
@@ -900,6 +901,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         if not organization:
             organization = Organization.objects.get_from_cache(id=self.project.organization_id)
 
+        self.organization = organization
         self.max_fetches = MAX_RESOURCE_FETCHES
         self.allow_scraping = organization.get_option(
             "sentry:scrape_javascript", True
@@ -1194,7 +1196,35 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
 
             new_frames = [new_frame]
             raw_frames = [raw_frame] if changed_raw else None
+
+            try:
+                if features.has(
+                    "organizations:javascript-console-error-tag", self.organization, actor=None
+                ):
+                    self.tag_suspected_console_errors(new_frames)
+            except Exception as exc:
+                logger.exception("Failed to tag suspected console errors", exc_info=exc)
+
             return new_frames, raw_frames, all_errors
+
+    def tag_suspected_console_errors(self, new_frames):
+        suspected_console_errors = None
+        try:
+            suspected_console_errors = self.suspected_console_errors(new_frames)
+        except Exception as exc:
+            logger.error(
+                "Failed to evaluate event for suspected JavaScript browser console error",
+                exc_info=exc,
+            )
+
+        try:
+            set_tag(self.data, "empty_stacktrace.js_console", suspected_console_errors)
+        except Exception as exc:
+            logger.error(
+                "Failed to tag event with empty_stacktrace.js_console=%s for suspected JavaScript browser console error",
+                suspected_console_errors,
+                exc_info=exc,
+            )
 
     def expand_frame(self, frame, source=None):
         """
@@ -1350,6 +1380,40 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             metrics.incr(
                 "sourcemaps.processed", amount=len(self.sourcemaps_touched), skip_internal=True
             )
+
+    def suspected_console_errors(self, frames):
+        def is_suspicious_frame(frame) -> bool:
+            function = frame.get("function", None)
+            filename = frame.get("filename", None)
+            return function == "?" and filename == "<anonymous>"
+
+        def has_suspicious_frames(frames) -> bool:
+            if len(frames) == 2 and is_suspicious_frame(frames[0]):
+                return True
+            return all(is_suspicious_frame(frame) for frame in frames)
+
+        for info in self.stacktrace_infos:
+            is_exception = info.is_exception and info.container
+            mechanism = info.container.get("mechanism") if is_exception else None
+            error_type = info.container.get("type") if is_exception else None
+
+            if (
+                not frames
+                or not mechanism
+                or mechanism.get("type") != "onerror"
+                or mechanism.get("handled")
+            ):
+                return False
+
+            has_short_stacktrace = len(frames) <= 2
+            is_suspicious_error = error_type.lower() in [
+                "syntaxerror",
+                "referenceerror",
+                "typeerror",
+            ]
+
+            return has_short_stacktrace and is_suspicious_error and has_suspicious_frames(frames)
+        return False
 
 
 class JavaScriptSmCacheStacktraceProcessor(JavaScriptStacktraceProcessor):
@@ -1555,6 +1619,14 @@ class JavaScriptSmCacheStacktraceProcessor(JavaScriptStacktraceProcessor):
 
             new_frames = [new_frame]
             raw_frames = [raw_frame] if changed_raw else None
+
+            try:
+                if features.has(
+                    "organizations:javascript-console-error-tag", self.organization, actor=None
+                ):
+                    self.tag_suspected_console_errors(new_frames)
+            except Exception as exc:
+                logger.exception("Failed to tag suspected console errors", exc_info=exc)
             return new_frames, raw_frames, all_errors
 
     def expand_frame(self, frame, source_context=None, source=None):

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -11,6 +11,7 @@ import responses
 from requests.exceptions import RequestException
 
 from sentry import http, options
+from sentry.event_manager import get_tag
 from sentry.lang.javascript.errormapping import REACT_MAPPING_URL, rewrite_exception
 from sentry.lang.javascript.processor import (
     CACHE_CONTROL_MAX,
@@ -33,6 +34,7 @@ from sentry.lang.javascript.processor import (
 )
 from sentry.models import EventError, File, Release, ReleaseFile
 from sentry.models.releasefile import ARTIFACT_INDEX_FILENAME, update_artifact_index
+from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
@@ -93,6 +95,108 @@ class JavaScriptStacktraceProcessorTest(TestCase):
         assert processor.dist is not None
         assert processor.dist.name == "foo"
         assert processor.dist.date_added.timestamp() == processor.data["timestamp"]
+
+    def test_tag_suspected_console_error(self):
+        project = self.create_project()
+        release = self.create_release(project=project, version="12.31.12")
+
+        data = {
+            "is_exception": True,
+            "platform": "javascript",
+            "project": project.id,
+            "exception": {
+                "values": [
+                    {
+                        "type": "SyntaxError",
+                        "mechanism": {
+                            "type": "onerror",
+                        },
+                        "value": ("value"),
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "http://example.com/foo.js",
+                                    "filename": "<anonymous>",
+                                    "function": "?",
+                                    "lineno": 4,
+                                    "colno": 0,
+                                },
+                            ]
+                        },
+                    }
+                ]
+            },
+        }
+
+        stacktrace_infos = [
+            stacktrace for stacktrace in find_stacktraces_in_data(data, with_exceptions=True)
+        ]
+        processor = JavaScriptStacktraceProcessor(
+            data={"release": release.version, "dist": "foo", "timestamp": 123.4},
+            project=project,
+            stacktrace_infos=stacktrace_infos,
+        )
+
+        frames = processor.get_valid_frames()
+        assert processor.suspected_console_errors(frames) is True
+
+        processor.tag_suspected_console_errors(frames)
+        assert get_tag(processor.data, "empty_stacktrace.js_console") is True
+
+    def test_no_suspected_console_error(self):
+        project = self.create_project()
+        release = self.create_release(project=project, version="12.31.12")
+
+        data = {
+            "is_exception": True,
+            "platform": "javascript",
+            "project": project.id,
+            "exception": {
+                "values": [
+                    {
+                        "type": "SyntaxError",
+                        "mechanism": {
+                            "type": "onerror",
+                        },
+                        "value": ("value"),
+                        "stacktrace": {
+                            "frames": [
+                                {
+                                    "abs_path": "http://example.com/foo.js",
+                                    "filename": "<anonymous>",
+                                    "function": "name",
+                                    "lineno": 4,
+                                    "colno": 0,
+                                },
+                                {
+                                    "abs_path": "http://example.com/foo.js",
+                                    "filename": "<anonymous>",
+                                    "function": "new name",
+                                    "lineno": 4,
+                                    "colno": 0,
+                                },
+                            ]
+                        },
+                    }
+                ]
+            },
+        }
+
+        stacktrace_infos = [
+            stacktrace for stacktrace in find_stacktraces_in_data(data, with_exceptions=True)
+        ]
+
+        processor = JavaScriptStacktraceProcessor(
+            data={"release": release.version, "dist": "foo", "timestamp": 123.4},
+            project=project,
+            stacktrace_infos=stacktrace_infos,
+        )
+
+        frames = processor.get_valid_frames()
+        assert processor.suspected_console_errors(frames) is False
+
+        processor.tag_suspected_console_errors(frames)
+        assert get_tag(processor.data, "empty_stacktrace.js_console") is False
 
 
 def test_build_fetch_retry_condition() -> None:

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -36,6 +36,7 @@ from sentry.models import EventError, File, Release, ReleaseFile
 from sentry.models.releasefile import ARTIFACT_INDEX_FILENAME, update_artifact_index
 from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 from sentry.utils.strings import truncatechars
@@ -96,6 +97,7 @@ class JavaScriptStacktraceProcessorTest(TestCase):
         assert processor.dist.name == "foo"
         assert processor.dist.date_added.timestamp() == processor.data["timestamp"]
 
+    @with_feature("organizations:javascript-console-error-tag")
     def test_tag_suspected_console_error(self):
         project = self.create_project()
         release = self.create_release(project=project, version="12.31.12")
@@ -143,6 +145,7 @@ class JavaScriptStacktraceProcessorTest(TestCase):
         processor.tag_suspected_console_errors(frames)
         assert get_tag(processor.data, "empty_stacktrace.js_console") is True
 
+    @with_feature("organizations:javascript-console-error-tag")
     def test_no_suspected_console_error(self):
         project = self.create_project()
         release = self.create_release(project=project, version="12.31.12")


### PR DESCRIPTION
Add a new tag, empty_stacktrace.js_console, to tag JavaScript console errors.

This tag will available to filter issues on the "For Review" tab, based on a solution here https://github.com/getsentry/sentry-javascript/issues/5179.

[Spec](https://www.notion.so/sentry/Filtering-out-JS-console-errors-f9401214cc1f46a6a7dbd05740d1c805)
WOR-2202