### PR TITLE
ref(commit-context): Replace sorted(...)[-1] with max()

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -191,7 +191,7 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
         blame_range = self.get_blame_for_file(repo, filepath, ref, lineno)
 
         try:
-            commit = sorted(
+            commit = max(
                 (
                     blame
                     for blame in blame_range
@@ -200,7 +200,7 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
                 key=lambda blame: datetime.strptime(
                     blame.get("commit", {}).get("committedDate"), "%Y-%m-%dT%H:%M:%SZ"
                 ),
-            )[-1]
+            )
         except IndexError:
             return None
 

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -156,12 +156,12 @@ class GitlabIntegration(
         blame_range = self.get_blame_for_file(repo, filepath, ref, lineno)
 
         try:
-            commit = sorted(
+            commit = max(
                 blame_range,
                 key=lambda blame: datetime.strptime(
                     blame.get("commit", {}).get("committed_date"), "%Y-%m-%dT%H:%M:%S.%fZ"
                 ),
-            )[-1]
+            )
         except IndexError:
             return None
 


### PR DESCRIPTION
We want to get the most recent commit for git blame functionality. 
Sorting all commits is overkill if you just want to get the most recent one. 
That is what we can use `max()` for. 

This improves readability and reduces the theoretical runtime from `O(n log n)` to `O(n)`, but don't expect huge performance differences unless you have a lot of developers debating about a single line of code 😆 

related to #39381 @NisanthanNanthakumar 




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
