### PR TITLE
ref: add github workflow for fast-reverting pull requests

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -11,6 +11,9 @@
 - name: trigger-getsentry-external
   color: '3E5E06'
   description: 'once code is reviewed: apply label to PR to trigger getsentry tests'
+- name: 'Trigger: Revert'
+  color: '3E5E06'
+  description: 'add to a merged PR to revert it (skips CI)'
 
 # Dependabot
 - name: dependencies

--- a/.github/workflows/fast-revert.yml
+++ b/.github/workflows/fast-revert.yml
@@ -1,0 +1,40 @@
+on:
+  pull_request_target:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      pr:
+        required: true
+        description: pr number
+      co_authored_by:
+        required: true
+        description: '`name <email>` for triggering user'
+
+# disable all permissions -- we use the PAT's permissions instead
+permissions: {}
+
+jobs:
+  revert:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' || github.event.label.name == 'Trigger: Revert'
+    steps:
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8  # v3
+      with:
+        token: ${{ secrets.BUMP_SENTRY_TOKEN }}
+    - uses: getsentry/action-fast-revert@dc3703df06fd2774abdef6c45bfb3720a1278130  # v2.0.0
+      with:
+        pr: ${{ github.event.number || github.event.inputs.pr }}
+        co_authored_by: ${{ github.event.inputs.co_authored_by || format('{0} <{1}+{0}@users.noreply.github.com>', github.event.sender.login, github.event.sender.id) }}
+        committer_name: getsentry-bot
+        committer_email: bot@sentry.io
+        token: ${{ secrets.BUMP_SENTRY_TOKEN }}
+    - name: comment on failure
+      run: |
+        curl \
+            --silent \
+            -X POST \
+            -H 'Authorization: token ${{ secrets.SENTRY_BUMP_TOKEN }}' \
+            -d'{"body": "revert failed (conflict? already reverted?) -- [check the logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"}' \
+            https://api.github.com/repositories/${{ github.event.repository.id }}/issues/${{ github.event.number || github.event.inputs.pr }}/comments
+      if: failure()


### PR DESCRIPTION
see https://github.com/getsentry/action-fast-revert/pull/1

this adds a workflow where if a sentry employee adds the "Trigger: Revert" label to a merged PR it will revert it immediately without needing to go through a CI process.  this is to help expedite incident-related revert fixes where currently one would have to either need an admin or wait through CI to get such a thing merged

I've also set it up so it can be triggered via `workflow_dispatch` -- potentially opening the door for deleting [gitbot](https://github.com/getsentry/gitbot) and making the reversion process more transparent

I've tested this pretty extensively in my personal account -- but will do some quick validation after merging this (unfortunately due to the nature of how this works it's difficult to validate until it has landed)