### PR TITLE
fix(ui): Fix context content blowout

### DIFF
--- a/static/app/components/events/contextSummary/item.tsx
+++ b/static/app/components/events/contextSummary/item.tsx
@@ -40,14 +40,15 @@ const Details = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  max-width: 100%;
   min-height: 48px;
+  min-width: 0;
 `;
 
 const IconContainer = styled('div')`
   width: 36px;
   height: 36px;
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   justify-content: center;
 `;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/194139823-40853f9a-24be-462e-8846-bf4138911a1f.png)

Fixed using the `min-width: 0` trick

![image](https://user-images.githubusercontent.com/1421724/194139930-d760e79c-e508-489a-93b4-90bf4013b25f.png)
