### PR TITLE
fix(billing-consumer): Get correct format for prod servers

### DIFF
--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -23,6 +23,7 @@ from django.conf import settings
 from sentry.constants import DataCategory
 from sentry.sentry_metrics.indexer.strings import TRANSACTION_METRICS_NAMES
 from sentry.utils import json
+from sentry.utils.kafka_config import get_kafka_consumer_cluster_options
 from sentry.utils.outcomes import Outcome, track_outcome
 
 logger = logging.getLogger(__name__)
@@ -56,8 +57,8 @@ def get_metrics_billing_consumer(
 def _get_bootstrap_servers(topic: str, force_cluster: Union[str, None]) -> Sequence[str]:
     cluster = force_cluster or settings.KAFKA_TOPICS[topic]["cluster"]
 
-    options = settings.KAFKA_CLUSTERS[cluster]
-    servers = options["common"]["bootstrap.servers"]
+    options = get_kafka_consumer_cluster_options(cluster)
+    servers = options["bootstrap.servers"]
     if isinstance(servers, (list, tuple)):
         return servers
     return [servers]


### PR DESCRIPTION
There are two different Kafka cluster config formats:

In sentry:
```python
KAFKA_CLUSTERS = {
    "default": {
        "common": {"bootstrap.servers": "127.0.0.1:9092"},
        "producers": {
            "compression.type": "lz4",
            "message.max.bytes": 50000000,  # 50MB, default is 1MB
        },
        "consumers": {},
    },
    ...
}
```

In production:
```python
KAFKA_CLUSTERS = {
    "<cluster name>": {
        "bootstrap.servers": "<server bla bla bla>",
        "compression.type": "<ct>",
        "message.max.bytes": <some random number>,
    },
    ...
}
```

This broke a deploy. Using `get_kafka_consumer_cluster_options` patches both configs accordingly, returning a dictionary where `bootstrap.servers` is a top-level key.