### PR TITLE
fix(perf): Fix unique keys error in span tree

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -90,7 +90,9 @@ class SpanTree extends Component<PropType> {
 
     const showHiddenSpansMessage = !isCurrentSpanHidden && numOfSpansOutOfViewAbove > 0;
 
-    const firstHiddenSpanId = getSpanID(filteredSpansAbove[0].span);
+    const firstHiddenSpanId = filteredSpansAbove[0]
+      ? getSpanID(filteredSpansAbove[0].span)
+      : '0';
 
     if (showHiddenSpansMessage) {
       messages.push(

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -90,9 +90,11 @@ class SpanTree extends Component<PropType> {
 
     const showHiddenSpansMessage = !isCurrentSpanHidden && numOfSpansOutOfViewAbove > 0;
 
+    const firstHiddenSpanId = getSpanID(filteredSpansAbove[0].span);
+
     if (showHiddenSpansMessage) {
       messages.push(
-        <span key="spans-out-of-view">
+        <span key={`spans-out-of-view-${firstHiddenSpanId}`}>
           <strong>{numOfSpansOutOfViewAbove}</strong> {t('spans out of view')}
         </span>
       );
@@ -107,7 +109,7 @@ class SpanTree extends Component<PropType> {
       if (!isCurrentSpanHidden) {
         if (numOfFilteredSpansAbove === 1) {
           messages.push(
-            <span key="spans-filtered">
+            <span key={`spans-filtered-${firstHiddenSpanId}`}>
               {tct('[numOfSpans] hidden span', {
                 numOfSpans: <strong>{numOfFilteredSpansAbove}</strong>,
               })}
@@ -115,7 +117,7 @@ class SpanTree extends Component<PropType> {
           );
         } else {
           messages.push(
-            <span key="spans-filtered">
+            <span key={`spans-filtered-${firstHiddenSpanId}`}>
               {tct('[numOfSpans] hidden spans', {
                 numOfSpans: <strong>{numOfFilteredSpansAbove}</strong>,
               })}
@@ -131,6 +133,7 @@ class SpanTree extends Component<PropType> {
 
     return (
       <MessageRow
+        key={`message-row-${firstHiddenSpanId}`}
         onClick={
           focusedSpanIds
             ? () => {


### PR DESCRIPTION
Fixes an annoying console error that has been plaguing the span tree component for ages:

![image](https://user-images.githubusercontent.com/16740047/195199722-4d80bc1e-c5de-4bc3-8133-21aa8d668ed2.png)

Some components did not have unique keys, and also the `MessageRow` component needed a key as well.