### PR TITLE
fix(replays): Adjust replays-events-meta `finishedAt` time to account for `ms` offsets

### DIFF
--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -171,12 +171,19 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
         return [];
       }
 
+      // Clone the `finishedAt` time and bump it up one second because finishedAt
+      // has the `ms` portion truncated, while replays-events-meta operates on
+      // timestamps with `ms` attached. So finishedAt could be at time `12:00:00.000Z`
+      // while the event is saved with `12:00:00.450Z`.
+      const finishedAtClone = new Date(replayRecord.finishedAt);
+      finishedAtClone.setSeconds(finishedAtClone.getSeconds() + 1);
+
       const response = await api.requestPromise(
         `/organizations/${orgSlug}/replays-events-meta/`,
         {
           query: {
             start: replayRecord.startedAt.toISOString(),
-            end: replayRecord.finishedAt.toISOString(),
+            end: finishedAtClone.toISOString(),
             query: `id:[${String(replayRecord.errorIds)}]`,
           },
         }


### PR DESCRIPTION
When we make the request to `/replays-events-meta/` the start/end timestamps are without `ms` precision. For example:
```
end:   2022-10-19T14:44:07.000Z
start: 2022-10-19T14:43:49.000Z
```
These are the original timestamps, but truncated to remove `ms`.

So when SDK users have `captureOnlyOnError` enabled the error will happen right at the edge of the replay duration, which could be something like `14:44:07.555Z`,  or 555ms after our query bounds.

The result is that the truncated `end` timestamp will mean that we don't get the error that we're looking for. 

This change adjusts the timestamp by adding add 1 second to it ensuring that our time bounds are wide enough to find the specific errors that happened within the replay.