### PR TITLE
fix(perf_issues): Prevent duplicate performance issues

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2040,7 +2040,7 @@ def _detect_performance_problems(jobs, projects):
         job["performance_problems"] = detect_performance_problems(job["data"])
 
 
-class Performance_Job(TypedDict, total=False):
+class PerformanceJob(TypedDict, total=False):
     performance_problems: Sequence[PerformanceProblem]
     event: Event
     culprit: str
@@ -2072,7 +2072,7 @@ def _save_grouphash_and_group(
 
 
 @metrics.wraps("save_event.save_aggregate_performance")
-def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
+def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects):
 
     MAX_GROUPS = (
         10  # safety check in case we are passed too many. constant will live somewhere else tbd

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import ipaddress
 import logging
@@ -8,7 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from hashlib import md5
 from io import BytesIO
-from typing import Optional, Sequence, TypedDict
+from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence, TypedDict
 
 import sentry_sdk
 from django.conf import settings
@@ -105,6 +107,9 @@ from sentry.utils.performance_issues.performance_detection import (
     detect_performance_problems,
 )
 from sentry.utils.safe import get_path, safe_execute, setdefault_path, trim
+
+if TYPE_CHECKING:
+    from sentry.eventstore.models import Event
 
 logger = logging.getLogger("sentry.events")
 
@@ -2037,6 +2042,33 @@ def _detect_performance_problems(jobs, projects):
 
 class Performance_Job(TypedDict, total=False):
     performance_problems: Sequence[PerformanceProblem]
+    event: Event
+    culprit: str
+    received_timestamp: float
+    event_metadata: Mapping[str, Any]
+    platform: str
+    level: str
+    logger_name: str
+    release: Release
+
+
+def _save_grouphash_and_group(
+    project: Project, event: Event, new_grouphash: str, **group_kwargs
+) -> Group:
+    group = None
+    with transaction.atomic():
+        group_hash, created = GroupHash.objects.get_or_create(project=project, hash=new_grouphash)
+        if created:
+            group = _create_group(project, event, **group_kwargs)
+            group_hash.update(group=group)
+
+    if group is None:
+        # If we failed to create the group it means another worker beat us to
+        # it. Since a GroupHash can only be created in a transaction with the
+        # Group, we can guarantee that the Group will exist at this point and
+        # fetch it via GroupHash
+        group = Group.objects.get(grouphash__project=project, grouphash__hash=new_grouphash)
+    return group
 
 
 @metrics.wraps("save_event.save_aggregate_performance")
@@ -2120,8 +2152,9 @@ def _save_aggregate_performance(jobs: Sequence[Performance_Job], projects):
                             group_kwargs["data"]["metadata"], problem
                         )
 
-                        group = _create_group(project, event, **group_kwargs)
-                        GroupHash.objects.create(project=project, hash=new_grouphash, group=group)
+                        group = _save_grouphash_and_group(
+                            project, event, new_grouphash, **group_kwargs
+                        )
 
                         is_new = True
                         is_regression = False

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -27,6 +27,8 @@ from sentry.event_manager import (
     EventManager,
     EventUser,
     HashDiscarded,
+    _get_event_instance,
+    _save_grouphash_and_group,
     has_pending_commit_resolution,
 )
 from sentry.eventstore.models import Event
@@ -60,7 +62,12 @@ from sentry.models import (
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.projectoptions.defaults import DEFAULT_GROUPING_CONFIG, LEGACY_GROUPING_CONFIG
 from sentry.spans.grouping.utils import hash_values
-from sentry.testutils import SnubaTestCase, TestCase, assert_mock_called_once_with_partial
+from sentry.testutils import (
+    SnubaTestCase,
+    TestCase,
+    TransactionTestCase,
+    assert_mock_called_once_with_partial,
+)
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -73,6 +80,7 @@ from sentry.utils.performance_issues.performance_detection import (
     EventPerformanceProblem,
     PerformanceProblem,
 )
+from sentry.utils.samples import load_data
 from tests.sentry.integrations.github.test_repository import stub_installation_token
 from tests.sentry.utils.performance_issues.test_performance_detection import EVENTS
 
@@ -2689,3 +2697,17 @@ class ReleaseIssueTest(TestCase):
             last_seen=self.timestamp + 100,
             first_seen=self.timestamp + 100,
         )
+
+
+class TestSaveGroupHashAndGroup(TransactionTestCase):
+    def test(self):
+        perf_data = load_data("transaction-n-plus-one", timestamp=before_now(minutes=10))
+        event = _get_event_instance(perf_data, project_id=self.project.id)
+        group_hash = "some_group"
+        group = _save_grouphash_and_group(self.project, event, group_hash)
+        group_2 = _save_grouphash_and_group(self.project, event, group_hash)
+        assert group.id == group_2.id
+        assert Group.objects.filter(grouphash__hash=group_hash).count() == 1
+        group_3 = _save_grouphash_and_group(self.project, event, "new_hash")
+        assert group_2.id != group_3.id
+        assert Group.objects.filter(grouphash__hash=group_hash).count() == 1


### PR DESCRIPTION
This prevents a race condition when creating performance issues. It's possible that two processes will create/fetch the grouphash at the same time and make a group each. Adding the atomic.transaction prevents this.

Tested this manually, it's tricky to write an automated test.