### PR TITLE
(fix)e2e: Set report self hosted issues to false

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -34,6 +34,8 @@ steps:
     timeout: 300s
   - name: 'gcr.io/$PROJECT_ID/docker-compose'
     id: get-self-hosted-repo
+    env:
+      - 'REPORT_SELF_HOSTED_ISSUES=0'
     waitFor: ['-']
     entrypoint: 'bash'
     args:
@@ -41,7 +43,6 @@ steps:
       - '-c'
       - |
         mkdir self-hosted && cd self-hosted
-        echo "no" > .reporterrors
         curl -L "https://github.com/getsentry/self-hosted/archive/master.tar.gz" | tar xzf - --strip-components=1
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
   - name: 'gcr.io/$PROJECT_ID/docker-compose'


### PR DESCRIPTION
the .reporterrors file is deprecated, use env variable `REPORT_SELF_HOSTED_ISSUES` instead
