### PR TITLE
feat(metrics): Add support for 'has' operator on 'tags.key' column [TET-482]

### DIFF
--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -1477,7 +1477,7 @@ class ResolveTagsTestCase(TestCase):
                     Column(
                         name="tags.key",
                     ),
-                    resolve_tag_value(self.use_case_id, self.org_id, tag_key),
+                    resolve_weak(self.use_case_id, self.org_id, tag_key),
                 ],
             ),
             op=Op.EQ,

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -1446,3 +1446,40 @@ class ResolveTagsTestCase(TestCase):
                 ],
             ),
         )
+
+    def test_resolve_tags_with_has(self):
+        tag_key = "transaction"
+
+        indexer.record(use_case_id=self.use_case_id, org_id=self.org_id, string=tag_key)
+
+        resolved_query = resolve_tags(
+            self.use_case_id,
+            self.org_id,
+            Condition(
+                lhs=Function(
+                    function="has",
+                    parameters=[
+                        Column(
+                            name="tags.key",
+                        ),
+                        "transaction",
+                    ],
+                ),
+                op=Op.EQ,
+                rhs=1,
+            ),
+        )
+
+        assert resolved_query == Condition(
+            lhs=Function(
+                function="has",
+                parameters=[
+                    Column(
+                        name="tags.key",
+                    ),
+                    resolve_tag_value(self.use_case_id, self.org_id, tag_key),
+                ],
+            ),
+            op=Op.EQ,
+            rhs=1,
+        )


### PR DESCRIPTION
This PR aims at adding the support of the `has` [ClickHouse operator](https://clickhouse.com/docs/en/sql-reference/functions/array-functions/#hasarr-elem) in the MRI layer.