### PR TITLE
feat(issue-alerts): add regression + reappearance conditions to preview

### DIFF
--- a/src/sentry/rules/conditions/first_seen_event.py
+++ b/src/sentry/rules/conditions/first_seen_event.py
@@ -5,7 +5,7 @@ from sentry.eventstore.models import Event
 from sentry.models import Group
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
-from sentry.types.condition_activity import ActivityType, ConditionActivity
+from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 
 
 class FirstSeenEventCondition(EventCondition):
@@ -28,6 +28,8 @@ class FirstSeenEventCondition(EventCondition):
             .values_list("id", "first_seen")
         )
         return [
-            ConditionActivity(group_id=g[0], type=ActivityType.CREATE_ISSUE, timestamp=g[1])
+            ConditionActivity(
+                group_id=g[0], type=ConditionActivityType.CREATE_ISSUE, timestamp=g[1]
+            )
             for g in first_seen
         ]

--- a/src/sentry/rules/conditions/reappeared_event.py
+++ b/src/sentry/rules/conditions/reappeared_event.py
@@ -1,6 +1,12 @@
+from datetime import datetime
+from typing import Sequence
+
 from sentry.eventstore.models import Event
+from sentry.models import Activity
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
+from sentry.types.activity import ActivityType
+from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 
 
 class ReappearedEventCondition(EventCondition):
@@ -9,3 +15,23 @@ class ReappearedEventCondition(EventCondition):
 
     def passes(self, event: Event, state: EventState) -> bool:
         return state.has_reappeared
+
+    def get_activity(
+        self, start: datetime, end: datetime, limit: int
+    ) -> Sequence[ConditionActivity]:
+        # reappearances are recorded as SET_UNRESOLVED with no user
+        activities = (
+            Activity.objects.filter(
+                datetime__gte=start,
+                datetime__lt=end,
+                type=ActivityType.SET_UNRESOLVED.value,
+                user=None,
+            )
+            .order_by("-datetime")[:limit]
+            .values_list("group", "datetime")
+        )
+
+        return [
+            ConditionActivity(group_id=a[0], type=ConditionActivityType.REAPPEARED, timestamp=a[1])
+            for a in activities
+        ]

--- a/src/sentry/rules/conditions/regression_event.py
+++ b/src/sentry/rules/conditions/regression_event.py
@@ -1,6 +1,12 @@
+from datetime import datetime
+from typing import Sequence
+
 from sentry.eventstore.models import Event
+from sentry.models import Activity
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
+from sentry.types.activity import ActivityType
+from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 
 
 class RegressionEventCondition(EventCondition):
@@ -9,3 +15,19 @@ class RegressionEventCondition(EventCondition):
 
     def passes(self, event: Event, state: EventState) -> bool:
         return state.is_regression
+
+    def get_activity(
+        self, start: datetime, end: datetime, limit: int
+    ) -> Sequence[ConditionActivity]:
+        activities = (
+            Activity.objects.filter(
+                datetime__gte=start, datetime__lt=end, type=ActivityType.SET_REGRESSION.value
+            )
+            .order_by("-datetime")[:limit]
+            .values_list("group", "datetime")
+        )
+
+        return [
+            ConditionActivity(group_id=a[0], type=ConditionActivityType.REGRESSION, timestamp=a[1])
+            for a in activities
+        ]

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -6,14 +6,16 @@ from enum import Enum
 from typing import Any, Dict
 
 
-class ActivityType(Enum):
+class ConditionActivityType(Enum):
     CREATE_ISSUE = 0
+    REGRESSION = 1
+    REAPPEARED = 2
 
 
 @dataclass(frozen=True)
 class ConditionActivity:
     group_id: str
     # potentially can have multiple types if even more conditions are supported
-    type: ActivityType
+    type: ConditionActivityType
     timestamp: datetime
     data: Dict[str, Any] | None = None

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -3,16 +3,17 @@ from datetime import timedelta
 from django.utils import timezone
 from freezegun import freeze_time
 
-from sentry.models import Group
+from sentry.models import Activity, Group
 from sentry.rules.history.preview import PREVIEW_TIME_RANGE, get_hourly_bucket, preview
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
+from sentry.types.activity import ActivityType
 
 
 @freeze_time()
 @region_silo_test
 class ProjectRulePreviewTest(TestCase):
-    def set_up(self):
+    def _set_up_first_seen(self):
         hours = get_hourly_bucket(PREVIEW_TIME_RANGE)
         for i in range(hours):
             for j in range(i % 5):
@@ -21,10 +22,20 @@ class ProjectRulePreviewTest(TestCase):
                 )
         return hours
 
-    def test_first_seen(self):
-        hours = self.set_up()
-        conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
+    def _set_up_activity(self, condition_type):
+        hours = get_hourly_bucket(PREVIEW_TIME_RANGE)
+        for i in range(hours):
+            for j in range(i % 5):
+                Activity.objects.create(
+                    project=self.project,
+                    group=self.group,
+                    type=condition_type.value,
+                    datetime=timezone.now() - timedelta(hours=i + 1),
+                )
+        return hours
 
+    def _test_preview(self, hours, condition):
+        conditions = [{"id": condition}]
         result = preview(self.project, conditions, [], "all", "all", 0)
         for i in range(hours):
             assert result[hours - i - 1].count == i % 5
@@ -33,8 +44,26 @@ class ProjectRulePreviewTest(TestCase):
         for i in range(hours):
             assert result[i].count == (1 if i % 5 else 0)
 
+    def test_first_seen(self):
+        hours = self._set_up_first_seen()
+        self._test_preview(
+            hours, "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
+        )
+
+    def test_regression(self):
+        hours = self._set_up_activity(ActivityType.SET_REGRESSION)
+        self._test_preview(
+            hours, "sentry.rules.conditions.regression_event.RegressionEventCondition"
+        )
+
+    def test_reappeared(self):
+        hours = self._set_up_activity(ActivityType.SET_UNRESOLVED)
+        self._test_preview(
+            hours, "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"
+        )
+
     def test_unsupported_conditions(self):
-        self.set_up()
+        self._set_up_first_seen()
         # conditions with no immediate plan to support
         unsupported_conditions = [
             "sentry.rules.conditions.tagged_event.TaggedEventCondition",

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -36,10 +36,12 @@ class ProjectRulePreviewTest(TestCase):
 
     def _test_preview(self, hours, condition):
         conditions = [{"id": condition}]
+        # test with 0 frequency, no fires should be filtered
         result = preview(self.project, conditions, [], "all", "all", 0)
         for i in range(hours):
             assert result[hours - i - 1].count == i % 5
 
+        # test with 60min frequency, there should be at most 1 fire per 60min bucket
         result = preview(self.project, conditions, [], "all", "all", 60)
         for i in range(hours):
             assert result[i].count == (1 if i % 5 else 0)


### PR DESCRIPTION
Adds functionality for `RegressionEventCondition` and `ReappearedEventCondition` in issue alert previews. 

Renamed `condition_activity.ActivityType` to `ConditionActivityType` since there's already a `activity.ActivityType`
