### PR TITLE
docs(server-side-sampling): correct spelling of sdk option in example

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.tsx
@@ -193,7 +193,7 @@ export function RecommendedStepsModal({
                   <span className="token punctuation">{'  ...'}</span>
                   <br />
                   <span className="token literal-property property">
-                    {'  traceSampleRate'}
+                    {'  tracesSampleRate'}
                   </span>
                   <span className="token operator">:</span>{' '}
                   <span className="token string">{suggestedClientSampleRate || ''}</span>


### PR DESCRIPTION
The example code when configuring dynamic sampling rates has a typo in the sdk init option name.
<img width="615" alt="image" src="https://user-images.githubusercontent.com/742696/193975826-39583c5c-810e-4187-a5fb-7864e23c522d.png">

The prose references the correct `tracesSampleRate` spelling but the code example uses `traceSampleRate`.


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
