### PR TITLE
test(js): Remove warnOnMissingMocks

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -57,21 +57,15 @@ function compareRecord(want: Record<string, any>, check: Record<string, any>): b
 }
 
 afterEach(() => {
-  // if any errors are caught we console.warn them
+  // if any errors are caught we console.error them
   const errors = Object.values(Client.errors);
   if (errors.length > 0) {
     for (const err of errors) {
-      if (Client.shouldWarnOnMissingMocks) {
-        // eslint-disable-next-line no-console
-        console.warn(err);
-        continue;
-      }
       // eslint-disable-next-line no-console
       console.error(err);
     }
     Client.errors = {};
   }
-  Client.shouldWarnOnMissingMocks = false;
 });
 
 class Client implements ApiNamespace.Client {
@@ -218,13 +212,8 @@ class Client implements ApiNamespace.Client {
     });
   }
 
-  static shouldWarnOnMissingMocks: boolean = false;
-
-  /**
-   * @deprecated DO NOT USE THIS FUNCTION; we're using it to mark existing tests which do not correctly mock responses and would otherwise throw
-   */
-  static warnOnMissingMocks = () => (Client.shouldWarnOnMissingMocks = true);
   static errors: Record<string, Error> = {};
+
   // XXX(ts): We type the return type for requestPromise and request as `any`. Typically these woul
   request(url: string, options: Readonly<ApiNamespace.RequestOptions> = {}): any {
     const [response, mock] = Client.findMockResponse(url, options) || [

--- a/static/app/actionCreators/group.spec.jsx
+++ b/static/app/actionCreators/group.spec.jsx
@@ -81,12 +81,15 @@ describe('group', () => {
 
   describe('bulkUpdate()', function () {
     beforeEach(function () {
-      jest.spyOn(api, 'request');
       jest.spyOn(GroupStore, 'onUpdate'); // stub GroupStore.onUpdate call from update
     });
 
     it('should use itemIds as query if provided', function () {
-      MockApiClient.warnOnMissingMocks();
+      const request = MockApiClient.addMockResponse({
+        url: '/projects/1337/1337/issues/',
+        method: 'PUT',
+      });
+
       bulkUpdate(api, {
         orgId: '1337',
         projectId: '1337',
@@ -95,15 +98,19 @@ describe('group', () => {
         query: 'is:resolved',
       });
 
-      expect(api.request).toHaveBeenCalledTimes(1);
-      expect(api.request).toHaveBeenCalledWith(
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledWith(
         '/projects/1337/1337/issues/',
         expect.objectContaining({query: {id: [1, 2, 3]}})
       );
     });
 
     it('should use query as query if itemIds are absent', function () {
-      MockApiClient.warnOnMissingMocks();
+      const request = MockApiClient.addMockResponse({
+        url: '/projects/1337/1337/issues/',
+        method: 'PUT',
+      });
+
       bulkUpdate(api, {
         orgId: '1337',
         projectId: '1337',
@@ -112,15 +119,19 @@ describe('group', () => {
         query: 'is:resolved',
       });
 
-      expect(api.request).toHaveBeenCalledTimes(1);
-      expect(api.request).toHaveBeenCalledWith(
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledWith(
         '/projects/1337/1337/issues/',
         expect.objectContaining({query: {query: 'is:resolved'}})
       );
     });
 
     it('should apply project option', function () {
-      MockApiClient.warnOnMissingMocks();
+      const request = MockApiClient.addMockResponse({
+        url: '/organizations/1337/issues/',
+        method: 'PUT',
+      });
+
       bulkUpdate(api, {
         orgId: '1337',
         project: [99],
@@ -128,8 +139,8 @@ describe('group', () => {
         data: {status: 'unresolved'},
       });
 
-      expect(api.request).toHaveBeenCalledTimes(1);
-      expect(api.request).toHaveBeenCalledWith(
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledWith(
         '/organizations/1337/issues/',
         expect.objectContaining({query: {id: [1, 2, 3], project: [99]}})
       );
@@ -140,12 +151,15 @@ describe('group', () => {
     // TODO: this is totally copypasta from the test above. We need to refactor
     //       these API methods/tests.
     beforeEach(function () {
-      jest.spyOn(api, 'request');
       jest.spyOn(GroupStore, 'onMerge'); // stub GroupStore.onMerge call from mergeGroups
     });
 
     it('should use itemIds as query if provided', function () {
-      MockApiClient.warnOnMissingMocks();
+      const request = MockApiClient.addMockResponse({
+        url: '/projects/1337/1337/issues/',
+        method: 'PUT',
+      });
+
       mergeGroups(api, {
         orgId: '1337',
         projectId: '1337',
@@ -154,15 +168,19 @@ describe('group', () => {
         query: 'is:resolved',
       });
 
-      expect(api.request).toHaveBeenCalledTimes(1);
-      expect(api.request).toHaveBeenCalledWith(
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledWith(
         '/projects/1337/1337/issues/',
         expect.objectContaining({query: {id: [1, 2, 3]}})
       );
     });
 
     it('should use query as query if itemIds are absent', function () {
-      MockApiClient.warnOnMissingMocks();
+      const request = MockApiClient.addMockResponse({
+        url: '/projects/1337/1337/issues/',
+        method: 'PUT',
+      });
+
       mergeGroups(api, {
         orgId: '1337',
         projectId: '1337',
@@ -171,8 +189,8 @@ describe('group', () => {
         query: 'is:resolved',
       });
 
-      expect(api.request).toHaveBeenCalledTimes(1);
-      expect(api.request).toHaveBeenCalledWith(
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(request).toHaveBeenCalledWith(
         '/projects/1337/1337/issues/',
         expect.objectContaining({query: {query: 'is:resolved'}})
       );

--- a/static/app/components/events/interfaces/threadsV2.spec.tsx
+++ b/static/app/components/events/interfaces/threadsV2.spec.tsx
@@ -1078,8 +1078,12 @@ describe('ThreadsV2', function () {
           within(screen.getAllByTestId('stack-trace-frame')[1]).getByText('0x10008c5ac')
         ).toBeInTheDocument();
 
+        MockApiClient.addMockResponse({
+          url: `/projects/${organization.slug}/2/events/${event.id}/apple-crash-report?minified=false`,
+          body: '',
+        });
+
         // Click on raw stack trace option
-        MockApiClient.warnOnMissingMocks();
         userEvent.click(screen.getByText(displayOptions['raw-stack-trace']));
 
         // Download button is displayed

--- a/static/app/components/globalSdkUpdateAlert.spec.tsx
+++ b/static/app/components/globalSdkUpdateAlert.spec.tsx
@@ -225,22 +225,26 @@ describe('GlobalSDKUpdateAlert', () => {
       snoozed_ts: undefined,
     };
 
-    const promptsActivityMock = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: '/prompts-activity/',
       body: {data: promptResponse},
+    });
+
+    const promptsActivityMock = MockApiClient.addMockResponse({
+      url: '/prompts-activity/',
+      method: 'PUT',
     });
 
     render(<InnerGlobalSdkUpdateAlert sdkUpdates={sdkUpdates} />, {
       organization: TestStubs.Organization(),
     });
 
-    MockApiClient.warnOnMissingMocks();
     userEvent.click(await screen.findByText(/Remind me later/));
 
     expect(promptsActivityMock).toHaveBeenCalledWith(
       '/prompts-activity/',
       expect.objectContaining({
-        query: expect.objectContaining({
+        data: expect.objectContaining({
           feature: 'sdk_updates',
           organization_id: '3',
         }),

--- a/static/app/components/modals/diffModal.spec.jsx
+++ b/static/app/components/modals/diffModal.spec.jsx
@@ -5,8 +5,27 @@ import DiffModal from 'sentry/components/modals/diffModal';
 describe('DiffModal', function () {
   it('renders', function () {
     const project = TestStubs.ProjectDetails();
+    MockApiClient.addMockResponse({
+      url: '/issues/123/events/latest/',
+      body: {
+        eventID: '456',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/123/project-slug/events/456/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/issues/234/events/latest/',
+      body: {
+        eventID: '789',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/projects/123/project-slug/events/789/',
+      body: [],
+    });
 
-    MockApiClient.warnOnMissingMocks();
     render(
       <DiffModal
         orgId="123"

--- a/static/app/components/modals/emailVerificationModal.spec.tsx
+++ b/static/app/components/modals/emailVerificationModal.spec.tsx
@@ -4,7 +4,11 @@ import EmailVerificationModal from 'sentry/components/modals/emailVerificationMo
 
 describe('Email Verification Modal', function () {
   it('renders', function () {
-    MockApiClient.warnOnMissingMocks();
+    MockApiClient.addMockResponse({
+      url: '/users/me/emails/',
+      body: [],
+    });
+
     render(
       <EmailVerificationModal
         Body={(p => p.children) as any}
@@ -24,7 +28,11 @@ describe('Email Verification Modal', function () {
 
   it('renders with action param', function () {
     const actionMessage = 'accepting the tenet';
-    MockApiClient.warnOnMissingMocks();
+    MockApiClient.addMockResponse({
+      url: '/users/me/emails/',
+      body: [],
+    });
+
     render(
       <EmailVerificationModal
         Body={(p => p.children) as any}

--- a/static/app/components/quickTrace/index.spec.tsx
+++ b/static/app/components/quickTrace/index.spec.tsx
@@ -124,7 +124,11 @@ describe('Quick Trace', function () {
 
     // TODO
     it('renders partial trace with no children', async function () {
-      MockApiClient.warnOnMissingMocks();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: [],
+      });
+
       render(
         <QuickTrace
           event={makeTransactionEvent(4) as Event}
@@ -167,7 +171,11 @@ describe('Quick Trace', function () {
     });
 
     it('renders partial trace with multiple children', async function () {
-      MockApiClient.warnOnMissingMocks();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: [],
+      });
+
       render(
         <QuickTrace
           event={makeTransactionEvent(4) as Event}
@@ -241,7 +249,11 @@ describe('Quick Trace', function () {
     });
 
     it('renders full trace with multiple ancestors', async function () {
-      MockApiClient.warnOnMissingMocks();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: [],
+      });
+
       render(
         <QuickTrace
           event={makeTransactionEvent(5) as Event}
@@ -297,7 +309,11 @@ describe('Quick Trace', function () {
     });
 
     it('renders full trace with multiple descendants', async function () {
-      MockApiClient.warnOnMissingMocks();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: [],
+      });
+
       render(
         <QuickTrace
           event={makeTransactionEvent(0) as Event}
@@ -326,7 +342,11 @@ describe('Quick Trace', function () {
     });
 
     it('renders full trace', async function () {
-      MockApiClient.warnOnMissingMocks();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: [],
+      });
+
       render(
         <QuickTrace
           event={makeTransactionEvent(5) as Event}
@@ -405,7 +425,11 @@ describe('Quick Trace', function () {
     });
 
     it('renders multiple event targets', async function () {
-      MockApiClient.warnOnMissingMocks();
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: [],
+      });
+
       render(
         <QuickTrace
           event={makeTransactionEvent(0) as Event}

--- a/static/app/components/teamSelector.spec.jsx
+++ b/static/app/components/teamSelector.spec.jsx
@@ -121,12 +121,15 @@ describe('Team Selector', function () {
     expect(addTeamToProject).toHaveBeenCalled();
   });
 
-  it('allows searching by slug with useId', function () {
+  it('allows searching by slug with useId', async function () {
     const onChangeMock = jest.fn();
     createWrapper({useId: true, onChange: onChangeMock});
     userEvent.type(screen.getByText('Select...'), '{keyDown}');
 
-    MockApiClient.warnOnMissingMocks();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+    });
+
     userEvent.type(screen.getByLabelText('Select a team'), 'team2');
 
     expect(screen.getByText('#team2')).toBeInTheDocument();
@@ -135,5 +138,8 @@ describe('Team Selector', function () {
       expect.objectContaining({value: '2'}),
       expect.anything()
     );
+
+    // Wait for store to be updated from API response
+    await act(tick);
   });
 });

--- a/static/app/views/admin/adminBuffer.spec.jsx
+++ b/static/app/views/admin/adminBuffer.spec.jsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render} from 'sentry-test/reactTestingLibrary';
 
 import AdminBuffer from 'sentry/views/admin/adminBuffer';
 
@@ -7,10 +7,12 @@ import AdminBuffer from 'sentry/views/admin/adminBuffer';
 describe('AdminBuffer', function () {
   describe('render()', function () {
     it('renders', function () {
-      MockApiClient.warnOnMissingMocks();
-      const wrapper = render(<AdminBuffer params={{}} />);
+      MockApiClient.addMockResponse({
+        url: '/internal/stats/',
+        body: [],
+      });
 
-      expect(screen.getAllByTestId('loading-indicator')).toHaveLength(2);
+      const wrapper = render(<AdminBuffer params={{}} />);
       expect(wrapper.container).toSnapshot();
     });
   });

--- a/static/app/views/admin/adminQueue.spec.jsx
+++ b/static/app/views/admin/adminQueue.spec.jsx
@@ -49,7 +49,11 @@ describe('AdminQueue', function () {
     });
 
     it('renders', function () {
-      MockApiClient.warnOnMissingMocks();
+      MockApiClient.addMockResponse({
+        url: '/internal/stats/',
+        body: [],
+      });
+
       const wrapper = render(<AdminQueue params={{}} />);
       expect(wrapper.container).toSnapshot();
     });

--- a/static/app/views/admin/adminQuotas.spec.jsx
+++ b/static/app/views/admin/adminQuotas.spec.jsx
@@ -20,7 +20,11 @@ describe('AdminQuotas', function () {
     });
 
     it('renders', function () {
-      MockApiClient.warnOnMissingMocks();
+      MockApiClient.addMockResponse({
+        url: '/internal/stats/',
+        body: [],
+      });
+
       const wrapper = render(<AdminQuotas params={{}} />);
       expect(wrapper.container).toSnapshot();
     });

--- a/static/app/views/alerts/rules/metric/create.spec.jsx
+++ b/static/app/views/alerts/rules/metric/create.spec.jsx
@@ -39,7 +39,11 @@ describe('Incident Rules Create', function () {
 
   it('renders', function () {
     const {organization, project} = initializeOrg();
-    MockApiClient.warnOnMissingMocks();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-meta/`,
+      body: {count: 0},
+    });
+
     render(
       <MetricRulesCreate
         params={{orgId: organization.slug, projectId: project.slug}}

--- a/static/app/views/dashboardsV2/view.spec.tsx
+++ b/static/app/views/dashboardsV2/view.spec.tsx
@@ -28,7 +28,13 @@ describe('Dashboards > ViewEditDashboard', function () {
         statsPeriod: '7d',
       },
     };
-    MockApiClient.warnOnMissingMocks();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${initialData.organization.slug}/dashboards/1/visit/`,
+      statusCode: 200,
+      method: 'POST',
+    });
+
     render(
       <ViewEditDashboard
         location={TestStubs.location(location)}

--- a/static/app/views/issueList/actions/index.spec.jsx
+++ b/static/app/views/issueList/actions/index.spec.jsx
@@ -1,4 +1,5 @@
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -51,6 +52,11 @@ describe('IssueListActions', function () {
     GroupStore.reset();
     SelectedGroupStore.reset();
     SelectedGroupStore.add(['1', '2', '3']);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [TestStubs.Project({id: 1})],
+    });
   });
 
   describe('Bulk', function () {
@@ -250,6 +256,11 @@ describe('IssueListActions', function () {
     it('acknowledges group', function () {
       const mockOnMarkReviewed = jest.fn();
 
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        method: 'PUT',
+      });
+
       jest
         .spyOn(SelectedGroupStore, 'getSelectedIds')
         .mockImplementation(() => new Set(['1', '2', '3']));
@@ -263,7 +274,6 @@ describe('IssueListActions', function () {
           },
         });
       });
-      MockApiClient.warnOnMissingMocks();
       render(<WrappedComponent onMarkReviewed={mockOnMarkReviewed} />);
 
       const reviewButton = screen.getByRole('button', {name: 'Mark Reviewed'});
@@ -278,7 +288,6 @@ describe('IssueListActions', function () {
       SelectedGroupStore.toggleSelectAll();
       GroupStore.loadInitialData([TestStubs.Group({id: '1', inbox: null})]);
 
-      MockApiClient.warnOnMissingMocks();
       render(<WrappedComponent {...defaultProps} />);
 
       expect(screen.getByRole('button', {name: 'Mark Reviewed'})).toBeDisabled();
@@ -316,7 +325,6 @@ describe('IssueListActions', function () {
         }
       });
 
-      MockApiClient.warnOnMissingMocks();
       render(<WrappedComponent />);
 
       // Resolve and ignore are supported
@@ -384,7 +392,7 @@ describe('IssueListActions', function () {
         );
       });
 
-      it('silently filters out performance issues when bulk merging', function () {
+      it('silently filters out performance issues when bulk merging', async function () {
         const bulkMergeMock = MockApiClient.addMockResponse({
           url: '/organizations/org-slug/issues/',
           method: 'PUT',
@@ -404,7 +412,6 @@ describe('IssueListActions', function () {
           </OrganizationContext.Provider>
         );
 
-        MockApiClient.warnOnMissingMocks();
         userEvent.click(screen.getByRole('checkbox'));
 
         userEvent.click(screen.getByTestId('issue-list-select-all-notice-link'));
@@ -416,6 +423,9 @@ describe('IssueListActions', function () {
         expect(
           within(modal).getByText(/merging performance issues is not yet supported/i)
         ).toBeInTheDocument();
+
+        // Wait for ProjectStore to update before closing the modal
+        await act(tick);
 
         userEvent.click(within(modal).getByRole('button', {name: 'Bulk merge issues'}));
 

--- a/static/app/views/organizationStats/teamInsights/health.spec.jsx
+++ b/static/app/views/organizationStats/teamInsights/health.spec.jsx
@@ -165,7 +165,12 @@ describe('TeamStatsHealth', () => {
     });
     const context = TestStubs.routerContext([{organization}]);
     TeamStore.loadInitialData(teams, false, null);
-    MockApiClient.warnOnMissingMocks();
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: [],
+    });
+
     return render(<TeamStatsHealth router={mockRouter} location={{}} />, {
       context,
       organization,

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.spec.jsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.spec.jsx
@@ -10,7 +10,12 @@ describe('TeamAlertsTriggered', () => {
       url: `/teams/${organization.slug}/${team.slug}/alerts-triggered/`,
       body: TestStubs.TeamAlertsTriggered(),
     });
-    MockApiClient.warnOnMissingMocks();
+
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${team.slug}/alerts-triggered-index/`,
+      body: [],
+    });
+
     render(
       <TeamAlertsTriggered organization={organization} teamSlug={team.slug} period="8w" />
     );

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -83,7 +83,7 @@ function TeamMisery({
       {({isExpanded, showMoreButton}) => (
         <Fragment>
           <StyledPanelTable
-            isEmpty={projects.length === 0 || periodTableData?.data.length === 0}
+            isEmpty={projects.length === 0 || periodTableData?.data?.length === 0}
             emptyMessage={t('No key transactions starred by this team')}
             emptyAction={
               <Button

--- a/static/app/views/performance/transactionDetails/index.spec.jsx
+++ b/static/app/views/performance/transactionDetails/index.spec.jsx
@@ -1,4 +1,4 @@
-import {cleanup, render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, cleanup, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {OrganizationContext} from 'sentry/views/organizationContext';
@@ -10,7 +10,7 @@ const alertText =
 describe('EventDetails', () => {
   afterEach(cleanup);
 
-  it('renders alert for sample transaction', () => {
+  it('renders alert for sample transaction', async () => {
     const project = TestStubs.Project();
     ProjectsStore.loadInitialData([project]);
     const organization = TestStubs.Organization({
@@ -22,6 +22,21 @@ describe('EventDetails', () => {
     const routerContext = TestStubs.routerContext([]);
 
     MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/latest/events/1/grouping-info/`,
+      statusCode: 200,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      statusCode: 200,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/latest/events/1/committers/`,
+      statusCode: 200,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/latest/`,
       statusCode: 200,
       body: {
@@ -29,7 +44,6 @@ describe('EventDetails', () => {
       },
     });
 
-    MockApiClient.warnOnMissingMocks();
     render(
       <OrganizationContext.Provider value={organization}>
         <EventDetails
@@ -40,9 +54,12 @@ describe('EventDetails', () => {
       </OrganizationContext.Provider>
     );
     expect(screen.getByText(alertText)).toBeInTheDocument();
+
+    // Expect stores to be updated
+    await act(tick);
   });
 
-  it('does not reender alert if already received transaction', () => {
+  it('does not reender alert if already received transaction', async () => {
     const project = TestStubs.Project();
     ProjectsStore.loadInitialData([project]);
     const organization = TestStubs.Organization({
@@ -60,7 +77,6 @@ describe('EventDetails', () => {
       },
     });
 
-    MockApiClient.warnOnMissingMocks();
     render(
       <OrganizationContext.Provider value={organization}>
         <EventDetails
@@ -71,5 +87,8 @@ describe('EventDetails', () => {
       </OrganizationContext.Provider>
     );
     expect(screen.queryByText(alertText)).not.toBeInTheDocument();
+
+    // Expect stores to be updated
+    await act(tick);
   });
 });

--- a/static/app/views/performance/vitalDetail/index.spec.tsx
+++ b/static/app/views/performance/vitalDetail/index.spec.tsx
@@ -69,40 +69,40 @@ describe('Performance > VitalDetail', function () {
     ProjectsStore.loadInitialData(org.projects);
     browserHistory.push = jest.fn();
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/projects/',
+      url: `/organizations/${organization.slug}/projects/`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/tags/',
+      url: `/organizations/${organization.slug}/tags/`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events-stats/',
+      url: `/organizations/${organization.slug}/events-stats/`,
       body: {data: [[123, []]]},
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/tags/user.email/values/',
+      url: `/organizations/${organization.slug}/tags/user.email/values/`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/releases/stats/',
+      url: `/organizations/${organization.slug}/releases/stats/`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/users/',
+      url: `/organizations/${organization.slug}/users/`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/recent-searches/',
+      url: `/organizations/${organization.slug}/recent-searches/`,
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/recent-searches/',
+      url: `/organizations/${organization.slug}/recent-searches/`,
       method: 'POST',
       body: [],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events-vitals/',
+      url: `/organizations/${organization.slug}/events-vitals/`,
       body: {
         'measurements.lcp': {
           poor: 1,
@@ -114,7 +114,7 @@ describe('Performance > VitalDetail', function () {
       },
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
+      url: `/organizations/${organization.slug}/events/`,
       body: {
         meta: {
           fields: {
@@ -149,7 +149,7 @@ describe('Performance > VitalDetail', function () {
       ],
     });
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/events/',
+      url: `/organizations/${organization.slug}/events/`,
       body: {
         meta: {
           fields: {
@@ -188,20 +188,20 @@ describe('Performance > VitalDetail', function () {
     });
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: `/organizations/org-slug/key-transactions-list/`,
+      url: `/organizations/${organization.slug}/key-transactions-list/`,
       body: [],
     });
 
     // Metrics Requests
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: `/organizations/org-slug/metrics/tags/`,
+      url: `/organizations/${organization.slug}/metrics/tags/`,
       body: [],
     });
 
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: `/organizations/org-slug/metrics/data/`,
+      url: `/organizations/${organization.slug}/metrics/data/`,
       body: TestStubs.MetricsField({
         field: 'p75(sentry.transactions.measurements.lcp)',
       }),
@@ -214,7 +214,7 @@ describe('Performance > VitalDetail', function () {
 
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: `/organizations/org-slug/metrics/data/`,
+      url: `/organizations/${organization.slug}/metrics/data/`,
       body: TestStubs.MetricsFieldByMeasurementRating({
         field: 'count(sentry.transactions.measurements.lcp)',
       }),
@@ -228,7 +228,7 @@ describe('Performance > VitalDetail', function () {
 
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: `/organizations/org-slug/metrics/data/`,
+      url: `/organizations/${organization.slug}/metrics/data/`,
       body: TestStubs.MetricsField({
         field: 'p75(sentry.transactions.measurements.cls)',
       }),
@@ -241,7 +241,7 @@ describe('Performance > VitalDetail', function () {
 
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: `/organizations/org-slug/metrics/data/`,
+      url: `/organizations/${organization.slug}/metrics/data/`,
       body: TestStubs.MetricsFieldByMeasurementRating({
         field: 'count(sentry.transactions.measurements.cls)',
       }),
@@ -341,7 +341,7 @@ describe('Performance > VitalDetail', function () {
     );
 
     expect(newRouter.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/performance/summary/',
+      pathname: `/organizations/${organization.slug}/performance/summary/`,
       query: {
         transaction: 'something',
         project: undefined,
@@ -392,7 +392,7 @@ describe('Performance > VitalDetail', function () {
     );
 
     expect(newRouter.push).toHaveBeenCalledWith({
-      pathname: '/organizations/org-slug/performance/summary/',
+      pathname: `/organizations/${organization.slug}/performance/summary/`,
       query: {
         transaction: 'something',
         project: undefined,
@@ -512,7 +512,11 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    MockApiClient.warnOnMissingMocks();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: [],
+    });
+
     render(<TestComponent router={newRouter} />, {
       context: routerContext,
       organization: org,
@@ -532,7 +536,11 @@ describe('Performance > VitalDetail', function () {
       },
     };
 
-    MockApiClient.warnOnMissingMocks();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: [],
+    });
+
     render(<TestComponent router={newRouter} />, {
       context: routerContext,
       organization: org,

--- a/static/app/views/projectDetail/projectIssues.spec.jsx
+++ b/static/app/views/projectDetail/projectIssues.spec.jsx
@@ -15,7 +15,7 @@ describe('ProjectDetail > ProjectIssues', function () {
 
   beforeEach(function () {
     endpointMock = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/?limit=5&query=is%3Aunresolved%20error.unhandled%3Atrue&sort=freq&statsPeriod=14d`,
+      url: `/organizations/${organization.slug}/issues/?limit=5&query=error.unhandled%3Atrue%20is%3Aunresolved&sort=freq&statsPeriod=14d`,
       body: [TestStubs.Group(), TestStubs.Group({id: '2'})],
     });
 
@@ -53,7 +53,6 @@ describe('ProjectDetail > ProjectIssues', function () {
   });
 
   it('renders a link to Issues', function () {
-    MockApiClient.warnOnMissingMocks();
     render(
       <OrganizationContext.Provider value={organization}>
         <ProjectIssues organization={organization} location={router.location} />
@@ -79,7 +78,6 @@ describe('ProjectDetail > ProjectIssues', function () {
   });
 
   it('renders a link to Discover', function () {
-    MockApiClient.warnOnMissingMocks();
     render(
       <OrganizationContext.Provider value={organization}>
         <ProjectIssues organization={organization} location={router.location} />

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -28,6 +28,12 @@ const addMockResponses = (
     method: 'GET',
     body: organizationIntegrations,
   });
+
+  MockApiClient.addMockResponse({
+    url: '/projects/',
+    method: 'GET',
+    body: [],
+  });
 };
 
 const createWrapper = (
@@ -38,7 +44,7 @@ const createWrapper = (
   const {routerContext} = initializeOrg();
   const org = TestStubs.Organization();
   addMockResponses(notificationSettings, identities, organizationIntegrations);
-  MockApiClient.warnOnMissingMocks();
+
   return mountWithTheme(
     <NotificationSettingsByType notificationType="alerts" organizations={[org]} />,
     routerContext


### PR DESCRIPTION
This adds many missing API request mocks.

Since mosts of the tests weren't actually relying on the data being there, most return empty results.

I did have to add some `await act(tick)`s for a few scenarios where the API promises were resolving later and causing state updates.

**This makes our test output _almost_ completely clean again**