### PR TITLE
feat(hybrid-cloud): Propagate last org's customer domain feature

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -106,7 +106,7 @@ def _delete_activeorg(session):
         del session["activeorg"]
 
 
-def _resolve_last_org_slug(session, user):
+def _resolve_last_org(session, user):
     last_org_slug = session["activeorg"] if session and "activeorg" in session else None
     if not last_org_slug:
         return None
@@ -115,7 +115,7 @@ def _resolve_last_org_slug(session, user):
         if user is not None and not isinstance(user, AnonymousUser):
             try:
                 get_cached_organization_member(user.id, last_org.id)
-                return last_org_slug
+                return last_org
             except OrganizationMember.DoesNotExist:
                 return None
     except Organization.DoesNotExist:
@@ -163,9 +163,14 @@ def get_client_config(request=None):
 
     public_dsn = _get_public_dsn()
 
-    last_org_slug = _resolve_last_org_slug(session, user)
-    if last_org_slug is None:
+    last_org_slug = None
+    last_org = _resolve_last_org(session, user)
+    if last_org:
+        last_org_slug = last_org.slug
+    if last_org is None:
         _delete_activeorg(session)
+    if features.has("organizations:customer-domains", last_org):
+        enabled_features.append("organizations:customer-domains")
 
     context = {
         "singleOrganization": settings.SENTRY_SINGLE_ORGANIZATION,

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -91,6 +91,36 @@ class ClientConfigViewTest(TestCase):
         assert data["superUserCookieName"] == "su"
         assert data["superUserCookieName"] == superuser.COOKIE_NAME
 
+    def test_has_user_registration(self):
+        with self.options({"auth.allow-registration": True}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+            data = json.loads(resp.content)
+            assert data["features"] == ["organizations:create", "auth:register"]
+
+        with self.options({"auth.allow-registration": False}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+            data = json.loads(resp.content)
+            assert data["features"] == ["organizations:create"]
+
+    def test_org_create_feature(self):
+        with self.feature({"organizations:create": True}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+            data = json.loads(resp.content)
+            assert data["features"] == ["organizations:create"]
+
+        with self.feature({"organizations:create": False}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+            data = json.loads(resp.content)
+            assert data["features"] == []
+
     def test_unauthenticated(self):
         resp = self.client.get(self.path)
         assert resp.status_code == 200
@@ -99,6 +129,7 @@ class ClientConfigViewTest(TestCase):
         data = json.loads(resp.content)
         assert not data["isAuthenticated"]
         assert data["user"] is None
+        assert data["features"] == ["organizations:create"]
 
     def test_authenticated(self):
         user = self.create_user("foo@example.com")
@@ -112,6 +143,7 @@ class ClientConfigViewTest(TestCase):
         assert data["isAuthenticated"]
         assert data["user"]
         assert data["user"]["email"] == user.email
+        assert data["features"] == ["organizations:create"]
 
     def test_superuser(self):
         user = self.create_user("foo@example.com", is_superuser=True)

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -121,6 +121,21 @@ class ClientConfigViewTest(TestCase):
             data = json.loads(resp.content)
             assert data["features"] == []
 
+    def test_customer_domain_feature(self):
+        with self.feature({"organizations:customer-domains": True}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+            data = json.loads(resp.content)
+            assert data["features"] == ["organizations:create", "organizations:customer-domains"]
+
+        with self.feature({"organizations:customer-domains": False}):
+            resp = self.client.get(self.path)
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+            data = json.loads(resp.content)
+            assert data["features"] == ["organizations:create"]
+
     def test_unauthenticated(self):
         resp = self.client.get(self.path)
         assert resp.status_code == 200


### PR DESCRIPTION
Propagate the last organization's customer domain feature. I aim to consume this feature to apply frontend app redirects at the react router level. 

This was cherry-picked from the orgless slug route PoC in https://github.com/getsentry/sentry/pull/40215.