### PR TITLE
fix(discover-homepage): Remove feature flag check on homepage endpoint

### DIFF
--- a/src/sentry/discover/endpoints/discover_homepage_query.py
+++ b/src/sentry/discover/endpoints/discover_homepage_query.py
@@ -30,12 +30,9 @@ class DiscoverHomepageQueryEndpoint(OrganizationEndpoint):
     )
 
     def has_feature(self, organization, request):
-        return (
-            features.has("organizations:discover", organization, actor=request.user)
-            or features.has("organizations:discover-query", organization, actor=request.user)
-        ) and features.has(
-            "organizations:discover-query-builder-as-landing-page", organization, actor=request.user
-        )
+        return features.has(
+            "organizations:discover", organization, actor=request.user
+        ) or features.has("organizations:discover-query", organization, actor=request.user)
 
     def get(self, request: Request, organization) -> Response:
         if not self.has_feature(organization, request):


### PR DESCRIPTION
Removes the `discover-query-builder-as-landing-page` feature flag check because instability in flagr may cause the whole homepage view to error. Removing this check shouldn't be too impactful because the functionality is still flagged by discover-query and the user can only act on a single instance of a homepage query