### PR TITLE
feat(hybrid-cloud): Add customer domain support to org switcher

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
@@ -36,7 +36,179 @@ describe('SwitchOrganization', function () {
     expect(screen.getByRole('list')).toBeInTheDocument();
 
     expect(screen.getByText('Organization 1')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'org slug Organization 1'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/'
+    );
+
     expect(screen.getByText('Organization 2')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'org2 Organization 2'})).toHaveAttribute(
+      'href',
+      '/organizations/org2/'
+    );
+
+    jest.useRealTimers();
+  });
+
+  it('uses organizationUrl when customer domain is enabled', function () {
+    jest.useFakeTimers();
+    render(
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization={false}
+          organizations={[
+            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+            TestStubs.Organization({
+              name: 'Organization 2',
+              slug: 'org2',
+              links: {
+                organizationUrl: 'http://org2.sentry.io',
+                regionUrl: 'http://eu.sentry.io',
+              },
+              features: ['customer-domains'],
+            }),
+          ]}
+        />
+      )
+    );
+
+    userEvent.hover(screen.getByTestId('sidebar-switch-org'));
+    act(() => void jest.advanceTimersByTime(500));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
+    expect(org1Link).toBeInTheDocument();
+    expect(org1Link).toHaveAttribute('href', '/organizations/org1/');
+
+    const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
+    expect(org2Link).toBeInTheDocument();
+    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io/organizations/org2/');
+    jest.useRealTimers();
+  });
+
+  it('does not use organizationUrl when customer domain is disabled', function () {
+    jest.useFakeTimers();
+    render(
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization={false}
+          organizations={[
+            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+            TestStubs.Organization({
+              name: 'Organization 2',
+              slug: 'org2',
+              links: {
+                organizationUrl: 'http://org2.sentry.io',
+                regionUrl: 'http://eu.sentry.io',
+              },
+              features: [],
+            }),
+          ]}
+        />
+      )
+    );
+
+    userEvent.hover(screen.getByTestId('sidebar-switch-org'));
+    act(() => void jest.advanceTimersByTime(500));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
+    expect(org1Link).toBeInTheDocument();
+    expect(org1Link).toHaveAttribute('href', '/organizations/org1/');
+
+    const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
+    expect(org2Link).toBeInTheDocument();
+    expect(org2Link).toHaveAttribute('href', '/organizations/org2/');
+    jest.useRealTimers();
+  });
+
+  it('uses sentryUrl when current org has customer domain enabled', function () {
+    jest.useFakeTimers();
+    const currentOrg = TestStubs.Organization({
+      name: 'Organization 2',
+      slug: 'org2',
+      links: {
+        organizationUrl: 'http://org2.sentry.io',
+        regionUrl: 'http://eu.sentry.io',
+      },
+      features: ['customer-domains'],
+    });
+    render(
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization={false}
+          organizations={[
+            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+            currentOrg,
+          ]}
+        />,
+        currentOrg
+      )
+    );
+
+    userEvent.hover(screen.getByTestId('sidebar-switch-org'));
+    act(() => void jest.advanceTimersByTime(500));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
+    expect(org1Link).toBeInTheDocument();
+    // Current hostname in the URL is expected to be org2.sentry.io, so we need to make use of sentryUrl to link to an
+    // organization that does not support customer domains.
+    expect(org1Link).toHaveAttribute('href', 'https://sentry.io/organizations/org1/');
+
+    const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
+    expect(org2Link).toBeInTheDocument();
+    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io/organizations/org2/');
+    jest.useRealTimers();
+  });
+
+  it('does not use sentryUrl when current org does not have customer domain feature', function () {
+    jest.useFakeTimers();
+    const currentOrg = TestStubs.Organization({
+      name: 'Organization 2',
+      slug: 'org2',
+      links: {
+        organizationUrl: 'http://org2.sentry.io',
+        regionUrl: 'http://eu.sentry.io',
+      },
+      features: [],
+    });
+    render(
+      mountWithOrg(
+        <SwitchOrganization
+          canCreateOrganization={false}
+          organizations={[
+            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+            TestStubs.Organization({
+              name: 'Organization 3',
+              slug: 'org3',
+              links: {
+                organizationUrl: 'http://org3.sentry.io',
+                regionUrl: 'http://eu.sentry.io',
+              },
+              features: ['customer-domains'],
+            }),
+          ]}
+        />,
+        currentOrg
+      )
+    );
+
+    userEvent.hover(screen.getByTestId('sidebar-switch-org'));
+    act(() => void jest.advanceTimersByTime(500));
+
+    expect(screen.getByRole('list')).toBeInTheDocument();
+
+    const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
+    expect(org1Link).toBeInTheDocument();
+    expect(org1Link).toHaveAttribute('href', '/organizations/org1/');
+
+    const org3Link = screen.getByRole('link', {name: 'org3 Organization 3'});
+    expect(org3Link).toBeInTheDocument();
+    expect(org3Link).toHaveAttribute('href', 'http://org3.sentry.io/organizations/org3/');
     jest.useRealTimers();
   });
 

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
@@ -38,13 +38,13 @@ describe('SwitchOrganization', function () {
     expect(screen.getByText('Organization 1')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'org slug Organization 1'})).toHaveAttribute(
       'href',
-      '/organizations/org-slug/'
+      '/organizations/org-slug/issues/'
     );
 
     expect(screen.getByText('Organization 2')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'org2 Organization 2'})).toHaveAttribute(
       'href',
-      '/organizations/org2/'
+      '/organizations/org2/issues/'
     );
 
     jest.useRealTimers();
@@ -79,11 +79,14 @@ describe('SwitchOrganization', function () {
 
     const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
     expect(org1Link).toBeInTheDocument();
-    expect(org1Link).toHaveAttribute('href', '/organizations/org1/');
+    expect(org1Link).toHaveAttribute('href', '/organizations/org1/issues/');
 
     const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
     expect(org2Link).toBeInTheDocument();
-    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io/organizations/org2/');
+    expect(org2Link).toHaveAttribute(
+      'href',
+      'http://org2.sentry.io/organizations/org2/issues/'
+    );
     jest.useRealTimers();
   });
 
@@ -116,11 +119,11 @@ describe('SwitchOrganization', function () {
 
     const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
     expect(org1Link).toBeInTheDocument();
-    expect(org1Link).toHaveAttribute('href', '/organizations/org1/');
+    expect(org1Link).toHaveAttribute('href', '/organizations/org1/issues/');
 
     const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
     expect(org2Link).toBeInTheDocument();
-    expect(org2Link).toHaveAttribute('href', '/organizations/org2/');
+    expect(org2Link).toHaveAttribute('href', '/organizations/org2/issues/');
     jest.useRealTimers();
   });
 
@@ -157,11 +160,17 @@ describe('SwitchOrganization', function () {
     expect(org1Link).toBeInTheDocument();
     // Current hostname in the URL is expected to be org2.sentry.io, so we need to make use of sentryUrl to link to an
     // organization that does not support customer domains.
-    expect(org1Link).toHaveAttribute('href', 'https://sentry.io/organizations/org1/');
+    expect(org1Link).toHaveAttribute(
+      'href',
+      'https://sentry.io/organizations/org1/issues/'
+    );
 
     const org2Link = screen.getByRole('link', {name: 'org2 Organization 2'});
     expect(org2Link).toBeInTheDocument();
-    expect(org2Link).toHaveAttribute('href', 'http://org2.sentry.io/organizations/org2/');
+    expect(org2Link).toHaveAttribute(
+      'href',
+      'http://org2.sentry.io/organizations/org2/issues/'
+    );
     jest.useRealTimers();
   });
 
@@ -204,11 +213,14 @@ describe('SwitchOrganization', function () {
 
     const org1Link = screen.getByRole('link', {name: 'org1 Organization 1'});
     expect(org1Link).toBeInTheDocument();
-    expect(org1Link).toHaveAttribute('href', '/organizations/org1/');
+    expect(org1Link).toHaveAttribute('href', '/organizations/org1/issues/');
 
     const org3Link = screen.getByRole('link', {name: 'org3 Organization 3'});
     expect(org3Link).toBeInTheDocument();
-    expect(org3Link).toHaveAttribute('href', 'http://org3.sentry.io/organizations/org3/');
+    expect(org3Link).toHaveAttribute(
+      'href',
+      'http://org3.sentry.io/organizations/org3/issues/'
+    );
     jest.useRealTimers();
   });
 

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -23,7 +23,7 @@ function OrganizationMenuItem({organization}: {organization: OrganizationSummary
 
   const menuItemProps: Partial<React.ComponentProps<typeof SidebarMenuItem>> = {};
 
-  const route = useResolveRoute(`/organizations/${slug}/`, organization);
+  const route = useResolveRoute(`/organizations/${slug}/issues/`, organization);
 
   if (shouldUseLegacyRoute(organization)) {
     if (currentOrganization?.features.includes('customer-domains')) {

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -10,11 +10,48 @@ import {IconAdd, IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {OrganizationSummary} from 'sentry/types';
+import shouldUseLegacyRoute from 'sentry/utils/shouldUseLegacyRoute';
 import useResolveRoute from 'sentry/utils/useResolveRoute';
 import withOrganizations from 'sentry/utils/withOrganizations';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import Divider from './divider.styled';
+
+function OrganizationMenuItem({organization}: {organization: OrganizationSummary}) {
+  const currentOrganization = useContext(OrganizationContext);
+  const {slug} = organization;
+
+  const menuItemProps: Partial<React.ComponentProps<typeof SidebarMenuItem>> = {};
+
+  const route = useResolveRoute(`/organizations/${slug}/`, organization);
+
+  if (shouldUseLegacyRoute(organization)) {
+    if (currentOrganization?.features.includes('customer-domains')) {
+      // Case:
+      // - Current org has customer domains, so we expect the current url be current-org-slug.sentry.io.
+      // - Switching to sentry.io/org-slug requires href instead of a React router change.
+      menuItemProps.href = route;
+      menuItemProps.openInNewTab = false;
+    } else {
+      // Case:
+      // - Current org does not have customer domains, so we expect the current url be sentry.io/current-org-slug
+      // - Switching to sentry.io/org-slug only requires a React router change.
+      menuItemProps.to = route;
+    }
+  } else {
+    // Case:
+    // - Switching to org-slug.sentry.io requires href instead of a React router change, regardless if current org has
+    //   customer domains or not.
+    menuItemProps.href = route;
+    menuItemProps.openInNewTab = false;
+  }
+
+  return (
+    <SidebarMenuItem {...menuItemProps}>
+      <SidebarOrgSummary organization={organization} />
+    </SidebarMenuItem>
+  );
+}
 
 function CreateOrganization({canCreateOrganization}: {canCreateOrganization: boolean}) {
   const currentOrganization = useContext(OrganizationContext);
@@ -86,12 +123,11 @@ const SwitchOrganization = ({organizations, canCreateOrganization}: Props) => (
           >
             <OrganizationList role="list">
               {sortBy(organizations, ['status.id']).map(organization => {
-                const url = `/organizations/${organization.slug}/`;
-
                 return (
-                  <SidebarMenuItem key={organization.slug} to={url}>
-                    <SidebarOrgSummary organization={organization} />
-                  </SidebarMenuItem>
+                  <OrganizationMenuItem
+                    key={organization.slug}
+                    organization={organization}
+                  />
                 );
               })}
             </OrganizationList>


### PR DESCRIPTION
This pull request adds customer domain support to the organization list switcher:

<img width="565" alt="Screen Shot 2022-10-17 at 5 59 58 PM" src="https://user-images.githubusercontent.com/139499/196291887-403a33e8-c113-47ce-b74e-e42563d64bd2.png">
