### PR TITLE
feat(perf-issues): avoid two cases creating duplicate N+1 issues

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -47,8 +47,6 @@ class DetectorType(Enum):
     N_PLUS_ONE_SPANS = "n_plus_one"
     N_PLUS_ONE_DB_QUERIES = "n_plus_one_db"
     N_PLUS_ONE_DB_QUERIES_EXTENDED = "n_plus_one_db_ext"
-    N_PLUS_ONE_DB_QUERIES_NO_REDIS = "n_plus_one_db_noredis"
-    N_PLUS_ONE_DB_QUERIES_PARAMETERIZED = "n_plus_one_db_param"
 
 
 DETECTOR_TYPE_TO_GROUP_TYPE = {
@@ -62,8 +60,6 @@ DETECTOR_TYPE_TO_GROUP_TYPE = {
     DetectorType.N_PLUS_ONE_SPANS: GroupType.PERFORMANCE_N_PLUS_ONE,
     DetectorType.N_PLUS_ONE_DB_QUERIES: GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
     DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-    DetectorType.N_PLUS_ONE_DB_QUERIES_NO_REDIS: GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-    DetectorType.N_PLUS_ONE_DB_QUERIES_PARAMETERIZED: GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
 }
 
 # Detector and the corresponding system option must be added to this list to have issues created.
@@ -304,12 +300,6 @@ def _detect_performance_problems(data: Event, sdk_span: Any) -> List[Performance
         DetectorType.N_PLUS_ONE_SPANS: NPlusOneSpanDetector(detection_settings, data),
         DetectorType.N_PLUS_ONE_DB_QUERIES: NPlusOneDBSpanDetector(detection_settings, data),
         DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: NPlusOneDBSpanDetectorExtended(
-            detection_settings, data
-        ),
-        DetectorType.N_PLUS_ONE_DB_QUERIES_NO_REDIS: NPlusOneDBSpanDetectorWithoutRedis(
-            detection_settings, data
-        ),
-        DetectorType.N_PLUS_ONE_DB_QUERIES_PARAMETERIZED: NPlusOneDBSpanDetectorWithoutUnparameterizedQueries(
             detection_settings, data
         ),
     }
@@ -937,7 +927,7 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
         self._maybe_store_problem()
 
     def _is_db_op(self, op: str) -> bool:
-        return op.startswith("db")
+        return op.startswith("db") and not op.startswith("db.redis")
 
     def _contains_complete_query(self, span: Span, is_source: Optional[bool] = False) -> bool:
         # Remove the truncation check from the n_plus_one db detector.
@@ -1044,7 +1034,8 @@ class NPlusOneDBSpanDetector(PerformanceDetector):
             )
 
     def _contains_valid_repeating_query(self, span: Span) -> bool:
-        return True
+        query = span.get("description", None)
+        return query and PARAMETERIZED_SQL_QUERY_REGEX.search(query)
 
     def _metrics_for_extra_matching_spans(self):
         # Checks for any extra spans that match the detected problem but are not part of affected spans.
@@ -1085,43 +1076,6 @@ class NPlusOneDBSpanDetectorExtended(NPlusOneDBSpanDetector):
         "n_hash",
         "n_spans",
     )
-
-
-class NPlusOneDBSpanDetectorWithoutRedis(NPlusOneDBSpanDetector):
-    """
-    A temporary detector to collect metrics on how many fewer issues we create
-    with Redis excluded.
-    """
-
-    __slots__ = (
-        "stored_problems",
-        "potential_parents",
-        "source_span",
-        "n_hash",
-        "n_spans",
-    )
-
-    def _is_db_op(self, op: str) -> bool:
-        return op.startswith("db") and not op.startswith("db.redis")
-
-
-class NPlusOneDBSpanDetectorWithoutUnparameterizedQueries(NPlusOneDBSpanDetector):
-    """
-    A temporary detector to collect metrics on how many fewer issues we create
-    with unparameterized queries excluded.
-    """
-
-    __slots__ = (
-        "stored_problems",
-        "potential_parents",
-        "source_span",
-        "n_hash",
-        "n_spans",
-    )
-
-    def _contains_valid_repeating_query(self, span: Span) -> bool:
-        query = span.get("description", None)
-        return query and PARAMETERIZED_SQL_QUERY_REGEX.search(query)
 
 
 # Reports metrics and creates spans for detection

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -638,162 +638,6 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 14
-        sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
-            [
-                call(
-                    "_pi_all_issue_count",
-                    7,
-                ),
-                call(
-                    "_pi_sdk_name",
-                    "",
-                ),
-                call(
-                    "_pi_transaction",
-                    "da78af6000a6400aaa87cf6e14ddeb40",
-                ),
-                call(
-                    "_pi_duplicates",
-                    "86d2ede57bbf48d4",
-                ),
-                call("_pi_slow_span", "82428e8ef4c5a539"),
-                call(
-                    "_pi_sequential",
-                    "b409e78a092e642f",
-                ),
-                call(
-                    "_pi_n_plus_one_db_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db", "b8be6138369491dd"),
-                call(
-                    "_pi_n_plus_one_db_ext_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db_ext", "b8be6138369491dd"),
-                call(
-                    "_pi_n_plus_one_db_noredis_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db_noredis", "b8be6138369491dd"),
-                call(
-                    "_pi_n_plus_one_db_param_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db_param", "b8be6138369491dd"),
-            ],
-        )
-        assert_n_plus_one_db_problem(perf_problems)
-
-    def test_does_not_detect_n_plus_one_with_unparameterized_query_with_parameterized_detector(
-        self,
-    ):
-        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view-unparameterized"]
-        sdk_span_mock = Mock()
-
-        _detect_performance_problems(n_plus_one_event, sdk_span_mock)
-
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 12
-        sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
-            [
-                call(
-                    "_pi_all_issue_count",
-                    6,
-                ),
-                call(
-                    "_pi_sdk_name",
-                    "",
-                ),
-                call(
-                    "_pi_transaction",
-                    "da78af6000a6400aaa87cf6e14ddeb40",
-                ),
-                call(
-                    "_pi_duplicates",
-                    "86d2ede57bbf48d4",
-                ),
-                call("_pi_slow_span", "82428e8ef4c5a539"),
-                call(
-                    "_pi_sequential",
-                    "b409e78a092e642f",
-                ),
-                call(
-                    "_pi_n_plus_one_db_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db", "b8be6138369491dd"),
-                call(
-                    "_pi_n_plus_one_db_ext_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db_ext", "b8be6138369491dd"),
-                call(
-                    "_pi_n_plus_one_db_noredis_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db_noredis", "b8be6138369491dd"),
-            ],
-        )
-
-    def test_does_not_detect_n_plus_one_with_source_redis_query_with_noredis_detector(
-        self,
-    ):
-        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view-source-redis"]
-        sdk_span_mock = Mock()
-
-        _detect_performance_problems(n_plus_one_event, sdk_span_mock)
-
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 12
-        sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
-            [
-                call(
-                    "_pi_all_issue_count",
-                    6,
-                ),
-                call(
-                    "_pi_sdk_name",
-                    "",
-                ),
-                call(
-                    "_pi_transaction",
-                    "da78af6000a6400aaa87cf6e14ddeb40",
-                ),
-                call(
-                    "_pi_duplicates",
-                    "86d2ede57bbf48d4",
-                ),
-                call("_pi_slow_span", "82428e8ef4c5a539"),
-                call(
-                    "_pi_sequential",
-                    "8e554c84cdc9731e",
-                ),
-                call(
-                    "_pi_n_plus_one_db_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db", "b8be6138369491dd"),
-                call(
-                    "_pi_n_plus_one_db_ext_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db_ext", "b8be6138369491dd"),
-                call(
-                    "_pi_n_plus_one_db_param_fp",
-                    "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
-                ),
-                call("_pi_n_plus_one_db_param", "b8be6138369491dd"),
-            ],
-        )
-
-    def test_does_not_detect_n_plus_one_with_repeating_redis_query_with_noredis_detector(
-        self,
-    ):
-        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view-repeating-redis"]
-        sdk_span_mock = Mock()
-
-        _detect_performance_problems(n_plus_one_event, sdk_span_mock)
-
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 10
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
@@ -816,7 +660,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                 call("_pi_slow_span", "82428e8ef4c5a539"),
                 call(
                     "_pi_sequential",
-                    "8e554c84cdc9731e",
+                    "b409e78a092e642f",
                 ),
                 call(
                     "_pi_n_plus_one_db_fp",
@@ -828,6 +672,112 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "1-GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES-8d86357da4d8a866b19c97670edee38d037a7bc8",
                 ),
                 call("_pi_n_plus_one_db_ext", "b8be6138369491dd"),
+            ],
+        )
+        assert_n_plus_one_db_problem(perf_problems)
+
+    def test_does_not_detect_n_plus_one_with_unparameterized_query_with_parameterized_detector(
+        self,
+    ):
+        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view-unparameterized"]
+        sdk_span_mock = Mock()
+
+        _detect_performance_problems(n_plus_one_event, sdk_span_mock)
+
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 6
+        sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
+            [
+                call(
+                    "_pi_all_issue_count",
+                    3,
+                ),
+                call(
+                    "_pi_sdk_name",
+                    "",
+                ),
+                call(
+                    "_pi_transaction",
+                    "da78af6000a6400aaa87cf6e14ddeb40",
+                ),
+                call(
+                    "_pi_duplicates",
+                    "86d2ede57bbf48d4",
+                ),
+                call("_pi_slow_span", "82428e8ef4c5a539"),
+                call(
+                    "_pi_sequential",
+                    "b409e78a092e642f",
+                ),
+            ],
+        )
+
+    def test_does_not_detect_n_plus_one_with_source_redis_query_with_noredis_detector(
+        self,
+    ):
+        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view-source-redis"]
+        sdk_span_mock = Mock()
+
+        _detect_performance_problems(n_plus_one_event, sdk_span_mock)
+
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 6
+        sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
+            [
+                call(
+                    "_pi_all_issue_count",
+                    3,
+                ),
+                call(
+                    "_pi_sdk_name",
+                    "",
+                ),
+                call(
+                    "_pi_transaction",
+                    "da78af6000a6400aaa87cf6e14ddeb40",
+                ),
+                call(
+                    "_pi_duplicates",
+                    "86d2ede57bbf48d4",
+                ),
+                call("_pi_slow_span", "82428e8ef4c5a539"),
+                call(
+                    "_pi_sequential",
+                    "8e554c84cdc9731e",
+                ),
+            ],
+        )
+
+    def test_does_not_detect_n_plus_one_with_repeating_redis_query_with_noredis_detector(
+        self,
+    ):
+        n_plus_one_event = EVENTS["n-plus-one-in-django-index-view-repeating-redis"]
+        sdk_span_mock = Mock()
+
+        _detect_performance_problems(n_plus_one_event, sdk_span_mock)
+
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 6
+        sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
+            [
+                call(
+                    "_pi_all_issue_count",
+                    3,
+                ),
+                call(
+                    "_pi_sdk_name",
+                    "",
+                ),
+                call(
+                    "_pi_transaction",
+                    "da78af6000a6400aaa87cf6e14ddeb40",
+                ),
+                call(
+                    "_pi_duplicates",
+                    "86d2ede57bbf48d4",
+                ),
+                call("_pi_slow_span", "82428e8ef4c5a539"),
+                call(
+                    "_pi_sequential",
+                    "8e554c84cdc9731e",
+                ),
             ],
         )
 


### PR DESCRIPTION
Based on the metrics from https://github.com/getsentry/sentry/pull/40042, we're confident applying these changes to the main N+1 detector.

- ignore repeating queries that don't appear to be parameterized
- ignore redis commands (`db.redis*`)

Both of these cases were creating duplicate N+1s that should be joined in production. We'll come back later after GA so that we can fingerprint these cases properly, but for now don't create issues for them at all.