### PR TITLE
ref(tests): Convert `DataDownload` to RTL

### DIFF
--- a/static/app/views/dataExport/dataDownload.spec.jsx
+++ b/static/app/views/dataExport/dataDownload.spec.jsx
@@ -1,4 +1,5 @@
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ExportQueryType} from 'sentry/components/dataExport';
 import DataDownload, {DownloadStatus} from 'sentry/views/dataExport/dataDownload';
@@ -11,6 +12,7 @@ describe('DataDownload', function () {
     orgId: organization.slug,
     dataExportId: 721,
   };
+
   const getDataExportDetails = (body, statusCode = 200) =>
     MockApiClient.addMockResponse({
       url: `/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/`,
@@ -20,8 +22,9 @@ describe('DataDownload', function () {
 
   it('should send a request to the data export endpoint', function () {
     const getValid = getDataExportDetails(DownloadStatus.Valid);
-    mountWithTheme(<DataDownload params={mockRouteParams} />);
-    expect(getValid).toHaveBeenCalled();
+
+    render(<DataDownload params={mockRouteParams} />);
+    expect(getValid).toHaveBeenCalledTimes(1);
   });
 
   it("should render the 'Error' view when appropriate", function () {
@@ -35,30 +38,31 @@ describe('DataDownload', function () {
       },
     };
     getDataExportDetails({errors}, 403);
-    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
-    expect(wrapper.state('errors')).toBeDefined();
-    expect(wrapper.state('errors').download.status).toBe(403);
+
+    render(<DataDownload params={mockRouteParams} />);
+    expect(screen.getByRole('heading', {level: 3})).toHaveTextContent('403 -'); // Either the code or the mock is mistaken about the data return format
   });
 
   it("should render the 'Early' view when appropriate", function () {
     const status = DownloadStatus.Early;
     getDataExportDetails({status});
-    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
-    expect(wrapper.state('download')).toEqual({status});
-    expect(wrapper.state('download').dateExpired).toBeUndefined();
-    expect(wrapper.find('Header').text()).toBe('What are you doing here?');
+
+    render(<DataDownload params={mockRouteParams} />);
+    expect(screen.getByRole('heading', {level: 3})).toHaveTextContent(
+      'What are you doing here?'
+    );
+    expect(screen.getByText(/were you invited/)).toBeInTheDocument();
   });
 
   it("should render the 'Expired' view when appropriate", function () {
     const status = DownloadStatus.Expired;
     const response = {status, query: {type: ExportQueryType.IssuesByTag}};
     getDataExportDetails(response);
-    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
-    expect(wrapper.state('download')).toEqual(response);
-    expect(wrapper.state('download').dateExpired).toBeUndefined();
-    expect(wrapper.find('Header').text()).toBe('This is awkward.');
-    const buttonWrapper = wrapper.find('a[aria-label="Start a New Download"]');
-    expect(buttonWrapper.prop('href')).toBe(
+
+    render(<DataDownload params={mockRouteParams} />);
+    expect(screen.getByRole('heading', {level: 3})).toHaveTextContent('This is awkward.');
+    expect(screen.getByRole('button', {name: 'Start a New Download'})).toHaveAttribute(
+      'href',
       `/organizations/${mockRouteParams.orgId}/issues/`
     );
   });
@@ -66,15 +70,18 @@ describe('DataDownload', function () {
   it("should render the 'Valid' view when appropriate", function () {
     const status = DownloadStatus.Valid;
     getDataExportDetails({dateExpired, status});
-    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
-    expect(wrapper.state('download')).toEqual({dateExpired, status});
-    expect(wrapper.find('Header').text()).toBe('All done.');
-    const buttonWrapper = wrapper.find('a[aria-label="Download CSV"]');
-    expect(buttonWrapper.text()).toBe('Download CSV');
-    expect(buttonWrapper.prop('href')).toBe(
+
+    render(<DataDownload params={mockRouteParams} />);
+    expect(screen.getByRole('heading', {level: 3})).toHaveTextContent('All done.');
+    expect(screen.getByRole('button', {name: 'Download CSV'})).toHaveAttribute(
+      'href',
       `/api/0/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/?download=true`
     );
-    expect(wrapper.find('DateTime').prop('date')).toEqual(new Date(dateExpired));
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher("That link won't last forever — it expires:Oct 17, 2:41 AM")
+      )
+    ).toBeInTheDocument();
   });
 
   it('should render the Open in Discover button when needed', function () {
@@ -87,9 +94,9 @@ describe('DataDownload', function () {
         info: {},
       },
     });
-    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
-    const buttonWrapper = wrapper.find('button[aria-label="Open in Discover"]');
-    expect(buttonWrapper.exists()).toBeTruthy();
+
+    render(<DataDownload params={mockRouteParams} />);
+    expect(screen.getByRole('button', {name: 'Open in Discover'})).toBeInTheDocument();
   });
 
   it('should not render the Open in Discover button when not needed', function () {
@@ -102,8 +109,10 @@ describe('DataDownload', function () {
         info: {},
       },
     });
-    const wrapper = mountWithTheme(<DataDownload params={mockRouteParams} />);
-    const buttonWrapper = wrapper.find('button[aria-label="Open in Discover"]');
-    expect(buttonWrapper.exists()).toBeFalsy();
+
+    render(<DataDownload params={mockRouteParams} />);
+    expect(
+      screen.queryByRole('button', {name: 'Open in Discover'})
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/dataExport/dataDownload.spec.jsx
+++ b/static/app/views/dataExport/dataDownload.spec.jsx
@@ -40,7 +40,7 @@ describe('DataDownload', function () {
     getDataExportDetails({errors}, 403);
 
     render(<DataDownload params={mockRouteParams} />);
-    expect(screen.getByRole('heading', {level: 3})).toHaveTextContent('403 -'); // Either the code or the mock is mistaken about the data return format
+    expect(screen.getByText('403 -')).toBeInTheDocument(); // Either the code or the mock is mistaken about the data return format
   });
 
   it("should render the 'Early' view when appropriate", function () {
@@ -48,9 +48,9 @@ describe('DataDownload', function () {
     getDataExportDetails({status});
 
     render(<DataDownload params={mockRouteParams} />);
-    expect(screen.getByRole('heading', {level: 3})).toHaveTextContent(
-      'What are you doing here?'
-    );
+    expect(
+      screen.getByText(textWithMarkupMatcher('What are you doing here?'))
+    ).toBeInTheDocument();
     expect(screen.getByText(/were you invited/)).toBeInTheDocument();
   });
 
@@ -60,7 +60,7 @@ describe('DataDownload', function () {
     getDataExportDetails(response);
 
     render(<DataDownload params={mockRouteParams} />);
-    expect(screen.getByRole('heading', {level: 3})).toHaveTextContent('This is awkward.');
+    expect(screen.getByText('This is awkward.')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Start a New Download'})).toHaveAttribute(
       'href',
       `/organizations/${mockRouteParams.orgId}/issues/`
@@ -72,7 +72,7 @@ describe('DataDownload', function () {
     getDataExportDetails({dateExpired, status});
 
     render(<DataDownload params={mockRouteParams} />);
-    expect(screen.getByRole('heading', {level: 3})).toHaveTextContent('All done.');
+    expect(screen.getByText('All done.')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Download CSV'})).toHaveAttribute(
       'href',
       `/api/0/organizations/${mockRouteParams.orgId}/data-export/${mockRouteParams.dataExportId}/?download=true`


### PR DESCRIPTION
Didn't bother converting to JSX just yet, but I think it'll be pretty straight-forward. Updated tests, and added some assertion for on-screen text.
