### PR TITLE
fix(ecosystem): Lowercase repos in add repo dropdown

### DIFF
--- a/static/app/views/organizationIntegrations/integrationRepos.tsx
+++ b/static/app/views/organizationIntegrations/integrationRepos.tsx
@@ -209,7 +209,7 @@ class IntegrationRepos extends AsyncComponent<Props, State> {
         <Panel>
           <PanelHeader hasButtons>
             <div>{t('Repositories')}</div>
-            <div>{this.renderDropdown()}</div>
+            <DropdownWrapper>{this.renderDropdown()}</DropdownWrapper>
           </PanelHeader>
           <PanelBody>
             {itemList.length === 0 && (
@@ -252,6 +252,10 @@ const StyledReposLabel = styled('div')`
   font-size: 0.875em;
   padding: ${space(1)} 0;
   text-transform: uppercase;
+`;
+
+const DropdownWrapper = styled('div')`
+  text-transform: none;
 `;
 
 const StyledListElement = styled('div')`


### PR DESCRIPTION
Fixes repos being in all uppercase in the add repo dropdown.

![image](https://user-images.githubusercontent.com/1400464/197295676-d2a5392d-5ee7-41c4-91c3-eeb1425946f5.png)
