### PR TITLE
ref(metrics): Add mri string to metric meta

### DIFF
--- a/src/sentry/api/endpoints/organization_metrics.py
+++ b/src/sentry/api/endpoints/organization_metrics.py
@@ -54,6 +54,7 @@ class OrganizationMetricsEndpoint(OrganizationEndpoint):
         # endpoint does not
         for metric in metrics:
             del metric["metric_id"]
+            del metric["mri_string"]
         return Response(metrics, status=200)
 
 

--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -146,15 +146,15 @@ def get_metrics(projects: Sequence[Project], use_case_id: UseCaseKey) -> Sequenc
             org_id=org_id,
         ):
             try:
+                mri_string = reverse_resolve(use_case_id, org_id, row["metric_id"])
                 metrics_meta.append(
                     MetricMeta(
-                        name=get_public_name_from_mri(
-                            reverse_resolve(use_case_id, org_id, row["metric_id"])
-                        ),
+                        name=get_public_name_from_mri(mri_string),
                         type=metric_type,
                         operations=AVAILABLE_OPERATIONS[METRIC_TYPE_TO_ENTITY[metric_type].value],
                         unit=None,  # snuba does not know the unit
                         metric_id=row["metric_id"],
+                        mri_string=mri_string,
                     )
                 )
             except InvalidParams:
@@ -185,6 +185,7 @@ def get_metrics(projects: Sequence[Project], use_case_id: UseCaseKey) -> Sequenc
                 unit=derived_metric_obj.unit,
                 # Derived metrics won't have an id
                 metric_id=None,
+                mri_string=derived_metric_mri,
             )
         )
     return sorted(metrics_meta, key=itemgetter("name"))
@@ -220,6 +221,7 @@ def get_custom_measurements(
                         ],
                         unit=parsed_mri.unit,
                         metric_id=row["metric_id"],
+                        mri_string=parsed_mri.mri_string,
                     )
                 )
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -199,6 +199,7 @@ class MetricMeta(TypedDict):
     operations: Collection[MetricOperationType]
     unit: Optional[MetricUnit]
     metric_id: Optional[int]
+    mri_string: str
 
 
 class MetricMetaWithTagKeys(MetricMeta):

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -1385,6 +1385,7 @@ class GetCustomMeasurementsTestCase(MetricsEnhancedPerformanceTestCase):
                 "metric_id": indexer.resolve(
                     UseCaseKey.PERFORMANCE, self.organization.id, something_custom_metric
                 ),
+                "mri_string": something_custom_metric,
             }
         ]
 
@@ -1433,6 +1434,7 @@ class GetCustomMeasurementsTestCase(MetricsEnhancedPerformanceTestCase):
                 "metric_id": indexer.resolve(
                     UseCaseKey.PERFORMANCE, self.organization.id, something_custom_metric
                 ),
+                "mri_string": something_custom_metric,
             }
         ]
 


### PR DESCRIPTION
- This is because the metric layer expects MRIs instead of metric_ids, so the QueryBuilder needs this change to support custom performance metrics