### PR TITLE
fix(post-processor-group): don't post process for transactions with no associated groups

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -400,7 +400,9 @@ def post_process_group(
         }
 
         multi_groups: Sequence[Tuple[GroupEvent, GroupState]] = [
-            (group_events.get(gs.get("id")), gs) for gs in group_states if gs.get("id") is not None
+            (group_events.get(gs.get("id")), gs)
+            for gs in (group_states or ())
+            if gs.get("id") is not None
         ]
 
         group_jobs: Sequence[PostProcessJob] = [

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -380,7 +380,7 @@ def post_process_group(
 
         # TODO: Remove this check once we're sending all group ids as `group_states` and treat all
         # events the same way
-        if not is_transaction_event or group_states is None:
+        if not is_transaction_event and group_states is None:
             # error issue
             group_states = [
                 {


### PR DESCRIPTION
Fixes SENTRY-W6V