### PR TITLE
fix(auth): Make pipeline backed by redis store more bulletproof

### DIFF
--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -128,7 +128,11 @@ class Pipeline(abc.ABC):
         return views
 
     def is_valid(self) -> bool:
-        _is_valid: bool = self.state.is_valid() and self.state.signature == self.signature
+        _is_valid: bool = (
+            self.state.is_valid()
+            and self.state.signature == self.signature
+            and self.state.step_index is not None
+        )
         return _is_valid
 
     def initialize(self) -> None:


### PR DESCRIPTION


Fixes SENTRY-TNN - [see issue](https://sentry.io/organizations/sentry/issues/3170382105/events/11eca139a8d448efbf0bffdd53e6225c/?project=1)
Fixes SENTRY-W68 - [see issue](https://sentry.io/organizations/sentry/issues/3649042073/events/a99ed16058ce497db7a1b9c817522ce0/?project=1)

The `step_index` state backed by the redis store may be `None`. This could lead to issues since the pipeline cannot advance properly.


I'm patching the pipeline to bail out early by having `is_valid()` return `False` whenever `step_index` is invalid.