### PR TITLE
ref(profiling): Store images updated after symbolication to reflect their statuses

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -228,6 +228,9 @@ def _symbolicate(
 def _process_symbolicator_results(
     profile: Profile, modules: List[Any], stacktraces: List[Any]
 ) -> None:
+    # update images with status after symbolication
+    profile["debug_meta"]["images"] = modules
+
     if "version" in profile:
         profile["profile"]["frames"] = stacktraces[0]["frames"]
         _process_symbolicator_results_for_sample(profile, stacktraces)
@@ -237,9 +240,6 @@ def _process_symbolicator_results(
         _process_symbolicator_results_for_rust(profile, stacktraces)
     elif profile["platform"] == "cocoa":
         _process_symbolicator_results_for_cocoa(profile, stacktraces)
-
-    # update images with status after symbolication
-    profile["debug_meta"]["images"] = modules
 
     # rename the profile key to suggest it has been processed
     profile["profile"] = profile.pop("sampled_profile")


### PR DESCRIPTION
We were storing the `debug_meta` structure in order to see the images needed for a given profile but we were not updating the value of this list after symbolication, which is very important to know which image was missing or not. This PR aims to fix that.