### PR TITLE
fix(sampling): Fix tooltip content overflowing in breakdown chart - [TET-425]

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingBreakdown.tsx
@@ -50,7 +50,7 @@ export function SamplingBreakdown({orgSlug}: Props) {
   function projectWithPercentage(project: Project, percentage: number) {
     return (
       <ProjectWithPercentage key={project.slug}>
-        <ProjectBadge project={project} avatarSize={16} />
+        <StyledProjectBadge project={project} avatarSize={16} />
         {formatPercentage(percentage / 100)}
       </ProjectWithPercentage>
     );
@@ -139,7 +139,8 @@ const Projects = styled('div')`
 `;
 
 const ProjectWithPercentage = styled('div')`
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr max-content;
   align-items: center;
   gap: ${space(0.5)};
   color: ${p => p.theme.subText};
@@ -150,4 +151,9 @@ const EmptyMessage = styled('div')`
   align-items: center;
   min-height: 25px;
   color: ${p => p.theme.subText};
+`;
+
+const StyledProjectBadge = styled(ProjectBadge)`
+  max-width: 100%;
+  overflow: hidden;
 `;


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/29228205/194254989-5bf45cb2-aa5e-4622-a478-566273ed7297.png)

**After:**

![Screenshot 2022-10-06 at 09 58 43](https://user-images.githubusercontent.com/29228205/194254381-dbdba08d-5fd7-442b-8ed8-26d18ab5a1f7.png)
