### PR TITLE
fix(discover-homepage): Revert setting savedQuery in header

### DIFF
--- a/static/app/views/eventsV2/resultsHeader.tsx
+++ b/static/app/views/eventsV2/resultsHeader.tsx
@@ -150,7 +150,6 @@ class ResultsHeader extends Component<Props, State> {
             isHomepage={isHomepage}
             setHomepageQuery={updatedHomepageQuery => {
               this.setState({homepageQuery: updatedHomepageQuery});
-              setSavedQuery(updatedHomepageQuery);
             }}
             homepageQuery={homepageQuery}
           />


### PR DESCRIPTION
On saved queries, the header gets clobbered by the result of the PUT request to set a query as the homepage. This was to fix a flicker but is not necessary anymore due to fixing the page filters on the sidebar click. It triggers a remount now, so the flicker no longer occurs.