### PR TITLE
feat(perf-issues): Add all inclusive resources

### DIFF
--- a/static/app/components/events/interfaces/performance/resources.tsx
+++ b/static/app/components/events/interfaces/performance/resources.tsx
@@ -21,21 +21,13 @@ export function Resources(props: Props) {
   return (
     <EventDataSection type="resources-and-whatever" title={t('Resources and Whatever')}>
       {props.description}
-      {props.links.length === 0 ? (
-        <NoResourcesMessage>
-          {t(
-            "Well this is awkward. We don't appear to have any resources available for your project platform :("
-          )}
-        </NoResourcesMessage>
-      ) : (
-        <LinkSection>
-          {props.links.map(({link, text}) => (
-            <a key={link} href={link} target="_blank" rel="noreferrer">
-              <IconDocs /> {text}
-            </a>
-          ))}
-        </LinkSection>
-      )}
+      <LinkSection>
+        {props.links.map(({link, text}) => (
+          <a key={link} href={link} target="_blank" rel="noreferrer">
+            <IconDocs /> {text}
+          </a>
+        ))}
+      </LinkSection>
     </EventDataSection>
   );
 }
@@ -59,8 +51,4 @@ const LinkSection = styled('div')`
   svg {
     margin-right: ${space(1)};
   }
-`;
-
-const NoResourcesMessage = styled('p')`
-  margin-top: ${space(1)};
 `;

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -3,6 +3,13 @@ import {IssueType, PlatformType} from 'sentry/types';
 
 import {ResourceLink} from './resources';
 
+const ALL_INCLUSIVE_RESOURCE_LINKS: ResourceLink[] = [
+  {
+    text: t('Sentry Docs: N+1 Queries'),
+    link: 'https://docs.sentry.io/product/issues/performance-issues/n-one-queries/',
+  },
+];
+
 const RESOURCES_DESCRIPTIONS: Record<IssueType, string> = {
   [IssueType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES]: t(
     "N+1 queries are extraneous queries (N) caused by a single, initial query (+1). In the Span Evidence above, we've identified the parent span where the extraneous spans are located and the extraneous spans themselves. To learn more about how to fix N+1 problems, check out these resources:"
@@ -53,9 +60,9 @@ export function getResourceLinks(
   issueType: IssueType,
   platform: PlatformType | undefined
 ): ResourceLink[] {
-  if (!platform || !RESOURCE_LINKS[issueType][platform]) {
-    return [];
+  if (!platform || !RESOURCE_LINKS[issueType] || !RESOURCE_LINKS[issueType][platform]) {
+    return ALL_INCLUSIVE_RESOURCE_LINKS;
   }
 
-  return RESOURCE_LINKS[issueType][platform] ?? [];
+  return [...ALL_INCLUSIVE_RESOURCE_LINKS, ...RESOURCE_LINKS[issueType][platform]!];
 }

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -27,25 +27,11 @@ const RESOURCE_LINKS: Record<IssueType, PlatformSpecificResources> = {
         text: t('Finding and Fixing Django N+1 Problems'),
         link: 'https://blog.sentry.io/2020/09/14/finding-and-fixing-django-n-1-problems',
       },
-      {
-        text: t('Django select_related and prefetch_related'),
-        link: 'https://betterprogramming.pub/django-select-related-and-prefetch-related-f23043fd635d',
-      },
     ],
     'python-django': [
       {
         text: t('Finding and Fixing Django N+1 Problems'),
         link: 'https://blog.sentry.io/2020/09/14/finding-and-fixing-django-n-1-problems',
-      },
-      {
-        text: t('Django select_related and prefetch_related'),
-        link: 'https://betterprogramming.pub/django-select-related-and-prefetch-related-f23043fd635d',
-      },
-    ],
-    'ruby-rails': [
-      {
-        text: t('Rails Guide: Active Record Query Interface'),
-        link: 'https://guides.rubyonrails.org/active_record_querying.html#eager-loading-associations',
       },
     ],
   },


### PR DESCRIPTION
Adds our N+1 docs as a resource that is included across all project platforms. Also removes all third party resources and gets rid of the empty resources state since we always will have at least 1 resource now

### Before
![image](https://user-images.githubusercontent.com/16740047/195904219-5561c197-45c7-488b-be37-52ff4acc08bf.png)

### After
![image](https://user-images.githubusercontent.com/16740047/195904286-f883ae24-6019-4d4d-b0f3-bdb130082b7d.png)

