### PR TITLE
feat: adds events as reserved slug

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -105,6 +105,7 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "demo",
         "docs",
         "enterprise",
+        "events",
         "ext",
         "extension",
         "extensions",


### PR DESCRIPTION
We are already using sentry.io/events for showing events like Dex