### PR TITLE
meta(vscode-config): Auto-fix fixable eslint issues on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
 
   "[javascript]": {
     "editor.formatOnSave": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,12 @@
     "*.jsx": "javascriptreact"
   },
 
+  // Apply fix all auto-fixable eslint problems on save
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
+
   "[javascript]": {
     "editor.formatOnSave": true,
     "editor.tabSize": 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,6 @@
     "*.jsx": "javascriptreact"
   },
 
-  // Apply fix all auto-fixable eslint problems on save
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },


### PR DESCRIPTION
Normally when coding I'll auto-import a bunch of things, but VSCode puts them at the bottom of the import list, then I'll manually run "Fix all auto-fixable Problems".

This changes the config to auto-fix those problems on save.