### PR TITLE
fix(ui): Ensure that SmartSearchBar expands to fit long content [UP-188]

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1899,7 +1899,7 @@ export default withApi(withRouter(withOrganization(SmartSearchBarContainer)));
 export {SmartSearchBar, Props as SmartSearchBarProps};
 
 const Container = styled('div')<{inputHasFocus: boolean}>`
-  height: ${p => p.theme.form.md.height}px;
+  min-height: ${p => p.theme.form.md.height}px;
   border: 1px solid ${p => p.theme.border};
   box-shadow: inset ${p => p.theme.dropShadowLight};
   background: ${p => p.theme.background};


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/10888943/197267451-7377bc61-07f7-4414-a347-2cf2b0d8521d.png)

After: 

![image](https://user-images.githubusercontent.com/10888943/197267378-1dfc4995-6ebd-4b1e-8e67-70cc4fc6e68a.png)
