### PR TITLE
fix(reports): Remove personal statistics

### DIFF
--- a/src/sentry/web/frontend/debug/debug_performance_issue.py
+++ b/src/sentry/web/frontend/debug/debug_performance_issue.py
@@ -69,6 +69,6 @@ class DebugPerformanceIssueEmailView(View):
                 "commits": json.loads(COMMIT_EXAMPLE),
                 "transaction_data": [("Span Evidence", mark_safe(transaction_data), None)],
                 "issue_type": GROUP_TYPE_TO_TEXT.get(perf_group.issue_type, "Issue"),
-                "subtitle": get_performance_issue_alert_subtitle(self.event),
+                "subtitle": get_performance_issue_alert_subtitle(perf_event),
             },
         ).render(request)


### PR DESCRIPTION
We're no longer using personal statistics on weekly email, and it's causing some problems. Let's remove this.

Also fixed a bug that causes acceptance tests to fail.