### PR TITLE
fix(all-events) Filter sorting conditions by available fields

### DIFF
--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -1,5 +1,4 @@
 import {useState} from 'react';
-import {} from 'react-router';
 import {Location} from 'history';
 
 import LoadingError from 'sentry/components/loadingError';

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {} from 'react-router';
 import {Location} from 'history';
 
 import LoadingError from 'sentry/components/loadingError';
@@ -18,18 +19,22 @@ export interface Props {
 const AllEventsTable = (props: Props) => {
   const {location, organization, issueId, isPerfIssue, excludedTags} = props;
   const [error, setError] = useState<string>('');
-  const eventView: EventView = EventView.fromLocation(props.location);
-  eventView.sorts = decodeSorts(location);
-  eventView.fields = [
-    {field: 'id'},
-    {field: 'transaction'},
-    {field: 'trace'},
-    {field: 'release'},
-    {field: 'environment'},
-    {field: 'user.display'},
-    ...(isPerfIssue ? [{field: 'transaction.duration'}] : []),
-    {field: 'timestamp'},
+
+  const fields: string[] = [
+    'id',
+    'transaction',
+    'trace',
+    'release',
+    'environment',
+    'user.display',
+    ...(isPerfIssue ? ['transaction.duration'] : []),
+    'timestamp',
   ];
+
+  const eventView: EventView = EventView.fromLocation(props.location);
+  eventView.fields = fields.map(fieldName => ({field: fieldName}));
+
+  eventView.sorts = decodeSorts(location).filter(sort => fields.includes(sort.field));
 
   const idQuery = isPerfIssue
     ? `performance.issue_ids:${issueId}`

--- a/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
@@ -249,6 +249,23 @@ describe('groupEvents', function () {
       const perfEventsColumn = screen.getByText('transaction');
       expect(perfEventsColumn).toBeInTheDocument();
     });
+
+    it('removes sort if unsupported by the events table', function () {
+      render(
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging'], sort: 'user'}}}
+        />,
+        {context: routerContext, organization}
+      );
+      expect(discoverRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({query: expect.not.objectContaining({sort: 'user'})})
+      );
+    });
   });
 
   it('does not renders new events table if error', function () {


### PR DESCRIPTION
Quick fix, a bug where if the user has a incompatible sort in the url, the all events tab fails to load. Discover will fail if any sort doesn't match a respective field, so it makes sense to just filter out all the sorts.
We should probably remove incompatible sorts from the url too in the future.