### PR TITLE
ref(slack): Update workflow alerts for perf issues

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -88,7 +88,6 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
         return ev_metadata.get("value") or ev_metadata.get("function")
     elif ev_type == "transaction":
         if not event:
-            group = getattr(obj, "group", obj)
             event = group.get_latest_event()
         problem = get_matched_problem(event)
         return get_span_evidence_value_problem(problem)

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -87,6 +87,9 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
     if ev_type == "error":
         return ev_metadata.get("value") or ev_metadata.get("function")
     elif ev_type == "transaction":
+        if not event:
+            group = getattr(obj, "group", obj)
+            event = group.get_latest_event()
         problem = get_matched_problem(event)
         return get_span_evidence_value_problem(problem)
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -81,6 +81,7 @@ from sentry.auth.superuser import COOKIE_SALT as SU_COOKIE_SALT
 from sentry.auth.superuser import COOKIE_SECURE as SU_COOKIE_SECURE
 from sentry.auth.superuser import ORG_ID as SU_ORG_ID
 from sentry.auth.superuser import Superuser
+from sentry.event_manager import EventManager
 from sentry.eventstream.snuba import SnubaEventStream
 from sentry.mail import mail_adapter
 from sentry.models import AuthProvider as AuthProviderModel
@@ -121,14 +122,16 @@ from sentry.sentry_metrics import indexer
 from sentry.sentry_metrics.configuration import UseCaseKey
 from sentry.tagstore.snuba import SnubaTagStorage
 from sentry.testutils.factories import get_fixture_path
-from sentry.testutils.helpers.datetime import iso_format
+from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.slack import install_slack
 from sentry.types.integrations import ExternalProviders
+from sentry.types.issues import GroupType
 from sentry.utils import json
 from sentry.utils.auth import SsoSession
 from sentry.utils.json import dumps_htmlsafe
 from sentry.utils.pytest.selenium import Browser
 from sentry.utils.retries import TimedRetryPolicy
+from sentry.utils.samples import load_data
 from sentry.utils.snuba import _snuba_pool
 
 from ..snuba.metrics import MetricField, MetricGroupByField, MetricsQuery, OrderBy, get_date_range
@@ -462,6 +465,31 @@ class TestCase(BaseTestCase, TestCase):
 
 class TransactionTestCase(BaseTestCase, TransactionTestCase):
     pass
+
+
+class PerformanceIssueTestCase(BaseTestCase):
+    def create_performance_issue(self):
+        event_data = load_data(
+            "transaction-n-plus-one",
+            timestamp=before_now(minutes=10),
+            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE.value}-group1"],
+        )
+        perf_event_manager = EventManager(event_data)
+        perf_event_manager.normalize()
+        with override_options(
+            {
+                "performance.issues.all.problem-creation": 1.0,
+                "performance.issues.all.problem-detection": 1.0,
+                "performance.issues.n_plus_one_db.problem-creation": 1.0,
+            }
+        ), self.feature(
+            [
+                "organizations:performance-issues-ingest",
+                "projects:performance-suspect-spans-ingestion",
+            ]
+        ):
+            event = perf_event_manager.save(self.project.id)
+        return event.for_group(event.groups[0])
 
 
 class APITestCase(BaseTestCase, BaseAPITestCase):

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -5,13 +5,13 @@ import responses
 
 from sentry.models import Activity, Identity, IdentityProvider, IdentityStatus, Integration
 from sentry.notifications.notifications.activity import AssignedActivityNotification
-from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 from sentry.types.integrations import ExternalProviders
 
 
-class SlackAssignedNotificationTest(SlackActivityNotificationTest):
+class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_multiple_identities(self, mock_func):
@@ -144,6 +144,38 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest):
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_assignment_performance_issue(self, mock_func):
+        """
+        Test that a Slack message is sent with the expected payload when a performance issue is assigned
+        """
+        event = self.create_performance_issue()
+
+        with self.feature("organizations:performance-issues"):
+            notification = AssignedActivityNotification(
+                Activity(
+                    project=self.project,
+                    group=event.group,
+                    user=self.user,
+                    type=ActivityType.ASSIGNED,
+                    data={"assignee": self.user.id},
+                )
+            )
+            with self.tasks():
+                notification.send()
+        attachment, text = get_attachment()
+        assert text == f"Issue assigned to {self.name} by themselves"
+        assert attachment["title"] == "N+1 Query"
+        assert (
+            attachment["text"]
+            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+        )
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user|Notification Settings>"
         )
 
     def test_automatic_assignment(self):

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -153,19 +153,18 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         Test that a Slack message is sent with the expected payload when a performance issue is assigned
         """
         event = self.create_performance_issue()
-
-        with self.feature("organizations:performance-issues"):
-            notification = AssignedActivityNotification(
-                Activity(
-                    project=self.project,
-                    group=event.group,
-                    user=self.user,
-                    type=ActivityType.ASSIGNED,
-                    data={"assignee": self.user.id},
-                )
+        notification = AssignedActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.ASSIGNED,
+                data={"assignee": self.user.id},
             )
-            with self.tasks():
-                notification.send()
+        )
+        with self.feature("organizations:performance-issues"), self.tasks():
+            notification.send()
+
         attachment, text = get_attachment()
         assert text == f"Issue assigned to {self.name} by themselves"
         assert attachment["title"] == "N+1 Query"

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -96,16 +96,13 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             },
         )
 
-        with self.feature("organizations:performance-issues"):
-            notification = AlertRuleNotification(
-                Notification(event=event, rule=rule), ActionTargetType.MEMBER, self.user.id
-            )
-
-            with self.tasks():
-                notification.send()
+        notification = AlertRuleNotification(
+            Notification(event=event, rule=rule), ActionTargetType.MEMBER, self.user.id
+        )
+        with self.feature("organizations:performance-issues"), self.tasks():
+            notification.send()
 
         attachment, text = get_attachment()
-
         assert attachment["title"] == "N+1 Query"
         assert (
             attachment["text"]

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -29,7 +29,7 @@ from sentry.ownership.grammar import Rule as GrammarRule
 from sentry.ownership.grammar import dump_schema
 from sentry.plugins.base import Notification
 from sentry.tasks.digests import deliver_digest
-from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.testutils.silo import region_silo_test
 from sentry.types.integrations import ExternalProviders
@@ -37,7 +37,7 @@ from sentry.utils import json
 
 
 @region_silo_test
-class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
+class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_issue_alert_user(self, mock_func):
@@ -73,6 +73,47 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest):
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_performance_issue_alert_user(self, mock_func):
+        """Test that performance issue alerts are sent to a Slack user."""
+
+        event = self.create_performance_issue()
+
+        action_data = {
+            "id": "sentry.mail.actions.NotifyEmailAction",
+            "targetType": "Member",
+            "targetIdentifier": str(self.user.id),
+        }
+        rule = Rule.objects.create(
+            project=self.project,
+            label="ja rule",
+            data={
+                "match": "all",
+                "actions": [action_data],
+            },
+        )
+
+        with self.feature("organizations:performance-issues"):
+            notification = AlertRuleNotification(
+                Notification(event=event, rule=rule), ActionTargetType.MEMBER, self.user.id
+            )
+
+            with self.tasks():
+                notification.send()
+
+        attachment, text = get_attachment()
+
+        assert attachment["title"] == "N+1 Query"
+        assert (
+            attachment["text"]
+            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+        )
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
         )
 
     @responses.activate

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -49,22 +49,19 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         Test that a Slack message is sent with the expected payload when a comment is made on a performance issue
         """
         event = self.create_performance_issue()
-
-        with self.feature("organizations:performance-issues"):
-            notification = NoteActivityNotification(
-                Activity(
-                    project=self.project,
-                    group=event.group,
-                    user=self.user,
-                    type=ActivityType.NOTE,
-                    data={"text": "text", "mentions": []},
-                )
+        notification = NoteActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.NOTE,
+                data={"text": "text", "mentions": []},
             )
-            with self.tasks():
-                notification.send()
+        )
+        with self.feature("organizations:performance-issues"), self.tasks():
+            notification.send()
 
         attachment, text = get_attachment()
-
         assert text == f"New comment by {self.name}"
         assert attachment["title"] == "N+1 Query"
         assert (

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -4,12 +4,12 @@ import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import NoteActivityNotification
-from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
 
-class SlackNoteNotificationTest(SlackActivityNotificationTest):
+class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_note(self, mock_func):
@@ -40,4 +40,39 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest):
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_note_performance_issue(self, mock_func):
+        """
+        Test that a Slack message is sent with the expected payload when a comment is made on a performance issue
+        """
+        event = self.create_performance_issue()
+
+        with self.feature("organizations:performance-issues"):
+            notification = NoteActivityNotification(
+                Activity(
+                    project=self.project,
+                    group=event.group,
+                    user=self.user,
+                    type=ActivityType.NOTE,
+                    data={"text": "text", "mentions": []},
+                )
+            )
+            with self.tasks():
+                notification.send()
+
+        attachment, text = get_attachment()
+
+        assert text == f"New comment by {self.name}"
+        assert attachment["title"] == "N+1 Query"
+        assert (
+            attachment["title_link"]
+            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack"
+        )
+        assert attachment["text"] == notification.activity.data["text"]
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -44,19 +44,17 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         Test that a Slack message is sent with the expected payload when a performance issue regresses
         """
         event = self.create_performance_issue()
-
-        with self.feature("organizations:performance-issues"):
-            notification = RegressionActivityNotification(
-                Activity(
-                    project=self.project,
-                    group=event.group,
-                    user=self.user,
-                    type=ActivityType.SET_REGRESSION,
-                    data={},
-                )
+        notification = RegressionActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.SET_REGRESSION,
+                data={},
             )
-            with self.tasks():
-                notification.send()
+        )
+        with self.feature("organizations:performance-issues"), self.tasks():
+            notification.send()
 
         attachment, text = get_attachment()
         assert text == "Issue marked as regression"

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -44,13 +44,12 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         Test that a Slack message is sent with the expected payload when a performance issue regresses
         """
         event = self.create_performance_issue()
-        perf_group = event.group
 
         with self.feature("organizations:performance-issues"):
             notification = RegressionActivityNotification(
                 Activity(
                     project=self.project,
-                    group=perf_group,
+                    group=event.group,
                     user=self.user,
                     type=ActivityType.SET_REGRESSION,
                     data={},

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -2,11 +2,16 @@ from unittest import mock
 
 import responses
 
+from sentry.event_manager import EventManager
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import RegressionActivityNotification
 from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
+from sentry.types.issues import GroupType
+from sentry.utils.samples import load_data
 
 
 class SlackRegressionNotificationTest(SlackActivityNotificationTest):
@@ -30,7 +35,63 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest):
 
         attachment, text = get_attachment()
         assert text == "Issue marked as regression"
+        assert attachment["title"] == "こんにちは"
+        assert attachment["text"] == ""
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_regression_performance_issue(self, mock_func):
+        """
+        Test that a Slack message is sent with the expected payload when a performance issue regresses
+        """
+        event_data = load_data(
+            "transaction-n-plus-one",
+            timestamp=before_now(minutes=10),
+            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE.value}-group1"],
+        )
+        perf_event_manager = EventManager(event_data)
+        perf_event_manager.normalize()
+        with override_options(
+            {
+                "performance.issues.all.problem-creation": 1.0,
+                "performance.issues.all.problem-detection": 1.0,
+                "performance.issues.n_plus_one_db.problem-creation": 1.0,
+            }
+        ), self.feature(
+            [
+                "organizations:performance-issues-ingest",
+                "projects:performance-suspect-spans-ingestion",
+            ]
+        ):
+            event = perf_event_manager.save(self.project.id)
+        event = event.for_group(event.groups[0])
+        perf_group = event.group
+
+        with self.feature("organizations:performance-issues"):
+            notification = RegressionActivityNotification(
+                Activity(
+                    project=self.project,
+                    group=perf_group,
+                    user=self.user,
+                    type=ActivityType.SET_REGRESSION,
+                    data={},
+                )
+            )
+            with self.tasks():
+                notification.send()
+
+        attachment, text = get_attachment()
+        assert text == "Issue marked as regression"
+        assert attachment["title"] == "N+1 Query"
+        assert (
+            attachment["text"]
+            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+        )
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -45,19 +45,17 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         Test that a Slack message is sent with the expected payload when a performance issue is resolved
         """
         event = self.create_performance_issue()
-
-        with self.feature("organizations:performance-issues"):
-            notification = ResolvedActivityNotification(
-                Activity(
-                    project=self.project,
-                    group=event.group,
-                    user=self.user,
-                    type=ActivityType.SET_RESOLVED,
-                    data={"assignee": ""},
-                )
+        notification = ResolvedActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.SET_RESOLVED,
+                data={"assignee": ""},
             )
-            with self.tasks():
-                notification.send()
+        )
+        with self.feature("organizations:performance-issues"), self.tasks():
+            notification.send()
 
         attachment, text = get_attachment()
         assert (

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -4,12 +4,12 @@ import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import ResolvedActivityNotification
-from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
 
-class SlackResolvedNotificationTest(SlackActivityNotificationTest):
+class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_resolved(self, mock_func):
@@ -36,4 +36,40 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest):
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_resolved_performance_issue(self, mock_func):
+        """
+        Test that a Slack message is sent with the expected payload when a performance issue is resolved
+        """
+        event = self.create_performance_issue()
+
+        with self.feature("organizations:performance-issues"):
+            notification = ResolvedActivityNotification(
+                Activity(
+                    project=self.project,
+                    group=event.group,
+                    user=self.user,
+                    type=ActivityType.SET_RESOLVED,
+                    data={"assignee": ""},
+                )
+            )
+            with self.tasks():
+                notification.send()
+
+        attachment, text = get_attachment()
+        assert (
+            text
+            == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=activity_notification|{self.project.slug.upper()}-{event.group.short_id}> as resolved"
+        )
+        assert attachment["title"] == "N+1 Query"
+        assert (
+            attachment["text"]
+            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+        )
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -4,12 +4,14 @@ import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import ResolvedInReleaseActivityNotification
-from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
 
-class SlackResolvedInReleaseNotificationTest(SlackActivityNotificationTest):
+class SlackResolvedInReleaseNotificationTest(
+    SlackActivityNotificationTest, PerformanceIssueTestCase
+):
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_resolved_in_release(self, mock_func):
@@ -34,4 +36,38 @@ class SlackResolvedInReleaseNotificationTest(SlackActivityNotificationTest):
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_resolved_in_release_performance_issue(self, mock_func):
+        """
+        Test that a Slack message is sent with the expected payload when a performance issue is resolved in a release
+        """
+        event = self.create_performance_issue()
+
+        with self.feature("organizations:performance-issues"):
+            notification = ResolvedInReleaseActivityNotification(
+                Activity(
+                    project=self.project,
+                    group=event.group,
+                    user=self.user,
+                    type=ActivityType.SET_RESOLVED_IN_RELEASE,
+                    data={"version": "meow"},
+                )
+            )
+            with self.tasks():
+                notification.send()
+
+        attachment, text = get_attachment()
+        release_name = notification.activity.data["version"]
+        assert text == f"Issue marked as resolved in {release_name} by {self.name}"
+        assert attachment["title"] == "N+1 Query"
+        assert (
+            attachment["text"]
+            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+        )
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -45,19 +45,17 @@ class SlackResolvedInReleaseNotificationTest(
         Test that a Slack message is sent with the expected payload when a performance issue is resolved in a release
         """
         event = self.create_performance_issue()
-
-        with self.feature("organizations:performance-issues"):
-            notification = ResolvedInReleaseActivityNotification(
-                Activity(
-                    project=self.project,
-                    group=event.group,
-                    user=self.user,
-                    type=ActivityType.SET_RESOLVED_IN_RELEASE,
-                    data={"version": "meow"},
-                )
+        notification = ResolvedInReleaseActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.SET_RESOLVED_IN_RELEASE,
+                data={"version": "meow"},
             )
-            with self.tasks():
-                notification.send()
+        )
+        with self.feature("organizations:performance-issues"), self.tasks():
+            notification.send()
 
         attachment, text = get_attachment()
         release_name = notification.activity.data["version"]

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -4,12 +4,12 @@ import responses
 
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import UnassignedActivityNotification
-from sentry.testutils.cases import SlackActivityNotificationTest
+from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
 
-class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
+class SlackUnassignedNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
     @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_unassignment(self, mock_func):
@@ -34,4 +34,37 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest):
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_unassignment_performance_issue(self, mock_func):
+        """
+        Test that a Slack message is sent with the expected payload when a performance issue is unassigned
+        """
+        event = self.create_performance_issue()
+
+        with self.feature("organizations:performance-issues"):
+            notification = UnassignedActivityNotification(
+                Activity(
+                    project=self.project,
+                    group=event.group,
+                    user=self.user,
+                    type=ActivityType.ASSIGNED,
+                    data={"assignee": ""},
+                )
+            )
+            with self.tasks():
+                notification.send()
+
+        attachment, text = get_attachment()
+        assert text == f"Issue unassigned by {self.name}"
+        assert attachment["title"] == "N+1 Query"
+        assert (
+            attachment["text"]
+            == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
+        )
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -43,19 +43,17 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         Test that a Slack message is sent with the expected payload when a performance issue is unassigned
         """
         event = self.create_performance_issue()
-
-        with self.feature("organizations:performance-issues"):
-            notification = UnassignedActivityNotification(
-                Activity(
-                    project=self.project,
-                    group=event.group,
-                    user=self.user,
-                    type=ActivityType.ASSIGNED,
-                    data={"assignee": ""},
-                )
+        notification = UnassignedActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.ASSIGNED,
+                data={"assignee": ""},
             )
-            with self.tasks():
-                notification.send()
+        )
+        with self.feature("organizations:performance-issues"), self.tasks():
+            notification.send()
 
         attachment, text = get_attachment()
         assert text == f"Issue unassigned by {self.name}"


### PR DESCRIPTION
Slack workflow alerts for performance issues are showing a text value of "no value". This PR adds feature parity with error issues for workflow alerts so that they are shown with the proper data. 