### PR TITLE
fix(discover-homepage): Changes don't rerender after refresh

### DIFF
--- a/static/app/views/eventsV2/homepage.spec.tsx
+++ b/static/app/views/eventsV2/homepage.spec.tsx
@@ -340,4 +340,69 @@ describe('Discover > Homepage', () => {
     );
     expect(screen.getByText('event.type')).toBeInTheDocument();
   });
+
+  it('renders changes to the discover query when loaded with valid event view in url params', async () => {
+    initialData = initializeOrg({
+      ...initializeOrg(),
+      organization,
+      router: {
+        location: {
+          ...TestStubs.location(),
+          query: {
+            ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
+            field: ['title'],
+          },
+        },
+      },
+    });
+
+    const {rerender} = render(
+      <Homepage
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+        setSavedQuery={jest.fn()}
+        loading={false}
+      />,
+      {context: initialData.routerContext, organization: initialData.organization}
+    );
+
+    userEvent.click(screen.getByText('Columns'));
+    await act(async () => {
+      await mountGlobalModal();
+    });
+
+    userEvent.click(screen.getByTestId('label'));
+    userEvent.click(screen.getByText('event.type'));
+    userEvent.click(screen.getByText('Apply'));
+
+    const rerenderData = initializeOrg({
+      ...initializeOrg(),
+      organization,
+      router: {
+        location: {
+          ...TestStubs.location(),
+          query: {
+            ...EventView.fromSavedQuery(DEFAULT_EVENT_VIEW).generateQueryStringObject(),
+            field: ['event.type'],
+          },
+        },
+      },
+    });
+
+    rerender(
+      <Homepage
+        organization={organization}
+        location={rerenderData.router.location}
+        router={rerenderData.router}
+        setSavedQuery={jest.fn()}
+        loading={false}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText('Edit Columns')).not.toBeInTheDocument()
+    );
+    expect(screen.getByText('event.type')).toBeInTheDocument();
+  });
 });

--- a/static/app/views/eventsV2/homepage.tsx
+++ b/static/app/views/eventsV2/homepage.tsx
@@ -53,7 +53,7 @@ class HomepageQueryAPI extends AsyncComponent<Props, HomepageQueryState> {
     }
   }
 
-  setSavedQuery = (newSavedQuery: SavedQuery) => {
+  setSavedQuery = (newSavedQuery?: SavedQuery) => {
     this.setState({savedQuery: newSavedQuery});
   };
 

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -115,7 +115,7 @@ export class Results extends Component<Props, State> {
       );
       return {...prevState, eventView, savedQuery: nextProps.savedQuery};
     }
-    return prevState;
+    return {...prevState, savedQuery: nextProps.savedQuery};
   }
 
   state: State = {

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -65,7 +65,7 @@ type Props = {
   organization: Organization;
   router: InjectedRouter;
   selection: PageFilters;
-  setSavedQuery: (savedQuery: SavedQuery) => void;
+  setSavedQuery: (savedQuery?: SavedQuery) => void;
   isHomepage?: boolean;
   savedQuery?: SavedQuery;
 };
@@ -115,14 +115,16 @@ export class Results extends Component<Props, State> {
       );
       return {...prevState, eventView, savedQuery: nextProps.savedQuery};
     }
-    return {...prevState, savedQuery: nextProps.savedQuery};
+
+    return prevState;
   }
 
   state: State = {
     // If this is the homepage, force an invalid eventView so we can handle
-    // the redirect first
+    // the redirect first. This can't rely on the location because the
+    // location may have a valid eventView configuration
     eventView: this.props.isHomepage
-      ? EventView.fromSavedQueryOrLocation(undefined, this.props.location)
+      ? EventView.fromSavedQuery({...DEFAULT_EVENT_VIEW, fields: []})
       : EventView.fromSavedQueryOrLocation(this.props.savedQuery, this.props.location),
     error: '',
     errorCode: 200,
@@ -705,7 +707,7 @@ class SavedQueryAPI extends AsyncComponent<Props, SavedQueryState> {
     return endpoints;
   }
 
-  setSavedQuery = (newSavedQuery: SavedQuery) => {
+  setSavedQuery = (newSavedQuery?: SavedQuery) => {
     this.setState({savedQuery: newSavedQuery});
   };
 

--- a/static/app/views/eventsV2/resultsHeader.tsx
+++ b/static/app/views/eventsV2/resultsHeader.tsx
@@ -25,7 +25,7 @@ type Props = {
   location: Location;
   organization: Organization;
   router: InjectedRouter;
-  setSavedQuery: (savedQuery: SavedQuery) => void;
+  setSavedQuery: (savedQuery?: SavedQuery) => void;
   yAxis: string[];
   isHomepage?: boolean;
 };
@@ -148,9 +148,10 @@ class ResultsHeader extends Component<Props, State> {
             yAxis={yAxis}
             router={router}
             isHomepage={isHomepage}
-            setHomepageQuery={updatedHomepageQuery =>
-              this.setState({homepageQuery: updatedHomepageQuery})
-            }
+            setHomepageQuery={updatedHomepageQuery => {
+              this.setState({homepageQuery: updatedHomepageQuery});
+              setSavedQuery(updatedHomepageQuery);
+            }}
             homepageQuery={homepageQuery}
           />
         </Layout.HeaderActions>


### PR DESCRIPTION
In the initial state I was relying on `EventView.fromSavedQueryOrLocation` because I was
able to pass down `undefined`. The problem here is that the homepage state relies on
`checkEventView` to allow one pass using an invalid event view to set up the savedQuery.

When the homepage was loaded (or refreshed) with a valid eventView in its query params,
the eventView was being set but the savedQuery was not and subsequent updates with new
eventViews were not being set in `getDerivedStateFromProps`

I also noticed a small flicker that I ended up fixing in this PR. Let me know if you need me to
pull it out, I fixed it because I thought I introduced it with these changes.
