### PR TITLE
feat(alerts): Limit the activities returned with incidents

### DIFF
--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -60,7 +60,9 @@ class IncidentSerializer(Serializer):
                 results[incident]["has_seen"] = has_seen
 
         if "activities" in self.expand:
-            activities = list(IncidentActivity.objects.filter(incident__in=item_list))
+            # There could be many activities. An incident could seesaw between error/warning for a long period.
+            # e.g - every 1 minute for 10 months
+            activities = list(IncidentActivity.objects.filter(incident__in=item_list)[:1000])
             incident_activities = defaultdict(list)
             for activity, serialized_activity in zip(activities, serialize(activities, user=user)):
                 incident_activities[activity.incident_id].append(serialized_activity)


### PR DESCRIPTION
we're sending a massive number of incident activities, in some cases 35,000