### PR TITLE
Revert "fix(options): SENTRY_URL_PREFIX deprecation warning displayed when config value is not set"

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -589,9 +589,7 @@ def apply_legacy_settings(settings: Any) -> None:
         url_prefix = options.get("system.url-prefix", silent=True)
         if not url_prefix:
             # HACK: We need to have some value here for backwards compatibility
-            # Also set SENTRY_OPTIONS['system.url-prefix'] to avoid deprecation warning
             url_prefix = "http://sentry.example.com"
-            settings.SENTRY_OPTIONS["system.url-prefix"] = url_prefix
         settings.SENTRY_URL_PREFIX = url_prefix
 
     if settings.TIME_ZONE != "UTC":


### PR DESCRIPTION
Reverts getsentry/sentry#39804