### PR TITLE
feat(perf_issues): Add option for GA rollout of performance issue post process group

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -523,6 +523,9 @@ register(
 register(
     "performance.issues.all.post-process-group-early-adopter-rollout", default=0.0
 )  # EA rollout for processing transactions in post_process_group
+register(
+    "performance.issues.all.post-process-group-general-availability-rollout", default=0.0
+)  # GA rollout for processing transactions in post_process_group
 
 # Individual system-wide options in case we need to turn off specific detectors for load concerns, ignoring the set project options.
 register("performance.issues.n_plus_one_db.problem-detection", default=0.0)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -524,7 +524,7 @@ register(
     "performance.issues.all.post-process-group-early-adopter-rollout", default=0.0
 )  # EA rollout for processing transactions in post_process_group
 register(
-    "performance.issues.all.post-process-ga-availability-rollout", default=0.0
+    "performance.issues.all.post-process-group-ga-rollout", default=0.0
 )  # GA rollout for processing transactions in post_process_group
 
 # Individual system-wide options in case we need to turn off specific detectors for load concerns, ignoring the set project options.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -524,7 +524,7 @@ register(
     "performance.issues.all.post-process-group-early-adopter-rollout", default=0.0
 )  # EA rollout for processing transactions in post_process_group
 register(
-    "performance.issues.all.post-process-group-general-availability-rollout", default=0.0
+    "performance.issues.all.post-process-ga-availability-rollout", default=0.0
 )  # GA rollout for processing transactions in post_process_group
 
 # Individual system-wide options in case we need to turn off specific detectors for load concerns, ignoring the set project options.


### PR DESCRIPTION
Not sure whether we prefer to use this option or just switch post process group to use the same feature flag. Putting up prs for both so we can decide Monday