### PR TITLE
fix(discover-homepage): Fix flicker when loading homepage

### DIFF
--- a/static/app/views/eventsV2/homepage.tsx
+++ b/static/app/views/eventsV2/homepage.tsx
@@ -1,10 +1,9 @@
-import {browserHistory, InjectedRouter} from 'react-router';
+import {InjectedRouter} from 'react-router';
 import {Location} from 'history';
 
 import {Client} from 'sentry/api';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
 import {Organization, PageFilters, SavedQuery} from 'sentry/types';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -25,8 +24,6 @@ type Props = {
 };
 
 type HomepageQueryState = AsyncComponent['state'] & {
-  // Used to trigger intial redirect for the saved query
-  hasLoaded: boolean;
   savedQuery?: SavedQuery | null;
 };
 
@@ -46,30 +43,6 @@ class HomepageQueryAPI extends AsyncComponent<Props, HomepageQueryState> {
     }
     return endpoints;
   }
-
-  onRequestSuccess = ({stateKey, data}) => {
-    const {location} = this.props;
-    const {hasLoaded} = this.state;
-    if (stateKey === 'savedQuery' && !hasLoaded) {
-      this.setState({hasLoaded: true});
-      const normalizedDateTime = normalizeDateTimeParams({
-        start: data.start,
-        end: data.end,
-        statsPeriod: data.range,
-        utc: data.utc,
-      });
-
-      browserHistory.replace({
-        pathname: location.pathname,
-        query: {
-          project: data.projects ?? [],
-          environment: data.environment ?? [],
-          ...normalizedDateTime,
-          ...location.query,
-        },
-      });
-    }
-  };
 
   setSavedQuery = (newSavedQuery: SavedQuery) => {
     this.setState({savedQuery: newSavedQuery});

--- a/static/app/views/eventsV2/homepage.tsx
+++ b/static/app/views/eventsV2/homepage.tsx
@@ -28,6 +28,8 @@ type HomepageQueryState = AsyncComponent['state'] & {
 };
 
 class HomepageQueryAPI extends AsyncComponent<Props, HomepageQueryState> {
+  shouldReload = true;
+
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {organization} = this.props;
 
@@ -47,10 +49,6 @@ class HomepageQueryAPI extends AsyncComponent<Props, HomepageQueryState> {
   setSavedQuery = (newSavedQuery: SavedQuery) => {
     this.setState({savedQuery: newSavedQuery});
   };
-
-  renderLoading() {
-    return this.renderBody();
-  }
 
   renderBody(): React.ReactNode {
     const {savedQuery, loading} = this.state;

--- a/static/app/views/eventsV2/results.spec.jsx
+++ b/static/app/views/eventsV2/results.spec.jsx
@@ -1676,7 +1676,7 @@ describe('Results', function () {
     const initialData = initializeOrg({
       organization,
       router: {
-        location: {query: {fromMetric: true}},
+        location: {query: {fromMetric: true, id: '1'}},
       },
     });
 
@@ -1707,7 +1707,7 @@ describe('Results', function () {
     const initialData = initializeOrg({
       organization,
       router: {
-        location: {query: {showUnparameterizedBanner: true}},
+        location: {query: {showUnparameterizedBanner: true, id: '1'}},
       },
     });
 

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -689,6 +689,8 @@ type SavedQueryState = AsyncComponent['state'] & {
 };
 
 class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
+  shouldReload = true;
+
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {organization, location} = this.props;
 
@@ -706,10 +708,6 @@ class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
   setSavedQuery = (newSavedQuery: SavedQuery) => {
     this.setState({savedQuery: newSavedQuery});
   };
-
-  renderLoading() {
-    return this.renderBody();
-  }
 
   renderBody(): React.ReactNode {
     const {savedQuery, loading} = this.state;

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -105,8 +105,8 @@ function getYAxis(location: Location, eventView: EventView, savedQuery?: SavedQu
 export class Results extends Component<Props, State> {
   static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     if (
-      ((!nextProps.isHomepage || prevState.savedQuery) &&
-        (nextProps.savedQuery || !nextProps.loading)) ||
+      !nextProps.isHomepage ||
+      prevState.savedQuery ||
       nextProps.savedQuery === undefined // When user clicks on Discover in sidebar
     ) {
       const eventView = EventView.fromSavedQueryOrLocation(

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -106,7 +106,7 @@ export class Results extends Component<Props, State> {
     if (
       ((!nextProps.isHomepage || prevState.savedQuery) &&
         (nextProps.savedQuery || !nextProps.loading)) ||
-      nextProps.savedQuery === undefined
+      nextProps.savedQuery === undefined // When user clicks on Discover in sidebar
     ) {
       const eventView = EventView.fromSavedQueryOrLocation(
         nextProps.savedQuery,
@@ -121,7 +121,7 @@ export class Results extends Component<Props, State> {
     // If this is the homepage, force an invalid eventView so we can handle
     // the redirect first
     eventView: this.props.isHomepage
-      ? EventView.fromSavedQuery({...DEFAULT_EVENT_VIEW, fields: []})
+      ? EventView.fromSavedQueryOrLocation(undefined, this.props.location)
       : EventView.fromSavedQueryOrLocation(this.props.savedQuery, this.props.location),
     error: '',
     errorCode: 200,

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -19,6 +19,7 @@ import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import SearchBar from 'sentry/components/events/searchBar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import ExternalLink from 'sentry/components/links/externalLink';
+import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
@@ -553,6 +554,10 @@ export class Results extends Component<Props, State> {
     const query = eventView.query;
     const title = this.getDocumentTitle();
     const yAxisArray = getYAxis(location, eventView, savedQuery);
+
+    if (!eventView.isValid()) {
+      return <LoadingIndicator />;
+    }
 
     return (
       <SentryDocumentTitle title={title} orgSlug={organization.slug}>


### PR DESCRIPTION
The homepage relies on a fetch request to complete and a redirect to occur before getting events data (events-stats, events, events-meta). There is a gap by implementing a redirect in the child of AsyncComponent where the discover charts load up with the event view, but the page filters aren't set. If projects need to be loaded, this redirect occurs and then triggers another series of fetches. If the first series completes then there will be a flicker when the final state loads.

My fix here essentially treats the first render of the homepage view as an invalid event view. That way we can wait until the `checkEventView` function handles the redirecting and sets the page filters and gives us a valid event view. This reduces how many places we're handling redirect logic because I was able to move it out of the `HomepageQueryAPI` component.

Flickers are hard to test for, so I'm relying on the existing tests to check for functionality.