### PR TITLE
chore(attachments): Use attachment fixture

### DIFF
--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -24,13 +24,7 @@ class CreateAttachmentMixin:
         self.file = File.objects.create(name="hello.png", type="image/png; foo=bar")
         self.file.putfile(BytesIO(b"File contents here"))
 
-        self.attachment = EventAttachment.objects.create(
-            event_id=self.event.event_id,
-            project_id=self.event.project_id,
-            file_id=self.file.id,
-            type=self.file.type,
-            name="hello.png",
-        )
+        self.attachment = self.create_event_attachment(file=self.file, name="hello.png")
         assert self.attachment.mimetype == "image/png"
 
         return self.attachment

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -1,4 +1,4 @@
-from sentry.models import EventAttachment, File
+from sentry.models import File
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -17,20 +17,13 @@ class EventAttachmentsTest(APITestCase):
             data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=self.project.id
         )
 
-        attachment1 = EventAttachment.objects.create(
-            event_id=event1.event_id,
-            project_id=event1.project_id,
-            file_id=File.objects.create(name="hello.png", type="image/png").id,
+        attachment1 = self.create_event_attachment(
+            event=event1,
+            file=File.objects.create(name="hello.png", type="image/png"),
             name="hello.png",
         )
         file = File.objects.create(name="hello.png", type="image/png")
-        EventAttachment.objects.create(
-            event_id=event2.event_id,
-            project_id=event2.project_id,
-            file_id=file.id,
-            type=file.type,
-            name="hello.png",
-        )
+        self.create_event_attachment(event=event2, file=file, name="hello.png")
 
         path = f"/api/0/projects/{event1.project.organization.slug}/{event1.project.slug}/events/{event1.event_id}/attachments/"
 
@@ -50,18 +43,14 @@ class EventAttachmentsTest(APITestCase):
             data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=self.project.id
         )
 
-        attachment1 = EventAttachment.objects.create(
-            event_id=event1.event_id,
-            project_id=event1.project_id,
-            file_id=File.objects.create(name="screenshot.png", type="image/png").id,
+        attachment1 = self.create_event_attachment(
+            event=event1,
+            file=File.objects.create(name="screenshot.png", type="image/png"),
             name="screenshot.png",
         )
-        file = File.objects.create(name="screenshot-not.png", type="image/png")
-        EventAttachment.objects.create(
-            event_id=event1.event_id,
-            project_id=event1.project_id,
-            file_id=file.id,
-            type=file.type,
+        self.create_event_attachment(
+            event=event1,
+            file=File.objects.create(name="screenshot-not.png", type="image/png"),
             name="screenshot-not.png",
         )
 

--- a/tests/sentry/api/endpoints/test_group_attachments.py
+++ b/tests/sentry/api/endpoints/test_group_attachments.py
@@ -1,29 +1,23 @@
 from io import BytesIO
 from urllib.parse import urlencode
 
-from sentry.models import EventAttachment, File
+from sentry.models import File
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import region_silo_test
 
 
 @region_silo_test
 class GroupEventAttachmentsTest(APITestCase):
-    def create_attachment(self, type=None):
-        if type is None:
-            type = "event.attachment"
+    def create_attachment(self, event_type=None):
+        if event_type is None:
+            event_type = "event.attachment"
 
-        self.file = File.objects.create(name="hello.png", type=type)
+        self.file = File.objects.create(name="hello.png", type=event_type)
         self.file.putfile(BytesIO(b"File contents here"))
 
-        self.attachment = EventAttachment.objects.create(
-            event_id=self.event.event_id,
-            project_id=self.event.project_id,
-            group_id=self.group.id,
-            file_id=self.file.id,
-            type=self.file.type,
-            name="hello.png",
+        self.attachment = self.create_event_attachment(
+            file=self.file, group_id=self.group.id, name="hello.png"
         )
-
         return self.attachment
 
     def path(self, types=None):


### PR DESCRIPTION
- Update the attachment tests to use the attachment fixture instead of directly creating on the EventAttachment model