### PR TITLE
feat(ui): Make BookmarkStar have optimistic visual update

### DIFF
--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -217,6 +217,7 @@ function ProjectSelector({
     searchKey: project.slug,
     label: ({inputValue}: {inputValue: typeof project.slug}) => (
       <SelectorItem
+        key={project.slug}
         project={project}
         organization={organization}
         multi={isMulti}

--- a/static/app/components/projects/bookmarkStar.spec.tsx
+++ b/static/app/components/projects/bookmarkStar.spec.tsx
@@ -1,82 +1,90 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import BookmarkStar from 'sentry/components/projects/bookmarkStar';
+import ProjectsStore from 'sentry/stores/projectsStore';
 
 describe('BookmarkStar', function () {
-  let projectMock: jest.Mock;
+  const project = TestStubs.Project();
 
   beforeEach(function () {
-    projectMock = MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/',
-      method: 'PUT',
-      body: TestStubs.Project({isBookmarked: false, platform: 'javascript'}),
-    });
+    ProjectsStore.loadInitialData([project]);
   });
 
   afterEach(function () {
+    ProjectsStore.reset();
     MockApiClient.clearMockResponses();
   });
 
   it('renders', function () {
     const {container} = render(
-      <BookmarkStar
-        organization={TestStubs.Organization()}
-        project={TestStubs.Project()}
-      />
+      <BookmarkStar organization={TestStubs.Organization()} project={project} />
     );
 
     expect(container).toSnapshot();
   });
 
-  it('can star', function () {
-    render(
-      <BookmarkStar
-        organization={TestStubs.Organization()}
-        project={TestStubs.Project()}
-      />
-    );
+  it('can star', async function () {
+    render(<BookmarkStar organization={TestStubs.Organization()} project={project} />);
+
+    const projectMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      method: 'PUT',
+      body: TestStubs.Project({isBookmarked: true, platform: 'javascript'}),
+    });
 
     expect(screen.getByRole('button', {pressed: false})).toBeInTheDocument();
     userEvent.click(screen.getByRole('button'));
+
+    // Visually optimistically updated
+    expect(screen.getByRole('button', {pressed: true})).toBeInTheDocument();
 
     expect(projectMock).toHaveBeenCalledWith(
       '/projects/org-slug/project-slug/',
       expect.objectContaining({data: {isBookmarked: true}})
     );
+
+    // Not yet updated in the project store
+    expect(ProjectsStore.getBySlug(project.slug)?.isBookmarked).toBe(false);
+
+    // Project store is updated
+    await waitFor(() => {
+      const updatedProject = ProjectsStore.getBySlug(project.slug);
+      expect(updatedProject?.isBookmarked).toBe(true);
+    });
   });
 
-  it('can unstar', function () {
+  it('can unstar', async function () {
     render(
       <BookmarkStar
         organization={TestStubs.Organization()}
-        project={TestStubs.Project({
-          isBookmarked: true,
-        })}
+        project={TestStubs.Project({isBookmarked: true})}
       />
     );
 
+    const projectMock = MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      method: 'PUT',
+      body: TestStubs.Project({isBookmarked: false, platform: 'javascript'}),
+    });
+
     expect(screen.getByRole('button', {pressed: true})).toBeInTheDocument();
     userEvent.click(screen.getByRole('button'));
+
+    // Visually optimistically updated
+    expect(screen.getByRole('button', {pressed: false})).toBeInTheDocument();
 
     expect(projectMock).toHaveBeenCalledWith(
       '/projects/org-slug/project-slug/',
       expect.objectContaining({data: {isBookmarked: false}})
     );
-  });
 
-  it('takes a manual isBookmarked prop', async function () {
-    render(
-      <BookmarkStar
-        organization={TestStubs.Organization()}
-        project={TestStubs.Project()}
-        isBookmarked
-      />
-    );
+    // Not yet updated in the project store
+    expect(ProjectsStore.getBySlug(project.slug)?.isBookmarked).toBe(false);
 
-    expect(screen.getByRole('button', {pressed: true})).toBeInTheDocument();
-    userEvent.click(screen.getByRole('button'));
-
-    // State if isBookmarked is maintained via the prop
-    expect(await screen.findByRole('button', {pressed: true})).toBeInTheDocument();
+    // Project store is updated
+    await waitFor(() => {
+      const updatedProject = ProjectsStore.getBySlug(project.slug);
+      expect(updatedProject?.isBookmarked).toBe(false);
+    });
   });
 });

--- a/static/app/components/projects/bookmarkStar.tsx
+++ b/static/app/components/projects/bookmarkStar.tsx
@@ -1,4 +1,4 @@
-import styled from '@emotion/styled';
+import {useState} from 'react';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {update} from 'sentry/actionCreators/projects';
@@ -6,72 +6,46 @@ import Button from 'sentry/components/button';
 import {IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization, Project} from 'sentry/types';
-import {defined} from 'sentry/utils';
 import useApi from 'sentry/utils/useApi';
 
 type Props = {
   organization: Organization;
   project: Project;
   className?: string;
-  /**
-   * Allows the bookmarked state of the project to be overridden. Useful for
-   * optimistic updates.
-   */
-  isBookmarked?: boolean;
   onToggle?: (isBookmarked: boolean) => void;
 };
 
-const BookmarkStar = styled(
-  ({
-    isBookmarked: isBookmarkedProp,
-    className,
-    organization,
-    project,
-    onToggle,
-  }: Props) => {
-    const api = useApi();
+function BookmarkStar({className, organization, project, onToggle}: Props) {
+  const api = useApi();
+  const [isBookmarked, setIsBookmarked] = useState(project.isBookmarked);
 
-    const isBookmarked = defined(isBookmarkedProp)
-      ? isBookmarkedProp
-      : project.isBookmarked;
+  const toggleProjectBookmark = (event: React.MouseEvent) => {
+    // prevent dropdowns from closing
+    event.stopPropagation();
 
-    const toggleProjectBookmark = (event: React.MouseEvent) => {
-      update(api, {
-        orgId: organization.slug,
-        projectId: project.slug,
-        data: {isBookmarked: !isBookmarked},
-      }).catch(() =>
-        addErrorMessage(t('Unable to toggle bookmark for %s', project.slug))
-      );
+    update(api, {
+      orgId: organization.slug,
+      projectId: project.slug,
+      data: {isBookmarked: !isBookmarked},
+    }).catch(() => addErrorMessage(t('Unable to toggle bookmark for %s', project.slug)));
 
-      // prevent dropdowns from closing
-      event.stopPropagation();
+    setIsBookmarked(current => !current);
+    onToggle?.(!isBookmarked);
+  };
 
-      onToggle?.(!isBookmarked);
-    };
-
-    return (
-      <Button
-        aria-label="Bookmark Project"
-        aria-pressed={isBookmarked}
-        onClick={toggleProjectBookmark}
-        size="zero"
-        priority="link"
-        className={className}
-        icon={
-          <IconStar
-            color={isBookmarked ? 'yellow300' : 'subText'}
-            isSolid={isBookmarked}
-          />
-        }
-      />
-    );
-  }
-)`
-  &:hover svg {
-    fill: ${p =>
-      p.project.isBookmarked || p.isBookmarked ? p.theme.yellow400 : p.theme.textColor};
-  }
-`;
+  return (
+    <Button
+      aria-label="Bookmark Project"
+      aria-pressed={isBookmarked}
+      onClick={toggleProjectBookmark}
+      size="zero"
+      priority="link"
+      className={className}
+      icon={
+        <IconStar color={isBookmarked ? 'yellow300' : 'subText'} isSolid={isBookmarked} />
+      }
+    />
+  );
+}
 
 export default BookmarkStar;

--- a/static/app/views/settings/components/settingsProjectItem.tsx
+++ b/static/app/views/settings/components/settingsProjectItem.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
@@ -12,16 +11,9 @@ type Props = {
 };
 
 function ProjectItem({project, organization}: Props) {
-  const [isBookmarked, setBookmarked] = useState(project.isBookmarked);
-
   return (
     <Wrapper>
-      <BookmarkStar
-        organization={organization}
-        project={project}
-        isBookmarked={isBookmarked}
-        onToggle={state => setBookmarked(state)}
-      />
+      <BookmarkStar organization={organization} project={project} />
       <ProjectBadge
         to={`/settings/${organization.slug}/projects/${project.slug}/`}
         avatarSize={18}


### PR DESCRIPTION
Refs UP-179

Requires https://github.com/getsentry/sentry/pull/40229, https://github.com/getsentry/sentry/pull/40230

This isn't perfect, since the stars are still sorted AFTER the API request is complete.

Really we probably don't want to have the stars move __at all__ when ticking them.