### PR TITLE
fix(discover-homepage): Ignore name when comparing query for reset

### DIFF
--- a/static/app/views/eventsV2/results.spec.jsx
+++ b/static/app/views/eventsV2/results.spec.jsx
@@ -1785,7 +1785,7 @@ describe('Results', function () {
       statusCode: 200,
       body: {
         id: '2',
-        name: 'new',
+        name: '',
         projects: [],
         version: 2,
         expired: false,
@@ -1857,7 +1857,7 @@ describe('Results', function () {
       url: '/organizations/org-slug/discover/homepage/',
       method: 'PUT',
       statusCode: 200,
-      body: TRANSACTION_VIEWS[0],
+      body: {...TRANSACTION_VIEWS[0], name: ''},
     });
     const organization = TestStubs.Organization({
       features: [

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -411,7 +411,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
         eventView.isEqualTo(EventView.fromSavedQuery(DEFAULT_EVENT_VIEW)));
     if (
       homepageQuery &&
-      eventView.isEqualTo(EventView.fromSavedQuery(homepageQuery), ['id'])
+      eventView.isEqualTo(EventView.fromSavedQuery(homepageQuery), ['id', 'name'])
     ) {
       return (
         <Button


### PR DESCRIPTION
Since we changed the response to return an empty string for the name, the equality check between event views was returning false and the reset button wasn't appearing. Adds 'name' to the ignored fields in that comparison