### PR TITLE
feat(profiling): profile details page aggregate views

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -100,7 +100,11 @@ type GridEditableProps<DataRow, ColumnKey> = {
    * in these buttons and updating props to the GridEditable instance.
    */
   headerButtons?: () => React.ReactNode;
+  height?: string | number;
   isLoading?: boolean;
+
+  scrollable?: boolean;
+  stickyHeader?: boolean;
 
   /**
    * GridEditable (mostly) do not maintain any internal state and relies on the
@@ -301,7 +305,7 @@ class GridEditable<
   }
 
   renderGridHead() {
-    const {error, isLoading, columnOrder, grid, data} = this.props;
+    const {error, isLoading, columnOrder, grid, data, stickyHeader} = this.props;
 
     // Ensure that the last column cannot be removed
     const numColumn = columnOrder.length;
@@ -326,6 +330,7 @@ class GridEditable<
               data-test-id="grid-head-cell"
               key={`${i}.${column.key}`}
               isFirst={i === 0}
+              sticky={stickyHeader}
             >
               {grid.renderHeadCell ? grid.renderHeadCell(column, i) : column.name}
               {i !== numColumn - 1 && (
@@ -419,7 +424,7 @@ class GridEditable<
   }
 
   render() {
-    const {title, headerButtons} = this.props;
+    const {title, headerButtons, scrollable, height} = this.props;
     const showHeader = title || headerButtons;
     return (
       <Fragment>
@@ -433,7 +438,12 @@ class GridEditable<
             </Header>
           )}
           <Body>
-            <Grid data-test-id="grid-editable" ref={this.refGrid}>
+            <Grid
+              data-test-id="grid-editable"
+              scrollable={scrollable}
+              height={height}
+              ref={this.refGrid}
+            >
               <GridHead>{this.renderGridHead()}</GridHead>
               <GridBody>{this.renderGridBody()}</GridBody>
             </Grid>

--- a/static/app/components/gridEditable/styles.tsx
+++ b/static/app/components/gridEditable/styles.tsx
@@ -68,20 +68,26 @@ export const Body = styled(({children, ...props}) => (
  * <thead>, <tbody>, <tr> are ignored by CSS Grid.
  * The entire layout is determined by the usage of <th> and <td>.
  */
-export const Grid = styled('table')`
+export const Grid = styled('table')<{height?: string | number; scrollable?: boolean}>`
   position: inherit;
   display: grid;
 
   /* Overwritten by GridEditable.setGridTemplateColumns */
   grid-template-columns: repeat(auto-fill, minmax(50px, auto));
-
   box-sizing: border-box;
   border-collapse: collapse;
   margin: 0;
 
   z-index: ${Z_INDEX_GRID};
   overflow-x: auto;
-  overflow-y: hidden;
+  overflow-y: ${p => (p.scrollable ? 'scroll' : 'hidden')};
+  ${p =>
+    p.height
+      ? `
+      height: 100%;
+      max-height: ${typeof p.height === 'number' ? p.height + 'px' : p.height}
+      `
+      : ''}
 `;
 
 export const GridRow = styled('tr')`
@@ -104,7 +110,7 @@ export const GridHead = styled('thead')`
   display: contents;
 `;
 
-export const GridHeadCell = styled('th')<{isFirst: boolean}>`
+export const GridHeadCell = styled('th')<{isFirst: boolean; sticky?: boolean}>`
   /* By default, a grid item cannot be smaller than the size of its content.
      We override this by setting min-width to be 0. */
   position: relative; /* Used by GridResizer */
@@ -123,6 +129,8 @@ export const GridHeadCell = styled('th')<{isFirst: boolean}>`
   font-weight: 600;
   text-transform: uppercase;
   user-select: none;
+
+  ${p => (p.sticky ? `position: sticky; top: 0;` : '')}
 
   a,
   div,

--- a/static/app/components/searchBar.tsx
+++ b/static/app/components/searchBar.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'sentry/components/button';
@@ -35,6 +35,14 @@ function SearchBar({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [query, setQuery] = useState(queryProp ?? defaultQuery);
+
+  // if query prop keeps changing we should treat this as
+  // a controlled component and its internal state should be in sync
+  useEffect(() => {
+    if (typeof queryProp === 'string') {
+      setQuery(queryProp);
+    }
+  }, [queryProp]);
 
   const onQueryChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/static/app/utils/profiling/profile/importProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/importProfile.spec.tsx
@@ -8,7 +8,7 @@ import {JSSelfProfile} from 'sentry/utils/profiling/profile/jsSelfProfile';
 import {SampledProfile} from 'sentry/utils/profiling/profile/sampledProfile';
 
 import {SentrySampledProfile} from './sentrySampledProfile';
-import {makeSentrySampledProfile} from './sentrySampledProfile.spec';
+import {makeSentrySampledProfile} from './sentrySampledProfile.specutil';
 
 describe('importProfile', () => {
   it('imports evented profile', () => {

--- a/static/app/utils/profiling/profile/sentrySampledProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/sentrySampledProfile.spec.tsx
@@ -1,68 +1,7 @@
-import merge from 'lodash/merge';
-
-import {DeepPartial} from 'sentry/types/utils';
-
 import {makeTestingBoilerplate} from './profile.spec';
 import {SentrySampledProfile} from './sentrySampledProfile';
+import {makeSentrySampledProfile} from './sentrySampledProfile.specutil';
 import {createSentrySampleProfileFrameIndex} from './utils';
-
-export const makeSentrySampledProfile = (
-  profile?: DeepPartial<Profiling.SentrySampledProfile>
-) => {
-  return merge(
-    {
-      event_id: '1',
-      version: '1',
-      os: {
-        name: 'iOS',
-        version: '16.0',
-        build_number: '19H253',
-      },
-      device: {
-        architecture: 'arm64e',
-        is_emulator: false,
-        locale: 'en_US',
-        manufacturer: 'Apple',
-        model: 'iPhone14,3',
-      },
-      timestamp: '2022-09-01T09:45:00.000Z',
-      release: '0.1 (199)',
-      platform: 'cocoa',
-      profile: {
-        samples: [
-          {
-            stack_id: 0,
-            thread_id: '0',
-            elapsed_since_start_ns: '0',
-          },
-          {
-            stack_id: 1,
-            thread_id: '0',
-            elapsed_since_start_ns: '1000',
-          },
-        ],
-        frames: [
-          {
-            function: 'foo',
-            instruction_addr: '',
-            lineno: 2,
-            colno: 2,
-            file: 'main.c',
-          },
-          {
-            function: 'main',
-            instruction_addr: '',
-            lineno: 1,
-            colno: 1,
-            file: 'main.c',
-          },
-        ],
-        stacks: [[0], [0, 1]],
-      },
-    },
-    profile
-  ) as Profiling.SentrySampledProfile;
-};
 
 describe('SentrySampledProfile', () => {
   it('constructs a profile', () => {

--- a/static/app/utils/profiling/profile/sentrySampledProfile.specutil.ts
+++ b/static/app/utils/profiling/profile/sentrySampledProfile.specutil.ts
@@ -1,0 +1,61 @@
+import merge from 'lodash/merge';
+
+import {DeepPartial} from 'sentry/types/utils';
+
+export const makeSentrySampledProfile = (
+  profile?: DeepPartial<Profiling.SentrySampledProfile>
+) => {
+  return merge(
+    {
+      event_id: '1',
+      version: '1',
+      os: {
+        name: 'iOS',
+        version: '16.0',
+        build_number: '19H253',
+      },
+      device: {
+        architecture: 'arm64e',
+        is_emulator: false,
+        locale: 'en_US',
+        manufacturer: 'Apple',
+        model: 'iPhone14,3',
+      },
+      timestamp: '2022-09-01T09:45:00.000Z',
+      release: '0.1 (199)',
+      platform: 'cocoa',
+      profile: {
+        samples: [
+          {
+            stack_id: 0,
+            thread_id: '0',
+            elapsed_since_start_ns: '0',
+          },
+          {
+            stack_id: 1,
+            thread_id: '0',
+            elapsed_since_start_ns: '1000',
+          },
+        ],
+        frames: [
+          {
+            function: 'foo',
+            instruction_addr: '',
+            lineno: 2,
+            colno: 2,
+            file: 'main.c',
+          },
+          {
+            function: 'main',
+            instruction_addr: '',
+            lineno: 1,
+            colno: 1,
+            file: 'main.c',
+          },
+        ],
+        stacks: [[0], [0, 1]],
+      },
+    },
+    profile
+  ) as Profiling.SentrySampledProfile;
+};

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.spec.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.spec.tsx
@@ -1,0 +1,81 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import {RequestState} from 'sentry/types';
+import {importProfile, ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
+import {makeSentrySampledProfile} from 'sentry/utils/profiling/profile/sentrySampledProfile.specutil';
+
+import * as profileGroupProviderMod from '../../profileGroupProvider';
+
+import {ProfileDetailsTable} from './profileDetailsTable';
+
+const {routerContext} = initializeOrg();
+
+jest.mock('../../profileGroupProvider', () => {
+  return {
+    useProfileGroup: jest.fn(),
+  };
+});
+
+const useProfileGroupSpy = jest.spyOn(profileGroupProviderMod, 'useProfileGroup');
+
+const mockUseProfileData: RequestState<ProfileGroup> = {
+  type: 'resolved',
+  data: importProfile(makeSentrySampledProfile(), ''),
+};
+useProfileGroupSpy.mockImplementation(() => [mockUseProfileData, () => {}]);
+
+function assertTableHeaders(headerText: string[]) {
+  const gridHeadRow = screen.getByTestId('grid-head-row');
+  headerText.forEach(txt => {
+    expect(within(gridHeadRow).getByText(txt)).toBeInTheDocument();
+  });
+}
+
+async function selectView(selection: string) {
+  const dropdownSelect = screen.getByText('View');
+  userEvent.click(dropdownSelect);
+  // attempt to select option from the select option list
+  // not what is being shown as active selection
+  const option = await screen.findAllByText(selection);
+  userEvent.click(option[1] ?? option[0]);
+}
+
+describe('profileDetailsTable', () => {
+  it.each([
+    {
+      view: 'Slowest Functions',
+      tableHeaders: [
+        'Symbol',
+        'Package',
+        'File',
+        'Thread',
+        'Type',
+        'Self Weight',
+        'Total Weight',
+      ],
+    },
+    {
+      view: 'Group by Symbol',
+      tableHeaders: ['Symbol', 'Type', 'Package', 'P75(Self)', 'P95(Self)', 'Count'],
+    },
+    {
+      view: 'Group by Package',
+      tableHeaders: ['Package', 'Type', 'P75(Self)', 'P95(Self)', 'Count'],
+    },
+    {
+      view: 'Group by File',
+      tableHeaders: ['File', 'Type', 'P75(Self)', 'P95(Self)', 'Count'],
+    },
+  ])('renders the "$view" view', async ({view, tableHeaders}) => {
+    render(<ProfileDetailsTable />, {
+      context: routerContext,
+    });
+
+    await selectView(view);
+
+    expect(screen.getByTestId('grid-editable')).toBeInTheDocument();
+    expect(screen.getByText(view)).toBeInTheDocument();
+    assertTableHeaders(tableHeaders);
+  });
+});

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -313,12 +313,12 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
   },
   p75: {
     key: 'p75',
-    name: t('P75'),
+    name: t('P75(Self)'),
     width: COL_WIDTH_UNDEFINED,
   },
   p95: {
     key: 'p95',
-    name: t('P95'),
+    name: t('P95(Self)'),
     width: COL_WIDTH_UNDEFINED,
   },
   count: {
@@ -328,15 +328,16 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
   },
 };
 
-const quantile = (arr: number[], q: number) => {
-  const sorted = arr.sort();
-  const pos = (sorted.length - 1) * q;
-  const base = Math.floor(pos);
-  const rest = pos - base;
-  if (sorted[base + 1] !== undefined) {
-    return sorted[base] + rest * (sorted[base + 1] - sorted[base]);
+const quantile = (arr: readonly number[], q: number) => {
+  const sorted = Array.from(arr).sort((a, b) => a - b);
+  const position = q * (sorted.length - 1);
+  const int = Math.floor(position);
+  const frac = position % 1;
+  if (position === int) {
+    return sorted[position];
   }
-  return sorted[base];
+
+  return sorted[int] * (1 - frac) + sorted[int + 1] * frac;
 };
 
 const p75AggregateColumn: AggregateColumnConfig<TableColumnKey> = {
@@ -380,7 +381,7 @@ interface GroupByOptions<T> {
 const GROUP_BY_OPTIONS: Record<string, GroupByOptions<TableColumnKey>> = {
   occurrence: {
     option: {
-      label: t('All Functions'),
+      label: t('Slowest Functions'),
       value: 'occurrence',
     },
     columns: ['symbol', 'image', 'file', 'thread', 'type', 'self weight', 'total weight'],

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -36,7 +36,8 @@ export function ProfileDetailsTable() {
   const [groupByViewKey, setGroupByView] = useQuerystringState<
     keyof typeof GROUP_BY_OPTIONS
   >({key: 'detailView', defaultState: 'occurrence'});
-  const groupByView = GROUP_BY_OPTIONS[groupByViewKey];
+
+  const groupByView = GROUP_BY_OPTIONS[groupByViewKey] ?? GROUP_BY_OPTIONS.occurrence;
 
   const cursor = useMemo<number>(() => {
     const cursorQuery = decodeScalar(location.query.cursor, '');

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -30,7 +30,7 @@ import {aggregate, AggregateColumnConfig, collectProfileFrames} from '../utils';
 
 const RESULTS_PER_PAGE = 50;
 
-export function SlowestFunctions() {
+export function ProfileDetailsTable() {
   const location = useLocation();
   const [state] = useProfileGroup();
   const [groupByViewKey, setGroupByView] = useQuerystringState<

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -239,6 +239,8 @@ function ProfilingFunctionsTableCell({
     case 'self weight':
     case 'total weight':
       return <NumberContainer>{formatter(value as number)}</NumberContainer>;
+    case 'count':
+      return <NumberContainer>{value}</NumberContainer>;
     case 'image':
       return <Container>{value ?? t('Unknown')}</Container>;
     case 'thread': {

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -178,6 +178,9 @@ export function ProfileDetailsTable() {
         data={data}
         columnOrder={groupByView.columns.map(key => COLUMNS[key])}
         columnSortBy={[currentSort]}
+        scrollable
+        stickyHeader
+        height="75vh"
         grid={{
           renderHeadCell: renderTableHead({
             rightAlignedColumns: new Set(groupByView.rightAlignedColumns),

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -73,8 +73,6 @@ export function ProfileDetailsTable() {
     return search(searchQuery);
   });
 
-  const pageLinks = usePageLinks(filteredDataBySearch, cursor);
-
   const {filters, columnFilters, filterPredicate} = useColumnFilters(allData, [
     'type',
     'image',
@@ -101,10 +99,19 @@ export function ProfileDetailsTable() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allData, search]);
 
-  const data = filteredDataBySearch
-    .filter(filterPredicate)
-    .sort(sortCompareFn)
-    .slice(cursor, cursor + RESULTS_PER_PAGE);
+  const filteredData = useMemo(
+    () => filteredDataBySearch.filter(filterPredicate),
+    [filterPredicate, filteredDataBySearch]
+  );
+
+  const sortedData = useMemo(
+    () => filteredData.sort(sortCompareFn),
+    [filteredData, sortCompareFn]
+  );
+
+  const pageLinks = usePageLinks(sortedData, cursor);
+
+  const data = sortedData.slice(cursor, cursor + RESULTS_PER_PAGE);
 
   return (
     <Fragment>
@@ -233,7 +240,7 @@ function ProfilingFunctionsTableCell({
     case 'total weight':
       return <NumberContainer>{formatter(value as number)}</NumberContainer>;
     case 'image':
-      return <Container>{value ?? 'Unknown'}</Container>;
+      return <Container>{value ?? t('Unknown')}</Container>;
     case 'thread': {
       return (
         <Container>

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import {Link} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
@@ -35,17 +35,17 @@ export function ProfileDetailsTable() {
   const [state] = useProfileGroup();
   const [groupByViewKey, setGroupByView] = useQuerystringState({
     key: 'detailView',
-    defaultState: 'occurrence',
+    initialState: 'occurrence',
   });
 
   const [searchQuery, setSearchQuery] = useQuerystringState({
     key: 'query',
-    defaultState: '',
+    initialState: '',
   });
 
   const [paginationCursor, setPaginationCursor] = useQuerystringState({
     key: 'cursor',
-    defaultState: '',
+    initialState: '',
   });
 
   const groupByView = GROUP_BY_OPTIONS[groupByViewKey] ?? GROUP_BY_OPTIONS.occurrence;
@@ -73,10 +73,26 @@ export function ProfileDetailsTable() {
     return search(searchQuery);
   });
 
-  const {filters, columnFilters, filterPredicate} = useColumnFilters(allData, [
-    'type',
-    'image',
-  ]);
+  const [typeFilter, setTypeFilter] = useQuerystringState({
+    key: 'type',
+  });
+
+  const [imageFilter, setImageFilter] = useQuerystringState({
+    key: 'image',
+  });
+
+  const {filters, columnFilters, filterPredicate} = useColumnFilters(allData, {
+    columns: ['type', 'image'],
+    initialState: {
+      type: typeFilter,
+      image: imageFilter,
+    },
+  });
+
+  useEffect(() => {
+    setTypeFilter(filters.type);
+    setImageFilter(filters.image);
+  }, [filters, setTypeFilter, setImageFilter]);
 
   const {currentSort, generateSortLink, sortCompareFn} = useSortableColumns({
     ...groupByView.sort,

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -169,6 +169,7 @@ export function ProfileDetailsTable() {
           multiple
           onChange={columnFilters.image.onChange}
           placement="bottom right"
+          isSearchable
         />
       </ActionBar>
 

--- a/static/app/views/profiling/profileDetails/components/slowestFunctions.tsx
+++ b/static/app/views/profiling/profileDetails/components/slowestFunctions.tsx
@@ -104,6 +104,14 @@ export function SlowestFunctions() {
   return (
     <Fragment>
       <ActionBar>
+        <CompactSelect
+          options={[{label: 'None', value: 'none'}]}
+          value="none"
+          triggerProps={{
+            prefix: t('Group by'),
+          }}
+          placement="bottom right"
+        />
         <SearchBar
           defaultQuery=""
           query={query}
@@ -176,7 +184,7 @@ const SORTABLE_COLUMNS = new Set<TableColumnKey>(['self weight', 'total weight']
 
 const ActionBar = styled('div')`
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: auto 1fr auto auto;
   gap: ${space(2)};
   margin-bottom: ${space(2)};
 `;
@@ -243,6 +251,7 @@ function ProfilingFunctionsTableCell({
 const tableColumnKey = [
   'symbol',
   'image',
+  'file',
   'thread',
   'type',
   'self weight',
@@ -258,6 +267,7 @@ type TableColumn = GridColumnOrder<TableColumnKey>;
 const COLUMN_ORDER: TableColumnKey[] = [
   'symbol',
   'image',
+  'file',
   'thread',
   'type',
   'self weight',
@@ -274,6 +284,11 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
   image: {
     key: 'image',
     name: t('Package'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  file: {
+    key: 'file',
+    name: t('File'),
     width: COL_WIDTH_UNDEFINED,
   },
   thread: {

--- a/static/app/views/profiling/profileDetails/components/slowestFunctions.tsx
+++ b/static/app/views/profiling/profileDetails/components/slowestFunctions.tsx
@@ -10,13 +10,10 @@ import GridEditable, {
   GridColumnOrder,
   GridColumnSortBy,
 } from 'sentry/components/gridEditable';
-import * as Layout from 'sentry/components/layouts/thirds';
 import Pagination from 'sentry/components/pagination';
 import SearchBar from 'sentry/components/searchBar';
-import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {Container, NumberContainer} from 'sentry/utils/discover/styles';
 import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
@@ -26,10 +23,9 @@ import {makeFormatter} from 'sentry/utils/profiling/units/units';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
 import {useLocation} from 'sentry/utils/useLocation';
-import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 
-import {useProfileGroup} from './profileGroupProvider';
+import {useProfileGroup} from '../../profileGroupProvider';
 
 function collectTopProfileFrames(profile: Profile) {
   const nodes: CallTreeNode[] = [];
@@ -62,16 +58,9 @@ function collectTopProfileFrames(profile: Profile) {
 
 const RESULTS_PER_PAGE = 50;
 
-function ProfileDetails() {
+export function SlowestFunctions() {
   const location = useLocation();
   const [state] = useProfileGroup();
-  const organization = useOrganization();
-
-  useEffect(() => {
-    trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {
-      organization,
-    });
-  }, [organization]);
 
   const cursor = useMemo<number>(() => {
     const cursorQuery = decodeScalar(location.query.cursor, '');
@@ -271,80 +260,71 @@ function ProfileDetails() {
 
   return (
     <Fragment>
-      <SentryDocumentTitle
-        title={t('Profiling \u2014 Details')}
-        orgSlug={organization.slug}
-      >
-        <Layout.Body>
-          <Layout.Main fullWidth>
-            <ActionBar>
-              <SearchBar
-                defaultQuery=""
-                query={query}
-                placeholder={t('Search for frames')}
-                onChange={handleSearch}
-              />
+      <ActionBar>
+        <SearchBar
+          defaultQuery=""
+          query={query}
+          placeholder={t('Search for frames')}
+          onChange={handleSearch}
+        />
 
-              <CompactSelect
-                options={columnFilters.type.values.map(value => ({value, label: value}))}
-                value={filters.type}
-                triggerLabel={
-                  !filters.type ||
-                  (Array.isArray(filters.type) &&
-                    filters.type.length === columnFilters.type.values.length)
-                    ? t('All')
-                    : undefined
-                }
-                triggerProps={{
-                  prefix: t('Type'),
-                }}
-                multiple
-                onChange={columnFilters.type.onChange}
-                placement="bottom right"
-              />
+        <CompactSelect
+          options={columnFilters.type.values.map(value => ({value, label: value}))}
+          value={filters.type}
+          triggerLabel={
+            !filters.type ||
+            (Array.isArray(filters.type) &&
+              filters.type.length === columnFilters.type.values.length)
+              ? t('All')
+              : undefined
+          }
+          triggerProps={{
+            prefix: t('Type'),
+          }}
+          multiple
+          onChange={columnFilters.type.onChange}
+          placement="bottom right"
+        />
 
-              <CompactSelect
-                options={columnFilters.image.values.map(value => ({value, label: value}))}
-                value={filters.image}
-                triggerLabel={
-                  !filters.image ||
-                  (Array.isArray(filters.image) &&
-                    filters.image.length === columnFilters.image.values.length)
-                    ? t('All')
-                    : undefined
-                }
-                triggerProps={{
-                  prefix: t('Package'),
-                }}
-                multiple
-                onChange={columnFilters.image.onChange}
-                placement="bottom right"
-              />
-            </ActionBar>
+        <CompactSelect
+          options={columnFilters.image.values.map(value => ({value, label: value}))}
+          value={filters.image}
+          triggerLabel={
+            !filters.image ||
+            (Array.isArray(filters.image) &&
+              filters.image.length === columnFilters.image.values.length)
+              ? t('All')
+              : undefined
+          }
+          triggerProps={{
+            prefix: t('Package'),
+          }}
+          multiple
+          onChange={columnFilters.image.onChange}
+          placement="bottom right"
+        />
+      </ActionBar>
 
-            <GridEditable
-              title={t('Slowest Functions')}
-              isLoading={state.type === 'loading'}
-              error={state.type === 'errored'}
-              data={data}
-              columnOrder={COLUMN_ORDER.map(key => COLUMNS[key])}
-              columnSortBy={[currentSort]}
-              grid={{
-                renderHeadCell: renderTableHead({
-                  rightAlignedColumns: RIGHT_ALIGNED_COLUMNS,
-                  sortableColumns: RIGHT_ALIGNED_COLUMNS,
-                  currentSort,
-                  generateSortLink,
-                }),
-                renderBodyCell: renderFunctionCell,
-              }}
-              location={location}
-            />
+      <GridEditable
+        title={t('Slowest Functions')}
+        isLoading={state.type === 'loading'}
+        error={state.type === 'errored'}
+        data={data}
+        columnOrder={COLUMN_ORDER.map(key => COLUMNS[key])}
+        columnSortBy={[currentSort]}
+        grid={{
+          renderHeadCell: renderTableHead({
+            rightAlignedColumns: RIGHT_ALIGNED_COLUMNS,
+            sortableColumns: RIGHT_ALIGNED_COLUMNS,
+            currentSort,
+            generateSortLink,
+          }),
+          renderBodyCell: renderFunctionCell,
+        }}
+        location={location}
+      />
 
-            <Pagination pageLinks={pageLinks} />
-          </Layout.Main>
-        </Layout.Body>
-      </SentryDocumentTitle>
+      <Pagination pageLinks={pageLinks} />
     </Fragment>
   );
 }
@@ -484,5 +464,3 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
     width: COL_WIDTH_UNDEFINED,
   },
 };
-
-export default ProfileDetails;

--- a/static/app/views/profiling/profileDetails/hooks/useColumnFilters.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useColumnFilters.ts
@@ -1,0 +1,58 @@
+import {useMemo, useState} from 'react';
+
+import {pluckUniqueValues} from '../utils';
+
+type ColumnFilters<T extends string | number | symbol> = {
+  [key in T]: {
+    onChange: (values: {value: string}[]) => void;
+    values: string[];
+  };
+};
+
+export function useColumnFilters<
+  T extends Record<string, string>,
+  K extends string | number | symbol = keyof T
+>(data: T[], columns: K[]) {
+  const [filters, setFilters] = useState<Partial<Record<K, string[]>>>({});
+
+  const columnFilters = useMemo(() => {
+    function makeOnFilterChange(key: string) {
+      return (values: {value: string}[]) => {
+        setFilters(prevFilters => ({
+          ...prevFilters,
+          [key]: values.length > 0 ? values.map(val => val.value) : undefined,
+        }));
+      };
+    }
+
+    return columns.reduce((acc, key) => {
+      acc[key] = {
+        values: pluckUniqueValues(data, key as string).sort((a, b) => a.localeCompare(b)),
+        onChange: makeOnFilterChange(key as string),
+      };
+      return acc;
+    }, {} as ColumnFilters<K>);
+  }, [data, columns]);
+
+  const filterPredicate = (row: T) => {
+    let include = true;
+    for (const key in filters) {
+      const filterValues = filters[key];
+      if (!filterValues) {
+        continue;
+      }
+      const rowValue = row[key];
+      include = filterValues.includes(rowValue);
+      if (!include) {
+        return false;
+      }
+    }
+    return include;
+  };
+
+  return {
+    filters,
+    columnFilters,
+    filterPredicate,
+  };
+}

--- a/static/app/views/profiling/profileDetails/hooks/useColumnFilters.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useColumnFilters.ts
@@ -9,11 +9,38 @@ type ColumnFilters<T extends string | number | symbol> = {
   };
 };
 
+interface ColumnFiltersOptions<K extends string> {
+  columns: K[];
+  initialState?: Record<K, string[] | string | undefined>;
+}
+
+function parseInitialState(state?: Record<string, string[] | string | undefined>) {
+  if (!state) {
+    return {};
+  }
+  return Object.entries(state).reduce((acc, [key, val]) => {
+    acc[key] = undefined;
+
+    if (Array.isArray(val)) {
+      acc[key] = val;
+    }
+
+    if (typeof val === 'string') {
+      acc[key] = [val];
+    }
+
+    return acc;
+  }, {});
+}
+
 export function useColumnFilters<
   T extends Record<string, string | number>,
-  K extends string | number | symbol = keyof T
->(data: T[], columns: K[]) {
-  const [filters, setFilters] = useState<Partial<Record<K, string[]>>>({});
+  K extends string = Extract<keyof T, string>
+>(data: T[], options: ColumnFiltersOptions<K>) {
+  const {columns} = options;
+  const [filters, setFilters] = useState<Partial<Record<K, string[]>>>(
+    parseInitialState(options.initialState)
+  );
 
   const columnFilters = useMemo(() => {
     function makeOnFilterChange(key: string) {

--- a/static/app/views/profiling/profileDetails/hooks/useFuseSearch.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useFuseSearch.ts
@@ -1,0 +1,24 @@
+import {useCallback, useMemo} from 'react';
+import Fuse from 'fuse.js';
+
+export function useFuseSearch<T extends Record<string, unknown>>(
+  data: T[],
+  options: Fuse.IFuseOptions<T>
+) {
+  const searchIndex = useMemo(() => {
+    return new Fuse(data, options);
+  }, [data, options]);
+
+  const search = useCallback(
+    (...args: Parameters<Fuse<T>['search']>) => {
+      const [pattern, opts] = args;
+      if (!pattern) {
+        return data;
+      }
+      return searchIndex.search(pattern, opts).map(result => result.item);
+    },
+    [searchIndex, data]
+  );
+
+  return {search, searchIndex};
+}

--- a/static/app/views/profiling/profileDetails/hooks/useFuseSearch.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useFuseSearch.ts
@@ -7,7 +7,10 @@ export function useFuseSearch<T extends Record<string, unknown>>(
 ) {
   const searchIndex = useMemo(() => {
     return new Fuse(data, options);
-  }, [data, options]);
+    // purposely ignoring options as it will cause the effect to infinitely run
+    // data is sufficient as the index should only change if data ever changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
 
   const search = useCallback(
     (...args: Parameters<Fuse<T>['search']>) => {

--- a/static/app/views/profiling/profileDetails/hooks/usePageLinks.ts
+++ b/static/app/views/profiling/profileDetails/hooks/usePageLinks.ts
@@ -1,0 +1,33 @@
+import {useMemo} from 'react';
+import * as qs from 'query-string';
+
+import {useLocation} from 'sentry/utils/useLocation';
+
+const RESULTS_PER_PAGE = 50;
+
+export function usePageLinks(
+  data: any[],
+  cursor: number,
+  resultsPerPage = RESULTS_PER_PAGE
+) {
+  const location = useLocation();
+
+  const pageLinks = useMemo(() => {
+    const prevResults = cursor >= resultsPerPage ? 'true' : 'false';
+    const prevCursor = cursor >= resultsPerPage ? cursor - resultsPerPage : 0;
+    const prevQuery = {...location.query, cursor: prevCursor};
+    const prevHref = `${location.pathname}${qs.stringify(prevQuery)}`;
+    const prev = `<${prevHref}>; rel="previous"; results="${prevResults}"; cursor="${prevCursor}"`;
+
+    const nextResults = cursor + resultsPerPage < data.length ? 'true' : 'false';
+    const nextCursor =
+      cursor + resultsPerPage < data.length ? cursor + resultsPerPage : 0;
+    const nextQuery = {...location.query, cursor: nextCursor};
+    const nextHref = `${location.pathname}${qs.stringify(nextQuery)}`;
+    const next = `<${nextHref}>; rel="next"; results="${nextResults}"; cursor="${nextCursor}"`;
+
+    return `${prev},${next}`;
+  }, [cursor, location, data, resultsPerPage]);
+
+  return pageLinks;
+}

--- a/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
@@ -1,0 +1,62 @@
+import {useCallback, useEffect, useState} from 'react';
+import {browserHistory} from 'react-router';
+
+import {useLocation} from 'sentry/utils/useLocation';
+
+type QueryState = string | string[] | null | undefined;
+
+interface UseQuerystringStateOptions<T> {
+  key: string;
+  defaultState?: T;
+}
+
+export function useQuerystringState<T extends QueryState>({
+  key,
+  defaultState,
+}: UseQuerystringStateOptions<T>) {
+  const location = useLocation();
+  const [state, setState] = useState<T>((location.query[key] ?? defaultState) as T);
+
+  const createLocationDescriptor = useCallback(
+    (nextState: T) => {
+      return {
+        ...location,
+        query: {
+          ...location.query,
+          [key]: nextState,
+        },
+      };
+    },
+    [location, key]
+  );
+
+  const setQueryStringState = useCallback(
+    (nextState: T) => {
+      browserHistory.replace(createLocationDescriptor(nextState));
+    },
+    [createLocationDescriptor]
+  );
+  useEffect(() => {
+    const removeListener = browserHistory.listenBefore((nextLocation, next) => {
+      if (location.pathname === nextLocation.pathname) {
+        setState(nextLocation.query[key] as T);
+        next(nextLocation);
+        return;
+      }
+
+      if (key in nextLocation.query) {
+        delete nextLocation.query[key];
+      }
+
+      next(nextLocation);
+    });
+
+    return removeListener;
+  }, [key, location.pathname]);
+
+  return [state, setQueryStringState, createLocationDescriptor] as [
+    T,
+    typeof setQueryStringState,
+    typeof createLocationDescriptor
+  ];
+}

--- a/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
@@ -35,6 +35,7 @@ export function useQuerystringState({key, initialState}: UseQuerystringStateOpti
   const setQueryStringState = useCallback(
     (nextState: string | string[] | undefined) => {
       browserHistory.replace(createLocationDescriptor(nextState));
+      setState(nextState);
     },
     [createLocationDescriptor]
   );
@@ -52,8 +53,6 @@ export function useQuerystringState({key, initialState}: UseQuerystringStateOpti
         delete nextLocation.query[key];
         return;
       }
-
-      setState(nextLocation.query[key]);
     });
 
     return removeListener;

--- a/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useQuerystringState.ts
@@ -5,21 +5,22 @@ import {useLocation} from 'sentry/utils/useLocation';
 
 interface UseQuerystringStateOptions {
   key: string;
-  defaultState?: string;
+  initialState?: string;
 }
 
-export function useQuerystringState({key, defaultState}: UseQuerystringStateOptions) {
+export function useQuerystringState({key, initialState}: UseQuerystringStateOptions) {
   const location = useLocation();
   const [state, setState] = useState<string | string[] | null | undefined>(
-    location.query[key] ?? defaultState
+    location.query[key] ?? initialState
   );
 
   const createLocationDescriptor = useCallback(
-    (nextState: string | undefined) => {
+    (nextState: string | string[] | undefined) => {
       // we can't use the result of `useLocation` here
       // if there are multiple instances of `useQuerystringState` firing at once
       // the value of location will be stale in the callback
       const currentLocation = browserHistory.getCurrentLocation();
+
       return {
         ...currentLocation,
         query: {
@@ -32,7 +33,7 @@ export function useQuerystringState({key, defaultState}: UseQuerystringStateOpti
   );
 
   const setQueryStringState = useCallback(
-    (nextState: string | undefined) => {
+    (nextState: string | string[] | undefined) => {
       browserHistory.replace(createLocationDescriptor(nextState));
     },
     [createLocationDescriptor]

--- a/static/app/views/profiling/profileDetails/hooks/useSortableColumn.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useSortableColumn.ts
@@ -1,0 +1,95 @@
+import {useCallback, useEffect, useMemo} from 'react';
+import {browserHistory} from 'react-router';
+
+import {GridColumnSortBy} from 'sentry/components/gridEditable';
+import {useLocation} from 'sentry/utils/useLocation';
+
+export function useSortableColumns<T extends string>(options: {
+  defaultSort: GridColumnSortBy<T>;
+  querystringKey: string;
+  sortableColumns: Set<string>;
+}) {
+  const {sortableColumns, querystringKey, defaultSort} = options;
+  const location = useLocation();
+  const currentSort = useMemo<GridColumnSortBy<T>>(() => {
+    let key = location.query?.[querystringKey] ?? '';
+
+    const isDesc = key[0] === '-';
+    if (isDesc) {
+      key = key.slice(1);
+    }
+
+    if (!key || !sortableColumns.has(key as T)) {
+      return defaultSort;
+    }
+
+    return {
+      key,
+      order: isDesc ? 'desc' : 'asc',
+    } as GridColumnSortBy<T>;
+  }, [location.query, sortableColumns, defaultSort, querystringKey]);
+
+  useEffect(() => {
+    const removeListener = browserHistory.listenBefore((nextLocation, next) => {
+      if (location.pathname === nextLocation.pathname) {
+        next(nextLocation);
+        return;
+      }
+
+      if (querystringKey in nextLocation.query) {
+        delete nextLocation.query[querystringKey];
+      }
+
+      next(nextLocation);
+    });
+
+    return removeListener;
+  });
+
+  const generateSortLink = useCallback(
+    (column: T) => {
+      if (!sortableColumns.has(column)) {
+        return () => undefined;
+      }
+      if (!currentSort) {
+        return () => ({
+          ...location,
+          query: {
+            ...location.query,
+            functionsSort: column,
+          },
+        });
+      }
+
+      const direction =
+        currentSort.key !== column
+          ? 'desc'
+          : currentSort.order === 'desc'
+          ? 'asc'
+          : 'desc';
+
+      return () => ({
+        ...location,
+        query: {
+          ...location.query,
+          functionsSort: `${direction === 'desc' ? '-' : ''}${column}`,
+        },
+      });
+    },
+    [location, currentSort, sortableColumns]
+  );
+
+  // TODO: support strings
+  const sortCompareFn = (a: Record<T, number>, b: Record<T, number>) => {
+    if (currentSort.order === 'asc') {
+      return a[currentSort.key] - b[currentSort.key];
+    }
+    return b[currentSort.key] - a[currentSort.key];
+  };
+
+  return {
+    currentSort,
+    generateSortLink,
+    sortCompareFn,
+  };
+}

--- a/static/app/views/profiling/profileDetails/hooks/useSortableColumn.ts
+++ b/static/app/views/profiling/profileDetails/hooks/useSortableColumn.ts
@@ -41,11 +41,7 @@ export function useSortableColumns<T extends string>(options: {
       }
 
       const direction =
-        currentSort.key !== column
-          ? 'desc'
-          : currentSort.order === 'desc'
-          ? 'asc'
-          : 'desc';
+        currentSort.key === column && currentSort.order === 'desc' ? 'asc' : 'desc';
 
       return () =>
         createLocationDescriptor(`${direction === 'desc' ? '-' : ''}${column}`);

--- a/static/app/views/profiling/profileDetails/index.tsx
+++ b/static/app/views/profiling/profileDetails/index.tsx
@@ -1,0 +1,1 @@
+export {default as default} from './profileDetails';

--- a/static/app/views/profiling/profileDetails/profileDetails.tsx
+++ b/static/app/views/profiling/profileDetails/profileDetails.tsx
@@ -6,7 +6,7 @@ import {t} from 'sentry/locale';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import {SlowestFunctions} from './components/slowestFunctions';
+import {ProfileDetailsTable} from './components/profileDetailsTable';
 
 function ProfileDetails() {
   const organization = useOrganization();
@@ -25,7 +25,7 @@ function ProfileDetails() {
       >
         <Layout.Body>
           <Layout.Main fullWidth>
-            <SlowestFunctions />
+            <ProfileDetailsTable />
           </Layout.Main>
         </Layout.Body>
       </SentryDocumentTitle>

--- a/static/app/views/profiling/profileDetails/profileDetails.tsx
+++ b/static/app/views/profiling/profileDetails/profileDetails.tsx
@@ -1,0 +1,36 @@
+import {Fragment, useEffect} from 'react';
+
+import * as Layout from 'sentry/components/layouts/thirds';
+import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {t} from 'sentry/locale';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import {SlowestFunctions} from './components/slowestFunctions';
+
+function ProfileDetails() {
+  const organization = useOrganization();
+
+  useEffect(() => {
+    trackAdvancedAnalyticsEvent('profiling_views.profile_summary', {
+      organization,
+    });
+  }, [organization]);
+
+  return (
+    <Fragment>
+      <SentryDocumentTitle
+        title={t('Profiling \u2014 Details')}
+        orgSlug={organization.slug}
+      >
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <SlowestFunctions />
+          </Layout.Main>
+        </Layout.Body>
+      </SentryDocumentTitle>
+    </Fragment>
+  );
+}
+
+export default ProfileDetails;

--- a/static/app/views/profiling/profileDetails/utils.ts
+++ b/static/app/views/profiling/profileDetails/utils.ts
@@ -30,10 +30,61 @@ export function pluckUniqueValues<T extends Record<string, any>>(
   collection: T[],
   key: keyof T
 ) {
-  return collection.reduce((acc, val) => {
-    if (!acc.includes(val[key])) {
-      acc.push(val[key]);
+  return collection.reduce((acc, record) => {
+    const value = record[key];
+    if (value && !acc.includes(value)) {
+      acc.push(value);
     }
     return acc;
   }, [] as string[]);
+}
+
+type Row = Record<string, string | number | undefined>;
+export interface AggregateColumnConfig<T = Record<string, number>> {
+  compute: (data: T[]) => number;
+  key: string;
+}
+export function aggregate<T extends Row>(
+  data: T[],
+  groups: Extract<keyof T, string>[],
+  aggregates: AggregateColumnConfig<T>[]
+) {
+  const groupedData = groupBy(data, groups);
+
+  const rows: Row[] = [];
+  for (const groupedKey in groupedData) {
+    const row = makeRowFromGroupedKey(groupedKey, groups);
+    const groupedValues = groupedData[groupedKey];
+    aggregates.forEach(agg => {
+      row[agg.key] = agg.compute(groupedValues);
+    });
+    rows.push(row);
+  }
+  return rows;
+}
+
+function groupBy<T extends Row>(data: T[], groups: Extract<keyof T, string>[]) {
+  return data.reduce((acc, row) => {
+    const key = getGroupedKey(row, groups);
+    if (!acc[key]) {
+      acc[key] = [];
+    }
+
+    acc[key].push(row);
+    return acc;
+  }, {});
+}
+
+const FIELD_SEPARATOR = String.fromCharCode(31);
+
+function getGroupedKey(row: Record<string, unknown>, groups: string[]) {
+  return groups.map(key => row[key]).join(FIELD_SEPARATOR);
+}
+
+function makeRowFromGroupedKey(groupedKey: string, groups: string[]) {
+  const groupedKeyValues = groupedKey.split(FIELD_SEPARATOR);
+  return groups.reduce((acc, key, idx) => {
+    acc[key] = groupedKeyValues[idx];
+    return acc;
+  }, {} as Row);
 }

--- a/static/app/views/profiling/profileDetails/utils.ts
+++ b/static/app/views/profiling/profileDetails/utils.ts
@@ -17,6 +17,7 @@ export function collectProfileFrames(profile: Profile) {
     .sort((a, b) => b.selfWeight - a.selfWeight)
     .map(node => ({
       symbol: node.frame.name,
+      file: node.frame.file,
       image: node.frame.image,
       thread: profile.threadId,
       type: node.frame.is_application ? 'application' : 'system',

--- a/static/app/views/profiling/profileDetails/utils.ts
+++ b/static/app/views/profiling/profileDetails/utils.ts
@@ -1,0 +1,38 @@
+import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
+import {Profile} from 'sentry/utils/profiling/profile/profile';
+
+export function collectProfileFrames(profile: Profile) {
+  const nodes: CallTreeNode[] = [];
+
+  profile.forEach(
+    node => {
+      if (node.selfWeight > 0) {
+        nodes.push(node);
+      }
+    },
+    () => {}
+  );
+
+  return nodes
+    .sort((a, b) => b.selfWeight - a.selfWeight)
+    .map(node => ({
+      symbol: node.frame.name,
+      image: node.frame.image,
+      thread: profile.threadId,
+      type: node.frame.is_application ? 'application' : 'system',
+      'self weight': node.selfWeight,
+      'total weight': node.totalWeight,
+    }));
+}
+
+export function pluckUniqueValues<T extends Record<string, any>>(
+  collection: T[],
+  key: keyof T
+) {
+  return collection.reduce((acc, val) => {
+    if (!acc.includes(val[key])) {
+      acc.push(val[key]);
+    }
+    return acc;
+  }, [] as string[]);
+}

--- a/static/app/views/profiling/profileDetails/utils.ts
+++ b/static/app/views/profiling/profileDetails/utils.ts
@@ -39,16 +39,19 @@ export function pluckUniqueValues<T extends Record<string, any>>(
   }, [] as string[]);
 }
 
-type Row = Record<string, string | number | undefined>;
-export interface AggregateColumnConfig<T = Record<string, number>> {
-  compute: (data: T[]) => number;
+export type Row<K extends string = string> = Record<
+  Extract<K, string>,
+  string | number | undefined
+>;
+export interface AggregateColumnConfig<K extends string> {
+  compute: (data: Row<K>[]) => number;
   key: string;
 }
-export function aggregate<T extends Row>(
-  data: T[],
-  groups: Extract<keyof T, string>[],
+export function aggregate<T extends string>(
+  data: Partial<Row<T>>[],
+  groups: Extract<T, string>[],
   aggregates: AggregateColumnConfig<T>[]
-) {
+): Row<T>[] {
   const groupedData = groupBy(data, groups);
 
   const rows: Row[] = [];

--- a/static/app/views/profiling/profileDetails/utils.ts
+++ b/static/app/views/profiling/profileDetails/utils.ts
@@ -38,7 +38,7 @@ export function pluckUniqueValues<T extends Record<string, any>>(
       acc.push(value);
     }
     return acc;
-  }, [] as string[]);
+  }, [] as any[]);
 }
 
 export type Row<K extends string = string> = Record<
@@ -80,7 +80,7 @@ export function aggregate<T extends string>(
 const FIELD_SEPARATOR = String.fromCharCode(31);
 
 // getGroupedKey will derive a key from an objects values and delimit them using
-// the unit separator char
+// the unit separator
 function getGroupedKey(row: Record<string, unknown>, groups: string[]) {
   return groups.map(key => row[key]).join(FIELD_SEPARATOR);
 }

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -76,6 +76,8 @@ jest.mock('react-router', () => {
       push: jest.fn(),
       replace: jest.fn(),
       listen: jest.fn(() => {}),
+      listenBefore: jest.fn(),
+      getCurrentLocation: jest.fn(() => ({pathname: '', query: {}})),
     },
   };
 });


### PR DESCRIPTION
## Summary
This PR introduces new aggregated views to the Profile Details page;
- All Functions (renamed from slowest functions) 
  - Symbol, Package, File, Thread, Type, Self Weight, Total Weight
- Group by Symbol
  -   Symbol, Type, Package, p75(Self Weight), p95(Self Weight), Count 
- Group by Package
  -   Package, Type,  p75(Self Weight), p95(Self Weight), Count  
- Group by File
  -   File, Type, Package,  p75(Self Weight), p95(Self Weight), Count  

Notes for reviewers:
- `slowestFunctions` moved to `profileDetailsTable` but its not diffed; i'm guessing `git` treated it as a new file since it was a large change
- `profileDetailsTable` was decomposed into a number of smaller hooks to make it a bit easier to reason about
  -  some of these hooks can be moved to a more shareable place; unless theres a strong opinion on this, I prefer to leave them co-located and move them as necessary, there will be more work to this in following PRs.


What's missing:
- linking back to flamechart only works from the `All Functions` view as this existed before; i will follow up with another PR

Tracking here: https://github.com/getsentry/team-profiling/issues/61