### PR TITLE
feat: Switch default transactions topic

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2470,11 +2470,7 @@ KAFKA_CLUSTERS = {
 #     pick up the change.
 
 KAFKA_EVENTS = "events"
-# TODO: KAFKA_TRANSACTIONS is temporarily mapped to "events" since events
-# transactions curently share a Kafka topic. Once we are ready with the code
-# changes to support different topic, switch this to "transactions" to start
-# producing to the new topic.
-KAFKA_TRANSACTIONS = "events"
+KAFKA_TRANSACTIONS = "transactions"
 KAFKA_OUTCOMES = "outcomes"
 KAFKA_OUTCOMES_BILLING = "outcomes-billing"
 KAFKA_EVENTS_SUBSCRIPTIONS_RESULTS = "events-subscription-results"

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -52,10 +52,11 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
 
         produce_args, produce_kwargs = list(producer.produce.call_args)
         assert not produce_args
-        assert produce_kwargs["topic"] == settings.KAFKA_EVENTS
         if is_transaction_event:
+            assert produce_kwargs["topic"] == settings.KAFKA_TRANSACTIONS
             assert produce_kwargs["key"] is None
         else:
+            assert produce_kwargs["topic"] == settings.KAFKA_EVENTS
             assert produce_kwargs["key"] == str(self.project.id).encode("utf-8")
 
         version, type_, payload1, payload2 = json.loads(produce_kwargs["value"])


### PR DESCRIPTION
Should be (roughly) synchronized with equivalent change in Snuba (https://github.com/getsentry/snuba/pull/3250)

This would only affect self hosted and dev users who are using the Kafka backend. All Sentry prod envivonments have already been migrated via other methods to ensure zero downtime during the transition.