### PR TITLE
feat(issues) add ability to filter attachments by event_ids

### DIFF
--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -40,7 +40,14 @@ class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
         ):
             return self.respond(status=404)
 
-        attachments = EventAttachment.objects.filter(group_id=group.id)
+        event_ids = request.GET.get("event_ids")
+
+        if event_ids is not None:
+            attachments = EventAttachment.objects.filter(
+                group_id=group.id, event_id__in=event_ids.split(",")
+            )
+        else:
+            attachments = EventAttachment.objects.filter(group_id=group.id)
 
         types = request.GET.getlist("types") or ()
         if types:

--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -40,18 +40,14 @@ class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
         ):
             return self.respond(status=404)
 
-        event_ids = request.GET.get("event_ids")
-
-        if event_ids is not None:
-            attachments = EventAttachment.objects.filter(
-                group_id=group.id, event_id__in=event_ids.split(",")
-            )
-        else:
-            attachments = EventAttachment.objects.filter(group_id=group.id)
+        attachments = EventAttachment.objects.filter(group_id=group.id)
 
         types = request.GET.getlist("types") or ()
+        event_ids = request.GET.get("event_ids")
         if types:
             attachments = attachments.filter(type__in=types)
+        if event_ids is not None:
+            attachments = attachments.filter(event_id__in=event_ids.split(","))
 
         return self.paginate(
             default_per_page=20,

--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -43,11 +43,11 @@ class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
         attachments = EventAttachment.objects.filter(group_id=group.id)
 
         types = request.GET.getlist("types") or ()
-        event_ids = request.GET.get("event_ids")
+        event_ids = request.GET.getlist("event_id") or ()
         if types:
             attachments = attachments.filter(type__in=types)
-        if event_ids is not None:
-            attachments = attachments.filter(event_id__in=event_ids.split(","))
+        if event_ids:
+            attachments = attachments.filter(event_id__in=event_ids)
 
         return self.paginate(
             default_per_page=20,

--- a/tests/sentry/api/endpoints/test_group_attachments.py
+++ b/tests/sentry/api/endpoints/test_group_attachments.py
@@ -8,7 +8,7 @@ from sentry.testutils.silo import region_silo_test
 
 @region_silo_test
 class GroupEventAttachmentsTest(APITestCase):
-    def create_attachment(self, type=None):
+    def create_attachment(self, type=None, event_id=None):
         if type is None:
             type = "event.attachment"
 
@@ -16,7 +16,7 @@ class GroupEventAttachmentsTest(APITestCase):
         self.file.putfile(BytesIO(b"File contents here"))
 
         self.attachment = EventAttachment.objects.create(
-            event_id=self.event.event_id,
+            event_id=event_id or self.event.event_id,
             project_id=self.event.project_id,
             group_id=self.group.id,
             file_id=self.file.id,
@@ -26,12 +26,15 @@ class GroupEventAttachmentsTest(APITestCase):
 
         return self.attachment
 
-    def path(self, types=None):
+    def path(self, types=None, event_ids=None):
         path = f"/api/0/issues/{self.group.id}/attachments/"
 
         query = [("types", t) for t in types or ()]
         if query:
             path += "?" + urlencode(query)
+
+        if event_ids:
+            path += "?event_ids=" + event_ids
 
         return path
 
@@ -68,3 +71,15 @@ class GroupEventAttachmentsTest(APITestCase):
             response = self.client.get(self.path())
 
         assert response.status_code == 404, response.content
+
+    def test_event_id_filter(self):
+        self.login_as(user=self.user)
+        attachment = self.create_attachment()
+        self.create_attachment(event_id="b" * 32)
+
+        with self.feature("organizations:event-attachments"):
+            response = self.client.get(self.path(event_ids=attachment.event_id))
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["event_id"] == attachment.event_id

--- a/tests/sentry/api/endpoints/test_group_attachments.py
+++ b/tests/sentry/api/endpoints/test_group_attachments.py
@@ -31,10 +31,11 @@ class GroupEventAttachmentsTest(APITestCase):
 
         typesQuery = [("types", t) for t in types or ()]
         eventIdQuery = [("event_id", id) for id in event_ids or ()]
-        if typesQuery:
+        if typesQuery and eventIdQuery:
+            path += "?" + urlencode(typesQuery) + "&" + urlencode(eventIdQuery)
+        elif typesQuery:
             path += "?" + urlencode(typesQuery)
-
-        if eventIdQuery:
+        elif eventIdQuery:
             path += "?" + urlencode(eventIdQuery)
 
         return path


### PR DESCRIPTION
Adds a query param so that you can filter attachments within an issue by event ids.
Required for the new all events tab, which will show attachments associated to each event, in the events tab.