### PR TITLE
feat(mobile-exp): Add new issue details tag summary for mobile platforms 

### DIFF
--- a/static/app/components/group/sidebar.spec.jsx
+++ b/static/app/components/group/sidebar.spec.jsx
@@ -1,5 +1,5 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import GroupSidebar from 'sentry/components/group/sidebar';
 
@@ -175,6 +175,52 @@ describe('GroupSidebar', function () {
       expect(
         await screen.findByText('No tags found in the selected environments')
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('displays mobile tags when issue platform is mobile', function () {
+    beforeEach(function () {
+      group = TestStubs.Group();
+
+      MockApiClient.addMockResponse({
+        url: '/issues/1/',
+        body: group,
+      });
+    });
+
+    it('renders mobile tags on mobile platform', async function () {
+      render(
+        <GroupSidebar
+          group={group}
+          project={{...project, platform: 'android'}}
+          organization={{
+            ...organization,
+            features: [...organization.features, 'issue-details-tag-improvements'],
+          }}
+          event={TestStubs.Event()}
+          environments={[environment]}
+        />,
+        {organization}
+      );
+      expect(await screen.findByText('device')).toBeInTheDocument();
+    });
+
+    it('does not render mobile tags on non mobile platform', async function () {
+      render(
+        <GroupSidebar
+          group={group}
+          project={project}
+          organization={{
+            ...organization,
+            features: [...organization.features, 'issue-details-tag-improvements'],
+          }}
+          event={TestStubs.Event()}
+          environments={[environment]}
+        />,
+        {organization}
+      );
+      await waitFor(() => expect(tagsMock).toHaveBeenCalled());
+      expect(screen.queryByText('device')).not.toBeInTheDocument();
     });
   });
 });

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -35,7 +35,10 @@ import {
 import {Event} from 'sentry/types/event';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {isMobilePlatform} from 'sentry/utils/platform';
 import withApi from 'sentry/utils/withApi';
+
+import {MOBILE_TAGS, TagFacets} from './tagFacets';
 
 type Props = WithRouterProps & {
   api: Client;
@@ -214,6 +217,19 @@ class BaseGroupSidebar extends Component<Props, State> {
             <EnvironmentPageFilter alignDropdown="right" />
           </PageFiltersContainer>
         )}
+
+        <Feature
+          organization={organization}
+          features={['issue-details-tag-improvements']}
+        >
+          {isMobilePlatform(project.platform) && (
+            <TagFacets
+              environments={environments}
+              groupId={group.id}
+              tagKeys={MOBILE_TAGS}
+            />
+          )}
+        </Feature>
 
         <Feature organization={organization} features={['issue-details-owners']}>
           <OwnedBy group={group} project={project} organization={organization} />

--- a/static/app/components/group/tagFacets.spec.tsx
+++ b/static/app/components/group/tagFacets.spec.tsx
@@ -66,7 +66,7 @@ describe('TagDistributionMeter', function () {
     expect(screen.queryByText('release')).not.toBeInTheDocument();
   });
 
-  it('displays os tags', async function () {
+  it('displays os, device, and release tags', async function () {
     render(<TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} />);
     await waitFor(() => {
       expect(tagsMock).toHaveBeenCalled();
@@ -78,16 +78,7 @@ describe('TagDistributionMeter', function () {
     expect(screen.getByText('Android 12')).toBeInTheDocument();
     expect(screen.getByText('33%')).toBeInTheDocument();
     expect(screen.getByText('iOS 16.0')).toBeInTheDocument();
-  });
 
-  it('displays device tags', async function () {
-    render(<TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} />);
-    await waitFor(() => {
-      expect(tagsMock).toHaveBeenCalled();
-    });
-    expect(screen.getByText('os')).toBeInTheDocument();
-    expect(screen.getByText('device')).toBeInTheDocument();
-    expect(screen.getByText('release')).toBeInTheDocument();
     userEvent.click(screen.getByText('device'));
     expect(screen.getByText('23%')).toBeInTheDocument();
     expect(screen.getByText('iPhone15')).toBeInTheDocument();
@@ -95,16 +86,7 @@ describe('TagDistributionMeter', function () {
     expect(screen.getByText('Android Phone')).toBeInTheDocument();
     expect(screen.getByText('43%')).toBeInTheDocument();
     expect(screen.getByText('iPhone12')).toBeInTheDocument();
-  });
 
-  it('displays release tags', async function () {
-    render(<TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} />);
-    await waitFor(() => {
-      expect(tagsMock).toHaveBeenCalled();
-    });
-    expect(screen.getByText('os')).toBeInTheDocument();
-    expect(screen.getByText('device')).toBeInTheDocument();
-    expect(screen.getByText('release')).toBeInTheDocument();
     userEvent.click(screen.getByText('release'));
     expect(screen.getByText('100%')).toBeInTheDocument();
     expect(screen.getByText('org.mozilla.ios.Fennec@106.0')).toBeInTheDocument();

--- a/static/app/components/group/tagFacets.spec.tsx
+++ b/static/app/components/group/tagFacets.spec.tsx
@@ -1,0 +1,112 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {MOBILE_TAGS, TagFacets} from 'sentry/components/group/tagFacets';
+
+describe('TagDistributionMeter', function () {
+  let tagsMock;
+
+  beforeEach(function () {
+    tagsMock = MockApiClient.addMockResponse({
+      url: '/issues/1/tags/',
+      body: {
+        release: {
+          key: 'release',
+          topValues: [
+            {
+              name: 'org.mozilla.ios.Fennec@106.0',
+              count: 30,
+            },
+          ],
+        },
+        os: {
+          key: 'os',
+          topValues: [
+            {
+              name: 'Android 12',
+              count: 20,
+            },
+            {
+              name: 'iOS 16.0',
+              count: 10,
+            },
+          ],
+        },
+        device: {
+          key: 'device',
+          topValues: [
+            {
+              name: 'iPhone15',
+              count: 7,
+            },
+            {
+              name: 'Android Phone',
+              count: 10,
+            },
+            {
+              name: 'iPhone12',
+              count: 13,
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it('does not display anything if no tag values recieved', async function () {
+    tagsMock = MockApiClient.addMockResponse({
+      url: '/issues/1/tags/',
+      body: {},
+    });
+    render(<TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} />);
+    await waitFor(() => {
+      expect(tagsMock).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('os')).not.toBeInTheDocument();
+    expect(screen.queryByText('device')).not.toBeInTheDocument();
+    expect(screen.queryByText('release')).not.toBeInTheDocument();
+  });
+
+  it('displays os tags', async function () {
+    render(<TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} />);
+    await waitFor(() => {
+      expect(tagsMock).toHaveBeenCalled();
+    });
+    expect(screen.getByText('os')).toBeInTheDocument();
+    expect(screen.getByText('device')).toBeInTheDocument();
+    expect(screen.getByText('release')).toBeInTheDocument();
+    expect(screen.getByText('67%')).toBeInTheDocument();
+    expect(screen.getByText('Android 12')).toBeInTheDocument();
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    expect(screen.getByText('iOS 16.0')).toBeInTheDocument();
+  });
+
+  it('displays device tags', async function () {
+    render(<TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} />);
+    await waitFor(() => {
+      expect(tagsMock).toHaveBeenCalled();
+    });
+    expect(screen.getByText('os')).toBeInTheDocument();
+    expect(screen.getByText('device')).toBeInTheDocument();
+    expect(screen.getByText('release')).toBeInTheDocument();
+    userEvent.click(screen.getByText('device'));
+    expect(screen.getByText('23%')).toBeInTheDocument();
+    expect(screen.getByText('iPhone15')).toBeInTheDocument();
+    expect(screen.getByText('33%')).toBeInTheDocument();
+    expect(screen.getByText('Android Phone')).toBeInTheDocument();
+    expect(screen.getByText('43%')).toBeInTheDocument();
+    expect(screen.getByText('iPhone12')).toBeInTheDocument();
+  });
+
+  it('displays release tags', async function () {
+    render(<TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} />);
+    await waitFor(() => {
+      expect(tagsMock).toHaveBeenCalled();
+    });
+    expect(screen.getByText('os')).toBeInTheDocument();
+    expect(screen.getByText('device')).toBeInTheDocument();
+    expect(screen.getByText('release')).toBeInTheDocument();
+    userEvent.click(screen.getByText('release'));
+    expect(screen.getByText('100%')).toBeInTheDocument();
+    expect(screen.getByText('org.mozilla.ios.Fennec@106.0')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/group/tagFacets.tsx
+++ b/static/app/components/group/tagFacets.tsx
@@ -14,7 +14,7 @@ import Button from '../button';
 import ButtonBar from '../buttonBar';
 import BreakdownBars from '../charts/breakdownBars';
 
-export const MOBILE_TAGS = ['os', 'release', 'device'];
+export const MOBILE_TAGS = ['os', 'device', 'release'];
 
 type Props = {
   environments: Environment[];
@@ -49,37 +49,41 @@ export function TagFacets({groupId, tagKeys, environments}: Props) {
     });
   }, [api, environments, groupId, tagKeys]);
 
+  const availableTagKeys = tagKeys.filter(tagKey => tagsData[tagKey]!!);
   const points = tagsData[selectedTag]?.topValues.map(({name, count}) => {
     return {label: name, value: count};
   });
 
-  if (Object.keys(tagsData).length > 0 && !loading) {
-    return (
-      <SidebarSection.Wrap>
-        <SidebarSection.Title>{t('Tag Summary')}</SidebarSection.Title>
-        <TagFacetsContainer>
-          <ButtonBar merged active={selectedTag}>
-            {tagKeys.map(tagKey => {
-              return (
-                <Button
-                  size="xs"
-                  key={tagKey}
-                  barId={tagKey}
-                  onClick={() => {
-                    setSelectedTag(tagKey);
-                  }}
-                >
-                  {tagKey}
-                </Button>
-              );
-            })}
-          </ButtonBar>
-          <BreakdownBarsContainer>
-            <BreakdownBars data={points ?? []} />
-          </BreakdownBarsContainer>
-        </TagFacetsContainer>
-      </SidebarSection.Wrap>
-    );
+  if (!loading) {
+    if (availableTagKeys.length > 0) {
+      return (
+        <SidebarSection.Wrap>
+          <SidebarSection.Title>{t('Tag Summary')}</SidebarSection.Title>
+          <TagFacetsContainer>
+            <ButtonBar merged active={selectedTag}>
+              {availableTagKeys.map(tagKey => {
+                return (
+                  <Button
+                    size="xs"
+                    key={tagKey}
+                    barId={tagKey}
+                    onClick={() => {
+                      setSelectedTag(tagKey);
+                    }}
+                  >
+                    {tagKey}
+                  </Button>
+                );
+              })}
+            </ButtonBar>
+            <BreakdownBarsContainer>
+              <BreakdownBars data={points ?? []} />
+            </BreakdownBarsContainer>
+          </TagFacetsContainer>
+        </SidebarSection.Wrap>
+      );
+    }
+    return null;
   }
   return <Placeholder height="60px" />;
 }

--- a/static/app/components/group/tagFacets.tsx
+++ b/static/app/components/group/tagFacets.tsx
@@ -1,0 +1,93 @@
+import {useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+import keyBy from 'lodash/keyBy';
+import pickBy from 'lodash/pickBy';
+
+import Placeholder from 'sentry/components/placeholder';
+import * as SidebarSection from 'sentry/components/sidebarSection';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {Environment, TagWithTopValues} from 'sentry/types';
+import useApi from 'sentry/utils/useApi';
+
+import Button from '../button';
+import ButtonBar from '../buttonBar';
+import BreakdownBars from '../charts/breakdownBars';
+
+export const MOBILE_TAGS = ['os', 'release', 'device'];
+
+type Props = {
+  environments: Environment[];
+  groupId: string;
+  tagKeys: string[];
+};
+
+export function TagFacets({groupId, tagKeys, environments}: Props) {
+  const [tagsData, setTagsData] = useState<Record<string, TagWithTopValues>>({});
+  const [selectedTag, setSelectedTag] = useState<string>(
+    tagKeys.length > 0 ? tagKeys[0] : ''
+  );
+  const [loading, setLoading] = useState<boolean>(true);
+  const api = useApi();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      // Fetch the top values for the current group's top tags.
+      const data = await api.requestPromise(`/issues/${groupId}/tags/`, {
+        query: pickBy({
+          key: tagKeys,
+          environment: environments.map(env => env.name),
+        }),
+      });
+      setTagsData(keyBy(data, 'key'));
+      setLoading(false);
+    };
+    setLoading(true);
+    fetchData().catch(() => {
+      setTagsData({});
+      setLoading(false);
+    });
+  }, [api, environments, groupId, tagKeys]);
+
+  const points = tagsData[selectedTag]?.topValues.map(({name, count}) => {
+    return {label: name, value: count};
+  });
+
+  if (Object.keys(tagsData).length > 0 && !loading) {
+    return (
+      <SidebarSection.Wrap>
+        <SidebarSection.Title>{t('Tag Summary')}</SidebarSection.Title>
+        <TagFacetsContainer>
+          <ButtonBar merged active={selectedTag}>
+            {tagKeys.map(tagKey => {
+              return (
+                <Button
+                  size="xs"
+                  key={tagKey}
+                  barId={tagKey}
+                  onClick={() => {
+                    setSelectedTag(tagKey);
+                  }}
+                >
+                  {tagKey}
+                </Button>
+              );
+            })}
+          </ButtonBar>
+          <BreakdownBarsContainer>
+            <BreakdownBars data={points ?? []} />
+          </BreakdownBarsContainer>
+        </TagFacetsContainer>
+      </SidebarSection.Wrap>
+    );
+  }
+  return <Placeholder height="60px" />;
+}
+
+const TagFacetsContainer = styled('div')`
+  margin-top: ${space(2)};
+`;
+const BreakdownBarsContainer = styled('div')`
+  margin-top: ${space(2)};
+  overflow: hidden;
+`;


### PR DESCRIPTION
Adds a new wip Tag Summary for mobile platform issues to the top of the issue details sidebar.
This new ui is behind the `issue-details-tag-improvements` feature flag and only appears if the issue project is a mobile platform.
![image](https://user-images.githubusercontent.com/83961295/195932265-2409008c-3332-41d4-91ed-b9084e3e2ad7.png)