### PR TITLE
ref(perf issues): Add email debug view

### DIFF
--- a/fixtures/github.py
+++ b/fixtures/github.py
@@ -2831,3 +2831,36 @@ GET_LAST_2_COMMITS_EXAMPLE = """[
   ]
 }
 ]"""
+
+COMMIT_EXAMPLE = """[
+{
+    "repository": {
+        "status": "active",
+        "name": "Example Repo",
+        "url": "https://github.com/example/example",
+        "dateCreated": "2022-10-08T23:39:22.402Z",
+        "provider": {"id": "github", "name": "GitHub"},
+        "id": "1"
+    },
+    "score": 2,
+    "subject": "feat: Make stuff better",
+    "message": "feat: Make stuff better aptent vivamus vehicula tempus volutpat hac tortor",
+    "id": "1b17483ffc4a10609e7921ee21a8567bfe0ed006",
+    "shortId": "1b17483",
+    "author": {
+        "username": "colleen@sentry.io",
+        "isManaged": false,
+        "lastActive": "2022-03-01T18:25:28.149Z",
+        "id": "1",
+        "isActive": true,
+        "has2fa": false,
+        "name": "colleen@sentry.io",
+        "avatarUrl": "https://secure.gravatar.com/avatar/51567a4f786cd8a2c41c513b592de9f9?s=32&d=mm",
+        "dateJoined": "2022-10-07T22:04:32.847Z",
+        "emails": [{"is_verified": false, "id": "1", "email": "colleen@sentry.io"}],
+        "avatar": {"avatarUuid": "", "avatarType": "letter_avatar"},
+        "lastLogin": "2022-10-07T22:04:32.847Z",
+        "email": "colleen@sentry.io"
+    }
+}
+]"""

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -25,6 +25,7 @@
       </optgroup>
       <optgroup label="Alerts">
         <option value="mail/alert/">Alert</option>
+        <option value="mail/perf-alert/">Performance Alert</option>
         <option value="mail/digest/">Digest</option>
       </optgroup>
       <optgroup label="Account">

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -40,6 +40,7 @@ from sentry.web.frontend.debug.debug_organization_join_request import (
     DebugOrganizationJoinRequestEmailView,
 )
 from sentry.web.frontend.debug.debug_password_changed_email import DebugPasswordChangedEmailView
+from sentry.web.frontend.debug.debug_performance_issue import DebugPerformanceIssueEmailView
 from sentry.web.frontend.debug.debug_recovery_codes_regenerated_email import (
     DebugRecoveryCodesRegeneratedEmailView,
 )
@@ -70,6 +71,7 @@ from sentry.web.frontend.debug.debug_unassigned_email import DebugUnassignedEmai
 
 urlpatterns = [
     url(r"^debug/mail/alert/$", sentry.web.frontend.debug.mail.alert),
+    url(r"^debug/mail/perf-alert/$", DebugPerformanceIssueEmailView.as_view()),
     url(r"^debug/mail/note/$", DebugNoteEmailView.as_view()),
     url(r"^debug/mail/new-release/$", DebugNewReleaseEmailView.as_view()),
     url(r"^debug/mail/release-summary/$", DebugReleaseSummaryEmailView.as_view()),

--- a/src/sentry/web/frontend/debug/debug_performance_issue.py
+++ b/src/sentry/web/frontend/debug/debug_performance_issue.py
@@ -1,0 +1,67 @@
+import pytz
+from django.utils.safestring import mark_safe
+from django.views.generic import View
+
+from fixtures.github import COMMIT_EXAMPLE
+from sentry.event_manager import EventManager, get_event_type
+from sentry.models import Organization, Project, Rule
+from sentry.notifications.utils import get_group_settings_link, get_rules
+from sentry.testutils.helpers.datetime import before_now
+from sentry.utils import json
+from sentry.utils.samples import load_data
+
+from .mail import MailPreview, get_random, make_group_generator
+
+
+class DebugPerformanceIssueEmailView(View):
+    def get(self, request):
+        org = Organization(id=1, slug="example", name="Example")
+        project = Project(id=1, slug="example", name="Example", organization=org)
+        random = get_random(request)
+
+        perf_group = next(make_group_generator(random, project))
+        perf_data = load_data("transaction", timestamp=before_now(minutes=10))
+        perf_event_manager = EventManager(perf_data)
+        perf_event_manager.normalize()
+        perf_data = perf_event_manager.get_data()
+        perf_event = perf_event_manager.save(project.id)
+        perf_event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
+        perf_event_type = get_event_type(perf_event.data)
+        perf_group.message = perf_event.search_message
+        perf_group.data = {
+            "type": perf_event_type.key,
+            "metadata": perf_event_type.get_metadata(perf_data),
+        }
+
+        rule = Rule(id=1, label="Example performance rule")
+
+        # XXX: this interface_list code needs to be the same as in
+        #      src/sentry/mail/adapter.py
+        interface_list = []
+        for interface in perf_event.interfaces.values():
+            body = interface.to_email_html(perf_event)
+            if not body:
+                continue
+            text_body = interface.to_string(perf_event)
+            interface_list.append((interface.get_title(), mark_safe(body), text_body))
+
+        return MailPreview(
+            html_template="sentry/emails/error.html",
+            text_template="sentry/emails/error.txt",
+            context={
+                "rule": rule,
+                "rules": get_rules([rule], org, project),
+                "group": perf_group,
+                "event": perf_event,
+                "timezone": pytz.timezone("Europe/Vienna"),
+                # http://testserver/organizations/example/issues/<issue-id>/?referrer=alert_email
+                #       &alert_type=email&alert_timestamp=<ts>&alert_rule_id=1
+                "link": get_group_settings_link(
+                    perf_group, None, get_rules([rule], org, project), 1337
+                ),
+                "interfaces": interface_list,
+                "tags": perf_event.tags,
+                "project_label": project.slug,
+                "commits": json.loads(COMMIT_EXAMPLE),
+            },
+        ).render(request)


### PR DESCRIPTION
Add a performance issue alert email debug view to help future development improvements to performance issue alert emails. 

<img width="368" alt="Screen Shot 2022-10-06 at 4 33 08 PM" src="https://user-images.githubusercontent.com/29959063/194437143-b6421b5d-7445-451f-a835-004d3caba152.png">
