### PR TITLE
fix(replays): change sentry sdk calling to be more helpful

### DIFF
--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -127,7 +127,7 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
                     scope.set_tag("replay_id", message_dict["replay_id"])
                     scope.set_tag("project_id", message_dict["project_id"])
 
-                    sentry_sdk.capture_exception("Recording segment was already processed.")
+                    sentry_sdk.capture_exception("Recording segment was already processed.")  # type: ignore[arg-type]
 
                 parts.drop()
 

--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -8,7 +8,7 @@ from collections import deque
 from concurrent.futures import Future
 from datetime import datetime, timezone
 from io import BytesIO
-from typing import Any, Callable, Deque, Mapping, MutableMapping, NamedTuple, Optional, cast
+from typing import Callable, Deque, Mapping, MutableMapping, NamedTuple, Optional, cast
 
 import msgpack
 import sentry_sdk
@@ -29,7 +29,6 @@ from sentry.replays.consumers.recording.types import (
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.utils import json, metrics
 from sentry.utils.outcomes import Outcome, track_outcome
-from sentry.utils.sdk import configure_scope
 
 logger = logging.getLogger("sentry.replays")
 
@@ -125,7 +124,10 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
                 with sentry_sdk.push_scope() as scope:
                     scope.level = "warning"
                     scope.add_attachment(bytes=recording_segment, filename="dup_replay_segment")
-                    sentry_sdk.capture_message("Recording segment was already processed.")
+                    scope.set_tag("replay_id", message_dict["replay_id"])
+                    scope.set_tag("project_id", message_dict["project_id"])
+
+                    sentry_sdk.capture_exception("Recording segment was already processed.")
 
                 parts.drop()
 
@@ -209,7 +211,6 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
                 < getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0),
             ):
                 message_dict = msgpack.unpackb(message.payload.value)
-                self._configure_sentry_scope(message_dict)
 
                 if message_dict["type"] == "replay_recording_chunk":
                     sentry_sdk.set_extra("replay_id", message_dict["replay_id"])
@@ -288,12 +289,6 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
                 self.__commit(self.__commit_data)
                 self.__last_committed = now
                 self.__commit_data = {}
-
-    def _configure_sentry_scope(self, message_dict: dict[str, Any]) -> None:
-        with configure_scope() as scope:
-            scope.set_tag("replay_id", message_dict["replay_id"])
-            scope.set_tag("project_id", message_dict["project_id"])
-            # TODO: add replay sdk version once added
 
 
 def replay_recording_segment_cache_id(project_id: int, replay_id: str, segment_id: str) -> str:


### PR DESCRIPTION
- remove configure_scope call from `submit` function, as because of our threading this gets weird and wasn't working correctly
- add replayid/projectid tagging to the dupe segments block
- change `capture_message` to `capture_exception` so hopefully we get more breadcrumbs