### PR TITLE
feat(code-mappings): Use project platform to find Python projects

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import timedelta
-from typing import Any, List, Mapping, Optional, Set, Tuple
+from typing import Any, List, Mapping, Optional, Set
 
 from django.utils import timezone
 
@@ -29,15 +29,19 @@ def identify_stacktrace_paths(
     Generate a map of projects to stacktrace paths for specified organizations,
     or all active organizations if unspecified.
 
-    This filters out projects have not had an event in the last 7 days or have
-    non-python files in the stacktrace.
+    This filters out non-python projects, or projects without an event
+    in the last 7 days.
     """
     if organizations is None:
         organizations = Organization.objects.filter(status=OrganizationStatus.ACTIVE)
 
     filename_maps = {}
     for org in organizations:
-        projects = Project.objects.filter(organization=org, first_event__isnull=False)
+        projects = Project.objects.filter(
+            organization=org,
+            first_event__isnull=False,
+            platform="python",
+        )
         projects = [
             project
             for project in projects
@@ -60,15 +64,12 @@ def get_all_stacktrace_paths(project: Project) -> List[str]:
     all_stacktrace_paths = set()
     for group in groups:
         event = group.get_latest_event()
-        is_python_stacktrace, stacktrace_paths = get_stacktrace_paths(event.data)
-        if not is_python_stacktrace:
-            return []
-        all_stacktrace_paths.update(stacktrace_paths)
+        all_stacktrace_paths.update(get_stacktrace_paths(event.data))
 
     return list(all_stacktrace_paths)
 
 
-def get_stacktrace_paths(data: NodeData) -> Tuple[bool, Set[str]]:
+def get_stacktrace_paths(data: NodeData) -> Set[str]:
     """
     Get the stacktrace_paths from the stacktrace for the latest event for an issue.
     """
@@ -77,15 +78,10 @@ def get_stacktrace_paths(data: NodeData) -> Tuple[bool, Set[str]]:
     for stacktrace in stacktraces:
         try:
             paths = [frame["filename"] for frame in stacktrace["frames"]]
-            if len(paths) == 0:
-                continue
-            if paths[0].endswith(".py"):
-                stacktrace_paths.update(paths)
-            else:
-                return False, set()  # (is_python, stacktrace_paths)
+            stacktrace_paths.update(paths)
         except Exception:
             logger.exception("Error getting filenames for project {project.slug}")
-    return True, stacktrace_paths  # (is_python, stacktrace_paths)
+    return stacktrace_paths
 
 
 def get_stacktrace(data: NodeData) -> List[Mapping[str, Any]]:

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -77,7 +77,7 @@ def get_stacktrace_paths(data: NodeData) -> Set[str]:
     stacktrace_paths = set()
     for stacktrace in stacktraces:
         try:
-            paths = [frame["filename"] for frame in stacktrace["frames"]]
+            paths = {frame["filename"] for frame in stacktrace["frames"]}
             stacktrace_paths.update(paths)
         except Exception:
             logger.exception("Error getting filenames for project {project.slug}")

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -40,7 +40,6 @@ def identify_stacktrace_paths(
         projects = Project.objects.filter(
             organization=org,
             first_event__isnull=False,
-            platform="python",
         )
         projects = [
             project
@@ -58,7 +57,9 @@ def identify_stacktrace_paths(
 
 def get_all_stacktrace_paths(project: Project) -> List[str]:
     groups = Group.objects.filter(
-        project=project, last_seen__gte=timezone.now() - GROUP_ANALYSIS_RANGE
+        project=project,
+        last_seen__gte=timezone.now() - GROUP_ANALYSIS_RANGE,
+        platform="python",
     )
 
     all_stacktrace_paths = set()

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -138,18 +138,15 @@ class TestCommitContext(TestCase):
         ]
 
     def test_skips_nonpython_projects(self):
-        new_project = self.create_project(
-            organization=self.organization,
-            platform="javascript",
-        )
         self.store_event(self.test_data_1, project_id=self.project.id)
-        self.store_event(data=self.test_data_2, project_id=new_project.id)
+        nonpython_event = deepcopy(self.test_data_2)
+        nonpython_event["platform"] = "javascript"
+        self.store_event(data=nonpython_event, project_id=self.project.id)
 
         with self.tasks():
             mapping = identify_stacktrace_paths([self.organization])
         assert self.organization.slug in mapping
         stacktrace_paths = mapping[self.organization.slug]
-        assert new_project.slug not in stacktrace_paths
 
         assert self.project.slug in stacktrace_paths
         assert sorted(stacktrace_paths[self.project.slug]) == [


### PR DESCRIPTION
Use the project platform instead of stacktrace files to identify Python projects

Followup from #40271