### PR TITLE
fix(mobile-exp): Screenshots appear stretched on firefox

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/imageVisualization.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/imageVisualization.tsx
@@ -8,7 +8,6 @@ const ImageVisualization = styled(ImageViewer)`
   img {
     width: auto;
     height: 100%;
-    flex: 1;
   }
 `;
 


### PR DESCRIPTION
Remove flex:1 on image to prevent image from stretching
to fit in the container

before:
![Screen Shot 2022-10-17 at 2 24 18 PM](https://user-images.githubusercontent.com/63818634/196253876-fdd96cb4-b66f-4475-af0a-eeb45f972268.png)

after:
![Screen Shot 2022-10-17 at 2 25 10 PM](https://user-images.githubusercontent.com/63818634/196253959-3112ac1a-91bf-4714-a3e3-61a13749df0e.png)
