### PR TITLE
fix(tests): Disable flaky perf email test

### DIFF
--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -19,7 +19,7 @@ EMAILS = (
     ("/debug/mail/unable-to-fetch-commits/", "unable to fetch commits"),
     ("/debug/mail/unable-to-delete-repo/", "unable to delete repo"),
     ("/debug/mail/error-alert/", "alert"),
-    ("/debug/mail/performance-alert/", "performance"),
+    # ("/debug/mail/performance-alert/", "performance"), #TODO(ceo) this is flaky
     ("/debug/mail/digest/", "digest"),
     ("/debug/mail/invalid-identity/", "invalid identity"),
     ("/debug/mail/invitation/", "invitation"),


### PR DESCRIPTION
Disable a flaky test I introduced again (previously here: https://github.com/getsentry/sentry/pull/40358). I had tried to fix it in https://github.com/getsentry/sentry/pull/40414 but it's still failing due to changing timestamps. 