### PR TITLE
fix (all-events) remove attachments column and only display minidumps

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -65,6 +65,7 @@ export type RenderFunctionBaggage = {
   location: Location;
   organization: Organization;
   eventView?: EventView;
+  projectId?: string;
   unit?: string;
 };
 
@@ -321,15 +322,18 @@ const SPECIAL_FIELDS: SpecialFields = {
   // TODO - refactor code and remove from this file or add ability to query for attachments in Discover
   attachments: {
     sortField: null,
-    renderFunc: data => {
-      const attachments: Array<IssueAttachment & {url: string}> = data.attachments;
+    renderFunc: (data, {organization, projectId}) => {
+      const attachments: Array<IssueAttachment> = data.attachments;
 
       const items: MenuItemProps[] = attachments
         .filter(attachment => attachment.type !== 'event.minidump')
         .map(attachment => ({
           key: attachment.id,
           label: attachment.name,
-          onAction: () => window.open(attachment.url),
+          onAction: () =>
+            window.open(
+              `/api/0/projects/${organization.slug}/${projectId}/events/${attachment.event_id}/attachments/${attachment.id}/?download=1`
+            ),
         }));
 
       return (
@@ -354,7 +358,7 @@ const SPECIAL_FIELDS: SpecialFields = {
   },
   minidump: {
     sortField: null,
-    renderFunc: data => {
+    renderFunc: (data, {organization, projectId}) => {
       const attachments: Array<IssueAttachment & {url: string}> = data.attachments;
 
       const minidump = attachments.find(
@@ -366,7 +370,15 @@ const SPECIAL_FIELDS: SpecialFields = {
           <Button
             size="xs"
             disabled={!minidump}
-            onClick={() => window.open(minidump?.url)}
+            onClick={
+              minidump
+                ? () => {
+                    window.open(
+                      `/api/0/projects/${organization.slug}/${projectId}/events/${minidump.event_id}/attachments/${minidump.id}/?download=1`
+                    );
+                  }
+                : undefined
+            }
           >
             <IconDownload color="gray500" size="14px" />
             <DownloadCount>{minidump ? 1 : 0}</DownloadCount>

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -64,7 +64,6 @@ const AllEventsTable = (props: Props) => {
     t('user'),
     ...(isPerfIssue ? [t('total duration')] : []),
     t('timestamp'),
-    t('attachments'),
     t('minidump'),
   ];
 
@@ -81,7 +80,7 @@ const AllEventsTable = (props: Props) => {
       excludedTags={excludedTags}
       projectId={projectId}
       totalEventCount={totalEventCount}
-      customColumns={['attachments', 'minidump']}
+      customColumns={['minidump']}
       setError={() => {
         (msg: string) => setError(msg);
       }}

--- a/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
@@ -362,7 +362,7 @@ describe('groupEvents', function () {
         expect.objectContaining({
           query: expect.objectContaining({
             query: 'issue.id:1 ',
-            field: expect.not.arrayContaining(['s', 'minidump']),
+            field: expect.not.arrayContaining(['attachments', 'minidump']),
           }),
         })
       );

--- a/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
@@ -103,7 +103,7 @@ describe('groupEvents', function () {
     });
 
     attachmentsRequest = MockApiClient.addMockResponse({
-      url: '/api/0/issues/1/attachments/?event_id=id123',
+      url: '/api/0/issues/1/attachments/?per_page=50&types=event.minidump&event_id=id123',
       body: [],
     });
   });
@@ -275,7 +275,7 @@ describe('groupEvents', function () {
 
     it('displays minidumps', async () => {
       attachmentsRequest = MockApiClient.addMockResponse({
-        url: '/api/0/issues/1/attachments/?event_id=id123',
+        url: '/api/0/issues/1/attachments/?per_page=50&types=event.minidump&event_id=id123',
         body: [
           {
             id: 'id123',
@@ -308,9 +308,9 @@ describe('groupEvents', function () {
       expect(minidumpColumn).toBeInTheDocument();
     });
 
-    it('displays attachments', async () => {
+    it('does not display attachments but displays minidump', async () => {
       attachmentsRequest = MockApiClient.addMockResponse({
-        url: '/api/0/issues/1/attachments/?event_id=id123',
+        url: '/api/0/issues/1/attachments/?per_page=50&types=event.minidump&event_id=id123',
         body: [
           {
             id: 'id123',
@@ -340,7 +340,9 @@ describe('groupEvents', function () {
       );
       await waitForElementToBeRemoved(document.querySelector('div.loading-indicator'));
       const attachmentsColumn = screen.queryByText('attachments');
-      expect(attachmentsColumn).toBeInTheDocument();
+      const minidumpColumn = screen.queryByText('minidump');
+      expect(attachmentsColumn).not.toBeInTheDocument();
+      expect(minidumpColumn).toBeInTheDocument();
       expect(attachmentsRequest).toHaveBeenCalled();
     });
 
@@ -360,7 +362,7 @@ describe('groupEvents', function () {
         expect.objectContaining({
           query: expect.objectContaining({
             query: 'issue.id:1 ',
-            field: expect.not.arrayContaining(['attachments', 'minidump']),
+            field: expect.not.arrayContaining(['s', 'minidump']),
           }),
         })
       );

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -86,7 +86,7 @@ type Props = {
   setError: (msg: string | undefined) => void;
   transactionName: string;
   columnTitles?: string[];
-  customColumns?: string[];
+  customColumns?: ('attachments' | 'minidump')[];
   excludedTags?: string[];
   issueId?: string;
   projectId?: string;
@@ -148,7 +148,7 @@ class EventsTable extends Component<Props, State> {
     column: TableColumn<keyof TableDataRow>,
     dataRow: TableDataRow
   ): React.ReactNode {
-    const {eventView, organization, location, transactionName} = this.props;
+    const {eventView, organization, location, transactionName, projectId} = this.props;
 
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
@@ -156,7 +156,12 @@ class EventsTable extends Component<Props, State> {
     const tableMeta = tableData.meta;
     const field = String(column.key);
     const fieldRenderer = getFieldRenderer(field, tableMeta);
-    const rendered = fieldRenderer(dataRow, {organization, location, eventView});
+    const rendered = fieldRenderer(dataRow, {
+      organization,
+      location,
+      eventView,
+      projectId,
+    });
 
     const allowActions = [
       Actions.ADD,
@@ -343,7 +348,10 @@ class EventsTable extends Component<Props, State> {
         return col;
       });
 
-    if (this.props.customColumns?.length && this.state.attachments.length) {
+    if (
+      this.props.customColumns?.includes('attachments') &&
+      this.state.attachments.length
+    ) {
       columnOrder.push({
         isSortable: false,
         key: 'attachments',
@@ -351,44 +359,46 @@ class EventsTable extends Component<Props, State> {
         type: 'never',
         column: {field: 'attachments', kind: 'field', alias: undefined},
       });
-      if (this.state.hasMinidumps) {
-        columnOrder.push({
-          isSortable: false,
-          key: 'minidump',
-          name: 'minidump',
-          type: 'never',
-          column: {field: 'minidump', kind: 'field', alias: undefined},
-        });
-      }
+    }
+
+    if (this.props.customColumns?.includes('minidump') && this.state.hasMinidumps) {
+      columnOrder.push({
+        isSortable: false,
+        key: 'minidump',
+        name: 'minidump',
+        type: 'never',
+        column: {field: 'minidump', kind: 'field', alias: undefined},
+      });
     }
 
     const joinCustomData = ({data}: TableData) => {
-      if (this.state.attachments.length) {
-        const {projectId} = this.props;
-        const attachmentsWithUrl = this.state.attachments.map(attachment => ({
-          ...attachment,
-          url: `/api/0/projects/${organization.slug}/${projectId}/events/${attachment.event_id}/attachments/${attachment.id}/?download=1`,
-        }));
+      const eventIdMap = {};
 
-        const eventIdMap = {};
-        data.forEach(event => {
-          event.attachments = [] as any;
-          eventIdMap[event.id] = event;
-        });
-        attachmentsWithUrl.forEach(attachment => {
-          const eventAttachments = eventIdMap[attachment.event_id]?.attachments;
-          if (eventAttachments) {
-            eventAttachments.push(attachment);
-          }
-        });
-      }
+      data.forEach(event => {
+        event.attachments = [] as any;
+        eventIdMap[event.id] = event;
+      });
+
+      this.state.attachments.forEach(attachment => {
+        const eventAttachments = eventIdMap[attachment.event_id]?.attachments;
+        if (eventAttachments) {
+          eventAttachments.push(attachment);
+        }
+      });
     };
 
     const fetchAttachments = async ({data}: TableData, cursor: string) => {
       const eventIds = data.map(value => value.id);
-      const eventIdQuery = `event_id=${eventIds.join('&event_id=')}`;
+      const fetchOnlyMinidumps = !this.props.customColumns?.includes('attachments');
+
+      const queries: string = [
+        'per_page=50',
+        ...(fetchOnlyMinidumps ? ['types=event.minidump'] : []),
+        ...eventIds.map(eventId => `event_id=${eventId}`),
+      ].join('&');
+
       const res: IssueAttachment[] = await this.api.requestPromise(
-        `/api/0/issues/${this.props.issueId}/attachments/?${eventIdQuery}`
+        `/api/0/issues/${this.props.issueId}/attachments/?${queries}`
       );
 
       let hasMinidumps = false;
@@ -398,6 +408,7 @@ class EventsTable extends Component<Props, State> {
           hasMinidumps = true;
         }
       });
+
       this.setState({
         ...this.state,
         lastFetchedCursor: cursor,


### PR DESCRIPTION
This PR removes the attachments column (as it will require some more technical work/thoughts), and only displays minidumps.

In addition, there is some refactoring in the code the clean it up a bit based on reviews from previous PRs