### PR TITLE
feat(metrics): Handles granularity vs interval in metrics layer

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -671,7 +671,12 @@ def get_series(
 ) -> dict:
     """Get time series for the given query"""
     intervals = list(
-        get_intervals(metrics_query.start, metrics_query.end, metrics_query.granularity.granularity)
+        get_intervals(
+            metrics_query.start,
+            metrics_query.end,
+            metrics_query.granularity.granularity,
+            interval=metrics_query.interval,
+        )
     )
     results = {}
     meta = []

--- a/src/sentry/snuba/metrics/mqb_query_transformer.py
+++ b/src/sentry/snuba/metrics/mqb_query_transformer.py
@@ -95,6 +95,7 @@ def _transform_select(query_select):
 
 def _transform_groupby(query_groupby):
     mq_groupby = []
+    interval = None
     include_series = False
     for groupby_field in query_groupby:
         if isinstance(groupby_field, (Column, AliasedExpression)):
@@ -105,9 +106,6 @@ def _transform_groupby(query_groupby):
                 column_field = groupby_field
                 column_alias = None
 
-            if column_field.name == "bucketed_time":
-                include_series = True
-                continue
             if column_field.name in FIELD_ALIAS_MAPPINGS.keys() | FIELD_ALIAS_MAPPINGS.values():
                 mq_groupby.append(
                     MetricGroupByField(
@@ -137,13 +135,21 @@ def _transform_groupby(query_groupby):
                         alias=groupby_field.alias,
                     )
                 )
+            elif groupby_field.function == "toStartOfInterval":
+                include_series = True
+                assert (
+                    isinstance(groupby_field.parameters[1], Function)
+                    and groupby_field.parameters[1].function == "toIntervalSecond"
+                )
+                interval = groupby_field.parameters[1].parameters[0]
+                continue
             else:
                 raise MQBQueryTransformationException(
                     f"Cannot group by function {groupby_field.function}"
                 )
         else:
             raise MQBQueryTransformationException(f"Unsupported groupby field {groupby_field}")
-    return mq_groupby if len(mq_groupby) > 0 else None, include_series
+    return mq_groupby if len(mq_groupby) > 0 else None, include_series, interval
 
 
 def _get_mq_dict_params_from_where(query_where):
@@ -215,7 +221,7 @@ def tranform_mqb_query_to_metrics_query(query: Query) -> MetricsQuery:
             "Having clauses are not supported by the metrics layer"
         )
     # Handle groupby
-    groupby, include_series = _transform_groupby(query.groupby)
+    groupby, include_series, interval = _transform_groupby(query.groupby)
 
     mq_dict = {
         "select": _transform_select(query.select),
@@ -226,6 +232,7 @@ def tranform_mqb_query_to_metrics_query(query: Query) -> MetricsQuery:
         "include_series": include_series,
         "granularity": query.granularity if query.granularity is not None else Granularity(3600),
         "orderby": _transform_orderby(query.orderby),
+        "interval": interval,
         **_get_mq_dict_params_from_where(query.where),
     }
     return MetricsQuery(**mq_dict)

--- a/src/sentry/snuba/metrics/mqb_query_transformer.py
+++ b/src/sentry/snuba/metrics/mqb_query_transformer.py
@@ -136,12 +136,29 @@ def _transform_groupby(query_groupby):
                     )
                 )
             elif groupby_field.function == "toStartOfInterval":
+                # Checks against the following snuba function
+                # time_groupby_column = Function(
+                #    function="toStartOfInterval",
+                #    parameters=[
+                #        Column(name="timestamp"),
+                #        Function(
+                #            function="toIntervalSecond",
+                #            parameters=[self._metrics_query.interval],
+                #            alias=None,
+                #        ),
+                #        "Universal",
+                #    ],
+                #    alias=TS_COL_GROUP,
+                # )
                 include_series = True
+
+                # Maps to `toIntervalSecond` function
+                interval_func = groupby_field.parameters[1]
                 assert (
-                    isinstance(groupby_field.parameters[1], Function)
-                    and groupby_field.parameters[1].function == "toIntervalSecond"
+                    isinstance(interval_func, Function)
+                    and interval_func.function == "toIntervalSecond"
                 )
-                interval = groupby_field.parameters[1].parameters[0]
+                interval = interval_func.parameters[0]
                 continue
             else:
                 raise MQBQueryTransformationException(

--- a/src/sentry/snuba/metrics/query.py
+++ b/src/sentry/snuba/metrics/query.py
@@ -330,8 +330,10 @@ class MetricsQuery(MetricsQueryValidationRunner):
             )
 
     def validate_interval(self) -> None:
-        if self.use_case_key == UseCaseKey.RELEASE_HEALTH:
-            if self.interval is not None:
+        if self.interval is not None:
+            if self.use_case_key == UseCaseKey.RELEASE_HEALTH or (
+                self.use_case_key == UseCaseKey.PERFORMANCE and not self.include_series
+            ):
                 raise InvalidParams("Interval is only supported for timeseries performance queries")
 
     def __post_init__(self) -> None:

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -605,18 +605,8 @@ class SnubaQueryBuilder:
             series_limit = limit.limit * intervals_len
 
             if self._use_case_id == UseCaseKey.PERFORMANCE:
-                time_groupby_column = Function(
-                    function="toStartOfInterval",
-                    parameters=[
-                        Column(name="timestamp"),
-                        Function(
-                            function="toIntervalSecond",
-                            parameters=[self._metrics_query.interval],
-                            alias=None,
-                        ),
-                        "Universal",
-                    ],
-                    alias=TS_COL_GROUP,
+                time_groupby_column = self.__generate_time_groupby_column_for_discover_queries(
+                    self._metrics_query.interval
                 )
             else:
                 time_groupby_column = Column(TS_COL_GROUP)
@@ -626,6 +616,22 @@ class SnubaQueryBuilder:
             )
 
         return rv
+
+    @staticmethod
+    def __generate_time_groupby_column_for_discover_queries(interval: int) -> Function:
+        return Function(
+            function="toStartOfInterval",
+            parameters=[
+                Column(name="timestamp"),
+                Function(
+                    function="toIntervalSecond",
+                    parameters=[interval],
+                    alias=None,
+                ),
+                "Universal",
+            ],
+            alias=TS_COL_GROUP,
+        )
 
     def __update_query_dicts_with_component_entities(
         self, component_entities, metric_mri_to_obj_dict, fields_in_entities, parent_alias

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1270,6 +1270,7 @@ class BaseMetricsLayerTestCase(BaseMetricsTestCase):
         type: Optional[str] = None,
         org_id: Optional[int] = None,
         project_id: Optional[int] = None,
+        days_before_now: int = 0,
         hours_before_now: int = 0,
         minutes_before_now: int = 0,
         seconds_before_now: int = 0,
@@ -1290,6 +1291,7 @@ class BaseMetricsLayerTestCase(BaseMetricsTestCase):
             timestamp=(
                 self.now
                 - timedelta(
+                    days=days_before_now,
                     hours=hours_before_now,
                     minutes=minutes_before_now,
                     # We subtract 1 second -(+1) in order to account for right non-inclusivity in the queries.
@@ -1323,6 +1325,7 @@ class BaseMetricsLayerTestCase(BaseMetricsTestCase):
         type: Optional[str] = None,
         org_id: Optional[int] = None,
         project_id: Optional[int] = None,
+        days_before_now: int = 0,
         hours_before_now: int = 0,
         minutes_before_now: int = 0,
         seconds_before_now: int = 0,
@@ -1335,6 +1338,7 @@ class BaseMetricsLayerTestCase(BaseMetricsTestCase):
             org_id=org_id,
             project_id=project_id,
             use_case_id=UseCaseKey.PERFORMANCE,
+            days_before_now=days_before_now,
             hours_before_now=hours_before_now,
             minutes_before_now=minutes_before_now,
             seconds_before_now=seconds_before_now,
@@ -1348,6 +1352,7 @@ class BaseMetricsLayerTestCase(BaseMetricsTestCase):
         type: Optional[str] = None,
         org_id: Optional[int] = None,
         project_id: Optional[int] = None,
+        days_before_now: int = 0,
         hours_before_now: int = 0,
         minutes_before_now: int = 0,
         seconds_before_now: int = 0,
@@ -1360,6 +1365,7 @@ class BaseMetricsLayerTestCase(BaseMetricsTestCase):
             org_id=org_id,
             project_id=project_id,
             use_case_id=UseCaseKey.RELEASE_HEALTH,
+            days_before_now=days_before_now,
             hours_before_now=hours_before_now,
             minutes_before_now=minutes_before_now,
             seconds_before_now=seconds_before_now,

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -9,6 +9,7 @@ import pytest
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDict
 from freezegun import freeze_time
+from freezegun.api import FakeDatetime
 from snuba_sdk import Column, Condition, Direction, Function, Granularity, Limit, Offset, Op
 
 from sentry.api.utils import InvalidParams
@@ -25,10 +26,10 @@ from sentry.snuba.metrics import (
 )
 from sentry.snuba.metrics.datasource import get_custom_measurements, get_series
 from sentry.snuba.metrics.naming_layer import TransactionMetricKey, TransactionMRI
-from sentry.snuba.metrics.query_builder import QueryDefinition, get_date_range
+from sentry.snuba.metrics.query_builder import QueryDefinition
 from sentry.testutils import TestCase
 from sentry.testutils.cases import BaseMetricsLayerTestCase, MetricsEnhancedPerformanceTestCase
-from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.testutils.helpers.datetime import before_now
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -788,31 +789,21 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
             }
         ]
 
-    @pytest.mark.skip(reason="Contains granularity/rollup logic that is not yet implemented")
     def test_throughput_epm_hour_rollup_offset_of_hour(self):
         # Each of these denotes how many events to create in each hour
         day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
 
         event_counts = [6, 0, 6, 3, 0, 3]
-
-        self.store_metric(
-            org_id=self.organization.id,
-            project_id=self.project.id,
-            name=TransactionMRI.DURATION.value,
-            tags={},
-            timestamp=(day_ago + timedelta(hours=0, minutes=25)).timestamp(),
-            value=1,
-            use_case_id=UseCaseKey.PERFORMANCE,
-        )
-
         for hour, count in enumerate(event_counts):
             for minute in range(count):
-                self.store_metric(
+                self.store_performance_metric(
                     name=TransactionMRI.DURATION.value,
                     tags={},
-                    timestamp=(day_ago + timedelta(hours=hour, minutes=minute + 30)).timestamp(),
                     value=1,
-                    use_case_id=UseCaseKey.PERFORMANCE,
+                    minutes_before_now=-(minute + 30),
+                    days_before_now=1,
+                    hours_before_now=-hour,
+                    seconds_before_now=-1,
                 )
 
         metrics_query = MetricsQuery(
@@ -831,26 +822,48 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
             ],
             start=day_ago + timedelta(minutes=30),
             end=day_ago + timedelta(hours=6, minutes=30),
-            granularity=Granularity(granularity=1800),
+            granularity=Granularity(granularity=60),
             limit=Limit(limit=5),
             offset=Offset(offset=0),
             include_series=True,
+            interval=3600,
         )
-
-        start, end, rollup = get_date_range(
-            {
-                "start": iso_format(day_ago + timedelta(minutes=30)),
-                "end": iso_format(day_ago + timedelta(hours=6, minutes=30)),
-            }
-        )
-
         data = get_series(
             [self.project],
             metrics_query=metrics_query,
             include_meta=True,
             use_case_id=UseCaseKey.PERFORMANCE,
         )
-        assert data
+        assert data == {
+            "start": FakeDatetime(2022, 9, 28, 10, 30),
+            "end": FakeDatetime(2022, 9, 28, 16, 30),
+            "intervals": [
+                FakeDatetime(2022, 9, 28, 10, 0, tzinfo=timezone.utc),
+                FakeDatetime(2022, 9, 28, 11, 0, tzinfo=timezone.utc),
+                FakeDatetime(2022, 9, 28, 12, 0, tzinfo=timezone.utc),
+                FakeDatetime(2022, 9, 28, 13, 0, tzinfo=timezone.utc),
+                FakeDatetime(2022, 9, 28, 14, 0, tzinfo=timezone.utc),
+                FakeDatetime(2022, 9, 28, 15, 0, tzinfo=timezone.utc),
+            ],
+            "groups": [
+                {
+                    "by": {},
+                    "series": {
+                        "rate(transaction.duration)": [0.1, 0, 0.1, 0.05, 0, 0.05],
+                        "count(transaction.duration)": [6, 0, 6, 3, 0, 3],
+                    },
+                    "totals": {
+                        "rate(transaction.duration)": 0.3,
+                        "count(transaction.duration)": 18,
+                    },
+                }
+            ],
+            "meta": [
+                {"name": "bucketed_time", "type": "DateTime('Universal')"},
+                {"name": "count(transaction.duration)", "type": "UInt64"},
+                {"name": "rate(transaction.duration)", "type": "Float64"},
+            ],
+        }
 
     def test_throughput_eps_minute_rollup(self):
         event_counts = [6, 0, 6, 3, 0, 3]

--- a/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
+++ b/tests/sentry/snuba/metrics/test_mqb_query_transformer.py
@@ -56,7 +56,6 @@ based on time bounds provided and if this behaviour is intended to be different,
 the metrics layer. However, passing granularity is abstracted to metrics layer (There is an ongoing discussion about
 specifically this)
 """
-# ToDo Test Invalid queries:= Transform Function, Tags in the select, Ordering by bucketed_time
 
 VALID_QUERIES_INTEGRATION_TEST_CASES = [
     # Totals Query
@@ -646,7 +645,21 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
                     alias="count_unique_user",
                 )
             ],
-            groupby=[AliasedExpression(Column("bucketed_time"), "time")],
+            groupby=[
+                Function(
+                    function="toStartOfInterval",
+                    parameters=[
+                        Column(name="timestamp"),
+                        Function(
+                            function="toIntervalSecond",
+                            parameters=[3600],
+                            alias=None,
+                        ),
+                        "Universal",
+                    ],
+                    alias="time",
+                )
+            ],
             array_join=None,
             where=[
                 Condition(
@@ -705,6 +718,7 @@ VALID_QUERIES_INTEGRATION_TEST_CASES = [
             include_totals=True,
             limit=Limit(limit=50),
             offset=Offset(offset=0),
+            interval=3600,
         ),
         id="series query test case",
     ),

--- a/tests/sentry/snuba/metrics/test_query.py
+++ b/tests/sentry/snuba/metrics/test_query.py
@@ -39,6 +39,7 @@ class MetricsQueryBuilder:
         self.offset: Optional[Offset] = None
         self.include_series: bool = True
         self.include_totals: bool = True
+        self.interval: Optional[int] = None
 
     def with_select(self, select: Sequence[MetricField]) -> "MetricsQueryBuilder":
         self.select = select
@@ -80,6 +81,10 @@ class MetricsQueryBuilder:
         self.groupby = groupby
         return self
 
+    def with_interval(self, interval: int) -> "MetricsQueryBuilder":
+        self.interval = interval
+        return self
+
     def to_metrics_query_dict(self):
         return {
             "org_id": self.org_id,
@@ -95,6 +100,7 @@ class MetricsQueryBuilder:
             "offset": self.offset,
             "include_series": self.include_series,
             "include_totals": self.include_totals,
+            "interval": self.interval,
         }
 
 
@@ -507,3 +513,81 @@ def test_validate_metric_field_mri_is_public(alias):
         match="Unable to find a mri reverse mapping for 'e:sessions/error.preaggr@none'.",
     ):
         MetricField(op=None, metric_mri="e:sessions/error.preaggr@none", alias=alias)
+
+
+@pytest.mark.parametrize(
+    "select, interval, series",
+    [
+        pytest.param(
+            None,
+            3600,
+            False,
+            id="release health query, not series, interval provided",
+        ),
+        pytest.param(
+            None,
+            3600,
+            True,
+            id="release health query, series, interval provided",
+        ),
+        pytest.param(
+            [MetricField(op="p95", metric_mri=TransactionMRI.DURATION.value)],
+            3600,
+            False,
+            id="performance query, not series, interval provided",
+        ),
+    ],
+)
+def test_validate_interval(select, interval, series):
+    metrics_query = MetricsQueryBuilder().with_include_series(series)
+    if select:
+        metrics_query = metrics_query.with_select(select)
+    if interval:
+        metrics_query = metrics_query.with_interval(interval)
+    metrics_query_dict = metrics_query.to_metrics_query_dict()
+
+    with pytest.raises(
+        InvalidParams, match="Interval is only supported for timeseries performance queries"
+    ):
+        MetricsQuery(**metrics_query_dict)
+
+
+def test_ensure_interval_set_to_granularity_in_performance_queries():
+    metrics_query = (
+        MetricsQueryBuilder()
+        .with_select([MetricField(op="p95", metric_mri=TransactionMRI.DURATION.value)])
+        .with_include_series(True)
+    )
+    metrics_query_dict = metrics_query.to_metrics_query_dict()
+    mq = MetricsQuery(**metrics_query_dict)
+    assert mq.interval == mq.granularity.granularity
+
+
+@pytest.mark.parametrize(
+    "granularity, interval, expected_granularity",
+    [
+        pytest.param(
+            86400,
+            7200,
+            3600,
+            id="day granularity with 2 hour interval",
+        ),
+        pytest.param(
+            3600,
+            1800,
+            60,
+            id="hour granularity with 30 minute interval",
+        ),
+    ],
+)
+def test_ensure_granularity_is_less_than_interval(granularity, interval, expected_granularity):
+    metrics_query = (
+        MetricsQueryBuilder()
+        .with_select([MetricField(op="p95", metric_mri=TransactionMRI.DURATION.value)])
+        .with_include_series(True)
+        .with_granularity(Granularity(granularity))
+        .with_interval(interval)
+    )
+    metrics_query_dict = metrics_query.to_metrics_query_dict()
+    mq = MetricsQuery(**metrics_query_dict)
+    assert mq.granularity.granularity == expected_granularity


### PR DESCRIPTION
Handles the differences between granularity and interval for the metrics layer when carrying out performance queries

It achieves this by 
- Introducing groupBy behaviour using by `toStartOfInterval` rather than `bucketed_time` for perfromance queries
