### PR TITLE
feat(slack): Forward validation errors to the user

### DIFF
--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -9,6 +9,7 @@ import rest_framework
 from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.utils import timezone
+from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -207,7 +208,7 @@ def update_groups(
             },
         )
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            raise serializers.ValidationError(serializer.errors, code=400)
 
     if serializer is None:
         return

--- a/src/sentry/integrations/slack/webhooks/action.py
+++ b/src/sentry/integrations/slack/webhooks/action.py
@@ -171,7 +171,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
         group: Group,
         error: serializers.ValidationError,
         action_type: str,
-    ):
+    ) -> Response:
         logger.info(
             "slack.action.validation-error",
             extra={
@@ -181,7 +181,7 @@ class SlackActionEndpoint(Endpoint):  # type: ignore
             },
         )
 
-        text = list(*error.detail.values())[0]
+        text: str = list(*error.detail.values())[0]
         return self.respond_ephemeral(text)
 
     def on_assign(


### PR DESCRIPTION
## Objective:
Pen test conducted by Slack assumes that users/teams not in an organization/project can be assigned issues bc we don't display the validation error in the Slack UI. There is no security/data integrity issue. This PR forwards the validation errors that was squashed and logs them.