### PR TITLE
feat(hybrid-cloud): Add logic on when to proxy

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -7,16 +7,23 @@ from sentry.api_gateway.proxy import proxy_request
 from sentry.silo import SiloMode
 
 
-def _request_should_be_proxied(request: Request, view_kwargs) -> bool:
-    return SiloMode.get_current_mode() != SiloMode.MONOLITH and "organization_slug" in view_kwargs
+def _request_should_be_proxied(request: Request, view_func, view_kwargs) -> bool:
+    view_class = getattr(view_func, "view_class", None)
+    current_silo_mode = SiloMode.get_current_mode()
+    if view_class is not None:
+        endpoint_silo_limit = getattr(view_class, "silo_limit", None)
+        if endpoint_silo_limit is not None:
+            endpoint_silo_set = endpoint_silo_limit.modes
+            return current_silo_mode not in endpoint_silo_set and "organization_slug" in view_kwargs
+    return False
 
 
-def proxy_request_if_needed(request: Request, view_kwargs) -> HttpResponseBase | None:
+def proxy_request_if_needed(request: Request, view_func, view_kwargs) -> HttpResponseBase | None:
     """
     Main execution flow for the API Gateway
     returns None if proxying is not required
     """
-    if not _request_should_be_proxied(request, view_kwargs):
+    if not _request_should_be_proxied(request, view_func, view_kwargs):
         return None
 
     # Request should be proxied at this point

--- a/src/sentry/middleware/api_gateway.py
+++ b/src/sentry/middleware/api_gateway.py
@@ -20,6 +20,6 @@ class ApiGatewayMiddleware:
     def process_view(
         self, request: Request, view_func, view_args, view_kwargs
     ) -> HttpResponseBase | None:
-        proxy_response = proxy_request_if_needed(request, view_kwargs)
+        proxy_response = proxy_request_if_needed(request, view_func, view_kwargs)
         if proxy_response is not None:
             return proxy_response

--- a/src/sentry/testutils/helpers/api_gateway.py
+++ b/src/sentry/testutils/helpers/api_gateway.py
@@ -7,7 +7,7 @@ from django.test import override_settings
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint, control_silo_endpoint, pending_silo_endpoint
+from sentry.api.base import control_silo_endpoint, region_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.testutils import APITestCase
 from sentry.types.region import Region, RegionCategory
@@ -24,12 +24,14 @@ SENTRY_REGION_CONFIG = [
 
 
 @control_silo_endpoint
-class ControlEndpoint(Endpoint):
-    def get(self, request):
+class ControlEndpoint(OrganizationEndpoint):
+    permission_classes = (AllowAny,)
+
+    def get(self, request, organization):
         return Response({"proxy": False})
 
 
-@pending_silo_endpoint
+@region_silo_endpoint
 class RegionEndpoint(OrganizationEndpoint):
     permission_classes = (AllowAny,)
 


### PR DESCRIPTION
Request should only be proxied when the endpoint's silo limit doesn't match the current silo mode

