### PR TITLE
ref(perf-issues): Add metrics for detected/truncated problems

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -322,6 +322,9 @@ def _detect_performance_problems(data: Event, sdk_span: Any) -> List[Performance
 
     truncated_problems = detected_problems[:PERFORMANCE_GROUP_COUNT_LIMIT]
 
+    metrics.incr("performance.performance_issue.detected", len(detected_problems))
+    metrics.incr("performance.performance_issue.truncated", len(truncated_problems))
+
     performance_problems = [
         prepare_problem_for_grouping(problem, data, detector_type)
         for problem, detector_type in truncated_problems


### PR DESCRIPTION
Since we have a hard limit of 10 problems per event, we should add a metric for how many were detected before and after using the same sample rate. To get dropped we can use the formula (detected - truncated)

