### PR TITLE
fix(dyn-sampling): Rename `project_id` to camelCase

### DIFF
--- a/static/app/actionCreators/serverSideSampling.tsx
+++ b/static/app/actionCreators/serverSideSampling.tsx
@@ -33,7 +33,7 @@ export function fetchSamplingSdkVersions({
 
   const projectIds = [
     projectID,
-    ...(projectBreakdown?.map(projectBreakdownObj => projectBreakdownObj.project_id) ??
+    ...(projectBreakdown?.map(projectBreakdownObj => projectBreakdownObj.projectId) ??
       []),
   ];
 

--- a/static/app/types/sampling.tsx
+++ b/static/app/types/sampling.tsx
@@ -107,7 +107,7 @@ export type SamplingDistribution = {
     | {
         'count()': number;
         project: string;
-        project_id: number;
+        projectId: number;
       }[];
   sampleSize: number;
   startTimestamp: string | null;

--- a/static/app/views/settings/project/server-side-sampling/samplingBreakdown.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingBreakdown.spec.tsx
@@ -30,7 +30,7 @@ describe('Server-Side Sampling - SamplingBreakdown', function () {
     const projectBreakdown = mockedSamplingDistribution.projectBreakdown;
 
     ProjectsStore.loadInitialData(
-      projectBreakdown!.map(p => TestStubs.Project({id: p.project_id, slug: p.project}))
+      projectBreakdown!.map(p => TestStubs.Project({id: p.projectId, slug: p.project}))
     );
 
     ServerSideSamplingStore.distributionRequestSuccess(mockedSamplingDistribution);

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
@@ -54,7 +54,7 @@ function renderMockRequests({
     url: `/organizations/${organizationSlug}/projects/`,
     method: 'GET',
     body: mockedSamplingDistribution.projectBreakdown!.map(p =>
-      TestStubs.Project({id: p.project_id, slug: p.project})
+      TestStubs.Project({id: p.projectId, slug: p.project})
     ),
   });
 

--- a/static/app/views/settings/project/server-side-sampling/testUtils.tsx
+++ b/static/app/views/settings/project/server-side-sampling/testUtils.tsx
@@ -132,12 +132,12 @@ export const mockedSamplingDistribution: SamplingDistribution = {
   projectBreakdown: [
     {
       project: mockedProjects[0].slug,
-      project_id: mockedProjects[0].id,
+      projectId: mockedProjects[0].id,
       'count()': 888,
     },
     {
       project: mockedProjects[1].slug,
-      project_id: mockedProjects[1].id,
+      projectId: mockedProjects[1].id,
       'count()': 100,
     },
   ],


### PR DESCRIPTION
Renames `project_id` in `projectBreakdown` to
camel case to match the response from the project
dynamic sampling endpoint response

