### PR TITLE
ref(typing): update typing in rule processing to use GroupEvent

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import Any, Callable, Mapping, Sequence
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.integrations.slack.message_builder import SLACK_URL_FORMAT
 from sentry.models import Group, Project, Rule, Team, User
 from sentry.notifications.notifications.base import BaseNotification
@@ -31,7 +31,7 @@ def format_actor_option(actor: Team | User) -> Mapping[str, str]:
     raise NotImplementedError
 
 
-def build_attachment_title(obj: Group | Event) -> str:
+def build_attachment_title(obj: Group | GroupEvent) -> str:
     ev_metadata = obj.get_event_metadata()
     ev_type = obj.get_event_type()
 
@@ -55,7 +55,7 @@ def build_attachment_title(obj: Group | Event) -> str:
 
 def get_title_link(
     group: Group,
-    event: Event | None,
+    event: GroupEvent | None,
     link_to_event: bool,
     issue_details: bool,
     notification: BaseNotification | None,
@@ -78,7 +78,7 @@ def get_title_link(
     return url_str
 
 
-def build_attachment_text(group: Group, event: Event | None = None) -> Any | None:
+def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any | None:
     # Group and Event both implement get_event_{type,metadata}
     obj = event if event is not None else group
     ev_metadata = obj.get_event_metadata()

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Generator, Sequence
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.integrations.slack.actions.form import SlackNotifyServiceForm
 from sentry.integrations.slack.client import SlackClient
 from sentry.integrations.slack.message_builder.issues import build_group_attachment
@@ -37,7 +37,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             "tags": {"type": "string", "placeholder": "i.e environment,user,my_tag"},
         }
 
-    def after(self, event: Event, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
         channel = self.get_option("channel_id")
         tags = set(self.get_tags_list())
 
@@ -47,7 +47,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             # Integration removed, rule still active.
             return
 
-        def send_notification(event: Event, futures: Sequence[RuleFuture]) -> None:
+        def send_notification(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             rules = [f.rule for f in futures]
             attachments = [build_group_attachment(event.group, event=event, tags=tags, rules=rules)]
             # getsentry might add a billing related attachment

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -6,7 +6,7 @@ from django.core.cache import cache
 from sentry_relay import parse_release
 
 from sentry import tagstore
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.integrations.message_builder import (
     build_attachment_text,
     build_attachment_title,
@@ -208,12 +208,12 @@ def build_actions(
     return [resolve_button, ignore_button, assign_button], text, color
 
 
-def get_timestamp(group: Group, event: Event | None) -> float:
+def get_timestamp(group: Group, event: GroupEvent | None) -> float:
     ts = group.last_seen
     return to_timestamp(max(ts, event.datetime) if event else ts)
 
 
-def get_color(event_for_tags: Event | None, notification: BaseNotification | None) -> str:
+def get_color(event_for_tags: GroupEvent | None, notification: BaseNotification | None) -> str:
     if notification:
         if not isinstance(notification, AlertRuleNotification):
             return "info"
@@ -230,7 +230,7 @@ class SlackIssuesMessageBuilder(SlackMessageBuilder):
     def __init__(
         self,
         group: Group,
-        event: Event | None = None,
+        event: GroupEvent | None = None,
         tags: set[str] | None = None,
         identity: Identity | None = None,
         actions: Sequence[MessageAction] | None = None,
@@ -300,7 +300,7 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
     def __init__(
         self,
         group: Group,
-        event: Event | None = None,
+        event: GroupEvent | None = None,
         tags: set[str] | None = None,
         identity: Identity | None = None,
         actions: Sequence[MessageAction] | None = None,
@@ -397,7 +397,7 @@ class SlackReleaseIssuesMessageBuilder(SlackMessageBuilder):
 
 def build_group_attachment(
     group: Group,
-    event: Event | None = None,
+    event: GroupEvent | None = None,
     tags: set[str] | None = None,
     identity: Identity | None = None,
     actions: Sequence[MessageAction] | None = None,

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -4,7 +4,7 @@ import abc
 import logging
 from typing import Generator
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.rules.base import CallbackFuture, EventState, RuleBase
 
 logger = logging.getLogger("sentry.rules")
@@ -14,7 +14,7 @@ class EventAction(RuleBase, abc.ABC):
     rule_type = "action/event"
 
     @abc.abstractmethod
-    def after(self, event: Event, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
         """
         Executed after a Rule matches.
 

--- a/src/sentry/rules/actions/integrations/create_ticket/base.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 from typing import Any, Generator, Mapping
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.models import Integration
 from sentry.rules.actions.integrations.base import IntegrationEventAction
 from sentry.rules.actions.integrations.create_ticket.form import IntegrationNotifyServiceForm
@@ -80,7 +80,7 @@ class TicketEventAction(IntegrationEventAction, abc.ABC):
     def generate_footer(self, rule_url: str) -> str:
         pass
 
-    def after(self, event: Event, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
         integration_id = self.get_integration_id()
         key = f"{self.provider}:{integration_id}"
         yield self.future(

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -6,7 +6,7 @@ from typing import Callable, Sequence
 from rest_framework.response import Response
 
 from sentry.constants import ObjectStatus
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.integrations import IntegrationInstallation
 from sentry.models import ExternalIssue, GroupLink, Integration
 from sentry.types.rules import RuleFuture
@@ -17,7 +17,7 @@ logger = logging.getLogger("sentry.rules")
 def create_link(
     integration: Integration,
     installation: IntegrationInstallation,
-    event: Event,
+    event: GroupEvent,
     response: Response,
 ) -> None:
     """
@@ -49,7 +49,7 @@ def create_link(
 
 
 def build_description(
-    event: Event,
+    event: GroupEvent,
     rule_id: int,
     installation: IntegrationInstallation,
     generate_footer: Callable[[str], str],
@@ -66,7 +66,7 @@ def build_description(
     return description
 
 
-def create_issue(event: Event, futures: Sequence[RuleFuture]) -> None:
+def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
     """Create an issue for a given event"""
     organization = event.group.project.organization
 

--- a/src/sentry/rules/actions/notify_event.py
+++ b/src/sentry/rules/actions/notify_event.py
@@ -1,6 +1,6 @@
 from typing import Generator, Sequence
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.plugins.base import plugins
 from sentry.rules import EventState
 from sentry.rules.actions.base import EventAction
@@ -32,7 +32,7 @@ class NotifyEventAction(EventAction):
 
         return results
 
-    def after(self, event: Event, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
         group = event.group
 
         for plugin_ in self.get_plugins():

--- a/src/sentry/rules/actions/notify_event_service.py
+++ b/src/sentry/rules/actions/notify_event_service.py
@@ -10,7 +10,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.app_platform_event import AppPlatformEvent
 from sentry.api.serializers.models.incident import IncidentSerializer
 from sentry.constants import SentryAppInstallationStatus
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.incidents.models import (
     INCIDENT_STATUS,
     AlertRuleTriggerAction,
@@ -171,7 +171,7 @@ class NotifyEventServiceAction(EventAction):
             return f"(Legacy) {title}"
         return title
 
-    def after(self, event: Event, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
         service = self.get_option("service")
 
         extra = {"event_id": event.event_id}

--- a/src/sentry/rules/actions/sentry_apps/notify_event.py
+++ b/src/sentry/rules/actions/sentry_apps/notify_event.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.sentry_app_component import SentryAppAlertRuleActionSerializer
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.models import Project, SentryApp, SentryAppComponent, SentryAppInstallation
 from sentry.rules import EventState
 from sentry.rules.actions.sentry_apps import SentryAppEventAction
@@ -40,7 +40,7 @@ class NotifyEventSentryAppAction(SentryAppEventAction):
     # Required field for EventAction, value is ignored
     label = ""
 
-    def _get_sentry_app(self, event: Event) -> SentryApp | None:
+    def _get_sentry_app(self, event: GroupEvent) -> SentryApp | None:
         extra = {"event_id": event.event_id}
 
         sentry_app_installation_uuid = self.get_option("sentryAppInstallationUuid")
@@ -139,7 +139,7 @@ class NotifyEventSentryAppAction(SentryAppEventAction):
                 f"Unexpected setting(s) '{extra_keys_string}' configured for {sentry_app.name}"
             )
 
-    def after(self, event: Event, state: EventState) -> Generator[CallbackFuture, None, None]:
+    def after(self, event: GroupEvent, state: EventState) -> Generator[CallbackFuture, None, None]:
         sentry_app = self._get_sentry_app(event)
         yield self.future(
             notify_sentry_app,

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, MutableMapping, Sequence, Type
 
 from django import forms
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.models import Project, Rule
 from sentry.types.rules import RuleFuture
 
@@ -97,7 +97,7 @@ class RuleBase(abc.ABC):
 
     def future(
         self,
-        callback: Callable[[Event, Sequence[RuleFuture]], None],
+        callback: Callable[[GroupEvent, Sequence[RuleFuture]], None],
         key: str | None = None,
         **kwargs: Any,
     ) -> CallbackFuture:

--- a/src/sentry/rules/conditions/active_release.py
+++ b/src/sentry/rules/conditions/active_release.py
@@ -4,7 +4,7 @@ from typing import Optional
 from django.db.models import DateTimeField
 from django.utils import timezone
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.models import Deploy, Release, ReleaseEnvironment, ReleaseProjectEnvironment
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
@@ -14,7 +14,7 @@ class ActiveReleaseEventCondition(EventCondition):
     id = "sentry.rules.conditions.active_release.ActiveReleaseEventCondition"
     label = "A new issue is created within an active release (1 hour of deployment)"
 
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         if self.rule and self.rule.environment_id is None:
             return (state.is_new or state.is_regression) and self.is_in_active_release(event)
         else:
@@ -23,7 +23,7 @@ class ActiveReleaseEventCondition(EventCondition):
             ) and self.is_in_active_release(event)
 
     @staticmethod
-    def latest_release(event: Event) -> Optional[Release]:
+    def latest_release(event: GroupEvent) -> Optional[Release]:
         return Release.objects.filter(
             organization_id=event.project.organization_id,
             projects__id=event.project_id,
@@ -31,7 +31,7 @@ class ActiveReleaseEventCondition(EventCondition):
         ).first()
 
     @staticmethod
-    def is_in_active_release(event: Event) -> bool:
+    def is_in_active_release(event: GroupEvent) -> bool:
         if not event.group:
             return False
 

--- a/src/sentry/rules/conditions/base.py
+++ b/src/sentry/rules/conditions/base.py
@@ -2,7 +2,7 @@ import abc
 from datetime import datetime
 from typing import Sequence
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.rules.base import EventState, RuleBase
 from sentry.types.condition_activity import ConditionActivity
 
@@ -11,7 +11,7 @@ class EventCondition(RuleBase, abc.ABC):
     rule_type = "condition/event"
 
     @abc.abstractmethod
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         pass
 
     def get_activity(

--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -2,7 +2,7 @@ from typing import Any, Sequence
 
 from django import forms
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.rules import MATCH_CHOICES, EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
 
@@ -66,7 +66,7 @@ class EventAttributeCondition(EventCondition):
         "value": {"type": "string", "placeholder": "value"},
     }
 
-    def _get_attribute_values(self, event: Event, attr: str) -> Sequence[str]:
+    def _get_attribute_values(self, event: GroupEvent, attr: str) -> Sequence[str]:
         # TODO(dcramer): we should validate attributes (when we can) before
         path = attr.split(".")
 
@@ -176,7 +176,7 @@ class EventAttributeCondition(EventCondition):
         }
         return self.label.format(**data)
 
-    def passes(self, event: Event, state: EventState, **kwargs: Any) -> bool:
+    def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
         attr = self.get_option("attribute")
         match = self.get_option("match")
         value = self.get_option("value")

--- a/src/sentry/rules/conditions/every_event.py
+++ b/src/sentry/rules/conditions/every_event.py
@@ -1,4 +1,4 @@
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
 
@@ -7,7 +7,7 @@ class EveryEventCondition(EventCondition):
     id = "sentry.rules.conditions.every_event.EveryEventCondition"
     label = "The event occurs"
 
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         return True
 
     def is_enabled(self) -> bool:

--- a/src/sentry/rules/conditions/first_seen_event.py
+++ b/src/sentry/rules/conditions/first_seen_event.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Sequence
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.models import Group
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
@@ -12,7 +12,7 @@ class FirstSeenEventCondition(EventCondition):
     id = "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"
     label = "A new issue is created"
 
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         # TODO(mgaeta): Bug: Rule is optional.
         if self.rule.environment_id is None:  # type: ignore
             return state.is_new

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Tuple
 from django import forms
 
 from sentry.constants import LOG_LEVELS, LOG_LEVELS_MAP
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.rules import LEVEL_MATCH_CHOICES as MATCH_CHOICES
 from sentry.rules import EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
@@ -28,7 +28,7 @@ class LevelCondition(EventCondition):
         "match": {"type": "choice", "choices": list(MATCH_CHOICES.items())},
     }
 
-    def passes(self, event: Event, state: EventState, **kwargs: Any) -> bool:
+    def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
         desired_level_raw = self.get_option("level")
         desired_match = self.get_option("match")
 

--- a/src/sentry/rules/conditions/reappeared_event.py
+++ b/src/sentry/rules/conditions/reappeared_event.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Sequence
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.models import Activity
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
@@ -13,7 +13,7 @@ class ReappearedEventCondition(EventCondition):
     id = "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"
     label = "The issue changes state from ignored to unresolved"
 
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         return state.has_reappeared
 
     def get_activity(

--- a/src/sentry/rules/conditions/regression_event.py
+++ b/src/sentry/rules/conditions/regression_event.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Sequence
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.models import Activity
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition
@@ -13,7 +13,7 @@ class RegressionEventCondition(EventCondition):
     id = "sentry.rules.conditions.regression_event.RegressionEventCondition"
     label = "The issue changes state from resolved to unresolved"
 
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         return state.is_regression
 
     def get_activity(

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -5,7 +5,7 @@ from typing import Any
 from django import forms
 
 from sentry import tagstore
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.rules import MATCH_CHOICES, EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
 
@@ -38,7 +38,7 @@ class TaggedEventCondition(EventCondition):
         "value": {"type": "string", "placeholder": "value"},
     }
 
-    def passes(self, event: Event, state: EventState, **kwargs: Any) -> bool:
+    def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
         key = self.get_option("key")
         match = self.get_option("match")
         value = self.get_option("value")

--- a/src/sentry/rules/filters/age_comparison.py
+++ b/src/sentry/rules/filters/age_comparison.py
@@ -5,7 +5,7 @@ from typing import Sequence, Tuple
 from django import forms
 from django.utils import timezone
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.rules import EventState
 from sentry.rules.filters.base import EventFilter
 
@@ -55,7 +55,7 @@ class AgeComparisonFilter(EventFilter):
     label = "The issue is {comparison_type} than {value} {time}"
     prompt = "The issue is older or newer than..."
 
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         comparison_type = self.get_option("comparison_type")
         time = self.get_option("time")
         try:

--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Sequence
 
 from django import forms
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.mail.forms.assigned_to import AssignedToForm
 from sentry.notifications.types import ASSIGNEE_CHOICES, AssigneeTargetType
 from sentry.rules import EventState
@@ -31,7 +31,7 @@ class AssignedToFilter(EventFilter):
             cache.set(cache_key, assignee_list, 60)
         return assignee_list
 
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         target_type = AssigneeTargetType(self.get_option("targetType"))
 
         if target_type == AssigneeTargetType.UNASSIGNED:

--- a/src/sentry/rules/filters/base.py
+++ b/src/sentry/rules/filters/base.py
@@ -1,6 +1,6 @@
 import abc
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.rules.base import EventState, RuleBase
 
 
@@ -8,5 +8,5 @@ class EventFilter(RuleBase, abc.ABC):
     rule_type = "filter/event"
 
     @abc.abstractmethod
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         pass

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -1,9 +1,9 @@
 from collections import OrderedDict
-from typing import Any, Union
+from typing import Any
 
 from django import forms
 
-from sentry.eventstore.models import Event, GroupEvent
+from sentry.eventstore.models import GroupEvent
 from sentry.rules import EventState
 from sentry.rules.filters import EventFilter
 from sentry.types.issues import GroupCategory
@@ -23,7 +23,7 @@ class IssueCategoryFilter(EventFilter):
     label = "The issue's category is equal to {value}"
     prompt = "The issue's category is ..."
 
-    def passes(self, event: Union[Event, GroupEvent], state: EventState, **kwargs: Any) -> bool:
+    def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
         try:
             value: GroupCategory = GroupCategory(int(self.get_option("value")))
         except (TypeError, ValueError):

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.rules import EventState
 from sentry.rules.filters.base import EventFilter
 
@@ -16,7 +16,7 @@ class IssueOccurrencesFilter(EventFilter):
     label = "The issue has happened at least {value} times"
     prompt = "The issue has happened at least {x} times (Note: this is approximate)"
 
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         try:
             value = int(self.get_option("value"))
         except (TypeError, ValueError):

--- a/src/sentry/rules/filters/latest_release.py
+++ b/src/sentry/rules/filters/latest_release.py
@@ -5,7 +5,7 @@ from typing import Any
 from django.db.models.signals import post_delete, post_save, pre_delete
 
 from sentry import tagstore
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.models import Environment, Release, ReleaseEnvironment, ReleaseProject
 from sentry.rules import EventState
 from sentry.rules.filters.base import EventFilter
@@ -45,7 +45,7 @@ class LatestReleaseFilter(EventFilter):
     id = "sentry.rules.filters.latest_release.LatestReleaseFilter"
     label = "The event is from the latest release"
 
-    def get_latest_release(self, event: Event) -> Release | None:
+    def get_latest_release(self, event: GroupEvent) -> Release | None:
         environment_id = None if self.rule is None else self.rule.environment_id
         cache_key = get_project_release_cache_key(event.group.project_id, environment_id)
         latest_release = cache.get(cache_key)
@@ -74,7 +74,7 @@ class LatestReleaseFilter(EventFilter):
                 cache.set(cache_key, False, 600)
         return latest_release
 
-    def passes(self, event: Event, state: EventState) -> bool:
+    def passes(self, event: GroupEvent, state: EventState) -> bool:
         latest_release = self.get_latest_release(event)
         if not latest_release:
             return False

--- a/src/sentry/rules/processor.py
+++ b/src/sentry/rules/processor.py
@@ -9,7 +9,7 @@ from django.core.cache import cache
 from django.utils import timezone
 
 from sentry import analytics, features
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import GroupEvent
 from sentry.mail.actions import NotifyActiveReleaseEmailAction
 from sentry.models import GroupRuleStatus, Rule
 from sentry.notifications.types import ActionTargetType
@@ -31,7 +31,7 @@ class RuleProcessor:
 
     def __init__(
         self,
-        event: Event,
+        event: GroupEvent,
         is_new: bool,
         is_regression: bool,
         is_new_group_environment: bool,
@@ -47,7 +47,7 @@ class RuleProcessor:
         self.has_reappeared = has_reappeared
 
         self.grouped_futures: MutableMapping[
-            str, Tuple[Callable[[Event, Sequence[RuleFuture]], None], List[RuleFuture]]
+            str, Tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], List[RuleFuture]]
         ] = {}
 
     def get_rules(self) -> Sequence[Rule]:
@@ -321,7 +321,7 @@ class RuleProcessor:
 
     def apply(
         self,
-    ) -> Iterable[Tuple[Callable[[Event, Sequence[RuleFuture]], None], List[RuleFuture]]]:
+    ) -> Iterable[Tuple[Callable[[GroupEvent, Sequence[RuleFuture]], None], List[RuleFuture]]]:
         # we should only apply rules on unresolved issues
         if not self.event.group.is_unresolved():
             return {}.values()

--- a/tests/sentry/integrations/slack/notifications/test_active_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_active_release.py
@@ -18,6 +18,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
     def setUp(self):
         super().setUp()
         Rule.objects.filter(project=self.event.project).delete()
+        self.event = next(self.event.build_group_events())
         self.event.group._times_seen_pending = 0
         self.event.group.save()
         NotificationSetting.objects.update_settings(

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -50,6 +50,7 @@ class MockConditionTrue(EventCondition):
 class RuleProcessorTest(TestCase):
     def setUp(self):
         self.event = self.store_event(data={}, project_id=self.project.id)
+        self.event = next(self.event.build_group_events())
 
         Rule.objects.filter(project=self.event.project).delete()
         ProjectOwnership.objects.create(project_id=self.project.id, fallthrough=True)


### PR DESCRIPTION
Update post_process_group Rule processing pipeline to reference the actual type. Upstream we build the GroupEvents from the Event and iterate over the GroupEvents and pass it downstream to all the pipeline steps, so the concrete type should really be GroupEvent.

Basically updated all imports of `sentry.eventstore.models.Event` to `GroupEvent` within the `sentry/rules` package.