### PR TITLE
chore(perf issues): Change N+1 QB Queries to N+1 Query

### DIFF
--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -332,7 +332,6 @@ def perf_to_email_html(
     context = {
         "transaction_name": get_span_evidence_value_problem(problem),
         "parent_span": get_span_evidence_value(parent_span),
-        # "preceding_span": "SELECT idk FROM idk_what_a_preceding_span_is",
         "repeating_spans": get_span_evidence_value(repeating_spans),
         "num_repeating_spans": str(len(problem.offender_span_ids))
         if problem.offender_span_ids

--- a/src/sentry/types/issues.py
+++ b/src/sentry/types/issues.py
@@ -31,13 +31,13 @@ GROUP_TYPE_TO_CATEGORY = {
 
 GROUP_TYPE_TO_TEXT = {
     GroupType.ERROR: "Error",
-    GroupType.PERFORMANCE_N_PLUS_ONE: "N+1 Query",
+    GroupType.PERFORMANCE_N_PLUS_ONE: "N+1",  # may be N+1 Spans, N+1 Web Requests
     GroupType.PERFORMANCE_SLOW_SPAN: "Slow Span",
     GroupType.PERFORMANCE_SEQUENTIAL_SLOW_SPANS: "Sequential Slow Spans",
     GroupType.PERFORMANCE_LONG_TASK_SPANS: "Long Task Spans",
     GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN: "Render Blocking Asset Span",
     GroupType.PERFORMANCE_DUPLICATE_SPANS: "Duplicate Spans",
-    GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES: "N+1 DB Queries",
+    GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES: "N+1 Query",
 }
 
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -191,7 +191,7 @@ class BuildGroupAttachmentTest(TestCase):
         event = event.for_group(event.groups[0])
         attachments = SlackIssuesMessageBuilder(event.group, event).build()
 
-        assert attachments["title"] == "N+1 DB Queries"
+        assert attachments["title"] == "N+1 Query"
         assert (
             attachments["text"]
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -186,7 +186,7 @@ class NotifyEmailTest(RuleTestCase):
         assert len(mail.outbox) == 1
         sent = mail.outbox[0]
         assert sent.to == [self.user.email]
-        assert "N+1 DB Queries" in sent.subject
+        assert "N+1 Query" in sent.subject
 
     # XXX(gilbert): remove this later one
     @mock.patch("sentry.mail.actions.determine_eligible_recipients")

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -311,7 +311,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             self.adapter.notify(notification, ActionTargetType.ISSUE_OWNERS)
 
         msg = mail.outbox[0]
-        assert msg.subject == "[Sentry] BAR-1 - N+1 DB Queries"
+        assert msg.subject == "[Sentry] BAR-1 - N+1 Query"
         checked_values = [
             "Transaction Name",
             # TODO: Not sure if this is right


### PR DESCRIPTION
Update the display text for performance issue types to N+1 Query from N+1 DB Query to match what's used on the issue details page. This text is displayed in things like emails and Slack messages.