### PR TITLE
fix(ds): Set unassigned rule id to -1

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -95,7 +95,8 @@ class DynamicSamplingRuleSerializer(serializers.Serializer):
     )
     condition = DynamicSamplingConditionSerializer()
     active = serializers.BooleanField(default=False)
-    id = serializers.IntegerField(min_value=0, required=False)
+    # Setting the min value here to -1 because -1 is the rule id value for unassigned rules.
+    id = serializers.IntegerField(min_value=-1, required=False)
 
 
 class DynamicSamplingSerializer(serializers.Serializer):
@@ -131,9 +132,13 @@ class DynamicSamplingSerializer(serializers.Serializer):
             rules = raw_dynamic_sampling.get("rules", [])
 
             for rule in rules:
-                rid = rule.get("id", 0)
+                # We are setting the unassigned id to -1. It used to be 0 but we are modifying the behavior as 0 is a
+                # valid id according to relay's rule validation which states the a rule id is an unsigned integer.
+                rid = rule.get("id", -1)
                 original_rule = original_rules_dict.get(rid)
-                if rid == 0 or original_rule is None:
+                # ToDo(ahmed): Temporarily allowing for 0 to be the unassigned rule id for backwards compatibility,
+                #  and will remove that once the UI changes are deployed.
+                if rid in {0, -1} or original_rule is None:
                     # a new or unknown rule give it a new id
                     rule["id"] = next_id
                     next_id += 1

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -51,7 +51,7 @@ def _dyn_sampling_data(multiple_uniform_rules=False, uniform_rule_last_position=
                     {"op": "glob", "name": "field1", "value": ["val"]},
                 ],
             },
-            "id": 0,
+            "id": -1,
         },
         {
             "sampleRate": 0.8,
@@ -63,7 +63,7 @@ def _dyn_sampling_data(multiple_uniform_rules=False, uniform_rule_last_position=
                     {"op": "eq", "name": "field1", "value": ["val"]},
                 ],
             },
-            "id": 0,
+            "id": -1,
         },
     ]
     if uniform_rule_last_position:
@@ -76,7 +76,7 @@ def _dyn_sampling_data(multiple_uniform_rules=False, uniform_rule_last_position=
                     "op": "and",
                     "inner": [],
                 },
-                "id": 0,
+                "id": -1,
             },
         )
     if multiple_uniform_rules:
@@ -87,7 +87,7 @@ def _dyn_sampling_data(multiple_uniform_rules=False, uniform_rule_last_position=
                 "op": "and",
                 "inner": [],
             },
-            "id": 0,
+            "id": -1,
         }
         rules.insert(0, new_rule_1)
 
@@ -1179,7 +1179,7 @@ class ProjectUpdateTest(APITestCase):
                             {"op": "eq", "name": "field1", "value": ["val"]},
                         ],
                     },
-                    "id": 0,
+                    "id": -1,
                 },
                 {
                     "sampleRate": 0.8,
@@ -1190,7 +1190,7 @@ class ProjectUpdateTest(APITestCase):
                             {"op": "eq", "name": "field1", "value": ["val"]},
                         ],
                     },
-                    "id": 0,
+                    "id": -1,
                 },
                 {
                     "sampleRate": 0.9,
@@ -1199,7 +1199,7 @@ class ProjectUpdateTest(APITestCase):
                         "op": "and",
                         "inner": [],
                     },
-                    "id": 0,
+                    "id": -1,
                 },
             ]
         }
@@ -1232,7 +1232,7 @@ class ProjectUpdateTest(APITestCase):
                     {"op": "eq", "name": "field1", "value": ["val"]},
                 ],
             },
-            "id": 0,
+            "id": -1,
         }
 
         saved_config["rules"].insert(0, new_rule_1)
@@ -1244,7 +1244,7 @@ class ProjectUpdateTest(APITestCase):
                 "op": "and",
                 "inner": [],
             },
-            "id": 0,
+            "id": -1,
         }
 
         saved_config["rules"].append(new_rule_2)


### PR DESCRIPTION
Changes the unassigned rule id to -1 from the default of 0 because 0 is actually a valid rule id according to relay and it will be used as the reserved constant for DS uniform rules in dynamic sampling v2


