### PR TITLE
fix(profiling): Fix connection leak in vroom connection pool

### DIFF
--- a/src/sentry/api/endpoints/organization_profiling_profiles.py
+++ b/src/sentry/api/endpoints/organization_profiling_profiles.py
@@ -71,8 +71,6 @@ class OrganizationProfilingPaginatedBaseEndpoint(OrganizationProfilingBaseEndpoi
             return Response([])
 
         kwargs = {"params": params}
-        if "Accept-Encoding" in request.headers:
-            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
 
         return self.paginate(
             request,
@@ -143,8 +141,6 @@ class OrganizationProfilingFiltersEndpoint(OrganizationProfilingBaseEndpoint):
             return Response([])
 
         kwargs = {"params": params}
-        if "Accept-Encoding" in request.headers:
-            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
 
         return proxy_profiling_service("GET", f"/organizations/{organization.id}/filters", **kwargs)
 
@@ -174,8 +170,6 @@ class OrganizationProfilingStatsEndpoint(OrganizationProfilingBaseEndpoint):
             )
 
         kwargs = {"params": params}
-        if "Accept-Encoding" in request.headers:
-            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
 
         return proxy_profiling_service("GET", f"/organizations/{organization.id}/stats", **kwargs)
 

--- a/src/sentry/api/endpoints/project_profiling_profile.py
+++ b/src/sentry/api/endpoints/project_profiling_profile.py
@@ -52,8 +52,6 @@ class ProjectProfilingPaginatedBaseEndpoint(ProjectProfilingBaseEndpoint, ABC):
         params = self.get_profiling_params(request, project)
 
         kwargs = {"params": params}
-        if "Accept-Encoding" in request.headers:
-            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
 
         return self.paginate(
             request,
@@ -73,8 +71,6 @@ class ProjectProfilingTransactionIDProfileIDEndpoint(ProjectProfilingBaseEndpoin
             "method": "GET",
             "path": f"/organizations/{project.organization.id}/projects/{project.id}/transactions/{transaction_id}",
         }
-        if "Accept-Encoding" in request.headers:
-            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
         return proxy_profiling_service(**kwargs)
 
 
@@ -87,8 +83,6 @@ class ProjectProfilingProfileEndpoint(ProjectProfilingBaseEndpoint):
             "method": "GET",
             "path": f"/organizations/{project.organization.id}/projects/{project.id}/profiles/{profile_id}",
         }
-        if "Accept-Encoding" in request.headers:
-            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
         return proxy_profiling_service(**kwargs)
 
 
@@ -101,8 +95,6 @@ class ProjectProfilingRawProfileEndpoint(ProjectProfilingBaseEndpoint):
             "method": "GET",
             "path": f"/organizations/{project.organization.id}/projects/{project.id}/raw_profiles/{profile_id}",
         }
-        if "Accept-Encoding" in request.headers:
-            kwargs["headers"] = {"Accept-Encoding": request.headers.get("Accept-Encoding")}
         return proxy_profiling_service(**kwargs)
 
 

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -4,7 +4,7 @@ from urllib.parse import urlencode, urlparse
 
 import urllib3
 from django.conf import settings
-from django.http import StreamingHttpResponse
+from django.http import HttpResponse
 from parsimonious.exceptions import ParseError
 from urllib3.response import HTTPResponse
 
@@ -53,6 +53,7 @@ _profiling_pool = connection_from_url(
     ),
     timeout=30,
     maxsize=10,
+    headers={"Accept-Encoding": "br, gzip"},
 )
 
 
@@ -63,7 +64,7 @@ def get_from_profiling_service(
     headers: Optional[Dict[Any, Any]] = None,
     json_data: Any = None,
 ) -> HTTPResponse:
-    kwargs: Dict[str, Any] = {"headers": {}, "preload_content": False}
+    kwargs: Dict[str, Any] = {"headers": {}}
     if params:
         params = {
             key: value.isoformat() if isinstance(value, datetime) else value
@@ -87,23 +88,13 @@ def proxy_profiling_service(
     path: str,
     params: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, str]] = None,
-) -> StreamingHttpResponse:
+) -> HttpResponse:
     profiling_response = get_from_profiling_service(method, path, params=params, headers=headers)
-
-    def stream():  # type: ignore
-        yield from profiling_response.stream(decode_content=False)
-
-    response = StreamingHttpResponse(
-        streaming_content=stream(),  # type: ignore
+    return HttpResponse(
+        content=profiling_response.data,
         status=profiling_response.status,
-        content_type=profiling_response.headers.get("Content_type", "application/json"),
+        content_type=profiling_response.headers.get("Content-Type", "application/json"),
     )
-
-    for h in ["Content-Encoding", "Vary"]:
-        if h in profiling_response.headers:
-            response[h] = profiling_response.headers[h]
-
-    return response
 
 
 PROFILE_FILTERS = {


### PR DESCRIPTION
With streaming the response to the backend, we need to release the connection to the pool after we use it as it's not done automatically. It wasn't done, so connections would never be reused.

This reverts to a preloading the response from `vroom` instead of streaming.