### PR TITLE
fix(js): Correctly mark toggleEmbeddedChildren as an action

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -348,7 +348,7 @@ describe('SpanTreeModel', () => {
     let mockRemoveTraceBounds = jest.fn();
 
     // embed a child transaction
-    let promise = spanTreeModel.toggleEmbeddedChildren({
+    let promise = spanTreeModel.makeToggleEmbeddedChildren({
       addTraceBounds: mockAddTraceBounds,
       removeTraceBounds: mockRemoveTraceBounds,
     })({
@@ -456,7 +456,7 @@ describe('SpanTreeModel', () => {
     mockRemoveTraceBounds = jest.fn();
 
     // un-embed a child transaction
-    promise = spanTreeModel.toggleEmbeddedChildren({
+    promise = spanTreeModel.makeToggleEmbeddedChildren({
       addTraceBounds: mockAddTraceBounds,
       removeTraceBounds: mockRemoveTraceBounds,
     })({
@@ -502,7 +502,7 @@ describe('SpanTreeModel', () => {
 
     const spanTreeModel = new SpanTreeModel(rootSpan, parsedTrace.childSpans, api);
 
-    const promise = spanTreeModel.toggleEmbeddedChildren({
+    const promise = spanTreeModel.makeToggleEmbeddedChildren({
       addTraceBounds: () => {},
       removeTraceBounds: () => {},
     })({

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -82,7 +82,6 @@ class SpanTreeModel {
       showEmbeddedChildren: observable,
       embeddedChildren: observable,
       fetchEmbeddedChildrenState: observable,
-      toggleEmbeddedChildren: action,
       fetchEmbeddedTransactions: action,
       isNestedSpanGroupExpanded: observable,
       toggleNestedSpanGroup: action,
@@ -282,7 +281,7 @@ class SpanTreeModel {
       continuingTreeDepths,
       fetchEmbeddedChildrenState: this.fetchEmbeddedChildrenState,
       showEmbeddedChildren: this.showEmbeddedChildren,
-      toggleEmbeddedChildren: this.toggleEmbeddedChildren({
+      toggleEmbeddedChildren: this.makeToggleEmbeddedChildren({
         addTraceBounds,
         removeTraceBounds,
       }),
@@ -460,7 +459,7 @@ class SpanTreeModel {
                 continuingTreeDepths: descendantContinuingTreeDepths,
                 fetchEmbeddedChildrenState: spanModel.fetchEmbeddedChildrenState,
                 showEmbeddedChildren: spanModel.showEmbeddedChildren,
-                toggleEmbeddedChildren: spanModel.toggleEmbeddedChildren({
+                toggleEmbeddedChildren: spanModel.makeToggleEmbeddedChildren({
                   addTraceBounds,
                   removeTraceBounds,
                 }),
@@ -524,7 +523,7 @@ class SpanTreeModel {
             continuingTreeDepths: descendantContinuingTreeDepths,
             fetchEmbeddedChildrenState: spanModel.fetchEmbeddedChildrenState,
             showEmbeddedChildren: spanModel.showEmbeddedChildren,
-            toggleEmbeddedChildren: spanModel.toggleEmbeddedChildren({
+            toggleEmbeddedChildren: spanModel.makeToggleEmbeddedChildren({
               addTraceBounds,
               removeTraceBounds,
             }),
@@ -665,15 +664,14 @@ class SpanTreeModel {
     return [wrappedSpan, ...descendants];
   };
 
-  toggleEmbeddedChildren =
-    ({
-      addTraceBounds,
-      removeTraceBounds,
-    }: {
-      addTraceBounds: (bounds: TraceBound) => void;
-      removeTraceBounds: (eventSlug: string) => void;
-    }) =>
-    (props: {eventSlug: string; orgSlug: string}) => {
+  makeToggleEmbeddedChildren = ({
+    addTraceBounds,
+    removeTraceBounds,
+  }: {
+    addTraceBounds: (bounds: TraceBound) => void;
+    removeTraceBounds: (eventSlug: string) => void;
+  }) =>
+    action('toggleEmbeddedChildren', (props: {eventSlug: string; orgSlug: string}) => {
       this.showEmbeddedChildren = !this.showEmbeddedChildren;
       this.fetchEmbeddedChildrenState = 'idle';
 
@@ -695,7 +693,7 @@ class SpanTreeModel {
       }
 
       return Promise.resolve(undefined);
-    };
+    });
 
   fetchEmbeddedTransactions({
     orgSlug,


### PR DESCRIPTION
This was a bit tricky, the span tree model has a `toggleEmbeddedChildren`, but it's actually a factory function, which produces the _actual_ action function that triggers the toggle.

The factory function was being made a mobx action in the makeObservable call, but this is wrong. The factor function does not trigger any actions, the function it returns does.

To fix this we now wrap the returned function in the `action` decorator.

This stops the following message from being produced:

  [MobX] Since strict-mode is enabled, changing (observed) observable
         values without using an action is not allowed. Tried to modify:
         SpanTreeModel@44.fetchEmbeddedChildrenState

Now all tests pass without any console output at all

https://asciinema.org/a/Mqjdq84YPAtUy4q6Drmp8lLC8