### PR TITLE
feat(profiling): add profile details filter + sort

### DIFF
--- a/static/app/components/profiling/flamegraphOptionsMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsMenu.tsx
@@ -80,7 +80,7 @@ const X_AXIS: Record<FlamegraphPreferences['xAxis'], string> = {
 
 const COLOR_CODINGS: Record<FlamegraphPreferences['colorCoding'], string> = {
   'by symbol name': t('By Symbol Name'),
-  'by library': t('By Library'),
+  'by library': t('By Package'),
   'by system / application': t('By System / Application'),
   'by recursion': t('By Recursion'),
   'by frequency': t('By Frequency'),


### PR DESCRIPTION
This PR introduces basic filtering by library and type (application/system), in addition to this we introduce sorting for self weight + total weight. 

This is pretty quick and dirty since we're slicing/dicing on the front-end, and we're slicing the dataset before filters+sort is applied.  

https://user-images.githubusercontent.com/7349258/195189071-169f6c12-3d99-4a85-a2a5-c09f6d8ada16.mov

