### PR TITLE
fix(hovercard): Update hovercard position when content changes

### DIFF
--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
 import {createPortal} from 'react-dom';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -54,7 +54,7 @@ function Hovercard({
   ...hoverOverlayProps
 }: HovercardProps): React.ReactElement {
   const theme = useTheme();
-  const {wrapTrigger, isOpen, overlayProps, placement, arrowData, arrowProps} =
+  const {wrapTrigger, isOpen, overlayProps, placement, arrowData, arrowProps, update} =
     useHoverOverlay('hovercard', {
       offset,
       displayTimeout,
@@ -62,6 +62,14 @@ function Hovercard({
       className: containerClassName,
       ...hoverOverlayProps,
     });
+
+  // Changes to header and body can change the size of the overlay content
+  // which can result in the popper state being out of date
+  useEffect(() => {
+    if (isOpen) {
+      update?.();
+    }
+  }, [isOpen, update, header, body]);
 
   // Nothing to render if no header or body. Be consistent with wrapping the
   // children with the trigger in the case that the body / header is set while

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -156,7 +156,7 @@ function useHoverOverlay(
     [arrowElement, offset]
   );
 
-  const {styles, state} = usePopper(triggerElement, overlayElement, {
+  const {styles, state, update} = usePopper(triggerElement, overlayElement, {
     modifiers,
     placement: position,
   });
@@ -287,6 +287,7 @@ function useHoverOverlay(
     arrowProps,
     placement: state?.placement,
     arrowData: state?.modifiersData?.arrow,
+    update,
   };
 }
 


### PR DESCRIPTION
After making some changes to the issue stream stacktrace tooltip, I uncovered a bug where the Hovercard position would not update when changing the body content:

![image](https://user-images.githubusercontent.com/10888943/195916146-aae296b8-dcd5-430f-9195-66d30a05ba93.png)

Here the tooltip started with a loading spinner, then updated to a smaller content area, but popper did not recalculate the position.

This is a somewhat simplistic approach but seems to be low risk. This will result in unncessary calls to `update()` but such calls are inexpensive so I don't think it's too big of a deal. But if you have a better way to solve this LMK!