### PR TITLE
fix(ds): Move assigining rule ids into serializer

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -103,6 +103,50 @@ class DynamicSamplingSerializer(serializers.Serializer):
     next_id = serializers.IntegerField(min_value=0, required=False)
 
     @staticmethod
+    def fix_rule_ids(project, raw_dynamic_sampling):
+        """
+        Fixes rule ids in sampling configuration
+
+        When rules are changed or new rules are introduced they will get
+        new ids
+        :pparam raw_dynamic_sampling: the dynamic sampling config coming from UI
+            validated but without adjusted rule ids
+        :return: the dynamic sampling config with the rule ids adjusted to be
+        unique and with the next_id updated
+        """
+        # get the existing configuration for comparison.
+        original = project.get_option("sentry:dynamic_sampling")
+        original_rules = []
+
+        if original is None:
+            next_id = 1
+        else:
+            next_id = original.get("next_id", 1)
+            original_rules = original.get("rules", [])
+
+        # make a dictionary with the old rules to compare for changes
+        original_rules_dict = {rule["id"]: rule for rule in original_rules}
+
+        if raw_dynamic_sampling is not None:
+            rules = raw_dynamic_sampling.get("rules", [])
+
+            for rule in rules:
+                rid = rule.get("id", 0)
+                original_rule = original_rules_dict.get(rid)
+                if rid == 0 or original_rule is None:
+                    # a new or unknown rule give it a new id
+                    rule["id"] = next_id
+                    next_id += 1
+                else:
+                    if original_rule != rule:
+                        # something changed in this rule, give it a new id
+                        rule["id"] = next_id
+                        next_id += 1
+
+        raw_dynamic_sampling["next_id"] = next_id
+        return raw_dynamic_sampling
+
+    @staticmethod
     def _is_uniform_sampling_rule(rule):
         # A uniform sampling rule must be an 'and' with no rules. An 'or' with no rules will not
         # match anything.
@@ -140,6 +184,7 @@ class DynamicSamplingSerializer(serializers.Serializer):
         :return: the validated data or raise in case of error
         """
         try:
+            data = self.fix_rule_ids(self.context["project"], data)
             config_str = json.dumps(data)
             validate_sampling_configuration(config_str)
 
@@ -670,8 +715,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             )
 
         if "dynamicSampling" in result:
-            raw_dynamic_sampling = result["dynamicSampling"]
-            fixed_rules = self._fix_rule_ids(project, raw_dynamic_sampling)
+            fixed_rules = result["dynamicSampling"]
             if project.update_option("sentry:dynamic_sampling", fixed_rules):
                 changed_proj_settings["sentry:dynamic_sampling"] = result["dynamicSampling"]
 
@@ -850,49 +894,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             project.rename_on_pending_deletion()
 
         return Response(status=204)
-
-    def _fix_rule_ids(self, project, raw_dynamic_sampling):
-        """
-        Fixes rule ids in sampling configuration
-
-        When rules are changed or new rules are introduced they will get
-        new ids
-        :pparam raw_dynamic_sampling: the dynamic sampling config coming from UI
-            validated but without adjusted rule ids
-        :return: the dynamic sampling config with the rule ids adjusted to be
-        unique and with the next_id updated
-        """
-        # get the existing configuration for comparison.
-        original = project.get_option("sentry:dynamic_sampling")
-        original_rules = []
-
-        if original is None:
-            next_id = 1
-        else:
-            next_id = original.get("next_id", 1)
-            original_rules = original.get("rules", [])
-
-        # make a dictionary with the old rules to compare for changes
-        original_rules_dict = {rule["id"]: rule for rule in original_rules}
-
-        if raw_dynamic_sampling is not None:
-            rules = raw_dynamic_sampling.get("rules", [])
-
-            for rule in rules:
-                rid = rule.get("id", 0)
-                original_rule = original_rules_dict.get(rid)
-                if rid == 0 or original_rule is None:
-                    # a new or unknown rule give it a new id
-                    rule["id"] = next_id
-                    next_id += 1
-                else:
-                    if original_rule != rule:
-                        # something changed in this rule, give it a new id
-                        rule["id"] = next_id
-                        next_id += 1
-
-        raw_dynamic_sampling["next_id"] = next_id
-        return raw_dynamic_sampling
 
     def dynamic_sampling_audit_log(
         self, project, request, old_raw_dynamic_sampling, new_raw_dynamic_sampling

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1796,7 +1796,7 @@ class TestDynamicSamplingSerializers(BaseTestCase):
                     },
                 },
             ],
-            "next_id": 22,
+            "next_id": 3,
         }
 
         serializer = DynamicSamplingSerializer(


### PR DESCRIPTION
Moves method `_fix_rule_ids` into validation
so that we apply the rule id mutation logic before applying the relay validation

