### PR TITLE
ref(tabs): Infer `onChange` type from `value`/`defaultValue`

### DIFF
--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -16,7 +16,7 @@ const _Item = Item as (
 ) => JSX.Element;
 export {_Item as Item, TabList, TabPanels};
 
-export interface TabsProps
+export interface TabsProps<T>
   extends Omit<TabListProps<any>, 'children'>,
     Omit<AriaTabListProps<any>, 'children'> {
   children?: React.ReactNode;
@@ -25,21 +25,21 @@ export interface TabsProps
    * [Uncontrolled] Default selected tab. Must match the `key` prop on the
    * selected tab item.
    */
-  defaultValue?: TabListProps<any>['defaultSelectedKey'];
+  defaultValue?: T;
   disabled?: boolean;
   /**
    * Callback when the selected tab changes.
    */
-  onChange?: TabListProps<any>['onSelectionChange'];
+  onChange?: (key: T) => void;
   /**
    * [Controlled] Selected tab . Must match the `key` prop on the selected tab
    * item.
    */
-  value?: TabListProps<any>['selectedKey'];
+  value?: T;
 }
 
 interface TabContext {
-  rootProps: TabsProps & {orientation: Orientation};
+  rootProps: TabsProps<any> & {orientation: Orientation};
   setTabListState: (state: TabListState<any>) => void;
   tabListState?: TabListState<any>;
 }
@@ -54,7 +54,11 @@ export const TabsContext = createContext<TabContext>({
  * child components (TabList and TabPanels) to work together. See example
  * usage in tabs.stories.js
  */
-export function Tabs({orientation = 'horizontal', className, ...props}: TabsProps) {
+export function Tabs<T extends React.Key>({
+  orientation = 'horizontal',
+  className,
+  ...props
+}: TabsProps<T>) {
   const [tabListState, setTabListState] = useState<TabListState<any>>();
 
   return (

--- a/static/app/components/tabs/index.tsx
+++ b/static/app/components/tabs/index.tsx
@@ -77,6 +77,7 @@ const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
 }>`
   display: flex;
   flex-direction: ${p => (p.orientation === 'horizontal' ? 'column' : 'row')};
+  flex-grow: 1;
 
   ${p =>
     p.orientation === 'vertical' &&

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -646,10 +646,10 @@ class GroupDetails extends Component<Props, State> {
     }
 
     return (
-      <GroupTabs
+      <Tabs
         value={currentTab}
         onChange={tab => {
-          this.tabClickAnalyticsEvent(tab as Tab);
+          this.tabClickAnalyticsEvent(tab);
 
           router.push({
             pathname: `${baseUrl}${TabPaths[tab]}`,
@@ -671,7 +671,7 @@ class GroupDetails extends Component<Props, State> {
             {isValidElement(children) ? cloneElement(children, childProps) : children}
           </Item>
         </GroupTabPanels>
-      </GroupTabs>
+      </Tabs>
     );
   }
 
@@ -739,10 +739,6 @@ export default withApi(Sentry.withProfiler(GroupDetails));
 
 const StyledLoadingError = styled(LoadingError)`
   margin: ${space(2)};
-`;
-
-const GroupTabs = styled(Tabs)`
-  flex-grow: 1;
 `;
 
 const GroupTabPanels = styled(TabPanels)`


### PR DESCRIPTION
Use generic typing to automatically infer `onChange`'s type based on the type of `value`/`defaultValue` and vice versa.

**Before:** `onChange` is statically typed as `(value: React.Key) => void`, cuasing a type error
![Screen Shot 2022-10-05 at 10 18 20 AM](https://user-images.githubusercontent.com/44172267/194123472-149cda3a-3eb2-424c-b0fa-592745987b99.png)

**After:** `onChange` is automatically typed as `(value: LandingDisplayField) => void` since the type of the `value` prop we passed to it is `LandingDisplayField`.
![Screen Shot 2022-10-05 at 10 17 56 AM](https://user-images.githubusercontent.com/44172267/194123466-4f04c72a-cf46-4911-a942-225a497ef43f.png)
