### PR TITLE
fix(discover-homepage): Locked page filters being overridden

### DIFF
--- a/static/app/views/eventsV2/homepage.spec.tsx
+++ b/static/app/views/eventsV2/homepage.spec.tsx
@@ -4,6 +4,8 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountGlobalModal} from 'sentry-test/modal';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import * as pageFilterUtils from 'sentry/components/organizations/pageFilters/persistence';
+import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
 
 import {DEFAULT_EVENT_VIEW} from './data';
@@ -444,5 +446,33 @@ describe('Discover > Homepage', () => {
       expect(screen.queryByText('Edit Columns')).not.toBeInTheDocument()
     );
     expect(screen.getByText('event.type')).toBeInTheDocument();
+  });
+
+  it('overrides homepage filters with pinned filters if they exist', () => {
+    ProjectsStore.loadInitialData([TestStubs.Project({id: 2})]);
+    jest.spyOn(pageFilterUtils, 'getPageFilterStorage').mockReturnValueOnce({
+      pinnedFilters: new Set(['projects']),
+      state: {
+        project: [2],
+        environment: [],
+        start: null,
+        end: null,
+        period: '14d',
+        utc: null,
+      },
+    });
+
+    render(
+      <Homepage
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+        setSavedQuery={jest.fn()}
+        loading={false}
+      />,
+      {context: initialData.routerContext, organization: initialData.organization}
+    );
+
+    expect(screen.getByText('project-slug')).toBeInTheDocument();
   });
 });

--- a/static/app/views/eventsV2/homepage.tsx
+++ b/static/app/views/eventsV2/homepage.tsx
@@ -57,20 +57,16 @@ class HomepageQueryAPI extends AsyncComponent<Props, HomepageQueryState> {
       if (pageFilterState?.pinnedFilters) {
         pageFilterState.pinnedFilters.forEach(pinnedFilter => {
           if (pinnedFilter === 'projects') {
-            query.project = pageFilterState.state[pinnedFilter];
+            query.project = pageFilterState.state.project?.map(String);
           } else if (pinnedFilter === 'datetime') {
             const {period, start, end, utc} = getDatetimeFromState(pageFilterState.state);
-            if (period) {
-              query.statsPeriod = period;
-            } else {
-              query.statsPeriod = undefined;
-              query = {
-                ...query,
-                utc: utc?.toString(),
-                start: normalizeDateTimeString(start),
-                end: normalizeDateTimeString(end),
-              };
-            }
+            query = {
+              ...query,
+              statsPeriod: period ?? undefined,
+              utc: utc?.toString(),
+              start: normalizeDateTimeString(start),
+              end: normalizeDateTimeString(end),
+            };
           } else {
             query[pinnedFilter] = pageFilterState.state[pinnedFilter];
           }

--- a/static/app/views/eventsV2/homepage.tsx
+++ b/static/app/views/eventsV2/homepage.tsx
@@ -4,6 +4,11 @@ import {Location} from 'history';
 import {Client} from 'sentry/api';
 import AsyncComponent from 'sentry/components/asyncComponent';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
+import {
+  getDatetimeFromState,
+  normalizeDateTimeString,
+} from 'sentry/components/organizations/pageFilters/parse';
+import {getPageFilterStorage} from 'sentry/components/organizations/pageFilters/persistence';
 import {Organization, PageFilters, SavedQuery} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import withApi from 'sentry/utils/withApi';
@@ -41,9 +46,41 @@ class HomepageQueryAPI extends AsyncComponent<Props, HomepageQueryState> {
         sidebarClicked)
     ) {
       const eventView = EventView.fromSavedQuery(this.state.savedQuery);
-      browserHistory.replace(
-        eventView.getResultsViewUrlTarget(this.props.organization.slug, true)
-      );
+      const pageFilterState = getPageFilterStorage(this.props.organization.slug);
+      let query = {
+        ...eventView.generateQueryStringObject(),
+      };
+
+      // Handle locked filters explicitly because we can't expect
+      // PageFilterContainer to properly overwrite stored filters
+      // when pushing the homepage query to the URL
+      if (pageFilterState?.pinnedFilters) {
+        pageFilterState.pinnedFilters.forEach(pinnedFilter => {
+          if (pinnedFilter === 'projects') {
+            query.project = pageFilterState.state[pinnedFilter];
+          } else if (pinnedFilter === 'datetime') {
+            const {period, start, end, utc} = getDatetimeFromState(pageFilterState.state);
+            if (period) {
+              query.statsPeriod = period;
+            } else {
+              query.statsPeriod = undefined;
+              query = {
+                ...query,
+                utc: utc?.toString(),
+                start: normalizeDateTimeString(start),
+                end: normalizeDateTimeString(end),
+              };
+            }
+          } else {
+            query[pinnedFilter] = pageFilterState.state[pinnedFilter];
+          }
+        });
+      }
+
+      browserHistory.replace({
+        ...this.props.location,
+        query,
+      });
     }
     super.componentDidUpdate(prevProps, prevState);
   }
@@ -91,10 +128,7 @@ class HomepageQueryAPI extends AsyncComponent<Props, HomepageQueryState> {
 
 function HomepageContainer(props: Props) {
   return (
-    <PageFiltersContainer
-      skipLoadLastUsed={props.organization.features.includes('global-views')}
-      skipInitializeUrlParams
-    >
+    <PageFiltersContainer skipInitializeUrlParams>
       <HomepageQueryAPI {...props} />
     </PageFiltersContainer>
   );

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -23,7 +23,10 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
+import {
+  normalizeDateTimeParams,
+  normalizeDateTimeString,
+} from 'sentry/components/organizations/pageFilters/parse';
 import {CursorHandler} from 'sentry/components/pagination';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
@@ -296,6 +299,13 @@ export class Results extends Component<Props, State> {
     const nextEventView = EventView.fromNewQueryWithLocation(query, location);
     if (nextEventView.project.length === 0 && selection.projects) {
       nextEventView.project = selection.projects;
+    }
+    if (selection.datetime) {
+      const {period, utc, start, end} = selection.datetime;
+      nextEventView.statsPeriod = period ?? undefined;
+      nextEventView.utc = utc?.toString();
+      nextEventView.start = normalizeDateTimeString(start);
+      nextEventView.end = normalizeDateTimeString(end);
     }
     if (location.query?.query) {
       nextEventView.query = decodeScalar(location.query.query, '');


### PR DESCRIPTION
When navigating to the Discover homepage, locked page filters would be overridden. This was because we were manually pushing new filters from the homepage query into the URL and skipped loading previous ones like in saved queries. 

The problem is, the homepage is different in the sense that it's likely where users are trying to explore an issue, so you're more likely to have locked filters from other parts in the app and expect them to persist while you investigate. Because of this behaviour, I explicitly inspect the pinned filters and add them to the query params before the redirect. This also had to happen in `results.tsx` for the datetime filters in the case of _no_ homepage query because we rely on `checkEventView` to redirect us to the All Events query.