### PR TITLE
ref(emails): Handle perf issue email title and subtitles

### DIFF
--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -14,6 +14,7 @@ from sentry.notifications.utils import (
     get_group_settings_link,
     get_integration_link,
     get_interface_list,
+    get_performance_issue_alert_subtitle,
     get_rules,
     get_transaction_data,
     has_alert_integration,
@@ -22,7 +23,7 @@ from sentry.notifications.utils import (
 from sentry.notifications.utils.participants import get_send_to
 from sentry.plugins.base.structs import Notification
 from sentry.types.integrations import ExternalProviders
-from sentry.types.issues import GroupCategory
+from sentry.types.issues import GROUP_TYPE_TO_TEXT, GroupCategory
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -99,6 +100,7 @@ class AlertRuleNotification(ProjectNotification):
             "environment": environment,
             "slack_link": get_integration_link(self.organization, "slack"),
             "has_alert_integration": has_alert_integration(self.project),
+            "issue_type": GROUP_TYPE_TO_TEXT.get(self.group.issue_type, "Issue"),
         }
 
         # if the organization has enabled enhanced privacy controls we don't send
@@ -108,7 +110,10 @@ class AlertRuleNotification(ProjectNotification):
 
         if self.group.issue_category == GroupCategory.PERFORMANCE:
             context.update(
-                {"transaction_data": [("Span Evidence", get_transaction_data(self.event), None)]}
+                {
+                    "transaction_data": [("Span Evidence", get_transaction_data(self.event), None)],
+                    "subtitle": get_performance_issue_alert_subtitle(self.event),
+                },
             )
 
         return context

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -317,9 +317,7 @@ def get_span_evidence_value(
 
 
 def get_parent_and_repeating_spans(
-    spans: Union[List[Dict[str, Union[str, float]]], None],
-    problem: PerformanceProblem
-    # ) -> tuple[Union[Dict[str, Union[str, float]], None], Union[Dict[str, Union[str, float]], None]]:
+    spans: Union[List[Dict[str, Union[str, float]]], None], problem: PerformanceProblem
 ) -> tuple[Union[Dict[str, Union[str, float]], None], Union[Dict[str, Union[str, float]], None]]:
     """Parse out the parent and repeating spans given an event's spans"""
     if not spans:
@@ -381,12 +379,13 @@ def get_spans(
     if not len(entries):
         return None
 
-    spans: List[Union[Dict[str, Union[str, float]], None]] = []
+    spans: Optional[List[Dict[str, Union[str, float]]]] = None
     for entry in entries:
         if entry.get("type") == "spans":
-            spans = cast(List[Union[Dict[str, Union[str, float]], None]], entry.get("data"))
+            spans = cast(Optional[List[Dict[str, Union[str, float]]]], entry.get("data"))
+            break
 
-    return spans[0] if len(spans) else spans
+    return spans
 
 
 def get_span_and_problem(

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -297,16 +297,16 @@ def get_span_evidence_value_problem(problem: PerformanceProblem) -> str:
 
 
 def get_span_evidence_value(
-    span: Union[Dict[str, Union[str, float]], Any, None] = None, include_op: bool = True
+    span: Union[Dict[str, Union[str, float]], None] = None, include_op: bool = True
 ) -> str:
     """Get the 'span evidence' data for a given span. This is displayed in issue alert emails."""
     value = "no value"
     if not span:
         return value
     if not span.get("op") and span.get("description"):
-        return cast(str, span["description"])
+        value = cast(str, span["description"])
     if span.get("op") and not span.get("description"):
-        return cast(str, span["op"])
+        value = cast(str, span["op"])
     if span.get("op") and span.get("description"):
         op = cast(str, span["op"])
         desc = cast(str, span["description"])
@@ -318,10 +318,7 @@ def get_span_evidence_value(
 
 def get_parent_and_repeating_spans(
     spans: Optional[List[Dict[str, Union[str, float]]]], problem: PerformanceProblem
-) -> tuple[
-    Union[Dict[str, Union[str, float]], Any, None],
-    Union[Dict[str, Union[str, float]], PerformanceProblem, None],
-]:
+) -> tuple[Union[Dict[str, Union[str, float]], None], Union[Dict[str, Union[str, float]], None]]:
     """Parse out the parent and repeating spans given an event's spans"""
     if not spans:
         return (None, None)

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -317,7 +317,9 @@ def get_span_evidence_value(
 
 
 def get_parent_and_repeating_spans(
-    spans: Optional[List[Dict[str, Union[str, float]]]], problem: PerformanceProblem
+    spans: Union[List[Dict[str, Union[str, float]]], None],
+    problem: PerformanceProblem
+    # ) -> tuple[Union[Dict[str, Union[str, float]], None], Union[Dict[str, Union[str, float]], None]]:
 ) -> tuple[Union[Dict[str, Union[str, float]], None], Union[Dict[str, Union[str, float]], None]]:
     """Parse out the parent and repeating spans given an event's spans"""
     if not spans:
@@ -340,7 +342,7 @@ def get_parent_and_repeating_spans(
 
 
 def perf_to_email_html(
-    spans: Optional[List[Dict[str, Union[str, float]]]], problem: PerformanceProblem = None
+    spans: Union[List[Dict[str, Union[str, float]]], None], problem: PerformanceProblem = None
 ) -> Any:
     """Generate the email HTML for a performance issue alert"""
     if not problem:
@@ -373,13 +375,18 @@ def get_matched_problem(event: Event) -> Optional[EventPerformanceProblem]:
 
 
 def get_spans(
-    entries: tuple[List[Dict[str, List[Dict[str, Union[str, float]]]]], Dict[Any, Any]]
-) -> Union[List[Dict[str, Union[str, float]]], None]:
+    entries: List[Dict[str, Union[List[Dict[str, Union[str, float]]], str]]]
+) -> Optional[List[Dict[str, Union[str, float]]]]:
     """Get the given event's spans"""
     if not len(entries):
         return None
 
-    return [entry.get("data") for entry in entries[0] if entry.get("type") == "spans"][0]
+    spans: List[Union[Dict[str, Union[str, float]], None]] = []
+    for entry in entries:
+        if entry.get("type") == "spans":
+            spans = cast(List[Union[Dict[str, Union[str, float]], None]], entry.get("data"))
+
+    return spans[0] if len(spans) else spans
 
 
 def get_span_and_problem(
@@ -387,7 +394,7 @@ def get_span_and_problem(
 ) -> tuple[Optional[List[Dict[str, Union[str, float]]]], Optional[EventPerformanceProblem]]:
     """Get a given event's spans and performance problem"""
     entries = get_entries(event, None)
-    spans = get_spans(entries)
+    spans = get_spans(entries[0]) if len(entries) else None
     matched_problem = get_matched_problem(event)
     return (spans, matched_problem)
 

--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -121,6 +121,13 @@
                       {% endif %}
                     </h3>
                   </div>
+                {% elif type == "transaction" %}
+                  <div class="event-type transaction">
+                    <h3>
+                      <a href="{% absolute_uri link %}">{{ issue_type|truncatechars:40 }}</a><br />
+                        <span class="event-subtitle">{{ subtitle|truncatechars:40 }}</span>
+                    </h3>
+                  </div>
                 {% else %}
                   <div class="event-type default">
                     <h3>

--- a/src/sentry/web/frontend/debug/debug_performance_issue.py
+++ b/src/sentry/web/frontend/debug/debug_performance_issue.py
@@ -7,11 +7,13 @@ from sentry.models import Organization, Project, Rule
 from sentry.notifications.utils import (
     get_group_settings_link,
     get_interface_list,
+    get_performance_issue_alert_subtitle,
     get_rules,
     get_transaction_data,
 )
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now
+from sentry.types.issues import GROUP_TYPE_TO_TEXT
 from sentry.utils import json
 from sentry.utils.samples import load_data
 
@@ -99,5 +101,7 @@ class DebugPerformanceIssueEmailView(View):
                 "project_label": project.slug,
                 "commits": json.loads(COMMIT_EXAMPLE),
                 "transaction_data": [("Span Evidence", mark_safe(transaction_data), None)],
+                "issue_type": GROUP_TYPE_TO_TEXT.get(perf_group.issue_type, "Issue"),
+                "subtitle": get_performance_issue_alert_subtitle(self.event),
             },
         ).render(request)


### PR DESCRIPTION
Add handling in the issue alert email template for performance issues so that the title and subtitle render nicely.

**Before**

<img width="727" alt="Screen Shot 2022-10-17 at 12 38 53 PM" src="https://user-images.githubusercontent.com/29959063/196272956-0d9bd1e1-cd4f-4e9c-a54c-e353dc7fa42d.png">

**After**
<img width="725" alt="Screen Shot 2022-10-17 at 12 38 32 PM" src="https://user-images.githubusercontent.com/29959063/196273013-61c261f8-468e-4975-a92d-0ec8c51c00dd.png">
