### PR TITLE
fix(slack): Handle no group

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -43,7 +43,7 @@ def build_attachment_title(obj: Group | Event) -> str:
 
     else:
         group = getattr(obj, "group", obj)
-        if group and group.issue_category == GroupCategory.PERFORMANCE:
+        if group.issue_category == GroupCategory.PERFORMANCE:
             title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
         else:
             title = obj.title

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -43,7 +43,7 @@ def build_attachment_title(obj: Group | Event) -> str:
 
     else:
         group = getattr(obj, "group", obj)
-        if group.issue_category == GroupCategory.PERFORMANCE:
+        if group and group.issue_category == GroupCategory.PERFORMANCE:
             title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
         else:
             title = obj.title

--- a/src/sentry/integrations/slack/unfurl/issues.py
+++ b/src/sentry/integrations/slack/unfurl/issues.py
@@ -46,7 +46,11 @@ def unfurl_issues(
             group = group_by_id[issue_id]
             # lookup the event by the id
             event_id = link.args["event_id"]
-            event = eventstore.get_event_by_id(group.project_id, event_id) if event_id else None
+            event = (
+                eventstore.get_event_by_id(group.project_id, event_id, group.id)
+                if event_id
+                else None
+            )
             out[link.url] = build_group_attachment(
                 group_by_id[issue_id], event=event, link_to_event=True
             )


### PR DESCRIPTION
Check that a group exists before getting an attribute on it.
Fixes [SENTRY-W93](https://sentry.io/organizations/sentry/issues/3680069085/?project=1&referrer=slack)