### PR TITLE
ref(tabs): Add `hideBorder` prop

### DIFF
--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -67,9 +67,10 @@ function useOverflowTabs({
 
 interface TabListProps extends TabListStateProps<any>, AriaTabListProps<any> {
   className?: string;
+  hideBorder?: boolean;
 }
 
-function BaseTabList({className, ...props}: TabListProps) {
+function BaseTabList({hideBorder = false, className, ...props}: TabListProps) {
   const tabListRef = useRef<HTMLUListElement>(null);
   const {rootProps, setTabListState} = useContext(TabsContext);
   const {value, defaultValue, onChange, orientation, disabled, ...otherRootProps} =
@@ -116,6 +117,7 @@ function BaseTabList({className, ...props}: TabListProps) {
       <TabListWrap
         {...tabListProps}
         orientation={orientation}
+        hideBorder={hideBorder}
         className={className}
         ref={tabListRef}
       >
@@ -202,6 +204,7 @@ const TabListOuterWrap = styled('div')`
 `;
 
 const TabListWrap = styled('ul', {shouldForwardProp: tabsShouldForwardProp})<{
+  hideBorder: boolean;
   orientation: Orientation;
 }>`
   position: relative;
@@ -217,15 +220,15 @@ const TabListWrap = styled('ul', {shouldForwardProp: tabsShouldForwardProp})<{
         grid-auto-flow: column;
         justify-content: start;
         gap: ${space(2)};
-        border-bottom: solid 1px ${p.theme.border};
+        ${!p.hideBorder && `border-bottom: solid 1px ${p.theme.border};`}
       `
       : `
+        height: 100%;
         grid-auto-flow: row;
         align-content: start;
         gap: 1px;
         padding-right: ${space(2)};
-        border-right: solid 1px ${p.theme.border};
-        height: 100%;
+        ${!p.hideBorder && `border-right: solid 1px ${p.theme.border};`}
       `};
 `;
 

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -168,6 +168,7 @@ function GroupHeader({
 
     return (
       <StyledTabList
+        hideBorder
         onSelectionChange={key => {
           trackAdvancedAnalyticsEvent('issue_group_details.tab.clicked', {
             organization,
@@ -492,6 +493,5 @@ const IconBadge = styled(Badge)`
 `;
 
 const StyledTabList = styled(TabList)`
-  border-bottom: none;
   margin-top: ${space(2)};
 `;


### PR DESCRIPTION
Add a `hideBorder` prop to `Tabs` since there are many places where we don't want to render the default border.