### PR TITLE
fix(discover-homepage): Updates to default query do not rerender

### DIFF
--- a/static/app/views/eventsV2/homepage.tsx
+++ b/static/app/views/eventsV2/homepage.tsx
@@ -46,6 +46,13 @@ class HomepageQueryAPI extends AsyncComponent<Props, HomepageQueryState> {
     return endpoints;
   }
 
+  onRequestSuccess({stateKey, data}) {
+    // No homepage query results in a 204, returning an empty string
+    if (stateKey === 'savedQuery' && data === '') {
+      this.setState({savedQuery: null});
+    }
+  }
+
   setSavedQuery = (newSavedQuery: SavedQuery) => {
     this.setState({savedQuery: newSavedQuery});
   };


### PR DESCRIPTION
When the homepage request finishes and there is no saved query, it returns a 204 and the response body is treated as an empty string. This is saved in HomepageQueryAPI and causes downstream issues due to mismatched type checks. Instead, catch this case and coerce the result to null.