### PR TITLE
chore(routes): Clean up unused route hooks

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1455,7 +1455,6 @@ function buildRoutes() {
         path="status/warnings/"
         component={make(() => import('sentry/views/admin/adminWarnings'))}
       />
-      {hook('routes:admin')}
     </Route>
   );
 
@@ -1811,7 +1810,6 @@ function buildRoutes() {
         {rootRoutes}
         {organizationRoutes}
         {legacyRedirectRoutes}
-        {hook('routes')}
         <Route path="*" component={errorHandler(RouteNotFound)} />
       </Route>
     </Route>

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -45,8 +45,6 @@ export type HookName = keyof Hooks;
  * Route hooks.
  */
 export type RouteHooks = {
-  routes: RoutesHook;
-  'routes:admin': RoutesHook;
   'routes:api': RoutesHook;
   'routes:organization': RoutesHook;
 };


### PR DESCRIPTION
Clean up un-used or un-registered route hooks. I haven't seen these used or registered in https://github.com/getsentry/getsentry/blob/19614b6c1483bcc0c908d6bce38d4e1848da38ad/static/getsentry/gsApp/registerHooks.tsx#L71-L75

I'm auditing the `routes.tsx` to add orgless slug routes for customer domains work. 