### PR TITLE
fix(ui): Use corect aria-label for radiogroup

### DIFF
--- a/static/app/components/forms/controls/radioGroup.tsx
+++ b/static/app/components/forms/controls/radioGroup.tsx
@@ -52,12 +52,7 @@ const RadioGroup = <C extends string>({
   orientInline,
   ...props
 }: RadioGroupProps<C>) => (
-  <Container
-    orientInline={orientInline}
-    {...props}
-    role="radiogroup"
-    aria-labelledby={label}
-  >
+  <Container orientInline={orientInline} {...props} role="radiogroup" aria-label={label}>
     {choices.map(([id, name, description], index) => {
       const disabledChoice = disabledChoices.find(([choiceId]) => choiceId === id);
       const disabledChoiceReason = disabledChoice?.[1];


### PR DESCRIPTION
`aria-labelledby` is supposed to be given an `id`. Instead we were just giving it the label. Instead we should use `aria-label`.