### PR TITLE
ci(js): Turn on colors in yarn test output

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
   "scripts": {
     "test-wrap": "node scripts/test.js",
     "test": "yarn test-wrap --watch",
-    "test-ci": "yarn test-wrap --ci --coverage --runInBand",
+    "test-ci": "yarn test-wrap --ci --coverage --runInBand --colors",
     "test-debug": "node --inspect-brk scripts/test.js --runInBand",
     "test-precommit": "yarn test-wrap --bail --findRelatedTests -u",
     "test-staged": "yarn test-wrap --findRelatedTests $(git diff --name-only --cached)",


### PR DESCRIPTION
So much easier to read warnings vs errors

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/1421724/196335130-ca6db0b6-0521-4b0b-93b3-92c8a10979db.png">
