### PR TITLE
feat(perf_issues): Update `_capture_stats` usage to work with different issue types in post_process

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -10,6 +10,7 @@ from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task
 from sentry.types.activity import ActivityType
+from sentry.types.issues import GroupCategory
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.event_frames import get_sdk_name
@@ -74,29 +75,40 @@ def _should_send_error_created_hooks(project):
     return result
 
 
-def _capture_stats(job: PostProcessJob) -> None:
-    event, is_new = job["event"], job["group_state"]["is_new"]
-    # TODO(dcramer): limit platforms to... something?
+def should_write_event_stats(event: Event):
+    # For now, we only want to write these stats for error events. If we start writing them for
+    # other event types we'll throw off existing stats and potentially cause various alerts to fire.
+    # We might decide to write these stats for other event types later, either under different keys
+    # or with differentiating tags.
+    return event.group.issue_category == GroupCategory.Error and event.group.platform is not None
+
+
+def format_event_platform(event: Event):
     platform = event.group.platform
     if not platform:
         return
-    platform = platform.split("-", 1)[0].split("_", 1)[0]
+    return platform.split("-", 1)[0].split("_", 1)[0]
+
+
+def _capture_event_stats(event: Event) -> None:
+    if not should_write_event_stats(event):
+        return
+
+    platform = format_event_platform(event)
     tags = {"platform": platform}
-
-    if is_new:
-        metrics.incr("events.unique", tags=tags, skip_internal=False)
-
-    metrics.incr("events.processed", tags=tags, skip_internal=False)
+    metrics.incr("events.processed", tags={"platform": platform}, skip_internal=False)
     metrics.incr(f"events.processed.{platform}", skip_internal=False)
     metrics.timing("events.size.data", event.size, tags=tags)
 
-    # This is an experiment to understand whether we have, in production,
-    # mismatches between event and group before we permanently rely on events
-    # for the platform. before adding some more verbose logging on this
-    # case, using a stats will give us a sense of the magnitude of the problem.
-    if event.group:
-        if event.group.platform != event.platform:
-            metrics.incr("events.platform_mismatch", tags=tags)
+
+def _capture_group_stats(job: PostProcessJob) -> None:
+    event = (job["event"],)
+    if not job["group_state"]["is_new"] or not should_write_event_stats(event):
+        return
+
+    platform = format_event_platform(event)
+    tags = {"platform": platform}
+    metrics.incr("events.unique", tags=tags, skip_internal=False)
 
 
 def handle_owner_assignment(job):
@@ -384,6 +396,8 @@ def post_process_group(
             return
 
         update_event_group(event)
+        _capture_event_stats(event)
+
         bind_organization_context(event.project.organization)
 
         for group_state in group_states:
@@ -394,7 +408,7 @@ def post_process_group(
                 "has_reappeared": not group_state["is_new"],
             }
 
-            _capture_stats(job)
+            _capture_group_stats(job)
             process_snoozes(job)
             process_inbox_adds(job)
             handle_owner_assignment(job)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -82,7 +82,7 @@ def should_write_event_stats(event: Event):
     # other event types we'll throw off existing stats and potentially cause various alerts to fire.
     # We might decide to write these stats for other event types later, either under different keys
     # or with differentiating tags.
-    return event.group.issue_category == GroupCategory.Error and event.group.platform is not None
+    return event.group.issue_category == GroupCategory.ERROR and event.group.platform is not None
 
 
 def format_event_platform(event: Event):
@@ -104,7 +104,7 @@ def _capture_event_stats(event: Event) -> None:
 
 
 def _capture_group_stats(job: PostProcessJob) -> None:
-    event = (job["event"],)
+    event = job["event"]
     if not job["group_state"]["is_new"] or not should_write_event_stats(event):
         return
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING, Optional, TypedDict
 
@@ -30,8 +32,8 @@ locks = LockManager(build_instance_from_options(settings.SENTRY_POST_PROCESS_LOC
 
 
 class PostProcessJob(TypedDict, total=False):
-    event: "Event"
-    group_state: "GroupState"
+    event: Event
+    group_state: GroupState
     is_reprocessed: bool
     has_reappeared: bool
     has_alert: bool
@@ -429,7 +431,7 @@ def post_process_group(
                 )
 
 
-def process_event(data: dict, group_id: Optional[int]) -> "Event":
+def process_event(data: dict, group_id: Optional[int]) -> Event:
     from sentry.eventstore.models import Event
     from sentry.models import EventDict
 
@@ -446,7 +448,7 @@ def process_event(data: dict, group_id: Optional[int]) -> "Event":
     return event
 
 
-def update_event_group(event: "Event") -> None:
+def update_event_group(event: Event) -> None:
     # NOTE: we must pass through the full Event object, and not an
     # event_id since the Event object may not actually have been stored
     # in the database due to sampling.


### PR DESCRIPTION
`_capture_stats` writes metrics to datadog about error events. For now, we don't want to start writing these metrics for transactions, since it will throw off existing stats.

Split this function up into two pieces - event specific and group specific. This allows us to avoid inadvertently logging event level stats multiple times if an event has multiple groups. Doesn't matter in practice, since at the moment we'll only log for errors anyway, but this will help us avoid unintentional mistakes in the future.
