### PR TITLE
feat(auto-codemaps): Support fetching tree representation of repo

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -9,6 +9,7 @@ import sentry_sdk
 from sentry.integrations.client import ApiClient
 from sentry.integrations.github.utils import get_jwt, get_next_link
 from sentry.models import Integration, Repository
+from sentry.shared_integrations.exceptions.base import ApiError
 from sentry.utils import jwt
 from sentry.utils.json import JSONData
 
@@ -66,6 +67,49 @@ class GitHubClientMixin(ApiClient):  # type: ignore
         # Explicitly typing to satisfy mypy.
         repository: JSONData = self.get(f"/repos/{repo}")
         return repository
+
+    # https://docs.github.com/en/rest/git/trees#get-a-tree
+    def get_tree(self, repo_full_name: str, tree_sha: str = "master") -> JSONData:
+        tree = []
+        try:
+            contents = self.get(
+                f"/repos/{repo_full_name}/git/trees/{tree_sha}",
+                # Will cause all objects or subtrees referenced by the tree specified in :tree_sha
+                params={"recursive": 1},
+            )
+            # If truncated is true in the response then the number of items in the tree array exceeded our maximum limit.
+            # If you need to fetch more items, use the non-recursive method of fetching trees, and fetch one sub-tree at a time.
+            # Note: The limit for the tree array is 100,000 entries with a maximum size of 7 MB when using the recursive parameter.
+            # XXX: We will need to improve this by iterating through trees without using the recursive parameter
+            if contents.get("truncated"):
+                # e.g. getsentry/DataForThePeople
+                logger.warning(
+                    f"The tree for {repo_full_name} has been truncated. Use different a approach for retrieving contents of tree."
+                )
+            # tree -> list of mode, path, sha, type and url for file/directory
+            # XXX: We should optimize the data structure to be a tree from file to top src dir
+            tree = list(
+                map(
+                    lambda file_meta: file_meta["path"],
+                    filter(
+                        lambda x: x["type"] == "blob"
+                        # This is a Python language optimization and for a smaller data structure
+                        and x["path"].endswith(".py") and not x["path"].startswith("tests/"),
+                        contents["tree"],
+                    ),
+                )
+            )
+        except ApiError as e:
+            # TODO: Add condition for  getsentry/DataForThePeople
+            # e.g. getsentry/nextjs-sentry-example
+            if e.json.get("message") == "Git Repository is empty.":
+                logger.warning(f"{repo_full_name} is empty.")
+            elif e.json.get("message") == "Not Found":
+                logger.error(f"The Github App does not have access to {repo_full_name}.")
+            else:
+                sentry_sdk.capture_exception(e)
+
+        return tree
 
     def get_repositories(self) -> Sequence[JSONData]:
         """


### PR DESCRIPTION
This is a no-op change as we're only adding the logic to fetch a tree representation but not using it.

Following changes will add the ability of finding a file through all tree representations of a Github org.

Partially fixes WOR-2263