### PR TITLE
fix(dyn-sampling): Rename `project_id` to camelCase in response

### DIFF
--- a/src/sentry/api/endpoints/project_dynamic_sampling.py
+++ b/src/sentry/api/endpoints/project_dynamic_sampling.py
@@ -395,7 +395,7 @@ class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
                     # Run extra query to build project_breakdown,
                     # because in this case (project is the head of trace in some distributed trace
                     # and non-root in others) we can't create it based on parent_project_breakdown
-                    project_breakdown = self.__run_discover_query(
+                    project_breakdown_response = self.__run_discover_query(
                         columns=[
                             "project_id",
                             "project",
@@ -411,11 +411,19 @@ class ProjectDynamicSamplingDistributionEndpoint(ProjectEndpoint):
                         limit=20,
                         referrer=Referrer.DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PROJECT_BREAKDOWN.value,
                     )
+                    project_breakdown = [
+                        {
+                            "projectId": _project["project_id"],
+                            "project": _project["project"],
+                            "count()": _project["count()"],
+                        }
+                        for _project in project_breakdown_response
+                    ]
 
                 elif len(parent_project_breakdown) == 1:
                     project_breakdown = [
                         {
-                            "project_id": _project["project_id"],
+                            "projectId": _project["project_id"],
                             "project": _project["project"],
                             "count()": _project["count"],
                         }

--- a/tests/sentry/api/endpoints/test_project_dynamic_sampling.py
+++ b/tests/sentry/api/endpoints/test_project_dynamic_sampling.py
@@ -381,8 +381,8 @@ class ProjectDynamicSamplingDistributionQueryCallsTest(APITestCase):
 
             response_data = response.json()
             assert response_data["projectBreakdown"] == [
-                {"project_id": self.project.id, "project": self.project.slug, "count()": 2},
-                {"project_id": heart.id, "project": heart.slug, "count()": 1},
+                {"projectId": self.project.id, "project": self.project.slug, "count()": 2},
+                {"projectId": heart.id, "project": heart.slug, "count()": 1},
             ]
             assert response_data["parentProjectBreakdown"] == [
                 {"project": self.project.slug, "projectId": self.project.id, "percentage": 1.0}
@@ -503,8 +503,8 @@ class ProjectDynamicSamplingDistributionQueryCallsTest(APITestCase):
 
             response_data = response.json()
             assert response_data["projectBreakdown"] == [
-                {"project_id": self.project.id, "project": self.project.slug, "count()": 1},
-                {"project_id": heart.id, "project": heart.slug, "count()": 1},
+                {"projectId": self.project.id, "project": self.project.slug, "count()": 1},
+                {"projectId": heart.id, "project": heart.slug, "count()": 1},
             ]
             assert response_data["parentProjectBreakdown"] == [
                 {"project": self.project.slug, "projectId": self.project.id, "percentage": 0.5},
@@ -684,7 +684,7 @@ class ProjectDynamicSamplingDistributionQueryCallsTest(APITestCase):
             )
             response_data = response.json()
             assert response_data["projectBreakdown"] == [
-                {"project_id": self.project.id, "project": self.project.slug, "count()": 2},
+                {"projectId": self.project.id, "project": self.project.slug, "count()": 2},
             ]
             assert response_data["parentProjectBreakdown"] == [
                 {"project": self.project.slug, "projectId": self.project.id, "percentage": 1.0}
@@ -792,7 +792,7 @@ class ProjectDynamicSamplingDistributionQueryCallsTest(APITestCase):
             )
             response_data = response.json()
             assert response_data["projectBreakdown"] == [
-                {"project_id": self.project.id, "project": self.project.slug, "count()": 2},
+                {"projectId": self.project.id, "project": self.project.slug, "count()": 2},
             ]
             assert response_data["parentProjectBreakdown"] == [
                 {"project": self.project.slug, "projectId": self.project.id, "percentage": 1.0}
@@ -886,8 +886,8 @@ class ProjectDynamicSamplingDistributionIntegrationTest(SnubaTestCase, APITestCa
             response_data = response.json()
             assert sorted(response_data["projectBreakdown"], key=itemgetter("project")) == sorted(
                 [
-                    {"project_id": self.project.id, "project": self.project.slug, "count()": 1},
-                    {"project_id": heart.id, "project": heart.slug, "count()": 1},
+                    {"projectId": self.project.id, "project": self.project.slug, "count()": 1},
+                    {"projectId": heart.id, "project": heart.slug, "count()": 1},
                 ],
                 key=itemgetter("project"),
             )
@@ -953,8 +953,8 @@ class ProjectDynamicSamplingDistributionIntegrationTest(SnubaTestCase, APITestCa
             response_data = response.json()
             assert sorted(response_data["projectBreakdown"], key=itemgetter("project")) == sorted(
                 [
-                    {"project_id": self.project.id, "project": self.project.slug, "count()": 1},
-                    {"project_id": heart.id, "project": heart.slug, "count()": 1},
+                    {"projectId": self.project.id, "project": self.project.slug, "count()": 1},
+                    {"projectId": heart.id, "project": heart.slug, "count()": 1},
                 ],
                 key=itemgetter("project"),
             )
@@ -1064,7 +1064,7 @@ class ProjectDynamicSamplingDistributionIntegrationTest(SnubaTestCase, APITestCa
             response_data = response.json()
             assert sorted(response_data["projectBreakdown"], key=itemgetter("project")) == sorted(
                 # count is 3 because we set requested_sample_size = 3
-                [{"project_id": self.project.id, "project": self.project.slug, "count()": 3}],
+                [{"projectId": self.project.id, "project": self.project.slug, "count()": 3}],
                 key=itemgetter("project"),
             )
             assert sorted(
@@ -1116,8 +1116,8 @@ class ProjectDynamicSamplingDistributionIntegrationTest(SnubaTestCase, APITestCa
             response_data = response.json()
             assert sorted(response_data["projectBreakdown"], key=itemgetter("project")) == sorted(
                 [
-                    {"project_id": self.project.id, "project": self.project.slug, "count()": 1},
-                    {"project_id": heart.id, "project": heart.slug, "count()": 1},
+                    {"projectId": self.project.id, "project": self.project.slug, "count()": 1},
+                    {"projectId": heart.id, "project": heart.slug, "count()": 1},
                 ],
                 key=itemgetter("project"),
             )


### PR DESCRIPTION
Renames the `project_id` key to camel case in the `projectBreakdown` key in the project dynamic sampling response endpoint

