### PR TITLE
feat(perf-issues): Improve legibility of duration text within autogrouped spans & affected spans

### DIFF
--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -895,7 +895,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
     errors: TraceError[] | null;
     transactions: QuickTraceEvent[] | null;
   }) {
-    const {span, spanBarColor, spanBarType: spanBarType, spanNumber} = this.props;
+    const {span, spanBarColor, spanBarType, spanNumber} = this.props;
     const startTimestamp: number = span.start_timestamp;
     const endTimestamp: number = span.timestamp;
     const duration = Math.abs(endTimestamp - startTimestamp);

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -4,10 +4,7 @@ import {Component, createRef, Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Count from 'sentry/components/count';
-import {
-  ROW_HEIGHT,
-  SpanBarHatch,
-} from 'sentry/components/performance/waterfall/constants';
+import {ROW_HEIGHT, SpanBarType} from 'sentry/components/performance/waterfall/constants';
 import {MessageRow} from 'sentry/components/performance/waterfall/messageRow';
 import {
   Row,
@@ -137,7 +134,7 @@ type SpanBarProps = {
   isLast?: boolean;
   isRoot?: boolean;
   spanBarColor?: string;
-  spanBarHatch?: SpanBarHatch;
+  spanBarType?: SpanBarType;
   toggleSiblingSpanGroup?: ((span: SpanType, occurrence: number) => void) | undefined;
 };
 
@@ -475,7 +472,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
   }
 
   renderTitle(errors: TraceError[] | null) {
-    const {generateContentSpanBarRef, spanBarHatch} = this.props;
+    const {generateContentSpanBarRef, spanBarType} = this.props;
     const {
       span,
       treeDepth,
@@ -541,7 +538,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
         >
           <RowTitleContent
             errored={errored}
-            data-test-id={`row-title-content${spanBarHatch ? `-${spanBarHatch}` : ''}`}
+            data-test-id={`row-title-content${spanBarType ? `-${spanBarType}` : ''}`}
           >
             <strong>{titleFragments}</strong>
             {description}
@@ -898,7 +895,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
     errors: TraceError[] | null;
     transactions: QuickTraceEvent[] | null;
   }) {
-    const {span, spanBarColor, spanBarHatch, spanNumber} = this.props;
+    const {span, spanBarColor, spanBarType: spanBarType, spanNumber} = this.props;
     const startTimestamp: number = span.start_timestamp;
     const endTimestamp: number = span.timestamp;
     const duration = Math.abs(endTimestamp - startTimestamp);
@@ -942,7 +939,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
         >
           {displaySpanBar && (
             <RowRectangle
-              spanBarHatch={spanBarHatch}
+              spanBarType={spanBarType}
               style={{
                 backgroundColor: spanBarColor,
                 left: `min(${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
@@ -952,7 +949,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
               <DurationPill
                 durationDisplay={durationDisplay}
                 showDetail={this.state.showDetail}
-                spanBarHatch={spanBarHatch}
+                spanBarType={spanBarType}
               >
                 {durationString}
                 {this.renderWarningText()}

--- a/static/app/components/events/interfaces/spans/spanRectangleOverlay.tsx
+++ b/static/app/components/events/interfaces/spans/spanRectangleOverlay.tsx
@@ -1,3 +1,4 @@
+import {SpanBarType} from 'sentry/components/performance/waterfall/constants';
 import {DurationPill, RowRectangle} from 'sentry/components/performance/waterfall/rowBar';
 import {
   getDurationDisplay,
@@ -27,7 +28,11 @@ export function SpanRectangleOverlay({
         width: toPercent(bounds.width || 0),
       }}
     >
-      <DurationPill durationDisplay={durationDisplay} showDetail={false}>
+      <DurationPill
+        durationDisplay={durationDisplay}
+        showDetail={false}
+        spanBarType={SpanBarType.AUTOGROUPED}
+      >
         {durationString}
       </DurationPill>
     </RowRectangle>

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -2,7 +2,7 @@ import {Component} from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 
-import {SpanBarHatch} from 'sentry/components/performance/waterfall/constants';
+import {SpanBarType} from 'sentry/components/performance/waterfall/constants';
 import {MessageRow} from 'sentry/components/performance/waterfall/messageRow';
 import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {t, tct} from 'sentry/locale';
@@ -336,14 +336,14 @@ class SpanTree extends Component<PropType> {
           isEmbeddedSpanTree &&
           waterfallModel.affectedSpanIds?.includes(span.span_id);
 
-        let spanBarHatch: SpanBarHatch | undefined = undefined;
+        let spanBarType: SpanBarType | undefined = undefined;
 
         if (type === 'gap') {
-          spanBarHatch = SpanBarHatch.gap;
+          spanBarType = SpanBarType.GAP;
         }
 
         if (isAffectedSpan) {
-          spanBarHatch = SpanBarHatch.affected;
+          spanBarType = SpanBarType.AFFECTED;
         }
 
         acc.spanTree.push(
@@ -352,7 +352,7 @@ class SpanTree extends Component<PropType> {
             organization={organization}
             event={waterfallModel.event}
             spanBarColor={spanBarColor}
-            spanBarHatch={spanBarHatch}
+            spanBarType={spanBarType}
             span={span}
             showSpanTree={!waterfallModel.hiddenSpanSubTrees.has(getSpanID(span))}
             numOfSpanChildren={numOfSpanChildren}

--- a/static/app/components/performance/waterfall/constants.tsx
+++ b/static/app/components/performance/waterfall/constants.tsx
@@ -1,15 +1,37 @@
+import {Theme} from 'sentry/utils/theme';
+
 export const ROW_HEIGHT = 24;
 export const ROW_PADDING = 4;
 
-export enum SpanBarHatch {
-  gap = 'gap',
-  affected = 'affected',
+export enum SpanBarType {
+  GAP = 'gap',
+  AFFECTED = 'affected',
+  AUTOGROUPED = 'autogrouped',
 }
 
-export const SPAN_HATCH_TYPE_COLOURS: Record<
-  SpanBarHatch,
-  {alternate: string; primary: string}
-> = {
-  [SpanBarHatch.gap]: {primary: '#dedae3', alternate: '#f4f2f7'},
-  [SpanBarHatch.affected]: {primary: '#F55459', alternate: '#FAA9AC'},
+type SpanBarColours = {
+  alternate: string;
+  insetTextColour: string;
+  primary: string;
 };
+
+// TODO: Need to eventually add dark mode colours as well
+export function getSpanBarColours(
+  theme: Theme,
+  spanBarType?: SpanBarType
+): SpanBarColours {
+  switch (spanBarType) {
+    case SpanBarType.GAP:
+      return {primary: '#dedae3', alternate: '#f4f2f7', insetTextColour: theme.gray300};
+    case SpanBarType.AFFECTED:
+      return {primary: '#f55459', alternate: '#faa9ac', insetTextColour: theme.white};
+    case SpanBarType.AUTOGROUPED:
+      return {
+        primary: theme.blue300,
+        alternate: '#9ab9f4',
+        insetTextColour: theme.gray300,
+      };
+    default:
+      return {primary: '', alternate: '', insetTextColour: theme.white};
+  }
+}

--- a/static/app/components/performance/waterfall/constants.tsx
+++ b/static/app/components/performance/waterfall/constants.tsx
@@ -17,8 +17,8 @@ type SpanBarColours = {
 
 // TODO: Need to eventually add dark mode colours as well
 export function getSpanBarColours(
-  theme: Theme,
-  spanBarType?: SpanBarType
+  spanBarType: SpanBarType | undefined,
+  theme: Theme
 ): SpanBarColours {
   switch (spanBarType) {
     case SpanBarType.GAP:

--- a/static/app/components/performance/waterfall/constants.tsx
+++ b/static/app/components/performance/waterfall/constants.tsx
@@ -28,7 +28,7 @@ export function getSpanBarColours(
     case SpanBarType.AUTOGROUPED:
       return {
         primary: theme.blue300,
-        alternate: '#9ab9f4',
+        alternate: '#d1dff9',
         insetTextColour: theme.gray300,
       };
     default:

--- a/static/app/components/performance/waterfall/rowBar.tsx
+++ b/static/app/components/performance/waterfall/rowBar.tsx
@@ -3,17 +3,18 @@ import styled from '@emotion/styled';
 import {
   ROW_HEIGHT,
   ROW_PADDING,
-  SpanBarHatch,
+  SpanBarType,
 } from 'sentry/components/performance/waterfall/constants';
 import {DurationDisplay} from 'sentry/components/performance/waterfall/types';
 import {
   getDurationPillAlignment,
-  getDurationPillColour,
+  getDurationPillColours,
   getHatchPattern,
 } from 'sentry/components/performance/waterfall/utils';
+import space from 'sentry/styles/space';
 
 export const RowRectangle = styled('div')<{
-  spanBarHatch?: SpanBarHatch;
+  spanBarType?: SpanBarType;
 }>`
   position: absolute;
   height: ${ROW_HEIGHT - 2 * ROW_PADDING}px;
@@ -21,15 +22,17 @@ export const RowRectangle = styled('div')<{
   min-width: 1px;
   user-select: none;
   transition: border-color 0.15s ease-in-out;
-  ${p => getHatchPattern(p.spanBarHatch)}
+  ${p => getHatchPattern(p.spanBarType, p.theme)}
 `;
 
 export const DurationPill = styled('div')<{
   durationDisplay: DurationDisplay;
   showDetail: boolean;
-  spanBarHatch?: SpanBarHatch;
+  spanBarType?: SpanBarType;
 }>`
   position: absolute;
+  border-radius: ${p => p.theme.borderRadius};
+  padding: 0 ${space(0.5)};
   top: 50%;
   display: flex;
   align-items: center;
@@ -41,7 +44,7 @@ export const DurationPill = styled('div')<{
   line-height: 1;
 
   ${getDurationPillAlignment}
-  ${getDurationPillColour}
+  ${getDurationPillColours}
 
   @media (max-width: ${p => p.theme.breakpoints.medium}) {
     font-size: 10px;

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -87,8 +87,6 @@ export const getDurationPillColours = ({
   if (durationDisplay === 'inset') {
     const {alternate, insetTextColour} = getSpanBarColours(theme, spanBarType);
     return `background: ${alternate}; color: ${insetTextColour};`;
-    // const isGapSpan = spanBarType && spanBarType === SpanBarType.GAP;
-    // return `color: ${isGapSpan ? theme.gray300 : theme.white};`;
   }
 
   return `color: ${showDetail ? theme.gray200 : theme.gray300};`;

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -3,7 +3,7 @@ import CHART_PALETTE from 'sentry/constants/chartPalette';
 import space from 'sentry/styles/space';
 import {Theme} from 'sentry/utils/theme';
 
-import {SPAN_HATCH_TYPE_COLOURS, SpanBarHatch} from './constants';
+import {getSpanBarColours, SpanBarType} from './constants';
 
 export const getBackgroundColor = ({
   showStriping,
@@ -25,9 +25,9 @@ export const getBackgroundColor = ({
   return theme.background;
 };
 
-export function getHatchPattern(spanBarHatch: SpanBarHatch | undefined) {
-  if (spanBarHatch) {
-    const {primary, alternate} = SPAN_HATCH_TYPE_COLOURS[spanBarHatch];
+export function getHatchPattern(spanBarType: SpanBarType | undefined, theme: Theme) {
+  if (spanBarType) {
+    const {primary, alternate} = getSpanBarColours(theme, spanBarType);
 
     return `
       background-image: linear-gradient(135deg,
@@ -59,7 +59,7 @@ export const getDurationPillAlignment = ({
 }: {
   durationDisplay: DurationDisplay;
   theme: Theme;
-  spanBarHatch?: SpanBarHatch;
+  spanBarType?: SpanBarType;
 }) => {
   switch (durationDisplay) {
     case 'left':
@@ -73,24 +73,25 @@ export const getDurationPillAlignment = ({
   }
 };
 
-export const getDurationPillColour = ({
+export const getDurationPillColours = ({
   durationDisplay,
   theme,
   showDetail,
-  spanBarHatch,
+  spanBarType,
 }: {
   durationDisplay: DurationDisplay;
   showDetail: boolean;
   theme: Theme;
-  spanBarHatch?: SpanBarHatch;
+  spanBarType?: SpanBarType;
 }) => {
   if (durationDisplay === 'inset') {
-    return `color: ${
-      spanBarHatch && spanBarHatch === SpanBarHatch.gap ? theme.gray300 : theme.white
-    };`;
+    const {alternate, insetTextColour} = getSpanBarColours(theme, spanBarType);
+    return `background: ${alternate}; color: ${insetTextColour};`;
+    // const isGapSpan = spanBarType && spanBarType === SpanBarType.GAP;
+    // return `color: ${isGapSpan ? theme.gray300 : theme.white};`;
   }
 
-  return `color: ${showDetail === true ? theme.gray200 : theme.gray300};`;
+  return `color: ${showDetail ? theme.gray200 : theme.gray300};`;
 };
 
 export const getToggleTheme = ({

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -27,7 +27,7 @@ export const getBackgroundColor = ({
 
 export function getHatchPattern(spanBarType: SpanBarType | undefined, theme: Theme) {
   if (spanBarType) {
-    const {primary, alternate} = getSpanBarColours(theme, spanBarType);
+    const {primary, alternate} = getSpanBarColours(spanBarType, theme);
 
     return `
       background-image: linear-gradient(135deg,
@@ -85,7 +85,7 @@ export const getDurationPillColours = ({
   spanBarType?: SpanBarType;
 }) => {
   if (durationDisplay === 'inset') {
-    const {alternate, insetTextColour} = getSpanBarColours(theme, spanBarType);
+    const {alternate, insetTextColour} = getSpanBarColours(spanBarType, theme);
     return `background: ${alternate}; color: ${insetTextColour};`;
   }
 


### PR DESCRIPTION
This PR improves the legibility of the duration text within autogrouped spans & affected spans by introducing a backplate behind the text. 

The colours being used and other styling is tentative, need approval from Dora first! Also to note: There are some custom colours being used here that are not included in the theme. We may need dark mode colour alternatives, or to bring these colours into the themes as well.

For autogroups, this visual change will also be present on Event Details, not just on Issue Details.

## Affected Spans Before & After
![image](https://user-images.githubusercontent.com/16740047/197595907-e4cac232-deb1-4c3a-bb48-829cecaaa3aa.png)
![image](https://user-images.githubusercontent.com/16740047/197595944-0a337f3d-6450-4e92-8cbe-b313e9d8d1ce.png)

## Missing Instrumentation (Gap) Spans Before & After
![image](https://user-images.githubusercontent.com/16740047/197596058-8606c33a-3c34-4d9e-ba77-b61188bfce73.png)
![image](https://user-images.githubusercontent.com/16740047/197596102-affd8232-d0c6-4fe4-9bf6-03ba67f3e2b6.png)

## Autogrouped Spans Before & After
![image](https://user-images.githubusercontent.com/16740047/197636214-96a27c82-20fc-4f53-a888-b77877025b4d.png)
![image](https://user-images.githubusercontent.com/16740047/197636246-08a4e10f-8ecb-4f0e-8171-09110cc110c0.png)
### Another Example
![image](https://user-images.githubusercontent.com/16740047/197638733-e71fe236-7fe2-4e28-9f16-9937295ff2bf.png)
![image](https://user-images.githubusercontent.com/16740047/197638790-7a4835d8-cfd8-4b70-89a6-4905cc0844ff.png)


