### PR TITLE
fix: Use correct Laravel SDK name

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -41,7 +41,7 @@ ALLOWED_SDK_NAMES = frozenset(
         "sentry.ruby",  # Ruby
         "sentry.ruby.rails",  # Rails
         "sentry.php",  # PHP
-        "sentry.laravel",  # Laravel
+        "sentry.php.laravel",  # Laravel
     )
 )
 # We want sentry.java, sentry.java.spring, sentry.java.android, sentry.java.android.timber,


### PR DESCRIPTION
See https://github.com/getsentry/sentry-laravel/blob/0284f79aba670830caac892ae7dc5610f754da50/src/Sentry/Laravel/Version.php#L7