### PR TITLE
fix(ui): Replace all project.name with project.slug [UP-174]

### DIFF
--- a/docs-ui/stories/views/note.stories.js
+++ b/docs-ui/stories/views/note.stories.js
@@ -23,7 +23,7 @@ ProjectsStore.loadInitialData([
   {
     id: '2',
     slug: 'project-slug',
-    name: 'Project Name',
+    name: 'project-slug',
     hasAccess: true,
     isMember: true,
     isBookmarked: false,

--- a/static/app/components/modals/createReleaseIntegrationModal.tsx
+++ b/static/app/components/modals/createReleaseIntegrationModal.tsx
@@ -33,10 +33,10 @@ function CreateReleaseIntegrationModal({
       name: 'name',
       type: 'string',
 
-      placeholder: `${project.name} Release Integration`,
+      placeholder: `${project.slug} Release Integration`,
       label: t('Name'),
       help: <Fragment>{t('Name of new integration.')}</Fragment>,
-      defaultValue: `${project.name} Release Integration`,
+      defaultValue: `${project.slug} Release Integration`,
       required: true,
     },
   ];
@@ -74,7 +74,7 @@ function CreateReleaseIntegrationModal({
                     'member:write',
                   ],
                   verifyInstall: false,
-                  overview: `This internal integration was auto-generated to setup Releases for the ${project.name} project. It is needed to provide the token used to create a release. If this integration is deleted, your Releases workflow will stop working!`,
+                  overview: `This internal integration was auto-generated to setup Releases for the ${project.slug} project. It is needed to provide the token used to create a release. If this integration is deleted, your Releases workflow will stop working!`,
                 },
               });
               onSubmitSuccess(integration);

--- a/static/app/components/profiling/FrameStack/profileDetails.tsx
+++ b/static/app/components/profiling/FrameStack/profileDetails.tsx
@@ -189,7 +189,7 @@ export function ProfileDetails(props: ProfileDetailsProps) {
                       to={`/organizations/${organization.slug}/projects/${project.slug}/?project=${project.id}`}
                     >
                       <FlexRow>
-                        <ProjectAvatar project={project} size={12} /> {project.name}
+                        <ProjectAvatar project={project} size={12} /> {project.slug}
                       </FlexRow>
                     </Link>
                   </DetailsRow>

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
@@ -15,12 +15,12 @@ const MockRenderModalProps: ModalRenderProps = {
 } as unknown as ModalRenderProps;
 
 function selectProject(project: Project) {
-  if (!project.name) {
-    throw new Error(`Selected project requires a name, received ${project.name}`);
+  if (!project.slug) {
+    throw new Error(`Selected project requires a name, received ${project.slug}`);
   }
 
   userEvent.click(screen.getAllByRole('textbox')[0]);
-  userEvent.click(screen.getByText(project.name));
+  userEvent.click(screen.getByText(project.slug));
 }
 
 describe('ProfilingOnboarding', function () {

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -83,7 +83,7 @@ function asSelectOption(
   options: {disabled: boolean}
 ): SelectFieldProps<Project>['options'][0]['options'] {
   return {
-    label: project.name,
+    label: project.slug,
     value: project,
     disabled: options.disabled,
     leadingItems: project.platform ? <PlatformIcon platform={project.platform} /> : null,
@@ -280,7 +280,7 @@ function ProjectSdkUpdate({
         <Link
           to={`/organizations/${organization.slug}/projects/${project.slug}/?project=${project.id}`}
         >
-          {project.name}
+          {project.slug}
         </Link>
       </SDKUpdatesContainer>
 

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -51,6 +51,9 @@ export type Project = {
   hasUserReports?: boolean;
   latestDeploys?: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;
   latestRelease?: Release;
+  /**
+   * @deprecated Use project slug instead
+   */
   name?: string;
   options?: Record<string, boolean | string>;
   sessionStats?: {


### PR DESCRIPTION
The project `slug` is deprecated and should no longer be used. I added a clear deprecated jsdoc tag the field and replaced all existing uses.

The other option is removing the property completely from the type, but the risk is that someone could just re-add it again. This at least documents the decision not to use `name` anymore.