### PR TITLE
chore(deps): Bump eslint-config-sentry-app

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "benchmark": "^2.1.4",
     "eslint": "8.25.0",
-    "eslint-config-sentry-app": "^1.100.0",
+    "eslint-config-sentry-app": "^1.104.0",
     "html-webpack-plugin": "^5.5.0",
     "jest": "29.2.0",
     "jest-canvas-mock": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6985,41 +6985,41 @@ eslint-config-prettier@^8.5.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
-eslint-config-sentry-app@^1.100.0:
-  version "1.100.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.100.0.tgz#377453edc4db835a245348c34c620120f3a466d2"
-  integrity sha512-pirOGzyTdOOY7fMDnmlNKcOHt8kcdZrHhZDC3pUA03SKatkaAyyctNmJBj6jBMn9yaV49fSWrsuo6DZDsVZTfA==
+eslint-config-sentry-app@^1.104.0:
+  version "1.104.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.104.0.tgz#e310b443e253643c5e65eab33f23df7ed9ae386d"
+  integrity sha512-S+G9t6sXdbsxc99Nfa+9ubAhBVes8hDLUFqMIXX7qHbfOkqSJ3Fy2C0NzWy5x/gJ0frI4RVOetcqdstmkuJGhA==
   dependencies:
     "@emotion/eslint-plugin" "^11.10.0"
     "@typescript-eslint/eslint-plugin" "^5.37.0"
     "@typescript-eslint/parser" "^5.37.0"
     eslint-config-prettier "^8.5.0"
-    eslint-config-sentry "^1.100.0"
-    eslint-config-sentry-react "^1.100.0"
+    eslint-config-sentry "^1.104.0"
+    eslint-config-sentry-react "^1.104.0"
     eslint-import-resolver-typescript "^2.7.1"
     eslint-import-resolver-webpack "^0.13.2"
     eslint-plugin-import "^2.26.0"
     eslint-plugin-jest "^27.0.4"
     eslint-plugin-prettier "^4.2.1"
     eslint-plugin-react "^7.31.8"
-    eslint-plugin-sentry "^1.100.0"
+    eslint-plugin-sentry "^1.104.0"
     eslint-plugin-simple-import-sort "^8.0.0"
 
-eslint-config-sentry-react@^1.100.0:
-  version "1.100.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.100.0.tgz#8e5e5b2b231990d4a7ead4283233fd15a0110116"
-  integrity sha512-m2pVnj/ahxXT7EYL18vi989hYxj889ln9lnibl9lQgOnn3R6/DfS5mwlRL40UdHLFX3LEaH0mEoFP/llWIb8ng==
+eslint-config-sentry-react@^1.104.0:
+  version "1.104.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.104.0.tgz#31a4cc8faa50af7fdf13126fbe5cc91c3684edcc"
+  integrity sha512-6ZMBEx6Da0QEpzdbzrJAwj3R9Y5a8AbsybenljLbUDGVxqJgon3pkSZdoBtKs/2JYCTtPD2a35jcSoi1kqa1lQ==
   dependencies:
-    eslint-config-sentry "^1.100.0"
+    eslint-config-sentry "^1.104.0"
     eslint-plugin-jest-dom "^4.0.2"
     eslint-plugin-react-hooks "^4.6.0"
     eslint-plugin-testing-library "^5.6.3"
     eslint-plugin-typescript-sort-keys "^2.1.0"
 
-eslint-config-sentry@^1.100.0:
-  version "1.100.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.100.0.tgz#02165aaf33fdabf9724dce9c082ddf42dc4409cb"
-  integrity sha512-4dirczJ863u3C+xFz3ae89xozumeP7Pkd8tyT27nXmmsd5ctxrcmr0MiM5y1d2xNTgA5llVTwAMMzT/8aUUrbA==
+eslint-config-sentry@^1.104.0:
+  version "1.104.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.104.0.tgz#2f6f9d53080aaf2ccd9b2b9f1b756297ba1812d0"
+  integrity sha512-CVGBSRPWySqz0R1OzKkxNyJJbaLgNbNBUusPOFOcYuqWzhZdsM71OVpbZEj0kjsz1ENWsAbZE1/A+YssZFjnCQ==
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
@@ -7131,10 +7131,10 @@ eslint-plugin-react@^7.31.8:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
-eslint-plugin-sentry@^1.100.0:
-  version "1.100.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.100.0.tgz#08a2de1fbf216163d5ece60811bb2702583b0840"
-  integrity sha512-K+mbWNyvadr8YBJUXn1tjV8eOQZSgQGWptjJ5seau8a/eFiuK9yTbDpW+hvf2ywvparoACAgUPdu8ylmR9AwhQ==
+eslint-plugin-sentry@^1.104.0:
+  version "1.104.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.104.0.tgz#92aabc6b92ba7b9bbb80a4e2e17dd42dba223ba3"
+  integrity sha512-Oxlk+q8pdt9+ALqVtIimBkZ3B+ZTlMuFvkLiNCLYnV+5OiJmfyjM1c7Ff1liOGqErq8BLoR+SMHQcVU8uJPR9A==
   dependencies:
     requireindex "~1.2.0"
 


### PR DESCRIPTION
This brings in the no-dynamic-translations rule, to stop us from
incorrectly using `t()`.