### PR TITLE
fix(wmak): Facet query with or

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionTags/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/index.tsx
@@ -53,7 +53,7 @@ function generateEventView({
   location: Location;
   transactionName: string;
 }): EventView {
-  const query = decodeScalar(location.query.query, '');
+  const query = `(${decodeScalar(location.query.query, '')})`;
   const conditions = new MutableSearch(query);
 
   conditions.setFilterValues('event.type', ['transaction']);


### PR DESCRIPTION
- Facet queries with ors were returning invalid results because we were directly appending the event.type:transaction and transaction:name queries directly to the end.
  - This mean a user query like `a or b` would actually become `a or (b event.type:txn txn:name`