### PR TITLE
feat(issue-alerts): rule previews for FirstSeenEventCondition

### DIFF
--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -1,0 +1,57 @@
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import region_silo_endpoint
+from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework.rule import RuleSetSerializer
+from sentry.rules.history.endpoints.project_rule_stats import TimeSeriesValueSerializer
+from sentry.rules.history.preview import preview
+from sentry.web.decorators import transaction_start
+
+
+@region_silo_endpoint
+class ProjectRulePreviewEndpoint(ProjectEndpoint):
+    private = True
+    permission_classes = (ProjectAlertRulePermission,)
+
+    @transaction_start("ProjectRulePreviewEndpoint")
+    def get(self, request: Request, project) -> Response:
+        """
+        Get a list of alert triggers in past 2 weeks for given rules
+
+            {method} {path}
+            {{
+                "conditions": [],
+                "filters": [],
+                "actionMatch": "all",
+                "filterMatch": "all",
+                "frequency": 60,
+            }}
+
+        """
+        serializer = RuleSetSerializer(
+            context={"project": project, "organization": project.organization}, data=request.GET
+        )
+
+        if not serializer.is_valid():
+            return Response(exception=ValidationError, status=status.HTTP_400_BAD_REQUEST)
+
+        data = serializer.validated_data
+        results = preview(
+            project,
+            data.get("conditions", []),
+            data.get("filters", []),
+            data.get("actionMatch"),
+            data.get("filterMatch"),
+            data.get("frequency"),
+        )
+
+        if results is None:
+            return Response(
+                exception=ValidationError,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return Response(serialize(results, request.user, TimeSeriesValueSerializer()))

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -1,4 +1,3 @@
-from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -37,7 +36,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
         )
 
         if not serializer.is_valid():
-            return Response(exception=ValidationError, status=status.HTTP_400_BAD_REQUEST)
+            raise ValidationError
 
         data = serializer.validated_data
         results = preview(
@@ -50,8 +49,5 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
         )
 
         if results is None:
-            return Response(
-                exception=ValidationError,
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+            raise ValidationError
         return Response(serialize(results, request.user, TimeSeriesValueSerializer()))

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -1,3 +1,5 @@
+from ast import literal_eval
+
 from rest_framework import serializers
 
 from sentry import features
@@ -19,7 +21,12 @@ class RuleNodeField(serializers.Field):
         return value
 
     def to_internal_value(self, data):
-        if not isinstance(data, dict):
+        if isinstance(data, str):
+            try:
+                data = literal_eval(data)
+            except Exception:
+                raise ValidationError("Failed trying to parse dict from string")
+        elif not isinstance(data, dict):
             msg = "Incorrect type. Expected a mapping, but got %s"
             raise ValidationError(msg % type(data).__name__)
 
@@ -64,53 +71,18 @@ class RuleNodeField(serializers.Field):
         return data
 
 
-class RuleSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=64)
-    environment = serializers.CharField(max_length=64, required=False, allow_null=True)
+class RuleSetSerializer(serializers.Serializer):
+    conditions = ListField(child=RuleNodeField(type="condition/event"), required=False)
+    filters = ListField(child=RuleNodeField(type="filter/event"), required=False)
     actionMatch = serializers.ChoiceField(
         choices=(("all", "all"), ("any", "any"), ("none", "none"))
     )
     filterMatch = serializers.ChoiceField(
         choices=(("all", "all"), ("any", "any"), ("none", "none")), required=False
     )
-    actions = ListField(child=RuleNodeField(type="action/event"), required=False)
-    conditions = ListField(child=RuleNodeField(type="condition/event"), required=False)
-    filters = ListField(child=RuleNodeField(type="filter/event"), required=False)
     frequency = serializers.IntegerField(min_value=5, max_value=60 * 24 * 30)
-    owner = ActorField(required=False, allow_null=True)
-
-    def validate_environment(self, environment):
-        if environment is None:
-            return environment
-
-        try:
-            environment = Environment.get_for_organization_id(
-                self.context["project"].organization_id, environment
-            ).id
-        except Environment.DoesNotExist:
-            raise serializers.ValidationError("This environment has not been created.")
-
-        return environment
 
     def validate(self, attrs):
-        # XXX(meredith): For rules that have the Slack integration as an action
-        # we need to check if the channel_id needs to be looked up via an async task.
-        # If the "pending_save" attribute is set we want to bubble that up to the
-        # project_rule(_details) endpoints by setting it on attrs
-        actions = attrs.get("actions", tuple())
-        for action in actions:
-            # XXX(colleen): For ticket rules we need to ensure the user has
-            # at least done minimal configuration
-            if action["id"] in TICKET_ACTIONS:
-                if not action.get("dynamic_form_fields"):
-                    raise serializers.ValidationError(
-                        {"actions": "Must configure issue link settings."}
-                    )
-            # remove this attribute because we don't want it to be saved in the rule
-            if action.pop("pending_save", None):
-                attrs["pending_save"] = True
-                break
-
         # ensure that if filters are passed in that a filterMatch is also supplied
         filters = attrs.get("filters")
         if filters:
@@ -146,6 +118,47 @@ class RuleSerializer(serializers.Serializer):
             )
 
         return attrs
+
+
+class RuleSerializer(RuleSetSerializer):
+    name = serializers.CharField(max_length=64)
+    environment = serializers.CharField(max_length=64, required=False, allow_null=True)
+    actions = ListField(child=RuleNodeField(type="action/event"), required=False)
+    owner = ActorField(required=False, allow_null=True)
+
+    def validate_environment(self, environment):
+        if environment is None:
+            return environment
+
+        try:
+            environment = Environment.get_for_organization_id(
+                self.context["project"].organization_id, environment
+            ).id
+        except Environment.DoesNotExist:
+            raise serializers.ValidationError("This environment has not been created.")
+
+        return environment
+
+    def validate(self, attrs):
+        # XXX(meredith): For rules that have the Slack integration as an action
+        # we need to check if the channel_id needs to be looked up via an async task.
+        # If the "pending_save" attribute is set we want to bubble that up to the
+        # project_rule(_details) endpoints by setting it on attrs
+        actions = attrs.get("actions", tuple())
+        for action in actions:
+            # XXX(colleen): For ticket rules we need to ensure the user has
+            # at least done minimal configuration
+            if action["id"] in TICKET_ACTIONS:
+                if not action.get("dynamic_form_fields"):
+                    raise serializers.ValidationError(
+                        {"actions": "Must configure issue link settings."}
+                    )
+            # remove this attribute because we don't want it to be saved in the rule
+            if action.pop("pending_save", None):
+                attrs["pending_save"] = True
+                break
+
+        return super().validate(attrs)
 
     def save(self, rule):
         rule.project = self.context["project"]

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -1,5 +1,3 @@
-from ast import literal_eval
-
 from rest_framework import serializers
 
 from sentry import features
@@ -8,6 +6,7 @@ from sentry.api.serializers.rest_framework.list import ListField
 from sentry.constants import MIGRATED_CONDITIONS, SENTRY_APP_ACTIONS, TICKET_ACTIONS
 from sentry.models import Environment
 from sentry.rules import rules
+from sentry.utils import json
 
 ValidationError = serializers.ValidationError
 
@@ -23,7 +22,7 @@ class RuleNodeField(serializers.Field):
     def to_internal_value(self, data):
         if isinstance(data, str):
             try:
-                data = literal_eval(data)
+                data = json.loads(data.replace("'", '"'))
             except Exception:
                 raise ValidationError("Failed trying to parse dict from string")
         elif not isinstance(data, dict):

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -424,6 +424,7 @@ from .endpoints.project_releases_token import ProjectReleasesTokenEndpoint
 from .endpoints.project_repo_path_parsing import ProjectRepoPathParsingEndpoint
 from .endpoints.project_reprocessing import ProjectReprocessingEndpoint
 from .endpoints.project_rule_details import ProjectRuleDetailsEndpoint
+from .endpoints.project_rule_preview import ProjectRulePreviewEndpoint
 from .endpoints.project_rule_task_details import ProjectRuleTaskDetailsEndpoint
 from .endpoints.project_rules import ProjectRulesEndpoint
 from .endpoints.project_rules_configuration import ProjectRulesConfigurationEndpoint
@@ -2096,6 +2097,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/$",
                     ProjectRuleDetailsEndpoint.as_view(),
                     name="sentry-api-0-project-rule-details",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/preview$",
+                    ProjectRulePreviewEndpoint.as_view(),
+                    name="sentry-api-0-project-rule-preview",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/rules/(?P<rule_id>[^\/]+)/group-history/$",

--- a/src/sentry/rules/conditions/base.py
+++ b/src/sentry/rules/conditions/base.py
@@ -1,7 +1,10 @@
 import abc
+from datetime import datetime
+from typing import Sequence
 
 from sentry.eventstore.models import Event
 from sentry.rules.base import EventState, RuleBase
+from sentry.types.condition_activity import ConditionActivity
 
 
 class EventCondition(RuleBase, abc.ABC):
@@ -10,3 +13,8 @@ class EventCondition(RuleBase, abc.ABC):
     @abc.abstractmethod
     def passes(self, event: Event, state: EventState) -> bool:
         pass
+
+    def get_activity(
+        self, start: datetime, end: datetime, limit: int
+    ) -> Sequence[ConditionActivity]:
+        raise NotImplementedError

--- a/src/sentry/rules/conditions/first_seen_event.py
+++ b/src/sentry/rules/conditions/first_seen_event.py
@@ -1,6 +1,11 @@
+from datetime import datetime
+from typing import Sequence
+
 from sentry.eventstore.models import Event
+from sentry.models import Group
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
+from sentry.types.condition_activity import ActivityType, ConditionActivity
 
 
 class FirstSeenEventCondition(EventCondition):
@@ -13,3 +18,16 @@ class FirstSeenEventCondition(EventCondition):
             return state.is_new
         else:
             return state.is_new_group_environment
+
+    def get_activity(
+        self, start: datetime, end: datetime, limit: int
+    ) -> Sequence[ConditionActivity]:
+        first_seen = (
+            Group.objects.filter(project=self.project, first_seen__gte=start, first_seen__lt=end)
+            .order_by("-first_seen")[:limit]
+            .values_list("id", "first_seen")
+        )
+        return [
+            ConditionActivity(group_id=g[0], type=ActivityType.CREATE_ISSUE, timestamp=g[1])
+            for g in first_seen
+        ]

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, Dict, Sequence
+
+from django.utils import timezone
+
+from sentry.models import Project
+from sentry.rules import rules
+from sentry.rules.history.base import TimeSeriesValue
+
+PREVIEW_TIME_RANGE = timedelta(weeks=2)
+# limit on number of ConditionActivity's a condition will return
+# if limited, conditions should return the latest activity
+CONDITION_ACTIVITY_LIMIT = 1000
+
+
+def preview(
+    project: Project,
+    conditions: Sequence[Dict[str, Any]],
+    filters: Sequence[Dict[str, Any]],
+    condition_match: str,
+    filter_match: str,
+    frequency_minutes: int,
+) -> Sequence[TimeSeriesValue] | None:
+    end = timezone.now()
+    start = end - PREVIEW_TIME_RANGE
+    hours = get_hourly_bucket(PREVIEW_TIME_RANGE)
+    hourly_buckets = [0] * hours
+
+    # must have at least one condition to filter activity. Filters currently not supported
+    if len(conditions) == 0 or len(filters):
+        return None
+    # all the currently supported conditions are mutually exclusive
+    elif len(conditions) > 1 and condition_match == "all":
+        return [TimeSeriesValue(start + timedelta(hours=i), 0) for i in range(hours)]
+
+    activity_set = set()
+    for condition in conditions:
+        condition_cls = rules.get(condition["id"])
+        if condition_cls is None:
+            return None
+        # instantiates a EventCondition subclass and retrieves activities related to it
+        condition_inst = condition_cls(project, data=condition)
+        try:
+            activity_set.update(condition_inst.get_activity(start, end, CONDITION_ACTIVITY_LIMIT))
+        except NotImplementedError:
+            return None
+
+    k = lambda a: a.timestamp
+    activity = sorted(list(activity_set), key=k)
+
+    frequency = timedelta(minutes=frequency_minutes)
+    last_fire = start - frequency
+    # TODO: maintain each group's rolling status while going through the activities
+    # reappearance and regression will both consider UNRESOLVED activity,
+    # but it depends on the previous status which one will trigger
+    for event in activity:
+        # TODO: check conditions and filters to see if event passes, not needed for just FirstSeenEventCondition
+        if last_fire <= event.timestamp - frequency:
+            hourly_buckets[get_hourly_bucket(event.timestamp - start)] += 1
+            last_fire = event.timestamp
+
+    times_series_buckets = [
+        TimeSeriesValue(start + timedelta(hours=i), count) for i, count in enumerate(hourly_buckets)
+    ]
+
+    return times_series_buckets
+
+
+def get_hourly_bucket(time: timedelta) -> int:
+    return time.days * 24 + time.seconds // (60 * 60)

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -35,7 +35,7 @@ def preview(
     elif len(conditions) > 1 and condition_match == "all":
         return [TimeSeriesValue(start + timedelta(hours=i), 0) for i in range(hours)]
 
-    activity_set = set()
+    activity = []
     for condition in conditions:
         condition_cls = rules.get(condition["id"])
         if condition_cls is None:
@@ -43,12 +43,12 @@ def preview(
         # instantiates a EventCondition subclass and retrieves activities related to it
         condition_inst = condition_cls(project, data=condition)
         try:
-            activity_set.update(condition_inst.get_activity(start, end, CONDITION_ACTIVITY_LIMIT))
+            activity.extend(condition_inst.get_activity(start, end, CONDITION_ACTIVITY_LIMIT))
         except NotImplementedError:
             return None
 
     k = lambda a: a.timestamp
-    activity = sorted(list(activity_set), key=k)
+    activity.sort(key=k)
 
     frequency = timedelta(minutes=frequency_minutes)
     last_fire = start - frequency

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -52,9 +52,6 @@ def preview(
 
     frequency = timedelta(minutes=frequency_minutes)
     last_fire = start - frequency
-    # TODO: maintain each group's rolling status while going through the activities
-    # reappearance and regression will both consider UNRESOLVED activity,
-    # but it depends on the previous status which one will trigger
     for event in activity:
         # TODO: check conditions and filters to see if event passes, not needed for just FirstSeenEventCondition
         if last_fire <= event.timestamp - frequency:

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict
+
+
+class ActivityType(Enum):
+    CREATE_ISSUE = 0
+
+
+@dataclass(frozen=True)
+class ConditionActivity:
+    group_id: str
+    # potentially can have multiple types if even more conditions are supported
+    type: ActivityType
+    timestamp: datetime
+    data: Dict[str, Any] | None = None

--- a/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
@@ -1,0 +1,62 @@
+from datetime import timedelta
+
+from django.utils import timezone
+from freezegun import freeze_time
+
+from sentry.models import Group
+from sentry.testutils import APITestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@freeze_time()
+@region_silo_test
+class ProjectRulePreviewEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-project-rule-preview"
+
+    def setUp(self):
+        self.login_as(self.user)
+
+    def test(self):
+        Group.objects.create(project=self.project, first_seen=timezone.now() - timedelta(hours=1))
+        resp = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            conditions=[{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}],
+            filters=[],
+            actionMatch="any",
+            filterMatch="all",
+            frequency=10,
+        )
+        assert resp.data[-1]["count"] == 1
+
+    def test_invalid_conditions(self):
+        conditions = [
+            [],
+            [{"id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition"}],
+        ]
+        for invalid_condition in conditions:
+            resp = self.get_response(
+                self.organization.slug,
+                self.project.slug,
+                conditions=invalid_condition,
+                filters=[],
+                actionMatch="any",
+                filterMatch="all",
+                frequency=10,
+            )
+            assert resp.status_code == 400
+
+    def test_invalid_filters(self):
+        # No filters are currently supported
+        invalid_filter = [{"id": "anything"}]
+        condition = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
+        resp = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            conditions=condition,
+            filters=invalid_filter,
+            actionMatch="any",
+            filterMatch="all",
+            frequency=10,
+        )
+        assert resp.status_code == 400

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -1,0 +1,71 @@
+from datetime import timedelta
+
+from django.utils import timezone
+from freezegun import freeze_time
+
+from sentry.models import Group
+from sentry.rules.history.preview import PREVIEW_TIME_RANGE, get_hourly_bucket, preview
+from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@freeze_time()
+@region_silo_test
+class ProjectRulePreviewTest(TestCase):
+    def set_up(self):
+        hours = get_hourly_bucket(PREVIEW_TIME_RANGE)
+        for i in range(hours):
+            for j in range(i % 5):
+                Group.objects.create(
+                    project=self.project, first_seen=timezone.now() - timedelta(hours=i + 1)
+                )
+        return hours
+
+    def test_first_seen(self):
+        hours = self.set_up()
+        conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
+
+        result = preview(self.project, conditions, [], "all", "all", 0)
+        for i in range(hours):
+            assert result[hours - i - 1].count == i % 5
+
+        result = preview(self.project, conditions, [], "all", "all", 60)
+        for i in range(hours):
+            assert result[i].count == (1 if i % 5 else 0)
+
+    def test_unsupported_conditions(self):
+        self.set_up()
+        # conditions with no immediate plan to support
+        unsupported_conditions = [
+            "sentry.rules.conditions.tagged_event.TaggedEventCondition",
+            "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+            "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition",
+            "sentry.rules.conditions.event_attribute.EventAttributeCondition",
+            "sentry.rules.conditions.level.LevelCondition",
+        ]
+        for condition in unsupported_conditions:
+            result = preview(self.project, [{"id": condition}], [], "all", "all", 60)
+            assert result is None
+
+        # empty condition
+        assert None is preview(self.project, [], [], "all", "all", 60)
+        # filters
+        assert None is preview(
+            self.project,
+            [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}],
+            [{"id": "anything"}],
+            "all",
+            "all",
+            60,
+        )
+
+    def test_mutually_exclusive_conditions(self):
+        mutually_exclusive = [
+            {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+            {"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"},
+            {"id": "sentry.rules.conditions.regression_event.ReappearedEventCondition"},
+        ]
+
+        result = preview(self.project, mutually_exclusive, [], "all", "all", 60)
+        for bucket in result:
+            assert bucket.count == 0


### PR DESCRIPTION
Adds an endpoint for creating rule previews for rules, only supporting `FirstSeenEventCondition` right now.  

Looks for issues that are created at most 2 weeks ago, and returns a list containing hourly bucket counts to be graphically displayed on the frontend.

Support for other conditions and filters will also be later added.

