### PR TITLE
ref: use dict instead of OrderedDict since sentry is >python3.6

### DIFF
--- a/fixtures/bitbucket.py
+++ b/fixtures/bitbucket.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 COMPARE_COMMITS_EXAMPLE = b"""{
 "pagelen": 30,
  "values":
@@ -276,194 +274,64 @@ REPO = {
     "website": "",
     "has_wiki": True,
     "description": "",
-    "links": OrderedDict(
-        [
-            (
-                "watchers",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/watchers",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "branches",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/refs/branches",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "tags",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/refs/tags",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "commits",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/commits",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "clone",
-                [
-                    OrderedDict(
-                        [
-                            (
-                                "href",
-                                "https://laurynsentry@bitbucket.org/laurynsentry/helloworld.git",
-                            ),
-                            ("name", "https"),
-                        ]
-                    ),
-                    OrderedDict(
-                        [
-                            ("href", "git@bitbucket.org:laurynsentry/helloworld.git"),
-                            ("name", "ssh"),
-                        ]
-                    ),
-                ],
-            ),
-            (
-                "self",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "source",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/src",
-                        )
-                    ]
-                ),
-            ),
-            ("html", OrderedDict([("href", "https://bitbucket.org/laurynsentry/helloworld")])),
-            (
-                "avatar",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://bytebucket.org/ravatar/%7B2a47ac11-098a-4054-8496-193754cae14b%7D?ts=default",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "hooks",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/hooks",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "forks",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/forks",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "downloads",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/downloads",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "issues",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/issues",
-                        )
-                    ]
-                ),
-            ),
-            (
-                "pullrequests",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/pullrequests",
-                        )
-                    ]
-                ),
-            ),
-        ]
-    ),
+    "links": {
+        "watchers": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/watchers"
+        },
+        "branches": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/refs/branches"
+        },
+        "tags": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/refs/tags"
+        },
+        "commits": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/commits"
+        },
+        "clone": [
+            {
+                "href": "https://laurynsentry@bitbucket.org/laurynsentry/helloworld.git",
+                "name": "https",
+            },
+            {"href": "git@bitbucket.org:laurynsentry/helloworld.git", "name": "ssh"},
+        ],
+        "self": {"href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld"},
+        "source": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/src"
+        },
+        "html": {"href": "https://bitbucket.org/laurynsentry/helloworld"},
+        "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7B2a47ac11-098a-4054-8496-193754cae14b%7D?ts=default"
+        },
+        "hooks": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/hooks"
+        },
+        "forks": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/forks"
+        },
+        "downloads": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/downloads"
+        },
+        "issues": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/issues"
+        },
+        "pullrequests": {
+            "href": "https://api.bitbucket.org/2.0/repositories/laurynsentry/helloworld/pullrequests"
+        },
+    },
     "created_on": "2018-05-14T23:53:37.377674+00:00",
     "full_name": "laurynsentry/helloworld",
-    "owner": OrderedDict(
-        [
-            ("username", "laurynsentry"),
-            ("display_name", "Lauryn Brown"),
-            ("account_id", "5a00066393915e620920e0ae"),
-            (
-                "links",
-                OrderedDict(
-                    [
-                        (
-                            "self",
-                            OrderedDict(
-                                [("href", "https://api.bitbucket.org/2.0/users/laurynsentry")]
-                            ),
-                        ),
-                        ("html", OrderedDict([("href", "https://bitbucket.org/laurynsentry/")])),
-                        (
-                            "avatar",
-                            OrderedDict(
-                                [("href", "https://bitbucket.org/account/laurynsentry/avatar/")]
-                            ),
-                        ),
-                    ]
-                ),
-            ),
-            ("type", "user"),
-            ("uuid", "{e50a27fe-0686-4d75-ba44-d27608bbb718}"),
-        ]
-    ),
+    "owner": {
+        "username": "laurynsentry",
+        "display_name": "Lauryn Brown",
+        "account_id": "5a00066393915e620920e0ae",
+        "links": {
+            "self": {"href": "https://api.bitbucket.org/2.0/users/laurynsentry"},
+            "html": {"href": "https://bitbucket.org/laurynsentry/"},
+            "avatar": {"href": "https://bitbucket.org/account/laurynsentry/avatar/"},
+        },
+        "type": "user",
+        "uuid": "{e50a27fe-0686-4d75-ba44-d27608bbb718}",
+    },
     "has_issues": True,
     "slug": "helloworld",
     "is_private": False,
@@ -472,7 +340,7 @@ REPO = {
     "language": "",
     "fork_policy": "allow_forks",
     "uuid": "{2a47ac11-098a-4054-8496-193754cae14b}",
-    "mainbranch": OrderedDict([("type", "branch"), ("name", "master")]),
+    "mainbranch": {"type": "branch", "name": "master"},
     "updated_on": "2018-05-30T18:21:08.780363+00:00",
     "type": "repository",
 }

--- a/fixtures/bitbucket_server.py
+++ b/fixtures/bitbucket_server.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 EXAMPLE_PRIVATE_KEY = """-----BEGIN RSA PRIVATE KEY-----
 MIICWwIBAAKBgQC1cd9t8sA03awggLiX2gjZxyvOVUPJksLly1E662tttTeR3Wm9
 eo6onNeI8HRD+O4wubUp4h4Chc7DtLDmFEPhUZ8Qkwztiifm99Xo3s0nUq4Pygp5
@@ -113,72 +111,23 @@ REPO = {
     "state": "AVAILABLE",
     "statusMessage": "Available",
     "forkable": True,
-    "project": OrderedDict(
-        [
-            ("key", "laurynsentry"),
-            ("id", 75),
-            ("name", "laurynsentry"),
-            ("description", ""),
-            ("public", False),
-            ("type", "Normal"),
-            (
-                "links",
-                OrderedDict(
-                    [
-                        (
-                            "self",
-                            OrderedDict(
-                                [("href", "https://bitbucket.example.org/projects/laurynsentry")]
-                            ),
-                        )
-                    ]
-                ),
-            ),
-        ]
-    ),
+    "project": {
+        "key": "laurynsentry",
+        "id": 75,
+        "name": "laurynsentry",
+        "description": "",
+        "public": False,
+        "type": "Normal",
+        "links": {"self": {"href": "https://bitbucket.example.org/projects/laurynsentry"}},
+    },
     "public": False,
-    "links": OrderedDict(
-        [
-            (
-                "clone",
-                OrderedDict(
-                    [
-                        OrderedDict(
-                            [
-                                (
-                                    "href",
-                                    "https://bitbucket.example.org/scm/laurynsentry/helloworld.git",
-                                ),
-                                ("name", "http"),
-                            ]
-                        ),
-                        OrderedDict(
-                            [
-                                (
-                                    "href",
-                                    "ssh://git@bitbucket.example.org:7999/laurynsentry/helloworld.git",
-                                ),
-                                ("name", "ssh"),
-                            ]
-                        ),
-                    ]
-                ),
-            ),
-            (
-                "self",
-                OrderedDict(
-                    [
-                        (
-                            "href",
-                            "https://bitbucket.example.org/projects/laurynsentry/repos/helloworld/browse",
-                        )
-                    ]
-                ),
-            ),
-        ]
-    ),
+    "links": {
+        "clone": {"href": "name"},
+        "self": {
+            "href": "https://bitbucket.example.org/projects/laurynsentry/repos/helloworld/browse"
+        },
+    },
 }
-
 
 COMPARE_COMMITS_WITH_PAGES_1_2_EXAMPLE = {
     "values": [

--- a/src/sentry/api/endpoints/monitor_stats.py
+++ b/src/sentry/api/endpoints/monitor_stats.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,7 +13,7 @@ class MonitorStatsEndpoint(MonitorEndpoint, StatsMixin):
     def get(self, request: Request, project, monitor) -> Response:
         args = self._parse_args(request)
 
-        stats = OrderedDict()
+        stats = {}
         current = tsdb.normalize_to_epoch(args["start"], args["rollup"])
         end = tsdb.normalize_to_epoch(args["end"], args["rollup"])
         while current <= end:

--- a/src/sentry/api/endpoints/project_servicehook_stats.py
+++ b/src/sentry/api/endpoints/project_servicehook_stats.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -20,7 +18,7 @@ class ProjectServiceHookStatsEndpoint(ProjectEndpoint, StatsMixin):
 
         stat_args = self._parse_args(request)
 
-        stats = OrderedDict()
+        stats = {}
         for model, name in ((tsdb.models.servicehook_fired, "total"),):
             result = tsdb.get_range(model=model, keys=[hook.id], **stat_args)[hook.id]
             for ts, count in result:

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from croniter import croniter
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
@@ -8,15 +6,17 @@ from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.models import MonitorStatus, MonitorType, ScheduleType
 
-SCHEDULE_TYPES = OrderedDict(
-    [("crontab", ScheduleType.CRONTAB), ("interval", ScheduleType.INTERVAL)]
-)
+SCHEDULE_TYPES = {
+    "crontab": ScheduleType.CRONTAB,
+    "interval": ScheduleType.INTERVAL,
+}
 
-MONITOR_TYPES = OrderedDict([("cron_job", MonitorType.CRON_JOB)])
+MONITOR_TYPES = {"cron_job": MonitorType.CRON_JOB}
 
-MONITOR_STATUSES = OrderedDict(
-    [("active", MonitorStatus.ACTIVE), ("disabled", MonitorStatus.DISABLED)]
-)
+MONITOR_STATUSES = {
+    "active": MonitorStatus.ACTIVE,
+    "disabled": MonitorStatus.DISABLED,
+}
 
 INTERVAL_NAMES = ("year", "month", "week", "day", "hour", "minute")
 

--- a/src/sentry/apidocs/spectacular_ports.py
+++ b/src/sentry/apidocs/spectacular_ports.py
@@ -3,7 +3,7 @@
 import collections
 import inspect
 import typing
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from enum import Enum
 from typing import Any, Literal, Union
 from typing import get_type_hints as _get_type_hints
@@ -77,7 +77,7 @@ def resolve_type_hint(hint) -> Any:
             max_length=len(args),
             min_length=len(args),
         )
-    elif origin is dict or origin is defaultdict or origin is OrderedDict:
+    elif origin is dict or origin is defaultdict:
         schema = build_basic_type(OpenApiTypes.OBJECT)
         if args and args[1] is not typing.Any:
             schema["additionalProperties"] = resolve_type_hint(args[1])

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -5,7 +5,7 @@ web-server
 
 import logging
 import os.path
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from datetime import timedelta
 from typing import Dict, List, Optional, Sequence, Tuple, cast
 
@@ -40,18 +40,18 @@ COMMIT_RANGE_DELIMITER = ".."
 # semver constants
 SEMVER_FAKE_PACKAGE = "__sentry_fake__"
 
-SORT_OPTIONS = OrderedDict(
-    (
-        ("priority", _("Priority")),
-        ("date", _("Last Seen")),
-        ("new", _("First Seen")),
-        ("freq", _("Frequency")),
-    )
-)
+SORT_OPTIONS = {
+    "priority": _("Priority"),
+    "date": _("Last Seen"),
+    "new": _("First Seen"),
+    "freq": _("Frequency"),
+}
 
-SEARCH_SORT_OPTIONS = OrderedDict(
-    (("score", _("Score")), ("date", _("Last Seen")), ("new", _("First Seen")))
-)
+SEARCH_SORT_OPTIONS = {
+    "score": _("Score"),
+    "date": _("Last Seen"),
+    "new": _("First Seen"),
+}
 
 # XXX: Deprecated: use GroupStatus instead
 STATUS_UNRESOLVED = 0

--- a/src/sentry/digests/utils.py
+++ b/src/sentry/digests/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import Counter, OrderedDict, defaultdict
+from collections import Counter, defaultdict
 from datetime import datetime
 from typing import Any
 from typing import Counter as CounterType
@@ -96,9 +96,9 @@ def get_event_from_groups_in_digest(digest: Digest) -> Iterable[Event]:
 
 def build_custom_digest(original_digest: Digest, events: Iterable[Event]) -> Digest:
     """Given a digest and a set of events, filter the digest to only records that include the events."""
-    user_digest: Digest = OrderedDict()
+    user_digest: Digest = {}
     for rule, rule_groups in original_digest.items():
-        user_rule_groups = OrderedDict()
+        user_rule_groups = {}
         for group, group_records in rule_groups.items():
             user_group_records = [
                 record for record in group_records if record.value.event in events

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import abc
 import string
-from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime
 from hashlib import md5
@@ -504,8 +503,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
 
     def as_dict(self) -> Mapping[str, Any]:
         """Returns the data in normalized form for external consumers."""
-        # We use a OrderedDict to keep elements ordered for a potential JSON serializer
-        data: MutableMapping[str, Any] = OrderedDict()
+        data: MutableMapping[str, Any] = {}
         data["event_id"] = self.event_id
         data["project"] = self.project_id
         data["release"] = self.release

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Mapping, MutableMapping, Optional, Sequence, Set, Tuple
 
 from django.urls import reverse
@@ -79,8 +78,7 @@ class VstsIssueSync(IssueSyncMixin):  # type: ignore
         except (ApiError, ApiUnauthorized, KeyError) as e:
             raise self.raise_error(e)
 
-        # we want to maintain ordering of the items
-        item_type_map = OrderedDict()
+        item_type_map = {}
         for item in item_categories:
             for item_type_object in item["workItemTypes"]:
                 # the type is the last part of the url

--- a/src/sentry/interfaces/base.py
+++ b/src/sentry/interfaces/base.py
@@ -1,5 +1,4 @@
 import logging
-from collections import OrderedDict
 from html import escape
 from typing import Any, Dict, List, Optional, Union
 
@@ -51,9 +50,7 @@ def get_interfaces(data):
 
         result.append((key, value))
 
-    return OrderedDict(
-        (k, v) for k, v in sorted(result, key=lambda x: x[1].get_score(), reverse=True)
-    )
+    return {k: v for k, v in sorted(result, key=lambda x: x[1].get_score(), reverse=True)}
 
 
 class InterfaceValidationError(Exception):

--- a/src/sentry/models/eventuser.py
+++ b/src/sentry/models/eventuser.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from functools import reduce
 from operator import or_
 
@@ -14,9 +13,12 @@ from sentry.utils.hashlib import md5_text
 # when used in hashing and determining uniqueness. If you change the order
 # you will break stuff.
 KEYWORD_MAP = BidirectionalMapping(
-    OrderedDict(
-        (("ident", "id"), ("username", "username"), ("email", "email"), ("ip_address", "ip"))
-    )
+    {
+        "ident": "id",
+        "username": "username",
+        "email": "email",
+        "ip_address": "ip",
+    }
 )
 
 

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -1,8 +1,6 @@
 __all__ = ["PluginConfigMixin"]
 
 
-from collections import OrderedDict
-
 from django import forms
 from rest_framework import serializers
 
@@ -25,7 +23,7 @@ class ConfigValidator:
         self.result = {}
         self.context = context or {}
 
-        self.config = OrderedDict((f["name"], f) for f in config)
+        self.config = {f["name"]: f for f in config}
 
         self._data = data or {}
         self._initial = initial or {}

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import abc
 import re
-from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Dict, FrozenSet, Generic, Iterable, Mapping, Sequence, Tuple, Type, TypeVar
 
@@ -82,7 +81,7 @@ class RoleLevel(Generic[R]):
 
     def __init__(self, roles: Iterable[R], default_id: str | None = None) -> None:
         self._priority_seq = tuple(sorted(roles, key=lambda r: r.priority))
-        self._id_map = OrderedDict((r.id, r) for r in self._priority_seq)
+        self._id_map = {r.id: r for r in self._priority_seq}
 
         self._choices = tuple((r.id, r.name) for r in self._priority_seq)
         self._default = self._id_map[default_id] if default_id else self._priority_seq[0]
@@ -167,10 +166,10 @@ class RoleManager:
                     return team_role
             return team_roles.get_default()
 
-        return OrderedDict(
-            (org_role.id, get_highest_available_team_role(org_role).id)
+        return {
+            org_role.id: get_highest_available_team_role(org_role).id
             for org_role in organization_roles.get_all()
-        )
+        }
 
     def __iter__(self) -> Iterable[OrganizationRole]:
         yield from self.organization_roles.get_all()

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import OrderedDict
 from typing import Any, Callable, Tuple
 
 from django import forms
@@ -12,9 +11,7 @@ from sentry.rules import EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
 
 key: Callable[[Tuple[int, str]], int] = lambda x: x[0]
-LEVEL_CHOICES = OrderedDict(
-    [(f"{k}", v) for k, v in sorted(LOG_LEVELS.items(), key=key, reverse=True)]
-)
+LEVEL_CHOICES = {f"{k}": v for k, v in sorted(LOG_LEVELS.items(), key=key, reverse=True)}
 
 
 class LevelEventForm(forms.Form):  # type: ignore

--- a/src/sentry/rules/match.py
+++ b/src/sentry/rules/match.py
@@ -1,6 +1,3 @@
-from collections import OrderedDict
-
-
 class MatchType:
     CONTAINS = "co"
     ENDS_WITH = "ew"
@@ -16,25 +13,21 @@ class MatchType:
     STARTS_WITH = "sw"
 
 
-LEVEL_MATCH_CHOICES = OrderedDict(
-    [
-        (MatchType.EQUAL, "equal to"),
-        (MatchType.GREATER_OR_EQUAL, "greater than or equal to"),
-        (MatchType.LESS_OR_EQUAL, "less than or equal to"),
-    ]
-)
+LEVEL_MATCH_CHOICES = {
+    MatchType.EQUAL: "equal to",
+    MatchType.GREATER_OR_EQUAL: "greater than or equal to",
+    MatchType.LESS_OR_EQUAL: "less than or equal to",
+}
 
-MATCH_CHOICES = OrderedDict(
-    [
-        (MatchType.CONTAINS, "contains"),
-        (MatchType.ENDS_WITH, "ends with"),
-        (MatchType.EQUAL, "equals"),
-        (MatchType.IS_SET, "is set"),
-        (MatchType.NOT_CONTAINS, "does not contain"),
-        (MatchType.NOT_ENDS_WITH, "does not end with"),
-        (MatchType.NOT_EQUAL, "does not equal"),
-        (MatchType.NOT_SET, "is not set"),
-        (MatchType.NOT_STARTS_WITH, "does not start with"),
-        (MatchType.STARTS_WITH, "starts with"),
-    ]
-)
+MATCH_CHOICES = {
+    MatchType.CONTAINS: "contains",
+    MatchType.ENDS_WITH: "ends with",
+    MatchType.EQUAL: "equals",
+    MatchType.IS_SET: "is set",
+    MatchType.NOT_CONTAINS: "does not contain",
+    MatchType.NOT_ENDS_WITH: "does not end with",
+    MatchType.NOT_EQUAL: "does not equal",
+    MatchType.NOT_SET: "is not set",
+    MatchType.NOT_STARTS_WITH: "does not start with",
+    MatchType.STARTS_WITH: "starts with",
+}

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from datetime import datetime, timedelta
 
 import click
@@ -72,7 +71,7 @@ def organizations(metrics, since, until):
     def aggregate(series):
         return sum(value for timestamp, value in series)
 
-    metrics = OrderedDict((name, getattr(tsdb.models, name)) for name in metrics)
+    metrics = {name: getattr(tsdb.models, name) for name in metrics}
     if not metrics:
         return
 
@@ -90,7 +89,7 @@ def organizations(metrics, since, until):
     objects = Organization.objects.all()
 
     for chunk in chunked(objects, 100):
-        instances = OrderedDict((instance.pk, instance) for instance in chunk)
+        instances = {instance.pk: instance for instance in chunk}
 
         results = {}
         for metric in metrics.values():

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -8,7 +8,7 @@ efficient, we only look at the past 24 hours.
 
 __all__ = ("get_metrics", "get_tags", "get_tag_values", "get_series", "get_single_metric_info")
 import logging
-from collections import OrderedDict, defaultdict, deque
+from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass, replace
 from datetime import datetime
@@ -542,7 +542,7 @@ def _get_group_limit_filters(
         return None
 
     # Creates a mapping of groupBy fields to their equivalent SnQL
-    key_to_condition_dict: Dict[Groupable, Any] = OrderedDict()
+    key_to_condition_dict: Dict[Groupable, Any] = {}
     for metric_groupby_obj in metrics_query.groupby:
         key_to_condition_dict[
             metric_groupby_obj.name
@@ -562,9 +562,7 @@ def _get_group_limit_filters(
     # Get an ordered list of tuples containing the values of the group keys.
     # This needs to be deduplicated since in timeseries queries the same
     # grouping key will reappear for every time bucket.
-    values = list(
-        OrderedDict((tuple(row[col] for col in aliased_group_keys), None) for row in results).keys()
-    )
+    values = list({tuple(row[col] for col in aliased_group_keys): None for row in results})
     conditions = [
         Condition(
             Function("tuple", list(key_to_condition_dict.values())),

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -1,5 +1,5 @@
 import logging
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from datetime import datetime
 
 import sentry_sdk
@@ -457,7 +457,7 @@ def get_stacktrace_processing_task(infos, processors):
     # by_stacktrace_info requires stable sorting as it is used in
     # StacktraceProcessingTask.iter_processable_stacktraces. This is important
     # to guarantee reproducible symbolicator requests.
-    by_stacktrace_info = OrderedDict()
+    by_stacktrace_info = {}
 
     for info in infos:
         processable_frames = get_processable_frames(info, processors)

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -1,6 +1,6 @@
 import functools
 import re
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from collections.abc import Iterable
 from typing import Optional, Sequence
 
@@ -1152,27 +1152,21 @@ class SnubaTagStorage(TagStorage):
         if include_transactions:
             # With transaction_status we need to map the ids back to their names
             if transaction_status:
-                results = OrderedDict(
-                    [
-                        (SPAN_STATUS_CODE_TO_NAME[result_key], data)
-                        for result_key, data in results.items()
-                    ]
-                )
+                results = {
+                    SPAN_STATUS_CODE_TO_NAME[result_key]: data
+                    for result_key, data in results.items()
+                }
             # With project names we map the ids back to the project slugs
             elif key == PROJECT_ALIAS:
-                results = OrderedDict(
-                    [
-                        (project_slugs[value], data)
-                        for value, data in results.items()
-                        if value in project_slugs
-                    ]
-                )
+                results = {
+                    project_slugs[value]: data
+                    for value, data in results.items()
+                    if value in project_slugs
+                }
             elif is_fuzzy_numeric_key(key):
                 # numeric keys like measurements and breakdowns are nullable
                 # so filter out the None values from the results
-                results = OrderedDict(
-                    [(value, data) for value, data in results.items() if value is not None]
-                )
+                results = {value: data for value, data in results.items() if value is not None}
 
         tag_values = [
             TagValue(key=key, value=str(value), **fix_tag_value_data(data))

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -3,7 +3,7 @@ import logging
 import math
 import operator
 import zlib
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 from datetime import date, datetime, timedelta
 from functools import partial, reduce
 from itertools import zip_longest
@@ -265,7 +265,7 @@ def build_project_series(start__stop, project):
     )
     request = Request(dataset=Dataset.Outcomes.value, app_id="reports", query=outcomes_query)
     outcome_series = raw_snql_query(request, referrer="reports.outcome_series")
-    total_error_series = OrderedDict()
+    total_error_series = {}
     for v in outcome_series["data"]:
         if v["category"] in DataCategory.error_categories():
             timestamp = int(to_timestamp(parse_snuba_datetime(v["time"])))
@@ -1175,7 +1175,7 @@ def get_percentile(values, percentile):
 def colorize(spectrum, values):
     calculate_percentile = partial(get_percentile, sorted(values))
 
-    legend = OrderedDict()
+    legend = {}
     width = 1.0 / len(spectrum)
     for i, color in enumerate(spectrum, 1):
         legend[color] = calculate_percentile(i * width)

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -1,5 +1,5 @@
 import logging
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from functools import reduce
 from typing import Any, Mapping, Optional, Tuple
 
@@ -279,7 +279,7 @@ def collect_group_environment_data(events):
     Find the first release for a each group and environment pair from a
     date-descending sorted list of events.
     """
-    results = OrderedDict()
+    results = {}
     for event in events:
         results[(event.group_id, get_environment_name(event))] = event.get_tag("sentry:release")
     return results
@@ -300,7 +300,7 @@ def repair_group_environment_data(caches, project, events):
 
 
 def collect_tag_data(events):
-    results = OrderedDict()
+    results = {}
 
     for event in events:
         environment = get_environment_name(event)
@@ -323,7 +323,7 @@ def get_environment_name(event):
 
 
 def collect_release_data(caches, project, events):
-    results = OrderedDict()
+    results = {}
 
     for event in events:
         release = event.get_tag("sentry:release")

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import Callable
 from datetime import timedelta
 from enum import Enum
@@ -166,7 +165,7 @@ class BaseTSDB(Service):
         if rollups is None:
             rollups = settings.SENTRY_TSDB_ROLLUPS
 
-        self.rollups = OrderedDict(rollups)
+        self.rollups = dict(rollups)
 
         # The ``SENTRY_TSDB_LEGACY_ROLLUPS`` setting should be used to store
         # previous rollup configuration values after they are modified in

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -4,7 +4,7 @@ import os
 import random
 import re
 import time
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from copy import deepcopy
@@ -972,9 +972,9 @@ def query(
         )
     except (QueryOutsideRetentionError, QueryOutsideGroupActivityError):
         if totals:
-            return OrderedDict(), {}
+            return {}, {}
         else:
-            return OrderedDict()
+            return {}
 
     # Validate and scrub response, and translate snuba keys back to IDs
     aggregate_names = [a[2] for a in aggregations]
@@ -1008,10 +1008,10 @@ def nest_groups(data, groups, aggregate_cols):
             return {c: data[0][c] for c in aggregate_cols} if data else None
     else:
         g, rest = groups[0], groups[1:]
-        inter = OrderedDict()
+        inter = {}
         for d in data:
             inter.setdefault(d[g], []).append(d)
-        return OrderedDict((k, nest_groups(v, rest, aggregate_cols)) for k, v in inter.items())
+        return {k: nest_groups(v, rest, aggregate_cols) for k, v in inter.items()}
 
 
 def resolve_column(dataset) -> Callable[[str], str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-from collections import OrderedDict
 
 import pytest
 
@@ -76,8 +75,7 @@ def pytest_runtest_makereport(item, call):
 
 def _error_workflow_command(filesystempath, lineno, longrepr):
     # Build collection of arguments. Ordering is strict for easy testing
-    details_dict = OrderedDict()
-    details_dict["file"] = filesystempath
+    details_dict = {"file": filesystempath}
     if lineno is not None:
         details_dict["line"] = lineno
 

--- a/tests/sentry/test_canonical.py
+++ b/tests/sentry/test_canonical.py
@@ -1,35 +1,28 @@
 import unittest
-from collections import OrderedDict
 
 from sentry.utils.canonical import CanonicalKeyDict, CanonicalKeyView
 
 
 class CanonicalKeyViewTests(unittest.TestCase):
-    canonical_data = OrderedDict(
-        [
-            ("release", "asdf"),
-            ("exception", {"type": "DemoException"}),
-            ("user", {"id": "DemoUser"}),
-        ]
-    )
+    canonical_data = {
+        "release": "asdf",
+        "exception": {"type": "DemoException"},
+        "user": {"id": "DemoUser"},
+    }
 
-    legacy_data = OrderedDict(
-        [
-            ("release", "asdf"),
-            ("sentry.interfaces.Exception", {"type": "DemoException"}),
-            ("sentry.interfaces.User", {"id": "DemoUser"}),
-        ]
-    )
+    legacy_data = {
+        "release": "asdf",
+        "sentry.interfaces.Exception": {"type": "DemoException"},
+        "sentry.interfaces.User": {"id": "DemoUser"},
+    }
 
-    mixed_data = OrderedDict(
-        [
-            ("release", "asdf"),
-            ("sentry.interfaces.User", {"id": "INVALID"}),
-            ("exception", {"type": "DemoException"}),
-            ("user", {"id": "DemoUser"}),
-            ("sentry.interfaces.Exception", {"type": "INVALID"}),
-        ]
-    )
+    mixed_data = {
+        "release": "asdf",
+        "sentry.interfaces.User": {"id": "INVALID"},
+        "exception": {"type": "DemoException"},
+        "user": {"id": "DemoUser"},
+        "sentry.interfaces.Exception": {"type": "INVALID"},
+    }
 
     def test_len(self):
         assert len(CanonicalKeyView(self.canonical_data)) == 3

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -1,5 +1,4 @@
 import unittest
-from collections import OrderedDict
 from functools import partial
 from unittest.mock import Mock, patch
 
@@ -39,8 +38,8 @@ class TrimTest(unittest.TestCase):
     def test_sorted_trim(self):
         # Trim should always trim the keys in alpha order
         # regardless of the original order.
-        alpha = OrderedDict([("a", "12345"), ("z", "12345")])
-        reverse = OrderedDict([("z", "12345"), ("a", "12345")])
+        alpha = {"a": "12345", "z": "12345"}
+        reverse = {"z": "12345", "a": "12345"}
         trm = partial(trim, max_size=12)
         expected = {"a": "12345", "z": "1..."}
 

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -3,7 +3,6 @@ import hashlib
 import itertools
 import logging
 import uuid
-from collections import OrderedDict
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
@@ -215,7 +214,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
 
             return event
 
-        events = OrderedDict()
+        events = {}
 
         for event in (
             create_message_event(


### PR DESCRIPTION
partially automated (especially the fixtures) also via `\(([^]+), (.*)\),$` -> `\1: \2,`