### PR TITLE
fix(discover): Requesting equations on metrics dataset returns 500

### DIFF
--- a/static/app/views/eventsV2/metricsBaselineContainer.tsx
+++ b/static/app/views/eventsV2/metricsBaselineContainer.tsx
@@ -12,7 +12,7 @@ import {defined} from 'sentry/utils';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {EventsTableData} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
-import {aggregateMultiPlotType} from 'sentry/utils/discover/fields';
+import {aggregateMultiPlotType, isEquation} from 'sentry/utils/discover/fields';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import localStorage from 'sentry/utils/localStorage';
@@ -63,7 +63,8 @@ export function MetricsBaselineContainer({
   const disableProcessedBaselineToggle =
     metricsCardinality.outcome?.forceTransactionsOnly ||
     displayMode !== 'default' ||
-    !usesTransactionsDataset(eventView, yAxis);
+    !usesTransactionsDataset(eventView, yAxis) ||
+    yAxis.some(isEquation);
 
   const apiPayload = eventView.getEventsAPIPayload(location);
   apiPayload.query = '';


### PR DESCRIPTION
Don't make the metrics request if y axis has equations.

Fixes SENTRY-W2E