### PR TITLE
ref(event-contexts): Move feedback context entry to the top

### DIFF
--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -1,5 +1,4 @@
 import {Fragment} from 'react';
-import partition from 'lodash/partition';
 
 import {Group} from 'sentry/types';
 import {Event} from 'sentry/types/event';
@@ -15,21 +14,18 @@ type Props = {
 function Contexts({event, group}: Props) {
   const {user, contexts} = event;
 
-  const [feedbackContextKey, otherContextKeys] = partition(
-    Object.keys(contexts),
-    key => key === 'feedback'
-  );
+  const {feedback, ...otherContexts} = contexts;
 
   return (
     <Fragment>
-      {!!feedbackContextKey.length && (
+      {!objectIsEmpty(feedback) && (
         <Chunk
           key="feedback"
           type="feedback"
           alias="feedback"
           group={group}
           event={event}
-          value={contexts[feedbackContextKey[0]]}
+          value={feedback}
         />
       )}
       {user && !objectIsEmpty(user) && (
@@ -42,14 +38,14 @@ function Contexts({event, group}: Props) {
           value={user}
         />
       )}
-      {otherContextKeys.map(key => (
+      {Object.entries(otherContexts).map(([key, value]) => (
         <Chunk
           key={key}
-          type={contexts[feedbackContextKey[key]]?.type ?? ''}
+          type={value?.type ?? ''}
           alias={key}
           group={group}
           event={event}
-          value={contexts[feedbackContextKey[key]]}
+          value={value}
         />
       ))}
     </Fragment>

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import partition from 'lodash/partition';
 
 import {Group} from 'sentry/types';
 import {Event} from 'sentry/types/event';
@@ -14,8 +15,23 @@ type Props = {
 function Contexts({event, group}: Props) {
   const {user, contexts} = event;
 
+  const [feedbackContextKey, otherContextKeys] = partition(
+    Object.keys(contexts),
+    key => key === 'feedback'
+  );
+
   return (
     <Fragment>
+      {!!feedbackContextKey.length && (
+        <Chunk
+          key="feedback"
+          type="feedback"
+          alias="feedback"
+          group={group}
+          event={event}
+          value={contexts[feedbackContextKey[0]]}
+        />
+      )}
       {user && !objectIsEmpty(user) && (
         <Chunk
           key="user"
@@ -26,14 +42,14 @@ function Contexts({event, group}: Props) {
           value={user}
         />
       )}
-      {Object.entries(contexts).map(([key, value]) => (
+      {otherContextKeys.map(key => (
         <Chunk
           key={key}
-          type={value?.type ?? ''}
+          type={contexts[feedbackContextKey[key]]?.type ?? ''}
           alias={key}
           group={group}
           event={event}
-          value={value}
+          value={contexts[feedbackContextKey[key]]}
         />
       ))}
     </Fragment>

--- a/static/app/components/featureFeedback/feedbackModal.tsx
+++ b/static/app/components/featureFeedback/feedbackModal.tsx
@@ -108,7 +108,7 @@ export function FeedbackModal<T extends Data>({
   const handleSubmit = useCallback(
     (submitEventData?: Event) => {
       const commonEventProps: Event = {
-        message: `Feedback: ${props.featureName} feature`,
+        message: `${props.featureName} feedback by ${user.email}`,
         request: {
           url: location.pathname,
         },
@@ -129,8 +129,10 @@ export function FeedbackModal<T extends Data>({
         feedbackClient.captureEvent({
           ...commonEventProps,
           message: state.additionalInfo?.trim()
-            ? `Feedback: ${feedbackTypes[state.subject]} - ${state.additionalInfo}`
-            : `Feedback: ${feedbackTypes[state.subject]}`,
+            ? `${feedbackTypes[state.subject]} feedback by ${user.email} - ${
+                state.additionalInfo
+              }`
+            : `${feedbackTypes[state.subject]} feedback by ${user.email}`,
         });
       } else {
         feedbackClient.captureEvent({

--- a/static/app/components/featureFeedback/feedbackModal.tsx
+++ b/static/app/components/featureFeedback/feedbackModal.tsx
@@ -107,8 +107,10 @@ export function FeedbackModal<T extends Data>({
 
   const handleSubmit = useCallback(
     (submitEventData?: Event) => {
+      const message = `${props.featureName} feedback by ${user.email}`;
+
       const commonEventProps: Event = {
-        message: `${props.featureName} feedback by ${user.email}`,
+        message,
         request: {
           url: location.pathname,
         },
@@ -128,11 +130,14 @@ export function FeedbackModal<T extends Data>({
         const feedbackTypes = props.feedbackTypes ?? defaultFeedbackTypes;
         feedbackClient.captureEvent({
           ...commonEventProps,
+          contexts: {
+            feedback: {
+              additionalInfo: state.additionalInfo?.trim() ? state.additionalInfo : null,
+            },
+          },
           message: state.additionalInfo?.trim()
-            ? `${feedbackTypes[state.subject]} feedback by ${user.email} - ${
-                state.additionalInfo
-              }`
-            : `${feedbackTypes[state.subject]} feedback by ${user.email}`,
+            ? `${message} - ${feedbackTypes[state.subject]} - ${state.additionalInfo}`
+            : `${message} - ${feedbackTypes[state.subject]}`,
         });
       } else {
         feedbackClient.captureEvent({

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -384,6 +384,7 @@ type OSContext = {
 type EventContexts = {
   client_os?: OSContext;
   device?: DeviceContext;
+  feedback?: Record<string, any>;
   os?: OSContext;
   // TODO (udameli): add better types here
   // once perf issue data shape is more clear

--- a/static/app/views/settings/project/dynamicSampling/samplingFeedback.tsx
+++ b/static/app/views/settings/project/dynamicSampling/samplingFeedback.tsx
@@ -200,7 +200,7 @@ export function SamplingFeedback() {
               }
               submitEventData={{
                 contexts: {
-                  survey: {
+                  feedback: {
                     opinionAboutFeature: state.opinionAboutFeature || null,
                     tracingCapturingPriorities:
                       state.tracingCapturingPriorities


### PR DESCRIPTION
**What this PR does:**

Add logic to the contexts component to always render the entry with the `key` feedback first on the list. This is very useful for the `FeatureFeedback` events as the feedback will always be visible on the top.

One downside of this approach is that if a customer sends us a context with the same name, it will always be rendered before the user, but I guess this is fine as just the order is changed 



