### PR TITLE
ref(flagr): Move sourcemapcache-processor flag off flagr

### DIFF
--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -218,7 +218,7 @@ default_manager.add("projects:similarity-indexing", ProjectFeature)
 default_manager.add("projects:similarity-indexing-v2", ProjectFeature)
 default_manager.add("projects:similarity-view", ProjectFeature)
 default_manager.add("projects:similarity-view-v2", ProjectFeature)
-default_manager.add("projects:sourcemapcache-processor", ProjectFeature, True)
+default_manager.add("projects:sourcemapcache-processor", ProjectFeature)
 default_manager.add("projects:suspect-resolutions", ProjectFeature, True)
 
 # Project plugin features


### PR DESCRIPTION
This is causing a good amount of flagr timeouts, taking this off flagr.