### PR TITLE
feat(commit-context): Refactor Issue Owner auto-assignment

### DIFF
--- a/src/sentry/models/activity.py
+++ b/src/sentry/models/activity.py
@@ -145,3 +145,4 @@ class ActivityIntegration(Enum):
     PROJECT_OWNERSHIP = "projectOwnership"
     SLACK = "slack"
     MSTEAMS = "msteams"
+    SUSPECT_COMMITTER = "suspectCommitter"

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -231,7 +231,7 @@ class ProjectOwnership(Model):
                 if len(committer) > 0:
                     queue.append(
                         (
-                            committer[0].user,
+                            committer[0].owner(),
                             {
                                 "integration": ActivityIntegration.SUSPECT_COMMITTER.value,
                             },

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, Tuple, Union
 
 from django.db import models
 from django.db.models.signals import post_delete, post_save
@@ -7,9 +7,13 @@ from django.utils import timezone
 from sentry.db.models import Model, region_silo_model, sane_repr
 from sentry.db.models.fields import FlexibleForeignKey, JSONField
 from sentry.models import ActorTuple
+from sentry.models.groupowner import OwnerRuleType
 from sentry.ownership.grammar import Rule, load_schema, resolve_actors
 from sentry.utils import metrics
 from sentry.utils.cache import cache
+
+if TYPE_CHECKING:
+    from sentry.models import Team, User
 
 READ_CACHE_DURATION = 3600
 
@@ -127,44 +131,46 @@ class ProjectOwnership(Model):
         return ordered_actors, rules
 
     @classmethod
-    def _find_actors(cls, project_id, rules, limit):
+    def _hydrate_rules(cls, project_id, rules, type=OwnerRuleType.OWNERSHIP_RULE.value):
         """
         Get the last matching rule to take the most precedence.
         """
         owners = [owner for rule in rules for owner in rule.owners]
-        owners.reverse()
         actors = {
             key: val
             for key, val in resolve_actors({owner for owner in owners}, project_id).items()
             if val
         }
-        actors = [actors[owner] for owner in owners if owner in actors][:limit]
-        return actors
+        result = [
+            (rule, ActorTuple.resolve_many([actors[owner] for owner in rule.owners]), type)
+            for rule in rules
+        ]
+        return result
 
     @classmethod
-    def get_autoassign_owners(cls, project_id, data, limit=2):
+    def get_issue_owners(
+        cls, project_id, data, limit=2
+    ) -> Sequence[
+        Tuple[
+            "Rule",
+            Sequence[Union["Team", "User"]],
+            Union[OwnerRuleType.OWNERSHIP_RULE.value, OwnerRuleType.CODEOWNERS.value],
+        ]
+    ]:
         """
-        Get the auto-assign owner for a project if there are any.
+        Get the issue owners for a project if there are any.
 
         We combine the schemas from IssueOwners and CodeOwners.
 
-        Returns a tuple of (
-            auto_assignment_enabled: boolean,
-            list_of_owners,
-            assigned_by_codeowners: boolean,
-            auto_assigned_rule: Rule | None,
-            owner_source: List[str]
-        )
+        Returns list of tuple (rule, owners, rule_type)
         """
         from sentry.models import ProjectCodeOwners
-        from sentry.models.groupowner import OwnerRuleType
 
         with metrics.timer("projectownership.get_autoassign_owners"):
             ownership = cls.get_ownership_cached(project_id)
             codeowners = ProjectCodeOwners.get_codeowners_cached(project_id)
-            assigned_by_codeowners = False
             if not (ownership or codeowners):
-                return False, [], assigned_by_codeowners, None, []
+                return []
 
             if not ownership:
                 ownership = cls(project_id=project_id)
@@ -175,42 +181,118 @@ class ProjectOwnership(Model):
             )
 
             if not (codeowners_rules or ownership_rules):
-                return ownership.auto_assignment, [], assigned_by_codeowners, None, []
+                return []
 
-            ownership_actors = cls._find_actors(project_id, ownership_rules, limit)
-            codeowners_actors = cls._find_actors(project_id, codeowners_rules, limit)
-
-            # Can happen if the ownership rule references a user/team that no longer
-            # is assigned to the project or has been removed from the org.
-            if not (ownership_actors or codeowners_actors):
-                return ownership.auto_assignment, [], assigned_by_codeowners, None, []
-
-            # Ownership rules take precedence over codeowner rules.
-            actors = [*ownership_actors, *codeowners_actors][:limit]
-            actor_source = [
-                *([OwnerRuleType.OWNERSHIP_RULE.value] * len(ownership_actors)),
-                *([OwnerRuleType.CODEOWNERS.value] * len(codeowners_actors)),
-            ][:limit]
-
-            # Only the first item in the list is used for assignment, the rest are just used to suggest suspect owners.
-            # So if ownership_actors is empty, it will be assigned by codeowners_actors
-            if len(ownership_actors) == 0:
-                assigned_by_codeowners = True
-
-            # The rule that would be used for auto assignment
-            auto_assignment_rule = (
-                codeowners_rules[0] if assigned_by_codeowners else ownership_rules[0]
+            hydrated_ownership_rules = cls._hydrate_rules(
+                project_id, ownership_rules, OwnerRuleType.OWNERSHIP_RULE.value
+            )
+            hydrated_codeowners_rules = cls._hydrate_rules(
+                project_id, codeowners_rules, OwnerRuleType.CODEOWNERS.value
             )
 
-            from sentry.models import ActorTuple
-
-            return (
-                ownership.auto_assignment,
-                ActorTuple.resolve_many(actors),
-                assigned_by_codeowners,
-                auto_assignment_rule,
-                actor_source,
+            rules_in_evaluation_order = [
+                *hydrated_ownership_rules[::-1],
+                *hydrated_codeowners_rules[::-1],
+            ]
+            rules_with_owners = list(
+                filter(
+                    lambda item: len(item[1]) > 0,
+                    rules_in_evaluation_order,
+                )
             )
+
+            return rules_with_owners[:limit]
+
+    @classmethod
+    def handle_auto_assignment(cls, project_id, event):
+        """
+        Get the auto-assign owner for a project if there are any.
+
+        We combine the schemas from IssueOwners and CodeOwners.
+
+        """
+        from sentry import analytics
+        from sentry.models import ActivityIntegration, GroupAssignee, GroupOwner, GroupOwnerType
+
+        with metrics.timer("projectownership.get_autoassign_owners"):
+            ownership = cls.get_ownership_cached(project_id)
+            queue = []
+
+            if ownership.suspect_committer_auto_assignment:
+                try:
+                    committer = GroupOwner.objects.filter(
+                        group=event.group,
+                        type=GroupOwnerType.SUSPECT_COMMIT.value,
+                        project_id=project_id,
+                    )
+                except GroupOwner.DoesNotExist:
+                    committer = []
+
+                if len(committer) > 0:
+                    queue.append(
+                        (
+                            committer[0].user,
+                            {
+                                "integration": ActivityIntegration.SUSPECT_COMMITTER.value,
+                            },
+                        )
+                    )
+
+            if ownership.auto_assignment:
+                ownership_rules = GroupOwner.objects.filter(
+                    group=event.group,
+                    type=GroupOwnerType.OWNERSHIP_RULE.value,
+                    project_id=project_id,
+                )
+                codeowners = GroupOwner.objects.filter(
+                    group=event.group,
+                    type=GroupOwnerType.CODEOWNERS.value,
+                    project_id=project_id,
+                )
+
+                for issue_owner in ownership_rules:
+                    queue.append(
+                        (
+                            issue_owner.owner(),
+                            {
+                                "integration": ActivityIntegration.PROJECT_OWNERSHIP.value,
+                                "rule": (issue_owner.context or {}).get("rule", ""),
+                            },
+                        )
+                    )
+
+                for issue_owner in codeowners:
+                    queue.append(
+                        (
+                            issue_owner.owner(),
+                            {
+                                "integration": ActivityIntegration.CODEOWNERS.value,
+                                "rule": (issue_owner.context or {}).get("rule", ""),
+                            },
+                        )
+                    )
+
+            try:
+                owner, details = queue.pop(0)
+            except IndexError:
+                return
+
+            assignment = GroupAssignee.objects.assign(
+                event.group,
+                owner.resolve(),
+                create_only=True,
+                extra=details,
+            )
+
+            if assignment["new_assignment"] or assignment["updated_assignment"]:
+                analytics.record(
+                    "codeowners.assignment"
+                    if details.get("integration") == ActivityIntegration.CODEOWNERS.value
+                    else "issueowners.assignment",
+                    organization_id=ownership.project.organization_id,
+                    project_id=project_id,
+                    group_id=event.group.id,
+                )
 
     @classmethod
     def _matching_ownership_rules(

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -238,7 +238,8 @@ class ProjectOwnership(Model):
                         )
                     )
 
-            if ownership.auto_assignment:
+            # Skip if we already found a Suspect Committer
+            if ownership.auto_assignment and len(queue) == 0:
                 ownership_rules = GroupOwner.objects.filter(
                     group=event.group,
                     type=GroupOwnerType.OWNERSHIP_RULE.value,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Mapping, Optional, Sequence, Tuple, TypedDict,
 import sentry_sdk
 from django.conf import settings
 
-from sentry import analytics, features
+from sentry import features
 from sentry.exceptions import PluginError
 from sentry.killswitches import killswitch_matches_context
 from sentry.signals import event_processed, issue_unignored, transaction_processed
@@ -122,93 +122,68 @@ def handle_owner_assignment(job):
         return
 
     with sentry_sdk.start_span(op="tasks.post_process_group.handle_owner_assignment"):
-        from sentry.models import GroupAssignee, ProjectOwnership
+        try:
+            from sentry.models import ProjectOwnership
 
-        event = job["event"]
-        project, group = event.project, event.group
+            event = job["event"]
+            project, group = event.project, event.group
 
-        with metrics.timer("post_process.handle_owner_assignment"):
-            with sentry_sdk.start_span(op="post_process.handle_owner_assignment.cache_set_owner"):
-                owner_key = "owner_exists:1:%s" % group.id
-                owners_exists = cache.get(owner_key)
-                if owners_exists is None:
-                    owners_exists = group.groupowner_set.exists()
-                    # Cache for an hour if it's assigned. We don't need to move that fast.
-                    cache.set(owner_key, owners_exists, 3600 if owners_exists else 60)
-
-            with sentry_sdk.start_span(
-                op="post_process.handle_owner_assignment.cache_set_assignee"
-            ):
-                # Is the issue already assigned to a team or user?
-                assignee_key = "assignee_exists:1:%s" % group.id
-                assignees_exists = cache.get(assignee_key)
-                if assignees_exists is None:
-                    assignees_exists = group.assignee_set.exists()
-                    # Cache for an hour if it's assigned. We don't need to move that fast.
-                    cache.set(assignee_key, assignees_exists, 3600 if assignees_exists else 60)
-
-            if owners_exists and assignees_exists:
-                return
-
-            with sentry_sdk.start_span(
-                op="post_process.handle_owner_assignment.get_autoassign_owners"
-            ):
-                if killswitch_matches_context(
-                    "post_process.get-autoassign-owners",
-                    {
-                        "project_id": project.id,
-                    },
+            with metrics.timer("post_process.handle_owner_assignment"):
+                with sentry_sdk.start_span(
+                    op="post_process.handle_owner_assignment.cache_set_owner"
                 ):
-                    # see ProjectOwnership.get_autoassign_owners
-                    auto_assignment = False
-                    owners = []
-                    assigned_by_codeowners = False
-                    auto_assignment_rule = None
-                    owner_source = []
-                else:
-                    (
-                        auto_assignment,
-                        owners,
-                        assigned_by_codeowners,
-                        auto_assignment_rule,
-                        owner_source,
-                    ) = ProjectOwnership.get_autoassign_owners(group.project_id, event.data)
+                    owner_key = "owner_exists:1:%s" % group.id
+                    owners_exists = cache.get(owner_key)
+                    if owners_exists is None:
+                        owners_exists = group.groupowner_set.exists()
+                        # Cache for an hour if it's assigned. We don't need to move that fast.
+                        cache.set(owner_key, owners_exists, 3600 if owners_exists else 60)
 
-            with sentry_sdk.start_span(op="post_process.handle_owner_assignment.analytics_record"):
-                if auto_assignment and owners and not assignees_exists:
-                    from sentry.models.activity import ActivityIntegration
+                with sentry_sdk.start_span(
+                    op="post_process.handle_owner_assignment.cache_set_assignee"
+                ):
+                    # Is the issue already assigned to a team or user?
+                    assignee_key = "assignee_exists:1:%s" % group.id
+                    assignees_exists = cache.get(assignee_key)
+                    if assignees_exists is None:
+                        assignees_exists = group.assignee_set.exists()
+                        # Cache for an hour if it's assigned. We don't need to move that fast.
+                        cache.set(assignee_key, assignees_exists, 3600 if assignees_exists else 60)
 
-                    assignment = GroupAssignee.objects.assign(
-                        group,
-                        owners[0],
-                        create_only=True,
-                        extra={
-                            "integration": ActivityIntegration.CODEOWNERS.value
-                            if assigned_by_codeowners
-                            else ActivityIntegration.PROJECT_OWNERSHIP.value,
-                            "rule": str(auto_assignment_rule),
+                if owners_exists and assignees_exists:
+                    return
+
+                with sentry_sdk.start_span(
+                    op="post_process.handle_owner_assignment.get_issue_owners"
+                ):
+                    if killswitch_matches_context(
+                        "post_process.get-autoassign-owners",
+                        {
+                            "project_id": project.id,
                         },
-                    )
-                    if assignment["new_assignment"] or assignment["updated_assignment"]:
-                        analytics.record(
-                            "codeowners.assignment"
-                            if assigned_by_codeowners
-                            else "issueowners.assignment",
-                            organization_id=project.organization_id,
-                            project_id=project.id,
-                            group_id=group.id,
+                    ):
+                        # see ProjectOwnership.get_issue_owners
+                        issue_owners = []
+                    else:
+                        issue_owners = ProjectOwnership.get_issue_owners(
+                            group.project_id, event.data
                         )
 
-            with sentry_sdk.start_span(
-                op="post_process.handle_owner_assignment.handle_group_owners"
-            ):
-                if owners and not owners_exists:
-                    handle_group_owners(project, group, owners, owner_source)
+                with sentry_sdk.start_span(
+                    op="post_process.handle_owner_assignment.handle_group_owners"
+                ):
+                    if issue_owners and not owners_exists:
+                        try:
+                            handle_group_owners(project, group, issue_owners)
+                        except Exception:
+                            logger.exception("Failed to store group owners")
+        except Exception:
+            logger.exception("Failed to handle owner assignments")
 
 
-def handle_group_owners(project, group, owners, owner_source):
+def handle_group_owners(project, group, issue_owners):
     """
-    Stores group owners generated by `ProjectOwnership.get_autoassign_owners` in the
+    Stores group owners generated by `ProjectOwnership.get_issue_owners` in the
     `GroupOwner` model, and handles any diffing/changes of which owners we're keeping.
     :return:
     """
@@ -225,9 +200,15 @@ def handle_group_owners(project, group, owners, owner_source):
                 group=group,
                 type__in=[GroupOwnerType.OWNERSHIP_RULE.value, GroupOwnerType.CODEOWNERS.value],
             )
-            new_owners = {
-                (type(owner), owner.id, source) for owner, source in zip(owners, owner_source)
-            }
+            new_owners = {}
+            for rule, owners, source in issue_owners:
+                for owner in owners:
+                    # Can potentially have multiple rules pointing to the same owner
+                    if new_owners.get((type(owner), owner.id, source)):
+                        new_owners[(type(owner), owner.id, source)].append(rule)
+                    else:
+                        new_owners[(type(owner), owner.id, source)] = [rule]
+
             # Owners already in the database that we'll keep
             keeping_owners = set()
             for owner in current_group_owners:
@@ -241,16 +222,23 @@ def handle_group_owners(project, group, owners, owner_source):
                     if owner.team_id is not None
                     else (User, owner.user_id, owner_type)
                 )
+                # Old groupowner assignments get deleted
                 if lookup_key not in new_owners:
+                    owner.delete()
+                # Old groupowner assignment from outdated rules get deleted
+                if new_owners.get(lookup_key) and (owner.context or {}).get(
+                    "rule"
+                ) not in new_owners.get(lookup_key):
                     owner.delete()
                 else:
                     keeping_owners.add(lookup_key)
 
             new_group_owners = []
 
-            for key in new_owners:
+            for key in new_owners.keys():
                 if key not in keeping_owners:
                     owner_type, owner_id, owner_source = key
+                    rules = new_owners[key]
                     group_owner_type = (
                         GroupOwnerType.OWNERSHIP_RULE.value
                         if owner_source == OwnerRuleType.OWNERSHIP_RULE.value
@@ -262,16 +250,18 @@ def handle_group_owners(project, group, owners, owner_source):
                         user_id = owner_id
                     if owner_type is Team:
                         team_id = owner_id
-                    new_group_owners.append(
-                        GroupOwner(
-                            group=group,
-                            type=group_owner_type,
-                            user_id=user_id,
-                            team_id=team_id,
-                            project=project,
-                            organization=project.organization,
+                    for rule in rules:
+                        new_group_owners.append(
+                            GroupOwner(
+                                group=group,
+                                type=group_owner_type,
+                                user_id=user_id,
+                                team_id=team_id,
+                                project=project,
+                                organization=project.organization,
+                                context={"rule": str(rule)},
+                            )
                         )
-                    )
             if new_group_owners:
                 GroupOwner.objects.bulk_create(new_group_owners)
     except UnableToAcquireLock:
@@ -666,6 +656,19 @@ def process_commits(job: PostProcessJob) -> None:
         pass
 
 
+def handle_auto_assignment(job: PostProcessJob) -> None:
+    if job["is_reprocessed"]:
+        return
+
+    from sentry.models import ProjectOwnership
+
+    event = job["event"]
+    try:
+        ProjectOwnership.handle_auto_assignment(event.project.id, event)
+    except Exception:
+        logger.exception("Failed to set auto-assignment")
+
+
 def process_service_hooks(job: PostProcessJob) -> None:
     if job["is_reprocessed"]:
         return
@@ -768,9 +771,10 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE = {
         _capture_group_stats,
         process_snoozes,
         process_inbox_adds,
-        handle_owner_assignment,
-        process_rules,
         process_commits,
+        handle_owner_assignment,
+        handle_auto_assignment,
+        process_rules,
         process_service_hooks,
         process_resource_change_bounds,
         process_plugins,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -610,7 +610,7 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             "assigneeEmail": self.user.email,
             "assigneeType": "user",
             "integration": ActivityIntegration.PROJECT_OWNERSHIP.value,
-            "rule": str(Rule(Matcher("path", "src/app/*"), [Owner("team", self.team.name)])),
+            "rule": str(Rule(Matcher("path", "src/*"), [Owner("user", self.user.email)])),
         }
 
     def test_owner_assignment_extra_groups(self):


### PR DESCRIPTION
## Objective:
This PR refactors how we calculate the Issue Owners from Code Owners/Ownership Rules and who should get the auto-assignment. Auto Assignment will first go to the Suspect Committer (if it exists and the setting is on) then to Issue Owners (if it exists and the setting is on) then nothing. We will also store the rule that triggered the Issue Owner match in GroupOwner.