### PR TITLE
fix(profiling): assert against sdkName in profiling onboarding

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -368,7 +368,11 @@ function AndroidInstallSteps({
 }: InstallStepsProps) {
   const hasSdkUpdates = sdkUpdates.type === 'resolved' && sdkUpdates.data !== null;
   const requiresSdkUpdates =
-    hasSdkUpdates && sdkUpdates.data?.sdkVersion
+    hasSdkUpdates &&
+    sdkUpdates.data?.sdkVersion &&
+    ['sentry.java.android', 'sentry.java.android.timber'].includes(
+      sdkUpdates.data.sdkName
+    )
       ? semverCompare(sdkUpdates.data.sdkVersion, '6.0.0') < 0
       : false;
 
@@ -380,7 +384,7 @@ function AndroidInstallSteps({
         <li>
           <StepTitle>{t('Update your projects SDK version')}</StepTitle>
           <ProjectSdkUpdate
-            minSdkVersion="6.0.0 (sentry-android)"
+            minSdkVersion="6.0.0 (sentry.android)"
             project={project}
             sdkUpdates={sdkUpdates.data!}
             organization={organization}
@@ -416,7 +420,9 @@ function IOSInstallSteps({
 }: InstallStepsProps) {
   const hasSdkUpdates = sdkUpdates.type === 'resolved' && sdkUpdates.data !== null;
   const requiresSdkUpdates =
-    hasSdkUpdates && sdkUpdates.data?.sdkVersion
+    hasSdkUpdates &&
+    sdkUpdates.data?.sdkVersion &&
+    sdkUpdates.data?.sdkName === 'sentry.cocoa'
       ? semverCompare(sdkUpdates.data.sdkVersion, '7.23.0') < 0
       : false;
 
@@ -427,7 +433,7 @@ function IOSInstallSteps({
         <li>
           <StepTitle>{t('Update your projects SDK version')}</StepTitle>
           <ProjectSdkUpdate
-            minSdkVersion="7.23.0 (sentry-cocoa)"
+            minSdkVersion="7.23.0 (sentry.cocoa)"
             project={project}
             sdkUpdates={sdkUpdates.data!}
             organization={organization}

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -370,6 +370,7 @@ function AndroidInstallSteps({
   const requiresSdkUpdates =
     hasSdkUpdates &&
     sdkUpdates.data?.sdkVersion &&
+    // ensure we only prompt an upgrade when the sdk is one of the following
     ['sentry.java.android', 'sentry.java.android.timber'].includes(
       sdkUpdates.data.sdkName
     )


### PR DESCRIPTION
This PR corrects behavior on when we should prompt for an SDK update during the profiling onboarding flow.

Previously we would not assert against the `sdkName` assuming there would only be one sdk to satisfy each platform but this is not entirely true.

To fix this we explicitly check against `sentry.java.android` ,`sentry.java.android.timber`, and `sentry.coca`.

Thread: https://sentry.slack.com/archives/C02N5PB50JH/p1666378408921699