### PR TITLE
bug(replays): Allow requests without any project selected

### DIFF
--- a/static/app/utils/replays/fetchReplayList.tsx
+++ b/static/app/utils/replays/fetchReplayList.tsx
@@ -43,14 +43,6 @@ async function fetchReplayList({
   location,
   eventView,
 }: Props): Promise<Result> {
-  if (!eventView.project.length) {
-    return {
-      fetchError: undefined,
-      isFetching: false,
-      pageLinks: null,
-      replays: [],
-    };
-  }
   try {
     const path = `/organizations/${organization.slug}/replays/`;
 


### PR DESCRIPTION
This was added in #40429 but not really tested. If the Project Dropdown is "Locked" then things work great, but if it's unlocked then no request is made, which is not intended.

Removing, so now we'll have 2 requests in flight, but the user will only see the results of the 2nd request.

Fixes #39706