### PR TITLE
[DO NOT MERGE] feat(release_monitor): Switch release monitor to use metrics again

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1544,9 +1544,7 @@ SENTRY_RELEASE_HEALTH = "sentry.release_health.sessions.SessionsReleaseHealthBac
 SENTRY_RELEASE_HEALTH_OPTIONS = {}
 
 # Release Monitor
-SENTRY_RELEASE_MONITOR = (
-    "sentry.release_health.release_monitor.sessions.SessionReleaseMonitorBackend"
-)
+SENTRY_RELEASE_MONITOR = "sentry.release_health.release_monitor.metrics.MetricReleaseMonitorBackend"
 SENTRY_RELEASE_MONITOR_OPTIONS = {}
 
 


### PR DESCRIPTION
We disabled this due to data issues before. The sessions cluster will be turned off soon, so we need to switch back to metrics. I don't know whether metrics is actually enabled in ST/self-hosted, so maybe we want to hold off on the change here for now.
