### PR TITLE
fix(perf-issues): Update resource documentation path

### DIFF
--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -6,7 +6,7 @@ import {ResourceLink} from './resources';
 const ALL_INCLUSIVE_RESOURCE_LINKS: ResourceLink[] = [
   {
     text: t('Sentry Docs: N+1 Queries'),
-    link: 'https://docs.sentry.io/product/issues/performance-issues/n-one-queries/',
+    link: 'https://docs.sentry.io/product/issues/issue-details/performance-issues/n-one-queries/',
   },
 ];
 


### PR DESCRIPTION
The path changed in getsentry/sentry-docs/pull/5633 with a redirect, but it's nicer to link to the correct path.
