### PR TITLE
ref(sampling): Skip acceptance flaky test temp

### DIFF
--- a/tests/acceptance/test_project_settings_sampling.py
+++ b/tests/acceptance/test_project_settings_sampling.py
@@ -142,6 +142,7 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
                     event=audit_log.get_event_id("PROJECT_EDIT"),
                 )
 
+    @pytest.mark.skip(reason="flaky behaviour. Needs investigation")
     def test_add_specific_rule(self):
         with self.feature(FEATURE_NAME):
             self.project.update_option(

--- a/tests/acceptance/test_project_settings_sampling_deprecated.py
+++ b/tests/acceptance/test_project_settings_sampling_deprecated.py
@@ -511,6 +511,7 @@ class ProjectSettingsSamplingTest(AcceptanceTestCase):
                     event=audit_log.get_event_id("PROJECT_EDIT"),
                 )
 
+    @pytest.mark.skip(reason="flaky behaviour. Needs investigation")
     def test_add_specific_rule(self):
         with self.feature(FEATURE_NAME):
             self.project.update_option(


### PR DESCRIPTION
**What this PR does:**

- Temporarily skip the dynamic sampling acceptance test "test_add_specific_rule" which is currently flaky
