### PR TITLE
fix(profiling): Use raw weights for sample timestamps

### DIFF
--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -34,7 +34,9 @@ function ThreadMenuSelector({
         details: (
           <ThreadLabelDetails
             duration={makeFormatter(profile.unit)(profile.duration)}
-            samples={profile.samples.length}
+            // plus 1 because the last sample always has a weight of 0
+            // and is not included in the raw weights
+            samples={profile.rawWeights.length + 1}
           />
         ),
       };

--- a/static/app/utils/profiling/profile/eventedProfile.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.tsx
@@ -81,9 +81,17 @@ export class EventedProfile extends Profile {
     }
   }
 
+  recordRawWeight(at: number) {
+    const weight = at - this.lastValue;
+    if (weight > 0) {
+      this.rawWeights.push(weight);
+    }
+  }
+
   enterFrame(frame: Frame, at: number): void {
     this.addWeightToFrames(at);
     this.addWeightsToNodes(at);
+    this.recordRawWeight(at);
 
     const lastTop = lastOfArray(this.appendOrderStack);
 
@@ -138,6 +146,7 @@ export class EventedProfile extends Profile {
     this.addWeightToFrames(at);
     this.addWeightsToNodes(at);
     this.trackSampleStats(at);
+    this.recordRawWeight(at);
 
     const leavingStackTop = this.appendOrderStack.pop();
 

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -36,6 +36,7 @@ export class Profile {
 
   samples: CallTreeNode[] = [];
   weights: number[] = [];
+  rawWeights: number[] = [];
 
   stats: ProfileStats = {
     discardedSamplesCount: 0,

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -113,6 +113,7 @@ export class SampledProfile extends Profile {
       this.samples.push(node);
       this.weights.push(weight);
     }
+    this.rawWeights.push(weight);
   }
 
   build(): Profile {

--- a/static/app/utils/profiling/renderers/sampleTickRenderer.tsx
+++ b/static/app/utils/profiling/renderers/sampleTickRenderer.tsx
@@ -42,7 +42,7 @@ class SampleTickRenderer {
     this.theme = theme;
     this.intervals = computeAbsoluteSampleTimestamps(
       configSpace.x,
-      this.flamegraph.profile.weights
+      this.flamegraph.profile.rawWeights
     );
     this.context = getContext(canvas, '2d');
   }


### PR DESCRIPTION
Currently, we use `profile.weights` to determine the width of each frame. However, these weights are the combined weights of neighbouring samples. This change introduces a `profile.rawWeights` for when we need to access the weights of the individual samples.