### PR TITLE
feat(monitors): Record monitor failure

### DIFF
--- a/src/sentry/analytics/events/__init__.py
+++ b/src/sentry/analytics/events/__init__.py
@@ -34,6 +34,7 @@ from .join_request_link_viewed import *  # noqa: F401,F403
 from .manual_issue_assignment import *  # noqa: F401,F403
 from .member_invited import *  # noqa: F401,F403
 from .metric_alert_with_ui_component_created import *  # noqa: F401,F403
+from .monitor_mark_failed import *  # noqa: F401,F403
 from .notifications_settings_updated import *  # noqa: F401,F403
 from .onboarding_continuation_sent import *  # noqa: F401,F403
 from .organization_created import *  # noqa: F401,F403

--- a/src/sentry/analytics/events/monitor_mark_failed.py
+++ b/src/sentry/analytics/events/monitor_mark_failed.py
@@ -1,0 +1,14 @@
+from sentry import analytics
+
+
+class MonitorMarkFailed(analytics.Event):
+    type = "monitor.mark_failed"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("monitor_id"),
+        analytics.Attribute("project_id"),
+    )
+
+
+analytics.register(MonitorMarkFailed)

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -31,6 +31,7 @@ from sentry.signals import (
     issue_unignored,
     issue_unresolved,
     member_joined,
+    monitor_failed,
     ownership_rule_created,
     plugin_enabled,
     project_created,
@@ -625,6 +626,16 @@ def record_issue_deleted(group, user, delete_type, **kwargs):
         organization_id=group.project.organization_id,
         group_id=group.id,
         delete_type=delete_type,
+    )
+
+
+@monitor_failed.connect(weak=False)
+def record_monitor_failure(monitor, **kwargs):
+    analytics.record(
+        "monitor.mark_failed",
+        organization_id=monitor.organization_id,
+        monitor_id=monitor.guid,
+        project_id=monitor.project_id,
     )
 
 


### PR DESCRIPTION
Record when a monitor is marked as failed. Also needed to verify if monitors are being marked as failed properly in production.