### PR TITLE
feat(suspect-spans): Switch to new span grouping strategy

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -89,7 +89,6 @@ from sentry.ratelimits.sliding_windows import Quota, RedisSlidingWindowRateLimit
 from sentry.reprocessing2 import is_reprocessed_event, save_unprocessed_event
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.signals import first_event_received, first_transaction_received, issue_unresolved
-from sentry.spans.grouping.strategy.config import INCOMING_DEFAULT_CONFIG_ID
 from sentry.tasks.commits import fetch_commits
 from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.process_buffer import buffer_incr
@@ -2024,27 +2023,6 @@ def _calculate_span_grouping(jobs, projects):
             metrics.incr(
                 "save_event.transaction.span_group_count.default",
                 amount=len(unique_default_hashes),
-                tags={"platform": job["platform"] or "unknown"},
-            )
-
-            # Try the second, looser config, and see how many groups it
-            # generates for comparison against the base. Do not store changes,
-            # record the number of generated unique groups.
-            with metrics.timer("event_manager.save.get_span_groupings.incoming"):
-                experimental_groupings = event.get_span_groupings(
-                    {"id": INCOMING_DEFAULT_CONFIG_ID}
-                )
-
-            unique_incoming_hashes = set(experimental_groupings.results.values())
-            metrics.incr(
-                "save_event.transaction.span_group_count.incoming",
-                amount=len(unique_incoming_hashes),
-                tags={"platform": job["platform"] or "unknown"},
-            )
-
-            metrics.incr(
-                "save_event.transaction.span_group_count.difference",
-                amount=len(unique_default_hashes ^ unique_incoming_hashes),
                 tags={"platform": job["platform"] or "unknown"},
             )
         except Exception:

--- a/src/sentry/spans/grouping/strategy/config.py
+++ b/src/sentry/spans/grouping/strategy/config.py
@@ -40,7 +40,7 @@ def register_configuration(config_id: str, strategies: Sequence[CallableStrategy
     CONFIGURATIONS[config_id] = SpanGroupingConfig(config_id, strategy)
 
 
-DEFAULT_CONFIG_ID = "default:2021-08-25"
+DEFAULT_CONFIG_ID = "default:2022-10-04"
 
 register_configuration(
     "default:2021-08-25",

--- a/src/sentry/spans/grouping/strategy/config.py
+++ b/src/sentry/spans/grouping/strategy/config.py
@@ -41,8 +41,6 @@ def register_configuration(config_id: str, strategies: Sequence[CallableStrategy
 
 
 DEFAULT_CONFIG_ID = "default:2021-08-25"
-INCOMING_DEFAULT_CONFIG_ID = "default:2022-10-04"
-
 
 register_configuration(
     "default:2021-08-25",

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1531,7 +1531,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             event = manager.save(self.project.id)
             data = event.data
             assert data["type"] == "transaction"
-            assert data["span_grouping_config"]["id"] == "default:2021-08-25"
+            assert data["span_grouping_config"]["id"] == "default:2022-10-04"
             spans = [{"hash": span["hash"]} for span in data["spans"]]
             # the basic strategy is to simply use the description
             assert spans == [{"hash": hash_values([span["description"]])} for span in data["spans"]]
@@ -2159,7 +2159,7 @@ class EventManagerTest(TestCase, EventManagerTestMixin):
             data = event.data
             expected_hash = "19e15e0444e0bc1d5159fb07cd4bd2eb"
             assert event.get_event_type() == "transaction"
-            assert data["span_grouping_config"]["id"] == "default:2021-08-25"
+            assert data["span_grouping_config"]["id"] == "default:2022-10-04"
             assert data["hashes"] == [expected_hash]
             spans = [{"hash": span["hash"]} for span in data["spans"]]
             # the basic strategy is to simply use the description


### PR DESCRIPTION
Follow-up to #39473, #39636, and most importantly #39646. Switching span grouping to a new strategy. It has one difference from the existing strategy: much looser regular expression for collapsing SQL "IN" statements. Closes PERF-1761

With this strategy, `IN (?, ?, ?, ?)` and `IN (?, ?, ?)` result in the same hash. This is how it worked for Django this whole time, and we're extending it to Laravel and Rails. This'll improve suspect spans _and_ will improve performance issue grouping, which relies on hashes generated for span groups.

For metrics, we checked the symmetrical difference (e.g., `old_hashes ^ new_hashes`) between the strategies and found that the symmetrical difference count is about 1% of the total original hash count. In Ruby, about 7%. In PHP it's the highest, at 20%. For Python it is 0, as expected.

Minor cleanup will follow.

## Appendix A: Symmetrical Difference

The 20% for PHP seems high, but consider how symmetrical difference works:

```python
hashes_a = set(['a', 'b', 'c', 'd'])
hashes_b = set(['c', 'd', 'e', 'f'])

difference = hashes_a ^ hashes_b
len(difference)
```

The difference is 4, which is the same as the original hash count, which is 100%. Which is to say, the actual tangible difference doesn't have to be high to get a very high percentage.
