### PR TITLE
fix(alerts): show correct spend allocation alert setting

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -51,7 +51,13 @@ type State = {
 } & AsyncComponent['state'];
 
 const typeMappedChildren = {
-  quota: ['quotaErrors', 'quotaTransactions', 'quotaAttachments', 'quotaWarnings'],
+  quota: [
+    'quotaErrors',
+    'quotaTransactions',
+    'quotaAttachments',
+    'quotaWarnings',
+    'quotaSpendAllocations',
+  ],
 };
 
 const getQueryParams = (notificationType: string) => {


### PR DESCRIPTION
<img width="767" alt="Screen Shot 2022-10-18 at 2 31 13 PM" src="https://user-images.githubusercontent.com/70817427/196548787-d90955a4-5782-4f1f-8693-0076b71cb707.png">

The selector used to only show `--` if you load the page, but now correctly shows `On` or `Off`.