### PR TITLE
fix(appconnect): Add app_id_str field to AppConnectBuild

### DIFF
--- a/src/sentry/migrations/0325_add_appid_str.py
+++ b/src/sentry/migrations/0325_add_appid_str.py
@@ -31,6 +31,6 @@ class Migration(CheckedMigration):
         migrations.AddField(
             model_name="appconnectbuild",
             name="app_id_str",
-            field=models.CharField(default="0", max_length=256),
+            field=models.CharField(max_length=256, null=True),
         ),
     ]

--- a/src/sentry/migrations/0325_add_appid_str.py
+++ b/src/sentry/migrations/0325_add_appid_str.py
@@ -31,6 +31,6 @@ class Migration(CheckedMigration):
         migrations.AddField(
             model_name="appconnectbuild",
             name="app_id_str",
-            field=models.CharField(max_length=256, null=True),
+            field=models.CharField(default="0", max_length=256),
         ),
     ]

--- a/src/sentry/models/appconnectbuilds.py
+++ b/src/sentry/models/appconnectbuilds.py
@@ -28,10 +28,10 @@ class AppConnectBuild(Model):
     project = FlexibleForeignKey("sentry.Project", db_constraint=False)
 
     # The integer ID of the app inside App Store Connect.
-    #
-    # TODO: On the AppStoreConnect API this is a str field, it was a mistake to make this
-    #    int.
     app_id = models.IntegerField()
+
+    # The integer ID of the app inside App Store Connect, as a string.
+    app_id_str = models.CharField(max_length=256)
 
     # The unique Bundle ID, like a slug for app_id
     #

--- a/src/sentry/tasks/app_store_connect.py
+++ b/src/sentry/tasks/app_store_connect.py
@@ -133,6 +133,7 @@ def get_or_create_persisted_build(
         build_state = AppConnectBuild(
             project=project,
             app_id=int(build.app_id),
+            app_id_str=build.app_id,
             bundle_id=config.bundleId,
             platform=build.platform,
             bundle_short_version=build.version,

--- a/tests/sentry/tasks/test_app_store_connect.py
+++ b/tests/sentry/tasks/test_app_store_connect.py
@@ -65,6 +65,7 @@ class TestUpdateDsyms:
         AppConnectBuild.objects.create(
             project=default_project,
             app_id=build.app_id,
+            app_id_str=build.app_id,
             bundle_id=config.bundleId,
             platform=build.platform,
             bundle_short_version=build.version,
@@ -104,6 +105,7 @@ class TestUpdateDsyms:
         AppConnectBuild.objects.create(
             project=default_project,
             app_id=build.app_id,
+            app_id_str=build.app_id,
             bundle_id=config.bundleId,
             platform=build.platform,
             bundle_short_version=build.version,
@@ -133,6 +135,7 @@ class TestUpdateDsyms:
         expected_build = AppConnectBuild(
             project=default_project,
             app_id=int(build.app_id),
+            app_id_str=build.app_id,
             bundle_id=config.bundleId,
             platform=build.platform,
             bundle_short_version=build.version,
@@ -145,6 +148,7 @@ class TestUpdateDsyms:
         assert returned_build.fetched == expected_build.fetched
         assert returned_build.project == expected_build.project
         assert returned_build.app_id == expected_build.app_id
+        assert returned_build.app_id_str == expected_build.app_id_str
         assert returned_build.bundle_id == expected_build.bundle_id
         assert returned_build.platform == expected_build.platform
         assert returned_build.bundle_short_version == expected_build.bundle_short_version
@@ -162,6 +166,7 @@ class TestUpdateDsyms:
         assert saved_build.fetched == expected_build.fetched
         assert saved_build.project == expected_build.project
         assert saved_build.app_id == expected_build.app_id
+        assert saved_build.app_id_str == expected_build.app_id_str
         assert saved_build.bundle_id == expected_build.bundle_id
         assert saved_build.platform == expected_build.platform
         assert saved_build.bundle_short_version == expected_build.bundle_short_version
@@ -175,6 +180,7 @@ class TestUpdateDsyms:
         AppConnectBuild.objects.create(
             project=default_project,
             app_id=build.app_id,
+            app_id_str=build.app_id,
             bundle_id=config.bundleId,
             platform=build.platform,
             bundle_short_version=build.version,
@@ -189,6 +195,7 @@ class TestUpdateDsyms:
         assert existing_build.fetched
         assert existing_build.project == default_project
         assert str(existing_build.app_id) == build.app_id
+        assert existing_build.app_id_str == build.app_id
         assert existing_build.bundle_id == config.bundleId
         assert existing_build.platform == build.platform
         assert existing_build.bundle_short_version == build.version
@@ -202,6 +209,7 @@ class TestUpdateDsyms:
         AppConnectBuild.objects.create(
             project=default_project,
             app_id=build.app_id,
+            app_id_str=build.app_id,
             bundle_id=config.bundleId,
             platform=build.platform,
             bundle_short_version=build.version,
@@ -216,6 +224,7 @@ class TestUpdateDsyms:
         assert not existing_build.fetched
         assert existing_build.project == default_project
         assert str(existing_build.app_id) == build.app_id
+        assert existing_build.app_id_str == build.app_id
         assert existing_build.bundle_id == config.bundleId
         assert existing_build.platform == build.platform
         assert existing_build.bundle_short_version == build.version


### PR DESCRIPTION


This is step 2 in the effort to change the type of `AppConnectBuild.app_id` from an integer to a string.

It adds a new field `app_id_str` of type `CharField` to `AppConnectBuild`.

Depends on https://github.com/getsentry/sentry/pull/40261.