### PR TITLE
fix(issue-alerts): paginate over groups instead of returning graph bu…

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -339,6 +339,7 @@ class Endpoint(APIView):
         cursor_cls=Cursor,
         response_cls=Response,
         response_kwargs=None,
+        count_hits=False,
         **paginator_kwargs,
     ):
         assert (paginator and not paginator_kwargs) or (paginator_cls and paginator_kwargs)
@@ -364,7 +365,12 @@ class Endpoint(APIView):
                 sentry_sdk.set_tag(
                     "query.per_page.grouped", format_grouped_length(per_page, [1, 10, 50, 100])
                 )
-                cursor_result = paginator.get_result(limit=per_page, cursor=input_cursor)
+                if isinstance(paginator, Paginator):
+                    cursor_result = paginator.get_result(
+                        limit=per_page, cursor=input_cursor, count_hits=count_hits
+                    )
+                else:
+                    cursor_result = paginator.get_result(limit=per_page, cursor=input_cursor)
         except BadPaginationError as e:
             raise ParseError(detail=str(e))
 

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -56,11 +56,6 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
             queryset=results,
             order_by="-id",
             on_results=lambda x: serialize(x, request.user),
+            count_hits=True,
         )
-
-        response.data = {
-            "data": response.data,
-            "totalCount": results.count(),
-        }
-
         return response

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -60,7 +60,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
 
         response.data = {
             "data": response.data,
-            "totalCount": len(results),
+            "totalCount": results.count(),
         }
 
         return response

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -30,7 +30,7 @@ def preview(
         return None
     # all the currently supported conditions are mutually exclusive
     elif len(conditions) > 1 and condition_match == "all":
-        return []
+        return Group.objects.none()
 
     activity = []
     for condition in conditions:

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Sequence
 
 from django.utils import timezone
 
+from sentry.db.models import BaseQuerySet
 from sentry.models import Group, Project
 from sentry.rules import rules
 
@@ -21,7 +22,7 @@ def preview(
     condition_match: str,
     filter_match: str,
     frequency_minutes: int,
-) -> Sequence[Group] | None:
+) -> BaseQuerySet | None:
     end = timezone.now()
     start = end - PREVIEW_TIME_RANGE
 
@@ -56,6 +57,4 @@ def preview(
             group_ids.add(event.group_id)
             last_fire = event.timestamp
 
-    # typing to satisfy mypy
-    results: Sequence[Group] = Group.objects.filter(id__in=group_ids)
-    return results
+    return Group.objects.filter(id__in=group_ids)

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -5,9 +5,8 @@ from typing import Any, Dict, Sequence
 
 from django.utils import timezone
 
-from sentry.models import Project
+from sentry.models import Group, Project
 from sentry.rules import rules
-from sentry.rules.history.base import TimeSeriesValue
 
 PREVIEW_TIME_RANGE = timedelta(weeks=2)
 # limit on number of ConditionActivity's a condition will return
@@ -22,18 +21,16 @@ def preview(
     condition_match: str,
     filter_match: str,
     frequency_minutes: int,
-) -> Sequence[TimeSeriesValue] | None:
+) -> Sequence[Group] | None:
     end = timezone.now()
     start = end - PREVIEW_TIME_RANGE
-    hours = get_hourly_bucket(PREVIEW_TIME_RANGE)
-    hourly_buckets = [0] * hours
 
     # must have at least one condition to filter activity. Filters currently not supported
     if len(conditions) == 0 or len(filters):
         return None
     # all the currently supported conditions are mutually exclusive
     elif len(conditions) > 1 and condition_match == "all":
-        return [TimeSeriesValue(start + timedelta(hours=i), 0) for i in range(hours)]
+        return []
 
     activity = []
     for condition in conditions:
@@ -52,18 +49,13 @@ def preview(
 
     frequency = timedelta(minutes=frequency_minutes)
     last_fire = start - frequency
+    group_ids = set()
     for event in activity:
         # TODO: check conditions and filters to see if event passes, not needed for just FirstSeenEventCondition
         if last_fire <= event.timestamp - frequency:
-            hourly_buckets[get_hourly_bucket(event.timestamp - start)] += 1
+            group_ids.add(event.group_id)
             last_fire = event.timestamp
 
-    times_series_buckets = [
-        TimeSeriesValue(start + timedelta(hours=i), count) for i, count in enumerate(hourly_buckets)
-    ]
-
-    return times_series_buckets
-
-
-def get_hourly_bucket(time: timedelta) -> int:
-    return time.days * 24 + time.seconds // (60 * 60)
+    # typing to satisfy mypy
+    results: Sequence[Group] = Group.objects.filter(id__in=group_ids)
+    return results

--- a/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
@@ -32,8 +32,8 @@ class ProjectRulePreviewEndpointTest(APITestCase):
             filterMatch="all",
             frequency=10,
         )
-        assert len(resp.data["data"]) == 1
-        assert resp.data["data"][0]["id"] == str(group.id)
+        assert len(resp.data) == 1
+        assert resp.data[0]["id"] == str(group.id)
 
     def test_invalid_conditions(self):
         conditions = [

--- a/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
@@ -18,7 +18,11 @@ class ProjectRulePreviewEndpointTest(APITestCase):
         self.login_as(self.user)
 
     def test(self):
-        Group.objects.create(project=self.project, first_seen=timezone.now() - timedelta(hours=1))
+        group = Group.objects.create(
+            project=self.project,
+            first_seen=timezone.now() - timedelta(hours=1),
+            data={"metadata": {"title": "title"}},
+        )
         resp = self.get_success_response(
             self.organization.slug,
             self.project.slug,
@@ -28,7 +32,8 @@ class ProjectRulePreviewEndpointTest(APITestCase):
             filterMatch="all",
             frequency=10,
         )
-        assert resp.data[-1]["count"] == 1
+        assert len(resp.data["data"]) == 1
+        assert resp.data["data"][0]["id"] == str(group.id)
 
     def test_invalid_conditions(self):
         conditions = [

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -4,64 +4,64 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from sentry.models import Activity, Group
-from sentry.rules.history.preview import PREVIEW_TIME_RANGE, get_hourly_bucket, preview
+from sentry.rules.history.preview import PREVIEW_TIME_RANGE, preview
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
+
+
+def get_hours(time: timedelta) -> int:
+    return time.days * 24 + time.seconds // (60 * 60)
 
 
 @freeze_time()
 @region_silo_test
 class ProjectRulePreviewTest(TestCase):
     def _set_up_first_seen(self):
-        hours = get_hourly_bucket(PREVIEW_TIME_RANGE)
+        hours = get_hours(PREVIEW_TIME_RANGE)
         for i in range(hours):
             for j in range(i % 5):
                 Group.objects.create(
                     project=self.project, first_seen=timezone.now() - timedelta(hours=i + 1)
                 )
-        return hours
 
     def _set_up_activity(self, condition_type):
-        hours = get_hourly_bucket(PREVIEW_TIME_RANGE)
+        hours = get_hours(PREVIEW_TIME_RANGE)
         for i in range(hours):
-            for j in range(i % 5):
-                Activity.objects.create(
-                    project=self.project,
-                    group=self.group,
-                    type=condition_type.value,
-                    datetime=timezone.now() - timedelta(hours=i + 1),
-                )
-        return hours
+            group = Group.objects.create(id=i, project=self.project)
+            Activity.objects.create(
+                project=self.project,
+                group=group,
+                type=condition_type.value,
+                datetime=timezone.now() - timedelta(hours=i + 1),
+            )
 
-    def _test_preview(self, hours, condition):
+    def _test_preview(self, condition, result1, result2):
         conditions = [{"id": condition}]
-        # test with 0 frequency, no fires should be filtered
         result = preview(self.project, conditions, [], "all", "all", 0)
-        for i in range(hours):
-            assert result[hours - i - 1].count == i % 5
+        assert len(result) == result1
 
-        # test with 60min frequency, there should be at most 1 fire per 60min bucket
-        result = preview(self.project, conditions, [], "all", "all", 60)
-        for i in range(hours):
-            assert result[i].count == (1 if i % 5 else 0)
+        result = preview(self.project, conditions, [], "all", "all", 120)
+        assert len(result) == result2
 
     def test_first_seen(self):
-        hours = self._set_up_first_seen()
+        self._set_up_first_seen()
         self._test_preview(
-            hours, "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
+            "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition", 670, 134
         )
 
     def test_regression(self):
-        hours = self._set_up_activity(ActivityType.SET_REGRESSION)
+        self._set_up_activity(ActivityType.SET_REGRESSION)
         self._test_preview(
-            hours, "sentry.rules.conditions.regression_event.RegressionEventCondition"
+            "sentry.rules.conditions.regression_event.RegressionEventCondition",
+            336,
+            168,
         )
 
     def test_reappeared(self):
-        hours = self._set_up_activity(ActivityType.SET_UNRESOLVED)
+        self._set_up_activity(ActivityType.SET_UNRESOLVED)
         self._test_preview(
-            hours, "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"
+            "sentry.rules.conditions.reappeared_event.ReappearedEventCondition", 336, 168
         )
 
     def test_unsupported_conditions(self):
@@ -98,5 +98,4 @@ class ProjectRulePreviewTest(TestCase):
         ]
 
         result = preview(self.project, mutually_exclusive, [], "all", "all", 60)
-        for bucket in result:
-            assert bucket.count == 0
+        assert len(result) == 0


### PR DESCRIPTION
Preview endpoint now returns the groups that would have triggered the rule instead of buckets for a graph. Looks like [this](https://github.com/getsentry/sentry/pull/40338) on the frontend.