### PR TITLE
feat: Remove combined errors/transactions post process forwarder

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -163,7 +163,7 @@ class EventStream(Service):
 
     def run_post_process_forwarder(
         self,
-        entity: Union[Literal["all"], Literal["errors"], Literal["transactions"]],
+        entity: Union[Literal["errors"], Literal["transactions"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -190,7 +190,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def _build_consumer(
         self,
-        entity: Union[Literal["all"], Literal["errors"], Literal["transactions"]],
+        entity: Union[Literal["errors"], Literal["transactions"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,
@@ -206,16 +206,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
         elif entity == PostProcessForwarderType.ERRORS:
             default_topic = self.topic
         else:
-            # Default implementation which processes both errors and transactions
-            # irrespective of values in the header. This would most likely be the case
-            # for development environments. For the combined post process forwarder
-            # to work KAFKA_EVENTS and KAFKA_TRANSACTIONS must be the same currently.
-            assert (
-                settings.KAFKA_TOPICS[settings.KAFKA_EVENTS]["cluster"]
-                == settings.KAFKA_TOPICS[settings.KAFKA_TRANSACTIONS]["cluster"]
-            )
-            default_topic = self.topic
-            assert self.topic == self.transactions_topic
+            raise ValueError("Invalid entity")
 
         worker = PostProcessForwarderWorker(concurrency=concurrency)
 
@@ -241,7 +232,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def run_batched_consumer(
         self,
-        entity: Union[Literal["all"], Literal["errors"], Literal["transactions"]],
+        entity: Union[Literal["errors"], Literal["transactions"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,
@@ -273,7 +264,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def run_post_process_forwarder(
         self,
-        entity: Union[Literal["all"], Literal["errors"], Literal["transactions"]],
+        entity: Union[Literal["errors"], Literal["transactions"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,

--- a/src/sentry/eventstream/kafka/postprocessworker.py
+++ b/src/sentry/eventstream/kafka/postprocessworker.py
@@ -26,7 +26,6 @@ _MESSAGES_METRIC = "eventstream.messages"
 class PostProcessForwarderType(str, Enum):
     ERRORS = "errors"
     TRANSACTIONS = "transactions"
-    ALL = "all"
 
 
 @contextmanager

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -349,8 +349,8 @@ def cron(**options):
 )
 @click.option(
     "--entity",
-    type=click.Choice(["all", "errors", "transactions"]),
-    help="The type of entity to process (all, errors, transactions).",
+    type=click.Choice(["errors", "transactions"]),
+    help="The type of entity to process (errors, transactions).",
 )
 @log_options()
 @configuration

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -683,7 +683,7 @@ class BatchedConsumerTest(TestCase):
 
         eventstream = KafkaEventStream()
         consumer = eventstream._build_consumer(
-            entity="all",
+            entity="errors",
             consumer_group=consumer_group,
             topic=None,
             commit_log_topic=self.commit_log_topic,


### PR DESCRIPTION
Since the errors and transactions topics are split by default, this should no longer be supported.
