### PR TITLE
fix(profiling): Do not proxy project objects to profiling

### DIFF
--- a/src/sentry/profiles/utils.py
+++ b/src/sentry/profiles/utils.py
@@ -84,6 +84,9 @@ def get_from_profiling_service(
         params = {
             key: value.isoformat() if isinstance(value, datetime) else value
             for key, value in params.items()
+            # do not want to proxy the project_objects to the profiling service
+            # this make the query param unnecessarily large
+            if key != "project_objects"
         }
         path = f"{path}?{urlencode(params, doseq=True)}"
     if headers:


### PR DESCRIPTION
Not sure if this will fix the issue but we were passing the project objects to the params which was serialized as a bunch of strings in the query params. This made the query params unnecessarily long.