### PR TITLE
ref: Simplify post process, remove hack that uses transaction forwarder header

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2470,7 +2470,11 @@ KAFKA_CLUSTERS = {
 #     pick up the change.
 
 KAFKA_EVENTS = "events"
-KAFKA_TRANSACTIONS = "transactions"
+# TODO: KAFKA_TRANSACTIONS is temporarily mapped to "events" since events
+# transactions curently share a Kafka topic. Once we are ready with the code
+# changes to support different topic, switch this to "transactions" to start
+# producing to the new topic.
+KAFKA_TRANSACTIONS = "events"
 KAFKA_OUTCOMES = "outcomes"
 KAFKA_OUTCOMES_BILLING = "outcomes-billing"
 KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS = "events-subscription-results"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2470,11 +2470,7 @@ KAFKA_CLUSTERS = {
 #     pick up the change.
 
 KAFKA_EVENTS = "events"
-# TODO: KAFKA_TRANSACTIONS is temporarily mapped to "events" since events
-# transactions curently share a Kafka topic. Once we are ready with the code
-# changes to support different topic, switch this to "transactions" to start
-# producing to the new topic.
-KAFKA_TRANSACTIONS = "events"
+KAFKA_TRANSACTIONS = "transactions"
 KAFKA_OUTCOMES = "outcomes"
 KAFKA_OUTCOMES_BILLING = "outcomes-billing"
 KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS = "events-subscription-results"

--- a/src/sentry/eventstream/kafka/postprocessworker.py
+++ b/src/sentry/eventstream/kafka/postprocessworker.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 Message = Any
 _DURATION_METRIC = "eventstream.duration"
 _MESSAGES_METRIC = "eventstream.messages"
-_TRANSACTION_FORWARDER_HEADER = "transaction_forwarder"
 
 
 class PostProcessForwarderType(str, Enum):

--- a/src/sentry/eventstream/kafka/postprocessworker.py
+++ b/src/sentry/eventstream/kafka/postprocessworker.py
@@ -8,7 +8,6 @@ from typing import Any, Generator, Mapping, Optional, Sequence
 from sentry import options
 from sentry.eventstream.base import GroupStates
 from sentry.eventstream.kafka.protocol import (
-    decode_bool,
     get_task_kwargs_for_message,
     get_task_kwargs_for_message_from_headers,
 )
@@ -136,44 +135,3 @@ class PostProcessForwarderWorker(AbstractBatchWorker):
 
     def shutdown(self) -> None:
         self.__executor.shutdown()
-
-
-class ErrorsPostProcessForwarderWorker(PostProcessForwarderWorker):
-    """
-    ErrorsPostProcessForwarderWorker will processes messages only in the following scenarios:
-    1. _TRANSACTION_FORWARDER_HEADER is missing from the kafka headers. This is a backward compatibility
-    use case. There can be messages in the queue which do not have this header. Those messages should be
-    handled by the errors post process forwarder
-    2. _TRANSACTION_FORWARDER_HEADER is False in the kafka headers.
-    """
-
-    def process_message(self, message: Message) -> Optional[Future]:
-        headers = {header: value for header, value in message.headers()}
-
-        # Backwards-compatibility case for messages missing header.
-        if _TRANSACTION_FORWARDER_HEADER not in headers:
-            return super().process_message(message)
-
-        if decode_bool(headers.get(_TRANSACTION_FORWARDER_HEADER)) is False:
-            return super().process_message(message)
-
-        return None
-
-
-class TransactionsPostProcessForwarderWorker(PostProcessForwarderWorker):
-    """
-    TransactionsPostProcessForwarderWorker will processes messages only in the following scenarios:
-    1. _TRANSACTION_FORWARDER_HEADER is True in the kafka headers.
-    """
-
-    def process_message(self, message: Message) -> Optional[Future]:
-        headers = {header: value for header, value in message.headers()}
-
-        # Backwards-compatibility for messages missing headers.
-        if _TRANSACTION_FORWARDER_HEADER not in headers:
-            return None
-
-        if decode_bool(headers.get(_TRANSACTION_FORWARDER_HEADER)) is True:
-            return super().process_message(message)
-
-        return None

--- a/tests/sentry/eventstream/kafka/test_postprocessworker.py
+++ b/tests/sentry/eventstream/kafka/test_postprocessworker.py
@@ -4,11 +4,7 @@ import pytest
 
 import sentry.tasks.post_process
 from sentry import options
-from sentry.eventstream.kafka.postprocessworker import (
-    ErrorsPostProcessForwarderWorker,
-    PostProcessForwarderWorker,
-    TransactionsPostProcessForwarderWorker,
-)
+from sentry.eventstream.kafka.postprocessworker import PostProcessForwarderWorker
 from sentry.eventstream.kafka.protocol import InvalidVersion
 from sentry.testutils.helpers import TaskRunner
 from sentry.utils import json
@@ -160,14 +156,14 @@ def test_post_process_forwarder_bad_message(kafka_message_payload):
 
 @pytest.mark.django_db
 @patch("sentry.eventstream.kafka.postprocessworker.dispatch_post_process_group_task", autospec=True)
-def test_errors_post_process_forwarder_missing_headers(
+def test_post_process_forwarder_missing_headers(
     dispatch_post_process_group_task, kafka_message_without_transaction_header
 ):
     """
     Tests that the errors post process forwarder calls dispatch_post_process_group_task
     when the header "transaction_forwarder" is missing.
     """
-    forwarder = ErrorsPostProcessForwarderWorker(concurrency=1)
+    forwarder = PostProcessForwarderWorker(concurrency=1)
     future = forwarder.process_message(kafka_message_without_transaction_header)
     assert future is not None
 
@@ -198,88 +194,13 @@ def test_errors_post_process_forwarder_false_headers(
     Test that the errors post process forwarder calls dispatch_post_process_group_task
     when the header "transaction_forwarder" is set to False.
     """
-    forwarder = ErrorsPostProcessForwarderWorker(concurrency=1)
+    forwarder = PostProcessForwarderWorker(concurrency=1)
     future = forwarder.process_message(kafka_message_with_transaction_header_false)
     assert future is not None
 
     forwarder.flush_batch([future])
 
     dispatch_post_process_group_task.assert_called_once_with(
-        event_id="fe0ee9a2bc3b415497bad68aaf70dc7f",
-        project_id=1,
-        group_id=43,
-        primary_hash="311ee66a5b8e697929804ceb1c456ffe",
-        is_new=False,
-        is_regression=None,
-        is_new_group_environment=False,
-        group_states=[
-            {"id": 43, "is_new": False, "is_regression": None, "is_new_group_environment": False}
-        ],
-    )
-
-    forwarder.shutdown()
-
-
-@pytest.mark.django_db
-def test_errors_post_process_forwarder_true_headers(kafka_message_with_transaction_header_true):
-    """
-    Tests that the errors post process forwarder's process_message returns None
-    when the header "transaction_forwarder" is set to True.
-    """
-    forwarder = ErrorsPostProcessForwarderWorker(concurrency=1)
-    future = forwarder.process_message(kafka_message_with_transaction_header_true)
-
-    assert future is None
-
-    forwarder.shutdown()
-
-
-@pytest.mark.django_db
-def test_transactions_post_process_forwarder_missing_headers(
-    kafka_message_without_transaction_header,
-):
-    """
-    Tests that the transactions post process forwarder's process_message returns None
-    when the header "transaction_forwarder" is missing.
-    """
-    forwarder = TransactionsPostProcessForwarderWorker(concurrency=1)
-    future = forwarder.process_message(kafka_message_without_transaction_header)
-    assert future is None
-
-    forwarder.shutdown()
-
-
-@pytest.mark.django_db
-def test_transactions_post_process_forwarder_false_headers(
-    kafka_message_with_transaction_header_false,
-):
-    """
-    Tests that the transactions post process forwarder's process_message returns None
-    when the header "transaction_forwarder" is set to False.
-    """
-    forwarder = TransactionsPostProcessForwarderWorker(concurrency=1)
-    future = forwarder.process_message(kafka_message_with_transaction_header_false)
-    assert future is None
-
-    forwarder.shutdown()
-
-
-@pytest.mark.django_db
-@patch("sentry.eventstream.kafka.postprocessworker.dispatch_post_process_group_task", autospec=True)
-def test_transactions_post_process_forwarder_true_headers(
-    dispatch_post_process_group_task, kafka_message_with_transaction_header_true
-):
-    """
-    Tests that the transactions post process forwarder calls dispatch_post_process_group_task
-    when the header "transaction_forwarder" is set to True.
-    """
-    forwarder = TransactionsPostProcessForwarderWorker(concurrency=1)
-    future = forwarder.process_message(kafka_message_with_transaction_header_true)
-
-    assert future is not None
-    forwarder.flush_batch([future])
-
-    dispatch_post_process_group_task.assert_called_with(
         event_id="fe0ee9a2bc3b415497bad68aaf70dc7f",
         project_id=1,
         group_id=43,
@@ -304,7 +225,7 @@ def test_errors_post_process_forwarder_calls_post_process_group(
     post_process_group_spy,
     kafka_message_without_transaction_header,
 ):
-    forwarder = ErrorsPostProcessForwarderWorker(concurrency=1)
+    forwarder = PostProcessForwarderWorker(concurrency=1)
 
     with TaskRunner():
         assert post_process_group_spy.call_count == 0
@@ -345,7 +266,7 @@ def test_transactions_post_process_forwarder_calls_post_process_group(
     post_process_group_spy,
     kafka_message_with_transaction_header_true,
 ):
-    forwarder = TransactionsPostProcessForwarderWorker(concurrency=1)
+    forwarder = PostProcessForwarderWorker(concurrency=1)
 
     with TaskRunner():
         assert post_process_group_spy.call_count == 0


### PR DESCRIPTION
This was a hack for Sentry prod only that allowed each post process forwarder to filter messages that weren't relevant to it (since errors and transactions shared a topic). Now they are split and every message should be processed, we no longer need this.