### PR TITLE
feat(hybrid-cloud): Add a test for file upload

### DIFF
--- a/src/sentry/api_gateway/proxy.py
+++ b/src/sentry/api_gateway/proxy.py
@@ -46,9 +46,7 @@ def proxy_request(request: Request, org_slug: str) -> StreamingHttpResponse:
         "headers": request.headers,
         "params": dict(query_params) if query_params is not None else None,
         "files": getattr(request, "FILES", None),
-        "data": getattr(request, "body", None)
-        if request.content_type == "application/json"
-        else None,
+        "data": getattr(request, "body", None) if not getattr(request, "FILES", None) else None,
         "stream": True,
         "timeout": settings.GATEWAY_PROXY_TIMEOUT,
     }

--- a/src/sentry/api_gateway/proxy.py
+++ b/src/sentry/api_gateway/proxy.py
@@ -45,12 +45,15 @@ def proxy_request(request: Request, org_slug: str) -> StreamingHttpResponse:
     request_args = {
         "headers": request.headers,
         "params": dict(query_params) if query_params is not None else None,
-        "data": getattr(request, "body", None),
+        "files": getattr(request, "FILES", None),
+        "data": getattr(request, "body", None)
+        if request.content_type == "application/json"
+        else None,
         "stream": True,
         "timeout": settings.GATEWAY_PROXY_TIMEOUT,
     }
     try:
-        resp: ExternalResponse = external_request(request.method, target_url, **request_args)
+        resp: ExternalResponse = external_request(request.method, url=target_url, **request_args)
     except Timeout:
         # remote silo timeout. Use DRF timeout instead
         raise RequestTimeout()

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -93,7 +93,7 @@ def verify_file_body(file_body, headers):
     """Wrapper for a callback function for responses.add_callback"""
 
     def request_callback(request):
-        assert request.body == file_body
+        assert file_body in request.body
         assert (request.headers[key] == headers[key] for key in headers)
         return 200, {}, json.dumps({"proxy": True})
 

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -55,7 +55,10 @@ def verify_request_body(body, headers):
     """Wrapper for a callback function for responses.add_callback"""
 
     def request_callback(request):
-        assert json.loads(request.body) == body
+        if request.headers["content-type"] == "application/json":
+            assert json.loads(request.body) == body
+        else:
+            assert request.body == body
         assert (request.headers[key] == headers[key] for key in headers)
         return 200, {}, json.dumps({"proxy": True})
 
@@ -93,7 +96,7 @@ def verify_file_body(file_body, headers):
     """Wrapper for a callback function for responses.add_callback"""
 
     def request_callback(request):
-        assert file_body in request.body
+        assert file_body in request.body or file_body in request.body.read()
         assert (request.headers[key] == headers[key] for key in headers)
         return 200, {}, json.dumps({"proxy": True})
 

--- a/tests/sentry/api_gateway/test_proxy.py
+++ b/tests/sentry/api_gateway/test_proxy.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 
 import pytest
 import responses
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test.client import RequestFactory
 from rest_framework.exceptions import NotFound
 
@@ -10,6 +11,7 @@ from sentry.api_gateway.proxy import proxy_request
 from sentry.testutils.helpers.api_gateway import (
     SENTRY_REGION_CONFIG,
     ApiGatewayTestCase,
+    verify_file_body,
     verify_request_body,
     verify_request_headers,
 )
@@ -141,6 +143,28 @@ class ProxyTestCase(ApiGatewayTestCase):
 
         request = RequestFactory().delete(
             "http://sentry.io/delete", data=request_body, content_type="application/json"
+        )
+        resp = proxy_request(request, self.organization.slug)
+        resp_json = json.loads(b"".join(resp.streaming_content))
+
+        assert resp.status_code == 200
+        assert resp_json["proxy"]
+
+    @responses.activate
+    def test_file_upload(self, _):
+        foo = dict(test="a", file="b", what="c")
+        contents = json.dumps(foo).encode()
+        request_body = {
+            "test.js": SimpleUploadedFile("test.js", contents, content_type="application/json")
+        }
+
+        responses.add_callback(
+            responses.POST,
+            "http://region1.testserver/post",
+            verify_file_body(contents, {"test": "header"}),
+        )
+        request = RequestFactory().post(
+            "http://sentry.io/post", data=request_body, format="multipart"
         )
         resp = proxy_request(request, self.organization.slug)
         resp_json = json.loads(b"".join(resp.streaming_content))


### PR DESCRIPTION
This just ensures that the file body is in the request body that's being proxied

I'm kinda at an impasse here because I need to see what's coming into the django view from the proxied request. Parsing the raw request object is strange because I can't seem to extract the input buffer
