### PR TITLE
feat(dyn-sampling): Adds `get_blended_sample_rate` to `Quota` abstraction

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -1,4 +1,6 @@
+import typing
 from enum import IntEnum, unique
+from typing import Optional
 
 from django.conf import settings
 from django.core.cache import cache
@@ -6,6 +8,9 @@ from django.core.cache import cache
 from sentry import options
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.services import Service
+
+if typing.TYPE_CHECKING:
+    from sentry.models import Project
 
 
 @unique
@@ -375,3 +380,11 @@ class Quota(Service):
         Return the maximum capable rate for an organization.
         """
         return (_limit_from_settings(options.get("system.rate-limit")), 60)
+
+    def get_blended_sample_rate(self, project: "Project") -> Optional[float]:
+        """
+        Returns the blended sample rate for an org based on the package that they are currently on. Returns ``None``
+        if the creation of a uniform rule with blended sample rate is not supported for that project.
+
+        :param project: The project model.
+        """


### PR DESCRIPTION
Adds `get_blended_sample_rate` method to the `Quota` abstraction to support functionality on both sentry/getsentry to create and thereby send uniform sampling rules as part of the ProjectConfig sent to Relay.

This method will be called:
- When UI requests project details endpoint, we return all DS rules including the uniform rule as part of the response. And so we inject the uniform sampling rule with the `blended_sample_rate` into the response.
- When computing `ProjectConfig` as in `sentry/relay/config/init.py::_get_project_config`. This is called when the `schedule_invalidate_project_config` task is invoked. 

Thereby we would expect the project config cache to be invalidated when:
- Beginning of the billing cycle due to plan downgrades/upgrades or crossing from on demand back to prepaid 
- Crossing over from prepaid to on demand budget
- Is there other scenarios where we should invalidate cache in?
