### PR TITLE
ref(sampling): Does not allow conditional rule creation if uniform sample rate 100% - [TET-477]

### DIFF
--- a/static/app/views/settings/project/dynamicSampling/dynamicSamping.spec.tsx
+++ b/static/app/views/settings/project/dynamicSampling/dynamicSamping.spec.tsx
@@ -274,7 +274,7 @@ describe('Dynamic Sampling', function () {
           dynamicSampling: {
             rules: [
               {
-                sampleRate: 1,
+                sampleRate: 0.5,
                 type: 'trace',
                 active: false,
                 condition: {
@@ -447,6 +447,42 @@ describe('Dynamic Sampling', function () {
     expect(
       await screen.findByText(
         'To enable the rule, the recommended sdk version have to be updated'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('does not let user add conditional rules, if the sample rate of the uniform rule is 100%', async function () {
+    const {organization, router, project} = initializeOrg({
+      ...initializeOrg(),
+      organization: {
+        ...initializeOrg().organization,
+        features,
+      },
+      projects: [
+        TestStubs.Project({
+          dynamicSampling: {
+            rules: [{...TestStubs.DynamicSamplingConfig().uniformRule, sampleRate: 1}],
+          },
+        }),
+      ],
+    });
+
+    renderMockRequests({
+      organizationSlug: organization.slug,
+      projectSlug: project.slug,
+    });
+
+    render(
+      <TestComponent router={router} organization={organization} project={project} />
+    );
+
+    expect(await screen.findByRole('button', {name: 'Add Rule'})).toBeDisabled();
+
+    userEvent.hover(screen.getByText('Add Rule'));
+
+    expect(
+      await screen.findByText(
+        /Conditional rules are only available for projects with uniform rules with sample rate below 100%/
       )
     ).toBeInTheDocument();
   });

--- a/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
+++ b/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
@@ -316,6 +316,7 @@ export function DynamicSampling({project}: Props) {
   }));
 
   const uniformRule = rules.find(isUniformRule);
+  const uniformRuleMaximumSampleRate = uniformRule?.sampleRate === 1;
 
   return (
     <SentryDocumentTitle title={t('Dynamic Sampling')}>
@@ -476,10 +477,26 @@ export function DynamicSampling({project}: Props) {
                   {t('Read Docs')}
                 </Button>
                 <AddRuleButton
-                  disabled={!hasAccess}
+                  disabled={!hasAccess || uniformRuleMaximumSampleRate}
                   title={
-                    !hasAccess ? t("You don't have permission to add a rule") : undefined
+                    !hasAccess
+                      ? t("You don't have permission to add a rule")
+                      : uniformRuleMaximumSampleRate
+                      ? tct(
+                          'Conditional rules are only available for projects with uniform rules with sample rate below 100%. [docsLink:Read more in the docs]',
+                          {
+                            docsLink: (
+                              <ExternalLink
+                                href={`${SERVER_SIDE_SAMPLING_DOC_LINK}#3-set-a-sampling-rate-based-on-a-condition`} // TODO(sampling): Update docs with this new constraint
+                              />
+                            ),
+                          }
+                        )
+                      : undefined
                   }
+                  tooltipProps={{
+                    isHoverable: uniformRuleMaximumSampleRate,
+                  }}
                   priority="primary"
                   onClick={() => navigate(`${samplingProjectSettingsPath}rules/new/`)}
                   icon={<IconAdd isCircled />}


### PR DESCRIPTION
**What this PR does:**

- Add a new check to the "Add Rule" button, not allowing users to add conditional rules if the sample rate of the uniform rule is 100%
- Add a new test for this new constraint 


**Preview:**


https://user-images.githubusercontent.com/29228205/196147257-54014ef3-c61e-42d7-aadb-92edc898469c.mov

