### PR TITLE
perf(replays): fix N+1 issue in recording segment index

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
@@ -1,6 +1,7 @@
 import zlib
 from concurrent.futures import ThreadPoolExecutor
 
+from django.db.models import Prefetch
 from django.http import StreamingHttpResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,7 +11,8 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.models.file import File
+from sentry.models.file import File, FileBlobIndex
+from sentry.replays.lib.segment_file import get_chunked_blob_from_indexes
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.serializers import ReplayRecordingSegmentSerializer
 
@@ -62,12 +64,24 @@ class ProjectReplayRecordingSegmentIndexEndpoint(ProjectEndpoint):
         get the files associated with the segment range requested. prefetch the files
         in a threadpool.
         """
-        recording_segment_files = File.objects.filter(id__in=[r.file_id for r in results])
+
         # TODO: deflate files as theyre fetched, instead of having
         # to wait untill all of them are complete before starting work.
+
+        recording_segment_files = File.objects.filter(
+            id__in=[r.file_id for r in results]
+        ).prefetch_related(
+            Prefetch(
+                "blobs",
+                queryset=FileBlobIndex.objects.select_related("blob").order_by("offset"),
+                to_attr="file_blob_indexes",
+            )
+        )
         with ThreadPoolExecutor(max_workers=4) as exe:
+
             file_objects = exe.map(
-                lambda file: file.getfile(prefetch=True), recording_segment_files
+                lambda file: get_chunked_blob_from_indexes(file.file_blob_indexes),
+                recording_segment_files,
             )
 
         return iter(self.segment_generator(list(file_objects)))

--- a/src/sentry/replays/lib/segment_file.py
+++ b/src/sentry/replays/lib/segment_file.py
@@ -1,0 +1,16 @@
+from uuid import uuid4
+
+from django.core.files.base import File as FileObj
+
+from sentry.models.file import ChunkedFileBlobIndexWrapper
+
+
+def get_chunked_blob_from_indexes(file_blob_indexes):
+    chunked_file_index_wrapper = ChunkedFileBlobIndexWrapper(
+        file_blob_indexes,
+        mode=None,
+        prefetch=True,
+        prefetch_to=None,
+        delete=True,
+    )
+    return FileObj(chunked_file_index_wrapper, uuid4().hex)


### PR DESCRIPTION
### Problem:
Previously when downloading files for a replay, for each file we would make a separate database query to grab the associated `FileBlobIndex`. example transaction [here](https://sentry.io/organizations/sentry/performance/sentry:8d6aa06aa2d747ce933652092ccc023d/?project=1&query=http.method%3AGET&statsPeriod=24h&transaction=%2Fapi%2F0%2Fprojects%2F%7Borganization_slug%7D%2F%7Bproject_slug%7D%2Freplays%2F%7Breplay_id%7D%2Frecording-segments%2F&unselectedSeries=p100%28%29).
### Solution
We fix this by selecting all related `FileBlobIndex` using a prefetch, and defining our own wrapper function for `ChunkedFileBlobIndexWrapper` that can take in a list of indexes. 
