### PR TITLE
feat(replays): Link from the Discover table to Replays

### DIFF
--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -1,5 +1,6 @@
 import {Component, Fragment} from 'react';
-import {browserHistory} from 'react-router';
+// eslint-disable-next-line no-restricted-imports
+import {browserHistory, withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {Location, LocationDescriptorObject} from 'history';
@@ -40,6 +41,7 @@ import {
   eventDetailsRouteWithEventView,
   generateEventSlug,
 } from 'sentry/utils/discover/urls';
+import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {decodeList} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import withProjects from 'sentry/utils/withProjects';
@@ -89,7 +91,7 @@ export type TableViewProps = {
  * In most cases, the new EventView object differs from the previous EventView
  * object. The new EventView object is pushed to the location object.
  */
-class TableView extends Component<TableViewProps> {
+class TableView extends Component<TableViewProps & WithRouterProps> {
   /**
    * Updates a column on resizing
    */
@@ -295,6 +297,25 @@ class TableView extends Component<TableViewProps> {
         cell = (
           <Tooltip title={t('View Trace')}>
             <StyledLink data-test-id="view-trace" to={target}>
+              {cell}
+            </StyledLink>
+          </Tooltip>
+        );
+      }
+    } else if (columnKey === 'replayId') {
+      if (dataRow.replayId) {
+        const replaySlug = `${dataRow['project.name']}:${dataRow.replayId}`;
+        const referrer = encodeURIComponent(getRouteStringFromRoutes(this.props.routes));
+
+        const target = {
+          pathname: `/organizations/${organization.slug}/replays/${replaySlug}`,
+          query: {
+            referrer,
+          },
+        };
+        cell = (
+          <Tooltip title={t('View Replay')}>
+            <StyledLink data-test-id="view-replay" to={target}>
               {cell}
             </StyledLink>
           </Tooltip>
@@ -573,7 +594,7 @@ const StyledTooltip = styled(Tooltip)`
 `;
 
 const StyledLink = styled(Link)`
-  > div {
+  & div {
     display: inline;
   }
 `;
@@ -582,4 +603,4 @@ const StyledIcon = styled(IconStack)`
   vertical-align: middle;
 `;
 
-export default withProjects(TableView);
+export default withRouter(withProjects(TableView));


### PR DESCRIPTION
When the `replayId` is visible you'll get an icon and link! (icon was prior to this PR)

**With Values:**
<img width="854" alt="Screen Shot 2022-10-14 at 4 53 42 PM" src="https://user-images.githubusercontent.com/187460/195959112-7a8713b4-0aed-4bc6-98e7-8821026038ae.png">

**Empty Value:**
<img width="829" alt="Screen Shot 2022-10-14 at 4 54 11 PM" src="https://user-images.githubusercontent.com/187460/195958964-752ee7bf-4c1f-43d3-84e7-ab0897fd2593.png">

That other `replay_id` column without the icon+link treatment comes from internal/backend `replays.consumer.process_recording` transactions. They're internal to sentry and the python convention is to be snake_case, so that's why they're a thing. Shown here for completeness.

There is also a change to the StyledLink component, so I've also shown the other column types that rely on those links. None of them have nested icons so `> div` vs `& div` isn't impacting them.

Fixes #39713
