### PR TITLE
fix(ui): More robust solution for updating hovercard position when content changes

### DIFF
--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -1,7 +1,8 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment, useCallback, useRef} from 'react';
 import {createPortal} from 'react-dom';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {useResizeObserver} from '@react-aria/utils';
 import {AnimatePresence} from 'framer-motion';
 
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
@@ -40,6 +41,67 @@ interface HovercardProps extends Omit<UseHoverOverlayProps, 'isHoverable'> {
   tipColor?: ColorOrAlias;
 }
 
+type UseOverOverlayState = ReturnType<typeof useHoverOverlay>;
+
+interface HovercardContentProps
+  extends Pick<
+    HovercardProps,
+    'bodyClassName' | 'className' | 'header' | 'body' | 'tipColor' | 'tipBorderColor'
+  > {
+  hoverOverlayState: Omit<UseOverOverlayState, 'isOpen' | 'wrapTrigger'>;
+}
+
+function useUpdateOverlayPositionOnContentChange({
+  update,
+}: Pick<UseOverOverlayState, 'update'>) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  const onResize = useCallback(() => {
+    update?.();
+  }, [update]);
+
+  useResizeObserver({
+    ref,
+    onResize,
+  });
+
+  return ref;
+}
+
+function HovercardContent({
+  body,
+  bodyClassName,
+  className,
+  tipBorderColor,
+  tipColor,
+  header,
+  hoverOverlayState: {arrowData, arrowProps, overlayProps, placement, update},
+}: HovercardContentProps) {
+  const theme = useTheme();
+  const ref = useUpdateOverlayPositionOnContentChange({update});
+
+  return (
+    <PositionWrapper zIndex={theme.zIndex.hovercard} {...overlayProps}>
+      <StyledHovercard
+        animated
+        arrowProps={{
+          ...arrowProps,
+          size: 20,
+          background: tipColor,
+          border: tipBorderColor,
+        }}
+        originPoint={arrowData}
+        placement={placement}
+        className={className}
+        ref={ref}
+      >
+        {header ? <Header>{header}</Header> : null}
+        {body ? <Body className={bodyClassName}>{body}</Body> : null}
+      </StyledHovercard>
+    </PositionWrapper>
+  );
+}
+
 function Hovercard({
   body,
   bodyClassName,
@@ -53,23 +115,13 @@ function Hovercard({
   tipColor = 'backgroundElevated',
   ...hoverOverlayProps
 }: HovercardProps): React.ReactElement {
-  const theme = useTheme();
-  const {wrapTrigger, isOpen, overlayProps, placement, arrowData, arrowProps, update} =
-    useHoverOverlay('hovercard', {
-      offset,
-      displayTimeout,
-      isHoverable: true,
-      className: containerClassName,
-      ...hoverOverlayProps,
-    });
-
-  // Changes to header and body can change the size of the overlay content
-  // which can result in the popper state being out of date
-  useEffect(() => {
-    if (isOpen) {
-      update?.();
-    }
-  }, [isOpen, update, header, body]);
+  const {wrapTrigger, isOpen, ...hoverOverlayState} = useHoverOverlay('hovercard', {
+    offset,
+    displayTimeout,
+    isHoverable: true,
+    className: containerClassName,
+    ...hoverOverlayProps,
+  });
 
   // Nothing to render if no header or body. Be consistent with wrapping the
   // children with the trigger in the case that the body / header is set while
@@ -78,30 +130,27 @@ function Hovercard({
     return <Fragment>{wrapTrigger(children)}</Fragment>;
   }
 
-  const hovercardContent = isOpen && (
-    <PositionWrapper zIndex={theme.zIndex.hovercard} {...overlayProps}>
-      <StyledHovercard
-        animated
-        arrowProps={{
-          ...arrowProps,
-          size: 20,
-          background: tipColor,
-          border: tipBorderColor,
-        }}
-        originPoint={arrowData}
-        placement={placement}
-        className={className}
-      >
-        {header ? <Header>{header}</Header> : null}
-        {body ? <Body className={bodyClassName}>{body}</Body> : null}
-      </StyledHovercard>
-    </PositionWrapper>
-  );
-
   return (
     <Fragment>
       {wrapTrigger(children)}
-      {createPortal(<AnimatePresence>{hovercardContent}</AnimatePresence>, document.body)}
+      {createPortal(
+        <AnimatePresence>
+          {isOpen && (
+            <HovercardContent
+              {...{
+                body,
+                bodyClassName,
+                className,
+                tipBorderColor,
+                tipColor,
+                header,
+                hoverOverlayState,
+              }}
+            />
+          )}
+        </AnimatePresence>,
+        document.body
+      )}
     </Fragment>
   );
 }

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -130,27 +130,24 @@ function Hovercard({
     return <Fragment>{wrapTrigger(children)}</Fragment>;
   }
 
+  const hovercardContent = isOpen && (
+    <HovercardContent
+      {...{
+        body,
+        bodyClassName,
+        className,
+        tipBorderColor,
+        tipColor,
+        header,
+        hoverOverlayState,
+      }}
+    />
+  );
+
   return (
     <Fragment>
       {wrapTrigger(children)}
-      {createPortal(
-        <AnimatePresence>
-          {isOpen && (
-            <HovercardContent
-              {...{
-                body,
-                bodyClassName,
-                className,
-                tipBorderColor,
-                tipColor,
-                header,
-                hoverOverlayState,
-              }}
-            />
-          )}
-        </AnimatePresence>,
-        document.body
-      )}
+      {createPortal(<AnimatePresence>{hovercardContent}</AnimatePresence>, document.body)}
     </Fragment>
   );
 }

--- a/static/app/components/overlay.tsx
+++ b/static/app/components/overlay.tsx
@@ -93,33 +93,38 @@ function computeOriginFromArrow(
  * `<AnimatePresence />`.
  */
 const Overlay = styled(
-  ({
-    children,
-    arrowProps,
-    animated,
-    placement,
-    originPoint,
-    style,
-    overlayStyle: _overlayStyle,
-    ...props
-  }: OverlayProps) => {
-    const animationProps = animated
-      ? {
-          ...overlayAnimation,
-          style: {
-            ...style,
-            ...computeOriginFromArrow(placement, originPoint),
-          },
-        }
-      : {style};
+  forwardRef<HTMLDivElement, OverlayProps>(
+    (
+      {
+        children,
+        arrowProps,
+        animated,
+        placement,
+        originPoint,
+        style,
+        overlayStyle: _overlayStyle,
+        ...props
+      },
+      ref
+    ) => {
+      const animationProps = animated
+        ? {
+            ...overlayAnimation,
+            style: {
+              ...style,
+              ...computeOriginFromArrow(placement, originPoint),
+            },
+          }
+        : {style};
 
-    return (
-      <motion.div {...props} {...animationProps}>
-        {defined(arrowProps) && <OverlayArrow {...arrowProps} />}
-        {children}
-      </motion.div>
-    );
-  }
+      return (
+        <motion.div {...props} {...animationProps} ref={ref}>
+          {defined(arrowProps) && <OverlayArrow {...arrowProps} />}
+          {children}
+        </motion.div>
+      );
+    }
+  )
 )`
   position: relative;
   border-radius: ${p => p.theme.borderRadius};


### PR DESCRIPTION
Uses useResizeObserver to update the overlay position when the header/body size changes, which previously wasn't always updating frequently enough.

The issue tooltips are where I've noticed it, since they have a loading state. Here you can see that the tooltip should be centered on the text, but is not:

![image](https://user-images.githubusercontent.com/10888943/197249137-9485a469-1028-4ccf-938a-262a169c957c.png)
