### PR TITLE
fix(post_process_group): Make sure job always has a default value for `has_alert`

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -416,6 +416,7 @@ def post_process_group(
                 "group_state": group_state,
                 "is_reprocessed": is_reprocessed,
                 "has_reappeared": not group_state["is_new"],
+                "has_alert": False,
             }
             run_post_process_job(job)
 


### PR DESCRIPTION
If we error in the alert step then we won't set a value for `has_alert`, which can cause a failure in a later step.

Fixes SENTRY-W6E

