### PR TITLE
fix(metrics): Fix flaky test [TET-387]

### DIFF
--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -544,6 +544,7 @@ def compare_results(
     path: Optional[str] = None,
     schema: Optional[Schema] = None,
 ) -> List[ComparisonError]:
+    return [ComparisonError(f"unmatched field at path {path}, sessions=None, metrics={metrics}")]
     if path is None:
         path = ""
 

--- a/src/sentry/release_health/duplex.py
+++ b/src/sentry/release_health/duplex.py
@@ -544,7 +544,6 @@ def compare_results(
     path: Optional[str] = None,
     schema: Optional[Schema] = None,
 ) -> List[ComparisonError]:
-    return [ComparisonError(f"unmatched field at path {path}, sessions=None, metrics={metrics}")]
     if path is None:
         path = ""
 

--- a/tests/sentry/release_health/test_metrics_sessions_v2.py
+++ b/tests/sentry/release_health/test_metrics_sessions_v2.py
@@ -69,7 +69,9 @@ class MetricsSessionsV2Test(APITestCase, SnubaTestCase):
         sessions data is the same as in the sessions implementation.
 
         """
-        interval_days = "1d"
+        interval_days_int = 1
+        interval_days = f"{interval_days_int}d"
+
         groupbyes = _session_groupby_powerset()
 
         for groupby in groupbyes:
@@ -88,7 +90,7 @@ class MetricsSessionsV2Test(APITestCase, SnubaTestCase):
             errors = compare_results(
                 sessions=sessions_data,
                 metrics=metrics_data,
-                rollup=interval_days * 24 * 60 * 60,  # days to seconds
+                rollup=interval_days_int * 24 * 60 * 60,  # days to seconds
             )
             assert len(errors) == 0
 

--- a/tests/sentry/release_health/test_metrics_sessions_v2.py
+++ b/tests/sentry/release_health/test_metrics_sessions_v2.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
+from freezegun import freeze_time
 from snuba_sdk import Column, Condition, Function, Op
 
 from sentry.release_health.duplex import compare_results
@@ -20,6 +21,7 @@ from tests.snuba.api.endpoints.test_organization_sessions import result_sorted
 pytestmark = pytest.mark.sentry_metrics
 
 
+@freeze_time("2022-09-29 10:00:00")
 class MetricsSessionsV2Test(APITestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
@@ -61,7 +63,6 @@ class MetricsSessionsV2Test(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         return response.data
 
-    @pytest.mark.skip(reason="flaky: INGEST-1610")
     def test_sessions_metrics_equal_num_keys(self):
         """
         Tests whether the number of keys in the metrics implementation of


### PR DESCRIPTION
This PR aims at fixing the flakiness reproduced [here](https://sentry.io/organizations/sentry/issues/3070580114/?project=2423079&query=is:unresolved+test_sessions_metrics_equal_num_keys&statsPeriod=14d). 