### PR TITLE
fix(hybrid-cloud): Do not bork the org switcher if the current org does not exist

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
@@ -122,4 +122,27 @@ describe('SwitchOrganization', function () {
     expect(screen.getByTestId('pending-deletion-icon')).toBeInTheDocument();
     jest.useRealTimers();
   });
+
+  it('renders when there is no current organization', function () {
+    // This can occur when disabled members of an organization will not have a current organization.
+    jest.useFakeTimers();
+    render(
+      <SwitchOrganization
+        canCreateOrganization={false}
+        organizations={[
+          TestStubs.Organization({name: 'Organization 1'}),
+          TestStubs.Organization({name: 'Organization 2', slug: 'org2'}),
+        ]}
+      />
+    );
+
+    userEvent.hover(screen.getByTestId('sidebar-switch-org'));
+    act(() => void jest.advanceTimersByTime(500));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    expect(screen.getByText('Organization 1')).toBeInTheDocument();
+    expect(screen.getByText('Organization 2')).toBeInTheDocument();
+    jest.useRealTimers();
+  });
 });

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useContext} from 'react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
@@ -10,14 +10,14 @@ import {IconAdd, IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {OrganizationSummary} from 'sentry/types';
-import useOrganization from 'sentry/utils/useOrganization';
 import useResolveRoute from 'sentry/utils/useResolveRoute';
 import withOrganizations from 'sentry/utils/withOrganizations';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import Divider from './divider.styled';
 
 function CreateOrganization({canCreateOrganization}: {canCreateOrganization: boolean}) {
-  const currentOrganization = useOrganization();
+  const currentOrganization = useContext(OrganizationContext);
   const route = useResolveRoute('/organizations/new/');
 
   if (!canCreateOrganization) {
@@ -26,7 +26,7 @@ function CreateOrganization({canCreateOrganization}: {canCreateOrganization: boo
 
   const menuItemProps: Partial<React.ComponentProps<typeof SidebarMenuItem>> = {};
 
-  if (currentOrganization.features.includes('customer-domains')) {
+  if (currentOrganization?.features.includes('customer-domains')) {
     menuItemProps.href = route;
     menuItemProps.openInNewTab = false;
   } else {

--- a/static/app/utils/useResolveRoute.tsx
+++ b/static/app/utils/useResolveRoute.tsx
@@ -1,6 +1,8 @@
+import {useContext} from 'react';
+
 import ConfigStore from 'sentry/stores/configStore';
 import {OrganizationSummary} from 'sentry/types';
-import useOrganization from 'sentry/utils/useOrganization';
+import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import shouldUseLegacyRoute from './shouldUseLegacyRoute';
 
@@ -12,8 +14,8 @@ import shouldUseLegacyRoute from './shouldUseLegacyRoute';
  */
 function useResolveRoute(route: string, organization?: OrganizationSummary) {
   const {sentryUrl} = ConfigStore.get('links');
-  const currentOrganization = useOrganization();
-  const hasCustomerDomain = currentOrganization.features.includes('customer-domains');
+  const currentOrganization = useContext(OrganizationContext);
+  const hasCustomerDomain = currentOrganization?.features.includes('customer-domains');
 
   if (!organization) {
     if (hasCustomerDomain) {


### PR DESCRIPTION
Fixes JAVASCRIPT-25ZY - https://sentry.io/organizations/sentry/issues/2754060735/?project=11276

`useOrganization()` will throw an exception if the user does not have a current organization. On `getsentry`, this could occur if the user is "disabled" for their current organization. 

One scenario of being "disabled" is if an organization downgrades from a business/team plan to a free plan which only supports 1 member (i.e. the owner).