### PR TITLE
fix(issue-alerts): make preview endpoint post

### DIFF
--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -16,8 +16,9 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
     private = True
     permission_classes = (ProjectAlertRulePermission,)
 
+    # a post endpoint because it's too hard to pass a list of objects from the frontend
     @transaction_start("ProjectRulePreviewEndpoint")
-    def get(self, request: Request, project) -> Response:
+    def post(self, request: Request, project) -> Response:
         """
         Get a list of alert triggers in past 2 weeks for given rules
 
@@ -32,7 +33,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
 
         """
         serializer = RuleSetSerializer(
-            context={"project": project, "organization": project.organization}, data=request.GET
+            context={"project": project, "organization": project.organization}, data=request.data
         )
 
         if not serializer.is_valid():

--- a/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
@@ -12,6 +12,7 @@ from sentry.testutils.silo import region_silo_test
 @region_silo_test
 class ProjectRulePreviewEndpointTest(APITestCase):
     endpoint = "sentry-api-0-project-rule-preview"
+    method = "post"
 
     def setUp(self):
         self.login_as(self.user)


### PR DESCRIPTION
Makes `ProjectRulePreviewEndpoint` POST instead of GET. Frontend currently doesn't support encoding nested objects into url, so send data in post body instead.
