### PR TITLE
ref(sampling): Update affect other projects transactions alert logic - [TET-436]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/modals/affectOtherProjectsTransactionsAlert.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/affectOtherProjectsTransactionsAlert.spec.tsx
@@ -1,0 +1,55 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {getMockData} from '../testUtils';
+
+import {AffectOtherProjectsTransactionsAlert} from './affectOtherProjectsTransactionsAlert';
+
+describe("Affect other project's transactions alert", function () {
+  it('does not render', function () {
+    const {project} = getMockData();
+
+    const {rerender} = render(
+      <AffectOtherProjectsTransactionsAlert
+        isProjectIncompatible
+        projectSlug={project.slug}
+        affectedProjects={[project]}
+      />
+    );
+
+    expect(screen.queryByText(/This rate will affect/)).not.toBeInTheDocument(); // project is incompatible
+
+    rerender(
+      <AffectOtherProjectsTransactionsAlert
+        isProjectIncompatible={false}
+        projectSlug={project.slug}
+        affectedProjects={[project]}
+      />
+    );
+
+    expect(screen.queryByText(/This rate will affect/)).not.toBeInTheDocument(); // there is only one affected project and it is the current project
+
+    rerender(
+      <AffectOtherProjectsTransactionsAlert
+        isProjectIncompatible={false}
+        projectSlug={project.slug}
+        affectedProjects={[]}
+      />
+    );
+
+    expect(screen.queryByText(/This rate will affect/)).not.toBeInTheDocument(); // there is no affected project
+  });
+
+  it('renders', function () {
+    const {projects} = getMockData();
+
+    render(
+      <AffectOtherProjectsTransactionsAlert
+        isProjectIncompatible={false}
+        projectSlug="some-project-slug"
+        affectedProjects={projects}
+      />
+    );
+
+    expect(screen.getByText(/This rate will affect/)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/settings/project/server-side-sampling/modals/affectOtherProjectsTransactionsAlert.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/affectOtherProjectsTransactionsAlert.tsx
@@ -1,0 +1,60 @@
+import Alert from 'sentry/components/alert';
+import Button from 'sentry/components/button';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import {t} from 'sentry/locale';
+import {Project} from 'sentry/types';
+
+import {SERVER_SIDE_SAMPLING_DOC_LINK} from '../utils';
+
+import {Projects} from './uniformRateModal';
+
+type Props = {
+  affectedProjects: Project[];
+  isProjectIncompatible: boolean;
+  /**
+   * Slug of current project's page
+   */
+  projectSlug: Project['slug'];
+};
+
+export function AffectOtherProjectsTransactionsAlert({
+  isProjectIncompatible,
+  affectedProjects,
+  projectSlug,
+}: Props) {
+  if (
+    affectedProjects.length === 0 ||
+    isProjectIncompatible ||
+    (affectedProjects.length === 1 && affectedProjects[0].slug === projectSlug)
+  ) {
+    return null;
+  }
+
+  return (
+    <Alert
+      type="info"
+      showIcon
+      trailingItems={
+        <Button
+          href={`${SERVER_SIDE_SAMPLING_DOC_LINK}#traces--propagation-of-sampling-decisions`}
+          priority="link"
+          borderless
+          external
+        >
+          {t('Learn More')}
+        </Button>
+      }
+    >
+      {t('This rate will affect the transactions for the following projects:')}
+      <Projects>
+        {affectedProjects.map(affectedProject => (
+          <ProjectBadge
+            key={affectedProject.id}
+            project={affectedProject}
+            avatarSize={16}
+          />
+        ))}
+      </Projects>
+    </Alert>
+  );
+}

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -7,7 +7,6 @@ import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import {NumberField} from 'sentry/components/forms';
-import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import ExternalLink from 'sentry/components/links/externalLink';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -42,6 +41,7 @@ import {projectStatsToSeries} from '../utils/projectStatsToSeries';
 import {useProjectStats} from '../utils/useProjectStats';
 import {useRecommendedSdkUpgrades} from '../utils/useRecommendedSdkUpgrades';
 
+import {AffectOtherProjectsTransactionsAlert} from './affectOtherProjectsTransactionsAlert';
 import {RecommendedStepsModal, RecommendedStepsModalProps} from './recommendedStepsModal';
 import {SpecifyClientRateModal} from './specifyClientRateModal';
 import {UniformRateChart} from './uniformRateChart';
@@ -555,34 +555,11 @@ export function UniformRateModal({
             </Alert>
           )}
 
-          {!isProjectIncompatible && affectedProjects.length > 0 && (
-            <Alert
-              data-test-id="affected-sdk-alert"
-              type="info"
-              showIcon
-              trailingItems={
-                <Button
-                  href={`${SERVER_SIDE_SAMPLING_DOC_LINK}#traces--propagation-of-sampling-decisions`}
-                  priority="link"
-                  borderless
-                  external
-                >
-                  {t('Learn More')}
-                </Button>
-              }
-            >
-              {t('This rate will affect the transactions for the following projects:')}
-              <Projects>
-                {affectedProjects.map(affectedProject => (
-                  <ProjectBadge
-                    key={affectedProject.id}
-                    project={affectedProject}
-                    avatarSize={16}
-                  />
-                ))}
-              </Projects>
-            </Alert>
-          )}
+          <AffectOtherProjectsTransactionsAlert
+            affectedProjects={affectedProjects}
+            projectSlug={project.slug}
+            isProjectIncompatible={isProjectIncompatible}
+          />
         </Fragment>
       </Body>
       <Footer>
@@ -705,7 +682,7 @@ const RefreshRatesColumn = styled('div')`
   display: inline-flex;
 `;
 
-const Projects = styled('div')`
+export const Projects = styled('div')`
   display: flex;
   flex-wrap: wrap;
   gap: ${space(1.5)};


### PR DESCRIPTION
**What this PR does:**

- Update the logic to display the alert saying that this rate will affect the following projects, if there is only one affected project and if this affected project is the same as the current project's settings page 
- Move he Alert to a separate file and Create a test