### PR TITLE
ref: Remove the default entity from the post process forwarder

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -349,7 +349,6 @@ def cron(**options):
 )
 @click.option(
     "--entity",
-    default="all",
     type=click.Choice(["all", "errors", "transactions"]),
     help="The type of entity to process (all, errors, transactions).",
 )


### PR DESCRIPTION
This is no longer a good default (and should probably be eventually deprecated all together) since errors and transactions are now being mapped to different topics by default in Sentry and Snuba (which prevents this from working properly). This change forces the user to pass a value here.