### PR TITLE
fix(useKeyPress): add timeout to enter keypress

### DIFF
--- a/static/app/utils/useKeyPress.tsx
+++ b/static/app/utils/useKeyPress.tsx
@@ -11,6 +11,7 @@ const useKeyPress = (targetKey: string, target?: HTMLElement) => {
     const downHandler = ({key}: KeyboardEvent) => {
       if (key === targetKey) {
         setKeyPressed(true);
+        setTimeout(() => setKeyPressed(false), 200);
       }
     };
 


### PR DESCRIPTION

<!-- Describe your PR here. -->

certain browsers have weird oddities to the key handlers
One current oddity is that chrome doesn't handle the KeyUp for the enter key :|
https://bugs.chromium.org/p/chromedriver/issues/detail?id=1411

adding this timeout to reset the key pressed value which will enable multiple enter presses

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
