### PR TITLE
test(js): Use RTL renderGlobalModal in RTL test

### DIFF
--- a/static/app/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -1,6 +1,6 @@
-import {mountGlobalModal} from 'sentry-test/modal';
 import {
   render,
+  renderGlobalModal,
   screen,
   userEvent,
   waitFor,
@@ -94,7 +94,7 @@ describe('Organization Developer Settings', function () {
       expect(deleteButton).toHaveAttribute('aria-disabled', 'false');
 
       userEvent.click(deleteButton);
-      await mountGlobalModal();
+      renderGlobalModal();
       const dialog = await screen.findByRole('dialog');
       expect(dialog).toBeInTheDocument();
 
@@ -126,7 +126,7 @@ describe('Organization Developer Settings', function () {
       expect(publishButton).toHaveAttribute('aria-disabled', 'false');
       userEvent.click(publishButton);
 
-      await mountGlobalModal();
+      renderGlobalModal();
       const dialog = await screen.findByRole('dialog');
       expect(dialog).toBeInTheDocument();
       const questionnaire = [


### PR DESCRIPTION
This test was already using RTL, but was using the enzyme modal render.