### PR TITLE
feat(fetch-commits-task): Report errors to Sentry

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -1,5 +1,6 @@
 import logging
 
+import sentry_sdk
 from django.urls import reverse
 
 from sentry.exceptions import InvalidIdentity, PluginError
@@ -146,6 +147,8 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
                     "start_sha": start_sha,
                 },
             )
+            span = sentry_sdk.Hub.current.scope.span
+            span.set_status("unknown_error")
             logger.exception(e)
             if isinstance(e, InvalidIdentity) and getattr(e, "identity", None):
                 handle_invalid_identity(identity=e.identity, commit_failure=True)

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -146,6 +146,7 @@ def fetch_commits(release_id, user_id, refs, prev_release_id=None, **kwargs):
                     "start_sha": start_sha,
                 },
             )
+            logger.exception(e)
             if isinstance(e, InvalidIdentity) and getattr(e, "identity", None):
                 handle_invalid_identity(identity=e.identity, commit_failure=True)
             elif isinstance(e, (PluginError, InvalidIdentity, IntegrationError)):


### PR DESCRIPTION
In some case we fly blind when failing to fetch commits. This change give us the missing errors.

See sample [error](https://sentry.io/organizations/sentry-test/issues/3693406028/):

<img width="744" alt="image" src="https://user-images.githubusercontent.com/44410/197553667-f205261f-5c9b-4bd4-b2b4-939dce2f1afd.png">

This also marks the celery span as "unknown" rather than "ok". See [span](https://sentry.io/organizations/sentry-test/performance/armenzg-test:20112727818249ef99a48f26739fec1b/?project=6730869&query=&statsPeriod=1m&transaction=sentry.tasks.commits.fetch_commits&unselectedSeries=p100%28%29).

<img width="900" alt="image" src="https://user-images.githubusercontent.com/44410/197556123-f350eda4-7cd0-4f7a-b93c-f183043d4b54.png">


This is in support of ISSUE-1615