### PR TITLE
ref(profiling): Set sentry context on process profile task

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -50,9 +50,9 @@ def process_profile(
             "organization_id": profile["organization_id"],
             "project_id": profile["project_id"],
             "profile_id": event_id,
-            "platform": profile["platform"],
         },
     )
+    sentry_sdk.set_tag("platform", profile["platform"])
 
     try:
         if _should_symbolicate(profile):


### PR DESCRIPTION
Previously, the sentry context was only being set when we encounter the recursion error. We can set it at the beginning so it's set for all errors for easier debugging.