### PR TITLE
docs(kafka-conf): Add warning on reading configs

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2442,8 +2442,8 @@ INVALID_EMAIL_ADDRESS_PATTERN = re.compile(r"\@qq\.com$", re.I)
 SENTRY_USER_PERMISSIONS = ("broadcasts.admin", "users.admin", "options.admin")
 
 # WARNING(iker): there are two different formats for KAFKA_CLUSTERS: the one we
-# use below, and a different one in the file on the same path in `getsentry`.
-# Reading directly items from this default configuration will break deploys.
+# use below, and a legacy one still used in `getsentry`.
+# Reading items from this default configuration directly might break deploys.
 # To correctly read items from this dictionary and not worry about the format,
 # see `sentry.utils.kafka_config.get_kafka_consumer_cluster_options`.
 KAFKA_CLUSTERS = {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2441,6 +2441,11 @@ INVALID_EMAIL_ADDRESS_PATTERN = re.compile(r"\@qq\.com$", re.I)
 # (currently the values not used anymore so this is more for documentation purposes)
 SENTRY_USER_PERMISSIONS = ("broadcasts.admin", "users.admin", "options.admin")
 
+# WARNING(iker): there are two different formats for KAFKA_CLUSTERS: the one we
+# use below, and a different one in the file on the same path in `getsentry`.
+# Reading directly items from this default configuration will break deploys.
+# To correctly read items from this dictionary and not worry about the format,
+# see `sentry.utils.kafka_config.get_kafka_consumer_cluster_options`.
 KAFKA_CLUSTERS = {
     "default": {
         "common": {"bootstrap.servers": "127.0.0.1:9092"},


### PR DESCRIPTION
See comment in diff.

Ideally, we update the default configuration to match the config in production and make sure no one uses the old configuration. That's out of scope for now.