### PR TITLE
feat(options): Cache options values to avoid database queries

### DIFF
--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from pytz import UTC
 from rest_framework import status
 
-from sentry import audit_log
+from sentry import audit_log, options
 from sentry.api.endpoints.organization_details import ERR_NO_2FA, ERR_SSO_ENABLED
 from sentry.auth.authenticators import TotpInterface
 from sentry.constants import RESERVED_ORGANIZATION_SLUGS
@@ -131,7 +131,10 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         expected_queries += 1
 
         # Symbolication Low Priority Queue stats reads two killswitches
-        expected_queries += 8
+        # make sure options are not cached the first time to get predictable number of database queries
+        options.delete("store.symbolicate-event-lpq-always")
+        options.delete("store.symbolicate-event-lpq-never")
+        expected_queries += 2
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -124,17 +124,13 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
         expected_queries = 36
 
-        # TODO(mgaeta): Extra query while we're "dual reading" from UserOptions and NotificationSettings.
-        expected_queries += 1
-
-        # sentry_option query related to userip.
-        expected_queries += 1
-
-        # Symbolication Low Priority Queue stats reads two killswitches
         # make sure options are not cached the first time to get predictable number of database queries
+        options.delete("system.rate-limit")
+        options.delete("hc.region-to-control.monolith-publish")
         options.delete("store.symbolicate-event-lpq-always")
         options.delete("store.symbolicate-event-lpq-never")
-        expected_queries += 2
+
+        expected_queries += 4
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -45,6 +45,7 @@ class OptionsManagerTest(TestCase):
     def test_simple(self):
         assert self.manager.get("foo") == ""
 
+        self.manager.delete("foo")
         with self.settings(SENTRY_OPTIONS={"foo": "bar"}):
             assert self.manager.get("foo") == "bar"
 

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -32,7 +32,7 @@ class OptionsStoreTest(TestCase):
     def test_simple(self):
         store, key = self.store, self.key
 
-        assert store.get(key) == ""
+        assert store.get(key) is None
         assert store.set(key, "bar")
         assert store.get(key) == "bar"
         assert store.delete(key)
@@ -41,7 +41,7 @@ class OptionsStoreTest(TestCase):
         store = OptionsStore(cache=None)
         key = self.key
 
-        assert store.get(key) == ""
+        assert store.get(key) is None
 
         with pytest.raises(AssertionError):
             store.set(key, "bar")

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -32,7 +32,7 @@ class OptionsStoreTest(TestCase):
     def test_simple(self):
         store, key = self.store, self.key
 
-        assert store.get(key) is None
+        assert store.get(key) == ""
         assert store.set(key, "bar")
         assert store.get(key) == "bar"
         assert store.delete(key)
@@ -41,7 +41,7 @@ class OptionsStoreTest(TestCase):
         store = OptionsStore(cache=None)
         key = self.key
 
-        assert store.get(key) is None
+        assert store.get(key) == ""
 
         with pytest.raises(AssertionError):
             store.set(key, "bar")


### PR DESCRIPTION
Cache option values also for options that are not in `options.store` or are hardcoded (`settings.SENTRY_OPTIONS`) to avoid repeatedly hitting the database.
