### PR TITLE
fix(discover): Trim whitespace when generating eq as string

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -868,7 +868,7 @@ export function generateFieldAsString(value: QueryFieldValue): string {
   }
 
   if (value.kind === 'equation') {
-    return `${EQUATION_PREFIX}${value.field}`;
+    return `${EQUATION_PREFIX}${value.field.trim()}`;
   }
 
   const aggregation = value.function[0];


### PR DESCRIPTION
Trim leading/trailing whitespace when transforming
equation to string so sorts and API requests don't
have leading/trailing whitespace.

Fixes a bug where sorts on equations don't work if there
is a trailing whitespace