### PR TITLE
feat(mobile-exp): Resize screenshots to fit in viewport

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -130,6 +130,7 @@ const Value = styled(Label)`
 const StyledImageVisualization = styled(ImageVisualization)`
   img {
     border-radius: ${p => p.theme.borderRadius};
+    max-height: calc(100vh - 300px);
   }
 `;
 


### PR DESCRIPTION
In the mobile screenshot modal, the image. now takes up
100% of the viewport height - 300px for all the modal padding
and header content so the full image is always in view without
additional scrolling

