### PR TITLE
perf(replays): add sampling arg to process_recordings tx

### DIFF
--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+import random
 import time
 from collections import deque
 from concurrent.futures import Future
@@ -177,6 +178,8 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
             with sentry_sdk.start_transaction(
                 op="replays.consumer.process_recording",
                 description="Replay recording segment message received.",
+                sampled=random.random()
+                < getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0),
             ):
                 message_dict = msgpack.unpackb(message.payload.value)
                 self._configure_sentry_scope(message_dict)


### PR DESCRIPTION
if there is no sampled kwarg our sdk settings set the sample rate to 0. add this kwarg w/ the rate controlled by a setting, letting the default be 0 so we can get transactions for our recordings processor.