### PR TITLE
feat(discover-homepage): Add analytics events

### DIFF
--- a/static/app/utils/analytics/discoverAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/discoverAnalyticsEvents.tsx
@@ -5,10 +5,13 @@ export type DiscoverEventParameters = {
   'discover_v2.facet_map.clicked': {tag: string};
   'discover_v2.prebuilt_query_click': {query_name?: string};
   'discover_v2.processed_baseline_toggle.clicked': {toggled: string};
+  'discover_v2.remove_default': {isHomepage: boolean};
   'discover_v2.saved_query_click': {};
+  'discover_v2.set_as_default': {isHomepage: boolean};
   'discover_v2.tour.advance': {duration: number; step: number};
   'discover_v2.tour.close': {duration: number; step: number};
   'discover_v2.tour.start': {};
+  'discover_v2.view_saved_queries': {};
   'discover_views.add_to_dashboard.confirm': {};
   'discover_views.add_to_dashboard.modal_open': {saved_query: boolean};
 };
@@ -27,6 +30,9 @@ export const discoverEventMap: Record<DiscoverEventKey, string | null> = {
   'discover_v2.tour.close': 'Discoverv2: Tour Close',
   'discover_v2.tour.start': 'Discoverv2: Tour Start',
   'discover_v2.saved_query_click': 'Discoverv2: Click a saved query',
+  'discover_v2.view_saved_queries': 'Discoverv2: Click Saved Queries button',
+  'discover_v2.set_as_default': 'Discoverv2: Click set as default',
+  'discover_v2.remove_default': 'Discoverv2: Click remove default',
   'discover_views.add_to_dashboard.modal_open':
     'Discover2: Add to Dashboard modal opened',
   'discover_views.add_to_dashboard.confirm':

--- a/static/app/utils/analytics/discoverAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/discoverAnalyticsEvents.tsx
@@ -5,9 +5,13 @@ export type DiscoverEventParameters = {
   'discover_v2.facet_map.clicked': {tag: string};
   'discover_v2.prebuilt_query_click': {query_name?: string};
   'discover_v2.processed_baseline_toggle.clicked': {toggled: string};
-  'discover_v2.remove_default': {isHomepage: boolean};
+  'discover_v2.remove_default': {source: 'homepage' | 'prebuilt-query' | 'saved-query'};
   'discover_v2.saved_query_click': {};
-  'discover_v2.set_as_default': {isHomepage: boolean};
+  'discover_v2.set_as_default': {
+    source: 'homepage' | 'prebuilt-query' | 'saved-query' | 'context-menu';
+    // For breaking down context-menu events
+    type?: 'prebuilt-query' | 'saved-query';
+  };
   'discover_v2.tour.advance': {duration: number; step: number};
   'discover_v2.tour.close': {duration: number; step: number};
   'discover_v2.tour.start': {};

--- a/static/app/views/eventsV2/queryList.tsx
+++ b/static/app/views/eventsV2/queryList.tsx
@@ -183,6 +183,11 @@ class QueryList extends Component<Props> {
                 label: t('Set as Default'),
                 onAction: () => {
                   handleUpdateHomepageQuery(api, organization, eventView.toNewQuery());
+                  trackAdvancedAnalyticsEvent('discover_v2.set_as_default', {
+                    organization,
+                    source: 'context-menu',
+                    type: 'prebuilt-query',
+                  });
                 },
               },
             ]
@@ -269,6 +274,11 @@ class QueryList extends Component<Props> {
                 label: t('Set as Default'),
                 onAction: () => {
                   handleUpdateHomepageQuery(api, organization, eventView.toNewQuery());
+                  trackAdvancedAnalyticsEvent('discover_v2.set_as_default', {
+                    organization,
+                    source: 'context-menu',
+                    type: 'saved-query',
+                  });
                 },
               },
             ]

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -26,6 +26,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project, SavedQuery} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {getDiscoverQueriesUrl} from 'sentry/utils/discover/urls';
 import useOverlay from 'sentry/utils/useOverlay';
@@ -310,7 +311,9 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
     const {organization} = this.props;
     return (
       <Button
-        onClick={() => {}}
+        onClick={() => {
+          trackAdvancedAnalyticsEvent('discover_v2.view_saved_queries', {organization});
+        }}
         data-test-id="discover2-savedquery-button-view-saved"
         disabled={disabled}
         size="sm"
@@ -464,6 +467,10 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
           data-test-id="reset-discover-homepage"
           onClick={async () => {
             await handleResetHomepageQuery(api, organization);
+            trackAdvancedAnalyticsEvent('discover_v2.remove_default', {
+              organization,
+              isHomepage: isHomepage ?? false,
+            });
             setHomepageQuery(undefined);
             if (isHomepage) {
               const nextEventView = EventView.fromNewQueryWithLocation(
@@ -496,6 +503,10 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
             organization,
             eventView.toNewQuery()
           );
+          trackAdvancedAnalyticsEvent('discover_v2.set_as_default', {
+            organization,
+            isHomepage: isHomepage ?? false,
+          });
           if (updatedHomepageQuery) {
             setHomepageQuery(updatedHomepageQuery);
           }

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -457,6 +457,12 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
       queryDataLoading ||
       (!homepageQuery &&
         eventView.isEqualTo(EventView.fromSavedQuery(DEFAULT_EVENT_VIEW)));
+
+    const analyticsEventSource = isHomepage
+      ? 'homepage'
+      : eventView.id
+      ? 'saved-query'
+      : 'prebuilt-query';
     if (
       homepageQuery &&
       eventView.isEqualTo(EventView.fromSavedQuery(homepageQuery), ['id', 'name'])
@@ -469,7 +475,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
             await handleResetHomepageQuery(api, organization);
             trackAdvancedAnalyticsEvent('discover_v2.remove_default', {
               organization,
-              isHomepage: isHomepage ?? false,
+              source: analyticsEventSource,
             });
             setHomepageQuery(undefined);
             if (isHomepage) {
@@ -505,7 +511,7 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
           );
           trackAdvancedAnalyticsEvent('discover_v2.set_as_default', {
             organization,
-            isHomepage: isHomepage ?? false,
+            source: analyticsEventSource,
           });
           if (updatedHomepageQuery) {
             setHomepageQuery(updatedHomepageQuery);


### PR DESCRIPTION
Tracks events on navigating to Saved Queries and setting/removing the default. Setting and removing events have a `source` prop because it might be interesting to get a breakdown of where this feature gets used the most/least.
Likewise, the context menu items on the manage page have a `type` prop to further break those down into saved/prebuilt.