### PR TITLE
ref(tests): Replace more usages of mock django timezone with freezegun

### DIFF
--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -1,10 +1,10 @@
 import copy
-from datetime import timedelta
-from unittest.mock import patch
+from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
 import pytest
 import pytz
+from freezegun import freeze_time
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
@@ -182,10 +182,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - all events query - empty state - no tags")
 
-    @patch("django.utils.timezone.now")
-    def test_all_events_query(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
-        mock_now.return_value = now
+    @freeze_time()
+    def test_all_events_query(self):
+        now = datetime.now(pytz.utc)
         five_mins_ago = iso_format(now - timedelta(minutes=5))
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
         self.store_event(
@@ -243,10 +242,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
                 "events-v2 - errors query - empty state - querybuilder - column edit state"
             )
 
-    @patch("django.utils.timezone.now")
-    def test_errors_query(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
-        mock_now.return_value = now
+    @freeze_time()
+    def test_errors_query(self):
+        now = datetime.now(pytz.utc)
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
         self.store_event(
             data={
@@ -299,10 +297,8 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
             self.browser.snapshot("events-v2 - transactions query - empty state - no tags")
 
-    @patch("django.utils.timezone.now")
-    def test_transactions_query(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_transactions_query(self):
         event_data = generate_transaction()
 
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
@@ -315,10 +311,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             )
             self.browser.snapshot("events-v2 - transactions query - list")
 
-    @patch("django.utils.timezone.now")
-    def test_event_detail_view_from_all_events(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
-        mock_now.return_value = now
+    @freeze_time()
+    def test_event_detail_view_from_all_events(self):
+        now = datetime.now(pytz.utc)
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
 
         event_data = load_data("python")
@@ -353,10 +348,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
             self.browser.snapshot("events-v2 - single error details view")
 
-    @patch("django.utils.timezone.now")
-    def test_event_detail_view_from_errors_view(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
-        mock_now.return_value = now
+    @freeze_time()
+    def test_event_detail_view_from_errors_view(self):
+        now = datetime.now(pytz.utc)
 
         event_data = load_data("javascript")
         event_data.update(
@@ -389,10 +383,10 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
 
             self.browser.snapshot("events-v2 - error event detail view")
 
-    @patch("django.utils.timezone.now")
-    def test_event_detail_view_from_transactions_query(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_event_detail_view_from_transactions_query(
+        self,
+    ):
         event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
 
@@ -438,10 +432,8 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.click(child_button)
             self.wait_until_loaded()
 
-    @patch("django.utils.timezone.now")
-    def test_event_detail_view_from_transactions_query_siblings(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_event_detail_view_from_transactions_query_siblings(self):
         event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
 
         # Arranges sibling spans to be autogrouped in a way that will cover many edgecases
@@ -526,10 +518,8 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
                 "events-v2 - transactions event after regrouping expanded sibling auto-grouped spans"
             )
 
-    @patch("django.utils.timezone.now")
-    def test_transaction_event_detail_view_ops_filtering(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_transaction_event_detail_view_ops_filtering(self):
         event_data = generate_transaction(trace="a" * 32, span="ab" * 8)
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
 
@@ -676,10 +666,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             assert DiscoverSavedQuery.objects.filter(name=duplicate_name).exists()
 
     @pytest.mark.skip(reason="causing timeouts in github actions and travis")
-    @patch("django.utils.timezone.now")
-    def test_drilldown_result(self, mock_now):
-        now = before_now().replace(tzinfo=pytz.utc)
-        mock_now.return_value = now
+    @freeze_time()
+    def test_drilldown_result(self):
+        now = datetime.now(pytz.utc)
         ten_mins_ago = iso_format(now - timedelta(minutes=10))
         events = (
             ("a" * 32, "oh no", "group-1"),
@@ -715,10 +704,9 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             assert expected == actual
 
     @pytest.mark.skip(reason="not done")
-    @patch("django.utils.timezone.now")
-    def test_usage(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_usage(self):
+        pass
         # TODO: load events
 
         # go to landing

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -1,9 +1,7 @@
-from datetime import datetime
-from unittest.mock import patch
-
 import pytest
 import pytz
 from django.utils import timezone
+from freezegun import freeze_time
 
 from fixtures.page_objects.issue_details import IssueDetailsPage
 from fixtures.page_objects.issue_list import IssueListPage
@@ -272,8 +270,8 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
             )
 
-    @patch("django.utils.timezone.now")
-    def test_issues_list_to_details_and_back_with_all_projects(self, mock_now):
+    @freeze_time()
+    def test_issues_list_to_details_and_back_with_all_projects(self):
         """
         If user has access to the `global-views` feature, which allows selecting multiple projects,
         they should be able to visit issues list with no project in URL and list issues
@@ -283,7 +281,6 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         "My Projects" in issues list.
         """
         with self.feature("organizations:global-views"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
             self.create_issues()
             self.issues_list.visit_issue_list(self.org.slug)
             self.issues_list.wait_for_issue()
@@ -310,13 +307,12 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
             )
 
-    @patch("django.utils.timezone.now")
-    def test_issues_list_to_details_and_back_with_initial_project(self, mock_now):
+    @freeze_time()
+    def test_issues_list_to_details_and_back_with_initial_project(self):
         """
         If user has a project defined in URL, if they visit an issue and then
         return back to issues list, that project id should still exist in URL
         """
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
         self.create_issues()
         self.issues_list.visit_issue_list(self.org.slug, query=f"?project={self.project_2.id}")
         self.issues_list.wait_for_issue()
@@ -343,14 +339,13 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         assert f"project={self.project_3.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
 
-    @patch("django.utils.timezone.now")
-    def test_issue_details_to_stream_with_initial_env_no_project(self, mock_now):
+    @freeze_time()
+    def test_issue_details_to_stream_with_initial_env_no_project(self):
         """
         Visiting issue details directly with no project but with an environment defined in URL.
         When navigating back to issues stream, should keep environment and project in context.
         """
 
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
         self.create_issues()
         self.issue_details.visit_issue_in_environment(self.org.slug, self.issue_2.group.id, "prod")
 
@@ -371,17 +366,14 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_2.slug
         assert self.issue_details.global_selection.get_selected_environment() == "prod"
 
-    @patch("django.utils.timezone.now")
-    def test_issue_details_to_stream_with_initial_env_no_project_with_multi_project_feature(
-        self, mock_now
-    ):
+    @freeze_time()
+    def test_issue_details_to_stream_with_initial_env_no_project_with_multi_project_feature(self):
         """
         Visiting issue details directly with no project but with an environment defined in URL.
         When navigating back to issues stream, should keep environment and project in context.
         """
 
         with self.feature("organizations:global-views"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
             self.create_issues()
             self.issue_details.visit_issue_in_environment(
                 self.org.slug, self.issue_2.group.id, "prod"

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -1,8 +1,6 @@
-from datetime import datetime
-from unittest.mock import patch
-
 import pytz
 from django.utils import timezone
+from freezegun import freeze_time
 
 from fixtures.page_objects.issue_list import IssueListPage
 from sentry.models import AssistantActivity, GroupInboxReason, GroupStatus
@@ -65,9 +63,8 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
         self.browser.wait_until_test_id("empty-state")
         self.browser.snapshot("organization issues no results")
 
-    @patch("django.utils.timezone.now")
-    def test_with_results(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    @freeze_time()
+    def test_with_results(self):
         self.create_issues()
         self.page.visit_issue_list(self.org.slug)
         self.page.wait_for_stream()
@@ -78,9 +75,8 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
         assert "oh snap" in groups[0].text
         assert "oh no" in groups[1].text
 
-    @patch("django.utils.timezone.now")
-    def test_resolve_issues(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    @freeze_time()
+    def test_resolve_issues(self):
         self.create_issues()
         self.page.visit_issue_list(self.org.slug)
         self.page.wait_for_stream()
@@ -94,9 +90,8 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
         assert len(resolved_groups) == 2
 
-    @patch("django.utils.timezone.now")
-    def test_resolve_issues_removal(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    @freeze_time()
+    def test_resolve_issues_removal(self):
         self.create_issues()
         # TODO(Kelly): update once issue-list-removal-action feature is stable
         with self.feature("organizations:issue-list-removal-action"):
@@ -115,9 +110,8 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
             assert len(groups) == 1
 
-    @patch("django.utils.timezone.now")
-    def test_resolve_issues_multi_projects(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    @freeze_time()
+    def test_resolve_issues_multi_projects(self):
         self.create_issues()
 
         with self.feature("organizations:global-views"):
@@ -133,9 +127,8 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
             assert len(resolved_groups) == 2
 
-    @patch("django.utils.timezone.now")
-    def test_resolve_issues_removal_multi_projects(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    @freeze_time()
+    def test_resolve_issues_removal_multi_projects(self):
         self.create_issues()
 
         # TODO(Kelly): update once issue-list-removal-action feature is stable
@@ -157,11 +150,10 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
             assert len(groups) == 1
 
-    @patch("django.utils.timezone.now")
-    def test_ignore_issues(self, mock_now):
+    @freeze_time()
+    def test_ignore_issues(self):
         # TODO(Kelly): update once issue-list-removal-action feature is stable
         with self.feature("organizations:issue-list-removal-action"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
             self.create_issues()
 
             group1 = self.event_a.group
@@ -179,11 +171,10 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
             assert len(groups) == 1
 
-    @patch("django.utils.timezone.now")
-    def test_ignore_issues_multi_projects(self, mock_now):
+    @freeze_time()
+    def test_ignore_issues_multi_projects(self):
         # TODO(Kelly): update once issue-list-removal-action feature is stable
         with self.feature("organizations:issue-list-removal-action"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
             self.create_issues()
 
             group1 = self.event_a.group
@@ -202,11 +193,10 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
                 assert len(groups) == 1
 
-    @patch("django.utils.timezone.now")
-    def test_delete_issues(self, mock_now):
+    @freeze_time()
+    def test_delete_issues(self):
         # TODO(Kelly): update once issue-list-removal-action feature is stable
         with self.feature("organizations:issue-list-removal-action"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
             self.create_issues()
 
             group1 = self.event_a.group
@@ -224,11 +214,10 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
             assert len(groups) == 1
 
-    @patch("django.utils.timezone.now")
-    def test_delete_issues_multi_projects(self, mock_now):
+    @freeze_time()
+    def test_delete_issues_multi_projects(self):
         # TODO(Kelly): update once issue-list-removal-action feature is stable
         with self.feature("organizations:issue-list-removal-action"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
             self.create_issues()
 
             group1 = self.event_a.group
@@ -247,11 +236,10 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
                 assert len(groups) == 1
 
-    @patch("django.utils.timezone.now")
-    def test_merge_issues(self, mock_now):
+    @freeze_time()
+    def test_merge_issues(self):
         # TODO(Kelly): update once issue-list-removal-action feature is stable
         with self.feature("organizations:issue-list-removal-action"):
-            mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
             self.create_issues()
 
             group1 = self.event_a.group
@@ -272,9 +260,8 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
             assert len(groups) == 1
 
-    @patch("django.utils.timezone.now")
-    def test_inbox_results(self, mock_now):
-        mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
+    @freeze_time()
+    def test_inbox_results(self):
         self.create_issues()
         # Disable for_review_guide
         AssistantActivity.objects.create(user=self.user, guide_id=9, viewed_ts=timezone.now())

--- a/tests/acceptance/test_performance_landing.py
+++ b/tests/acceptance/test_performance_landing.py
@@ -1,7 +1,5 @@
-from unittest.mock import patch
-
-import pytz
 from django.db.models import F
+from freezegun import freeze_time
 
 from fixtures.page_objects.base import BasePage
 from sentry.models import Project
@@ -29,10 +27,8 @@ class PerformanceLandingTest(AcceptanceTestCase, SnubaTestCase):
 
         self.page = BasePage(self.browser)
 
-    @patch("django.utils.timezone.now")
-    def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_with_data(self):
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)
         self.project.update(flags=F("flags").bitor(Project.flags.has_transactions))

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -1,7 +1,5 @@
-from unittest.mock import patch
-
-import pytz
 from django.db.models import F
+from freezegun import freeze_time
 
 from fixtures.page_objects.base import BasePage
 from sentry.models import Project
@@ -29,19 +27,15 @@ class PerformanceOverviewTest(AcceptanceTestCase, SnubaTestCase):
 
         self.page = BasePage(self.browser)
 
-    @patch("django.utils.timezone.now")
-    def test_onboarding(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_onboarding(self):
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)
             self.page.wait_until_loaded()
             self.browser.snapshot("performance overview - onboarding")
 
-    @patch("django.utils.timezone.now")
-    def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_with_data(self):
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)
         self.project.update(flags=F("flags").bitor(Project.flags.has_transactions))

--- a/tests/acceptance/test_performance_span_summary.py
+++ b/tests/acceptance/test_performance_span_summary.py
@@ -1,9 +1,8 @@
 from datetime import timedelta
-from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
-import pytz
+from freezegun import freeze_time
 
 from fixtures.page_objects.base import BasePage
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
@@ -89,10 +88,8 @@ class PerformanceSpanSummaryTest(AcceptanceTestCase, SnubaTestCase):
         return self.store_event(data, project_id=self.project.id)
 
     @pytest.mark.skip(reason="Has been flaky lately.")
-    @patch("django.utils.timezone.now")
-    def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_with_data(self):
         self.create_event()
 
         with self.feature(FEATURES):

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -1,7 +1,6 @@
-from unittest.mock import patch
 from urllib.parse import urlencode
 
-import pytz
+from freezegun import freeze_time
 
 from fixtures.page_objects.transaction_summary import TransactionSummaryPage
 from sentry.models import AssistantActivity
@@ -39,10 +38,8 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
         self.page = TransactionSummaryPage(self.browser)
 
-    @patch("django.utils.timezone.now")
-    def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_with_data(self):
         # Create a transaction
         event = make_event(load_data("transaction", timestamp=before_now(minutes=3)))
         self.store_event(data=event, project_id=self.project.id)
@@ -64,10 +61,8 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
             self.page.wait_until_loaded()
             self.browser.snapshot("performance summary - with data")
 
-    @patch("django.utils.timezone.now")
-    def test_view_details_from_summary(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_view_details_from_summary(self):
         event = make_event(
             load_data(
                 "transaction", timestamp=before_now(minutes=3), trace="a" * 32, span_id="ab" * 8
@@ -84,10 +79,8 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
             self.page.wait_until_loaded()
             self.browser.snapshot("performance event details")
 
-    @patch("django.utils.timezone.now")
-    def test_tags_page(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_tags_page(self):
         tags_path = "/organizations/{}/performance/summary/tags/?{}".format(
             self.org.slug,
             urlencode({"transaction": "/country_by_code/", "project": self.project.id}),
@@ -104,10 +97,8 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
             self.page.wait_until_loaded()
             self.browser.snapshot("transaction summary tags page")
 
-    @patch("django.utils.timezone.now")
-    def test_transaction_vitals(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_transaction_vitals(self):
         vitals_path = "/organizations/{}/performance/summary/vitals/?{}".format(
             self.org.slug,
             urlencode({"transaction": "/country_by_code/", "project": self.project.id}),
@@ -127,10 +118,8 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
             self.browser.snapshot("real user monitoring")
 
-    @patch("django.utils.timezone.now")
-    def test_transaction_vitals_filtering(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_transaction_vitals_filtering(self):
         vitals_path = "/organizations/{}/performance/summary/vitals/?{}".format(
             self.org.slug,
             urlencode(
@@ -191,10 +180,8 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
 
             self.browser.snapshot("real user monitoring - view all data")
 
-    @patch("django.utils.timezone.now")
-    def test_transaction_threshold_modal(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_transaction_threshold_modal(self):
         # Create a transaction
         event = make_event(load_data("transaction", timestamp=before_now(minutes=3)))
         self.store_event(data=event, project_id=self.project.id)

--- a/tests/acceptance/test_performance_trace_detail.py
+++ b/tests/acceptance/test_performance_trace_detail.py
@@ -1,8 +1,7 @@
 from datetime import timedelta
-from unittest.mock import patch
 from uuid import uuid4
 
-import pytz
+from freezegun import freeze_time
 
 from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -187,10 +186,10 @@ class PerformanceTraceDetailTest(AcceptanceTestCase, SnubaTestCase):
             iso_format(before_now(days=1).replace(hour=11, minute=0, second=0, microsecond=0)),
         )
 
-    @patch("django.utils.timezone.now")
-    def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_with_data(
+        self,
+    ):
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')

--- a/tests/acceptance/test_performance_trends.py
+++ b/tests/acceptance/test_performance_trends.py
@@ -1,8 +1,7 @@
-from unittest.mock import patch
 from urllib.parse import urlencode
 
-import pytz
 from django.db.models import F
+from freezegun import freeze_time
 
 from fixtures.page_objects.base import BasePage
 from sentry.models import Project
@@ -55,9 +54,10 @@ class PerformanceTrendsTest(AcceptanceTestCase, SnubaTestCase):
 
         self.page = BasePage(self.browser)
 
-    @patch("django.utils.timezone.now")
-    def test_with_data(self, mock_now):
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
+    @freeze_time()
+    def test_with_data(
+        self,
+    ):
         values = range(1, 100, 5)
 
         self.make_trend("improvement", [v for v in reversed(values)])

--- a/tests/acceptance/test_performance_vital_detail.py
+++ b/tests/acceptance/test_performance_vital_detail.py
@@ -1,8 +1,7 @@
-from unittest.mock import patch
 from urllib.parse import urlencode
 
-import pytz
 from django.db.models import F
+from freezegun import freeze_time
 
 from fixtures.page_objects.base import BasePage
 from sentry.models import Project
@@ -30,11 +29,8 @@ class PerformanceVitalDetailsTest(AcceptanceTestCase, SnubaTestCase):
 
         self.page = BasePage(self.browser)
 
-    @patch("django.utils.timezone.now")
-    def test_with_data(self, mock_now):
-
-        mock_now.return_value = before_now().replace(tzinfo=pytz.utc)
-
+    @freeze_time()
+    def test_with_data(self):
         event = load_data("transaction", timestamp=before_now(minutes=10))
         self.store_event(data=event, project_id=self.project.id)
         self.project.update(flags=F("flags").bitor(Project.flags.has_transactions))

--- a/tests/sentry/utils/test_request_cache.py
+++ b/tests/sentry/utils/test_request_cache.py
@@ -1,19 +1,39 @@
-from unittest.mock import patch
-
 from django.core.handlers.wsgi import WSGIHandler
 from django.core.signals import request_finished
 from django.http import HttpRequest
-from django.utils import timezone
+from freezegun import freeze_time
 
 from sentry import app
 from sentry.testutils import TestCase
 from sentry.utils.request_cache import clear_cache, request_cache
 
 
+class CountCalls:
+    def __init__(self, func):
+        self._count = 0
+        self._func = func
+
+    def __call__(self, *args, **kwargs):
+        self._count += 1
+        return self._func(*args, **kwargs)
+
+    @property
+    def call_count(self):
+        return self._count
+
+    def reset_count(self):
+        self._count = 0
+
+
+@CountCalls
+def some_func():
+    pass
+
+
 @request_cache
 def cached_fn(arg1, arg2=None):
-    # call this so we can mock it and see how often it's called
-    timezone.now()
+    # call this so we can see how often it's called
+    some_func()
     if arg2:
         return arg1 + arg2
     return arg1
@@ -31,49 +51,50 @@ class RequestCacheTest(TestCase):
         app.env.request = None
         request_finished.send(sender=WSGIHandler)
         request_finished.receivers = self.original_receivers
+        some_func.reset_count()
         super().tearDown()
 
-    @patch("django.utils.timezone.now")
-    def test_basic_cache(self, mock_now):
+    @freeze_time()
+    def test_basic_cache(self):
         app.env.request = HttpRequest()
         assert cached_fn("cat", arg2="dog") == "catdog"
         assert cached_fn("cat", arg2="dog") == "catdog"
-        assert mock_now.call_count == 1
+        assert some_func.call_count == 1
 
-    @patch("django.utils.timezone.now")
-    def test_cache_none(self, mock_now):
+    @freeze_time()
+    def test_cache_none(self):
         app.env.request = HttpRequest()
         assert cached_fn(None) is None
         assert cached_fn(None) is None
-        assert mock_now.call_count == 1
+        assert some_func.call_count == 1
 
-    @patch("django.utils.timezone.now")
-    def test_different_args(self, mock_now):
+    @freeze_time()
+    def test_different_args(self):
         app.env.request = HttpRequest()
         assert cached_fn("cat", arg2="dog") == "catdog"
         assert cached_fn("hey", arg2="dog") == "heydog"
-        assert mock_now.call_count == 2
+        assert some_func.call_count == 2
 
-    @patch("django.utils.timezone.now")
-    def test_different_kwargs(self, mock_now):
+    @freeze_time()
+    def test_different_kwargs(self):
         app.env.request = HttpRequest()
         assert cached_fn("cat", arg2="dog") == "catdog"
         assert cached_fn("cat", arg2="hat") == "cathat"
-        assert mock_now.call_count == 2
+        assert some_func.call_count == 2
 
-    @patch("django.utils.timezone.now")
-    def test_different_request(self, mock_now):
+    @freeze_time()
+    def test_different_request(self):
         app.env.request = HttpRequest()
         assert cached_fn("cat") == "cat"
         request_finished.send(sender=WSGIHandler)
         app.env.request = HttpRequest()
         assert cached_fn("cat") == "cat"
-        assert mock_now.call_count == 2
+        assert some_func.call_count == 2
 
-    @patch("django.utils.timezone.now")
-    def test_request_over(self, mock_now):
+    @freeze_time()
+    def test_request_over(self):
         app.env.request = HttpRequest()
         assert cached_fn("cat") == "cat"
         app.env.request = None
         assert cached_fn("cat") == "cat"
-        assert mock_now.call_count == 2
+        assert some_func.call_count == 2


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/39321/ in which I replace the remaining usages of mock django timezone. 