### PR TITLE
fix(api): get projects by slug with no match

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -210,6 +210,8 @@ class OrganizationEndpoint(Endpoint):
                 ).values_list("id", flat=True)
                 project_ids = set(projects)
 
+                # return early to prevent passing empty set of project_ids to _get_projects_by_id
+                # which would return all projects in the organization
                 if not project_ids:
                     return []
             else:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -209,6 +209,9 @@ class OrganizationEndpoint(Endpoint):
                     organization=organization, slug__in=slugs
                 ).values_list("id", flat=True)
                 project_ids = set(projects)
+
+                if not project_ids:
+                    return []
             else:
                 project_ids = self.get_requested_project_ids_unchecked(request)
 

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -389,6 +389,12 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
             False,
         )
 
+    def test_get_projects_by_slugs_no_projects_with_slug(self):
+        project_slugs = ["hello"]
+        request = self.build_request(projectSlug=project_slugs)
+
+        assert not self.endpoint.get_projects(request, self.org)
+
 
 class GetEnvironmentsTest(BaseOrganizationEndpointTest):
     def setUp(self):


### PR DESCRIPTION
Currently, if you call `get_projects` with a `project_slugs` argument that contains a single slug that doesn't match any project slugs, we end up returning all of the projects in the org because we pass an empty set of `project_ids` to `_get_projects_by_id`.

This PR adds an early return to prevent the calling of `_get_projects_by_id` with an empty set of `project_ids`.