### PR TITLE
chore(org): Set org id for the default internal org

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1260,7 +1260,7 @@ SENTRY_PROJECT_KEY = None
 
 # Default organization to represent the Internal Sentry project.
 # Used as a default when in SINGLE_ORGANIZATION mode.
-SENTRY_ORGANIZATION = None
+SENTRY_ORGANIZATION = 1
 
 # Project ID for recording frontend (javascript) exceptions
 SENTRY_FRONTEND_PROJECT = None

--- a/src/sentry/receivers/core.py
+++ b/src/sentry/receivers/core.py
@@ -69,7 +69,9 @@ def create_default_project(id, name, slug, verbosity=2, **kwargs):
     except IndexError:
         user = None
 
-    org, _ = Organization.objects.get_or_create(slug="sentry", defaults={"name": "Sentry"})
+    org, _ = Organization.objects.get_or_create(
+        slug="sentry", defaults={"name": "Sentry"}, id=getattr(settings, "SENTRY_ORGANIZATION", 1)
+    )
 
     if user:
         OrganizationMember.objects.get_or_create(user=user, organization=org, role="owner")

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -729,7 +729,7 @@ class OrganizationDeleteTest(OrganizationDetailsTestBase):
 
     def test_cannot_remove_default(self):
         Organization.objects.all().delete()
-        org = self.create_organization(owner=self.user)
+        org = self.create_organization(owner=self.user, id=1)
 
         with self.settings(SENTRY_SINGLE_ORGANIZATION=True):
             self.get_error_response(org.slug, status_code=400)

--- a/tests/sentry/receivers/test_core.py
+++ b/tests/sentry/receivers/test_core.py
@@ -31,6 +31,12 @@ class CreateDefaultProjectsTest(TestCase):
         # ensure that we don't hit an error here
         create_default_projects(config)
 
+        # check default org
+        default_org = Organization.get_default()
+        assert default_org.id == 1
+        assert default_org.slug == "sentry"
+        assert default_org.name == "Sentry"
+
     @override_settings(SENTRY_PROJECT=1)
     def test_without_user(self):
         User.objects.filter(is_superuser=True).delete()
@@ -76,3 +82,27 @@ class CreateDefaultProjectsTest(TestCase):
 
             # ensure that we don't hit an error here
             create_default_projects(config)
+
+    @override_settings(SENTRY_PROJECT=1, SENTRY_ORGANIZATION=2022)
+    def test_custom_org_id(self):
+        user, _ = User.objects.get_or_create(is_superuser=True, defaults={"username": "test"})
+        Organization.objects.all().delete()
+        Team.objects.filter(slug="sentry").delete()
+        Project.objects.filter(id=settings.SENTRY_PROJECT).delete()
+        config = apps.get_app_config("sentry")
+
+        create_default_projects(config)
+
+        other_org, _ = Organization.objects.get_or_create(slug="orgslug")
+
+        # check default org
+        default_org = Organization.get_default()
+        assert default_org.id == 2022
+        assert default_org.slug == "sentry"
+        assert default_org.name == "Sentry"
+
+        assert other_org.id > 2022
+        assert other_org.slug == "orgslug"
+
+        # ensure that we don't hit an error here
+        create_default_projects(config)


### PR DESCRIPTION
Before snowflake IDs was introduced, the internal Sentry org was assumed to have an ID of `1`. This assumption is relied upon for both `sentry` and `getsentry`, especially for granting superuser/sudo privileges. 

With snowflake IDs, the internal Sentry org will have an id that is an arbitrarily large positive integer.

Here, I'm changing so that we create the internal Sentry org with the id from `SENTRY_ORGANIZATION` option (which was introduced years ago). And I've updated the `SENTRY_ORGANIZATION` to have a value of `1` by default.
