### PR TITLE
test(replays): Add test for Tag Panel component

### DIFF
--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
 
+import EmptyMessage from 'sentry/components/emptyMessage';
 import {KeyValueTable} from 'sentry/components/keyValueTable';
 import {Panel as BasePanel} from 'sentry/components/panels';
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import ReplayTagsTableRow from 'sentry/components/replays/replayTagsTableRow';
+import {t} from 'sentry/locale';
 import FluidPanel from 'sentry/views/replays/detail/layout/fluidPanel';
 
 function TagPanel() {
@@ -15,14 +17,20 @@ function TagPanel() {
     return <Placeholder testId="replay-tags-loading-placeholder" height="100%" />;
   }
 
+  const tags = Object.entries(replayRecord.tags);
+
   return (
     <Panel>
       <FluidPanel>
-        <KeyValueTable>
-          {Object.entries(replayRecord.tags).map(([key, value]) => (
-            <ReplayTagsTableRow key={key} tag={{key, value}} />
-          ))}
-        </KeyValueTable>
+        {tags.length ? (
+          <KeyValueTable>
+            {tags.map(([key, value]) => (
+              <ReplayTagsTableRow key={key} tag={{key, value}} />
+            ))}
+          </KeyValueTable>
+        ) : (
+          <EmptyMessage>{t('No tags for this replay were found.')}</EmptyMessage>
+        )}
       </FluidPanel>
     </Panel>
   );

--- a/static/app/views/replays/detail/tagPanel/index.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.tsx
@@ -12,7 +12,7 @@ function TagPanel() {
   const replayRecord = replay?.getReplay();
 
   if (!replayRecord) {
-    return <Placeholder height="100%" />;
+    return <Placeholder testId="replay-tags-loading-placeholder" height="100%" />;
   }
 
   return (

--- a/static/app/views/replays/detail/tagPanel/tagPanel.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/tagPanel.spec.tsx
@@ -1,0 +1,105 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
+import ReplayReader from 'sentry/utils/replays/replayReader';
+import {OrganizationContext} from 'sentry/views/organizationContext';
+import TagPanel from 'sentry/views/replays/detail/tagPanel';
+import {RouteContext} from 'sentry/views/routeContext';
+
+// Get replay data with the mocked replay reader params
+const replayReaderParams = TestStubs.ReplayReaderParams({
+  replayRecord: {
+    tags: {
+      'browser.name': ['Chrome'],
+      'browser.version': ['105.0.0'],
+      'device.brand': ['Apple'],
+      'device.family': ['Mac family'],
+      'device.model': ['Mac model'],
+      organization: ['1176005'],
+      'organization.slug': ['sentry-emerging-tech'],
+      'os.name': ['Mac OS X'],
+      'os.version': ['10.15.7'],
+      'sdk.name': ['sentry.javascript.react'],
+      'sdk.version': ['7.13.0', '7.13.2'],
+      'user.ip_address': ['127.0.0.1'],
+    },
+  },
+});
+
+const mockReplay = ReplayReader.factory(replayReaderParams);
+
+const renderComponent = (replay: ReplayReader | null) => {
+  const {router, organization} = initializeOrg();
+
+  return render(
+    <OrganizationContext.Provider value={organization}>
+      <RouteContext.Provider
+        value={{
+          router,
+          location: router.location,
+          params: router.params,
+          routes: router.routes,
+        }}
+      >
+        <ReplayContextProvider replay={replay}>
+          <TagPanel />
+        </ReplayContextProvider>
+      </RouteContext.Provider>
+    </OrganizationContext.Provider>
+  );
+};
+
+describe('TagPanel', () => {
+  it("should show a placeholder if there's no replay record", () => {
+    renderComponent(null);
+
+    expect(screen.getByTestId('replay-tags-loading-placeholder')).toBeInTheDocument();
+  });
+
+  it('should show the tags correctly', () => {
+    renderComponent(mockReplay);
+
+    expect(screen.getByText('browser.name')).toBeInTheDocument();
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+
+    expect(screen.getByText('browser.version')).toBeInTheDocument();
+    expect(screen.getByText('105.0.0')).toBeInTheDocument();
+
+    expect(screen.getByText('device.family')).toBeInTheDocument();
+    expect(screen.getByText('Mac family')).toBeInTheDocument();
+
+    expect(screen.getByText('device.model')).toBeInTheDocument();
+    expect(screen.getByText('Mac model')).toBeInTheDocument();
+
+    expect(screen.getByText('os.name')).toBeInTheDocument();
+    expect(screen.getByText('Mac OS X')).toBeInTheDocument();
+
+    expect(screen.getByText('os.version')).toBeInTheDocument();
+    expect(screen.getByText('10.15.7')).toBeInTheDocument();
+
+    expect(screen.getByText('sdk.name')).toBeInTheDocument();
+    expect(screen.getByText('sentry.javascript.react')).toBeInTheDocument();
+
+    expect(screen.getByText('sdk.version')).toBeInTheDocument();
+    expect(screen.getByText('7.13.0')).toBeInTheDocument();
+    expect(screen.getByText('7.13.2')).toBeInTheDocument();
+
+    expect(screen.getByText('user.ip_address')).toBeInTheDocument();
+    expect(screen.getByText('127.0.0.1')).toBeInTheDocument();
+
+    expect(screen.getByText('organization')).toBeInTheDocument();
+    expect(screen.getByText('1176005')).toBeInTheDocument();
+
+    expect(screen.getByText('organization.slug')).toBeInTheDocument();
+    expect(screen.getByText('sentry-emerging-tech')).toBeInTheDocument();
+  });
+
+  it('should snaptshot empty state', async () => {
+    const {container} = renderComponent(null);
+
+    await waitFor(() => {
+      expect(container).toSnapshot();
+    });
+  });
+});

--- a/static/app/views/replays/detail/tagPanel/tagPanel.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/tagPanel.spec.tsx
@@ -12,17 +12,7 @@ const replayReaderParams = TestStubs.ReplayReaderParams({
   replayRecord: {
     tags: {
       'browser.name': ['Chrome'],
-      'browser.version': ['105.0.0'],
-      'device.brand': ['Apple'],
-      'device.family': ['Mac family'],
-      'device.model': ['Mac model'],
-      organization: ['1176005'],
-      'organization.slug': ['sentry-emerging-tech'],
-      'os.name': ['Mac OS X'],
-      'os.version': ['10.15.7'],
-      'sdk.name': ['sentry.javascript.react'],
       'sdk.version': ['7.13.0', '7.13.2'],
-      'user.ip_address': ['127.0.0.1'],
     },
   },
 });
@@ -57,42 +47,19 @@ describe('TagPanel', () => {
     expect(screen.getByTestId('replay-tags-loading-placeholder')).toBeInTheDocument();
   });
 
-  it('should show the tags correctly', () => {
+  it('should show the tags correctly inside ReplayTagsTableRow component with single item array', () => {
     renderComponent(mockReplay);
 
     expect(screen.getByText('browser.name')).toBeInTheDocument();
     expect(screen.getByText('Chrome')).toBeInTheDocument();
+  });
 
-    expect(screen.getByText('browser.version')).toBeInTheDocument();
-    expect(screen.getByText('105.0.0')).toBeInTheDocument();
-
-    expect(screen.getByText('device.family')).toBeInTheDocument();
-    expect(screen.getByText('Mac family')).toBeInTheDocument();
-
-    expect(screen.getByText('device.model')).toBeInTheDocument();
-    expect(screen.getByText('Mac model')).toBeInTheDocument();
-
-    expect(screen.getByText('os.name')).toBeInTheDocument();
-    expect(screen.getByText('Mac OS X')).toBeInTheDocument();
-
-    expect(screen.getByText('os.version')).toBeInTheDocument();
-    expect(screen.getByText('10.15.7')).toBeInTheDocument();
-
-    expect(screen.getByText('sdk.name')).toBeInTheDocument();
-    expect(screen.getByText('sentry.javascript.react')).toBeInTheDocument();
+  it('should show the tags correctly inside ReplayTagsTableRow component with multiple items array', () => {
+    renderComponent(mockReplay);
 
     expect(screen.getByText('sdk.version')).toBeInTheDocument();
     expect(screen.getByText('7.13.0')).toBeInTheDocument();
     expect(screen.getByText('7.13.2')).toBeInTheDocument();
-
-    expect(screen.getByText('user.ip_address')).toBeInTheDocument();
-    expect(screen.getByText('127.0.0.1')).toBeInTheDocument();
-
-    expect(screen.getByText('organization')).toBeInTheDocument();
-    expect(screen.getByText('1176005')).toBeInTheDocument();
-
-    expect(screen.getByText('organization.slug')).toBeInTheDocument();
-    expect(screen.getByText('sentry-emerging-tech')).toBeInTheDocument();
   });
 
   it('should snaptshot empty state', async () => {
@@ -101,5 +68,23 @@ describe('TagPanel', () => {
     await waitFor(() => {
       expect(container).toSnapshot();
     });
+  });
+
+  it('should snaptshot state with tags', async () => {
+    const {container} = renderComponent(mockReplay);
+
+    await waitFor(() => {
+      expect(container).toSnapshot();
+    });
+  });
+
+  it('should show not found message when no tags are found', () => {
+    if (mockReplay) {
+      mockReplay.getReplay = jest.fn().mockReturnValue({tags: {}});
+    }
+
+    renderComponent(mockReplay);
+
+    expect(screen.getByText('No tags for this replay were found.')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- Describe your PR here. -->
### Changes
- Added new tests for the `tagPanel` component
- Added new "not found" message inside `tagPanel` if there are no tags found

![image](https://user-images.githubusercontent.com/39612839/194402565-29224df2-6fff-4be9-8f9b-cb58940d507a.png)


Closes #39562 

### Test coverage

- Assert that the placeholder in shown when fetching for the replay
- Assert that tags info renders correctly
- Take snapshot of empty state
- Take snapshot of state with tags data
- Assert that a message is displayed if no tags are found


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
