### PR TITLE
feat(alerts): add spend allocation notification select

### DIFF
--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -177,4 +177,13 @@ export const QUOTA_FIELDS = [
       ['never', t('Off')],
     ] as const,
   },
+  {
+    name: 'quotaSpendAllocations',
+    label: t('Spend Allocations'),
+    help: t('Receive notifications about your spend allocations.'),
+    choices: [
+      ['always', t('On')],
+      ['never', t('Off')],
+    ] as const,
+  },
 ];

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -3,6 +3,7 @@ import {Fragment} from 'react';
 import FeatureBadge from 'sentry/components/featureBadge';
 import {Field} from 'sentry/components/forms/types';
 import ExternalLink from 'sentry/components/links/externalLink';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import {getDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
 
@@ -179,7 +180,12 @@ export const QUOTA_FIELDS = [
   },
   {
     name: 'quotaSpendAllocations',
-    label: t('Spend Allocations'),
+    label: (
+      <Fragment>
+        {t('Spend Allocations')}{' '}
+        <QuestionTooltip position="top" title="Business plan only" size="xs" />
+      </Fragment>
+    ),
     help: t('Receive notifications about your spend allocations.'),
     choices: [
       ['always', t('On')],


### PR DESCRIPTION
Adds dropdown for opting in/out of spend allocation notifications under the `Quota` category in `Notifications`.

Since users may be part of multiple organizations, some of which may or may not have the spend allocation organization option, it seems more straightforward to keep it as an overall yes/no to all spend allocation notifications rather than have them on a per organization basis.

<img width="1201" alt="Screen Shot 2022-10-13 at 3 50 32 PM" src="https://user-images.githubusercontent.com/70817427/195724786-8b80a58d-ef0e-412d-9dfa-613d0fdd1e92.png">

