### PR TITLE
feat(discover-homepage): PUT responds with serialized query

### DIFF
--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -80,7 +80,7 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
                 version=data["version"],
             )
             previous_homepage.set_projects(data["project_ids"])
-            return Response(status=status.HTTP_204_NO_CONTENT)
+            return Response(serialize(previous_homepage), status=status.HTTP_200_OK)
 
         model = DiscoverSavedQuery.objects.create(
             organization=organization,
@@ -93,7 +93,7 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
 
         model.set_projects(data["project_ids"])
 
-        return Response(status=status.HTTP_201_CREATED)
+        return Response(serialize(model), status=status.HTTP_201_CREATED)
 
     def delete(self, request: Request, organization) -> Response:
         if not self.has_feature(organization, request):

--- a/tests/snuba/api/endpoints/test_discover_homepage_query.py
+++ b/tests/snuba/api/endpoints/test_discover_homepage_query.py
@@ -56,9 +56,10 @@ class DiscoverHomepageQueryTest(DiscoverSavedQueryBase):
                 },
             )
 
-        assert response.status_code == 204, response.content
+        assert response.status_code == 200, response.content
 
         saved_query.refresh_from_db()
+        assert response.data == serialize(saved_query)
         assert saved_query.name == "A new homepage query update"
         assert saved_query.query["fields"] == ["field1", "field2"]
         assert set(saved_query.projects.values_list("id", flat=True)) == set(self.project_ids)
@@ -81,6 +82,7 @@ class DiscoverHomepageQueryTest(DiscoverSavedQueryBase):
         new_query = DiscoverSavedQuery.objects.get(
             created_by=self.user, organization=self.org, is_homepage=True
         )
+        assert response.data == serialize(new_query)
         assert new_query.name == homepage_query_payload["name"]
         assert new_query.query["fields"] == homepage_query_payload["fields"]
         assert new_query.query["environment"] == homepage_query_payload["environment"]


### PR DESCRIPTION
Adding the serialized homepage query as a response on PUT because it'll make
checking dirty state in the frontend easier if we can save the response.