### PR TITLE
fix(sdk): Set the default upstream_dsn on sentry_sdk.init

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -384,6 +384,9 @@ def configure_sdk():
                     )
 
     sentry_sdk.init(
+        # set back the upstream_dsn popped above since we need a default dsn on the client
+        # for dynamic sampling context public_key population
+        dsn=upstream_dsn,
         transport=MultiplexingTransport(),
         integrations=[
             DjangoAtomicIntegration(),


### PR DESCRIPTION
The SDK assumes that `client.options["dsn"]` is populated when it's in 'on' mode.
Our multiplexer magic breaks this assumption, so set back the `upstream_dsn` on init.

This caused a missing `public_key` in the `DynamicSamplingContext` on traces originating
from python as the head SDK which caused relay to throw a parsing failure and not
populate `client_sample_rate`.

---
#### Testing
`print(envelope.headers)` inside `transport._send_envelope`

Before:
```python
12:53:59 server  | {'event_id': '8adf6c595d8d4ee28fc4f3342f87a9a8', 'sent_at': '2022-10-12T12:53:59.868891Z', 'trace': {'trace_id': 'd8820ee437da42b1adf13256d8af1d39', 'sample_rate': '1.0', 'release': 'backend@22.10.0.dev0+652a6dcc58aaf04376deeeaee39b2790d3b3ea21', 'environment': 'development', 'transaction': '/api/0/organizations/{organization_slug}/stats_v2/'}}
```

After:
```python
13:08:48 server  | {'event_id': 'a3a8d52048d84ad9a2dd781e1bfe03ba', 'sent_at': '2022-10-13T13:08:48.833990Z', 'trace': {'trace_id': '8557827e11eb463b826de9a6cb923acc', 'public_key': 'd655584d05f14c58b86e9034aab6817f', 'sample_rate': '1.0', 'release': 'backend@22.10.0.dev0+652a6dcc58aaf04376deeeaee39b2790d3b3ea21', 'environment': 'development', 'transaction': '/api/0/organizations/{organization_slug}/stats_v2/'}}
```
