### PR TITLE
fix(ui): Give SecretField the textbox role

### DIFF
--- a/static/app/components/forms/fields/secretField.tsx
+++ b/static/app/components/forms/fields/secretField.tsx
@@ -3,7 +3,12 @@ import InputField, {InputFieldProps} from './inputField';
 export interface SecretFieldProps extends Omit<InputFieldProps, 'type'> {}
 
 function SecretField(props: SecretFieldProps) {
-  return <InputField {...props} type="password" />;
+  // XXX: We explicitly give the password field a aria textbox role. This field
+  // does not typically have a role, but for testability reasons it's preferred
+  // for it to have a role. See [0]
+  //
+  // [0]: https://github.com/testing-library/dom-testing-library/issues/567
+  return <InputField {...props} type="password" role="textbox" />;
 }
 
 export default SecretField;


### PR DESCRIPTION
This should fix a number of tests that are failing in #39858, which don't work because we can't select the password field since it doesn't have a proper role.