### PR TITLE
fix(perf-issues): Fix metric name collision

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -322,7 +322,7 @@ def _detect_performance_problems(data: Event, sdk_span: Any) -> List[Performance
 
     truncated_problems = detected_problems[:PERFORMANCE_GROUP_COUNT_LIMIT]
 
-    metrics.incr("performance.performance_issue.detected", len(detected_problems))
+    metrics.incr("performance.performance_issue.pretruncated", len(detected_problems))
     metrics.incr("performance.performance_issue.truncated", len(truncated_problems))
 
     performance_problems = [


### PR DESCRIPTION
It's colliding with another metric of the same name, need to split them so we can better compare between truncated before and after vs. overall detection across all detector types (for detector limits are applied).


