### PR TITLE
fix(perf-issues): fix None in render-blocking asset detector method chain

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -724,7 +724,8 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
 
         # Only concern ourselves with transactions where the FCP is within the
         # range we care about.
-        fcp_hash = self.event().get("measurements", {}).get("fcp", {})
+        measurements = self.event().get("measurements") or {}
+        fcp_hash = measurements.get("fcp") or {}
         fcp_value = fcp_hash.get("value")
         if fcp_value and ("unit" not in fcp_hash or fcp_hash["unit"] == "millisecond"):
             fcp = timedelta(milliseconds=fcp_value)

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -564,6 +564,14 @@ class PerformanceDetectionTest(unittest.TestCase):
                 create_span("resource.script", duration=1000.0),
             ],
         }
+        no_measurements_event = {
+            "event_id": "a" * 16,
+            "project": PROJECT_ID,
+            "measurements": None,
+            "spans": [
+                create_span("resource.script", duration=1000.0),
+            ],
+        }
         short_render_blocking_asset_event = {
             "event_id": "a" * 16,
             "project": PROJECT_ID,
@@ -587,6 +595,9 @@ class PerformanceDetectionTest(unittest.TestCase):
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
 
         _detect_performance_problems(no_fcp_event, sdk_span_mock)
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
+
+        _detect_performance_problems(no_measurements_event, sdk_span_mock)
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
 
         _detect_performance_problems(render_blocking_asset_event, sdk_span_mock)


### PR DESCRIPTION
If the incoming event JSON contains `{"measurements": null}`, `self.event().get("measurements", {})` returns `None` instead of `{}` and the next call to `get` fails. Instead make sure we're working with an actual dict at each step.

Fixes SENTRY-FOR-SENTRY-NSS