### PR TITLE
fix(profiling): Check for specific keys we need to proceed

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -65,7 +65,11 @@ def process_profile(
     try:
         if _should_symbolicate(profile):
             if "debug_meta" not in profile or not profile["debug_meta"]:
-                sentry_sdk.capture_message("profile doesn't have a debug_meta key")
+                metrics.incr(
+                    "process_profile.missing_keys.debug_meta",
+                    tags={"platform": profile["platform"]},
+                    sample_rate=1.0,
+                )
                 return
 
             modules, stacktraces = _prepare_frames_from_profile(profile)
@@ -90,7 +94,11 @@ def process_profile(
     try:
         if _should_deobfuscate(profile):
             if "profile" not in profile or not profile["profile"]:
-                sentry_sdk.capture_message("profile doesn't have a profile key")
+                metrics.incr(
+                    "process_profile.missing_keys.profile",
+                    tags={"platform": profile["platform"]},
+                    sample_rate=1.0,
+                )
                 return
 
             _deobfuscate(profile=profile, project=project)

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -64,6 +64,10 @@ def process_profile(
 
     try:
         if _should_symbolicate(profile):
+            if "debug_meta" not in profile:
+                sentry_sdk.capture_message("profile doesn't have a debug_meta key")
+                return
+
             modules, stacktraces = _prepare_frames_from_profile(profile)
             modules, stacktraces = _symbolicate(
                 project=project,
@@ -85,6 +89,10 @@ def process_profile(
 
     try:
         if _should_deobfuscate(profile):
+            if "profile" not in profile:
+                sentry_sdk.capture_message("profile doesn't have a profile key")
+                return
+
             _deobfuscate(profile=profile, project=project)
     except Exception as e:
         sentry_sdk.capture_exception(e)

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -64,7 +64,7 @@ def process_profile(
 
     try:
         if _should_symbolicate(profile):
-            if "debug_meta" not in profile:
+            if "debug_meta" not in profile or not profile["debug_meta"]:
                 sentry_sdk.capture_message("profile doesn't have a debug_meta key")
                 return
 
@@ -89,7 +89,7 @@ def process_profile(
 
     try:
         if _should_deobfuscate(profile):
-            if "profile" not in profile:
+            if "profile" not in profile or not profile["profile"]:
                 sentry_sdk.capture_message("profile doesn't have a profile key")
                 return
 


### PR DESCRIPTION
We received errors suggesting those 2 keys where not on the profile when `relay` is supposed to either add them or reject data without them. In any case, we can't proceed without them so we're going to reject the profiles without here too.