### PR TITLE
fix(replays): Do not render older index responses that are replaced

### DIFF
--- a/static/app/utils/replays/fetchReplayList.tsx
+++ b/static/app/utils/replays/fetchReplayList.tsx
@@ -43,6 +43,14 @@ async function fetchReplayList({
   location,
   eventView,
 }: Props): Promise<Result> {
+  if (!eventView.project.length) {
+    return {
+      fetchError: undefined,
+      isFetching: false,
+      pageLinks: null,
+      replays: [],
+    };
+  }
   try {
     const path = `/organizations/${organization.slug}/replays/`;
 

--- a/static/app/utils/replays/fetchReplayList.tsx
+++ b/static/app/utils/replays/fetchReplayList.tsx
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/react';
+import type {Location} from 'history';
 
+import type {Client} from 'sentry/api';
+import type {Organization} from 'sentry/types';
+import type EventView from 'sentry/utils/discover/eventView';
 import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
 import type RequestError from 'sentry/utils/requestError/requestError';
 import type {ReplayListRecord} from 'sentry/views/replays/types';
@@ -26,12 +30,19 @@ type State = {
 
 type Result = State;
 
+type Props = {
+  api: Client;
+  eventView: EventView;
+  location: Location;
+  organization: Organization;
+};
+
 async function fetchReplayList({
   api,
   organization,
   location,
   eventView,
-}): Promise<Result> {
+}: Props): Promise<Result> {
   try {
     const path = `/organizations/${organization.slug}/replays/`;
 


### PR DESCRIPTION
Add an AbortController so that when updated props appear we only update state with the most recent response. Older requests will not hijack the page.

For example, we may have an in-flight request but then something causes `location` to change, resulting in a new index request. If the 2nd request is fast it may complete before the 1st. We want to abort the 1st request in that case and not update state.

| Before | After |
| --- | --- |
| <img width="150" alt="Screen Shot 2022-10-21 at 4 45 23 PM" src="https://user-images.githubusercontent.com/187460/197305832-d2464d22-c704-4c74-9858-0dfc3339367c.png"> | <img width="150" alt="Screen Shot 2022-10-21 at 4 45 54 PM" src="https://user-images.githubusercontent.com/187460/197305837-342daa13-a459-4dc4-8dfc-215af5bf3755.png"> |

Fixes #39252