### PR TITLE
feat(hybrid-cloud): Consume superUserCookieName on frontend

### DIFF
--- a/fixtures/js-stubs/config.js
+++ b/fixtures/js-stubs/config.js
@@ -7,6 +7,7 @@ export function Config(params = {}) {
     messages: [],
     languageCode: 'en',
     csrfCookieName: 'csrf-test-cookie',
+    superUserCookieName: 'su-test-cookie',
     features: new Set(),
     singleOrganization: false,
     urlPrefix: 'https://sentry-jest-tests.example.com/',

--- a/static/app/bootstrap/index.tsx
+++ b/static/app/bootstrap/index.tsx
@@ -4,6 +4,7 @@ const BOOTSTRAP_URL = '/api/client-config/';
 
 const bootApplication = (data: Config) => {
   window.csrfCookieName = data.csrfCookieName;
+  window.superUserCookieName = data.superUserCookieName;
 
   return data;
 };

--- a/static/app/components/acl/role.spec.tsx
+++ b/static/app/components/acl/role.spec.tsx
@@ -66,7 +66,7 @@ describe('Role', function () {
     });
 
     it('gives access to a superuser with insufficient role', function () {
-      ConfigStore.config.user = {isSuperuser: true};
+      ConfigStore.config.user = TestStubs.User({isSuperuser: true});
       Cookies.set = jest.fn();
 
       render(<Role role="owner">{childrenMock}</Role>, {context: routerContext});
@@ -74,8 +74,8 @@ describe('Role', function () {
       expect(childrenMock).toHaveBeenCalledWith({
         hasRole: true,
       });
-      expect(Cookies.set).toHaveBeenCalledWith('su', 'test');
-      ConfigStore.config.user = {isSuperuser: false};
+      expect(Cookies.set).toHaveBeenCalledWith('su-test-cookie', 'test');
+      ConfigStore.config.user = TestStubs.User({isSuperuser: false});
     });
 
     it('does not give access to a made up role', function () {
@@ -90,7 +90,7 @@ describe('Role', function () {
 
     it('handles no user', function () {
       const user = {...ConfigStore.config.user};
-      ConfigStore.config.user = undefined;
+      ConfigStore.config.user = undefined as any;
       render(<Role role="member">{childrenMock}</Role>, {context: routerContext});
 
       expect(childrenMock).toHaveBeenCalledWith({
@@ -101,7 +101,7 @@ describe('Role', function () {
 
     it('updates if user changes', function () {
       const user = {...ConfigStore.config.user};
-      ConfigStore.config.user = undefined;
+      ConfigStore.config.user = undefined as any;
       const {rerender} = render(<Role role="member">{childrenMock}</Role>, {
         context: routerContext,
       });

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -101,11 +101,14 @@ declare global {
      */
     adblockSuspected?: boolean;
     /**
-     * The CSRF cookie ised on the backend
+     * The CSRF cookie used on the backend
      */
     csrfCookieName?: string;
-
     sentryEmbedCallback?: ((embed: any) => void) | null;
+    /**
+     * The superuser cookie used on the backend
+     */
+    superUserCookieName?: string;
   }
 }
 
@@ -120,8 +123,8 @@ export interface Config {
   features: Set<string>;
   gravatarBaseUrl: string;
   invitesEnabled: boolean;
-
   isAuthenticated: boolean;
+
   // Maintain isOnPremise key for backcompat (plugins?).
   isOnPremise: boolean;
   isSelfHosted: boolean;
@@ -137,14 +140,15 @@ export interface Config {
    */
   messages: {level: keyof Theme['alert']; message: string}[];
   needsUpgrade: boolean;
-
   privacyUrl: string | null;
+
   sentryConfig: {
     dsn: string;
     release: string;
     whitelistUrls: string[];
   };
   singleOrganization: boolean;
+  superUserCookieName: string;
   supportEmail: string;
   termsUrl: string | null;
   theme: 'light' | 'dark';

--- a/static/app/utils/isActiveSuperuser.tsx
+++ b/static/app/utils/isActiveSuperuser.tsx
@@ -2,7 +2,7 @@ import Cookies from 'js-cookie';
 
 import ConfigStore from 'sentry/stores/configStore';
 
-const SUPERUSER_COOKIE_NAME = 'su';
+const SUPERUSER_COOKIE_NAME = window.superUserCookieName ?? 'su';
 
 /**
  * Checking for just isSuperuser on a config object may not be enough as backend often checks for *active* superuser.
@@ -12,14 +12,16 @@ export function isActiveSuperuser() {
   const {isSuperuser} = ConfigStore.get('user') || {};
 
   if (isSuperuser) {
+    const superUserCookieName =
+      ConfigStore.get('superUserCookieName') || SUPERUSER_COOKIE_NAME;
     /**
      * Superuser cookie cannot be checked for existence as it is HttpOnly.
      * As a workaround, we try to change it to something else and if that fails we can assume that it's being present.
      * There may be an edgecase where it's present and expired but for current usage it's not a big deal.
      */
-    Cookies.set(SUPERUSER_COOKIE_NAME, 'test');
+    Cookies.set(superUserCookieName, 'test');
 
-    if (Cookies.get(SUPERUSER_COOKIE_NAME) === undefined) {
+    if (Cookies.get(superUserCookieName) === undefined) {
       return true;
     }
   }


### PR DESCRIPTION
This consumes the `superUserCookieName` configuration on the frontend app added in https://github.com/getsentry/sentry/pull/40015.