### PR TITLE
fix(scim): Fix invite member if member already exists but didn't accept invite

### DIFF
--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -395,17 +395,25 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
 
         result = serializer.validated_data
         with transaction.atomic():
-            member = OrganizationMember(
-                organization=organization,
-                email=result["email"],
-                role=result["role"],
-                inviter=request.user,
+            member_query = OrganizationMember.objects.filter(
+                organization=organization, email=result["email"], role=result["role"]
             )
 
-            # TODO: are invite tokens needed for SAML orgs?
-            if settings.SENTRY_ENABLE_INVITES:
-                member.token = member.generate_token()
-            member.save()
+            if member_query.exists():
+                member = member_query[0]
+
+            else:
+                member = OrganizationMember(
+                    organization=organization,
+                    email=result["email"],
+                    role=result["role"],
+                    inviter=request.user,
+                )
+
+                # TODO: are invite tokens needed for SAML orgs?
+                if settings.SENTRY_ENABLE_INVITES:
+                    member.token = member.generate_token()
+                member.save()
 
         self.create_audit_entry(
             request=request,

--- a/src/sentry/scim/endpoints/members.py
+++ b/src/sentry/scim/endpoints/members.py
@@ -400,7 +400,9 @@ class OrganizationSCIMMemberIndex(SCIMEndpoint):
             )
 
             if member_query.exists():
-                member = member_query[0]
+                member = member_query.first()
+                if member.token_expired:
+                    member.regenerate_token()
 
             else:
                 member = OrganizationMember(

--- a/tests/apidocs/endpoints/scim/test_member_index.py
+++ b/tests/apidocs/endpoints/scim/test_member_index.py
@@ -36,3 +36,28 @@ class SCIMMemberIndexDocs(APIDocsTestCase, SCIMTestCase):
         response = self.client.post(self.url, post_data)
         request = RequestFactory().post(self.url, post_data)
         self.validate_schema(request, response)
+
+    def test_post_member_exists_but_not_accepted(self):
+        self.create_member(
+            user=self.create_user(),
+            organization=self.organization,
+            email="test.user@okta.local",
+            role="member",
+            invite_status=1,
+        )
+        post_data = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+            "userName": "test.user@okta.local",
+            "name": {"givenName": "Test", "familyName": "User"},
+            "emails": [{"primary": True, "value": "test.user@okta.local", "type": "work"}],
+            "displayName": "Test User",
+            "locale": "en-US",
+            "externalId": "00ujl29u0le5T6Aj10h7",
+            "groups": [],
+            "password": "1mz050nq",
+            "active": True,
+        }
+
+        response = self.client.post(self.url, post_data)
+        request = RequestFactory().post(self.url, post_data)
+        self.validate_schema(request, response)


### PR DESCRIPTION
If SCIM invites an user that is associated with an existing organization member, but that org member didn't accept their invite, the following happens:

https://sentry.io/organizations/sentry/issues/3585935994/?project=1&referrer=slack

To combat this, we now resend an invite to the existing user