### PR TITLE
ref(ui): Remove processed transaction data category

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -216,7 +216,6 @@ export const DATA_CATEGORY_NAMES = {
   [DataCategory.ERRORS]: t('Errors'),
   [DataCategory.TRANSACTIONS]: t('Transactions'),
   [DataCategory.ATTACHMENTS]: t('Attachments'),
-  [DataCategory.TRANSACTIONS_PROCESSED]: t('Processed Transactions'),
   [DataCategory.PROFILES]: t('Profiles'),
 };
 

--- a/static/app/types/core.tsx
+++ b/static/app/types/core.tsx
@@ -68,7 +68,6 @@ export enum DataCategory {
   ERRORS = 'errors',
   TRANSACTIONS = 'transactions',
   ATTACHMENTS = 'attachments',
-  TRANSACTIONS_PROCESSED = 'transactionsProcessed',
   PROFILES = 'profiles',
 }
 


### PR DESCRIPTION
We're no longer displaying "processed transactions". Processed transactions will be aliased to "transactions" in the api, so the data category can be removed.