### PR TITLE
fix(discover): Don't escape modified query from table cell exclusions

### DIFF
--- a/static/app/views/eventsV2/table/cellAction.spec.jsx
+++ b/static/app/views/eventsV2/table/cellAction.spec.jsx
@@ -482,10 +482,12 @@ describe('updateQuery()', function () {
     expect(results.formatString()).toEqual('b:2 !a:3');
     updateQuery(results, Actions.EXCLUDE, columnB, '4');
     expect(results.formatString()).toEqual('!a:3 !b:4');
-    updateQuery(results, Actions.EXCLUDE, columnA, '*dontescapeme*');
-    expect(results.formatString()).toEqual('!b:4 !a:3 !a:*dontescapeme*');
-    updateQuery(results, Actions.EXCLUDE, columnA, '5');
-    expect(results.formatString()).toEqual('!b:4 !a:3 !a:*dontescapeme* !a:5');
+    results.addFilterValues('!a', ['*dontescapeme*'], false);
+    expect(results.formatString()).toEqual('!a:3 !b:4 !a:*dontescapeme*');
+    updateQuery(results, Actions.EXCLUDE, columnA, '*escapeme*');
+    expect(results.formatString()).toEqual(
+      '!b:4 !a:3 !a:*dontescapeme* !a:"\\*escapeme\\*"'
+    );
     updateQuery(results, Actions.ADD, columnA, '5');
     expect(results.formatString()).toEqual('!b:4 a:5');
     updateQuery(results, Actions.ADD, columnB, '6');

--- a/static/app/views/eventsV2/table/cellAction.spec.jsx
+++ b/static/app/views/eventsV2/table/cellAction.spec.jsx
@@ -482,6 +482,10 @@ describe('updateQuery()', function () {
     expect(results.formatString()).toEqual('b:2 !a:3');
     updateQuery(results, Actions.EXCLUDE, columnB, '4');
     expect(results.formatString()).toEqual('!a:3 !b:4');
+    updateQuery(results, Actions.EXCLUDE, columnA, '*dontescapeme*');
+    expect(results.formatString()).toEqual('!b:4 !a:3 !a:*dontescapeme*');
+    updateQuery(results, Actions.EXCLUDE, columnA, '5');
+    expect(results.formatString()).toEqual('!b:4 !a:3 !a:*dontescapeme* !a:5');
     updateQuery(results, Actions.ADD, columnA, '5');
     expect(results.formatString()).toEqual('!b:4 a:5');
     updateQuery(results, Actions.ADD, columnB, '6');

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -89,8 +89,18 @@ export function updateQuery(
         const negation = `!${key}`;
         value = Array.isArray(value) ? value : [String(value)];
         const currentNegations = results.getFilterValues(negation);
-        value = [...new Set([...currentNegations, ...value])];
-        results.setFilterValues(negation, value, false);
+        results.removeFilter(negation);
+        // We shouldn't escape any of the existing conditions since the
+        // existing conditions have already been set an verified by the user
+        results.addFilterValues(
+          negation,
+          currentNegations.filter(
+            filterValue => !(value as string[]).includes(filterValue)
+          ),
+          false
+        );
+        // Escapes the new condition if necessary
+        results.addFilterValues(negation, value);
       }
       break;
     case Actions.SHOW_GREATER_THAN: {

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -90,7 +90,7 @@ export function updateQuery(
         value = Array.isArray(value) ? value : [String(value)];
         const currentNegations = results.getFilterValues(negation);
         value = [...new Set([...currentNegations, ...value])];
-        results.setFilterValues(negation, value);
+        results.setFilterValues(negation, value, false);
       }
       break;
     case Actions.SHOW_GREATER_THAN: {


### PR DESCRIPTION
In discover, using the `Exclude from filter` option in table cells causes the existing query filter to be escaped (on the same key). We shouldn't escape the existing query since it's not expected behaviour.