### PR TITLE
feat(discover-homepage): Move Discover Banner to homepage

### DIFF
--- a/static/app/views/eventsV2/banner.tsx
+++ b/static/app/views/eventsV2/banner.tsx
@@ -78,9 +78,14 @@ const TOUR_STEPS: TourStep[] = [
 type Props = {
   organization: Organization;
   resultsUrl: string;
+  showBuildNewQueryButton?: boolean;
 };
 
-function DiscoverBanner({organization, resultsUrl}: Props) {
+function DiscoverBanner({
+  organization,
+  resultsUrl,
+  showBuildNewQueryButton = true,
+}: Props) {
   function onAdvance(step: number, duration: number) {
     trackAdvancedAnalyticsEvent('discover_v2.tour.advance', {
       organization,
@@ -104,16 +109,18 @@ function DiscoverBanner({organization, resultsUrl}: Props) {
       backgroundComponent={<BackgroundSpace />}
       dismissKey="discover"
     >
-      <Button
-        size={isSmallBanner ? 'xs' : undefined}
-        translucentBorder
-        to={resultsUrl}
-        onClick={() => {
-          trackAdvancedAnalyticsEvent('discover_v2.build_new_query', {organization});
-        }}
-      >
-        {t('Build a new query')}
-      </Button>
+      {showBuildNewQueryButton && (
+        <Button
+          size={isSmallBanner ? 'xs' : undefined}
+          translucentBorder
+          to={resultsUrl}
+          onClick={() => {
+            trackAdvancedAnalyticsEvent('discover_v2.build_new_query', {organization});
+          }}
+        >
+          {t('Build a new query')}
+        </Button>
+      )}
       <FeatureTourModal
         steps={TOUR_STEPS}
         doneText={t('View all Events')}

--- a/static/app/views/eventsV2/homepage.spec.tsx
+++ b/static/app/views/eventsV2/homepage.spec.tsx
@@ -83,6 +83,24 @@ describe('Discover > Homepage', () => {
     });
   });
 
+  it('renders the Discover banner', async () => {
+    render(
+      <Homepage
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+        setSavedQuery={jest.fn()}
+        loading={false}
+      />,
+      {context: initialData.routerContext, organization: initialData.organization}
+    );
+
+    await screen.findByText('Discover Trends');
+    screen.getByText('Get a Tour');
+
+    expect(screen.queryByText('Build a new query')).not.toBeInTheDocument();
+  });
+
   it('fetches from the homepage URL and renders fields, page filters, and chart information', async () => {
     render(
       <Homepage

--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -187,6 +187,10 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
     const to = eventView.getResultsViewUrlTarget(organization.slug);
     const resultsUrl = `${to.pathname}?${stringify(to.query)}`;
 
+    if (organization.features.includes('discover-query-builder-as-landing-page')) {
+      return null;
+    }
+
     return <Banner organization={organization} resultsUrl={resultsUrl} />;
   }
 

--- a/static/app/views/eventsV2/resultsHeader.tsx
+++ b/static/app/views/eventsV2/resultsHeader.tsx
@@ -2,10 +2,12 @@ import {Component} from 'react';
 import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
+import {stringify} from 'query-string';
 
 import {fetchHomepageQuery} from 'sentry/actionCreators/discoverHomepageQueries';
 import {fetchSavedQuery} from 'sentry/actionCreators/discoverSavedQueries';
 import {Client} from 'sentry/api';
+import Feature from 'sentry/components/acl/feature';
 import * as Layout from 'sentry/components/layouts/thirds';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
@@ -14,7 +16,9 @@ import {Organization, SavedQuery} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import withApi from 'sentry/utils/withApi';
 
+import Banner from './banner';
 import DiscoverBreadcrumb from './breadcrumb';
+import {DEFAULT_EVENT_VIEW} from './data';
 import EventInputName from './eventInputName';
 import SavedQueryButtonGroup from './savedQuery';
 
@@ -105,6 +109,23 @@ class ResultsHeader extends Component<Props, State> {
     );
   }
 
+  renderBanner() {
+    const {location, organization} = this.props;
+    const eventView = EventView.fromNewQueryWithLocation(DEFAULT_EVENT_VIEW, location);
+    const to = eventView.getResultsViewUrlTarget(organization.slug);
+    const resultsUrl = `${to.pathname}?${stringify(to.query)}`;
+
+    return (
+      <BannerWrapper>
+        <Banner
+          organization={organization}
+          resultsUrl={resultsUrl}
+          showBuildNewQueryButton={false}
+        />
+      </BannerWrapper>
+    );
+  }
+
   render() {
     const {
       organization,
@@ -154,6 +175,14 @@ class ResultsHeader extends Component<Props, State> {
             homepageQuery={homepageQuery}
           />
         </Layout.HeaderActions>
+        {isHomepage && (
+          <Feature
+            organization={organization}
+            features={['discover-query-builder-as-landing-page']}
+          >
+            {({hasFeature}) => hasFeature && this.renderBanner()}
+          </Feature>
+        )}
       </Layout.Header>
     );
   }
@@ -168,6 +197,10 @@ const Subtitle = styled('h4')`
 
 const StyledHeaderContent = styled(Layout.HeaderContent)`
   overflow: unset;
+`;
+
+const BannerWrapper = styled('div')`
+  grid-column: 1 / -1;
 `;
 
 export default withApi(ResultsHeader);


### PR DESCRIPTION
We want to keep the Discover banner, and since the landing page has moved from the manage page to the homepage, that also needs to move. The difference between the two is that in the design the "Build a new query" button isn't rendered because we're already in a query builder.

The old banner should still show up on the manage page if they don't have the `discover-query-builder-as-landing-page` feature flag

![Screen Shot 2022-10-18 at 5 04 28 PM](https://user-images.githubusercontent.com/22846452/196544598-956d3f3a-8666-4a50-8f30-0014f7c856f3.png)
