### PR TITLE
ref(rabbitmq): delete post_process_performance queue for OPS-2465

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -661,8 +661,6 @@ CELERY_QUEUES = [
     Queue("options", routing_key="options"),
     Queue("post_process_errors", routing_key="post_process_errors"),
     Queue("post_process_transactions", routing_key="post_process_transactions"),
-    # TODO(rjo100): to be removed after post_process_transactions is set up
-    Queue("post_process_performance", routing_key="post_process_performance"),
     Queue("relay_config", routing_key="relay_config"),
     Queue("relay_config_bulk", routing_key="relay_config_bulk"),
     Queue("reports.deliver", routing_key="reports.deliver"),


### PR DESCRIPTION

Now that the`post_process_transactions` queue has a workergroup set up (see https://github.com/getsentry/ops/pull/5507), it's safe to remove the old `post_process_performance` queue.
