### PR TITLE
fix(replays): Adjust replay duration based on startedAt/finishedAt

### DIFF
--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -223,11 +223,14 @@ def mock_segment_fullsnapshot(timestamp: datetime.datetime, bodyChildNodes) -> S
         tagName="html",
         childNodes=[bodyNode],
     )
+
+    # rrweb timestamps are in ms, sentry data is in seconds
+    miliseconds = int(timestamp.timestamp())
     return [
         {
             "type": EventType.FullSnapshot,
             "data": {
-                "timestamp": int(timestamp.timestamp()),
+                "timestamp": miliseconds,
                 "node": {
                     "type": EventType.DomContentLoaded,
                     "childNodes": [htmlNode],
@@ -238,14 +241,16 @@ def mock_segment_fullsnapshot(timestamp: datetime.datetime, bodyChildNodes) -> S
 
 
 def mock_segment_console(timestamp: datetime.datetime) -> SegmentList:
+    # sentry data is recorded in seconds, mocks should match
+    seconds = int(timestamp.timestamp()) / 1000
     return [
         {
             "type": EventType.Custom,
-            "timestamp": int(timestamp.timestamp()),
+            "timestamp": seconds,
             "data": {
                 "tag": "breadcrumb",
                 "payload": {
-                    "timestamp": int(timestamp.timestamp()) / 1000,
+                    "timestamp": seconds,
                     "type": "default",
                     "category": "console",
                     "data": {
@@ -263,10 +268,12 @@ def mock_segment_console(timestamp: datetime.datetime) -> SegmentList:
 
 
 def mock_segment_breadcrumb(timestamp: datetime.datetime, payload) -> SegmentList:
+    # sentry data is recorded in seconds, mocks should match
+    seconds = int(timestamp.timestamp()) / 1000
     return [
         {
             "type": 5,
-            "timestamp": int(timestamp.timestamp()),
+            "timestamp": seconds,
             "data": {
                 "tag": "breadcrumb",
                 "payload": payload,
@@ -278,10 +285,12 @@ def mock_segment_breadcrumb(timestamp: datetime.datetime, payload) -> SegmentLis
 def mock_segment_nagivation(
     timestamp: datetime.datetime, hrefFrom: str = "/", hrefTo: str = "/profile/"
 ) -> SegmentList:
+    # sentry data is recorded in seconds, mocks should match
+    seconds = int(timestamp.timestamp()) / 1000
     return mock_segment_breadcrumb(
         timestamp,
         {
-            "timestamp": int(timestamp.timestamp()) / 1000,
+            "timestamp": seconds,
             "type": "default",
             "category": "navigation",
             "data": {"from": hrefFrom, "to": hrefTo},

--- a/static/app/components/replays/replayHighlight.tsx
+++ b/static/app/components/replays/replayHighlight.tsx
@@ -13,14 +13,15 @@ function ReplayHighlight({replay}: Props) {
 
   if (replay) {
     const {countErrors, duration, urls} = replay;
+    const durationSec = duration.asSeconds();
     const pagesVisited = urls.length;
 
-    const pagesVisitedOverTime = pagesVisited / (duration || 1);
+    const pagesVisitedOverTime = pagesVisited / (durationSec || 1);
 
     score = (countErrors * 25 + pagesVisited * 5 + pagesVisitedOverTime) / 10;
     // negatively score sub 5 second replays
-    if (duration <= 5) {
-      score = score - 10 / (duration || 1);
+    if (durationSec <= 5) {
+      score = score - 10 / (durationSec || 1);
     }
 
     score = Math.floor(Math.min(10, Math.max(1, score)));

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -115,15 +115,6 @@ export function breadcrumbFactory(
       url: initialUrl,
     },
   } as BreadcrumbTypeDefault;
-  const finalBreadcrumb = {
-    type: BreadcrumbType.INIT,
-    timestamp: replayRecord.finishedAt.toISOString(),
-    level: BreadcrumbLevelType.INFO,
-    data: {
-      action: 'replay-finish',
-      label: t('Finish recording'),
-    },
-  } as BreadcrumbTypeDefault;
 
   const errorCrumbs: RawCrumb[] = errors.map(error => ({
     type: BreadcrumbType.ERROR,
@@ -201,7 +192,6 @@ export function breadcrumbFactory(
     ...rawCrumbsWithTimestamp,
     ...errorCrumbs,
     ...spanCrumbs,
-    finalBreadcrumb,
   ]);
 
   return result.sort((a, b) => +new Date(a.timestamp || 0) - +new Date(b.timestamp || 0));

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -1,4 +1,5 @@
 import first from 'lodash/first';
+import {duration} from 'moment';
 
 import {transformCrumbs} from 'sentry/components/events/interfaces/breadcrumbs/utils';
 import {t} from 'sentry/locale';
@@ -69,6 +70,7 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
     ...apiResponse,
     ...(apiResponse.startedAt ? {startedAt: new Date(apiResponse.startedAt)} : {}),
     ...(apiResponse.finishedAt ? {finishedAt: new Date(apiResponse.finishedAt)} : {}),
+    ...(apiResponse.duration ? {duration: duration(apiResponse.duration * 1000)} : {}),
     tags,
   };
 }
@@ -111,6 +113,15 @@ export function breadcrumbFactory(
       action: 'replay-init',
       label: t('Start recording'),
       url: initialUrl,
+    },
+  } as BreadcrumbTypeDefault;
+  const finalBreadcrumb = {
+    type: BreadcrumbType.INIT,
+    timestamp: replayRecord.finishedAt.toISOString(),
+    level: BreadcrumbLevelType.INFO,
+    data: {
+      action: 'replay-finish',
+      label: t('Finish recording'),
     },
   } as BreadcrumbTypeDefault;
 
@@ -190,6 +201,7 @@ export function breadcrumbFactory(
     ...rawCrumbsWithTimestamp,
     ...errorCrumbs,
     ...spanCrumbs,
+    finalBreadcrumb,
   ]);
 
   return result.sort((a, b) => +new Date(a.timestamp || 0) - +new Date(b.timestamp || 0));

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -1,3 +1,5 @@
+import {duration} from 'moment';
+
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import {
   breadcrumbFactory,
@@ -71,6 +73,9 @@ export default class ReplayReader {
     );
     replayRecord.startedAt = new Date(startTimestampMs);
     replayRecord.finishedAt = new Date(endTimestampMs);
+    replayRecord.duration = duration(
+      replayRecord.finishedAt.getTime() - replayRecord.startedAt.getTime()
+    );
 
     const sortedSpans = spansFactory(spans);
     this.networkSpans = sortedSpans.filter(isNetworkSpan);
@@ -95,7 +100,7 @@ export default class ReplayReader {
    * @returns Duration of Replay (milliseonds)
    */
   getDurationMs = () => {
-    return this.replayRecord.duration * 1000;
+    return this.replayRecord.duration.asMilliseconds();
   };
 
   getReplay = () => {

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -61,7 +61,11 @@ function ReplayMetaData({replayRecord}: Props) {
         {replayRecord ? (
           <Fragment>
             <IconClock color="gray300" />
-            <Duration seconds={replayRecord?.duration.asSeconds()} abbreviation exact />
+            <Duration
+              seconds={Math.trunc(replayRecord?.duration.asSeconds())}
+              abbreviation
+              exact
+            />
           </Fragment>
         ) : (
           <HeaderPlaceholder />

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -61,7 +61,7 @@ function ReplayMetaData({replayRecord}: Props) {
         {replayRecord ? (
           <Fragment>
             <IconClock color="gray300" />
-            <Duration seconds={replayRecord?.duration} abbreviation exact />
+            <Duration seconds={replayRecord?.duration.asSeconds()} abbreviation exact />
           </Fragment>
         ) : (
           <HeaderPlaceholder />

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -258,7 +258,7 @@ function ReplayTableRow({
         </Item>
       )}
       <Item>
-        <Duration seconds={Math.floor(replay.duration)} exact abbreviation />
+        <Duration seconds={replay.duration.asSeconds()} exact abbreviation />
       </Item>
       <Item data-test-id="replay-table-count-errors">{replay.countErrors || 0}</Item>
       <Item>

--- a/static/app/views/replays/types.tsx
+++ b/static/app/views/replays/types.tsx
@@ -1,3 +1,4 @@
+import type {Duration} from 'moment';
 import type {eventWithTime} from 'rrweb/typings/types';
 
 import type {RawCrumb} from 'sentry/types/breadcrumbs';
@@ -29,9 +30,9 @@ export type ReplayRecord = {
   };
   dist: null | string;
   /**
-   * Difference of `updated-at` and `created-at` in seconds.
+   * Difference of `finishedAt` and `startedAt` in seconds.
    */
-  duration: number; // Seconds
+  duration: Duration;
   environment: null | string;
   errorIds: string[];
   /**


### PR DESCRIPTION
Prevent rendering from overflowing the Timeline component by re-computing `duration` based on our calculated `startedAt` and `finishedAt` fields.

| Before | After |
| --- | --- |
| <img width="101" alt="Screen Shot 2022-10-19 at 12 00 33 PM" src="https://user-images.githubusercontent.com/187460/196796712-9f88efef-513c-445e-b48f-21b18f49b7a5.png"> | <img width="94" alt="Screen Shot 2022-10-19 at 1 18 25 PM" src="https://user-images.githubusercontent.com/187460/196796556-3cf9f641-fdc8-48fb-9deb-6b64367b7a6b.png"> |

If you look really carefully you'll notice that the 'after' screen shot includes a dotted gridline which marks the `02:55` position. The Timeline in this case is rendering from `t=0` to `t=2:55.398` which is just enough for it to render that extra gridline.

Clicking and hovering the last console message, which happened at `18:53:59.397Z`  shows no overflow in the timeline.

This is similar to, but doesn't conflict with #40272