### PR TITLE
feat(ecosystem): Load integration repos in the background

### DIFF
--- a/static/app/views/organizationIntegrations/integrationRepos.spec.jsx
+++ b/static/app/views/organizationIntegrations/integrationRepos.spec.jsx
@@ -31,7 +31,6 @@ describe('IntegrationRepos', function () {
       });
 
       const wrapper = mountWithTheme(<IntegrationRepos integration={integration} />);
-      expect(wrapper.find('PanelBody')).toHaveLength(0);
       expect(wrapper.find('Alert')).toHaveLength(1);
     });
   });

--- a/static/app/views/organizationIntegrations/integrationRepos.tsx
+++ b/static/app/views/organizationIntegrations/integrationRepos.tsx
@@ -207,9 +207,9 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
         )}
 
         <Panel>
-          <PanelHeader disablePadding hasButtons>
-            <HeaderText>{t('Repositories')}</HeaderText>
-            <DropdownWrapper>{this.renderDropdown()}</DropdownWrapper>
+          <PanelHeader hasButtons>
+            <div>{t('Repositories')}</div>
+            <div>{this.renderDropdown()}</div>
           </PanelHeader>
           <PanelBody>
             {itemList.length === 0 && (
@@ -246,16 +246,6 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
 }
 
 export default withOrganization(IntegrationRepos);
-
-const HeaderText = styled('div')`
-  padding-left: ${space(2)};
-  flex: 1;
-`;
-
-const DropdownWrapper = styled('div')`
-  padding-right: ${space(1)};
-  text-transform: none;
-`;
 
 const StyledReposLabel = styled('div')`
   width: 250px;

--- a/static/app/views/organizationIntegrations/integrationRepos.tsx
+++ b/static/app/views/organizationIntegrations/integrationRepos.tsx
@@ -41,19 +41,17 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
       adding: false,
       itemList: [],
       integrationRepos: {repos: [], searchable: false},
-      dropdownBusy: false,
+      dropdownBusy: true,
     };
+  }
+
+  componentDidMount() {
+    this.searchRepositoriesRequest();
   }
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const orgId = this.props.organization.slug;
-    return [
-      ['itemList', `/organizations/${orgId}/repos/`, {query: {status: ''}}],
-      [
-        'integrationRepos',
-        `/organizations/${orgId}/integrations/${this.props.integration.id}/repos/`,
-      ],
-    ];
+    return [['itemList', `/organizations/${orgId}/repos/`, {query: {status: ''}}]];
   }
 
   getIntegrationRepos() {
@@ -82,7 +80,7 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
     200
   );
 
-  searchRepositoriesRequest = (searchQuery: string) => {
+  searchRepositoriesRequest = (searchQuery?: string) => {
     const orgId = this.props.organization.slug;
     const query = {search: searchQuery};
     const endpoint = `/organizations/${orgId}/integrations/${this.props.integration.id}/repos/`;
@@ -98,9 +96,9 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
     });
   };
 
-  handleSearchRepositories = (e: React.ChangeEvent<HTMLInputElement>) => {
+  handleSearchRepositories = (e?: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({dropdownBusy: true});
-    this.debouncedSearchRepositoriesRequest(e.target.value);
+    this.debouncedSearchRepositoriesRequest(e?.target.value);
   };
 
   addRepo(selection: {label: JSX.Element; searchKey: string; value: string}) {


### PR DESCRIPTION
Instead of showing the spinner until integration repos load, load them in the background and show the spinner inside the dropdown if it's still loading.

this is the page being changed
![image](https://user-images.githubusercontent.com/1400464/197077501-e6eda4ba-e4c6-4623-b7b5-3857b3e6802a.png)

fixes https://getsentry.atlassian.net/browse/WOR-2270
