### PR TITLE
fix(useKeyPress) to utilize ref rather than optional ref.current

### DIFF
--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -5,7 +5,7 @@ import {RefObject, useEffect, useState} from 'react';
  */
 const useKeyPress = (targetKey: string, ref?: RefObject<HTMLElement>) => {
   const [keyPressed, setKeyPressed] = useState(false);
-  const target = (ref && ref.current) ?? document.body;
+  const target = ref ? ref.current : document.body;
 
   useEffect(() => {
     const downHandler = ({key}: KeyboardEvent) => {

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -1,9 +1,9 @@
-import {RefObject, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 /**
  * Hook to detect when a specific key is being pressed
  */
-const useKeyPress = (targetKey: string, ref?: RefObject<HTMLElement>) => {
+const useKeyPress = (targetKey: string, ref?: React.RefObject<HTMLElement>) => {
   const [keyPressed, setKeyPressed] = useState(false);
   const target = ref ? ref.current : document.body;
 

--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -1,11 +1,11 @@
-import {useEffect, useState} from 'react';
+import {RefObject, useEffect, useState} from 'react';
 
 /**
  * Hook to detect when a specific key is being pressed
  */
-const useKeyPress = (targetKey: string, target?: HTMLElement) => {
+const useKeyPress = (targetKey: string, ref?: RefObject<HTMLElement>) => {
   const [keyPressed, setKeyPressed] = useState(false);
-  const current = target ?? document.body;
+  const target = (ref && ref.current) ?? document.body;
 
   useEffect(() => {
     const downHandler = ({key}: KeyboardEvent) => {
@@ -20,14 +20,14 @@ const useKeyPress = (targetKey: string, target?: HTMLElement) => {
       }
     };
 
-    current.addEventListener('keydown', downHandler);
-    current.addEventListener('keyup', upHandler);
+    target?.addEventListener('keydown', downHandler);
+    target?.addEventListener('keyup', upHandler);
 
     return () => {
-      current.removeEventListener('keydown', downHandler);
-      current.removeEventListener('keyup', upHandler);
+      target?.removeEventListener('keydown', downHandler);
+      target?.removeEventListener('keyup', upHandler);
     };
-  }, [targetKey, current]);
+  }, [targetKey, target]);
 
   return keyPressed;
 };


### PR DESCRIPTION

<!-- Describe your PR here. -->

Previously `ref.current` was passed as a param to this hook, but current is null on component load.
Instead pass the actual ref object, so current will be captured once its populated 🤪 

NOTE: this is going to break getsentry TS for a moment before the GetSentry PR gets merged

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
