### PR TITLE
ref(js): Fix incorrect interpolation in t()

### DIFF
--- a/static/app/actionCreators/indicator.tsx
+++ b/static/app/actionCreators/indicator.tsx
@@ -167,18 +167,17 @@ export function saveOnBlurUndoMessage(
   // Hide the change text when formatMessageValue is explicitly set to false
   const showChangeText = model.getDescriptor(fieldName, 'formatMessageValue') !== false;
 
+  const tctArgsSuccess = {
+    root: <MessageContainer />,
+    fieldName: <FieldName>{label}</FieldName>,
+    oldValue: <FormValue>{prettifyValue(change.old)}</FormValue>,
+    newValue: <FormValue>{prettifyValue(change.new)}</FormValue>,
+  };
+
   addSuccessMessage(
-    tct(
-      showChangeText
-        ? 'Changed [fieldName] from [oldValue] to [newValue]'
-        : 'Changed [fieldName]',
-      {
-        root: <MessageContainer />,
-        fieldName: <FieldName>{label}</FieldName>,
-        oldValue: <FormValue>{prettifyValue(change.old)}</FormValue>,
-        newValue: <FormValue>{prettifyValue(change.new)}</FormValue>,
-      }
-    ),
+    showChangeText
+      ? tct('Changed [fieldName] from [oldValue] to [newValue]', tctArgsSuccess)
+      : tct('Changed [fieldName]', tctArgsSuccess),
     {
       modelArg: {
         model,
@@ -202,36 +201,40 @@ export function saveOnBlurUndoMessage(
           // `saveField` can return null if it can't save
           const saveResult = model.saveField(fieldName, newValue);
 
+          const tctArgsFail = {
+            root: <MessageContainer />,
+            fieldName: <FieldName>{label}</FieldName>,
+            oldValue: <FormValue>{prettifyValue(oldValue)}</FormValue>,
+            newValue: <FormValue>{prettifyValue(newValue)}</FormValue>,
+          };
+
           if (!saveResult) {
             addErrorMessage(
-              tct(
-                showChangeText
-                  ? 'Unable to restore [fieldName] from [oldValue] to [newValue]'
-                  : 'Unable to restore [fieldName]',
-                {
-                  root: <MessageContainer />,
-                  fieldName: <FieldName>{label}</FieldName>,
-                  oldValue: <FormValue>{prettifyValue(oldValue)}</FormValue>,
-                  newValue: <FormValue>{prettifyValue(newValue)}</FormValue>,
-                }
-              )
+              showChangeText
+                ? tct(
+                    'Unable to restore [fieldName] from [oldValue] to [newValue]',
+                    tctArgsFail
+                  )
+                : tct('Unable to restore [fieldName]', tctArgsFail)
             );
             return;
           }
 
+          const tctArgsRestored = {
+            root: <MessageContainer />,
+            fieldName: <FieldName>{label}</FieldName>,
+            oldValue: <FormValue>{prettifyValue(oldValue)}</FormValue>,
+            newValue: <FormValue>{prettifyValue(newValue)}</FormValue>,
+          };
+
           saveResult.then(() => {
             addMessage(
-              tct(
-                showChangeText
-                  ? 'Restored [fieldName] from [oldValue] to [newValue]'
-                  : 'Restored [fieldName]',
-                {
-                  root: <MessageContainer />,
-                  fieldName: <FieldName>{label}</FieldName>,
-                  oldValue: <FormValue>{prettifyValue(oldValue)}</FormValue>,
-                  newValue: <FormValue>{prettifyValue(newValue)}</FormValue>,
-                }
-              ),
+              showChangeText
+                ? tct(
+                    'Restored [fieldName] from [oldValue] to [newValue]',
+                    tctArgsRestored
+                  )
+                : tct('Restored [fieldName]', tctArgsRestored),
               'undo',
               {
                 duration: DEFAULT_TOAST_DURATION,

--- a/static/app/actionCreators/sentryAppInstallations.tsx
+++ b/static/app/actionCreators/sentryAppInstallations.tsx
@@ -30,7 +30,7 @@ export function installSentryApp(
   );
   promise.then(
     () => clearIndicators(),
-    () => addErrorMessage(t(`Unable to install ${app.name}`))
+    () => addErrorMessage(t('Unable to install %s', app.name))
   );
   return promise;
 }
@@ -53,7 +53,7 @@ export function uninstallSentryApp(
     install.app.slug.charAt(0).toUpperCase() + install.app.slug.slice(1);
   promise.then(
     () => {
-      addSuccessMessage(t(`${capitalizedAppSlug} successfully uninstalled.`));
+      addSuccessMessage(t('%s successfully uninstalled.', capitalizedAppSlug));
     },
     () => clearIndicators()
   );

--- a/static/app/components/assistant/getGuidesContent.tsx
+++ b/static/app/components/assistant/getGuidesContent.tsx
@@ -88,7 +88,7 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
               link: <Link to={orgSlug ? `/settings/${orgSlug}` : `/settings`} />,
             }
           ),
-          nextText: t(`Allow`),
+          nextText: t('Allow'),
           hasNextGuide: true,
         },
       ],
@@ -114,7 +114,7 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
         {
           title: t('Transactions Details'),
           target: 'trace_view_guide_row_details',
-          description: t(`Click on any transaction to see more details.`),
+          description: t('Click on any transaction to see more details.'),
         },
       ],
     },
@@ -306,7 +306,7 @@ function getDemoModeGuides(): GuidesContent {
           description: t(
             `Query and unlock insights into the health of your entire system and get answers to critical business questions all in one place.`
           ),
-          nextText: t(`Got it`),
+          nextText: t('Got it'),
         },
       ],
     },
@@ -330,7 +330,7 @@ function getDemoModeGuides(): GuidesContent {
         {
           title: t('Details'),
           target: 'issue_details',
-          description: t(`See the who, what, and where of every error right at the top`),
+          description: t('See the who, what, and where of every error right at the top'),
         },
         {
           title: t('Exception'),
@@ -382,12 +382,12 @@ function getDemoModeGuides(): GuidesContent {
         {
           title: t('Chart'),
           target: 'release_chart',
-          description: t(`Click and drag to zoom in on a specific section of the chart.`),
+          description: t('Click and drag to zoom in on a specific section of the chart.'),
         },
         {
           title: t('Discover'),
           target: 'release_issues_open_in_discover',
-          description: t(`Analyze these errors by URL, geography, device, browser, etc.`),
+          description: t('Analyze these errors by URL, geography, device, browser, etc.'),
         },
         {
           title: t('Discover'),
@@ -496,7 +496,7 @@ function getDemoModeGuidesV2(): GuidesContent {
           description: t(
             `Query and unlock insights into the health of your entire system and get answers to critical business questions all in one place.`
           ),
-          nextText: t(`Got it`),
+          nextText: t('Got it'),
         },
       ],
     },
@@ -525,7 +525,7 @@ function getDemoModeGuidesV2(): GuidesContent {
           description: t(
             `Sentry automatically captures breadcrumbs for events so you can see the sequence of events so you can see the sequence of events leading up to the error.`
           ),
-          nextText: t(`Got it`),
+          nextText: t('Got it'),
         },
       ],
     },
@@ -599,7 +599,7 @@ function getDemoModeGuidesV2(): GuidesContent {
           description: t(
             'Select an Event ID from a list of slow transactions to uncover slow spans.'
           ),
-          nextText: t(`Got it`),
+          nextText: t('Got it'),
         },
       ],
     },

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -8,7 +8,6 @@ import type {Location} from 'history';
 import moment from 'moment';
 
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import {t} from 'sentry/locale';
 import {EventsStats, MultiSeriesEventsStats, PageFilters} from 'sentry/types';
 import {defined, escape} from 'sentry/utils';
 import {getFormattedDate, parsePeriodToHours} from 'sentry/utils/dates';
@@ -377,6 +376,6 @@ export function useEchartsAriaLabels(
 
   return {
     enabled: true,
-    label: {description: t([title, ...seriesDescriptions].join('. '))},
+    label: {description: [title, ...seriesDescriptions].join('. ')},
   };
 }

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -272,7 +272,7 @@ class ContextPickerModal extends Component<Props> {
         label: t('My Projects'),
         options: memberProjects.map(p => ({
           value: p.slug,
-          label: t(`${p.slug}`),
+          label: p.slug,
           disabled: false,
         })),
       },
@@ -280,7 +280,7 @@ class ContextPickerModal extends Component<Props> {
         label: t('All Projects'),
         options: nonMemberProjects.map(p => ({
           value: p.slug,
-          label: t(`${p.slug}`),
+          label: p.slug,
           disabled: isSuperuser ? false : true,
         })),
       },

--- a/static/app/components/dataExport.tsx
+++ b/static/app/components/dataExport.tsx
@@ -95,9 +95,11 @@ function DataExport({
         }
         const message =
           err?.responseJSON?.detail ??
-          "We tried our hardest, but we couldn't export your data. Give it another go.";
+          t(
+            "We tried our hardest, but we couldn't export your data. Give it another go."
+          );
 
-        addErrorMessage(t(message));
+        addErrorMessage(message);
         setInProgress(false);
       });
   }, [payload.queryInfo, payload.queryType, organization.slug, api]);
@@ -108,7 +110,9 @@ function DataExport({
         <Button
           size="sm"
           priority="default"
-          title="You can get on with your life. We'll email you when your data's ready."
+          title={t(
+            "You can get on with your life. We'll email you when your data's ready."
+          )}
           disabled
           icon={icon}
         >
@@ -120,7 +124,9 @@ function DataExport({
           disabled={disabled || false}
           size="sm"
           priority="default"
-          title="Put your data to work. Start your export and we'll email you when it's finished."
+          title={t(
+            "Put your data to work. Start your export and we'll email you when it's finished."
+          )}
           icon={icon}
         >
           {children ? children : t('Export All to CSV')}

--- a/static/app/components/discover/performanceCardTable.tsx
+++ b/static/app/components/discover/performanceCardTable.tsx
@@ -132,7 +132,7 @@ function PerformanceCardTable({
       return (
         <SubTitle key={idx}>
           <Link to={newView.getResultsViewUrlTarget(organization.slug)}>
-            {t(span.title)}
+            {span.title}
           </Link>
         </SubTitle>
       );
@@ -310,7 +310,7 @@ function PerformanceCardTable({
       return (
         <SubTitle key={idx}>
           <Link to={newView.getResultsViewUrlTarget(organization.slug)}>
-            {t(span.title)}
+            {span.title}
           </Link>
         </SubTitle>
       );

--- a/static/app/components/events/interfaces/frame/openInContextLine.tsx
+++ b/static/app/components/events/interfaces/frame/openInContextLine.tsx
@@ -43,7 +43,7 @@ const OpenInContextLine = ({lineNo, filename, components}: Props) => {
             openInNewTab
           >
             <SentryAppComponentIcon sentryAppComponent={component} />
-            <OpenInName>{t(`${component.sentryApp.name}`)}</OpenInName>
+            <OpenInName>{component.sentryApp.name}</OpenInName>
           </OpenInLink>
         );
       })}

--- a/static/app/components/group/seenInfo.tsx
+++ b/static/app/components/group/seenInfo.tsx
@@ -61,7 +61,7 @@ function SeenInfo({
           date ? (
             <StyledDateTime date={date} />
           ) : (
-            <NoEnvironment>{t(`N/A for ${environment}`)}</NoEnvironment>
+            <NoEnvironment>{t('N/A for %s', environment)}</NoEnvironment>
           )
         }
         position="top"

--- a/static/app/components/integrationExternalMappingForm.tsx
+++ b/static/app/components/integrationExternalMappingForm.tsx
@@ -81,7 +81,7 @@ export default class IntegrationExternalMappingForm extends Component<Props> {
         type: 'select_async',
         required: true,
         label: isInline ? undefined : tct('Sentry [type]', {type: capitalize(type)}),
-        placeholder: t(`Select Sentry ${capitalize(type)}`),
+        placeholder: t('Select Sentry %s', capitalize(type)),
         url: dataEndpoint,
         defaultOptions: this.getDefaultOptions(mapping),
         onResults: result => {

--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -178,9 +178,9 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
         >
           <MenuItemActionLink
             shouldConfirm
-            message={t(`Are you sure you want to remove this external ${type} mapping?`)}
+            message={t('Are you sure you want to remove this external %s mapping?', type)}
             onAction={() => onDelete(mapping)}
-            aria-label={t(`Delete External ${capitalize(type)}`)}
+            aria-label={t('Delete External %s', capitalize(type))}
             data-test-id="delete-mapping-button"
           >
             <RedText>{t('Delete')}</RedText>
@@ -189,7 +189,7 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
       </Tooltip>
     ) : (
       <Tooltip
-        title={t(`This ${type} mapping suggestion was generated from a CODEOWNERS file`)}
+        title={t('This %s mapping suggestion was generated from a CODEOWNERS file', type)}
       >
         <Button
           disabled
@@ -197,7 +197,8 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
           size="sm"
           icon={<IconQuestion size="sm" />}
           aria-label={t(
-            `This ${type} mapping suggestion was generated from a CODEOWNERS file`
+            `This %s mapping suggestion was generated from a CODEOWNERS file`,
+            type
           )}
           data-test-id="suggestion-option"
         />

--- a/static/app/components/modals/debugFileCustomRepository/utils.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/utils.tsx
@@ -12,7 +12,7 @@ import {CustomRepoType} from 'sentry/types/debugFiles';
 import {uniqueId} from 'sentry/utils/guid';
 
 function objectToChoices(obj: Record<string, string>): [key: string, value: string][] {
-  return Object.entries(obj).map(([key, value]) => [key, t(value)]);
+  return Object.entries(obj).map(([key, value]) => [key, value]);
 }
 
 type FieldMap = Record<string, Field>;

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -218,7 +218,7 @@ class SudoModal extends Component<Props, State> {
           </StyledTextBlock>
           {error && (
             <StyledAlert type="error" showIcon>
-              {t(errorType)}
+              {errorType}
             </StyledAlert>
           )}
           {isSuperuser ? (
@@ -272,7 +272,7 @@ class SudoModal extends Component<Props, State> {
 
         {error && (
           <StyledAlert type="error" showIcon>
-            {t(errorType)}
+            {errorType}
           </StyledAlert>
         )}
 

--- a/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
@@ -76,14 +76,14 @@ export default function DesyncedFilterAlert({
         </Fragment>
       }
     >
-      {tct(
-        message ??
+      {message ??
+        tct(
           'The [filter] [has] been overwritten. This can happen when you open sentry.io links with filter parameters that are different from your current filter values.',
-        {
-          filter: getReadableDesyncedFilterList(desyncedFilters),
-          has: desyncedFilters.size > 1 ? t('have') : t('has'),
-        }
-      )}
+          {
+            filter: getReadableDesyncedFilterList(desyncedFilters),
+            has: desyncedFilters.size > 1 ? t('have') : t('has'),
+          }
+        )}
     </DesyncedAlert>
   );
 }

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -323,7 +323,7 @@ const PulsingIndicator = styled('div')`
 const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
   <div {...p}>
     <PulsingIndicator />
-    {t(`Waiting for this project's first transaction event`)}
+    {t("Waiting for this project's first transaction event")}
   </div>
 ))`
   display: flex;
@@ -336,7 +336,7 @@ const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) =
 const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
   <div {...p}>
     {'🎉 '}
-    {t(`We've received this project's first transaction event!`)}
+    {t("We've received this project's first transaction event!")}
   </div>
 ))`
   display: flex;

--- a/static/app/components/projects/missingProjectMembership.tsx
+++ b/static/app/components/projects/missingProjectMembership.tsx
@@ -121,7 +121,7 @@ class MissingProjectMembership extends Component<Props, State> {
   getPendingTeamOption = (team: string) => {
     return {
       value: team,
-      label: <DisabledLabel>{t(`#${team}`)}</DisabledLabel>,
+      label: <DisabledLabel>{`#${team}`}</DisabledLabel>,
     };
   };
 
@@ -136,7 +136,7 @@ class MissingProjectMembership extends Component<Props, State> {
         label: t('Request Access'),
         options: this.getTeamsForAccess()[0].map(request => ({
           value: request,
-          label: t(`#${request}`),
+          label: `#${request}`,
         })),
       },
       {

--- a/static/app/components/replays/player/fastForwardBadge.tsx
+++ b/static/app/components/replays/player/fastForwardBadge.tsx
@@ -13,7 +13,7 @@ type Props = {
 function FastForwardBadge({speed, className}: Props) {
   return (
     <Badge className={className}>
-      <FastForwardTooltip title={t(`Fast forwarding at ${speed}x`)}>
+      <FastForwardTooltip title={t('Fast forwarding at %sx', speed)}>
         {t('Fast forwarding through inactivity')}
         <IconArrow size="sm" direction="right" />
       </FastForwardTooltip>

--- a/static/app/components/repositoryFileSummary.tsx
+++ b/static/app/components/repositoryFileSummary.tsx
@@ -64,11 +64,7 @@ class RepositoryFileSummary extends Component<Props, State> {
     return (
       <Container>
         <h5>
-          {tn(
-            '%s file changed in ' + repository,
-            '%s files changed in ' + repository,
-            fileCount
-          )}
+          {tn('%s file changed in %s', '%s files changed in %s', fileCount, repository)}
         </h5>
         <ListGroup striped>
           {files.map(filename => {

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -663,7 +663,7 @@ export class TokenConverter {
       this.config.supportedTags &&
       !this.config.supportedTags[key.text]
     ) {
-      return {reason: t(`Invalid key. "${key.text}" is not a supported search key.`)};
+      return {reason: t('Invalid key. "%s" is not a supported search key.', key.text)};
     }
 
     // Explicit tag keys will always be treated as text filters

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -331,7 +331,7 @@ function BaseGroupRow({
                   )}
 
                   <StyledMenuItem to={getDiscoverUrl()}>
-                    <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
+                    <MenuItemText>{t('Total in %s', summary)}</MenuItemText>
                     <MenuItemCount value={group.count} />
                   </StyledMenuItem>
 
@@ -387,7 +387,7 @@ function BaseGroupRow({
                 )}
 
                 <StyledMenuItem to={getDiscoverUrl()}>
-                  <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
+                  <MenuItemText>{t('Total in %s', summary)}</MenuItemText>
                   <MenuItemCount value={group.userCount} />
                 </StyledMenuItem>
 

--- a/static/app/components/superuserAccessForm.tsx
+++ b/static/app/components/superuserAccessForm.tsx
@@ -164,7 +164,7 @@ class SuperuserAccessForm extends Component<Props, State> {
         >
           {error && (
             <StyledAlert type="error" showIcon>
-              {t(errorType)}
+              {errorType}
             </StyledAlert>
           )}
           {showAccessForms && <Hook name="component:superuser-access-category" />}

--- a/static/app/components/u2f/u2finterface.tsx
+++ b/static/app/components/u2f/u2finterface.tsx
@@ -299,11 +299,10 @@ class U2fInterface extends Component<Props, State> {
               DUPLICATE_DEVICE: t('This device is already registered with Sentry.'),
               UNKNOWN_DEVICE: t('The device you used for sign-in is unknown.'),
               BAD_APPID: tct(
-                '[p1:The Sentry server administrator modified the ' +
-                  'device registrations.]' +
-                  '[p2:You need to remove and re-add the device to continue ' +
-                  'using your U2F device. Use a different sign-in method or ' +
-                  'contact [support] for assistance.]',
+                `[p1:The Sentry server administrator modified the device
+                 registrations.] [p2:You need to remove and re-add the device to continue using
+                 your U2F device. Use a different sign-in method or contact [support] for
+                 assistance.]`,
                 {
                   p1: <p />,
                   p2: <p />,

--- a/static/app/constants/superuserAccessErrors.tsx
+++ b/static/app/constants/superuserAccessErrors.tsx
@@ -1,3 +1,5 @@
+// TODO(epurkhiser): These can't be translated with `t()` because they're an
+// Enum. We should probably just use a regular map
 export enum ErrorCodes {
   invalidPassword = 'Incorrect password',
   invalidSSOSession = 'Your SSO Session has expired, please reauthenticate',

--- a/static/app/data/forms/organizationSecurityAndPrivacyGroups.tsx
+++ b/static/app/data/forms/organizationSecurityAndPrivacyGroups.tsx
@@ -23,9 +23,7 @@ export default [
         ),
         confirm: {
           true: t(
-            'This will remove all members without two-factor authentication' +
-              ' from your organization. It will also send them an email to setup 2FA' +
-              ' and reinstate their access and settings. Do you want to continue?'
+            'This will remove all members without two-factor authentication from your organization. It will also send them an email to setup 2FA and reinstate their access and settings. Do you want to continue?'
           ),
           false: t(
             'Are you sure you want to allow users to access your organization without having two-factor authentication enabled?'
@@ -40,9 +38,7 @@ export default [
         visible: ({features}) => features.has('required-email-verification'),
         confirm: {
           true: t(
-            'This will remove all members whose email addresses are not verified' +
-              ' from your organization. It will also send them an email to verify their address' +
-              ' and reinstate their access and settings. Do you want to continue?'
+            'This will remove all members whose email addresses are not verified from your organization. It will also send them an email to verify their address and reinstate their access and settings. Do you want to continue?'
           ),
           false: t(
             'Are you sure you want to allow users to access your organization without verifying their email address?'

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -122,8 +122,7 @@ export const fields: Record<string, Field> = {
     },
     saveOnBlur: false,
     saveMessage: tct(
-      '[strong:Caution]: Enabling auto resolve will immediately resolve anything that has ' +
-        'not been seen within this period of time. There is no undo!',
+      '[strong:Caution]: Enabling auto resolve will immediately resolve anything that has not been seen within this period of time. There is no undo!',
       {
         strong: <strong />,
       }

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -351,10 +351,10 @@ const storeConfig: GroupStoreDefinition = {
     const ids = this.itemIdsOrAll(itemIds);
 
     if (ids.length > 1) {
-      showAlert(t(`Deleted ${ids.length} Issues`), 'success');
+      showAlert(t('Deleted %d Issues', ids.length), 'success');
     } else {
       const shortId = ids.map(item => GroupStore.get(item)?.shortId).join('');
-      showAlert(t(`Deleted ${shortId}`), 'success');
+      showAlert(t('Deleted %s', shortId), 'success');
     }
 
     const itemIdSet = new Set(ids);
@@ -419,7 +419,7 @@ const storeConfig: GroupStoreDefinition = {
     );
 
     if (ids.length > 0) {
-      showAlert(t(`Merged ${ids.length} Issues`), 'success');
+      showAlert(t('Merged %d Issues', ids.length), 'success');
     }
 
     this.updateItems(ids);

--- a/static/app/utils/dashboards/issueFieldRenderers.tsx
+++ b/static/app/utils/dashboards/issueFieldRenderers.tsx
@@ -179,7 +179,7 @@ const issuesCountRenderer = (
               </Fragment>
             ) : null}
             <StyledLink to={discoverLink}>
-              {t(`Total in ${selectionDateString}`)}
+              {t('Total in %s', selectionDateString)}
               <WrappedCount value={count} />
             </StyledLink>
             <Divider />

--- a/static/app/views/acceptProjectTransfer.tsx
+++ b/static/app/views/acceptProjectTransfer.tsx
@@ -83,10 +83,7 @@ class AcceptProjectTransfer extends AsyncView<Props, State> {
         <SettingsPageHeader title={t('Approve Transfer Project Request')} />
         <p>
           {tct(
-            'Projects must be transferred to a specific [organization]. ' +
-              'You can grant specific teams access to the project later under the [projectSettings]. ' +
-              '(Note that granting access to at least one team is necessary for the project to ' +
-              'appear in all parts of the UI.)',
+            'Projects must be transferred to a specific [organization]. You can grant specific teams access to the project later under the [projectSettings]. (Note that granting access to at least one team is necessary for the project to appear in all parts of the UI.)',
             {
               organization: <strong>{t('Organization')}</strong>,
               projectSettings: <strong>{t('Project Settings')}</strong>,

--- a/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
+++ b/static/app/views/alerts/rules/issue/ticketRuleModal.tsx
@@ -202,9 +202,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     return (
       <BodyText>
         {tct(
-          'When this alert is triggered [ticketType] will be ' +
-            'created with the following fields. It will also [linkToDocs] ' +
-            'with the new Sentry Issue.',
+          'When this alert is triggered [ticketType] will be created with the following fields. It will also [linkToDocs] with the new Sentry Issue.',
           {
             linkToDocs: <ExternalLink href={link}>{t('stay in sync')}</ExternalLink>,
             ticketType,

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -505,7 +505,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
         !validTriggers && t('critical threshold'),
       ].filter(x => x);
 
-      addErrorMessage(t(`Alert not valid: missing %s`, missingFields.join(' ')));
+      addErrorMessage(t('Alert not valid: missing %s', missingFields.join(' ')));
       return;
     }
 

--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -546,7 +546,8 @@ class ColumnEditCollection extends Component<Props, State> {
     const title = canAdd
       ? undefined
       : t(
-          `Sorry, you've reached the maximum number of columns (${MAX_COL_COUNT}). Delete columns to add more.`
+          `Sorry, you've reached the maximum number of columns (%d). Delete columns to add more.`,
+          MAX_COL_COUNT
         );
 
     const singleColumn = columns.length === 1;

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -86,9 +86,13 @@ export function getConfirm({
     const question = allInQuerySelected
       ? getBulkConfirmMessage(`${action}${append}`, queryCount)
       : tn(
-          `Are you sure you want to ${action} this %s issue${append}?`,
-          `Are you sure you want to ${action} these %s issues${append}?`,
-          numIssues
+          // Use sprintf argument swapping since the number value must come
+          // first. See https://github.com/alexei/sprintf.js#argument-swapping
+          `Are you sure you want to %2$s this %s issue%3$s?`,
+          `Are you sure you want to %2$s these %s issues%3$s?`,
+          numIssues,
+          action,
+          append
         );
 
     let message: React.ReactNode;
@@ -146,12 +150,10 @@ export function getLabel(numIssues: number, allInQuerySelected: boolean) {
   return function (action: string, append = '') {
     const capitalized = capitalize(action);
     const text = allInQuerySelected
-      ? t(`Bulk ${action} issues`)
-      : tn(
-          `${capitalized} %s selected issue`,
-          `${capitalized} %s selected issues`,
-          numIssues
-        );
+      ? t('Bulk %s issues', action)
+      : // Use sprintf argument swapping to put the capitalized string first. See
+        // https://github.com/alexei/sprintf.js#argument-swapping
+        tn(`%2$s %s selected issue`, `%2$s %s selected issues`, numIssues, capitalized);
 
     return text + append;
   };

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -29,7 +29,7 @@ import QueryCount from 'sentry/components/queryCount';
 import {parseSearch} from 'sentry/components/searchSyntax/parser';
 import ProcessingIssueList from 'sentry/components/stream/processingIssueList';
 import {DEFAULT_QUERY, DEFAULT_STATS_PERIOD} from 'sentry/constants';
-import {t, tct} from 'sentry/locale';
+import {t, tct, tn} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {PageContent} from 'sentry/styles/organization';
 import {
@@ -1043,10 +1043,14 @@ class IssueListOverview extends Component<Props, State> {
 
     if (!isForReviewQuery(query)) {
       if (itemIds.length > 1) {
-        addMessage(t(`Reviewed ${itemIds.length} Issues`), 'success', {duration: 4000});
+        addMessage(
+          tn('Reviewed %s Issue', 'Reviewed %s Issues', itemIds.length),
+          'success',
+          {duration: 4000}
+        );
       } else {
         const shortId = itemIds.map(item => GroupStore.get(item)?.shortId).toString();
-        addMessage(t(`Reviewed ${shortId}`), 'success', {duration: 4000});
+        addMessage(t('Reviewed %s', shortId), 'success', {duration: 4000});
       }
       return;
     }
@@ -1085,13 +1089,13 @@ class IssueListOverview extends Component<Props, State> {
     actionType: 'Reviewed' | 'Resolved' | 'Ignored'
   ) => {
     if (itemIds.length > 1) {
-      addMessage(t(`${actionType} ${itemIds.length} Issues`), 'success', {
+      addMessage(`${actionType} ${itemIds.length} ${t('Issues')}`, 'success', {
         duration: 4000,
         ...(actionType !== 'Reviewed' && {undo: this.onUndo}),
       });
     } else {
       const shortId = itemIds.map(item => GroupStore.get(item)?.shortId).toString();
-      addMessage(t(`${actionType} ${shortId}`), 'success', {
+      addMessage(`${actionType} ${shortId}`, 'success', {
         duration: 4000,
         ...(actionType !== 'Reviewed' && {undo: this.onUndo}),
       });

--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -172,8 +172,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
           );
         if (deployedReleases.length === 1) {
           return tct(
-            '[author] marked this issue as resolved in [version] [break]' +
-              'This commit was released in [release]',
+            '[author] marked this issue as resolved in [version] [break]This commit was released in [release]',
             {
               author,
               version: (
@@ -196,12 +195,10 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
         }
         if (deployedReleases.length > 1) {
           return tct(
-            '[author] marked this issue as resolved in [version] [break]' +
-              'This commit was released in [release] and ' +
-              (deployedReleases.length - 1) +
-              ' others',
+            '[author] marked this issue as resolved in [version] [break]This commit was released in [release] and [otherCount] others',
             {
               author,
+              otherCount: deployedReleases.length - 1,
               version: (
                 <CommitLink
                   inline

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -332,7 +332,7 @@ class AbstractIntegrationDetailedView<
             className={this.state.tab === tabName ? 'active' : ''}
             onClick={() => this.onTabChange(tabName)}
           >
-            <CapitalizedLink>{t(this.getTabDisplay(tabName))}</CapitalizedLink>
+            <CapitalizedLink>{this.getTabDisplay(tabName)}</CapitalizedLink>
           </li>
         ))}
       </ul>
@@ -371,7 +371,7 @@ class AbstractIntegrationDetailedView<
             {this.resourceLinks.map(({title, url}) => (
               <ExternalLinkContainer key={url}>
                 {this.getIcon(title)}
-                <ExternalLink href={url}>{t(title)}</ExternalLink>
+                <ExternalLink href={url}>{title}</ExternalLink>
               </ExternalLinkContainer>
             ))}
           </Metadata>

--- a/static/app/views/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/organizationIntegrations/addIntegrationButton.tsx
@@ -26,7 +26,8 @@ export function AddIntegrationButton({
   modalParams,
   ...buttonProps
 }: AddIntegrationButtonProps) {
-  const label = buttonText || t(reinstall ? 'Enable' : 'Add %s', provider.metadata.noun);
+  const label =
+    buttonText ?? (reinstall ? t('Enable') : t('Add %s', provider.metadata.noun));
 
   return (
     <Tooltip

--- a/static/app/views/organizationIntegrations/integrationRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.tsx
@@ -203,7 +203,7 @@ const LearnMore = styled(Link)`
 type PublishStatusProps = {status: SentryApp['status']; theme?: any};
 
 const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
-  <div {...props}>{t(`${status}`)}</div>
+  <div {...props}>{status}</div>
 ))`
   color: ${(props: PublishStatusProps) =>
     props.status === 'published' ? props.theme.success : props.theme.gray300};

--- a/static/app/views/organizationIntegrations/integrationStatus.tsx
+++ b/static/app/views/organizationIntegrations/integrationStatus.tsx
@@ -2,7 +2,6 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import CircleIndicator from 'sentry/components/circleIndicator';
-import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {IntegrationInstallationStatus} from 'sentry/types';
 
@@ -23,7 +22,7 @@ const IntegrationStatus = styled(({status, ...p}: StatusProps) => {
   return (
     <StatusWrapper>
       <CircleIndicator size={6} color={theme[COLORS[status]]} />
-      <div {...p}>{`${t(status)}`}</div>
+      <div {...p}>{status}</div>
     </StatusWrapper>
   );
 })`

--- a/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -148,7 +148,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
     }
 
     if (!sentryApp.redirectUrl) {
-      addSuccessMessage(t(`${sentryApp.slug} successfully installed.`));
+      addSuccessMessage(t('%s successfully installed.', sentryApp.slug));
       this.setState({appInstalls: [install, ...this.state.appInstalls]});
 
       // hack for split so we can show the install ID to users for them to copy
@@ -177,7 +177,7 @@ class SentryAppDetailedView extends AbstractIntegrationDetailedView<
       );
       return this.setState({appInstalls});
     } catch (error) {
-      return addErrorMessage(t(`Unable to uninstall ${this.sentryApp.name}`));
+      return addErrorMessage(t('Unable to uninstall %s', this.sentryApp.name));
     }
   };
 

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -177,7 +177,7 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
                 headers={[
                   t('Project'),
                   ...statuses.map(action => (
-                    <AlignRight key={action}>{t(action)}</AlignRight>
+                    <AlignRight key={action}>{action}</AlignRight>
                   )),
                   <AlignRight key="total">
                     {t('total')}{' '}

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -182,7 +182,7 @@ export function PerformanceLanding(props: Props) {
 
             <TabList hideBorder>
               {LANDING_DISPLAYS.map(({label, field}) => (
-                <Item key={field}>{t(label)}</Item>
+                <Item key={field}>{label}</Item>
               ))}
             </TabList>
           </Layout.Header>

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -38,23 +38,23 @@ export enum LandingDisplayField {
 
 export const LANDING_DISPLAYS = [
   {
-    label: 'All Transactions',
+    label: t('All Transactions'),
     field: LandingDisplayField.ALL,
   },
   {
-    label: 'Web Vitals',
+    label: t('Web Vitals'),
     field: LandingDisplayField.FRONTEND_PAGELOAD,
   },
   {
-    label: 'Frontend',
+    label: t('Frontend'),
     field: LandingDisplayField.FRONTEND_OTHER,
   },
   {
-    label: 'Backend',
+    label: t('Backend'),
     field: LandingDisplayField.BACKEND,
   },
   {
-    label: 'Mobile',
+    label: t('Mobile'),
     field: LandingDisplayField.MOBILE,
   },
 ];

--- a/static/app/views/performance/landing/vitalsCards.tsx
+++ b/static/app/views/performance/landing/vitalsCards.tsx
@@ -466,7 +466,7 @@ function VitalCard(props: VitalCardProps) {
   return (
     <StyledCard interactive={!isNotInteractive} minHeight={minHeight}>
       <HeaderTitle>
-        <OverflowEllipsis>{t(title)}</OverflowEllipsis>
+        <OverflowEllipsis>{title}</OverflowEllipsis>
         <QuestionTooltip size="sm" position="top" title={tooltip} />
       </HeaderTitle>
       <CardContent horizontal={horizontal}>

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -66,7 +66,7 @@ function EventsContent(props: Props) {
   const transactionsListTitles = TRANSACTIONS_LIST_TITLES.slice();
 
   if (webVital) {
-    transactionsListTitles.splice(3, 0, t(webVital));
+    transactionsListTitles.splice(3, 0, webVital);
   }
 
   const spanOperationBreakdownConditions = filterToSearchConditions(
@@ -76,7 +76,7 @@ function EventsContent(props: Props) {
 
   if (spanOperationBreakdownConditions) {
     eventView.query = `${eventView.query} ${spanOperationBreakdownConditions}`.trim();
-    transactionsListTitles.splice(2, 1, t(`${spanOperationBreakdownFilter} duration`));
+    transactionsListTitles.splice(2, 1, t('%s duration', spanOperationBreakdownFilter));
   }
 
   if (organization.features.includes('session-replay-ui')) {

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -110,7 +110,7 @@ function TrendChart({
       <QuestionTooltip
         size="sm"
         position="top"
-        title={t(`Trends shows the smoothed value of an aggregate over time.`)}
+        title={t('Trends shows the smoothed value of an aggregate over time.')}
       />
     </HeaderTitleLegend>
   );

--- a/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
@@ -68,7 +68,7 @@ function UserMiseryChart({
       <QuestionTooltip
         size="sm"
         position="top"
-        title={t(getTermHelp(organization as Organization, PERFORMANCE_TERM.USER_MISERY))}
+        title={getTermHelp(organization as Organization, PERFORMANCE_TERM.USER_MISERY)}
       />
     </HeaderTitleLegend>
   );

--- a/static/app/views/performance/vitalDetail/utils.tsx
+++ b/static/app/views/performance/vitalDetail/utils.tsx
@@ -116,23 +116,27 @@ export function getVitalDetailTableMehStatusFunction(vitalName: WebVital): strin
 }
 
 export const vitalMap: Partial<Record<WebVital, string>> = {
-  [WebVital.FCP]: 'First Contentful Paint',
-  [WebVital.CLS]: 'Cumulative Layout Shift',
-  [WebVital.FID]: 'First Input Delay',
-  [WebVital.LCP]: 'Largest Contentful Paint',
+  [WebVital.FCP]: t('First Contentful Paint'),
+  [WebVital.CLS]: t('Cumulative Layout Shift'),
+  [WebVital.FID]: t('First Input Delay'),
+  [WebVital.LCP]: t('Largest Contentful Paint'),
 };
 
 export const vitalChartTitleMap = vitalMap;
 
 export const vitalDescription: Partial<Record<WebVital, string>> = {
-  [WebVital.FCP]:
-    'First Contentful Paint (FCP) measures the amount of time the first content takes to render in the viewport. Like FP, this could also show up in any form from the document object model (DOM), such as images, SVGs, or text blocks. At the moment, there is support for FCP in the following browsers:',
-  [WebVital.CLS]:
-    'Cumulative Layout Shift (CLS) is the sum of individual layout shift scores for every unexpected element shift during the rendering process. Imagine navigating to an article and trying to click a link before the page finishes loading. Before your cursor even gets there, the link may have shifted down due to an image rendering. Rather than using duration for this Web Vital, the CLS score represents the degree of disruptive and visually unstable shifts. At the moment, there is support for CLS in the following browsers:',
-  [WebVital.FID]:
-    'First Input Delay (FID) measures the response time when the user tries to interact with the viewport. Actions maybe include clicking a button, link or other custom Javascript controller. It is key in helping the user determine if a page is usable or not. At the moment, there is support for FID in the following browsers:',
-  [WebVital.LCP]:
-    'Largest Contentful Paint (LCP) measures the render time for the largest content to appear in the viewport. This may be in any form from the document object model (DOM), such as images, SVGs, or text blocks. It’s the largest pixel area in the viewport, thus most visually defining. LCP helps developers understand how long it takes to see the main content on the page. At the moment, there is support for LCP in the following browsers:',
+  [WebVital.FCP]: t(
+    'First Contentful Paint (FCP) measures the amount of time the first content takes to render in the viewport. Like FP, this could also show up in any form from the document object model (DOM), such as images, SVGs, or text blocks. At the moment, there is support for FCP in the following browsers:'
+  ),
+  [WebVital.CLS]: t(
+    'Cumulative Layout Shift (CLS) is the sum of individual layout shift scores for every unexpected element shift during the rendering process. Imagine navigating to an article and trying to click a link before the page finishes loading. Before your cursor even gets there, the link may have shifted down due to an image rendering. Rather than using duration for this Web Vital, the CLS score represents the degree of disruptive and visually unstable shifts. At the moment, there is support for CLS in the following browsers:'
+  ),
+  [WebVital.FID]: t(
+    'First Input Delay (FID) measures the response time when the user tries to interact with the viewport. Actions maybe include clicking a button, link or other custom Javascript controller. It is key in helping the user determine if a page is usable or not. At the moment, there is support for FID in the following browsers:'
+  ),
+  [WebVital.LCP]: t(
+    'Largest Contentful Paint (LCP) measures the render time for the largest content to appear in the viewport. This may be in any form from the document object model (DOM), such as images, SVGs, or text blocks. It’s the largest pixel area in the viewport, thus most visually defining. LCP helps developers understand how long it takes to see the main content on the page. At the moment, there is support for LCP in the following browsers:'
+  ),
 };
 
 export const vitalAbbreviations: Partial<Record<WebVital, string>> = {

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -93,7 +93,7 @@ function VitalChart({
           <QuestionTooltip
             size="sm"
             position="top"
-            title={t(`The durations shown should fall under the vital threshold.`)}
+            title={t('The durations shown should fall under the vital threshold.')}
           />
         </HeaderTitleLegend>
         <ChartZoom router={router} period={statsPeriod} start={start} end={end} utc={utc}>

--- a/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
@@ -86,7 +86,7 @@ function VitalChartMetrics({
           <QuestionTooltip
             size="sm"
             position="top"
-            title={t(`The durations shown should fall under the vital threshold.`)}
+            title={t('The durations shown should fall under the vital threshold.')}
           />
         </HeaderTitleLegend>
         <ChartZoom router={router} period={statsPeriod} start={start} end={end} utc={utc}>

--- a/static/app/views/performance/vitalDetail/vitalPercents.tsx
+++ b/static/app/views/performance/vitalDetail/vitalPercents.tsx
@@ -46,7 +46,7 @@ export default function VitalPercents(props: Props) {
       {props.percents.map(pct => (
         <VitalStatus data-test-id="vital-status" key={pct.vitalState}>
           {vitalStateIcons[pct.vitalState]}
-          {props.showVitalPercentNames && t(`${pct.vitalState}`)}{' '}
+          {props.showVitalPercentNames && pct.vitalState}{' '}
           {formatPercentage(pct.percent, 0)}
           {props.showVitalThresholds && getVitalStateText(props.vital, pct.vitalState)}
         </VitalStatus>

--- a/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/twoFactorRequired.tsx
@@ -10,8 +10,7 @@ const TwoFactorRequired = () =>
   !getPendingInvite() ? null : (
     <StyledAlert data-test-id="require-2fa" type="error" showIcon>
       {tct(
-        'You have been invited to an organization that requires [link:two-factor authentication].' +
-          ' Setup two-factor authentication below to join your organization.',
+        'You have been invited to an organization that requires [link:two-factor authentication]. Setup two-factor authentication below to join your organization.',
         {
           link: <ExternalLink href="https://docs.sentry.io/accounts/require-2fa/" />,
         }

--- a/static/app/views/settings/account/accountSecurity/components/u2fEnrolledDetails.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/u2fEnrolledDetails.tsx
@@ -78,7 +78,7 @@ const Device = props => {
               <Fragment>
                 <ConfirmHeader>{t('Do you want to remove U2F device?')}</ConfirmHeader>
                 <TextBlock>
-                  {t(`Are you sure you want to remove the U2F device "${device.name}"?`)}
+                  {t('Are you sure you want to remove the U2F device "%s"?', device.name)}
                 </TextBlock>
               </Fragment>
             }

--- a/static/app/views/settings/account/accountSecurity/index.tsx
+++ b/static/app/views/settings/account/accountSecurity/index.tsx
@@ -186,7 +186,8 @@ class AccountSecurity extends AsyncView<Props> {
                         {!isBackupInterface && isEnrolled && (
                           <Tooltip
                             title={t(
-                              `Two-factor authentication is required for organization(s): ${this.formatOrgSlugs()}.`
+                              `Two-factor authentication is required for organization(s): %s.`,
+                              this.formatOrgSlugs()
                             )}
                             disabled={!deleteDisabled}
                           >

--- a/static/app/views/settings/organizationApiKeys/index.tsx
+++ b/static/app/views/settings/organizationApiKeys/index.tsx
@@ -78,7 +78,7 @@ class OrganizationApiKeys extends AsyncView<Props, State> {
             routes: this.props.routes,
           })
         );
-        addSuccessMessage(t(`Created a new API key "${data.label}"`));
+        addSuccessMessage(t('Created a new API key "%s"', data.label));
       }
     } catch {
       this.setState({busy: false});

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -148,8 +148,8 @@ export default class PermissionSelection extends Component<Props, State> {
               name={`${config.resource}--permission`}
               key={config.resource}
               options={options}
-              help={t(config.help)}
-              label={t(config.label || config.resource)}
+              help={config.help}
+              label={config.label || config.resource}
               onChange={this.onChange.bind(this, config.resource)}
               value={value}
               defaultValue={value}

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/actionButtons.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/actionButtons.tsx
@@ -53,8 +53,8 @@ const ActionButtons = ({
   ) : null;
 
   const deleteConfirmMessage = t(
-    `Deleting ${app.slug} will also delete any and all of its installations. \
-         This is a permanent action. Do you wish to continue?`
+    `Deleting %s will also delete any and all of its installations. This is a permanent action. Do you wish to continue?`,
+    app.slug
   );
   const deleteButton = showDelete ? (
     disableDeleteReason ? (

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
@@ -6,7 +6,6 @@ import Link from 'sentry/components/links/link';
 import SentryAppPublishRequestModal from 'sentry/components/modals/sentryAppPublishRequestModal';
 import {PanelItem} from 'sentry/components/panels';
 import SentryAppIcon from 'sentry/components/sentryAppIcon';
-import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, SentryApp} from 'sentry/types';
 
@@ -111,7 +110,7 @@ type PublishStatusProps = {status: SentryApp['status']; theme?: any};
 
 const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
   <CenterFlex>
-    <div {...props}>{t(`${status}`)}</div>
+    <div {...props}>{status}</div>
   </CenterFlex>
 ))`
   color: ${(props: PublishStatusProps) =>

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import Checkbox from 'sentry/components/checkbox';
 import FeatureBadge from 'sentry/components/featureBadge';
 import Tooltip from 'sentry/components/tooltip';
-import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -61,12 +60,10 @@ export class SubscriptionBox extends Component<Props> {
           <SubscriptionGridItem disabled={disabled}>
             <SubscriptionInfo>
               <SubscriptionTitle>
-                {t(`${resource}`)}
+                {resource}
                 {isNew && <FeatureBadge type="new" />}
               </SubscriptionTitle>
-              <SubscriptionDescription>
-                {t(`${DESCRIPTIONS[resource]}`)}
-              </SubscriptionDescription>
+              <SubscriptionDescription>{DESCRIPTIONS[resource]}</SubscriptionDescription>
             </SubscriptionInfo>
             <Checkbox
               key={`${resource}${checked}`}

--- a/static/app/views/settings/organizationRepositories/organizationRepositories.tsx
+++ b/static/app/views/settings/organizationRepositories/organizationRepositories.tsx
@@ -36,9 +36,7 @@ function OrganizationRepositories({itemList, onRepositoryChange, params}: Props)
         <div className="m-b-2">
           <TextBlock>
             {t(
-              'Connecting a repository allows Sentry to capture commit data via webhooks. ' +
-                'This enables features like suggested assignees and resolving issues via commit message. ' +
-                "Once you've connected a repository, you can associate commits with releases via the API."
+              "Connecting a repository allows Sentry to capture commit data via webhooks. This enables features like suggested assignees and resolving issues via commit message. Once you've connected a repository, you can associate commits with releases via the API."
             )}
             &nbsp;
             {tct('See our [link:documentation] for more details.', {

--- a/static/app/views/settings/project/projectFilters/groupTombstones.tsx
+++ b/static/app/views/settings/project/projectFilters/groupTombstones.tsx
@@ -46,11 +46,7 @@ function GroupTombstoneRow({data, onUndiscard}: RowProps) {
       <ActionContainer>
         <Confirm
           message={t(
-            'Undiscarding this issue means that ' +
-              'incoming events that match this will no longer be discarded. ' +
-              'New incoming events will count toward your event quota ' +
-              'and will display on your issues dashboard. ' +
-              'Are you sure you wish to continue?'
+            'Undiscarding this issue means that incoming events that match this will no longer be discarded. New incoming events will count toward your event quota and will display on your issues dashboard. Are you sure you wish to continue?'
           )}
           onConfirm={() => onUndiscard(data.id)}
         >

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -121,7 +121,7 @@ class AddCodeOwnerModal extends AsyncComponent<Props, State> {
         if (err.responseJSON.raw) {
           this.setState({error: true, errorJSON: err.responseJSON, isLoading: false});
         } else {
-          addErrorMessage(t(Object.values(err.responseJSON).flat().join(' ')));
+          addErrorMessage(Object.values(err.responseJSON).flat().join(' '));
         }
       }
     }

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -360,7 +360,7 @@ tags.sku_class:enterprise #enterprise`;
                     {
                       name: 'codeownersAutoSync',
                       type: 'boolean',
-                      label: t(`Sync changes from CODEOWNERS`),
+                      label: t('Sync changes from CODEOWNERS'),
                       help: t(
                         'We’ll update any changes you make to your CODEOWNERS files during a release.'
                       ),

--- a/static/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/static/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -96,7 +96,10 @@ class OwnerInput extends Component<Props, State> {
           error.responseJSON.raw[0].startsWith('Invalid rule owners:')
         ) {
           addErrorMessage(
-            t('Unable to save issue ownership rule changes: ' + error.responseJSON.raw[0])
+            t(
+              'Unable to save issue ownership rule changes: %s',
+              error.responseJSON.raw[0]
+            )
           );
         } else {
           addErrorMessage(t('Unable to save issue ownership rule changes'));

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -119,9 +119,7 @@ class ProjectTeams extends AsyncView<Props, State> {
     const canCreateTeam = this.canCreateTeam();
     const hasAccess = organization.access.includes('project:write');
     const confirmRemove = t(
-      'This is the last team with access to this project. Removing it will mean ' +
-        'only organization owners and managers will be able to access the project pages. Are ' +
-        'you sure you want to remove this team from the project %s?',
+      'This is the last team with access to this project. Removing it will mean only organization owners and managers will be able to access the project pages. Are you sure you want to remove this team from the project %s?',
       params.projectId
     );
     const {projectTeams} = this.state;


### PR DESCRIPTION
The `t` function should ONLY accept static strings. Since the way
translations work is that we extract out the static string *at compile
time* (that is, when webpack is run with SENTRY_EXTRACT_TRANSLATIONS)
and use those strings as the keys for the translator.

 [!!] This means these strings CANNOT be dynamic! The translated string
      will not be able to be looked up if it is not a static string!

 Because of this interpolation MUST be done by using the
 sprintf style parameterization