### PR TITLE
feat(flamechart): allow copying of function name

### DIFF
--- a/static/app/components/profiling/ProfilingContextMenu/profilingContextMenu.tsx
+++ b/static/app/components/profiling/ProfilingContextMenu/profilingContextMenu.tsx
@@ -83,7 +83,9 @@ const MenuItemCheckbox = forwardRef(
 export {MenuItemCheckbox as ProfilingContextMenuItemCheckbox};
 
 interface MenuItemButtonProps
-  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {}
+  extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+  icon?: React.ReactNode;
+}
 
 const MenuItemButton = forwardRef(
   (props: MenuItemButtonProps, ref: React.Ref<HTMLDivElement> | undefined) => {
@@ -91,7 +93,10 @@ const MenuItemButton = forwardRef(
     return (
       <MenuContentOuterContainer>
         <MenuContentContainer ref={ref} role="menuitem" {...rest}>
-          <MenuButton>{children}</MenuButton>
+          {props.icon ? <MenuLeadingItem>{props.icon}</MenuLeadingItem> : null}
+          <MenuContent>
+            <MenuButton>{children}</MenuButton>
+          </MenuContent>
         </MenuContentContainer>
       </MenuContentOuterContainer>
     );

--- a/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
@@ -62,10 +62,7 @@ export function FlamegraphOptionsContextMenu(props: FlameGraphOptionsContextMenu
             <ProfilingContextMenuHeading>{t('Frame')}</ProfilingContextMenuHeading>
             <ProfilingContextMenuItemCheckbox
               {...props.contextMenu.getMenuItemProps({
-                onClick: () => {
-                  // We need to prevent the click from propagating to the context menu layer.
-                  props.onHighlightAllOccurencesClick();
-                },
+                onClick: props.onHighlightAllOccurencesClick,
               })}
               checked={props.isHighlightingAllOccurences}
             >

--- a/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
@@ -62,13 +62,11 @@ export function FlamegraphOptionsContextMenu(props: FlameGraphOptionsContextMenu
             <ProfilingContextMenuHeading>{t('Frame')}</ProfilingContextMenuHeading>
             <ProfilingContextMenuItemCheckbox
               {...props.contextMenu.getMenuItemProps({
-                onClick: props.onHighlightAllOccurencesClick,
+                onClick: () => {
+                  // We need to prevent the click from propagating to the context menu layer.
+                  props.onHighlightAllOccurencesClick();
+                },
               })}
-              onClick={e => {
-                // We need to prevent the click from propagating to the context menu layer.
-                e.preventDefault();
-                props.onHighlightAllOccurencesClick();
-              }}
               checked={props.isHighlightingAllOccurences}
             >
               {t('Highlight all occurrences')}
@@ -81,13 +79,6 @@ export function FlamegraphOptionsContextMenu(props: FlameGraphOptionsContextMenu
                   props.contextMenu.setOpen(false);
                 },
               })}
-              onClick={e => {
-                // We need to prevent the click from propagating to the context menu layer.
-                e.preventDefault();
-                props.onCopyFunctionNameClick();
-                // This is a button, so close the context menu.
-                props.contextMenu.setOpen(false);
-              }}
               icon={<IconCopy size="xs" />}
             >
               {t('Copy function name')}

--- a/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
+++ b/static/app/components/profiling/flamegraphOptionsContextMenu.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
 
+import {IconCopy} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {
   FlamegraphAxisOptions,
@@ -16,6 +17,7 @@ import {
   ProfilingContextMenu,
   ProfilingContextMenuGroup,
   ProfilingContextMenuHeading,
+  ProfilingContextMenuItemButton,
   ProfilingContextMenuItemCheckbox,
   ProfilingContextMenuLayer,
 } from './ProfilingContextMenu/profilingContextMenu';
@@ -35,6 +37,7 @@ interface FlameGraphOptionsContextMenuProps {
   contextMenu: ReturnType<typeof useContextMenu>;
   hoveredNode: FlamegraphFrame | null;
   isHighlightingAllOccurences: boolean;
+  onCopyFunctionNameClick: () => void;
   onHighlightAllOccurencesClick: () => void;
 }
 
@@ -70,6 +73,25 @@ export function FlamegraphOptionsContextMenu(props: FlameGraphOptionsContextMenu
             >
               {t('Highlight all occurrences')}
             </ProfilingContextMenuItemCheckbox>
+            <ProfilingContextMenuItemButton
+              {...props.contextMenu.getMenuItemProps({
+                onClick: () => {
+                  props.onCopyFunctionNameClick();
+                  // This is a button, so close the context menu.
+                  props.contextMenu.setOpen(false);
+                },
+              })}
+              onClick={e => {
+                // We need to prevent the click from propagating to the context menu layer.
+                e.preventDefault();
+                props.onCopyFunctionNameClick();
+                // This is a button, so close the context menu.
+                props.contextMenu.setOpen(false);
+              }}
+              icon={<IconCopy size="xs" />}
+            >
+              {t('Copy function name')}
+            </ProfilingContextMenuItemButton>
           </ProfilingContextMenuGroup>
         ) : null}
         <ProfilingContextMenuGroup>

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -720,6 +720,14 @@ function FlamegraphZoomView({
     ]);
   }, [canvasPoolManager, flamegraph, scheduler]);
 
+  const handleCopyFunctionName = useCallback(async () => {
+    if (!hoveredNodeOnContextMenuOpen.current) {
+      return;
+    }
+
+    await navigator.clipboard.writeText(hoveredNodeOnContextMenuOpen.current.frame.name);
+  }, []);
+
   return (
     <CanvasContainer>
       <Canvas
@@ -741,6 +749,7 @@ function FlamegraphZoomView({
         contextMenu={contextMenu}
         hoveredNode={hoveredNodeOnContextMenuOpen.current}
         isHighlightingAllOccurences={highlightingAllOccurences}
+        onCopyFunctionNameClick={handleCopyFunctionName}
         onHighlightAllOccurencesClick={handleHighlightAllFramesClick}
       />
       {flamegraphCanvas &&

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -2,6 +2,8 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {mat3, vec2} from 'gl-matrix';
 
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
@@ -720,12 +722,19 @@ function FlamegraphZoomView({
     ]);
   }, [canvasPoolManager, flamegraph, scheduler]);
 
-  const handleCopyFunctionName = useCallback(async () => {
+  const handleCopyFunctionName = useCallback(() => {
     if (!hoveredNodeOnContextMenuOpen.current) {
       return;
     }
 
-    await navigator.clipboard.writeText(hoveredNodeOnContextMenuOpen.current.frame.name);
+    navigator.clipboard
+      .writeText(hoveredNodeOnContextMenuOpen.current.frame.name)
+      .then(() => {
+        addSuccessMessage(t('Function name copied to clipboard'));
+      })
+      .catch(() => {
+        addErrorMessage(t('Failed to copy function name to clipboard'));
+      });
   }, []);
 
   return (

--- a/static/app/utils/profiling/hooks/useContextMenu.tsx
+++ b/static/app/utils/profiling/hooks/useContextMenu.tsx
@@ -69,7 +69,8 @@ export function useContextMenu({container}: UseContextMenuOptions) {
 
       return {
         ...menuItemProps,
-        onClick: () => {
+        onClick: (evt: React.MouseEvent) => {
+          evt.preventDefault();
           onClick?.();
         },
         onKeyDown: (evt: React.KeyboardEvent) => {

--- a/static/app/utils/profiling/hooks/useContextMenu.tsx
+++ b/static/app/utils/profiling/hooks/useContextMenu.tsx
@@ -69,6 +69,9 @@ export function useContextMenu({container}: UseContextMenuOptions) {
 
       return {
         ...menuItemProps,
+        onClick: () => {
+          onClick?.();
+        },
         onKeyDown: (evt: React.KeyboardEvent) => {
           if (evt.key === 'Escape') {
             wrapSetOpen(false);


### PR DESCRIPTION
Users were previously unable to easily copy function information which resulted in poor UX and forced users to manually copy the function name.

https://user-images.githubusercontent.com/9317857/197037065-1052ff11-57f3-4eb5-a3e9-08d6bf727cf9.mp4


While this does provide functionality to be able to copy the frame name, users may sometimes want to copy other frame information like binary/path/line/col which is still not possible. We should explore options to have a similar reverse link as we do with the table -> flamechart such that users that identify a frame on the flamechart can easily jump to that frame in the table view where the information can be copied from.

https://user-images.githubusercontent.com/9317857/197036947-2667e44e-46f1-489e-97e1-abbfcc9b43f6.mp4

