### PR TITLE
fix(discover-homepage): Saving from homepage fails

### DIFF
--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -65,7 +65,8 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
             raise ParseError(detail="No Projects found, join a Team")
 
         serializer = DiscoverSavedQuerySerializer(
-            data=request.data,
+            # HACK: To ensure serializer data is valid, pass along a name temporarily
+            data={**request.data, "name": "New Query"},
             context={"params": params},
         )
         if not serializer.is_valid():

--- a/tests/snuba/api/endpoints/test_discover_homepage_query.py
+++ b/tests/snuba/api/endpoints/test_discover_homepage_query.py
@@ -107,6 +107,27 @@ class DiscoverHomepageQueryTest(DiscoverSavedQueryBase):
         assert new_query.name == ""
         assert response.data["name"] == ""
 
+    def test_put_with_no_name(self):
+        homepage_query_payload = {
+            "version": 2,
+            "name": "",
+            "projects": self.project_ids,
+            "environment": ["alpha"],
+            "fields": ["environment", "platform.name"],
+            "orderby": "-timestamp",
+            "range": None,
+        }
+        with self.feature(FEATURES):
+            response = self.client.put(self.url, data=homepage_query_payload)
+
+        assert response.status_code == 201, response.content
+
+        new_query = DiscoverSavedQuery.objects.get(
+            created_by=self.user, organization=self.org, is_homepage=True
+        )
+        assert new_query.name == ""
+        assert response.data["name"] == ""
+
     def test_post_not_allowed(self):
         homepage_query_payload = {
             "version": 2,


### PR DESCRIPTION
Saving from the homepage fails because it sends along name as an empty string. The DiscoverSavedQuerySerializer expects a name so we can temporarily set one for the purposes of bypassing this condition