### PR TITLE
fix(metric-layer): Allow environment filtering

### DIFF
--- a/src/sentry/snuba/metrics/mqb_query_transformer.py
+++ b/src/sentry/snuba/metrics/mqb_query_transformer.py
@@ -186,6 +186,10 @@ def _get_mq_dict_params_from_where(query_where):
                     mq_dict["start"] = condition.rhs
                 elif condition.op == Op.LT:
                     mq_dict["end"] = condition.rhs
+            elif condition.lhs.name == "tags[environment]":
+                where.append(condition)
+            else:
+                raise MQBQueryTransformationException(f"Unsupported column for where {condition}")
         elif isinstance(condition.lhs, Function):
             if condition.lhs.function in DERIVED_OPS:
                 if not DERIVED_OPS[condition.lhs.function].can_filter:


### PR DESCRIPTION
- This handles a bug where environment wasn't being allowed as a filter in the qb transformer
- Also raise an error so its less transparent when a filter isn't allowed