### PR TITLE
feat(perf-issue): make use of multiple groups in post_process_group

### DIFF
--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -1,5 +1,5 @@
 from sentry.api.serializers import ExternalEventSerializer, serialize
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.client import ApiClient
 
 LEVEL_SEVERITY_MAP = {
@@ -28,7 +28,7 @@ class PagerDutyClient(ApiClient):
 
     def send_trigger(self, data):
         # expected payload: https://v2.developer.pagerduty.com/docs/send-an-event-events-api-v2
-        if isinstance(data, Event):
+        if isinstance(data, (Event, GroupEvent)):
             source = data.transaction or data.culprit or "<unknown>"
             group = data.group
             level = data.get_tag("level") or "error"

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -486,12 +486,14 @@ def update_event_groups(event: Event, group_states: Optional[GroupStates] = None
     # Re-bind Group since we're reading the Event object
     # from cache, which may contain a stale group and project
     group_states = group_states or ([{"id": event.group_id}] if event.group_id else [])
-    event.groups = [
-        get_group_with_redirect(group_state["id"])[0]
-        for group_state in group_states
-        if group_state.get("id")
-    ]
+    rebound_groups = []
+    for group_state in group_states:
+        if group_state.get("id"):
+            rebound_group = get_group_with_redirect(group_state["id"])[0]
+            group_state["id"] = rebound_group.id
+            rebound_groups.append(rebound_group)
 
+    event.groups = rebound_groups
     for group in event.groups:
         # We fetch buffered updates to group aggregates here and populate them on the Group. This
         # helps us avoid problems with processing group ignores and alert rules that rely on these

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, List, Mapping, Optional, Tuple, TypedDict, Union
+from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Tuple, TypedDict, Union
 
 import sentry_sdk
 from django.conf import settings
@@ -414,21 +414,19 @@ def post_process_group(
             ge.group_id: ge for ge in list(event.build_group_events())
         }
 
-        multi_groups: Mapping[int, Tuple[GroupEvent, GroupState]] = {
-            gs.get("id"): (group_events.get(gs.get("id")), gs)
-            for gs in group_states
-            if gs.get("id") is not None
-        }
+        multi_groups: Sequence[Tuple[GroupEvent, GroupState]] = [
+            (group_events.get(gs.get("id")), gs) for gs in group_states if gs.get("id") is not None
+        ]
 
-        group_jobs: List[PostProcessJob] = [
+        group_jobs: Sequence[PostProcessJob] = [
             {
-                "event": v[0],
-                "group_state": v[1],
+                "event": ge,
+                "group_state": gs,
                 "is_reprocessed": is_reprocessed,
-                "has_reappeared": bool(not v[1]["is_new"]),
+                "has_reappeared": bool(not gs["is_new"]),
                 "has_alert": False,
             }
-            for k, v in multi_groups.items()
+            for ge, gs in multi_groups
         ]
 
         for job in group_jobs:

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -19,7 +19,7 @@ from requests.exceptions import RequestException
 from sentry import analytics, features
 from sentry.api.serializers import AppPlatformEvent, serialize
 from sentry.constants import SentryAppInstallationStatus
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import Event, GroupEvent
 from sentry.models import (
     Activity,
     Group,
@@ -198,7 +198,11 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
 
     org = None
 
-    if isinstance(instance, Group) or isinstance(instance, Event):
+    if (
+        isinstance(instance, Group)
+        or isinstance(instance, Event)
+        or isinstance(instance, GroupEvent)
+    ):
         org = Organization.objects.get_from_cache(
             id=Project.objects.get_from_cache(id=instance.project_id).organization_id
         )
@@ -212,7 +216,7 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
 
     for installation in installations:
         data = {}
-        if isinstance(instance, Event):
+        if isinstance(instance, Event) or isinstance(instance, GroupEvent):
             data[name] = _webhook_event_data(instance, instance.group_id, instance.project_id)
         else:
             data[name] = serialize(instance)
@@ -222,7 +226,7 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
 
     if features.has("organizations:sentry-functions", org):
         data = {}
-        if not isinstance(instance, Event):
+        if not isinstance(instance, Event) and not isinstance(instance, GroupEvent):
             data[name] = serialize(instance)
             event_type = event.split(".")[0]
             # not sending error webhooks as of yet, can be added later

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -198,11 +198,7 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
 
     org = None
 
-    if (
-        isinstance(instance, Group)
-        or isinstance(instance, Event)
-        or isinstance(instance, GroupEvent)
-    ):
+    if isinstance(instance, (Group, Event, GroupEvent)):
         org = Organization.objects.get_from_cache(
             id=Project.objects.get_from_cache(id=instance.project_id).organization_id
         )

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -996,11 +996,17 @@ class PostProcessGroupAssignmentTest(TestCase):
 
 @region_silo_test
 class PostProcessGroupPerformanceTest(TestCase, SnubaTestCase, PerfIssueTransactionTestMixin):
+    @with_feature("organizations:performance-issues-post-process-group")
+    @patch("sentry.tasks.post_process.run_post_process_job")
     @patch("sentry.rules.processor.RuleProcessor")
     @patch("sentry.signals.transaction_processed.send_robust")
     @patch("sentry.signals.event_processed.send_robust")
     def test_full_pipeline_with_group_states(
-        self, event_processed_signal_mock, transaction_processed_signal_mock, mock_processor
+        self,
+        event_processed_signal_mock,
+        transaction_processed_signal_mock,
+        mock_processor,
+        run_post_process_job_mock,
     ):
         min_ago = before_now(minutes=1).replace(tzinfo=pytz.utc)
         event = self.store_transaction(
@@ -1030,3 +1036,4 @@ class PostProcessGroupPerformanceTest(TestCase, SnubaTestCase, PerfIssueTransact
         assert transaction_processed_signal_mock.call_count == 1
         assert event_processed_signal_mock.call_count == 0
         assert mock_processor.call_count == 0
+        assert run_post_process_job_mock.call_count == 2


### PR DESCRIPTION
We've introduced the plumbing in post_process_group to take in multiple groups associated with an event. 

This PR begins to make use of these multiple groups by modifying `post_process_group` to apply logic to multiple groups before deleting the event from the cache.