### PR TITLE
feat(hybrid-cloud): Add customerDomain type to config on frontend

### DIFF
--- a/fixtures/js-stubs/config.js
+++ b/fixtures/js-stubs/config.js
@@ -44,7 +44,11 @@ export function Config(params = {}) {
     apmSampling: 1,
     dsn_requests: '',
     demoMode: false,
-    customerDomain: 'foobar',
+    customerDomain: {
+      subdomain: 'foobar',
+      organizationUrl: 'https://foobar.sentry.io',
+      sentryUrl: 'https://sentry.io',
+    },
     links: {
       sentryUrl: 'https://sentry.io',
       organizationUrl: 'https://foobar.sentry.io',

--- a/fixtures/js-stubs/config.js
+++ b/fixtures/js-stubs/config.js
@@ -44,6 +44,7 @@ export function Config(params = {}) {
     apmSampling: 1,
     dsn_requests: '',
     demoMode: false,
+    customerDomain: 'foobar',
     links: {
       sentryUrl: 'https://sentry.io',
       organizationUrl: 'https://foobar.sentry.io',

--- a/static/app/stores/configStore.spec.tsx
+++ b/static/app/stores/configStore.spec.tsx
@@ -17,4 +17,9 @@ describe('ConfigStore', () => {
     const superUserCookieName = ConfigStore.get('superUserCookieName');
     expect(superUserCookieName).toEqual('su-test-cookie');
   });
+
+  it('should have customerDomain', () => {
+    const customerDomain = ConfigStore.get('customerDomain');
+    expect(customerDomain).toEqual('foobar');
+  });
 });

--- a/static/app/stores/configStore.spec.tsx
+++ b/static/app/stores/configStore.spec.tsx
@@ -20,6 +20,10 @@ describe('ConfigStore', () => {
 
   it('should have customerDomain', () => {
     const customerDomain = ConfigStore.get('customerDomain');
-    expect(customerDomain).toEqual('foobar');
+    expect(customerDomain).toEqual({
+      subdomain: 'foobar',
+      organizationUrl: 'https://foobar.sentry.io',
+      sentryUrl: 'https://sentry.io',
+    });
   });
 });

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -115,6 +115,7 @@ declare global {
 export interface Config {
   apmSampling: number;
   csrfCookieName: string;
+  customerDomain: string | undefined;
   demoMode: boolean;
   disableU2FForSUForm: boolean;
   distPrefix: string;

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -112,10 +112,15 @@ declare global {
   }
 }
 
+interface CustomerDomain {
+  organizationUrl: string | undefined;
+  sentryUrl: string;
+  subdomain: string;
+}
 export interface Config {
   apmSampling: number;
   csrfCookieName: string;
-  customerDomain: string | null;
+  customerDomain: CustomerDomain | null;
   demoMode: boolean;
   disableU2FForSUForm: boolean;
   distPrefix: string;

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -115,7 +115,7 @@ declare global {
 export interface Config {
   apmSampling: number;
   csrfCookieName: string;
-  customerDomain: string | undefined;
+  customerDomain: string | null;
   demoMode: boolean;
   disableU2FForSUForm: boolean;
   distPrefix: string;


### PR DESCRIPTION
The frontend cousin to https://github.com/getsentry/sentry/pull/40226