### PR TITLE
fix(widget-builder): Remove Dashboards request

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -48,7 +48,6 @@ import {
 } from 'sentry/views/dashboardsV2/layoutUtils';
 import {
   DashboardDetails,
-  DashboardListItem,
   DashboardWidgetSource,
   DisplayType,
   Widget,
@@ -124,7 +123,6 @@ interface Props extends RouteComponentProps<RouteParams, {}> {
 }
 
 interface State {
-  dashboards: DashboardListItem[];
   dataSet: DataSet;
   displayType: Widget['displayType'];
   interval: Widget['interval'];
@@ -136,7 +134,7 @@ interface State {
   title: string;
   userHasModified: boolean;
   errors?: Record<string, any>;
-  selectedDashboard?: string;
+  selectedDashboard?: DashboardDetails['id'];
   widgetToBeUpdated?: Widget;
 }
 
@@ -216,7 +214,6 @@ function WidgetBuilder({
       limit: limit ? Number(limit) : undefined,
       errors: undefined,
       loading: !!notDashboardsOrigin,
-      dashboards: [],
       userHasModified: false,
       prebuiltWidgetId: null,
       dataSet: DataSet.EVENTS,
@@ -311,7 +308,6 @@ function WidgetBuilder({
         queries,
         errors: undefined,
         loading: false,
-        dashboards: [],
         userHasModified: false,
         dataSet: widgetFromDashboard.widgetType
           ? WIDGET_TYPE_TO_DATA_SET[widgetFromDashboard.widgetType]

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -23,13 +23,7 @@ import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
-import {
-  DateString,
-  Organization,
-  PageFilters,
-  SelectValue,
-  TagCollection,
-} from 'sentry/types';
+import {DateString, Organization, PageFilters, TagCollection} from 'sentry/types';
 import {defined, objectIsEmpty} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {CustomMeasurementsProvider} from 'sentry/utils/customMeasurements/customMeasurementsProvider';
@@ -142,7 +136,7 @@ interface State {
   title: string;
   userHasModified: boolean;
   errors?: Record<string, any>;
-  selectedDashboard?: SelectValue<string>;
+  selectedDashboard?: string;
   widgetToBeUpdated?: Widget;
 }
 
@@ -227,10 +221,7 @@ function WidgetBuilder({
       prebuiltWidgetId: null,
       dataSet: DataSet.EVENTS,
       queryConditionsValid: true,
-      selectedDashboard: {
-        label: dashboard.title,
-        value: dashboard.id || NEW_DASHBOARD_ID,
-      },
+      selectedDashboard: dashboard.id || NEW_DASHBOARD_ID,
     };
 
     if (defaultWidgetQuery) {
@@ -367,7 +358,7 @@ function WidgetBuilder({
     widgetType,
   };
 
-  const currentDashboardId = state.selectedDashboard?.value ?? dashboardId;
+  const currentDashboardId = state.selectedDashboard ?? dashboardId;
   const queryParamsWithoutSource = omit(location.query, 'source');
   const previousLocation = {
     pathname:
@@ -874,7 +865,7 @@ function WidgetBuilder({
     };
 
     addSuccessMessage(t('Added widget.'));
-    goToDashboards(state.selectedDashboard.value, pathQuery);
+    goToDashboards(state.selectedDashboard, pathQuery);
   }
 
   function goToDashboards(id: string, query?: Record<string, any>) {


### PR DESCRIPTION
The widget builder has an extra request to the dashboards endpoint. We used to need this because before the modal existed we had a select field to choose which dashboard you wanted to add the widget to. Since we select that from the AddToDashboardModal, this becomes obsolete and we can just pull the ID from the dashboard object.

This should remove overhead from some of the widget builder tests.