### PR TITLE
fix(replays): use logging.exception instead of sentry capture_exception

### DIFF
--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -129,7 +129,7 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
                     scope.set_tag("replay_id", message_dict["replay_id"])
                     scope.set_tag("project_id", message_dict["project_id"])
 
-                    sentry_sdk.capture_exception("Recording segment was already processed.")  # type: ignore[arg-type]
+                    logging.exception("Recording segment was already processed.")
 
                 parts.drop()
 


### PR DESCRIPTION
the usage of capture_exception is slightly off here (https://github.com/getsentry/sentry/pull/40464/) use logging.exception instead

follow up to #40456 