### PR TITLE
fix(sampling): remove redundant keys from sampling endpoint

### DIFF
--- a/static/app/types/sampling.tsx
+++ b/static/app/types/sampling.tsx
@@ -102,7 +102,6 @@ export type SamplingRule = {
 
 export type SamplingDistribution = {
   endTimestamp: string | null;
-  null_sample_rate_percentage: null | number;
   project_breakdown:
     | null
     | {
@@ -110,15 +109,6 @@ export type SamplingDistribution = {
         project: string;
         project_id: number;
       }[];
-  sample_rate_distributions: null | {
-    avg: null | number;
-    max: null | number;
-    min: null | number;
-    p50: null | number;
-    p90: null | number;
-    p95: null | number;
-    p99: null | number;
-  };
   sample_size: number;
   startTimestamp: string | null;
 };

--- a/static/app/views/settings/project/server-side-sampling/testUtils.tsx
+++ b/static/app/views/settings/project/server-side-sampling/testUtils.tsx
@@ -142,16 +142,6 @@ export const mockedSamplingDistribution: SamplingDistribution = {
     },
   ],
   sample_size: 100,
-  null_sample_rate_percentage: 98,
-  sample_rate_distributions: {
-    min: 1,
-    max: 1,
-    avg: 1,
-    p50: 1,
-    p90: 1,
-    p95: 1,
-    p99: 1,
-  },
   startTimestamp: '2017-08-04T07:52:11Z',
   endTimestamp: '2017-08-05T07:52:11Z',
 };


### PR DESCRIPTION
Removes `sampling_rate_distributions` and `null_sample_rate_precentage` from types as they will be removed from endpoint response

BE counterpart needs to be merged first: https://github.com/getsentry/sentry/pull/39673
