### PR TITLE
feat(perf-issue): add feature flag for processing transactions in post_process_group

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1129,6 +1129,8 @@ SENTRY_FEATURES = {
     "organizations:performance-transaction-name-only-search": False,
     # Enable showing INP web vital in default views
     "organizations:performance-vitals-inp": False,
+    # Enable processing transactions in post_process_group
+    "organizations:performance-issues-post-process-group": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable populating suggested assignees with release committers

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -119,6 +119,7 @@ default_manager.add("organizations:performance-dry-run-mep", OrganizationFeature
 default_manager.add("organizations:performance-frontend-use-events-endpoint", OrganizationFeature, True)
 default_manager.add("organizations:performance-issues", OrganizationFeature, True)
 default_manager.add("organizations:performance-issues-ingest", OrganizationFeature)
+default_manager.add("organizations:performance-issues-post-process-group", OrganizationFeature)
 default_manager.add("organizations:performance-issues-dev", OrganizationFeature, True)
 default_manager.add("organizations:performance-issues-all-events-tab", OrganizationFeature, True)
 default_manager.add("organizations:performance-onboarding-checklist", OrganizationFeature, True)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -525,6 +525,9 @@ register("performance.issues.all.problem-creation", default=0.0)
 register(
     "performance.issues.all.early-adopter-rollout", default=0.0
 )  # Only used for EA rollout, bound to the feature flag handler for performance-issue-ingest
+register(
+    "performance.issues.all.post-process-group-early-adopter-rollout", default=0.0
+)  # EA rollout for processing transactions in post_process_group
 
 # Individual system-wide options in case we need to turn off specific detectors for load concerns, ignoring the set project options.
 register("performance.issues.n_plus_one_db.problem-detection", default=0.0)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -382,13 +382,8 @@ def post_process_group(
                     project=event.project,
                     event=event,
                 )
-            if (
-                event.project
-                and event.project.organization
-                and not features.has(
-                    "organizations:performance-issues-post-process-group",
-                    event.project.organization,
-                )
+            if not features.has(
+                "organizations:performance-issues-post-process-group", event.project.organization
             ):
                 return
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -382,8 +382,15 @@ def post_process_group(
                     project=event.project,
                     event=event,
                 )
-
-            return
+            if (
+                event.project
+                and event.project.organization
+                and not features.has(
+                    "organizations:performance-issues-post-process-group",
+                    event.project.organization,
+                )
+            ):
+                return
 
         group_states = kwargs.get("group_states")
 


### PR DESCRIPTION
Adds a feature flag to toggle on/off processing transactions in post_process_group.

Related to this PR in `getsentry` https://github.com/getsentry/getsentry/pull/8516