### PR TITLE
test(js): Replace unnecessary uses org/router context in event tests

### DIFF
--- a/static/app/components/events/contextSummary/index.spec.tsx
+++ b/static/app/components/events/contextSummary/index.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -7,8 +6,6 @@ import {ContextSummaryGPU} from 'sentry/components/events/contextSummary/context
 import {ContextSummaryOS} from 'sentry/components/events/contextSummary/contextSummaryOS';
 import {ContextSummaryUser} from 'sentry/components/events/contextSummary/contextSummaryUser';
 import {FILTER_MASK} from 'sentry/constants';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 const CONTEXT_USER = {
   email: 'mail@example.org',
@@ -49,25 +46,6 @@ const CONTEXT_BROWSER = {
   name: 'Chrome',
 };
 
-function TestComponent({children}: {children: React.ReactNode}) {
-  const {organization, router} = initializeOrg();
-
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
-
 describe('ContextSummary', function () {
   describe('render()', function () {
     it('renders nothing without contexts', function () {
@@ -77,11 +55,7 @@ describe('ContextSummary', function () {
         contexts: {},
       };
 
-      const {container} = render(
-        <TestComponent>
-          <ContextSummary event={event} />
-        </TestComponent>
-      );
+      const {container} = render(<ContextSummary event={event} />);
       expect(container).toSnapshot();
     });
 
@@ -93,11 +67,7 @@ describe('ContextSummary', function () {
         contexts: {},
       };
 
-      const {container} = render(
-        <TestComponent>
-          <ContextSummary event={event} />
-        </TestComponent>
-      );
+      const {container} = render(<ContextSummary event={event} />);
       expect(container).toSnapshot();
     });
 
@@ -112,11 +82,7 @@ describe('ContextSummary', function () {
         },
       };
 
-      const {container} = render(
-        <TestComponent>
-          <ContextSummary event={event} />
-        </TestComponent>
-      );
+      const {container} = render(<ContextSummary event={event} />);
       expect(container).toSnapshot();
     });
 
@@ -130,11 +96,7 @@ describe('ContextSummary', function () {
         },
       };
 
-      const {container} = render(
-        <TestComponent>
-          <ContextSummary event={event} />
-        </TestComponent>
-      );
+      const {container} = render(<ContextSummary event={event} />);
       expect(container).toSnapshot();
     });
 
@@ -151,11 +113,7 @@ describe('ContextSummary', function () {
         },
       };
 
-      const {container} = render(
-        <TestComponent>
-          <ContextSummary event={event} />
-        </TestComponent>
-      );
+      const {container} = render(<ContextSummary event={event} />);
       expect(container).toSnapshot();
     });
 
@@ -172,11 +130,7 @@ describe('ContextSummary', function () {
         },
       };
 
-      const {container} = render(
-        <TestComponent>
-          <ContextSummary event={event} />
-        </TestComponent>
-      );
+      const {container} = render(<ContextSummary event={event} />);
       expect(container).toSnapshot();
     });
 
@@ -192,11 +146,7 @@ describe('ContextSummary', function () {
         },
       };
 
-      const {container} = render(
-        <TestComponent>
-          <ContextSummary event={event} />
-        </TestComponent>
-      );
+      const {container} = render(<ContextSummary event={event} />);
       expect(container).toSnapshot();
     });
 
@@ -213,11 +163,7 @@ describe('ContextSummary', function () {
         },
       };
 
-      const {container} = render(
-        <TestComponent>
-          <ContextSummary event={event} />
-        </TestComponent>
-      );
+      const {container} = render(<ContextSummary event={event} />);
       expect(container).toSnapshot();
     });
 
@@ -233,11 +179,7 @@ describe('ContextSummary', function () {
         },
       };
 
-      const {container} = render(
-        <TestComponent>
-          <ContextSummary event={event} />
-        </TestComponent>
-      );
+      const {container} = render(<ContextSummary event={event} />);
       expect(container).toSnapshot();
     });
   });
@@ -247,67 +189,59 @@ describe('OsSummary', function () {
   describe('render()', function () {
     it('renders the version string', function () {
       const {container} = render(
-        <TestComponent>
-          <ContextSummaryOS
-            data={{
-              kernel_version: '17.5.0',
-              version: '10.13.4',
-              name: 'Mac OS X',
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryOS
+          data={{
+            kernel_version: '17.5.0',
+            version: '10.13.4',
+            name: 'Mac OS X',
+          }}
+          meta={{}}
+        />
       );
       expect(container).toSnapshot();
     });
 
     it('renders the kernel version when no version', function () {
       const {container} = render(
-        <TestComponent>
-          <ContextSummaryOS
-            data={{
-              kernel_version: '17.5.0',
-              name: 'Mac OS X',
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryOS
+          data={{
+            kernel_version: '17.5.0',
+            name: 'Mac OS X',
+          }}
+          meta={{}}
+        />
       );
       expect(container).toSnapshot();
     });
 
     it('renders unknown when no version', function () {
       const {container} = render(
-        <TestComponent>
-          <ContextSummaryOS
-            data={{
-              name: 'Mac OS X',
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryOS
+          data={{
+            name: 'Mac OS X',
+          }}
+          meta={{}}
+        />
       );
       expect(container).toSnapshot();
     });
 
     it('display redacted name', async function () {
       render(
-        <TestComponent>
-          <ContextSummaryOS
-            data={{
-              name: '',
-              version: '10',
-            }}
-            meta={{
-              name: {
-                '': {
-                  rem: [['project:0', 's', 0, 0]],
-                  len: 19,
-                },
+        <ContextSummaryOS
+          data={{
+            name: '',
+            version: '10',
+          }}
+          meta={{
+            name: {
+              '': {
+                rem: [['project:0', 's', 0, 0]],
+                len: 19,
               },
-            }}
-          />
-        </TestComponent>
+            },
+          }}
+        />
       );
       userEvent.hover(screen.getByText(/redacted/));
       expect(
@@ -321,22 +255,20 @@ describe('OsSummary', function () {
 
     it('handles invalid data', async function () {
       render(
-        <TestComponent>
-          <ContextSummaryOS
-            data={{
-              name: false,
-              version: false,
-            }}
-            meta={{
-              name: {
-                '': {
-                  rem: [['project:0', 's', 0, 0]],
-                  len: 19,
-                },
+        <ContextSummaryOS
+          data={{
+            name: false,
+            version: false,
+          }}
+          meta={{
+            name: {
+              '': {
+                rem: [['project:0', 's', 0, 0]],
+                len: 19,
               },
-            }}
-          />
-        </TestComponent>
+            },
+          }}
+        />
       );
       userEvent.hover(screen.getByText(/redacted/));
       expect(
@@ -354,50 +286,44 @@ describe('GpuSummary', function () {
   describe('render()', function () {
     it('renders name and vendor', function () {
       const {container} = render(
-        <TestComponent>
-          <ContextSummaryGPU
-            data={{
-              name: 'Mali-T880',
-              vendor_name: 'ARM',
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryGPU
+          data={{
+            name: 'Mali-T880',
+            vendor_name: 'ARM',
+          }}
+          meta={{}}
+        />
       );
       expect(container).toSnapshot();
     });
 
     it('renders unknown when no vendor', function () {
       const {container} = render(
-        <TestComponent>
-          <ContextSummaryGPU
-            data={{
-              name: 'Apple A8 GPU',
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryGPU
+          data={{
+            name: 'Apple A8 GPU',
+          }}
+          meta={{}}
+        />
       );
       expect(container).toSnapshot();
     });
 
     it('display redacted name', async function () {
       render(
-        <TestComponent>
-          <ContextSummaryGPU
-            data={{
-              name: '',
-            }}
-            meta={{
-              name: {
-                '': {
-                  rem: [['project:0', 's', 0, 0]],
-                  len: 19,
-                },
+        <ContextSummaryGPU
+          data={{
+            name: '',
+          }}
+          meta={{
+            name: {
+              '': {
+                rem: [['project:0', 's', 0, 0]],
+                len: 19,
               },
-            }}
-          />
-        </TestComponent>
+            },
+          }}
+        />
       );
       userEvent.hover(screen.getByText(/redacted/));
       expect(
@@ -422,11 +348,7 @@ describe('UserSummary', function () {
         name: 'Maisey Dog',
       };
 
-      const {rerender} = render(
-        <TestComponent>
-          <ContextSummaryUser data={user1} meta={{}} />
-        </TestComponent>
-      );
+      const {rerender} = render(<ContextSummaryUser data={user1} meta={{}} />);
       expect(screen.getByText(user1.email)).toBeInTheDocument();
 
       const user2 = {
@@ -436,11 +358,7 @@ describe('UserSummary', function () {
         name: 'Maisey Dog',
       };
 
-      rerender(
-        <TestComponent>
-          <ContextSummaryUser data={user2} meta={{}} />
-        </TestComponent>
-      );
+      rerender(<ContextSummaryUser data={user2} meta={{}} />);
       expect(screen.getByTestId('user-title')?.textContent).toEqual(user2.ip_address);
 
       const user3 = {
@@ -450,16 +368,14 @@ describe('UserSummary', function () {
       };
 
       rerender(
-        <TestComponent>
-          <ContextSummaryUser
-            data={{
-              id: '26',
-              username: 'maiseythedog',
-              name: 'Maisey Dog',
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryUser
+          data={{
+            id: '26',
+            username: 'maiseythedog',
+            name: 'Maisey Dog',
+          }}
+          meta={{}}
+        />
       );
       expect(screen.getByTestId('user-title')?.textContent).toEqual(user3.id);
 
@@ -468,24 +384,18 @@ describe('UserSummary', function () {
         name: 'Maisey Dog',
       };
 
-      rerender(
-        <TestComponent>
-          <ContextSummaryUser data={user4} meta={{}} />
-        </TestComponent>
-      );
+      rerender(<ContextSummaryUser data={user4} meta={{}} />);
       expect(screen.getByTestId('user-title')).toHaveTextContent(user4.username);
     });
 
     it('renders NoSummary if no email, IP, id, or username', function () {
       render(
-        <TestComponent>
-          <ContextSummaryUser
-            data={{
-              name: 'Maisey Dog',
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryUser
+          data={{
+            name: 'Maisey Dog',
+          }}
+          meta={{}}
+        />
       );
       expect(screen.queryByTestId('user-title')).not.toBeInTheDocument();
       expect(screen.getByTestId('no-summary-title')).toHaveTextContent('Unknown User');
@@ -493,14 +403,12 @@ describe('UserSummary', function () {
 
     it('does not use filtered values for title', function () {
       const {rerender} = render(
-        <TestComponent>
-          <ContextSummaryUser
-            data={{
-              email: FILTER_MASK,
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryUser
+          data={{
+            email: FILTER_MASK,
+          }}
+          meta={{}}
+        />
       );
       expect(screen.queryByTestId('user-title')).not.toBeInTheDocument();
       expect(screen.getByTestId('no-summary-title')).toHaveTextContent('Unknown User');
@@ -511,27 +419,23 @@ describe('UserSummary', function () {
       // if/when that changes.
 
       rerender(
-        <TestComponent>
-          <ContextSummaryUser
-            data={{
-              id: FILTER_MASK,
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryUser
+          data={{
+            id: FILTER_MASK,
+          }}
+          meta={{}}
+        />
       );
       expect(screen.queryByTestId('user-title')).not.toBeInTheDocument();
       expect(screen.getByTestId('no-summary-title')).toHaveTextContent('Unknown User');
 
       rerender(
-        <TestComponent>
-          <ContextSummaryUser
-            data={{
-              username: FILTER_MASK,
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryUser
+          data={{
+            username: FILTER_MASK,
+          }}
+          meta={{}}
+        />
       );
       expect(screen.queryByTestId('user-title')).not.toBeInTheDocument();
       expect(screen.getByTestId('no-summary-title')).toHaveTextContent('Unknown User');
@@ -543,63 +447,55 @@ describe('UserSummary', function () {
       // should be
 
       const {rerender} = render(
-        <TestComponent>
-          <ContextSummaryUser
-            data={{
-              id: '26',
-              name: FILTER_MASK,
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryUser
+          data={{
+            id: '26',
+            name: FILTER_MASK,
+          }}
+          meta={{}}
+        />
       );
       expect(screen.getByText('?')).toBeInTheDocument();
 
       rerender(
-        <TestComponent>
-          <ContextSummaryUser
-            data={{
-              id: '26',
-              email: FILTER_MASK,
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryUser
+          data={{
+            id: '26',
+            email: FILTER_MASK,
+          }}
+          meta={{}}
+        />
       );
       expect(screen.getByText('?')).toBeInTheDocument();
 
       rerender(
-        <TestComponent>
-          <ContextSummaryUser
-            data={{
-              id: '26',
-              username: FILTER_MASK,
-            }}
-            meta={{}}
-          />
-        </TestComponent>
+        <ContextSummaryUser
+          data={{
+            id: '26',
+            username: FILTER_MASK,
+          }}
+          meta={{}}
+        />
       );
       expect(screen.getByText('?')).toBeInTheDocument();
     });
 
     it('display redacted email', async function () {
       render(
-        <TestComponent>
-          <ContextSummaryUser
-            data={{
-              name: 'Maisey Dog',
-              email: '',
-            }}
-            meta={{
-              email: {
-                '': {
-                  rem: [['project:0', 's', 0, 0]],
-                  len: 19,
-                },
+        <ContextSummaryUser
+          data={{
+            name: 'Maisey Dog',
+            email: '',
+          }}
+          meta={{
+            email: {
+              '': {
+                rem: [['project:0', 's', 0, 0]],
+                len: 19,
               },
-            }}
-          />
-        </TestComponent>
+            },
+          }}
+        />
       );
       userEvent.hover(screen.getByText(/redacted/));
       expect(

--- a/static/app/components/events/contexts/app/index.spec.tsx
+++ b/static/app/components/events/contexts/app/index.spec.tsx
@@ -1,11 +1,8 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {AppEventContext} from 'sentry/components/events/contexts/app';
 import {AppData} from 'sentry/components/events/contexts/app/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 export const appMockData: AppData = {
   device_app_hash: '2421fae1ac9237a8131e74883e52b0f7034a143f',
@@ -46,28 +43,11 @@ const event = {
 
 describe('app event context', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
+    render(<AppEventContext event={event} data={appMockData} />, {
       organization: {
-        ...initializeOrg().organization,
         relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
       },
     });
-
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <AppEventContext event={event} data={appMockData} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
 
     expect(screen.getByText('Build Name')).toBeInTheDocument(); // subject
     expect(screen.getByText(/redacted/)).toBeInTheDocument(); // value

--- a/static/app/components/events/contexts/browser/index.spec.tsx
+++ b/static/app/components/events/contexts/browser/index.spec.tsx
@@ -1,10 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {BrowserEventContext} from 'sentry/components/events/contexts/browser';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 export const browserMockData = {
   version: '83.0.4103',
@@ -40,28 +37,11 @@ const event = {
 
 describe('browser event context', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
+    render(<BrowserEventContext event={event} data={browserMockData} />, {
       organization: {
-        ...initializeOrg().organization,
         relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
       },
     });
-
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <BrowserEventContext event={event} data={browserMockData} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
 
     expect(screen.getByText('Name')).toBeInTheDocument(); // subject
     expect(screen.getByText(/redacted/)).toBeInTheDocument(); // value

--- a/static/app/components/events/contexts/device/index.spec.tsx
+++ b/static/app/components/events/contexts/device/index.spec.tsx
@@ -1,11 +1,8 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {DeviceEventContext} from 'sentry/components/events/contexts/device';
 import {DeviceData} from 'sentry/components/events/contexts/device/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 export const deviceMockData = {
   screen_resolution: '1136x768',
@@ -60,28 +57,11 @@ const event = {
 
 describe('device event context', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
+    render(<DeviceEventContext event={event} data={deviceMockData} />, {
       organization: {
-        ...initializeOrg().organization,
         relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
       },
     });
-
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <DeviceEventContext event={event} data={deviceMockData} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
     expect(screen.getByText('Name')).toBeInTheDocument(); // subject
     expect(screen.getByText(/redacted/)).toBeInTheDocument(); // value
     userEvent.hover(screen.getByText(/redacted/));

--- a/static/app/components/events/contexts/gpu/index.spec.tsx
+++ b/static/app/components/events/contexts/gpu/index.spec.tsx
@@ -1,11 +1,8 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {GPUEventContext} from 'sentry/components/events/contexts/gpu';
 import {GPUData} from 'sentry/components/events/contexts/gpu/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 export const gpuMockData: GPUData = {
   name: '',
@@ -45,28 +42,11 @@ const event = {
 
 describe('gpu event context', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
+    render(<GPUEventContext event={event} data={gpuMockData} />, {
       organization: {
-        ...initializeOrg().organization,
         relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
       },
     });
-
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <GPUEventContext event={event} data={gpuMockData} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
 
     expect(screen.getByText('API Type')).toBeInTheDocument(); // subject
     userEvent.hover(screen.getAllByText(/redacted/)[0]);

--- a/static/app/components/events/contexts/operatingSystem/index.spec.tsx
+++ b/static/app/components/events/contexts/operatingSystem/index.spec.tsx
@@ -1,10 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {OperatingSystemEventContext} from 'sentry/components/events/contexts/operatingSystem';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 export const operatingSystemMockData = {
   name: 'Mac OS X 10.14.0',
@@ -42,28 +39,11 @@ const event = {
 
 describe('operating system event context', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
+    render(<OperatingSystemEventContext event={event} data={operatingSystemMockData} />, {
       organization: {
-        ...initializeOrg().organization,
         relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
       },
     });
-
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <OperatingSystemEventContext event={event} data={operatingSystemMockData} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
 
     expect(screen.getByText('Raw Description')).toBeInTheDocument(); // subject
     userEvent.hover(screen.getByText(/redacted/));

--- a/static/app/components/events/contexts/runtime/index.spec.tsx
+++ b/static/app/components/events/contexts/runtime/index.spec.tsx
@@ -1,10 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {RuntimeEventContext} from 'sentry/components/events/contexts/runtime';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 export const runtimeMockData = {
   version: '1.7.13',
@@ -41,21 +38,7 @@ const event = {
 
 describe('runtime event context', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg();
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <RuntimeEventContext event={event} data={runtimeMockData} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<RuntimeEventContext event={event} data={runtimeMockData} />);
 
     expect(screen.getByText('Name')).toBeInTheDocument(); // subject
     expect(screen.getByText(/redacted/)).toBeInTheDocument(); // value

--- a/static/app/components/events/contexts/state.spec.tsx
+++ b/static/app/components/events/contexts/state.spec.tsx
@@ -1,43 +1,27 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {StateEventContext} from 'sentry/components/events/contexts/state';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('StateContext', function () {
   it('renders', function () {
-    const {organization, router} = initializeOrg();
-
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <StateEventContext
-            data={{
-              state: {
-                type: 'redux',
-                value: {
-                  a: 'abc',
-                },
-              },
-              otherState: {
-                value: {
-                  b: 'bcd',
-                },
-              },
-            }}
-            event={TestStubs.Event()}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <StateEventContext
+        data={{
+          state: {
+            type: 'redux',
+            value: {
+              a: 'abc',
+            },
+          },
+          otherState: {
+            value: {
+              b: 'bcd',
+            },
+          },
+        }}
+        event={TestStubs.Event()}
+      />
     );
 
     expect(screen.getByText('State (Redux)')).toBeInTheDocument();
@@ -66,34 +50,21 @@ describe('StateContext', function () {
       },
     };
 
-    const {organization, router} = initializeOrg();
-
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <StateEventContext
-            data={{
-              state: {
-                type: 'redux',
-                value: null,
-              },
-              otherState: {
-                value: {
-                  b: 'bcd',
-                },
-              },
-            }}
-            event={event}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <StateEventContext
+        data={{
+          state: {
+            type: 'redux',
+            value: null,
+          },
+          otherState: {
+            value: {
+              b: 'bcd',
+            },
+          },
+        }}
+        event={event}
+      />
     );
 
     expect(screen.getByText('State (Redux)')).toBeInTheDocument();

--- a/static/app/components/events/contexts/trace/index.spec.tsx
+++ b/static/app/components/events/contexts/trace/index.spec.tsx
@@ -1,10 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {TraceEventContext} from 'sentry/components/events/contexts/trace';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 export const traceMockData = {
   trace_id: '61d2d7c5acf448ffa8e2f8f973e2cd36',
@@ -34,7 +31,6 @@ const event = {
 };
 
 describe('trace event context', function () {
-  const {organization, router} = initializeOrg();
   const data = {
     tags: {
       url: 'https://github.com/getsentry/sentry/',
@@ -42,20 +38,7 @@ describe('trace event context', function () {
   };
 
   it('renders text url as a link', function () {
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <TraceEventContext data={data} event={event} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<TraceEventContext data={data} event={event} />);
 
     expect(screen.getByRole('link', {name: 'Open link'})).toHaveAttribute(
       'href',
@@ -64,20 +47,7 @@ describe('trace event context', function () {
   });
 
   it('display redacted data', async function () {
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <TraceEventContext data={data} event={event} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<TraceEventContext data={data} event={event} />);
 
     expect(screen.getByText('Operation Name')).toBeInTheDocument(); // subject
     expect(screen.getByText(/redacted/)).toBeInTheDocument(); // value

--- a/static/app/components/events/contexts/user/index.spec.tsx
+++ b/static/app/components/events/contexts/user/index.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -6,8 +5,6 @@ import {
   UserEventContext,
   UserEventContextData,
 } from 'sentry/components/events/contexts/user';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 // the values of this mock are correct and the types need to be updated
 export const userMockData = {
@@ -60,22 +57,7 @@ const event = {
 
 describe('user event context', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg();
-
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <UserEventContext event={event} data={userMockData} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<UserEventContext event={event} data={userMockData} />);
 
     expect(screen.getByText('ID')).toBeInTheDocument(); // subject
     expect(screen.getByText(/redacted/)).toBeInTheDocument(); // value

--- a/static/app/components/events/errorItem.spec.tsx
+++ b/static/app/components/events/errorItem.spec.tsx
@@ -1,36 +1,20 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {ErrorItem} from 'sentry/components/events/errorItem';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Issue error item', function () {
   it('expand subitems', function () {
-    const {organization, router} = initializeOrg();
-
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <ErrorItem
-            error={{
-              data: {
-                mapping_uuid: 'd270a1a0-1970-3c05-cb09-2cb00b4335ee',
-              },
-              type: 'proguard_missing_mapping',
-              message: 'A proguard mapping file was missing.',
-            }}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <ErrorItem
+        error={{
+          data: {
+            mapping_uuid: 'd270a1a0-1970-3c05-cb09-2cb00b4335ee',
+          },
+          type: 'proguard_missing_mapping',
+          message: 'A proguard mapping file was missing.',
+        }}
+      />
     );
 
     expect(screen.getByText('A proguard mapping file was missing.')).toBeInTheDocument();
@@ -43,34 +27,21 @@ describe('Issue error item', function () {
   });
 
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg();
-
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <ErrorItem
-            error={{
-              data: {
-                image_path: '',
-                image_uuid: '6b77ffb6-5aba-3b5f-9171-434f9660f738',
-                message: '',
-              },
-              message: 'A required debug information file was missing.',
-              type: 'native_missing_dsym',
-            }}
-            meta={{
-              image_path: {'': {rem: [['project:2', 's', 0, 0]], len: 117}},
-            }}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <ErrorItem
+        error={{
+          data: {
+            image_path: '',
+            image_uuid: '6b77ffb6-5aba-3b5f-9171-434f9660f738',
+            message: '',
+          },
+          message: 'A required debug information file was missing.',
+          type: 'native_missing_dsym',
+        }}
+        meta={{
+          image_path: {'': {rem: [['project:2', 's', 0, 0]], len: 117}},
+        }}
+      />
     );
 
     userEvent.click(screen.getByLabelText('Expand'));

--- a/static/app/components/events/eventDataSection.spec.jsx
+++ b/static/app/components/events/eventDataSection.spec.jsx
@@ -1,10 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render} from 'sentry-test/reactTestingLibrary';
 
 import EventDataSection from 'sentry/components/events/eventDataSection';
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 const data = {
   metadata: {
@@ -17,25 +14,6 @@ const data = {
   },
   culprit: 'culprit',
 };
-
-function TestComponent({children}) {
-  const {organization, router} = initializeOrg();
-
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
 
 describe('EventDataSection', function () {
   const groupData = {
@@ -52,15 +30,13 @@ describe('EventDataSection', function () {
   };
   it('renders formatted', function () {
     const wrapper = render(
-      <TestComponent>
-        <EventDataSection
-          group={groupData}
-          event={eventData}
-          type="extra"
-          title="Additional Data"
-          raw={false}
-        />
-      </TestComponent>
+      <EventDataSection
+        group={groupData}
+        event={eventData}
+        type="extra"
+        title="Additional Data"
+        raw={false}
+      />
     );
 
     expect(wrapper.container).toSnapshot();
@@ -68,15 +44,13 @@ describe('EventDataSection', function () {
 
   it('renders raw', function () {
     const wrapper = render(
-      <TestComponent>
-        <EventDataSection
-          group={groupData}
-          event={eventData}
-          type="extra"
-          title="Additional Data"
-          raw
-        />
-      </TestComponent>
+      <EventDataSection
+        group={groupData}
+        event={eventData}
+        type="extra"
+        title="Additional Data"
+        raw
+      />
     );
     expect(wrapper.container).toSnapshot();
   });
@@ -97,20 +71,14 @@ describe('KeyValueList', function () {
 
   it('renders formatted', function () {
     const wrapper = render(
-      <TestComponent>
-        <KeyValueList data={extraDataArray} isContextData raw={false} />
-      </TestComponent>
+      <KeyValueList data={extraDataArray} isContextData raw={false} />
     );
 
     expect(wrapper.container).toSnapshot();
   });
 
   it('renders raw', function () {
-    const wrapper = render(
-      <TestComponent>
-        <KeyValueList data={extraDataArray} isContextData raw />
-      </TestComponent>
-    );
+    const wrapper = render(<KeyValueList data={extraDataArray} isContextData raw />);
 
     expect(wrapper.container).toSnapshot();
   });

--- a/static/app/components/events/eventEntries.spec.tsx
+++ b/static/app/components/events/eventEntries.spec.tsx
@@ -5,10 +5,8 @@ import type {Error} from 'sentry/components/events/errors';
 import EventEntries from 'sentry/components/events/eventEntries';
 import {Group, IssueCategory} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
-const {organization, project, router} = initializeData({
+const {organization, project} = initializeData({
   features: ['performance-issues'],
 });
 
@@ -16,24 +14,13 @@ const api = new MockApiClient();
 
 async function renderComponent(event: Event, errors?: Array<Error>) {
   render(
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        <EventEntries
-          organization={organization}
-          event={{...event, errors: errors ?? event.errors}}
-          project={project}
-          location={location}
-          api={api}
-        />
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
+    <EventEntries
+      organization={organization}
+      event={{...event, errors: errors ?? event.errors}}
+      project={project}
+      location={location}
+      api={api}
+    />
   );
 
   const alertSummaryInfo = await screen.findByTestId('event-error-alert');
@@ -313,16 +300,15 @@ describe('EventEntries', function () {
       };
 
       render(
-        <OrganizationContext.Provider value={organization}>
-          <EventEntries
-            organization={organization}
-            event={newEvent}
-            project={project}
-            location={location}
-            api={api}
-            group={group}
-          />
-        </OrganizationContext.Provider>
+        <EventEntries
+          organization={organization}
+          event={newEvent}
+          project={project}
+          location={location}
+          api={api}
+          group={group}
+        />,
+        {organization}
       );
 
       const resourcesHeadingText = screen.getByRole('heading', {
@@ -357,25 +343,14 @@ describe('EventEntries', function () {
       };
 
       render(
-        <OrganizationContext.Provider value={organization}>
-          <RouteContext.Provider
-            value={{
-              router,
-              location: router.location,
-              params: {},
-              routes: [],
-            }}
-          >
-            <EventEntries
-              organization={organization}
-              event={newEvent}
-              project={project}
-              location={location}
-              api={api}
-              group={group}
-            />
-          </RouteContext.Provider>
-        </OrganizationContext.Provider>
+        <EventEntries
+          organization={organization}
+          event={newEvent}
+          project={project}
+          location={location}
+          api={api}
+          group={group}
+        />
       );
 
       const eventEntriesContainer = screen.getByTestId('event-entries-loading-false');

--- a/static/app/components/events/eventExtraData/index.spec.tsx
+++ b/static/app/components/events/eventExtraData/index.spec.tsx
@@ -1,10 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import EventExtraData from 'sentry/components/events/eventExtraData';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('EventExtraData', function () {
   it('display redacted data', async function () {
@@ -173,28 +170,11 @@ describe('EventExtraData', function () {
       },
     };
 
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
+    render(<EventExtraData event={event} />, {
       organization: {
-        ...initializeOrg().organization,
         relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
       },
     });
-
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <EventExtraData event={event} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
 
     expect(await screen.findAllByText(/redacted/)).toHaveLength(10);
 

--- a/static/app/components/events/eventSdk.spec.tsx
+++ b/static/app/components/events/eventSdk.spec.tsx
@@ -1,21 +1,10 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {EventSdk} from 'sentry/components/events/eventSdk';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('event sdk', function () {
   it('display redacted tags', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
-      organization: {
-        ...initializeOrg().organization,
-        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
-      },
-    });
-
     const event = {
       ...TestStubs.Event(),
       sdk: {
@@ -29,20 +18,11 @@ describe('event sdk', function () {
       },
     };
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <EventSdk sdk={event.sdk} meta={event._meta.sdk} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<EventSdk sdk={event.sdk} meta={event._meta.sdk} />, {
+      organization: {
+        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+      },
+    });
 
     userEvent.hover(screen.getByText(/redacted/));
     expect(

--- a/static/app/components/events/eventTags/index.spec.tsx
+++ b/static/app/components/events/eventTags/index.spec.tsx
@@ -3,8 +3,6 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {EventTags} from 'sentry/components/events/eventTags';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('event tags', function () {
   it('display redacted tags', async function () {
@@ -25,23 +23,13 @@ describe('event tags', function () {
     });
 
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <EventTags
-            organization={organization}
-            projectId={project.id}
-            location={router.location}
-            event={event}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <EventTags
+        organization={organization}
+        projectId={project.id}
+        location={router.location}
+        event={event}
+      />,
+      {organization}
     );
 
     userEvent.hover(screen.getByText(/redacted/));
@@ -83,23 +71,13 @@ describe('event tags', function () {
     });
 
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <EventTags
-            organization={organization}
-            projectId={project.id}
-            location={router.location}
-            event={event}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <EventTags
+        organization={organization}
+        projectId={project.id}
+        location={router.location}
+        event={event}
+      />,
+      {organization}
     );
 
     expect(screen.getByText('device.family')).toBeInTheDocument();

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/default.spec.tsx
@@ -5,8 +5,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {Default} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/default';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Breadcrumb Data Default', function () {
   const project = TestStubs.Project({
@@ -27,49 +25,42 @@ describe('Breadcrumb Data Default', function () {
 
   it('display redacted message', async function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Default
-            meta={{
-              message: {
-                '': {
-                  rem: [['project:0', 's', 0, 0]],
-                  len: 19,
-                  chunks: [
-                    {
-                      type: 'redaction',
-                      text: '',
-                      rule_id: 'project:0',
-                      remark: 's',
-                    },
-                  ],
+      <Default
+        meta={{
+          message: {
+            '': {
+              rem: [['project:0', 's', 0, 0]],
+              len: 19,
+              chunks: [
+                {
+                  type: 'redaction',
+                  text: '',
+                  rule_id: 'project:0',
+                  remark: 's',
                 },
-              },
-            }}
-            event={TestStubs.Event()}
-            orgSlug="org-slug"
-            searchTerm=""
-            breadcrumb={{
-              type: BreadcrumbType.DEBUG,
-              timestamp: '2017-08-04T07:52:11Z',
-              level: BreadcrumbLevelType.INFO,
-              message: '',
-              category: 'started',
-              data: {
-                controller: '<sentry_ios_cocoapods.ViewController: 0x100e09ec0>',
-              },
-              event_id: null,
-            }}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+              ],
+            },
+          },
+        }}
+        event={TestStubs.Event()}
+        orgSlug="org-slug"
+        searchTerm=""
+        breadcrumb={{
+          type: BreadcrumbType.DEBUG,
+          timestamp: '2017-08-04T07:52:11Z',
+          level: BreadcrumbLevelType.INFO,
+          message: '',
+          category: 'started',
+          data: {
+            controller: '<sentry_ios_cocoapods.ViewController: 0x100e09ec0>',
+          },
+          event_id: null,
+        }}
+      />,
+      {
+        organization,
+        router,
+      }
     );
 
     expect(
@@ -87,38 +78,28 @@ describe('Breadcrumb Data Default', function () {
 
   it('display redacted data', async function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Default
-            meta={{
-              data: {
-                '': {
-                  rem: [['project:0', 'x']],
-                },
-              },
-            }}
-            event={TestStubs.Event()}
-            orgSlug="org-slug"
-            searchTerm=""
-            breadcrumb={{
-              type: BreadcrumbType.DEBUG,
-              timestamp: '2017-08-04T07:52:11Z',
-              level: BreadcrumbLevelType.INFO,
-              message: '',
-              category: 'started',
-              data: null,
-              event_id: null,
-            }}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <Default
+        meta={{
+          data: {
+            '': {
+              rem: [['project:0', 'x']],
+            },
+          },
+        }}
+        event={TestStubs.Event()}
+        orgSlug="org-slug"
+        searchTerm=""
+        breadcrumb={{
+          type: BreadcrumbType.DEBUG,
+          timestamp: '2017-08-04T07:52:11Z',
+          level: BreadcrumbLevelType.INFO,
+          message: '',
+          category: 'started',
+          data: null,
+          event_id: null,
+        }}
+      />,
+      {organization, router}
     );
 
     expect(

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/exception.spec.tsx
@@ -5,8 +5,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {Exception} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/exception';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Breadcrumb Data Exception', function () {
   const project = TestStubs.Project({
@@ -27,47 +25,37 @@ describe('Breadcrumb Data Exception', function () {
 
   it('display redacted message', async function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Exception
-            meta={{
-              message: {
-                '': {
-                  rem: [['project:0', 's', 0, 0]],
-                  len: 19,
-                  chunks: [
-                    {
-                      type: 'redaction',
-                      text: '',
-                      rule_id: 'project:1',
-                      remark: 's',
-                    },
-                  ],
+      <Exception
+        meta={{
+          message: {
+            '': {
+              rem: [['project:0', 's', 0, 0]],
+              len: 19,
+              chunks: [
+                {
+                  type: 'redaction',
+                  text: '',
+                  rule_id: 'project:1',
+                  remark: 's',
                 },
-              },
-            }}
-            searchTerm=""
-            breadcrumb={{
-              type: BreadcrumbType.EXCEPTION,
-              timestamp: '2017-08-04T07:52:11Z',
-              level: BreadcrumbLevelType.INFO,
-              message: '',
-              category: 'started',
-              data: {
-                controller: '<sentry_ios_cocoapods.ViewController: 0x100e09ec0>',
-              },
-              event_id: null,
-            }}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+              ],
+            },
+          },
+        }}
+        searchTerm=""
+        breadcrumb={{
+          type: BreadcrumbType.EXCEPTION,
+          timestamp: '2017-08-04T07:52:11Z',
+          level: BreadcrumbLevelType.INFO,
+          message: '',
+          category: 'started',
+          data: {
+            controller: '<sentry_ios_cocoapods.ViewController: 0x100e09ec0>',
+          },
+          event_id: null,
+        }}
+      />,
+      {organization, router}
     );
 
     expect(
@@ -85,36 +73,26 @@ describe('Breadcrumb Data Exception', function () {
 
   it('display redacted data', async function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Exception
-            meta={{
-              data: {
-                '': {
-                  rem: [['project:0', 'x']],
-                },
-              },
-            }}
-            searchTerm=""
-            breadcrumb={{
-              type: BreadcrumbType.EXCEPTION,
-              timestamp: '2017-08-04T07:52:11Z',
-              level: BreadcrumbLevelType.INFO,
-              message: '',
-              category: 'started',
-              data: null,
-              event_id: null,
-            }}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <Exception
+        meta={{
+          data: {
+            '': {
+              rem: [['project:0', 'x']],
+            },
+          },
+        }}
+        searchTerm=""
+        breadcrumb={{
+          type: BreadcrumbType.EXCEPTION,
+          timestamp: '2017-08-04T07:52:11Z',
+          level: BreadcrumbLevelType.INFO,
+          message: '',
+          category: 'started',
+          data: null,
+          event_id: null,
+        }}
+      />,
+      {organization, router}
     );
 
     expect(

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumb/data/http.spec.tsx
@@ -5,8 +5,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {Http} from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/data/http';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Breadcrumb Data Http', function () {
   const project = TestStubs.Project({
@@ -27,47 +25,37 @@ describe('Breadcrumb Data Http', function () {
 
   it('display redacted url', async function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Http
-            meta={{
-              data: {
-                url: {
-                  '': {
-                    rem: [['project:0', 's', 0, 0]],
-                    len: 19,
-                    chunks: [
-                      {
-                        type: 'redaction',
-                        text: '',
-                        rule_id: 'project:0',
-                        remark: 's',
-                      },
-                    ],
+      <Http
+        meta={{
+          data: {
+            url: {
+              '': {
+                rem: [['project:0', 's', 0, 0]],
+                len: 19,
+                chunks: [
+                  {
+                    type: 'redaction',
+                    text: '',
+                    rule_id: 'project:0',
+                    remark: 's',
                   },
-                },
+                ],
               },
-            }}
-            searchTerm=""
-            breadcrumb={{
-              type: BreadcrumbType.HTTP,
-              level: BreadcrumbLevelType.INFO,
-              data: {
-                method: 'POST',
-                url: '',
-                status_code: 0,
-              },
-            }}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+            },
+          },
+        }}
+        searchTerm=""
+        breadcrumb={{
+          type: BreadcrumbType.HTTP,
+          level: BreadcrumbLevelType.INFO,
+          data: {
+            method: 'POST',
+            url: '',
+            status_code: 0,
+          },
+        }}
+      />,
+      {organization, router}
     );
 
     expect(screen.getByText('POST')).toBeInTheDocument();
@@ -84,32 +72,22 @@ describe('Breadcrumb Data Http', function () {
 
   it('display redacted data', async function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Http
-            meta={{
-              data: {
-                '': {
-                  rem: [['project:0', 'x']],
-                },
-              },
-            }}
-            searchTerm=""
-            breadcrumb={{
-              type: BreadcrumbType.HTTP,
-              level: BreadcrumbLevelType.INFO,
-              data: null,
-            }}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <Http
+        meta={{
+          data: {
+            '': {
+              rem: [['project:0', 'x']],
+            },
+          },
+        }}
+        searchTerm=""
+        breadcrumb={{
+          type: BreadcrumbType.HTTP,
+          level: BreadcrumbLevelType.INFO,
+          data: null,
+        }}
+      />,
+      {organization, router}
     );
 
     expect(screen.queryByText('http://example.com/foo')).not.toBeInTheDocument();

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -1,15 +1,10 @@
-import {InjectedRouter} from 'react-router';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import Breadcrumbs from 'sentry/components/events/interfaces/breadcrumbs';
-import {Organization} from 'sentry/types';
 import {BreadcrumbLevelType, BreadcrumbType} from 'sentry/types/breadcrumbs';
 import ReplayReader from 'sentry/utils/replays/replayReader';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 const mockReplay = ReplayReader.factory(TestStubs.ReplayReaderParams());
 
@@ -34,34 +29,9 @@ jest.mock('sentry/utils/replays/hooks/useReplayData', () => {
   };
 });
 
-function TestComponent({
-  organization,
-  router,
-  children,
-}: {
-  children: React.ReactNode;
-  organization: Organization;
-  router: InjectedRouter;
-}) {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
-
 describe('Breadcrumbs', () => {
   let props: React.ComponentProps<typeof Breadcrumbs>;
-  const {router, organization} = initializeOrg();
+  const {router} = initializeOrg();
 
   beforeEach(() => {
     props = {
@@ -122,11 +92,7 @@ describe('Breadcrumbs', () => {
 
   describe('filterCrumbs', function () {
     it('should filter crumbs based on crumb message', async function () {
-      render(
-        <TestComponent organization={organization} router={router}>
-          <Breadcrumbs {...props} />
-        </TestComponent>
-      );
+      render(<Breadcrumbs {...props} />);
 
       userEvent.type(screen.getByPlaceholderText('Search breadcrumbs'), 'hi');
 
@@ -146,11 +112,7 @@ describe('Breadcrumbs', () => {
     });
 
     it('should filter crumbs based on crumb level', function () {
-      render(
-        <TestComponent organization={organization} router={router}>
-          <Breadcrumbs {...props} />
-        </TestComponent>
-      );
+      render(<Breadcrumbs {...props} />);
 
       userEvent.type(screen.getByPlaceholderText('Search breadcrumbs'), 'war');
 
@@ -160,11 +122,7 @@ describe('Breadcrumbs', () => {
     });
 
     it('should filter crumbs based on crumb category', function () {
-      render(
-        <TestComponent organization={organization} router={router}>
-          <Breadcrumbs {...props} />
-        </TestComponent>
-      );
+      render(<Breadcrumbs {...props} />);
 
       userEvent.type(screen.getByPlaceholderText('Search breadcrumbs'), 'error');
 
@@ -176,11 +134,7 @@ describe('Breadcrumbs', () => {
     it('should display the correct number of crumbs with no filter', function () {
       props.data.values = props.data.values.slice(0, 4);
 
-      render(
-        <TestComponent organization={organization} router={router}>
-          <Breadcrumbs {...props} />
-        </TestComponent>
-      );
+      render(<Breadcrumbs {...props} />);
 
       // data.values + virtual crumb
       expect(screen.getAllByTestId('crumb')).toHaveLength(4);
@@ -191,11 +145,7 @@ describe('Breadcrumbs', () => {
     it('should display the correct number of crumbs with a filter', function () {
       props.data.values = props.data.values.slice(0, 4);
 
-      render(
-        <TestComponent organization={organization} router={router}>
-          <Breadcrumbs {...props} />
-        </TestComponent>
-      );
+      render(<Breadcrumbs {...props} />);
 
       const searchInput = screen.getByPlaceholderText('Search breadcrumbs');
 
@@ -221,11 +171,7 @@ describe('Breadcrumbs', () => {
         },
       ];
 
-      render(
-        <TestComponent organization={organization} router={router}>
-          <Breadcrumbs {...props} />
-        </TestComponent>
-      );
+      render(<Breadcrumbs {...props} />);
 
       // data.values + virtual crumb
       expect(screen.getByTestId('crumb')).toBeInTheDocument();
@@ -235,18 +181,16 @@ describe('Breadcrumbs', () => {
 
     it('should render a replay when there is a replayId', async function () {
       render(
-        <TestComponent organization={organization} router={router}>
-          <Breadcrumbs
-            {...props}
-            event={TestStubs.Event({
-              entries: [],
-              tags: [{key: 'replayId', value: '761104e184c64d439ee1014b72b4d83b'}],
-            })}
-            organization={TestStubs.Organization({
-              features: ['session-replay-ui'],
-            })}
-          />
-        </TestComponent>
+        <Breadcrumbs
+          {...props}
+          event={TestStubs.Event({
+            entries: [],
+            tags: [{key: 'replayId', value: '761104e184c64d439ee1014b72b4d83b'}],
+          })}
+          organization={TestStubs.Organization({
+            features: ['session-replay-ui'],
+          })}
+        />
       );
 
       await waitFor(() => {

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -6,8 +6,6 @@ import {Content} from 'sentry/components/events/interfaces/crashContent/exceptio
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {EntryType} from 'sentry/types';
 import {STACK_TYPE, STACK_VIEW} from 'sentry/types/stacktrace';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Exception Content', function () {
   it('display redacted values from exception entry', async function () {
@@ -106,28 +104,18 @@ describe('Exception Content', function () {
     };
 
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Content
-            type={STACK_TYPE.ORIGINAL}
-            groupingCurrentLevel={0}
-            hasHierarchicalGrouping
-            newestFirst
-            platform="python"
-            stackView={STACK_VIEW.APP}
-            event={event}
-            values={event.entries[0].data.values}
-            meta={event._meta.entries[0].data.values}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <Content
+        type={STACK_TYPE.ORIGINAL}
+        groupingCurrentLevel={0}
+        hasHierarchicalGrouping
+        newestFirst
+        platform="python"
+        stackView={STACK_VIEW.APP}
+        event={event}
+        values={event.entries[0].data.values}
+        meta={event._meta.entries[0].data.values}
+      />,
+      {organization, router}
     );
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
@@ -3,7 +3,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import ExceptionStacktraceContent from 'sentry/components/events/interfaces/crashContent/exception/stackTrace';
 import {STACK_VIEW} from 'sentry/types/stacktrace';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 const frames = [
   {
@@ -92,23 +91,15 @@ const props: React.ComponentProps<typeof ExceptionStacktraceContent> = {
 };
 
 describe('ExceptionStacktraceContent', function () {
-  const organization = TestStubs.Organization();
-
   it('default behaviour', function () {
-    const {container} = render(
-      <OrganizationContext.Provider value={organization}>
-        <ExceptionStacktraceContent {...props} />
-      </OrganizationContext.Provider>
-    );
+    const {container} = render(<ExceptionStacktraceContent {...props} />);
 
     expect(container).toSnapshot();
   });
 
   it('should return an emptyRender', function () {
     const {container} = render(
-      <OrganizationContext.Provider value={organization}>
-        <ExceptionStacktraceContent {...props} stacktrace={null} />
-      </OrganizationContext.Provider>
+      <ExceptionStacktraceContent {...props} stacktrace={null} />
     );
 
     expect(container).toBeEmptyDOMElement();
@@ -116,14 +107,12 @@ describe('ExceptionStacktraceContent', function () {
 
   it('shows stack trace', function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <ExceptionStacktraceContent
-          {...props}
-          stackView={STACK_VIEW.APP}
-          chainedException={false}
-          stacktrace={{...stacktrace, frames: []}}
-        />
-      </OrganizationContext.Provider>
+      <ExceptionStacktraceContent
+        {...props}
+        stackView={STACK_VIEW.APP}
+        chainedException={false}
+        stacktrace={{...stacktrace, frames: []}}
+      />
     );
 
     expect(
@@ -133,12 +122,10 @@ describe('ExceptionStacktraceContent', function () {
 
   it('does not show stack trace', function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <ExceptionStacktraceContent
-          {...props}
-          stacktrace={{...stacktrace, frames: [{...frames[0], inApp: true}, frames[1]]}}
-        />
-      </OrganizationContext.Provider>
+      <ExceptionStacktraceContent
+        {...props}
+        stacktrace={{...stacktrace, frames: [{...frames[0], inApp: true}, frames[1]]}}
+      />
     );
     expect(
       screen.getByText(textWithMarkupMatcher('foo/baz.c at line 1'))
@@ -147,13 +134,11 @@ describe('ExceptionStacktraceContent', function () {
 
   it('should render system frames if "stackView: app" and there are no inApp frames and is a chained exceptions', function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <ExceptionStacktraceContent
-          {...props}
-          stackView={STACK_VIEW.APP}
-          chainedException
-        />
-      </OrganizationContext.Provider>
+      <ExceptionStacktraceContent
+        {...props}
+        stackView={STACK_VIEW.APP}
+        chainedException
+      />
     );
 
     for (const frame of frames) {
@@ -163,13 +148,11 @@ describe('ExceptionStacktraceContent', function () {
 
   it('should not render system frames if "stackView: app" and there are inApp frames and is a chained exceptions', () => {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <ExceptionStacktraceContent
-          {...props}
-          stacktrace={{...stacktrace, frames: [{...frames[0], inApp: true}, frames[1]]}}
-          chainedException
-        />
-      </OrganizationContext.Provider>
+      <ExceptionStacktraceContent
+        {...props}
+        stacktrace={{...stacktrace, frames: [{...frames[0], inApp: true}, frames[1]]}}
+        chainedException
+      />
     );
 
     // There must be two elements, one being the inApp frame and the other

--- a/static/app/components/events/interfaces/crashContent/index.spec.jsx
+++ b/static/app/components/events/interfaces/crashContent/index.spec.jsx
@@ -2,27 +2,23 @@ import {render} from 'sentry-test/reactTestingLibrary';
 
 import CrashContent from 'sentry/components/events/interfaces/crashContent';
 import {withMeta} from 'sentry/components/events/meta/metaProxy';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('CrashContent', function () {
   const exc = TestStubs.ExceptionWithMeta({platform: 'cocoa'});
   const event = TestStubs.Event();
-  const organization = TestStubs.Organization();
 
   const proxiedExc = withMeta(exc);
 
   it('renders with meta data', function () {
     const wrapper = render(
-      <OrganizationContext.Provider value={organization}>
-        <CrashContent
-          projectId="sentry"
-          stackView="full"
-          stackType="original"
-          event={event}
-          newestFirst
-          exception={proxiedExc.exception}
-        />
-      </OrganizationContext.Provider>
+      <CrashContent
+        projectId="sentry"
+        stackView="full"
+        stackType="original"
+        event={event}
+        newestFirst
+        exception={proxiedExc.exception}
+      />
     );
 
     expect(wrapper.container).toSnapshot();

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -1,10 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import StackTraceContent from 'sentry/components/events/interfaces/crashContent/stackTrace/content';
 import {StacktraceType} from 'sentry/types/stacktrace';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 const eventEntryStacktrace = TestStubs.EventEntryStacktrace();
 const event = TestStubs.Event({entries: [eventEntryStacktrace]});
@@ -14,29 +11,16 @@ const data = eventEntryStacktrace.data as Required<StacktraceType>;
 function renderedComponent(
   props: Partial<React.ComponentProps<typeof StackTraceContent>>
 ) {
-  const {organization, router} = initializeOrg();
-
   return render(
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        <StackTraceContent
-          data={data}
-          className="no-exception"
-          platform="other"
-          event={event}
-          newestFirst
-          includeSystemFrames
-          {...props}
-        />
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
+    <StackTraceContent
+      data={data}
+      className="no-exception"
+      platform="other"
+      event={event}
+      newestFirst
+      includeSystemFrames
+      {...props}
+    />
   );
 }
 

--- a/static/app/components/events/interfaces/csp/index.spec.tsx
+++ b/static/app/components/events/interfaces/csp/index.spec.tsx
@@ -1,22 +1,11 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {Csp} from 'sentry/components/events/interfaces/csp';
 import {EntryType} from 'sentry/types/event';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Csp report entry', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
-      organization: {
-        ...initializeOrg().organization,
-        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
-      },
-    });
-
     const event = {
       ...TestStubs.Event(),
       entries: [{type: EntryType.CSP, data: {effective_directive: ''}}],
@@ -30,20 +19,11 @@ describe('Csp report entry', function () {
         },
       },
     };
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Csp data={event.entries[0].data} event={event} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<Csp data={event.entries[0].data} event={event} />, {
+      organization: {
+        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+      },
+    });
 
     expect(screen.getByText(/redacted/)).toBeInTheDocument();
 

--- a/static/app/components/events/interfaces/frame/contexts.spec.tsx
+++ b/static/app/components/events/interfaces/frame/contexts.spec.tsx
@@ -1,86 +1,58 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {DeviceEventContext} from 'sentry/components/events/contexts/device';
 import {commonDisplayResolutions} from 'sentry/components/events/contexts/device/utils';
 import {UserEventContext} from 'sentry/components/events/contexts/user';
 import {FILTER_MASK} from 'sentry/constants';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
-
-function ComponentProviders({children}: {children: React.ReactNode}) {
-  const {organization, router} = initializeOrg();
-
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
 
 describe('User', function () {
   it("displays filtered values but doesn't use them for avatar", function () {
     const {rerender} = render(
-      <ComponentProviders>
-        <UserEventContext
-          data={{
-            id: '26',
-            name: FILTER_MASK,
-            email: '',
-            username: '',
-            ip_address: '',
-            data: {},
-          }}
-          event={TestStubs.Event()}
-        />
-      </ComponentProviders>
+      <UserEventContext
+        data={{
+          id: '26',
+          name: FILTER_MASK,
+          email: '',
+          username: '',
+          ip_address: '',
+          data: {},
+        }}
+        event={TestStubs.Event()}
+      />
     );
 
     expect(screen.getByTestId('user-context-name-value')).toHaveTextContent(FILTER_MASK);
     expect(screen.getByText('?')).toBeInTheDocument();
 
     rerender(
-      <ComponentProviders>
-        <UserEventContext
-          data={{
-            id: '26',
-            name: '',
-            email: FILTER_MASK,
-            username: '',
-            ip_address: '',
-            data: {},
-          }}
-          event={TestStubs.Event()}
-        />
-      </ComponentProviders>
+      <UserEventContext
+        data={{
+          id: '26',
+          name: '',
+          email: FILTER_MASK,
+          username: '',
+          ip_address: '',
+          data: {},
+        }}
+        event={TestStubs.Event()}
+      />
     );
 
     expect(screen.getByTestId('user-context-email-value')).toHaveTextContent(FILTER_MASK);
     expect(screen.getByText('?')).toBeInTheDocument();
 
     rerender(
-      <ComponentProviders>
-        <UserEventContext
-          data={{
-            id: '26',
-            name: '',
-            email: '',
-            username: FILTER_MASK,
-            ip_address: '',
-            data: {},
-          }}
-          event={TestStubs.Event()}
-        />
-      </ComponentProviders>
+      <UserEventContext
+        data={{
+          id: '26',
+          name: '',
+          email: '',
+          username: FILTER_MASK,
+          ip_address: '',
+          data: {},
+        }}
+        event={TestStubs.Event()}
+      />
     );
 
     expect(screen.getByTestId('user-context-username-value')).toHaveTextContent(
@@ -102,9 +74,7 @@ describe('Device', function () {
   describe('getInferredData', function () {
     it('renders', function () {
       const {container} = render(
-        <ComponentProviders>
-          <DeviceEventContext data={device} event={TestStubs.Event()} />
-        </ComponentProviders>
+        <DeviceEventContext data={device} event={TestStubs.Event()} />
       );
 
       expect(container).toSnapshot();
@@ -112,12 +82,10 @@ describe('Device', function () {
 
     it('renders screen_resolution inferred from screen_width_pixels and screen_height_pixels', function () {
       render(
-        <ComponentProviders>
-          <DeviceEventContext
-            data={{...device, screen_resolution: undefined}}
-            event={TestStubs.Event()}
-          />
-        </ComponentProviders>
+        <DeviceEventContext
+          data={{...device, screen_resolution: undefined}}
+          event={TestStubs.Event()}
+        />
       );
 
       expect(
@@ -139,16 +107,14 @@ describe('Device', function () {
 
     it('renders screen_width_pixels and screen_height_pixels inferred from screen_resolution', function () {
       render(
-        <ComponentProviders>
-          <DeviceEventContext
-            data={{
-              ...device,
-              screen_width_pixels: undefined,
-              screen_height_pixels: undefined,
-            }}
-            event={TestStubs.Event()}
-          />
-        </ComponentProviders>
+        <DeviceEventContext
+          data={{
+            ...device,
+            screen_width_pixels: undefined,
+            screen_height_pixels: undefined,
+          }}
+          event={TestStubs.Event()}
+        />
       );
 
       expect(

--- a/static/app/components/events/interfaces/frame/frameRegisters/index.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameRegisters/index.spec.tsx
@@ -1,29 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {FrameRegisters} from 'sentry/components/events/interfaces/frame/frameRegisters';
 import {FrameRegisterValue} from 'sentry/components/events/interfaces/frame/frameRegisters/value';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
-
-function TestComponent({children}: {children: React.ReactNode}) {
-  const {organization, router} = initializeOrg();
-
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
 
 describe('FrameRegisters', function () {
   it('should render registers', function () {
@@ -33,11 +11,7 @@ describe('FrameRegisters', function () {
       r12: '0x0000000000000000',
     };
 
-    const {container} = render(
-      <TestComponent>
-        <FrameRegisters registers={registers} />
-      </TestComponent>
-    );
+    const {container} = render(<FrameRegisters registers={registers} />);
     expect(container).toSnapshot();
   });
 
@@ -48,11 +22,7 @@ describe('FrameRegisters', function () {
       r12: '0x0000000000000000',
     };
 
-    const {container} = render(
-      <TestComponent>
-        <FrameRegisters registers={registers} />
-      </TestComponent>
-    );
+    const {container} = render(<FrameRegisters registers={registers} />);
     expect(container).toSnapshot();
   });
 });
@@ -63,20 +33,12 @@ describe('FrameRegistersValue', function () {
 
   describe('with string value', function () {
     it('should display the hexadecimal value', function () {
-      render(
-        <TestComponent>
-          <FrameRegisterValue value={hexadecimalValue} />
-        </TestComponent>
-      );
+      render(<FrameRegisterValue value={hexadecimalValue} />);
       expect(screen.getByText(hexadecimalValue)).toBeInTheDocument();
     });
 
     it('should display the numeric value', function () {
-      render(
-        <TestComponent>
-          <FrameRegisterValue value={hexadecimalValue} />
-        </TestComponent>
-      );
+      render(<FrameRegisterValue value={hexadecimalValue} />);
       userEvent.click(screen.getByLabelText('Toggle register value format'));
       expect(screen.queryByText(hexadecimalValue)).not.toBeInTheDocument();
       expect(screen.getByText(numericValue)).toBeInTheDocument();
@@ -85,20 +47,12 @@ describe('FrameRegistersValue', function () {
 
   describe('with numeric value', function () {
     it('should display the hexadecimal value', function () {
-      render(
-        <TestComponent>
-          <FrameRegisterValue value={numericValue} />
-        </TestComponent>
-      );
+      render(<FrameRegisterValue value={numericValue} />);
       expect(screen.getByText(hexadecimalValue)).toBeInTheDocument();
     });
 
     it('should display the numeric value', function () {
-      render(
-        <TestComponent>
-          <FrameRegisterValue value={numericValue} />
-        </TestComponent>
-      );
+      render(<FrameRegisterValue value={numericValue} />);
       userEvent.click(screen.getByLabelText('Toggle register value format'));
       expect(screen.queryByText(hexadecimalValue)).not.toBeInTheDocument();
       expect(screen.getByText(numericValue)).toBeInTheDocument();
@@ -109,20 +63,12 @@ describe('FrameRegistersValue', function () {
     const unknownValue = 'xyz';
 
     it('should display the hexadecimal value', function () {
-      render(
-        <TestComponent>
-          <FrameRegisterValue value={unknownValue} />
-        </TestComponent>
-      );
+      render(<FrameRegisterValue value={unknownValue} />);
       expect(screen.getByText(unknownValue)).toBeInTheDocument();
     });
 
     it('should display the numeric value', function () {
-      render(
-        <TestComponent>
-          <FrameRegisterValue value={unknownValue} />
-        </TestComponent>
-      );
+      render(<FrameRegisterValue value={unknownValue} />);
       userEvent.click(screen.getByLabelText('Toggle register value format'));
       expect(screen.getByText(unknownValue)).toBeInTheDocument();
     });

--- a/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
@@ -4,8 +4,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {FrameVariables} from 'sentry/components/events/interfaces/frame/frameVariables';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Frame Variables', function () {
   it('renders', async function () {
@@ -26,58 +24,48 @@ describe('Frame Variables', function () {
     ProjectsStore.loadInitialData([project]);
 
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <FrameVariables
-            data={{
-              "'client'": '',
-              "'data'": null,
-              "'k'": '',
-              "'options'": {
-                "'data'": null,
-                "'tags'": null,
-              },
-            }}
-            meta={{
-              "'client'": {
-                '': {
-                  rem: [['project:0', 's', 0, 0]],
-                  len: 41,
-                  chunks: [
-                    {
-                      type: 'redaction',
-                      text: '',
-                      rule_id: 'project:0',
-                      remark: 's',
-                    },
-                  ],
+      <FrameVariables
+        data={{
+          "'client'": '',
+          "'data'": null,
+          "'k'": '',
+          "'options'": {
+            "'data'": null,
+            "'tags'": null,
+          },
+        }}
+        meta={{
+          "'client'": {
+            '': {
+              rem: [['project:0', 's', 0, 0]],
+              len: 41,
+              chunks: [
+                {
+                  type: 'redaction',
+                  text: '',
+                  rule_id: 'project:0',
+                  remark: 's',
                 },
-              },
-              "'k'": {
-                '': {
-                  rem: [['project:0', 's', 0, 0]],
-                  len: 12,
-                  chunks: [
-                    {
-                      type: 'redaction',
-                      text: '',
-                      rule_id: 'project:0',
-                      remark: 's',
-                    },
-                  ],
+              ],
+            },
+          },
+          "'k'": {
+            '': {
+              rem: [['project:0', 's', 0, 0]],
+              len: 12,
+              chunks: [
+                {
+                  type: 'redaction',
+                  text: '',
+                  rule_id: 'project:0',
+                  remark: 's',
                 },
-              },
-            }}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+              ],
+            },
+          },
+        }}
+      />,
+      {organization, router}
     );
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);

--- a/static/app/components/events/interfaces/frame/line.spec.tsx
+++ b/static/app/components/events/interfaces/frame/line.spec.tsx
@@ -1,29 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import Line from 'sentry/components/events/interfaces/frame/line';
 import {Frame} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
-
-function TestComponent({children}: {children: React.ReactNode}) {
-  const {organization, router} = initializeOrg();
-
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
 
 describe('Frame - Line', function () {
   const event = TestStubs.Event();
@@ -51,19 +29,17 @@ describe('Frame - Line', function () {
   describe('renderOriginalSourceInfo()', function () {
     it('should render the source map information as a HTML string', function () {
       const {container} = render(
-        <TestComponent>
-          <Line
-            data={{
-              origAbsPath: 'https://beta.getsentry.com/_static/sentry/dist/vendor.js',
-              mapUrl: 'https://beta.getsentry.com/_static/sentry/dist/vendor.js.map',
-              map: 'vendor.js.map',
-              ...data,
-            }}
-            registers={{}}
-            components={[]}
-            event={event}
-          />
-        </TestComponent>
+        <Line
+          data={{
+            origAbsPath: 'https://beta.getsentry.com/_static/sentry/dist/vendor.js',
+            mapUrl: 'https://beta.getsentry.com/_static/sentry/dist/vendor.js.map',
+            map: 'vendor.js.map',
+            ...data,
+          }}
+          registers={{}}
+          components={[]}
+          event={event}
+        />
       );
       expect(container).toSnapshot();
     });
@@ -72,67 +48,61 @@ describe('Frame - Line', function () {
   describe('renderContext()', () => {
     it('should render context lines', () => {
       render(
-        <TestComponent>
-          <Line
-            data={{
-              ...data,
-              context: [
-                [
-                  211,
-                  '    # Mark the crashed thread and add its stacktrace to the exception',
-                ],
-                [212, "    crashed_thread = data['threads'][state.requesting_thread]"],
-                [213, "    crashed_thread['crashed'] = True"],
+        <Line
+          data={{
+            ...data,
+            context: [
+              [
+                211,
+                '    # Mark the crashed thread and add its stacktrace to the exception',
               ],
-            }}
-            registers={{}}
-            components={[]}
-            event={event}
-            isExpanded
-          />
-        </TestComponent>
+              [212, "    crashed_thread = data['threads'][state.requesting_thread]"],
+              [213, "    crashed_thread['crashed'] = True"],
+            ],
+          }}
+          registers={{}}
+          components={[]}
+          event={event}
+          isExpanded
+        />
       );
       expect(screen.getByRole('list')).toSnapshot();
     });
 
     it('should render register values', () => {
       render(
-        <TestComponent>
-          <Line
-            data={data}
-            registers={{
-              r10: '0x00007fff9300bf70',
-              r11: '0xffffffffffffffff',
-              r12: '0x0000000000000000',
-              r13: '0x0000000000000000',
-              r14: '0x000000000000000a',
-              r15: '0x0000000000000000',
-              r8: '0x00007fff9300bf78',
-              r9: '0x0000000000000040',
-              rax: '0x00007fff9291e660',
-              rbp: '0x00007ffedfdff7e0',
-              rbx: '0x00007fff9291e660',
-              rcx: '0x0000000000000008',
-              rdi: '0x00007ffedfdff790',
-              rdx: '0x0000020000000303',
-              rip: '0x000000010fe00a59',
-              rsi: '0x0000000000000300',
-              rsp: '0x00007ffedfdff7c0',
-            }}
-            components={[]}
-            event={event}
-            isExpanded
-          />
-        </TestComponent>
+        <Line
+          data={data}
+          registers={{
+            r10: '0x00007fff9300bf70',
+            r11: '0xffffffffffffffff',
+            r12: '0x0000000000000000',
+            r13: '0x0000000000000000',
+            r14: '0x000000000000000a',
+            r15: '0x0000000000000000',
+            r8: '0x00007fff9300bf78',
+            r9: '0x0000000000000040',
+            rax: '0x00007fff9291e660',
+            rbp: '0x00007ffedfdff7e0',
+            rbx: '0x00007fff9291e660',
+            rcx: '0x0000000000000008',
+            rdi: '0x00007ffedfdff790',
+            rdx: '0x0000020000000303',
+            rip: '0x000000010fe00a59',
+            rsi: '0x0000000000000300',
+            rsp: '0x00007ffedfdff7c0',
+          }}
+          components={[]}
+          event={event}
+          isExpanded
+        />
       );
       expect(screen.getByText('Registers')).toBeInTheDocument();
     });
 
     it('should not render empty registers', () => {
       render(
-        <TestComponent>
-          <Line data={data} registers={{}} components={[]} event={event} isExpanded />
-        </TestComponent>
+        <Line data={data} registers={{}} components={[]} event={event} isExpanded />
       );
 
       expect(screen.queryByText('Registers')).not.toBeInTheDocument();
@@ -151,15 +121,13 @@ describe('Frame - Line', function () {
       };
 
       render(
-        <TestComponent>
-          <Line
-            data={{...data, vars}}
-            registers={{}}
-            components={[]}
-            event={event}
-            isExpanded
-          />
-        </TestComponent>
+        <Line
+          data={{...data, vars}}
+          registers={{}}
+          components={[]}
+          event={event}
+          isExpanded
+        />
       );
 
       for (const [key, value] of Object.entries(vars)) {

--- a/static/app/components/events/interfaces/generic.spec.tsx
+++ b/static/app/components/events/interfaces/generic.spec.tsx
@@ -1,41 +1,21 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {Generic} from 'sentry/components/events/interfaces/generic';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Generic entry', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
-      organization: {
-        ...initializeOrg().organization,
-        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
-      },
-    });
-
     const event = {
       ...TestStubs.Event(),
       _meta: {
         hpkp: {'': {rem: [['organization:1', 'x']]}},
       },
     };
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Generic type="hpkp" data={null} meta={event._meta.hpkp} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<Generic type="hpkp" data={null} meta={event._meta.hpkp} />, {
+      organization: {
+        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+      },
+    });
 
     expect(screen.getByText(/redacted/)).toBeInTheDocument();
 

--- a/static/app/components/events/interfaces/keyValueList/index.spec.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.spec.tsx
@@ -1,28 +1,6 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, within} from 'sentry-test/reactTestingLibrary';
 
 import KeyValueList from 'sentry/components/events/interfaces/keyValueList';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
-
-function ComponentProviders({children}: {children?: React.ReactNode}) {
-  const {organization, router} = initializeOrg();
-
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
 
 describe('KeyValueList', function () {
   it('should render a definition list of key/value pairs', function () {
@@ -31,11 +9,7 @@ describe('KeyValueList', function () {
       {key: 'b', value: 'y', subject: 'b'},
     ];
 
-    render(
-      <ComponentProviders>
-        <KeyValueList data={data} />
-      </ComponentProviders>
-    );
+    render(<KeyValueList data={data} />);
 
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(2);
@@ -55,11 +29,7 @@ describe('KeyValueList', function () {
       {key: 'a', value: 'x', subject: 'a'},
     ];
 
-    render(
-      <ComponentProviders>
-        <KeyValueList data={data} />
-      </ComponentProviders>
-    );
+    render(<KeyValueList data={data} />);
 
     const rows = screen.getAllByRole('row');
 
@@ -78,11 +48,7 @@ describe('KeyValueList', function () {
       {key: 'a', value: '', subject: 'a'}, // empty string
     ];
 
-    render(
-      <ComponentProviders>
-        <KeyValueList data={data} />
-      </ComponentProviders>
-    );
+    render(<KeyValueList data={data} />);
 
     const rows = screen.getAllByRole('row');
 
@@ -101,11 +67,7 @@ describe('KeyValueList', function () {
       {key: 'a', value: [3, 2, 1], subject: 'a'},
     ];
 
-    render(
-      <ComponentProviders>
-        <KeyValueList isContextData data={data} />
-      </ComponentProviders>
-    );
+    render(<KeyValueList isContextData data={data} />);
 
     const rows = screen.getAllByRole('row');
 
@@ -120,11 +82,7 @@ describe('KeyValueList', function () {
   it('should coerce non-strings into strings', function () {
     const data = [{key: 'a', value: false, subject: 'a'}];
 
-    render(
-      <ComponentProviders>
-        <KeyValueList data={data} />
-      </ComponentProviders>
-    );
+    render(<KeyValueList data={data} />);
 
     const cells = screen.getAllByRole('cell');
     expect(cells[0]).toHaveTextContent('a');
@@ -134,11 +92,7 @@ describe('KeyValueList', function () {
   it("shouldn't blow up on null", function () {
     const data = [{key: 'a', value: null, subject: 'a'}];
 
-    render(
-      <ComponentProviders>
-        <KeyValueList data={data} />
-      </ComponentProviders>
-    );
+    render(<KeyValueList data={data} />);
 
     const cells = screen.getAllByRole('cell');
     expect(cells[0]).toHaveTextContent('a');

--- a/static/app/components/events/interfaces/message.spec.tsx
+++ b/static/app/components/events/interfaces/message.spec.tsx
@@ -1,21 +1,10 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {Message} from 'sentry/components/events/interfaces/message';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Message entry', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
-      organization: {
-        ...initializeOrg().organization,
-        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
-      },
-    });
-
     const event = {
       ...TestStubs.Event(),
       entries: [
@@ -36,20 +25,11 @@ describe('Message entry', function () {
         },
       },
     };
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Message data={{formatted: null}} event={event} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<Message data={{formatted: null}} event={event} />, {
+      organization: {
+        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+      },
+    });
 
     expect(screen.getByText(/redacted/)).toBeInTheDocument();
 

--- a/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.spec.tsx
@@ -7,30 +7,11 @@ import {
 } from 'sentry-test/performance/utils';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {EventTransaction} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
-
 import {SpanEvidenceSection} from './spanEvidence';
 
-const {organization, router} = initializeData({
+const {organization} = initializeData({
   features: ['performance-issues'],
 });
-
-const WrappedComponent = ({event}: {event: EventTransaction}) => (
-  <OrganizationContext.Provider value={organization}>
-    <RouteContext.Provider
-      value={{
-        router,
-        location: router.location,
-        params: {},
-        routes: [],
-      }}
-    >
-      <SpanEvidenceSection organization={organization} event={event} />
-    </RouteContext.Provider>
-  </OrganizationContext.Provider>
-);
 
 describe('spanEvidence', () => {
   it('renders and highlights the correct data in the span evidence section', () => {
@@ -91,7 +72,10 @@ describe('spanEvidence', () => {
 
     builder.addSpan(parentProblemSpan);
 
-    render(<WrappedComponent event={builder.getEvent()} />);
+    render(
+      <SpanEvidenceSection event={builder.getEvent()} organization={organization} />,
+      {organization}
+    );
 
     // Verify the surfaced fields in the span evidence section are correct
     const transactionKey = screen.getByRole('cell', {name: 'Transaction'});

--- a/static/app/components/events/interfaces/request/index.spec.tsx
+++ b/static/app/components/events/interfaces/request/index.spec.tsx
@@ -1,21 +1,10 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {Request} from 'sentry/components/events/interfaces/request';
 import {EntryRequest, EntryType} from 'sentry/types/event';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('Request entry', function () {
-  const {organization, router} = initializeOrg({
-    ...initializeOrg(),
-    organization: {
-      ...initializeOrg().organization,
-      relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
-    },
-  });
-
   it('display redacted data', async function () {
     const event = {
       ...TestStubs.Event(),
@@ -170,20 +159,11 @@ describe('Request entry', function () {
       },
     };
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <Request event={event} data={event.entries[0].data} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<Request event={event} data={event.entries[0].data} />, {
+      organization: {
+        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+      },
+    });
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(5);
 
@@ -226,20 +206,11 @@ describe('Request entry', function () {
         ],
       };
 
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <RouteContext.Provider
-            value={{
-              router,
-              location: router.location,
-              params: {},
-              routes: [],
-            }}
-          >
-            <Request event={event} data={event.entries[0].data} />
-          </RouteContext.Provider>
-        </OrganizationContext.Provider>
-      );
+      render(<Request event={event} data={event.entries[0].data} />, {
+        organization: {
+          relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+        },
+      });
 
       expect(
         screen.getByTestId('rich-http-content-body-section-pre')
@@ -269,20 +240,11 @@ describe('Request entry', function () {
         ],
       };
 
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <RouteContext.Provider
-            value={{
-              router,
-              location: router.location,
-              params: {},
-              routes: [],
-            }}
-          >
-            <Request event={event} data={event.entries[0].data} />
-          </RouteContext.Provider>
-        </OrganizationContext.Provider>
-      );
+      render(<Request event={event} data={event.entries[0].data} />, {
+        organization: {
+          relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+        },
+      });
 
       expect(
         screen.getByTestId('rich-http-content-body-key-value-list')
@@ -312,20 +274,11 @@ describe('Request entry', function () {
         ],
       };
 
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <RouteContext.Provider
-            value={{
-              router,
-              location: router.location,
-              params: {},
-              routes: [],
-            }}
-          >
-            <Request event={event} data={event.entries[0].data} />
-          </RouteContext.Provider>
-        </OrganizationContext.Provider>
-      );
+      render(<Request event={event} data={event.entries[0].data} />, {
+        organization: {
+          relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+        },
+      });
 
       expect(
         screen.getByTestId('rich-http-content-body-context-data')
@@ -357,20 +310,11 @@ describe('Request entry', function () {
       };
 
       expect(() =>
-        render(
-          <OrganizationContext.Provider value={organization}>
-            <RouteContext.Provider
-              value={{
-                router,
-                location: router.location,
-                params: {},
-                routes: [],
-              }}
-            >
-              <Request event={event} data={event.entries[0].data} />
-            </RouteContext.Provider>
-          </OrganizationContext.Provider>
-        )
+        render(<Request event={event} data={event.entries[0].data} />, {
+          organization: {
+            relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+          },
+        })
       ).not.toThrow();
     });
 
@@ -397,20 +341,11 @@ describe('Request entry', function () {
       };
 
       expect(() =>
-        render(
-          <OrganizationContext.Provider value={organization}>
-            <RouteContext.Provider
-              value={{
-                router,
-                location: router.location,
-                params: {},
-                routes: [],
-              }}
-            >
-              <Request event={event} data={event.entries[0].data} />
-            </RouteContext.Provider>
-          </OrganizationContext.Provider>
-        )
+        render(<Request event={event} data={event.entries[0].data} />, {
+          organization: {
+            relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+          },
+        })
       ).not.toThrow();
     });
   });

--- a/static/app/components/events/interfaces/spans/traceView.spec.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.spec.tsx
@@ -19,19 +19,12 @@ import WaterfallModel from 'sentry/components/events/interfaces/spans/waterfallM
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import QuickTraceQuery from 'sentry/utils/performance/quickTrace/quickTraceQuery';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 function initializeData(settings) {
   const data = _initializeData(settings);
   act(() => void ProjectsStore.loadInitialData(data.organization.projects));
   return data;
 }
-
-const WrappedTraceView = ({organization, waterfallModel}) => (
-  <OrganizationContext.Provider value={organization}>
-    <TraceView organization={organization} waterfallModel={waterfallModel} />
-  </OrganizationContext.Provider>
-);
 
 describe('TraceView', () => {
   afterEach(() => {
@@ -84,10 +77,7 @@ describe('TraceView', () => {
       const waterfallModel = new WaterfallModel(event);
 
       render(
-        <WrappedTraceView
-          organization={data.organization}
-          waterfallModel={waterfallModel}
-        />
+        <TraceView organization={data.organization} waterfallModel={waterfallModel} />
       );
 
       expect(await screen.findByTestId('minimap-sibling-group-bar')).toBeInTheDocument();
@@ -143,10 +133,7 @@ describe('TraceView', () => {
       const waterfallModel = new WaterfallModel(event);
 
       render(
-        <WrappedTraceView
-          organization={data.organization}
-          waterfallModel={waterfallModel}
-        />
+        <TraceView organization={data.organization} waterfallModel={waterfallModel} />
       );
 
       const groupedSiblingsSpan = await screen.findByText('Autogrouped — http —');
@@ -218,10 +205,7 @@ describe('TraceView', () => {
       const waterfallModel = new WaterfallModel(event);
 
       render(
-        <WrappedTraceView
-          organization={data.organization}
-          waterfallModel={waterfallModel}
-        />
+        <TraceView organization={data.organization} waterfallModel={waterfallModel} />
       );
 
       expect(await screen.findByText('group me')).toBeInTheDocument();
@@ -271,10 +255,7 @@ describe('TraceView', () => {
       const waterfallModel = new WaterfallModel(event);
 
       render(
-        <WrappedTraceView
-          organization={data.organization}
-          waterfallModel={waterfallModel}
-        />
+        <TraceView organization={data.organization} waterfallModel={waterfallModel} />
       );
 
       const grouped = await screen.findByText('group me');
@@ -362,10 +343,7 @@ describe('TraceView', () => {
       const waterfallModel = new WaterfallModel(event);
 
       render(
-        <WrappedTraceView
-          organization={data.organization}
-          waterfallModel={waterfallModel}
-        />
+        <TraceView organization={data.organization} waterfallModel={waterfallModel} />
       );
 
       expect(screen.queryAllByText('group me')).toHaveLength(2);
@@ -475,10 +453,7 @@ describe('TraceView', () => {
         <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
           {results => (
             <QuickTraceContext.Provider value={results}>
-              <WrappedTraceView
-                organization={organization}
-                waterfallModel={waterfallModel}
-              />
+              <TraceView organization={organization} waterfallModel={waterfallModel} />
             </QuickTraceContext.Provider>
           )}
         </QuickTraceQuery>
@@ -539,7 +514,7 @@ describe('TraceView', () => {
       );
 
       const {rerender} = render(
-        <WrappedTraceView
+        <TraceView
           organization={data.organization}
           waterfallModel={new WaterfallModel(event1)}
         />
@@ -556,7 +531,7 @@ describe('TraceView', () => {
       generateSampleSpan(null, 'http', 'f000000000000000', 'a000000000000000', event2);
 
       rerender(
-        <WrappedTraceView
+        <TraceView
           organization={data.organization}
           waterfallModel={new WaterfallModel(event2)}
         />
@@ -574,7 +549,7 @@ describe('TraceView', () => {
       generateSampleSpan(null, null, 'f000000000000000', 'a000000000000000', event3);
 
       rerender(
-        <WrappedTraceView
+        <TraceView
           organization={data.organization}
           waterfallModel={new WaterfallModel(event3)}
         />
@@ -634,10 +609,7 @@ describe('TraceView', () => {
 
       render(
         <AnchorLinkManager.Provider>
-          <WrappedTraceView
-            organization={data.organization}
-            waterfallModel={waterfallModel}
-          />
+          <TraceView organization={data.organization} waterfallModel={waterfallModel} />
         </AnchorLinkManager.Provider>
       );
 
@@ -691,10 +663,7 @@ describe('TraceView', () => {
 
       render(
         <AnchorLinkManager.Provider>
-          <WrappedTraceView
-            organization={data.organization}
-            waterfallModel={waterfallModel}
-          />
+          <TraceView organization={data.organization} waterfallModel={waterfallModel} />
         </AnchorLinkManager.Provider>
       );
 
@@ -749,10 +718,7 @@ describe('TraceView', () => {
     const waterfallModel = new WaterfallModel(event);
 
     render(
-      <WrappedTraceView
-        organization={data.organization}
-        waterfallModel={waterfallModel}
-      />
+      <TraceView organization={data.organization} waterfallModel={waterfallModel} />
     );
 
     const fcpLabelContainer = screen.getByText(/fcp/i).parentElement?.parentElement;

--- a/static/app/components/events/interfaces/threadsV2.spec.tsx
+++ b/static/app/components/events/interfaces/threadsV2.spec.tsx
@@ -1,42 +1,13 @@
-import {InjectedRouter} from 'react-router';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import ThreadsV2 from 'sentry/components/events/interfaces/threadsV2';
 import {displayOptions} from 'sentry/components/events/traceEventDataSection';
-import {EventOrGroupType, Organization} from 'sentry/types';
+import {EventOrGroupType} from 'sentry/types';
 import {EntryType, Event} from 'sentry/types/event';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
-
-function TestComponent({
-  organization,
-  router,
-  children,
-}: {
-  children: React.ReactNode;
-  organization: Organization;
-  router: InjectedRouter;
-}) {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
 
 describe('ThreadsV2', function () {
-  const {project, organization, router} = initializeOrg();
+  const {project, organization} = initializeOrg();
   const org = {...organization, features: ['native-stack-trace-v2']};
 
   describe('non native platform', function () {
@@ -232,14 +203,9 @@ describe('ThreadsV2', function () {
       };
 
       it('renders', function () {
-        const {container} = render(
-          <TestComponent organization={org} router={router}>
-            <ThreadsV2 {...props} />
-          </TestComponent>,
-          {
-            organization: org,
-          }
-        );
+        const {container} = render(<ThreadsV2 {...props} />, {
+          organization: org,
+        });
 
         // Title
         expect(screen.getByRole('heading', {name: 'Stack Trace'})).toBeInTheDocument();
@@ -266,12 +232,7 @@ describe('ThreadsV2', function () {
       });
 
       it('toggle full stack trace button', function () {
-        render(
-          <TestComponent organization={org} router={router}>
-            <ThreadsV2 {...props} />
-          </TestComponent>,
-          {organization: org}
-        );
+        render(<ThreadsV2 {...props} />, {organization: org});
 
         expect(screen.queryAllByTestId('stack-trace-frame')).toHaveLength(3);
 
@@ -289,12 +250,7 @@ describe('ThreadsV2', function () {
       });
 
       it('toggle sort by display option', function () {
-        render(
-          <TestComponent organization={org} router={router}>
-            <ThreadsV2 {...props} />
-          </TestComponent>,
-          {organization: org}
-        );
+        render(<ThreadsV2 {...props} />, {organization: org});
 
         expect(
           within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
@@ -334,12 +290,7 @@ describe('ThreadsV2', function () {
       });
 
       it('check display options', async function () {
-        render(
-          <TestComponent organization={org} router={router}>
-            <ThreadsV2 {...props} />
-          </TestComponent>,
-          {organization: org}
-        );
+        render(<ThreadsV2 {...props} />, {organization: org});
 
         userEvent.click(screen.getByRole('button', {name: 'Options'}));
 
@@ -912,12 +863,7 @@ describe('ThreadsV2', function () {
       };
 
       it('renders', function () {
-        const {container} = render(
-          <TestComponent organization={org} router={router}>
-            <ThreadsV2 {...props} />
-          </TestComponent>,
-          {organization: org}
-        );
+        const {container} = render(<ThreadsV2 {...props} />, {organization: org});
         // Title
         expect(screen.getByTestId('thread-selector')).toBeInTheDocument();
 
@@ -945,12 +891,7 @@ describe('ThreadsV2', function () {
       });
 
       it('toggle full stack trace button', function () {
-        render(
-          <TestComponent organization={org} router={router}>
-            <ThreadsV2 {...props} />
-          </TestComponent>,
-          {organization: org}
-        );
+        render(<ThreadsV2 {...props} />, {organization: org});
 
         expect(screen.queryAllByTestId('stack-trace-frame')).toHaveLength(3);
 
@@ -968,12 +909,7 @@ describe('ThreadsV2', function () {
       });
 
       it('toggle sort by option', function () {
-        render(
-          <TestComponent organization={org} router={router}>
-            <ThreadsV2 {...props} />
-          </TestComponent>,
-          {organization: org}
-        );
+        render(<ThreadsV2 {...props} />, {organization: org});
 
         expect(
           within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
@@ -1017,12 +953,7 @@ describe('ThreadsV2', function () {
       });
 
       it('check display options', async function () {
-        render(
-          <TestComponent organization={org} router={router}>
-            <ThreadsV2 {...props} />
-          </TestComponent>,
-          {organization: org}
-        );
+        render(<ThreadsV2 {...props} />, {organization: org});
 
         userEvent.click(screen.getByRole('button', {name: 'Options'}));
 

--- a/static/app/components/events/packageData.spec.tsx
+++ b/static/app/components/events/packageData.spec.tsx
@@ -1,21 +1,10 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {EventPackageData} from 'sentry/components/events/packageData';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('EventPackageData', function () {
   it('display redacted data', async function () {
-    const {organization, router} = initializeOrg({
-      ...initializeOrg(),
-      organization: {
-        ...initializeOrg().organization,
-        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
-      },
-    });
-
     const event = {
       ...TestStubs.Event(),
       packages: {
@@ -35,20 +24,11 @@ describe('EventPackageData', function () {
       },
     };
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <EventPackageData event={event} />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
-    );
+    render(<EventPackageData event={event} />, {
+      organization: {
+        relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
+      },
+    });
 
     expect(screen.getByText(/redacted/)).toBeInTheDocument();
 

--- a/static/app/components/tagsTable.spec.tsx
+++ b/static/app/components/tagsTable.spec.tsx
@@ -1,10 +1,7 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {TagsTable} from 'sentry/components/tagsTable';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('tags table', function () {
   it('display redacted tag value', async function () {
@@ -27,25 +24,12 @@ describe('tags table', function () {
       },
     };
 
-    const {organization, router} = initializeOrg();
-
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <TagsTable
-            event={event}
-            query="transaction.duration:<15m transaction.op:pageload"
-            generateUrl={jest.fn()}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <TagsTable
+        event={event}
+        query="transaction.duration:<15m transaction.op:pageload"
+        generateUrl={jest.fn()}
+      />
     );
 
     userEvent.hover(screen.getByText(/redacted/));
@@ -60,8 +44,6 @@ describe('tags table', function () {
   });
 
   it('display redacted tag key', async function () {
-    const {organization, router} = initializeOrg();
-
     const tags = [
       {key: 'gpu.name', value: 'AMD Radeon Pro 560'},
       {key: null, value: 'iOS'},
@@ -82,22 +64,11 @@ describe('tags table', function () {
     };
 
     render(
-      <OrganizationContext.Provider value={organization}>
-        <RouteContext.Provider
-          value={{
-            router,
-            location: router.location,
-            params: {},
-            routes: [],
-          }}
-        >
-          <TagsTable
-            event={event}
-            query="transaction.duration:<15m transaction.op:pageload"
-            generateUrl={jest.fn()}
-          />
-        </RouteContext.Provider>
-      </OrganizationContext.Provider>
+      <TagsTable
+        event={event}
+        query="transaction.duration:<15m transaction.op:pageload"
+        generateUrl={jest.fn()}
+      />
     );
 
     userEvent.hover(screen.getByText(/redacted/));


### PR DESCRIPTION
Now that we render the context by default, we can remove a lot of unnecessary code.

This focuses on tests under `components/events`