### PR TITLE
fix(ui): Give RangeSlider the field ID

### DIFF
--- a/static/app/components/forms/controls/rangeSlider/index.spec.tsx
+++ b/static/app/components/forms/controls/rangeSlider/index.spec.tsx
@@ -5,9 +5,9 @@ import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
 describe('RangeSlider', function () {
   it('changes value / has right label', function () {
     render(<RangeSlider name="test" value={5} min={0} max={10} onChange={() => {}} />);
-    expect(screen.getByRole('slider', {name: '5'})).toBeInTheDocument();
+    expect(screen.getByRole('slider')).toHaveValue('5');
     fireEvent.change(screen.getByRole('slider'), {target: {value: '7'}});
-    expect(screen.getByRole('slider', {name: '7'})).toBeInTheDocument();
+    expect(screen.getByRole('slider')).toHaveValue('7');
   });
 
   it('can use formatLabel', function () {
@@ -52,10 +52,14 @@ describe('RangeSlider', function () {
     );
 
     // With `allowedValues` sliderValue will be the index to value in `allowedValues`
-    expect(screen.getByRole('slider', {name: '1000'})).toBeInTheDocument();
+    expect(screen.getByRole('slider')).toHaveValue('2');
+
+    // Bounded by the maximum allowed value index
+    fireEvent.change(screen.getByRole('slider'), {target: {value: '10'}});
+    expect(screen.getByRole('slider')).toHaveValue('4');
 
     fireEvent.change(screen.getByRole('slider'), {target: {value: '0'}});
-    expect(screen.getByRole('slider', {name: '0'})).toBeInTheDocument();
+    expect(screen.getByRole('slider')).toHaveValue('0');
 
     // onChange will callback with a value from `allowedValues`
     expect(onChange).toHaveBeenCalledWith(0, expect.anything());
@@ -75,7 +79,7 @@ describe('RangeSlider', function () {
     );
 
     fireEvent.change(screen.getByRole('slider'), {target: {value: '-2'}});
-    expect(screen.getByRole('slider', {name: '0'})).toBeInTheDocument();
+    expect(screen.getByRole('slider')).toHaveValue('0');
 
     // onChange will callback with a value from `allowedValues`
     expect(onChange).toHaveBeenCalledWith(0, expect.anything());

--- a/static/app/components/forms/controls/rangeSlider/index.tsx
+++ b/static/app/components/forms/controls/rangeSlider/index.tsx
@@ -1,5 +1,4 @@
 import {forwardRef as reactForwardRef, useEffect, useState} from 'react';
-import {useId} from '@react-aria/utils';
 
 import Input from 'sentry/components/input';
 import {t} from 'sentry/locale';
@@ -30,13 +29,18 @@ type SliderProps = {
   className?: string;
 
   disabled?: boolean;
+
   /**
    * Render prop for slider's label
    * Is passed the value as an argument
    */
   formatLabel?: (value: number | '') => React.ReactNode;
-
   forwardRef?: React.Ref<HTMLDivElement>;
+
+  /**
+   * HTML id of the range input
+   */
+  id?: string;
 
   /**
    * max allowed value, not needed if using `allowedValues`
@@ -77,6 +81,7 @@ type SliderProps = {
 };
 
 function RangeSlider({
+  id,
   value,
   allowedValues,
   showCustomInput,
@@ -91,7 +96,6 @@ function RangeSlider({
   showLabel = true,
   ...props
 }: SliderProps) {
-  const elementId = useId();
   const [sliderValue, setSliderValue] = useState(
     allowedValues ? allowedValues.indexOf(Number(value || 0)) : value
   );
@@ -170,19 +174,16 @@ function RangeSlider({
   }
 
   const {min, max, step, actualValue, displayValue} = getSliderData();
+  const labelText = formatLabel?.(actualValue) ?? displayValue;
 
   return (
     <div className={className} ref={forwardRef}>
-      {!showCustomInput && showLabel && (
-        <SliderLabel htmlFor={elementId}>
-          {formatLabel?.(actualValue) ?? displayValue}
-        </SliderLabel>
-      )}
+      {!showCustomInput && showLabel && <SliderLabel>{labelText}</SliderLabel>}
       <SliderAndInputWrapper showCustomInput={showCustomInput}>
         <Slider
           type="range"
-          id={elementId}
           name={name}
+          id={id}
           min={min}
           max={max}
           step={step}
@@ -193,6 +194,7 @@ function RangeSlider({
           onKeyUp={handleBlur}
           value={sliderValue}
           hasLabel={!showCustomInput}
+          aria-valuetext={labelText}
         />
         {showCustomInput && (
           <Input

--- a/static/app/views/settings/projectAlerts/settings.spec.jsx
+++ b/static/app/views/settings/projectAlerts/settings.spec.jsx
@@ -39,8 +39,12 @@ describe('ProjectAlertSettings', () => {
     );
 
     expect(screen.getByPlaceholderText('e.g. $shortID - $title')).toBeInTheDocument();
-    expect(screen.getByRole('slider', {name: '12 minutes'})).toBeInTheDocument();
-    expect(screen.getByRole('slider', {name: '55 minutes'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('slider', {name: 'Minimum delivery interval'})
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('slider', {name: 'Maximum delivery interval'})
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         "Oops! Looks like there aren't any available integrations installed."


### PR DESCRIPTION
Prior to this we had a label element that was being used to describe the current text value of the slider, because of this our slider didn't receive he `id` for the form field label.

Instead we now use aria-valuetext to describe the sliders value in a human format, and pass the ID from the parent field.

Requires #39858 