### PR TITLE
ref(metrics): Change default rule id from 0 to -1

### DIFF
--- a/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
+++ b/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
@@ -208,7 +208,7 @@ export function DynamicSampling({project}: Props) {
       if (r.id === rule.id) {
         return {
           ...r,
-          id: 0,
+          id: -1,
           active: !r.active,
         };
       }

--- a/static/app/views/settings/project/dynamicSampling/modals/specificConditionsModal/index.spec.tsx
+++ b/static/app/views/settings/project/dynamicSampling/modals/specificConditionsModal/index.spec.tsx
@@ -49,7 +49,7 @@ describe('Dynamic Sampling - Specific Conditions Modal', function () {
         inner: [{name: 'trace.release', op: 'glob', value: ['1.2.3']}],
         op: 'and',
       },
-      id: 0,
+      id: -1,
       sampleRate: 0.6,
       type: 'trace',
       active: false,
@@ -195,7 +195,7 @@ describe('Dynamic Sampling - Specific Conditions Modal', function () {
 
     const newRule = {
       ...TestStubs.DynamicSamplingConfig().specificRule,
-      id: 0,
+      id: -1,
       sampleRate: 0.6,
       condition: {
         ...TestStubs.DynamicSamplingConfig().specificRule.condition,
@@ -343,7 +343,7 @@ describe('Dynamic Sampling - Specific Conditions Modal', function () {
         ],
         op: 'and',
       },
-      id: 0,
+      id: -1,
       sampleRate: 0.5,
       type: 'trace',
       active: false,

--- a/static/app/views/settings/project/dynamicSampling/modals/specificConditionsModal/index.tsx
+++ b/static/app/views/settings/project/dynamicSampling/modals/specificConditionsModal/index.tsx
@@ -110,8 +110,9 @@ export function SpecificConditionsModal({
     const sampleRate = percentageToRate(samplePercentage)!;
 
     const newRule: SamplingRule = {
-      // All new/updated rules must have id equal to 0
-      id: 0,
+      // All new rules must have the default id set to -1, signaling to the backend that a proper id should
+      // be assigned.
+      id: -1,
       active: rule ? rule.active : false,
       type: SamplingRuleType.TRACE,
       condition: {

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.spec.tsx
@@ -42,7 +42,7 @@ describe('Server-Side Sampling - Specific Conditions Modal', function () {
         inner: [{name: 'trace.release', op: 'glob', value: ['1.2.3']}],
         op: 'and',
       },
-      id: 0,
+      id: -1,
       sampleRate: 0.2,
       type: 'trace',
       active: false,
@@ -177,7 +177,7 @@ describe('Server-Side Sampling - Specific Conditions Modal', function () {
 
     const newRule = {
       ...specificRule,
-      id: 0,
+      id: -1,
       sampleRate: 0.6,
       condition: {
         ...specificRule.condition,
@@ -273,7 +273,7 @@ describe('Server-Side Sampling - Specific Conditions Modal', function () {
         ],
         op: 'and',
       },
-      id: 0,
+      id: -1,
       sampleRate: 0.5,
       type: 'trace',
       active: false,

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.tsx
@@ -142,8 +142,9 @@ export function SpecificConditionsModal({
     const sampleRate = percentageToRate(samplePercentage)!;
 
     const newRule: SamplingRule = {
-      // All new/updated rules must have id equal to 0
-      id: 0,
+      // All new rules must have the default id set to -1, signaling to the backend that a proper id should
+      // be assigned.
+      id: -1,
       active: rule ? rule.active : false,
       type: SamplingRuleType.TRACE,
       condition: {

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -352,7 +352,7 @@ export function ServerSideSampling({project}: Props) {
       if (r.id === rule.id) {
         return {
           ...r,
-          id: 0,
+          id: -1,
           active: !r.active,
         };
       }

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -173,8 +173,9 @@ export function ServerSideSampling({project}: Props) {
       }
 
       const newRule: SamplingRule = {
-        // All new/updated rules must have id equal to 0
-        id: 0,
+        // All new rules must have the default id set to -1, signaling to the backend that a proper id should
+        // be assigned.
+        id: -1,
         active: rule ? rule.active : false,
         type: SamplingRuleType.TRACE,
         condition: {


### PR DESCRIPTION
This PR changes the default rule id for any newly created rule on the frontend from 0 to -1. This has been done in order to accomodate for the new default uniform sampling rule that will be implemented on the backend side (look at this [PR](https://github.com/getsentry/sentry/pull/40034)).