### PR TITLE
ref(js): Use aria-label for FormFields

### DIFF
--- a/static/app/components/forms/field/index.tsx
+++ b/static/app/components/forms/field/index.tsx
@@ -68,6 +68,11 @@ export interface FieldProps
    */
   label?: React.ReactNode;
   /**
+   * May be used to give the field an aria-label when the field's label is a
+   * react node.
+   */
+  labelText?: string;
+  /**
    * Show "required" indicator
    */
   required?: boolean;
@@ -130,6 +135,7 @@ function Field({
     isSaving,
     isSaved,
     label,
+    labelText,
     hideLabel,
     stacked,
     children,
@@ -165,6 +171,11 @@ function Field({
     Control = <FieldControl {...controlProps}>{children}</FieldControl>;
   }
 
+  // Provide an `aria-label` to the FieldDescription label if our label is a
+  // string value. This helps with testing and accessability. Without this the
+  // aria label contains the entire description.
+  const ariaLabel = labelText ?? (typeof label === 'string' ? label : undefined);
+
   return (
     <FieldWrapper
       className={className}
@@ -175,7 +186,7 @@ function Field({
       style={style}
     >
       {((label && !hideLabel) || helpElement) && (
-        <FieldDescription inline={inline} htmlFor={id}>
+        <FieldDescription inline={inline} htmlFor={id} aria-label={ariaLabel}>
           {label && !hideLabel && (
             <FieldLabel disabled={isDisabled}>
               <span>

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -61,6 +61,11 @@ type BaseField = {
   // TODO(ts): FormField prop?
   inline?: boolean;
   label?: React.ReactNode | (() => React.ReactNode);
+  /**
+   * May be used to give the field an aria-label when the field's label is a
+   * react node.
+   */
+  labelText?: string;
   maxRows?: number;
   // TODO(ts): used in sentryAppPublishRequestModal
   meta?: string;

--- a/static/app/components/modals/sentryAppPublishRequestModal.tsx
+++ b/static/app/components/modals/sentryAppPublishRequestModal.tsx
@@ -75,7 +75,8 @@ export default class SentryAppPublishRequestModal extends Component<Props> {
         <PermissionLabel>{permissionQuestionBaseText}</PermissionLabel>
         {permissions.map((permission, i) => (
           <Fragment key={permission}>
-            {i > 0 && ', '} <Permission>{permission}</Permission>
+            {i > 0 && ', '}
+            <Permission>{permission}</Permission>
           </Fragment>
         ))}
         .
@@ -119,6 +120,7 @@ export default class SentryAppPublishRequestModal extends Component<Props> {
         type: 'textarea',
         required: true,
         label: permissionLabel,
+        labelText: permissionQuestionPlainText,
         autosize: true,
         rows: 1,
         inline: false,

--- a/static/app/components/modals/sudoModal.spec.jsx
+++ b/static/app/components/modals/sudoModal.spec.jsx
@@ -83,7 +83,7 @@ describe('Sudo Modal', function () {
     expect(sudoMock).not.toHaveBeenCalled();
 
     // "Sudo" auth
-    userEvent.type(screen.getByLabelText('Password'), 'password');
+    userEvent.type(screen.getByRole('textbox', {name: 'Password'}), 'password');
     userEvent.click(screen.getByRole('button', {name: 'Confirm Password'}));
 
     expect(sudoMock).toHaveBeenCalledWith(

--- a/static/app/views/integrationPipeline/awsLambdaFunctionSelect.spec.jsx
+++ b/static/app/views/integrationPipeline/awsLambdaFunctionSelect.spec.jsx
@@ -14,8 +14,8 @@ describe('AwsLambdaFunctionSelect', () => {
       />
     );
     expect(container).toSnapshot();
-    expect(screen.getByLabelText('lambdaB')).toBeInTheDocument();
-    expect(screen.getByLabelText('Finish Setup')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', {name: 'lambdaB'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Finish Setup'})).toBeInTheDocument();
     // TODO: add assertion for form post
   });
 });

--- a/static/app/views/issueList/actions/index.spec.jsx
+++ b/static/app/views/issueList/actions/index.spec.jsx
@@ -195,8 +195,11 @@ describe('IssueListActions', function () {
 
         const modal = screen.getByRole('dialog');
 
-        userEvent.clear(within(modal).getByLabelText('Number of users'));
-        userEvent.type(within(modal).getByLabelText('Number of users'), '300');
+        userEvent.clear(within(modal).getByRole('spinbutton', {name: 'Number of users'}));
+        userEvent.type(
+          within(modal).getByRole('spinbutton', {name: 'Number of users'}),
+          '300'
+        );
 
         userEvent.click(within(modal).getByRole('textbox'));
         userEvent.click(within(modal).getByText('per week'));

--- a/static/app/views/settings/account/passwordForm.spec.jsx
+++ b/static/app/views/settings/account/passwordForm.spec.jsx
@@ -6,10 +6,6 @@ const ENDPOINT = '/users/me/password/';
 
 describe('PasswordForm', function () {
   let putMock;
-  // The "help" message is currently inside the label element
-  const currentPasswordLabel = 'Current PasswordYour current password';
-  const newPasswordLabel = 'New Password';
-  const verifyNewPasswordLabel = 'Verify New PasswordVerify your new password';
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
@@ -21,38 +17,40 @@ describe('PasswordForm', function () {
 
   it('has 3 text inputs', function () {
     render(<PasswordForm />);
-    expect(screen.getByLabelText(currentPasswordLabel)).toBeInTheDocument();
-    expect(screen.getByLabelText(newPasswordLabel)).toBeInTheDocument();
-    expect(screen.getByLabelText(verifyNewPasswordLabel)).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Current Password'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'New Password'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', {name: 'Verify New Password'})
+    ).toBeInTheDocument();
   });
 
   it('does not submit when any password field is empty', function () {
     render(<PasswordForm />);
-    userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
+    userEvent.type(screen.getByRole('textbox', {name: 'Current Password'}), 'test');
     userEvent.click(screen.getByRole('button', {name: 'Change password'}));
     expect(putMock).not.toHaveBeenCalled();
 
-    userEvent.clear(screen.getByLabelText(currentPasswordLabel));
-    userEvent.type(screen.getByLabelText(newPasswordLabel), 'test');
-    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'test');
+    userEvent.clear(screen.getByRole('textbox', {name: 'Current Password'}));
+    userEvent.type(screen.getByRole('textbox', {name: 'New Password'}), 'test');
+    userEvent.type(screen.getByRole('textbox', {name: 'Verify New Password'}), 'test');
     userEvent.click(screen.getByRole('button', {name: 'Change password'}));
     expect(putMock).not.toHaveBeenCalled();
   });
 
   it('does not submit when new passwords do not match', function () {
     render(<PasswordForm />);
-    userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
-    userEvent.type(screen.getByLabelText(newPasswordLabel), 'test');
-    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest');
+    userEvent.type(screen.getByRole('textbox', {name: 'Current Password'}), 'test');
+    userEvent.type(screen.getByRole('textbox', {name: 'New Password'}), 'test');
+    userEvent.type(screen.getByRole('textbox', {name: 'Verify New Password'}), 'nottest');
     userEvent.click(screen.getByRole('button', {name: 'Change password'}));
     expect(putMock).not.toHaveBeenCalled();
   });
 
   it('calls API when all fields are validated and clears form on success', async function () {
     render(<PasswordForm />);
-    userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
-    userEvent.type(screen.getByLabelText(newPasswordLabel), 'nottest');
-    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest');
+    userEvent.type(screen.getByRole('textbox', {name: 'Current Password'}), 'test');
+    userEvent.type(screen.getByRole('textbox', {name: 'New Password'}), 'nottest');
+    userEvent.type(screen.getByRole('textbox', {name: 'Verify New Password'}), 'nottest');
     userEvent.click(screen.getByRole('button', {name: 'Change password'}));
     expect(putMock).toHaveBeenCalledWith(
       ENDPOINT,
@@ -67,21 +65,24 @@ describe('PasswordForm', function () {
     );
 
     await waitFor(() =>
-      expect(screen.getByLabelText(currentPasswordLabel)).toHaveValue('')
+      expect(screen.getByRole('textbox', {name: 'Current Password'})).toHaveValue('')
     );
   });
 
   it('validates mismatched passwords and remvoes validation on match', function () {
     render(<PasswordForm />);
-    userEvent.type(screen.getByLabelText(currentPasswordLabel), 'test');
-    userEvent.type(screen.getByLabelText(newPasswordLabel), 'nottest');
-    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest-mismatch');
+    userEvent.type(screen.getByRole('textbox', {name: 'Current Password'}), 'test');
+    userEvent.type(screen.getByRole('textbox', {name: 'New Password'}), 'nottest');
+    userEvent.type(
+      screen.getByRole('textbox', {name: 'Verify New Password'}),
+      'nottest-mismatch'
+    );
     userEvent.click(screen.getByRole('button', {name: 'Change password'}));
 
     expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
 
-    userEvent.clear(screen.getByLabelText(verifyNewPasswordLabel));
-    userEvent.type(screen.getByLabelText(verifyNewPasswordLabel), 'nottest');
+    userEvent.clear(screen.getByRole('textbox', {name: 'Verify New Password'}));
+    userEvent.type(screen.getByRole('textbox', {name: 'Verify New Password'}), 'nottest');
 
     expect(screen.queryByText('Passwords do not match')).not.toBeInTheDocument();
   });

--- a/static/app/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -147,7 +147,7 @@ describe('Organization Developer Settings', function () {
       ];
 
       for (const {question, answer} of questionnaire) {
-        const element = within(dialog).getByLabelText(question);
+        const element = within(dialog).getByRole('textbox', {name: question});
         userEvent.paste(element, answer);
       }
 

--- a/static/app/views/settings/projectSecurityHeaders/csp.spec.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.spec.tsx
@@ -59,11 +59,7 @@ describe('ProjectCspReports', function () {
     expect(mock).not.toHaveBeenCalled();
 
     // Click Regenerate Token
-    userEvent.click(
-      screen.getByRole('checkbox', {
-        name: 'Use default ignored sources Our default list will attempt to ignore common issues and reduce noise.',
-      })
-    );
+    userEvent.click(screen.getByRole('checkbox', {name: 'Use default ignored sources'}));
 
     expect(mock).toHaveBeenCalledWith(
       projectUrl,
@@ -98,9 +94,7 @@ describe('ProjectCspReports', function () {
     expect(mock).not.toHaveBeenCalled();
 
     userEvent.type(
-      screen.getByRole('textbox', {
-        name: 'Additional ignored sources Discard reports about requests from the given sources. Separate multiple entries with a newline.',
-      }),
+      screen.getByRole('textbox', {name: 'Additional ignored sources'}),
       'test\ntest2'
     );
 


### PR DESCRIPTION
This improves testability of our setting form fields by labeling the label with JUST the name of the field.

Prior to this the description was included as well, which made RTL testing difficult.