### PR TITLE
fix(workflow): Add post_process_transactions queue (OPS-2465)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -660,6 +660,8 @@ CELERY_QUEUES = [
     Queue("merge", routing_key="merge"),
     Queue("options", routing_key="options"),
     Queue("post_process_errors", routing_key="post_process_errors"),
+    Queue("post_process_transactions", routing_key="post_process_transactions"),
+    # TODO(rjo100): to be removed after post_process_transactions is set up
     Queue("post_process_performance", routing_key="post_process_performance"),
     Queue("relay_config", routing_key="relay_config"),
     Queue("relay_config_bulk", routing_key="relay_config_bulk"),


### PR DESCRIPTION
Adds `post_process_transactions` queue to move over workers from `post_process_performance` queue