### PR TITLE
ref(perf_issue): Add new referrer to issue events table

### DIFF
--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -88,6 +88,7 @@ const AllEventsTable = (props: Props) => {
       }}
       transactionName=""
       columnTitles={columnTitles.slice()}
+      referrer="api.issues.issue_events"
     />
   );
 };

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -89,6 +89,7 @@ type Props = {
   excludedTags?: string[];
   issueId?: string;
   projectId?: string;
+  referrer?: string;
   totalEventCount?: string;
 };
 
@@ -314,7 +315,8 @@ class EventsTable extends Component<Props, State> {
   };
 
   render() {
-    const {eventView, organization, location, setError, totalEventCount} = this.props;
+    const {eventView, organization, location, setError, totalEventCount, referrer} =
+      this.props;
 
     const totalTransactionsView = eventView.clone();
     totalTransactionsView.sorts = [];
@@ -400,7 +402,7 @@ class EventsTable extends Component<Props, State> {
           orgSlug={organization.slug}
           location={location}
           setError={error => setError(error?.message)}
-          referrer="api.performance.transaction-events"
+          referrer={referrer || 'api.performance.transaction-events'}
           useEvents
         >
           {({pageLinks, isLoading: isDiscoverQueryLoading, tableData}) => {


### PR DESCRIPTION
Previously, we're reusing a `referrer` from other Performance page. This makes it more clear where the request is originating from