### PR TITLE
fix(replays): Update "Slowest Transaction" column tooltip copy

### DIFF
--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -119,7 +119,7 @@ function ReplayTable({
           size="xs"
           position="top"
           title={t(
-            'Slowest single instance of this transactiono captured by this session.'
+            'Slowest single instance of this transaction captured by this session.'
           )}
         />
       </Header>

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -119,7 +119,7 @@ function ReplayTable({
           size="xs"
           position="top"
           title={t(
-            'The duration of the slowest transaction operation that was recorded during the replay session.'
+            'Slowest single instance of this transactiono captured by this session.'
           )}
         />
       </Header>


### PR DESCRIPTION
Updated copy (without extra `o`):

<img width="1204" alt="Screen Shot 2022-10-21 at 9 06 43 AM" src="https://user-images.githubusercontent.com/187460/197240413-d4be69fb-ea17-4881-b180-e4b3cc2916a1.png">
