### PR TITLE
fix(metrics): Implement proper type coercion for percentiles

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -69,6 +69,7 @@ from sentry.snuba.metrics.utils import (
     GENERIC_OP_TO_SNUBA_FUNCTION,
     GRANULARITY,
     OP_TO_SNUBA_FUNCTION,
+    OPERATIONS_PERCENTILES,
     TS_COL_QUERY,
     UNIT_TO_TYPE,
     DerivedMetricParseException,
@@ -354,6 +355,12 @@ class RawOp(MetricOperation):
         return False
 
     def get_meta_type(self) -> Optional[str]:
+        # If we have a percentile operation then we want to convert its type from Array(float64) to Float64
+        # because once we receive a percentile result from ClickHouse we automatically pop from the array the
+        # first element thus the datatype itself must also be changed in the metadata.
+        if self.op in OPERATIONS_PERCENTILES:
+            return "Float64"
+
         return None
 
     def run_post_query_function(

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -368,15 +368,11 @@ def translate_meta_results(
     for record in meta:
         operation, column_name = parse_expression(record["name"])
 
-        metric_field_of_record = alias_to_metric_field.get(record["name"], None)
+        metric_field = alias_to_metric_field.get(record["name"], None)
         # If we have a percentile operation then we want to convert its type from Array(float64) to Float64
         # because once we receive a percentile result from ClickHouse we automatically pop from the array the
         # first element thus the datatype itself must also be changed in the metadata.
-        if (
-            metric_field_of_record
-            and metric_field_of_record.op
-            and metric_field_of_record.op in OPERATIONS_PERCENTILES
-        ):
+        if metric_field and metric_field.op and metric_field.op in OPERATIONS_PERCENTILES:
             record["type"] = "Float64"
 
         # Column name could be either a mri, ["bucketed_time"] or a tag or a dataset col like

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -458,10 +458,6 @@ def translate_meta_results(
     return sorted(results, key=lambda elem: elem["name"])
 
 
-def coerce_rule_type():
-    ...
-
-
 class SnubaQueryBuilder:
 
     #: Datasets actually implemented in snuba:

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -368,13 +368,6 @@ def translate_meta_results(
     for record in meta:
         operation, column_name = parse_expression(record["name"])
 
-        metric_field = alias_to_metric_field.get(record["name"], None)
-        # If we have a percentile operation then we want to convert its type from Array(float64) to Float64
-        # because once we receive a percentile result from ClickHouse we automatically pop from the array the
-        # first element thus the datatype itself must also be changed in the metadata.
-        if metric_field and metric_field.op and metric_field.op in OPERATIONS_PERCENTILES:
-            record["type"] = "Float64"
-
         # Column name could be either a mri, ["bucketed_time"] or a tag or a dataset col like
         # "project_id" or "metric_id"
         is_tag = column_name in alias_to_metric_group_by_field.keys()

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -9,7 +9,6 @@ __all__ = (
     "translate_meta_results",
 )
 
-import re
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
@@ -69,7 +68,6 @@ from sentry.snuba.metrics.utils import (
     FIELD_ALIAS_MAPPINGS,
     NON_RESOLVABLE_TAG_VALUES,
     OPERATIONS_PERCENTILES,
-    PERCENTILE_OP_REGEX,
     TS_COL_GROUP,
     TS_COL_QUERY,
     DerivedMetricParseException,
@@ -377,7 +375,7 @@ def translate_meta_results(
         if (
             metric_field_of_record
             and metric_field_of_record.op
-            and re.search(PERCENTILE_OP_REGEX, metric_field_of_record.op)
+            and metric_field_of_record.op in OPERATIONS_PERCENTILES
         ):
             record["type"] = "Float64"
 

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -155,6 +155,8 @@ def generate_operation_regex():
 
 OP_REGEX = generate_operation_regex()
 
+# Regex that is used to validate that an operation is a percentile operation in the form p**.
+PERCENTILE_OP_REGEX = r"p\d\d"
 
 AVAILABLE_OPERATIONS = {
     type_: sorted(mapping.keys()) for type_, mapping in OP_TO_SNUBA_FUNCTION.items()

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -155,9 +155,6 @@ def generate_operation_regex():
 
 OP_REGEX = generate_operation_regex()
 
-# Regex that is used to validate that an operation is a percentile operation in the form p**.
-PERCENTILE_OP_REGEX = r"p\d\d"
-
 AVAILABLE_OPERATIONS = {
     type_: sorted(mapping.keys()) for type_, mapping in OP_TO_SNUBA_FUNCTION.items()
 }

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -689,8 +689,8 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
         assert data["meta"] == sorted(
             [
                 {"name": "bucketed_time", "type": "DateTime('Universal')"},
-                {"name": "p50_fcp", "type": "Array(Float64)"},
-                {"name": "p50_lcp", "type": "Array(Float64)"},
+                {"name": "p50_fcp", "type": "Float64"},
+                {"name": "p50_lcp", "type": "Float64"},
                 {"name": "project", "type": "string"},
                 {"name": "project_alias", "type": "string"},
                 {"name": "transaction_group", "type": "string"},
@@ -1220,7 +1220,7 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
         ]
         assert data["meta"] == sorted(
             [
-                {"name": "p95", "type": "Array(Float64)"},
+                {"name": "p95", "type": "Float64"},
                 {"name": "team_key_transactions", "type": "boolean"},
                 {"name": "transaction", "type": "string"},
             ],

--- a/tests/sentry/snuba/metrics/test_query_builder.py
+++ b/tests/sentry/snuba/metrics/test_query_builder.py
@@ -978,7 +978,7 @@ def test_get_intervals():
 
 def test_translate_meta_results():
     meta = [
-        {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Array(Float64)"},
+        {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Float64"},
         {"name": "team_key_transaction", "type": "UInt8"},
         {"name": "transaction", "type": "UInt64"},
         {"name": "project_id", "type": "UInt64"},
@@ -1005,7 +1005,7 @@ def test_translate_meta_results():
         },
     ) == sorted(
         [
-            {"name": "p50(transaction.measurements.lcp)", "type": "Array(Float64)"},
+            {"name": "p50(transaction.measurements.lcp)", "type": "Float64"},
             {"name": "team_key_transaction", "type": "boolean"},
             {"name": "transaction", "type": "string"},
             {"name": "project_id", "type": "UInt64"},
@@ -1017,8 +1017,8 @@ def test_translate_meta_results():
 
 def test_translate_meta_results_with_duplicates():
     meta = [
-        {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Array(Float64)"},
-        {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Array(Float64)"},
+        {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Float64"},
+        {"name": "p50(d:transactions/measurements.lcp@millisecond)", "type": "Float64"},
         {"name": "transaction", "type": "UInt64"},
         {"name": "transaction", "type": "UInt64"},
         {"name": "project_id", "type": "UInt64"},
@@ -1036,7 +1036,7 @@ def test_translate_meta_results_with_duplicates():
         {"transaction": MetricGroupByField("transaction")},
     ) == sorted(
         [
-            {"name": "p50(transaction.measurements.lcp)", "type": "Array(Float64)"},
+            {"name": "p50(transaction.measurements.lcp)", "type": "Float64"},
             {"name": "transaction", "type": "string"},
             {"name": "project_id", "type": "UInt64"},
         ],


### PR DESCRIPTION
This PR implements the proper type coercion in the metadata of percentile-based queries. Currently ClickHouse returns as the type of a percentile `Array(Float64)` but the metrics layer automatically pops the first element from that array and returns it, effectively making the type `Float64`. This PR implements this behavior.