### PR TITLE
fix(issues): Fix console warning in ignore dropdown due to non-accessible labels

### DIFF
--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -7,7 +7,6 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import CustomIgnoreCountModal from 'sentry/components/customIgnoreCountModal';
 import CustomIgnoreDurationModal from 'sentry/components/customIgnoreDurationModal';
 import DropdownMenuControl from 'sentry/components/dropdownMenuControl';
-import Duration from 'sentry/components/duration';
 import Tooltip from 'sentry/components/tooltip';
 import {IconChevron, IconMute} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
@@ -17,6 +16,7 @@ import {
   ResolutionStatusDetails,
   SelectValue,
 } from 'sentry/types';
+import {getDuration} from 'sentry/utils/formatters';
 
 const ONE_HOUR = 60;
 
@@ -136,7 +136,7 @@ const IgnoreActions = ({
       children: [
         ...IGNORE_DURATIONS.map(duration => ({
           key: `for-${duration}`,
-          label: <Duration seconds={duration * 60} />,
+          label: getDuration(duration * 60),
           onAction: () => onIgnore({ignoreDuration: duration}),
         })),
         {


### PR DESCRIPTION
Warning:

<img width="619" alt="image" src="https://user-images.githubusercontent.com/10888943/195205133-f38f3fc5-08d8-4ff8-8f6e-ed781757ac00.png">

Fix was to use the util function directly instead of the component which returned a <span>