### PR TITLE
fix(replays): Add conditions for when no replay id exist in the transaction

### DIFF
--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -10,6 +10,7 @@ import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
+import {objectIsEmpty} from 'sentry/utils';
 import {TableData, TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import EventView, {MetaType} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
@@ -141,7 +142,7 @@ class TransactionsTable extends PureComponent<Props> {
 
       const target = generateLink?.[field]?.(organization, row, location.query);
 
-      if (target) {
+      if (target && !objectIsEmpty(target)) {
         rendered = (
           <Link data-test-id={`view-${fields[index]}`} to={target}>
             {rendered}

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -343,8 +343,8 @@ const SPECIAL_FIELDS: SpecialFields = {
     sortField: 'replayId',
     renderFunc: data => {
       const replayId = data?.replayId;
-      if (typeof replayId !== 'string') {
-        return null;
+      if (typeof replayId !== 'string' || !replayId) {
+        return <Container>{t('N/A')}</Container>;
       }
 
       return (

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -344,7 +344,7 @@ const SPECIAL_FIELDS: SpecialFields = {
     renderFunc: data => {
       const replayId = data?.replayId;
       if (typeof replayId !== 'string' || !replayId) {
-        return <Container>{t('N/A')}</Container>;
+        return emptyValue;
       }
 
       return (

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -142,6 +142,10 @@ export function generateReplayLink(routes: PlainRoute<any>[]) {
     _query: Query
   ): LocationDescriptor => {
     const replayId = tableRow.replayId;
+    if (!replayId) {
+      return {};
+    }
+
     const replaySlug = `${tableRow['project.name']}:${replayId}`;
     const referrer = encodeURIComponent(getRouteStringFromRoutes(routes));
 


### PR DESCRIPTION

<!-- Describe your PR here. -->
### Changes
- Added conditions to control and show a value when no `replayId` is found in the transaction

Closes #39979

![image](https://user-images.githubusercontent.com/39612839/195662826-b9c4fadd-0f7b-4e33-9273-245e90e04411.png)


### Test notes

- Made sure unit tests of summary page were passing
- Tested it didn't render a link
- Tested it shows the right value when no `replay id` is found

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
