### PR TITLE
feat(mobile-screenshots): Add event id to serializer

### DIFF
--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -9,18 +9,6 @@ from sentry.api.serializers import EventAttachmentSerializer, serialize
 from sentry.models import EventAttachment
 
 
-class GroupEventAttachmentSerializer(EventAttachmentSerializer):
-    """
-    Serializes event attachments with event id for rendering in the group event
-    attachments UI.
-    """
-
-    def serialize(self, obj, attrs, user):
-        result = super().serialize(obj, attrs, user)
-        result["event_id"] = obj.event_id
-        return result
-
-
 @region_silo_endpoint
 class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
     def get(self, request: Request, group) -> Response:
@@ -54,6 +42,6 @@ class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
             request=request,
             queryset=attachments,
             order_by="-date_added",
-            on_results=lambda x: serialize(x, request.user, GroupEventAttachmentSerializer()),
+            on_results=lambda x: serialize(x, request.user, EventAttachmentSerializer()),
             paginator_cls=DateTimePaginator,
         )

--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -19,4 +19,5 @@ class EventAttachmentSerializer(Serializer):
             "sha1": file.checksum,
             "dateCreated": file.timestamp,
             "type": obj.type,
+            "event_id": obj.event_id,
         }

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -50,6 +50,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         assert response.status_code == 200, response.content
         assert response.data["id"] == str(self.attachment.id)
         assert response.data["mimetype"] == self.attachment.mimetype
+        assert response.data["event_id"] == self.event.event_id
 
     def test_download(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -41,6 +41,7 @@ class EventAttachmentsTest(APITestCase):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(attachment1.id)
         assert response.data[0]["mimetype"] == attachment1.mimetype
+        assert response.data[0]["event_id"] == attachment1.event_id
 
     def test_is_screenshot(self):
         self.login_as(user=self.user)
@@ -74,3 +75,4 @@ class EventAttachmentsTest(APITestCase):
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(attachment1.id)
         assert response.data[0]["mimetype"] == attachment1.mimetype
+        assert response.data[0]["event_id"] == attachment1.event_id


### PR DESCRIPTION
- This adds the event_id to the eventattachment serializer so now it'll show up on the details and list endpoints for event attachments