### PR TITLE
ref(js): Improve translation string in projectGeneralSettings resolveAge

### DIFF
--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -122,10 +122,10 @@ export const fields: Record<string, Field> = {
     },
     saveOnBlur: false,
     saveMessage: tct(
-      '[Caution]: Enabling auto resolve will immediately resolve anything that has ' +
+      '[strong:Caution]: Enabling auto resolve will immediately resolve anything that has ' +
         'not been seen within this period of time. There is no undo!',
       {
-        Caution: <strong>Caution</strong>,
+        strong: <strong />,
       }
     ),
     saveMessageAlertType: 'warning',


### PR DESCRIPTION
The `Caution` string wasn't translated