### PR TITLE
config(slicing): add logical partitioning map

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2871,4 +2871,4 @@ SENTRY_SLICING_LOGICAL_PARTITION_COUNT = 256
 #
 # For each dataset, the range [0, SENTRY_SLICING_LOGICAL_PARTITION_COUNT) must be mapped
 # to a slice ID
-SENTRY_SLICING_CONFIG: Mapping[str, Mapping[Tuple[int, int] : int]] = {}
+SENTRY_SLICING_CONFIG: Mapping[str, Mapping[Tuple[int, int], int]] = {}

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2866,7 +2866,7 @@ SENTRY_REGION_CONFIG: Iterable[Region] = ()
 GATEWAY_PROXY_TIMEOUT = None
 
 SENTRY_SLICING_LOGICAL_PARTITION_COUNT = 256
-# This maps a dataset for slicing by name and (lower logical partition, upper physical partition)
+# This maps a Sliceable for slicing by name and (lower logical partition, upper physical partition)
 # to a given slice. A slice is a set of physical resources in Sentry and Snuba.
 #
 # For each dataset, the range [0, SENTRY_SLICING_LOGICAL_PARTITION_COUNT) must be mapped

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -10,7 +10,7 @@ import socket
 import sys
 import tempfile
 from datetime import datetime, timedelta
-from typing import Iterable
+from typing import Iterable, Mapping, Tuple
 from urllib.parse import urlparse
 
 import sentry
@@ -2864,3 +2864,11 @@ SENTRY_REGION_CONFIG: Iterable[Region] = ()
 
 # How long we should wait for a gateway proxy request to return before giving up
 GATEWAY_PROXY_TIMEOUT = None
+
+SENTRY_SLICING_LOGICAL_PARTITION_COUNT = 256
+# This maps a dataset for slicing by name and (lower logical partition, upper physical partition)
+# to a given slice. A slice is a set of physical resources in Sentry and Snuba.
+#
+# For each dataset, the range [0, SENTRY_SLICING_LOGICAL_PARTITION_COUNT) must be mapped
+# to a slice ID
+SENTRY_SLICING_CONFIG: Mapping[str, Mapping[Tuple[int, int] : int]] = {}

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2869,6 +2869,6 @@ SENTRY_SLICING_LOGICAL_PARTITION_COUNT = 256
 # This maps a Sliceable for slicing by name and (lower logical partition, upper physical partition)
 # to a given slice. A slice is a set of physical resources in Sentry and Snuba.
 #
-# For each dataset, the range [0, SENTRY_SLICING_LOGICAL_PARTITION_COUNT) must be mapped
+# For each Sliceable, the range [0, SENTRY_SLICING_LOGICAL_PARTITION_COUNT) must be mapped
 # to a slice ID
 SENTRY_SLICING_CONFIG: Mapping[str, Mapping[Tuple[int, int], int]] = {}

--- a/src/sentry/ingest/partitioning.py
+++ b/src/sentry/ingest/partitioning.py
@@ -21,7 +21,7 @@ def map_logical_partition_to_slice(dataset_name: str, logical_partition: int) ->
 
     assert is_storage_partitioned(
         dataset_name
-    ), f"cannot retrieve slice of non-partitioned storage {dataset_name}"
+    ), f"cannot retrieve slice of non-partitioned dataset {dataset_name}"
     assert (
         dataset_name in settings.SENTRY_SLICING_CONFIG
     ), f"logical partition mapping missing for {dataset_name}"
@@ -37,7 +37,7 @@ def map_logical_partition_to_slice(dataset_name: str, logical_partition: int) ->
 
 def is_storage_partitioned(dataset_name: str) -> bool:
     """
-    Returns whether the storage set is partitioned.
+    Returns whether the dataset is partitioned.
     """
 
     return dataset_name in settings.SENTRY_SLICING_CONFIG.keys()

--- a/src/sentry/ingest/partitioning.py
+++ b/src/sentry/ingest/partitioning.py
@@ -24,9 +24,6 @@ def map_logical_partition_to_slice(sliceable: Sliceable, logical_partition: int)
     """
 
     assert is_sliced(sliceable), f"cannot retrieve slice of non-partitioned sliceable {sliceable}"
-    assert (
-        sliceable in settings.SENTRY_SLICING_CONFIG
-    ), f"logical partition mapping missing for {sliceable}"
 
     for ((logical_part_lo_incl, logical_part_hi_excl), slice_id) in settings.SENTRY_SLICING_CONFIG[
         sliceable

--- a/src/sentry/ingest/partitioning.py
+++ b/src/sentry/ingest/partitioning.py
@@ -8,10 +8,10 @@ from django.conf import settings
 
 def map_org_id_to_logical_partition(org_id: int) -> int:
     """
-    Maps an org_id to a logical partition. Since SENTRY_LOGICAL_PARTITIONS is
+    Maps an org_id to a logical partition. Since SENTRY_SLICING_LOGICAL_PARTITION_COUNT is
     fixed, an org id will always be mapped to the same logical partition.
     """
-    return org_id % settings.SENTRY_LOGICAL_PARTITIONS
+    return org_id % settings.SENTRY_SLICING_LOGICAL_PARTITION_COUNT
 
 
 def map_logical_partition_to_slice(dataset_name: str, logical_partition: int) -> int:

--- a/src/sentry/ingest/partitioning.py
+++ b/src/sentry/ingest/partitioning.py
@@ -1,0 +1,43 @@
+"""
+The number of logical partitions used to distinguish between where records
+should be stored. These do not require individual physical slices but allow
+for repartitioning with less code changes per physical change.
+"""
+from django.conf import settings
+
+
+def map_org_id_to_logical_partition(org_id: int) -> int:
+    """
+    Maps an org_id to a logical partition. Since SENTRY_LOGICAL_PARTITIONS is
+    fixed, an org id will always be mapped to the same logical partition.
+    """
+    return org_id % settings.SENTRY_LOGICAL_PARTITIONS
+
+
+def map_logical_partition_to_slice(dataset_name: str, logical_partition: int) -> int:
+    """
+    Maps a logical partition to a slice.
+    """
+
+    assert is_storage_partitioned(
+        dataset_name
+    ), f"cannot retrieve slice of non-partitioned storage {dataset_name}"
+    assert (
+        dataset_name in settings.SENTRY_SLICING_CONFIG
+    ), f"logical partition mapping missing for {dataset_name}"
+
+    for ((logical_part_lo_incl, logical_part_hi_excl), slice_id) in settings.SENTRY_SLICING_CONFIG[
+        dataset_name
+    ].items():
+        if logical_partition >= logical_part_lo_incl and logical_partition < logical_part_hi_excl:
+            return slice_id
+
+    assert False, f"no mapping for dataset {dataset_name} for logical_partition {logical_partition}"
+
+
+def is_storage_partitioned(dataset_name: str) -> bool:
+    """
+    Returns whether the storage set is partitioned.
+    """
+
+    return dataset_name in settings.SENTRY_SLICING_CONFIG.keys()

--- a/src/sentry/ingest/partitioning.py
+++ b/src/sentry/ingest/partitioning.py
@@ -3,7 +3,11 @@ The number of logical partitions used to distinguish between where records
 should be stored. These do not require individual physical slices but allow
 for repartitioning with less code changes per physical change.
 """
+from typing import Literal
+
 from django.conf import settings
+
+Sliceable = Literal["generic_metrics_sets", "generic_metrics_distributions"]
 
 
 def map_org_id_to_logical_partition(org_id: int) -> int:
@@ -14,30 +18,28 @@ def map_org_id_to_logical_partition(org_id: int) -> int:
     return org_id % settings.SENTRY_SLICING_LOGICAL_PARTITION_COUNT
 
 
-def map_logical_partition_to_slice(dataset_name: str, logical_partition: int) -> int:
+def map_logical_partition_to_slice(sliceable: Sliceable, logical_partition: int) -> int:
     """
     Maps a logical partition to a slice.
     """
 
-    assert is_storage_partitioned(
-        dataset_name
-    ), f"cannot retrieve slice of non-partitioned dataset {dataset_name}"
+    assert is_sliced(sliceable), f"cannot retrieve slice of non-partitioned sliceable {sliceable}"
     assert (
-        dataset_name in settings.SENTRY_SLICING_CONFIG
-    ), f"logical partition mapping missing for {dataset_name}"
+        sliceable in settings.SENTRY_SLICING_CONFIG
+    ), f"logical partition mapping missing for {sliceable}"
 
     for ((logical_part_lo_incl, logical_part_hi_excl), slice_id) in settings.SENTRY_SLICING_CONFIG[
-        dataset_name
+        sliceable
     ].items():
         if logical_partition >= logical_part_lo_incl and logical_partition < logical_part_hi_excl:
             return slice_id
 
-    assert False, f"no mapping for dataset {dataset_name} for logical_partition {logical_partition}"
+    assert False, f"no mapping for sliceable {sliceable} for logical_partition {logical_partition}"
 
 
-def is_storage_partitioned(dataset_name: str) -> bool:
+def is_sliced(sliceable: Sliceable) -> bool:
     """
-    Returns whether the dataset is partitioned.
+    Returns whether the sliceable is sliced (environment-specific).
     """
 
-    return dataset_name in settings.SENTRY_SLICING_CONFIG.keys()
+    return sliceable in settings.SENTRY_SLICING_CONFIG.keys()

--- a/tests/sentry/ingest/test_partitioning.py
+++ b/tests/sentry/ingest/test_partitioning.py
@@ -1,0 +1,31 @@
+from django.test import override_settings
+
+from sentry.ingest.partitioning import (
+    is_storage_partitioned,
+    map_logical_partition_to_slice,
+    map_org_id_to_logical_partition,
+)
+
+
+def test_is_storage_partitioned():
+    with override_settings(SENTRY_SLICING_CONFIG={"generic_metrics_sets": {(0, 256): 0}}):
+        assert is_storage_partitioned("generic_metrics_sets")
+        assert not is_storage_partitioned("errors")
+
+
+def test_map_logical_partition_to_slice():
+    with override_settings(
+        SENTRY_SLICING_CONFIG={"generic_metrics_sets": {(0, 128): 0, (128, 256): 1}}
+    ):
+        assert map_logical_partition_to_slice("generic_metrics_sets", 0) == 0
+        assert map_logical_partition_to_slice("generic_metrics_sets", 127) == 0
+        assert map_logical_partition_to_slice("generic_metrics_sets", 128) == 1
+        assert map_logical_partition_to_slice("generic_metrics_sets", 255) == 1
+
+
+def test_map_org_id_to_logical_partition():
+    base_org_id = 256 * 20
+
+    assert map_org_id_to_logical_partition(base_org_id + 1) == 1
+    assert map_org_id_to_logical_partition(base_org_id + 127) == 127
+    assert map_org_id_to_logical_partition(base_org_id + 256) == 0

--- a/tests/sentry/ingest/test_partitioning.py
+++ b/tests/sentry/ingest/test_partitioning.py
@@ -1,7 +1,7 @@
 from django.test import override_settings
 
 from sentry.ingest.partitioning import (
-    is_storage_partitioned,
+    is_sliced,
     map_logical_partition_to_slice,
     map_org_id_to_logical_partition,
 )
@@ -9,8 +9,8 @@ from sentry.ingest.partitioning import (
 
 def test_is_storage_partitioned():
     with override_settings(SENTRY_SLICING_CONFIG={"generic_metrics_sets": {(0, 256): 0}}):
-        assert is_storage_partitioned("generic_metrics_sets")
-        assert not is_storage_partitioned("errors")
+        assert is_sliced("generic_metrics_sets")
+        assert not is_sliced("errors")
 
 
 def test_map_logical_partition_to_slice():


### PR DESCRIPTION
This adds logical partitioning configuration to Sentry, mirroring what exists in Snuba.

References:
- https://github.com/getsentry/snuba/blob/master/snuba/datasets/partitioning.py
- https://getsentry.github.io/snuba/architecture/partitioning.html
- (internal) https://www.notion.so/sentry/Generic-Metrics-Slicing-9c206e02f92a4abca5948d2e21c6c00d