### PR TITLE
fix(Auth Access): fixed SentryApp.DoesNotExist 

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -414,7 +414,12 @@ def _from_sentry_app(user, organization: Optional[Organization] = None) -> Acces
     if not organization:
         return NoAccess()
 
-    sentry_app = SentryApp.objects.get(proxy_user=user)
+    sentry_app_query = SentryApp.objects.filter(proxy_user=user)
+
+    if not sentry_app_query.exists():
+        return NoAccess()
+
+    sentry_app = sentry_app_query[0]
 
     if not sentry_app.is_installed_on(organization):
         return NoAccess()

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -503,6 +503,16 @@ class FromSentryAppTest(TestCase):
         assert not result.has_project_access(self.out_of_scope_project)
         assert not result.permissions
 
+    def test_no_access_due_to_no_app(self):
+        user = self.create_user("integration2@example.com")
+        request = self.make_request(user=user)
+        result = access.from_request(request, self.org)
+        assert not result.has_team_access(self.team)
+        assert not result.has_team_access(self.team2)
+        assert not result.has_team_access(self.out_of_scope_team)
+        assert not result.has_project_access(self.project)
+        assert not result.has_project_access(self.out_of_scope_project)
+
     def test_no_access_due_to_no_installation_unowned(self):
         request = self.make_request(user=self.proxy_user)
         result = access.from_request(request, self.out_of_scope_org)


### PR DESCRIPTION
https://sentry.io/organizations/sentry/issues/3338911787/?project=1&referrer=slack

SentryApp.DoesNotExist  is a result of `SentryApp.objects.get(proxy_user=user)` not having an app that matches the query requirements. 

Now we'll do a filter and return no access if an app wasn't found