### PR TITLE
fix(mobile-exp): Stringify environments array in useEffect dependancy

### DIFF
--- a/static/app/components/group/tagFacets.tsx
+++ b/static/app/components/group/tagFacets.tsx
@@ -59,7 +59,7 @@ export function TagFacets({groupId, tagKeys, environments}: Props) {
     });
     // Don't want to requery everytime state changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [api, environments, groupId, tagKeys]);
+  }, [api, JSON.stringify(environments), groupId, tagKeys]);
 
   const availableTagKeys = tagKeys.filter(tagKey => !!state.tagsData[tagKey]);
   const points =


### PR DESCRIPTION
The environments array may have the same contents but the instance can change which will trigger the tags request to be fired again. need to stringify environments array in dependacy array to prevent this from happening