### PR TITLE
ref(slack): Handle fallback text for perf issues

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -53,6 +53,16 @@ def build_attachment_title(obj: Group | Event) -> str:
     return title_str
 
 
+def build_fallback_text(obj: Group | Event, project: Project) -> str:
+    title = obj.title
+    group = getattr(obj, "group", obj)
+
+    if group.issue_category == GroupCategory.PERFORMANCE:
+        title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
+
+    return f"[{project.slug}] {title}"
+
+
 def get_title_link(
     group: Group,
     event: Event | None,

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -53,16 +53,6 @@ def build_attachment_title(obj: Group | Event) -> str:
     return title_str
 
 
-def build_fallback_text(obj: Group | Event, project: Project) -> str:
-    title = obj.title
-    group = getattr(obj, "group", obj)
-
-    if group.issue_category == GroupCategory.PERFORMANCE:
-        title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
-
-    return f"[{project.slug}] {title}"
-
-
 def get_title_link(
     group: Group,
     event: Event | None,

--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 from abc import ABC
 from typing import Any, Mapping, MutableMapping, Sequence
 
+from sentry.eventstore.models import Event
 from sentry.integrations.message_builder import AbstractMessageBuilder
 from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackBody
-from sentry.models import Event, Group
+from sentry.models import Group
 from sentry.notifications.utils.actions import MessageAction
 from sentry.types.issues import GROUP_TYPE_TO_TEXT, GroupCategory
 from sentry.utils.assets import get_asset_url

--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -5,7 +5,9 @@ from typing import Any, Mapping, MutableMapping, Sequence
 
 from sentry.integrations.message_builder import AbstractMessageBuilder
 from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackBody
+from sentry.models import Event, Group
 from sentry.notifications.utils.actions import MessageAction
+from sentry.types.issues import GROUP_TYPE_TO_TEXT, GroupCategory
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 
@@ -32,6 +34,16 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
     def build(self) -> SlackBody:
         """Abstract `build` method that all inheritors must implement."""
         raise NotImplementedError
+
+    def build_fallback_text(self, obj: Group | Event, project_slug: str) -> str:
+        """Fallback text is used in the message preview popup."""
+        title = obj.title
+        group = getattr(obj, "group", obj)
+
+        if group.issue_category == GroupCategory.PERFORMANCE:
+            title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
+
+        return f"[{project_slug}] {title}"
 
     @staticmethod
     def _build(

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -10,7 +10,6 @@ from sentry.eventstore.models import Event
 from sentry.integrations.message_builder import (
     build_attachment_text,
     build_attachment_title,
-    build_fallback_text,
     build_footer,
     format_actor_options,
     get_title_link,
@@ -278,7 +277,7 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
             actions=payload_actions,
             callback_id=json.dumps({"issue": self.group.id}),
             color=color,
-            fallback=build_fallback_text(obj, project),
+            fallback=self.build_fallback_text(obj, project.slug),
             fields=fields,
             footer=footer,
             text=text,

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -10,6 +10,7 @@ from sentry.eventstore.models import Event
 from sentry.integrations.message_builder import (
     build_attachment_text,
     build_attachment_title,
+    build_fallback_text,
     build_footer,
     format_actor_options,
     get_title_link,
@@ -277,7 +278,7 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
             actions=payload_actions,
             callback_id=json.dumps({"issue": self.group.id}),
             color=color,
-            fallback=f"[{project.slug}] {obj.title}",
+            fallback=build_fallback_text(obj, project),
             fields=fields,
             footer=footer,
             text=text,

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -201,7 +201,7 @@ class BuildGroupAttachmentTest(TestCase):
             attachments["text"]
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
         )
-        assert attachments["fallback"] == f"[{self.project.slug}] N+1 DB Queries"
+        assert attachments["fallback"] == f"[{self.project.slug}] N+1 Query"
 
     def test_build_group_release_with_commits_attachment(self):
         group = self.create_group(project=self.project)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -196,6 +196,7 @@ class BuildGroupAttachmentTest(TestCase):
             attachments["text"]
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
         )
+        assert attachments["fallback"] == f"[{self.project.slug}] N+1 DB Queries"
 
     def test_build_group_release_with_commits_attachment(self):
         group = self.create_group(project=self.project)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -167,6 +167,11 @@ class BuildGroupAttachmentTest(TestCase):
         assert attachments["text"] == f"<{group_link}|*{group.title}*> \nFirst line of Text"
         assert "title_link" not in attachments
 
+    def test_build_error_issue_fallback_text(self):
+        event = self.store_event(data={}, project_id=self.project.id)
+        attachments = SlackIssuesMessageBuilder(event.group, event).build()
+        assert attachments["fallback"] == f"[{self.project.slug}] {event.group.title}"
+
     def test_build_performance_issue(self):
         event_data = load_data(
             "transaction-n-plus-one",


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/40150 where the popup text is handled. We don't seem to have a title for performance issues, so this adds the type of issue to the popup rather than saying "unknown" in the same way that we do for emails (see https://github.com/getsentry/sentry/pull/40143). 

<img width="349" alt="Screen Shot 2022-10-19 at 4 55 09 PM" src="https://user-images.githubusercontent.com/29959063/196826334-f0472a1a-d7a2-4626-a5e4-31ef7417fe72.png">
