### PR TITLE
feat(monitors): Add onboarding panel when no checkin present

### DIFF
--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -9,6 +9,7 @@ import MonitorCheckIns from './monitorCheckIns';
 import MonitorHeader from './monitorHeader';
 import MonitorIssues from './monitorIssues';
 import MonitorStats from './monitorStats';
+import MonitorOnboarding from './onboarding';
 import {Monitor} from './types';
 
 type Props = AsyncView['props'] &
@@ -48,6 +49,8 @@ class MonitorDetails extends AsyncView<Props, State> {
           orgId={this.props.params.orgId}
           onUpdate={this.onUpdate}
         />
+
+        {!monitor.lastCheckIn && <MonitorOnboarding monitor={monitor} />}
 
         <MonitorStats monitor={monitor} />
 

--- a/static/app/views/monitors/onboarding.tsx
+++ b/static/app/views/monitors/onboarding.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+
+import {CodeSnippet} from 'sentry/components/codeSnippet';
+import ExternalLink from 'sentry/components/links/externalLink';
+import List from 'sentry/components/list';
+import ListItem from 'sentry/components/list/listItem';
+import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+
+import {Monitor} from './types';
+
+type Props = {
+  monitor: Monitor;
+};
+
+const MonitorOnboarding = ({monitor}: Props) => {
+  const checkInUrl = `https://sentry.io/api/0/monitors/${monitor.id}/checkins/`;
+
+  return (
+    <Panel>
+      <PanelHeader>{t('How to instrument monitors')}</PanelHeader>
+      <PanelBody withPadding>
+        <List symbol="bullet">
+          <StyledListItem>
+            <OnboardingText>
+              {t('To report on the status of a job make POST requests using ')}
+              <ExternalLink href="https://docs.sentry.io/api/auth/#dsn-authentication">
+                {t('DSN authentication')}
+              </ExternalLink>
+            </OnboardingText>
+            <CodeSnippet language="text" hideActionBar>
+              {`POST ${checkInUrl}`}
+            </CodeSnippet>
+          </StyledListItem>
+          <StyledListItem>
+            <OnboardingText>
+              {t(
+                'Supply one of the following bodies to the request depending on the job status to be reported'
+              )}
+            </OnboardingText>
+            <OnboardingText>
+              {t('For the start of a job')}
+              <CodeSnippet language="json" hideActionBar>
+                {`{ status: "in_progress" }`}
+              </CodeSnippet>
+            </OnboardingText>
+            <OnboardingText>
+              {t('For job completion with optional duration in milliseconds')}
+              <CodeSnippet language="json" hideActionBar>
+                {`{ status: "ok", duration: 3000 }`}
+              </CodeSnippet>
+            </OnboardingText>
+            <OnboardingText>
+              {t('For a job failure with optional duration in milliseconds')}
+              <CodeSnippet language="json" hideActionBar>
+                {`{ status: "error", duration: 3000 }`}
+              </CodeSnippet>
+            </OnboardingText>
+          </StyledListItem>
+        </List>
+      </PanelBody>
+    </Panel>
+  );
+};
+
+const OnboardingText = styled('p')`
+  font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const StyledListItem = styled(ListItem)`
+  margin-bottom: ${space(2)};
+`;
+
+export default MonitorOnboarding;

--- a/static/app/views/monitors/onboarding.tsx
+++ b/static/app/views/monitors/onboarding.tsx
@@ -24,9 +24,14 @@ const MonitorOnboarding = ({monitor}: Props) => {
         <List symbol="bullet">
           <StyledListItem>
             <OnboardingText>
-              {tct('To report on the status of a job make POST requests using [linkDocs:DSN authentication]', {
-                    linkDocs:  <ExternalLink href="https://docs.sentry.io/api/auth/#dsn-authentication" />
-              })}
+              {tct(
+                'To report on the status of a job make POST requests using [linkDocs:DSN authentication]',
+                {
+                  linkDocs: (
+                    <ExternalLink href="https://docs.sentry.io/api/auth/#dsn-authentication" />
+                  ),
+                }
+              )}
             </OnboardingText>
             <CodeSnippet language="text" hideActionBar>
               {`POST ${checkInUrl}`}

--- a/static/app/views/monitors/onboarding.tsx
+++ b/static/app/views/monitors/onboarding.tsx
@@ -36,25 +36,25 @@ const MonitorOnboarding = ({monitor}: Props) => {
           <StyledListItem>
             <OnboardingText>
               {t(
-                'Supply one of the following bodies to the request depending on the job status to be reported'
+                'Supply one of the following JSON bodies to the POST request depending on the job status to be reported'
               )}
             </OnboardingText>
             <OnboardingText>
               {t('For the start of a job')}
               <CodeSnippet language="json" hideActionBar>
-                {`{ status: "in_progress" }`}
+                {`{ "status": "in_progress" }`}
               </CodeSnippet>
             </OnboardingText>
             <OnboardingText>
               {t('For job completion with optional duration in milliseconds')}
               <CodeSnippet language="json" hideActionBar>
-                {`{ status: "ok", duration: 3000 }`}
+                {`{ "status": "ok", "duration": 3000 }`}
               </CodeSnippet>
             </OnboardingText>
             <OnboardingText>
               {t('For a job failure with optional duration in milliseconds')}
               <CodeSnippet language="json" hideActionBar>
-                {`{ status: "error", duration: 3000 }`}
+                {`{ "status": "error", "duration": 3000 }`}
               </CodeSnippet>
             </OnboardingText>
           </StyledListItem>

--- a/static/app/views/monitors/onboarding.tsx
+++ b/static/app/views/monitors/onboarding.tsx
@@ -24,10 +24,9 @@ const MonitorOnboarding = ({monitor}: Props) => {
         <List symbol="bullet">
           <StyledListItem>
             <OnboardingText>
-              {t('To report on the status of a job make POST requests using ')}
-              <ExternalLink href="https://docs.sentry.io/api/auth/#dsn-authentication">
-                {t('DSN authentication')}
-              </ExternalLink>
+              {tct('To report on the status of a job make POST requests using [linkDocs:DSN authentication]', {
+                    linkDocs:  <ExternalLink href="https://docs.sentry.io/api/auth/#dsn-authentication" />
+              })}
             </OnboardingText>
             <CodeSnippet language="text" hideActionBar>
               {`POST ${checkInUrl}`}

--- a/static/app/views/monitors/onboarding.tsx
+++ b/static/app/views/monitors/onboarding.tsx
@@ -5,7 +5,7 @@ import ExternalLink from 'sentry/components/links/externalLink';
 import List from 'sentry/components/list';
 import ListItem from 'sentry/components/list/listItem';
 import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 
 import {Monitor} from './types';


### PR DESCRIPTION
Simple monitors onboarding panel which is shown for new monitors or monitors with no checkins reported.

Eventually when monitors is rolling out to a larger audience I would move this to our public docs and link into it from here.

<img width="1176" alt="image" src="https://user-images.githubusercontent.com/9372512/198115874-7ca8b480-6533-411d-9ddb-408b67e196db.png">
