### PR TITLE
ref(profiling): Retry the Celery task if insertion in vroom fails

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -535,6 +535,8 @@ def _insert_vroom_profile(profile: Profile) -> bool:
     except RecursionError as e:
         sentry_sdk.capture_exception(e)
         return True
+    except VroomTimeout:
+        raise
     except Exception as e:
         sentry_sdk.capture_exception(e)
         metrics.incr(

--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -66,7 +66,7 @@ _profiling_pool = connection_from_url(
         status_forcelist={502},
         allowed_methods={"GET", "POST"},
     ),
-    timeout=30,
+    timeout=10,
     maxsize=10,
     headers={"Accept-Encoding": "br, gzip"},
 )


### PR DESCRIPTION
The idea is to take advantage of the Celery retries so that, when GCS fails to store a profile, instead of returning an error and dropping the profile, we retry later.

For that, we updated the retry policy on `vroom` to return a `429` in case a GCS operation timeouts. We then throw a custom exception, catched by Celery which will schedule the task for retry later on.

I also lowered the retry on the connection pool. This could have a larger impact as to throw more exception due to suspect functions queries timing out. We don't have to do it at the same time here, but it seems like a good idea as a user will not want to wait for more than 10s for a request to fail anyway and we need to know if that happens in order to tweak the query.