### PR TITLE
fix(hybrid-cloud): Use window.csrfCookieName for login page

### DIFF
--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -33,7 +33,7 @@
     return null;
   }
   setInterval(function() {
-    var csrfCookieVal = getCookie('sc');
+    var csrfCookieVal = getCookie(window.csrfCookieName || 'sc');
     // combine strings for csrf name as some tests grep on the token name :(
     var csrfName = 'csrf'+'middleware'+'token';
     var csrfEls = document.getElementsByName(csrfName);


### PR DESCRIPTION
CSRF cookie name may not longer be `sc`, so we should rely on using `window.csrfCookieName` whenever possible.

This is defined here and propagated to `window`: https://github.com/getsentry/sentry/blob/7cc7176f56639adb0af74cb304190bb218d0f286/src/sentry/web/client_config.py#L194