### PR TITLE
fix(post_process): Make sure we cache `project` when creating `GroupEvents` from an `Event`

### DIFF
--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -720,13 +720,16 @@ class GroupEvent(BaseEvent):
 
     @classmethod
     def from_event(cls, event: Event, group: Group):
-        return cls(
+        group_event = cls(
             project_id=event.project_id,
             event_id=event.event_id,
             group=group,
             data=deepcopy(event.data),
             snuba_data=deepcopy(event._snuba_data),
         )
+        if hasattr(event, "_project_cache"):
+            group_event.project = event.project
+        return group_event
 
 
 class EventSubjectTemplate(string.Template):


### PR DESCRIPTION
We're seeing increased queries in `post_process_group` to the project/organization tables. This is because we don't pass the cached `Project` onto any `GroupEvent`s that we emit in `Event.build_group_events`. This fixes this to copy the cached project across if present in the `Event`.
