### PR TITLE
fix(js): Remove `role="button"` From dropdown actor

### DIFF
--- a/static/app/components/dropdownAutoComplete/index.tsx
+++ b/static/app/components/dropdownAutoComplete/index.tsx
@@ -18,7 +18,6 @@ const DropdownAutoComplete = ({allowActorToggle = false, children, ...props}: Pr
       return (
         <Actor
           isOpen={isOpen}
-          role="button"
           tabIndex={0}
           onClick={isOpen && allowActorToggle ? actions.close : actions.open}
           {...actorProps}


### PR DESCRIPTION
Typically the child WILL be a button, this helps us avoid having
multiple button elements with the same label.