### PR TITLE
Deprecate "kafka.send-project-transactions-to-new-topic" killswitch

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2477,10 +2477,6 @@ KAFKA_EVENTS = "events"
 # changes to support different topic, switch this to "transactions" to start
 # producing to the new topic.
 KAFKA_TRANSACTIONS = "events"
-# TODO: KAFKA_NEW_TRANSACTIONS only exists in order to facilitate the errors/transactions
-# split. It is only supposed to exist briefly so we can map transactions of a subset of
-# projects to the new topic first before migrating them all over.
-KAFKA_NEW_TRANSACTIONS = "transactions"
 KAFKA_OUTCOMES = "outcomes"
 KAFKA_OUTCOMES_BILLING = "outcomes-billing"
 KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS = "events-subscription-results"
@@ -2521,7 +2517,6 @@ KAFKA_SUBSCRIPTION_RESULT_TOPICS = {
 KAFKA_TOPICS = {
     KAFKA_EVENTS: {"cluster": "default"},
     KAFKA_TRANSACTIONS: {"cluster": "default"},
-    KAFKA_NEW_TRANSACTIONS: {"cluster": "default"},
     KAFKA_OUTCOMES: {"cluster": "default"},
     # When OUTCOMES_BILLING is None, it inherits from OUTCOMES and does not
     # create a separate producer. Check ``track_outcome`` for details.

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -26,20 +26,11 @@ class KafkaEventStream(SnubaProtocolEventStream):
     def __init__(self, **options: Any) -> None:
         self.topic = settings.KAFKA_EVENTS
         self.transactions_topic = settings.KAFKA_TRANSACTIONS
-        # TODO: KAFKA_NEW_TRANSACTIONS is temporary and only to be used during
-        # the errors/transactions split process.
-        self.new_transactions_topic = settings.KAFKA_NEW_TRANSACTIONS
         self.assign_transaction_partitions_randomly = (
             settings.SENTRY_EVENTSTREAM_PARTITION_TRANSACTIONS_RANDOMLY
         )
 
     def get_transactions_topic(self, project_id: int) -> str:
-        use_new_topic = killswitch_matches_context(
-            "kafka.send-project-transactions-to-new-topic",
-            {"project_id": project_id},
-        )
-        if use_new_topic:
-            return self.new_transactions_topic
         return self.transactions_topic
 
     def get_producer(self, topic: str) -> Producer:

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -451,14 +451,6 @@ register("reprocessing2.drop-delete-old-primary-hash", default=[])
 # e.g. [{"project_id": 2, "message_type": "error"}, {"project_id": 3, "message_type": "transaction"}]
 register("kafka.send-project-events-to-random-partitions", default=[])
 
-# Temporary option to be removed after rollout.
-# This sends events for the project IDs being passed here to the KAFKA_NEW_TRANSACTIONS
-# topic (default "transactions") instead of the KAFKA_TRANSACTIONS topic (currently "events").
-# e.g. [{"project_id": 2}, {"project_id": 3}]
-# Once transactions is fully rolled out and KAFKA_TRANSACTIONS is mapped to "transactions" instead
-# of "events" this should be removed.
-register("kafka.send-project-transactions-to-new-topic", default=[])
-
 # Rate to project_configs_v3, no longer used.
 register("relay.project-config-v3-enable", default=0.0)
 


### PR DESCRIPTION
This was used for the transition of transactions to a new topic/cluster in prod. It's no longer needed.

