### PR TITLE
WIP: fix(discover): Filter out empty equations from widget builder sort

### DIFF
--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -170,7 +170,7 @@ function getTableSortOptions(_organization: Organization, widgetQuery: WidgetQue
   const options: SelectValue<string>[] = [];
   let equations = 0;
   [...aggregates, ...columns]
-    .filter(field => !!field)
+    .filter(field => (isEquation(field) ? stripEquationPrefix(field) : !!field))
     .forEach(field => {
       let alias;
       const label = stripEquationPrefix(field);
@@ -218,7 +218,7 @@ function getTimeseriesSortOptions(
 
   let equations = 0;
   [...widgetQuery.aggregates, ...widgetQuery.columns]
-    .filter(field => !!field)
+    .filter(field => (isEquation(field) ? stripEquationPrefix(field) : !!field))
     .forEach(field => {
       let alias;
       const label = stripEquationPrefix(field);

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -980,5 +980,40 @@ describe('WidgetBuilder', function () {
         );
       });
     });
+
+    it('filters out empty equations from options for table', async function () {
+      renderTestComponent({
+        orgFeatures: [...defaultOrgFeatures, 'discover-frontend-use-events-endpoint'],
+        query: {
+          source: DashboardWidgetSource.DASHBOARDS,
+          displayType: DisplayType.TABLE,
+        },
+      });
+
+      userEvent.click(screen.getByText('Add an Equation'));
+
+      selectEvent.openMenu(screen.getAllByText('count()')[2]);
+
+      // No equation options in the opened menu
+      await waitFor(() => expect(screen.queryByText('equation')).not.toBeInTheDocument());
+    });
+
+    it('filters out empty equations from options for timeseries', async function () {
+      renderTestComponent({
+        orgFeatures: [...defaultOrgFeatures, 'discover-frontend-use-events-endpoint'],
+        query: {
+          source: DashboardWidgetSource.DASHBOARDS,
+          displayType: DisplayType.LINE,
+        },
+      });
+
+      await selectEvent.select(await screen.findByText('Select group'), 'project');
+      userEvent.click(screen.getByText('Add an Equation'));
+
+      selectEvent.openMenu(screen.getAllByText('count()')[2]);
+
+      // Only the custom equation option
+      expect(await screen.findByText('equation')).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Users are unable to sort by empty equations, so we should filter them out in errors and transaction widgets.

Also adds some more validation around what happens when the sorting falls back to other
aggregate values in the widget query. Check to ensure they're valid equations, or else default to
`count()`. This is necessary because the logic would provide a value, but the option would be
filtered out due to these changes, causing the input to become uncontrolled and throwing a
`console.error` error in jest tests.

Fixes SENTRY-VDM