### PR TITLE
feat(code_mappings): Order of stackframes not to affect results

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, NamedTuple, Union
+from typing import Dict, List, NamedTuple, Union
 
 logger = logging.getLogger("sentry.integrations.utils.code_mapping")
 logger.setLevel(logging.INFO)
@@ -15,7 +15,7 @@ class CodeMapping(NamedTuple):
     source_path: str
 
 
-def derive_code_mappings(stacktraces: List[str], trees: Dict[str, Any]) -> List[CodeMapping]:
+def derive_code_mappings(stacktraces: List[str], trees: Dict[str, List[str]]) -> List[CodeMapping]:
     """Generate the code mappings from a list of stack trace frames for a project and the trees for an org.
 
     WARNING: Do not pass stacktraces from different projects or the wrong code mappings will be returned.
@@ -48,12 +48,12 @@ class FrameFilename:
 
 
 class CodeMappingTreesHelper:
-    def __init__(self, trees: Dict[str, Any]):
+    def __init__(self, trees: Dict[str, List[str]]):
         self.trees = trees
         self.code_mappings: Dict[str, CodeMapping] = {}
 
-    def stacktrace_buckets(self, stacktraces: List[str]) -> Dict[str, Any]:
-        buckets: Dict[str, Any] = {}
+    def stacktrace_buckets(self, stacktraces: List[str]) -> Dict[str, List[FrameFilename]]:
+        buckets: Dict[str, List[FrameFilename]] = {}
         for stacktrace_frame_file_path in stacktraces:
             try:
                 frame_filename = FrameFilename(stacktrace_frame_file_path)
@@ -71,20 +71,35 @@ class CodeMappingTreesHelper:
                 continue
         return buckets
 
-    def generate_code_mappings(self, stacktraces: List[str]) -> List[CodeMapping]:
-        """Generate code mappings based on the initial trees object and the list of stack traces"""
-        # We need to make sure that calling this method with a new list of stack traces
-        # should always start with a clean slate
-        self.code_mappings = {}
-        buckets: Dict[str, Any] = self.stacktrace_buckets(stacktraces)
-
+    def process_stackframes(self, buckets: Dict[str, List[FrameFilename]]) -> bool:
+        """This processes all stackframes and returns if a new code mapping has been generated"""
+        reprocess = False
         for stackframe_root, stackframes in buckets.items():
             if not self.code_mappings.get(stackframe_root):
                 for frame_filename in stackframes:
                     code_mapping = self._find_code_mapping(frame_filename)
                     if code_mapping:
-                        # XXX: Reprocess feature
+                        # This allows processing some stack frames that
+                        # were matching more than one file
+                        reprocess = True
                         self.code_mappings[stackframe_root] = code_mapping
+        return reprocess
+
+    def generate_code_mappings(self, stacktraces: List[str]) -> List[CodeMapping]:
+        """Generate code mappings based on the initial trees object and the list of stack traces"""
+        # We need to make sure that calling this method with a new list of stack traces
+        # should always start with a clean slate
+        self.code_mappings = {}
+        buckets: Dict[str, List[FrameFilename]] = self.stacktrace_buckets(stacktraces)
+
+        # We reprocess stackframes until we are told that no code mappings were produced
+        # This is order to reprocess past stackframes in light of newly discovered code mappings
+        # This allows for idempotency since the order of the stackframes will not matter
+        # This has no performance issue because stackframes that match an existing code mapping
+        # will be skipped
+        while True:
+            if not self.process_stackframes(buckets):
+                break
 
         return list(self.code_mappings.values())
 

--- a/src/sentry/integrations/utils/tree.py
+++ b/src/sentry/integrations/utils/tree.py
@@ -1,9 +1,7 @@
 from typing import List
 
-from sentry.utils.json import JSONData
 
-
-def trim_tree(tree: JSONData, languages: List[str]) -> List[str]:
+def trim_tree(tree: List[str], languages: List[str]) -> List[str]:
     """This takes the tree representation of a repo and returns the file paths for the languages"""
 
     def should_include_file(file_path: str) -> bool:

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -611,7 +611,6 @@ class GitHubIntegrationTest(IntegrationTestCase):
         assert code_mappings == []
 
         # Case 3 - We derive sentry_plugins because we derive sentry first
-        # XXX: Order matters of processing matters. Fix code
         stacktraces = [
             "sentry/identity/oauth2.py",
             # This file matches two files in the repo, however, because we first
@@ -629,5 +628,5 @@ class GitHubIntegrationTest(IntegrationTestCase):
             "sentry/identity/oauth2.py",
         ]
         code_mappings = derive_code_mappings(stacktraces, trees)
-        # Order matters, this is why we only derive one of the two code mappings
-        assert code_mappings == [expected_code_mappings[0]]
+        # The reprocess feature allows determinging the sentry_plugins code mappings
+        assert code_mappings == expected_code_mappings


### PR DESCRIPTION
This guarantees the same result with the same trees + stackframes input.

It also gets rid of `Any` usage for data typing.

Fixes WOR-2317