### PR TITLE
ref: fix deprecated set-output calls

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -113,10 +113,10 @@ runs:
         MATRIX_INSTANCE: ${{ matrix.instance }}
       shell: bash
       run: |
-        echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
-        echo "::set-output name=matrix-instance-number::$(($MATRIX_INSTANCE+1))"
-        echo "::set-output name=matrix-instance-total::$(($MATRIX_INSTANCE_TOTAL))"
-        echo "::set-output name=acceptance-dir::.artifacts/visual-snapshots/acceptance"
+        echo "yarn-cache-dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
+        echo "matrix-instance-number=$(($MATRIX_INSTANCE+1))" >> "$GITHUB_OUTPUT"
+        echo "matrix-instance-total=$(($MATRIX_INSTANCE_TOTAL))" >> "$GITHUB_OUTPUT"
+        echo "acceptance-dir=.artifacts/visual-snapshots/acceptance" >> "$GITHUB_OUTPUT"
 
     - name: Install python dependencies
       shell: bash

--- a/.github/actions/setup-volta/bin/setup-volta
+++ b/.github/actions/setup-volta/bin/setup-volta
@@ -37,8 +37,9 @@ def _command_vars() -> int:
 
     cache_key = f"{sys.platform}-volta-{VOLTA}-node-{node}-yarn-{yarn}"
 
-    print(f"::set-output name=cache-key::{cache_key}")
-    print(f"::set-output name=volta-dir::{VOLTA_DIR}")
+    with open(os.environ["GITHUB_OUTPUT"], "a+") as f:
+        print(f"cache-key={cache_key}", file=f)
+        print(f"volta-dir={VOLTA_DIR}", file=f)
 
     print(f"adding {VOLTA_BIN} to path")
     with open(os.environ["GITHUB_PATH"], "a+") as f:
@@ -82,7 +83,8 @@ def _command_install() -> int:
 def _command_yarn_cache_dir() -> int:
     out = subprocess.check_output((_volta_bin("yarn"), "cache", "dir"))
     cache_dir = out.decode().strip()
-    print(f"::set-output name=cache-dir::{cache_dir}")
+    with open(os.environ["GITHUB_OUTPUT"], "a+") as f:
+        print(f"cache-dir={cache_dir}", file=f)
     return 0
 
 

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Step configurations
         id: config
-        run: echo "::set-output name=webpack-path::.webpack_cache"
+        run: echo "webpack-path=.webpack_cache" >> "$GITHUB_OUTPUT"
 
       - name: webpack cache
         uses: actions/cache@56046cbc4743437ac40542086317b1561d7705f8  # v3.0.8

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up
         id: info
         run: |
-          echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
+          echo "yarn-cache-dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       # Trick for unattended Docker installations
       # https://github.com/docker/for-mac/issues/2359#issuecomment-943131345

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -72,7 +72,7 @@ jobs:
       - name: eslint logic
         id: eslint
         if: (github.ref == 'refs/heads/master' || needs.files-changed.outputs.eslint_config == 'true' || needs.files-changed.outputs.yarn_lockfile == 'true')
-        run: echo "::set-output name=all-files::true"
+        run: echo "all-files=true" >> "$GITHUB_OUTPUT"
 
       # Lint entire frontend if:
       # - this is on main branch

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -77,7 +77,7 @@ jobs:
         id: file
         run: |
           echo $(git diff --diff-filter=A --name-only origin/master HEAD)
-          echo "::set-output name=added::$(git diff --diff-filter=A --name-only origin/master HEAD | grep 'src/sentry/migrations/')"
+          echo "added=$(git diff --diff-filter=A --name-only origin/master HEAD | grep 'src/sentry/migrations/')" >> "$GITHUB_OUTPUT"
 
       - name: Generate SQL for migration
         uses: getsentry/action-migrations@f1dc34590460c0fe06ec11c00fec6c16a2159977  # main


### PR DESCRIPTION
mostly automated with:

```
sed -i -r 's/echo "::set-output name=(.*)::(.*)"/echo "\1=\2" >> "$GITHUB_OUTPUT"/g;s/echo "::set-state name=(.*)::(.*)"/echo "\1=\2" >> "$GITHUB_STATE"/g' $(git grep -El '(set-output|set-state)')
```

setup-volta needed manual changes