### PR TITLE
fix(email): Remove Amixr logo

### DIFF
--- a/src/sentry/templates/sentry/emails/error.html
+++ b/src/sentry/templates/sentry/emails/error.html
@@ -217,7 +217,6 @@
             <img src="{% static 'sentry/images/logos/logo-opsgenie.svg' %}" class="logo" alt="OpsGenie"/>
             <img src="{% static 'sentry/images/logos/logo-twilio.svg' %}" class="logo" alt="Twilio"/>
             <img src="{% static 'sentry/images/logos/logo-victorops.svg' %}" class="logo" alt="VictorOps"/>
-            <img src="{% static 'sentry/images/logos/logo-amixr.svg' %}" class="logo" alt="Amixr"/>
         </div>
         <p class="align-center">
             <a href="{% absolute_uri 'settings/{}/integrations/?referrer=alert_email' group.project.organization.slug %}">{{ "Get this alert wherever you work" }}</a>


### PR DESCRIPTION
The `logo-amixr.svg` file doesn't exist anymore since https://github.com/getsentry/sentry/pull/30487 (and neither does Amixr as a company), so this PR removes it from the issue alert email footer.  

<img width="375" alt="Screen Shot 2022-10-06 at 3 20 29 PM" src="https://user-images.githubusercontent.com/29959063/194429793-5333eb6a-0323-40de-bbab-8cd9ae7ea6cd.png">
