### PR TITLE
fix(replays): Sort replay index table from largest-to-smallest first

### DIFF
--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.spec.tsx
@@ -392,7 +392,7 @@ describe('GroupReplays', () => {
     expect(mockRouterContext.context.router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/replays/',
       query: {
-        sort: 'duration',
+        sort: '-duration',
       },
     });
 
@@ -401,7 +401,7 @@ describe('GroupReplays', () => {
       getComponent({
         location: {
           query: {
-            sort: 'duration',
+            sort: '-duration',
           },
         },
       })
@@ -413,7 +413,7 @@ describe('GroupReplays', () => {
         mockUrl,
         expect.objectContaining({
           query: expect.objectContaining({
-            sort: 'duration',
+            sort: '-duration',
           }),
         })
       );
@@ -448,7 +448,7 @@ describe('GroupReplays', () => {
     expect(mockRouterContext.context.router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/replays/',
       query: {
-        sort: 'countErrors',
+        sort: '-countErrors',
       },
     });
 
@@ -457,7 +457,7 @@ describe('GroupReplays', () => {
       getComponent({
         location: {
           query: {
-            sort: 'countErrors',
+            sort: '-countErrors',
           },
         },
       })
@@ -469,7 +469,7 @@ describe('GroupReplays', () => {
         mockUrl,
         expect.objectContaining({
           query: expect.objectContaining({
-            sort: 'countErrors',
+            sort: '-countErrors',
           }),
         })
       );

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -357,7 +357,7 @@ describe('TransactionReplays', () => {
     expect(mockRouterContext.context.router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/replays/',
       query: {
-        sort: 'duration',
+        sort: '-duration',
         project: '1',
         transaction: 'transaction',
       },
@@ -369,7 +369,7 @@ describe('TransactionReplays', () => {
         getComponent({
           location: {
             query: {
-              sort: 'duration',
+              sort: '-duration',
               project: '1',
               transaction: 'transaction',
             },
@@ -384,7 +384,7 @@ describe('TransactionReplays', () => {
         mockUrl,
         expect.objectContaining({
           query: expect.objectContaining({
-            sort: 'duration',
+            sort: '-duration',
           }),
         })
       );
@@ -419,7 +419,7 @@ describe('TransactionReplays', () => {
     expect(mockRouterContext.context.router.push).toHaveBeenCalledWith({
       pathname: '/organizations/org-slug/replays/',
       query: {
-        sort: 'countErrors',
+        sort: '-countErrors',
         project: '1',
         transaction: 'transaction',
       },
@@ -431,7 +431,7 @@ describe('TransactionReplays', () => {
         getComponent({
           location: {
             query: {
-              sort: 'countErrors',
+              sort: '-countErrors',
               project: '1',
               transaction: 'transaction',
             },
@@ -446,7 +446,7 @@ describe('TransactionReplays', () => {
         mockUrl,
         expect.objectContaining({
           query: expect.objectContaining({
-            sort: 'countErrors',
+            sort: '-countErrors',
           }),
         })
       );

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -78,7 +78,11 @@ function SortableHeader({
         pathname: location.pathname,
         query: {
           ...location.query,
-          sort: sort.kind === 'desc' ? fieldName : '-' + fieldName,
+          sort: sort.field.endsWith(fieldName)
+            ? sort.kind === 'desc'
+              ? fieldName
+              : '-' + fieldName
+            : '-' + fieldName,
         },
       }}
     >


### PR DESCRIPTION
When I open the Replay Index page the data is sorted by Start Time, newest (largest timestamp) to oldest (smaller timestamp). The sort arrow is pointing _down_.

Clicking to sort other columns, like `duration` or `errors` should sort in the same direction by default. 

Previously changing columns would invert the existing sort direction, instead of resetting to descending by default.

Fixes #40409