### PR TITLE
fix(discover-homepage): Remove Feature component from routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -28,8 +28,6 @@ import redirectDeprecatedProjectRoute from 'sentry/views/projects/redirectDeprec
 import RouteNotFound from 'sentry/views/routeNotFound';
 import SettingsWrapper from 'sentry/views/settings/components/settingsWrapper';
 
-import Feature from './components/acl/feature';
-
 type CustomProps = {
   name?: string;
 };
@@ -1144,16 +1142,11 @@ function buildRoutes() {
       path="/organizations/:orgId/discover/"
       component={make(() => import('sentry/views/eventsV2'))}
     >
-      <Feature features={['discover-query-builder-as-landing-page']}>
-        <IndexRedirect to="homepage/" />
-      </Feature>
       <IndexRedirect to="queries/" />
-      <Feature features={['discover-query-builder-as-landing-page']}>
-        <Route
-          path="homepage/"
-          component={make(() => import('sentry/views/eventsV2/homepage'))}
-        />
-      </Feature>
+      <Route
+        path="homepage/"
+        component={make(() => import('sentry/views/eventsV2/homepage'))}
+      />
       <Route
         path="queries/"
         component={make(() => import('sentry/views/eventsV2/landing'))}


### PR DESCRIPTION
The preference is to keep components out of the routes file. Once this feature GA's then I can switch this redirect to the homepage URL.