### PR TITLE
fix(copy): events -> all events

### DIFF
--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -270,7 +270,7 @@ function GroupHeader({
           {t('Tags')}
         </Item>
         <Item key={Tab.EVENTS} disabled={disabledTabs.includes(Tab.EVENTS)}>
-          {t('Events')}
+          {t('All Events')}
         </Item>
       </StyledTabList>
     );


### PR DESCRIPTION
Renamed `Events` tab in Issue Details to `All Events` to keep Error/Performance tabs consistent.


## Before

<img width="551" alt="CleanShot 2022-10-21 at 11 32 55@2x" src="https://user-images.githubusercontent.com/1900676/197265612-93ac2025-1ab0-49a0-90c8-68678ffc8c09.png">

## After

<img width="537" alt="CleanShot 2022-10-21 at 11 33 03@2x" src="https://user-images.githubusercontent.com/1900676/197265976-daeb70ab-603d-46ad-a87d-31e556911561.png">

