### PR TITLE
feat(hybrid-cloud): Add customer domain to client config

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -122,6 +122,9 @@ def get_client_config(request=None):
     Provides initial bootstrap data needed to boot the frontend application.
     """
     if request is not None:
+        customer_domain = None
+        if hasattr(request, "subdomain") and request.subdomain:
+            customer_domain = request.subdomain
         user = getattr(request, "user", None) or AnonymousUser()
         messages = get_messages(request)
         session = getattr(request, "session", None)
@@ -135,6 +138,7 @@ def get_client_config(request=None):
             if user.name:
                 user_identity["name"] = user.name
     else:
+        customer_domain = None
         user = None
         user_identity = {}
         messages = []
@@ -167,6 +171,7 @@ def get_client_config(request=None):
         enabled_features.append("organizations:customer-domains")
 
     context = {
+        "customerDomain": customer_domain,
         "singleOrganization": settings.SENTRY_SINGLE_ORGANIZATION,
         "supportEmail": get_support_mail(),
         "urlPrefix": options.get("system.url-prefix"),

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -124,7 +124,11 @@ def get_client_config(request=None):
     if request is not None:
         customer_domain = None
         if hasattr(request, "subdomain") and request.subdomain:
-            customer_domain = request.subdomain
+            customer_domain = {
+                "subdomain": request.subdomain,
+                "organizationUrl": generate_organization_url(request.subdomain),
+                "sentryUrl": options.get("system.url-prefix"),
+            }
         user = getattr(request, "user", None) or AnonymousUser()
         messages = get_messages(request)
         session = getattr(request, "session", None)

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -155,6 +155,7 @@ class ClientConfigViewTest(TestCase):
         assert not data["isAuthenticated"]
         assert data["user"] is None
         assert data["features"] == ["organizations:create"]
+        assert data["customerDomain"] is None
 
     def test_authenticated(self):
         user = self.create_user("foo@example.com")
@@ -169,6 +170,7 @@ class ClientConfigViewTest(TestCase):
         assert data["user"]
         assert data["user"]["email"] == user.email
         assert data["features"] == ["organizations:create"]
+        assert data["customerDomain"] is None
 
     def test_superuser(self):
         user = self.create_user("foo@example.com", is_superuser=True)
@@ -523,3 +525,22 @@ class ClientConfigViewTest(TestCase):
                 "regionUrl": "http://foobar.us.testserver",
                 "sentryUrl": "http://testserver",
             }
+
+    def test_customer_domain(self):
+        # With customer domain
+        resp = self.client.get(self.path, HTTP_HOST="albertos-apples.testserver")
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+        assert not data["isAuthenticated"]
+        assert data["customerDomain"] == "albertos-apples"
+
+        # Without customer domain
+        resp = self.client.get(self.path, HTTP_HOST="testserver")
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+
+        data = json.loads(resp.content)
+        assert not data["isAuthenticated"]
+        assert data["customerDomain"] is None

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -534,7 +534,11 @@ class ClientConfigViewTest(TestCase):
 
         data = json.loads(resp.content)
         assert not data["isAuthenticated"]
-        assert data["customerDomain"] == "albertos-apples"
+        assert data["customerDomain"] == {
+            "organizationUrl": "http://albertos-apples.testserver",
+            "sentryUrl": "http://testserver",
+            "subdomain": "albertos-apples",
+        }
 
         # Without customer domain
         resp = self.client.get(self.path, HTTP_HOST="testserver")


### PR DESCRIPTION
Rather than inferring the customer domain on the frontend, it'll be better to propagate the customer domain being accessed via the client config.

I aim to make use of this in the orgless slug frontend work to make the appropriate redirects at the react router level.

This was cherry-picked from the orgless slug route PoC in https://github.com/getsentry/sentry/pull/40215.