### PR TITLE
feat(hybrid-cloud): Add superUserCookieName to client config serializer

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -10,6 +10,7 @@ from sentry import features, options
 from sentry.api.serializers.base import serialize
 from sentry.api.serializers.models.user import DetailedSelfUserSerializer
 from sentry.api.utils import generate_organization_url, generate_region_url
+from sentry.auth import superuser
 from sentry.auth.access import get_cached_organization_member
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import Organization, OrganizationMember, ProjectKey
@@ -192,6 +193,7 @@ def get_client_config(request=None):
         "languageCode": language_code,
         "userIdentity": user_identity,
         "csrfCookieName": settings.CSRF_COOKIE_NAME,
+        "superUserCookieName": superuser.COOKIE_NAME,
         "sentryConfig": {
             "dsn": public_dsn,
             # XXX: In the world of frontend / backend deploys being separated,

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -1,8 +1,10 @@
 from unittest import mock
 
+from django.conf import settings
 from django.urls import reverse
 from exam import fixture
 
+from sentry.auth import superuser
 from sentry.models import (
     ApiToken,
     Organization,
@@ -77,6 +79,17 @@ class ClientConfigViewTest(TestCase):
     @fixture
     def path(self):
         return reverse("sentry-api-client-config")
+
+    def test_cookie_names(self):
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+        assert data["csrfCookieName"] == "sc"
+        assert data["csrfCookieName"] == settings.CSRF_COOKIE_NAME
+        assert data["superUserCookieName"] == "su"
+        assert data["superUserCookieName"] == superuser.COOKIE_NAME
 
     def test_unauthenticated(self):
         resp = self.client.get(self.path)


### PR DESCRIPTION
I plan to inject the superuser cookie name into `window.superUserCookieName` so that the frontend app can make use of it. The name is currently hardcoded here https://github.com/getsentry/sentry/blob/d7dce718b23b7f80894e0facafdab3b88ee23260/static/app/utils/isActiveSuperuser.tsx#L5