### PR TITLE
Add .NET to supported SDKs for DS

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -46,7 +46,8 @@ ALLOWED_SDK_NAMES = frozenset(
 # We want sentry.java, sentry.java.spring, sentry.java.android, sentry.java.android.timber,
 # and all others to match
 # Same for sentry.dart, sentry.dart.browser, and sentry.dart.flutter
-ALLOWED_SDK_NAMES_PREFIXES = frozenset(("sentry.java", "sentry.dart"))
+# Same for sentry.dotnet, sentry.dotnet.aspnetcore, sentry.dotnet.maui, etc.
+ALLOWED_SDK_NAMES_PREFIXES = frozenset(("sentry.java", "sentry.dart", "sentry.dotnet"))
 
 
 class QueryBoundsException(Exception):


### PR DESCRIPTION
Add .NET to supported SDKs for DS, added with release 3.22.0

https://github.com/getsentry/sentry-dotnet/pull/1953

https://github.com/getsentry/sentry-docs/pull/5612