### PR TITLE
fix(discover): Support both equation sort syntax in EventView

### DIFF
--- a/static/app/utils/discover/eventView.spec.jsx
+++ b/static/app/utils/discover/eventView.spec.jsx
@@ -2545,6 +2545,28 @@ describe('EventView.sortOnField()', function () {
     });
   });
 
+  it('supports function format on equation sorts', function () {
+    const modifiedState = {
+      ...state,
+      fields: [{field: 'count()'}, {field: 'equation|count() + 100'}],
+      sorts: [{field: 'equation|count() + 100', kind: 'desc'}],
+    };
+
+    const eventView = new EventView(modifiedState);
+    expect(eventView).toMatchObject(modifiedState);
+  });
+
+  it('supports index format on equation sorts', function () {
+    const modifiedState = {
+      ...state,
+      fields: [{field: 'count()'}, {field: 'equation|count() + 100'}],
+      sorts: [{field: 'equation[0]', kind: 'desc'}],
+    };
+
+    const eventView = new EventView(modifiedState);
+    expect(eventView).toMatchObject(modifiedState);
+  });
+
   it('sort on new field', function () {
     const modifiedState = {
       ...state,

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -326,19 +326,20 @@ class EventView {
 
     // only include sort keys that are included in the fields
     let equations = 0;
-    const sortKeys = fields
-      .map(field => {
-        if (field.field && isEquation(field.field)) {
-          const sortKey = getSortKeyFromField(
-            {field: `equation[${equations}]`},
-            undefined
-          );
-          equations += 1;
-          return sortKey;
+    const sortKeys: string[] = [];
+    fields.forEach(field => {
+      if (field.field && isEquation(field.field)) {
+        const sortKey = getSortKeyFromField({field: `equation[${equations}]`}, undefined);
+        equations += 1;
+        if (sortKey) {
+          sortKeys.push(sortKey);
         }
-        return getSortKeyFromField(field, undefined);
-      })
-      .filter((sortKey): sortKey is string => !!sortKey);
+      }
+      const sortKey = getSortKeyFromField(field, undefined);
+      if (sortKey) {
+        sortKeys.push(sortKey);
+      }
+    });
 
     const sort = sorts.find(currentSort => sortKeys.includes(currentSort.field));
     sorts = sort ? [sort] : [];


### PR DESCRIPTION
Some places in the app use `equation[1]` index format and some seem to use the function sort `equation|x + y` format, updating EventView to support both.
