### PR TITLE
test(js): Remove more unnecessary uses of org/router context

### DIFF
--- a/static/app/components/eventOrGroupHeader.spec.tsx
+++ b/static/app/components/eventOrGroupHeader.spec.tsx
@@ -4,7 +4,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import EventOrGroupHeader from 'sentry/components/eventOrGroupHeader';
 import {EventOrGroupType} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 const group = TestStubs.Group({
   level: 'error',
@@ -40,9 +39,7 @@ describe('EventOrGroupHeader', function () {
   describe('Group', function () {
     it('renders with `type = error`', function () {
       const {container} = render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader organization={organization} data={group} {...router} />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader organization={organization} data={group} {...router} />
       );
 
       expect(container).toSnapshot();
@@ -50,16 +47,14 @@ describe('EventOrGroupHeader', function () {
 
     it('renders with `type = csp`', function () {
       const {container} = render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            organization={organization}
-            data={{
-              ...group,
-              type: EventOrGroupType.CSP,
-            }}
-            {...router}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          organization={organization}
+          data={{
+            ...group,
+            type: EventOrGroupType.CSP,
+          }}
+          {...router}
+        />
       );
 
       expect(container).toSnapshot();
@@ -67,20 +62,18 @@ describe('EventOrGroupHeader', function () {
 
     it('renders with `type = default`', function () {
       const {container} = render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            organization={organization}
-            data={{
-              ...group,
-              type: EventOrGroupType.DEFAULT,
-              metadata: {
-                ...group.metadata,
-                title: 'metadata title',
-              },
-            }}
-            {...router}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          organization={organization}
+          data={{
+            ...group,
+            type: EventOrGroupType.DEFAULT,
+            metadata: {
+              ...group.metadata,
+              title: 'metadata title',
+            },
+          }}
+          {...router}
+        />
       );
 
       expect(container).toSnapshot();
@@ -88,16 +81,14 @@ describe('EventOrGroupHeader', function () {
 
     it('renders metadata values in message for error events', function () {
       render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            organization={organization}
-            data={{
-              ...group,
-              type: EventOrGroupType.ERROR,
-            }}
-            {...router}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          organization={organization}
+          data={{
+            ...group,
+            type: EventOrGroupType.ERROR,
+          }}
+          {...router}
+        />
       );
 
       expect(screen.getByText('metadata value')).toBeInTheDocument();
@@ -105,20 +96,18 @@ describe('EventOrGroupHeader', function () {
 
     it('renders location', function () {
       render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            organization={organization}
-            data={{
-              ...group,
-              metadata: {
-                filename: 'path/to/file.swift',
-              },
-              platform: 'swift',
-              type: EventOrGroupType.ERROR,
-            }}
-            {...router}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          organization={organization}
+          data={{
+            ...group,
+            metadata: {
+              filename: 'path/to/file.swift',
+            },
+            platform: 'swift',
+            type: EventOrGroupType.ERROR,
+          }}
+          {...router}
+        />
       );
 
       expect(
@@ -130,97 +119,87 @@ describe('EventOrGroupHeader', function () {
   describe('Event', function () {
     it('renders with `type = error`', function () {
       const {container} = render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            organization={organization}
-            data={{
-              ...event,
-              type: EventOrGroupType.ERROR,
-            }}
-            {...router}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          organization={organization}
+          data={{
+            ...event,
+            type: EventOrGroupType.ERROR,
+          }}
+          {...router}
+        />
       );
       expect(container).toSnapshot();
     });
 
     it('renders with `type = csp`', function () {
       const {container} = render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            organization={organization}
-            data={{
-              ...event,
-              type: EventOrGroupType.CSP,
-            }}
-            {...router}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          organization={organization}
+          data={{
+            ...event,
+            type: EventOrGroupType.CSP,
+          }}
+          {...router}
+        />
       );
       expect(container).toSnapshot();
     });
 
     it('renders with `type = default`', function () {
       const {container} = render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            organization={organization}
-            data={{
-              ...event,
-              type: EventOrGroupType.DEFAULT,
-              metadata: {
-                ...event.metadata,
-                title: 'metadata title',
-              },
-            }}
-            {...router}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          organization={organization}
+          data={{
+            ...event,
+            type: EventOrGroupType.DEFAULT,
+            metadata: {
+              ...event.metadata,
+              title: 'metadata title',
+            },
+          }}
+          {...router}
+        />
       );
       expect(container).toSnapshot();
     });
 
     it('hides level tag', function () {
       const {container} = render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            projectId="projectId"
-            hideLevel
-            organization={organization}
-            data={{
-              ...event,
-              type: EventOrGroupType.DEFAULT,
-              metadata: {
-                ...event.metadata,
-                title: 'metadata title',
-              },
-            }}
-            {...router}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          projectId="projectId"
+          hideLevel
+          organization={organization}
+          data={{
+            ...event,
+            type: EventOrGroupType.DEFAULT,
+            metadata: {
+              ...event.metadata,
+              title: 'metadata title',
+            },
+          }}
+          {...router}
+        />
       );
       expect(container).toSnapshot();
     });
 
     it('keeps sort in link when query has sort', function () {
       render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            organization={organization}
-            data={{
-              ...event,
-              type: EventOrGroupType.DEFAULT,
-            }}
-            {...router}
-            location={{
-              ...router.location,
-              query: {
-                ...router.location.query,
-                sort: 'freq',
-              },
-            }}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          organization={organization}
+          data={{
+            ...event,
+            type: EventOrGroupType.DEFAULT,
+          }}
+          {...router}
+          location={{
+            ...router.location,
+            query: {
+              ...router.location.query,
+              sort: 'freq',
+            },
+          }}
+        />
       );
 
       expect(screen.getByRole('link')).toHaveAttribute(
@@ -231,20 +210,18 @@ describe('EventOrGroupHeader', function () {
 
     it('lack of project adds allp parameter', function () {
       render(
-        <OrganizationContext.Provider value={organization}>
-          <EventOrGroupHeader
-            organization={organization}
-            data={{
-              ...event,
-              type: EventOrGroupType.DEFAULT,
-            }}
-            {...router}
-            location={{
-              ...router.location,
-              query: {},
-            }}
-          />
-        </OrganizationContext.Provider>
+        <EventOrGroupHeader
+          organization={organization}
+          data={{
+            ...event,
+            type: EventOrGroupType.DEFAULT,
+          }}
+          {...router}
+          location={{
+            ...router.location,
+            query: {},
+          }}
+        />
       );
 
       expect(screen.getByRole('link')).toHaveAttribute(

--- a/static/app/components/eventOrGroupTitle.spec.tsx
+++ b/static/app/components/eventOrGroupTitle.spec.tsx
@@ -1,11 +1,7 @@
-import {FC} from 'react';
-
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EventOrGroupTitle from 'sentry/components/eventOrGroupTitle';
 import {BaseGroup, EventOrGroupType, IssueCategory} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('EventOrGroupTitle', function () {
   const data = {
@@ -17,28 +13,18 @@ describe('EventOrGroupTitle', function () {
     culprit: 'culprit',
   };
 
-  const {organization} = initializeOrg();
-
-  const TestComponent: FC = ({children}) => (
-    <OrganizationContext.Provider value={organization}>
-      {children}
-    </OrganizationContext.Provider>
-  );
-
   it('renders with subtitle when `type = error`', function () {
     const wrapper = render(
-      <TestComponent>
-        <EventOrGroupTitle
-          data={
-            {
-              ...data,
-              ...{
-                type: EventOrGroupType.ERROR,
-              },
-            } as BaseGroup
-          }
-        />
-      </TestComponent>
+      <EventOrGroupTitle
+        data={
+          {
+            ...data,
+            ...{
+              type: EventOrGroupType.ERROR,
+            },
+          } as BaseGroup
+        }
+      />
     );
 
     expect(wrapper.container).toSnapshot();
@@ -46,18 +32,16 @@ describe('EventOrGroupTitle', function () {
 
   it('renders with subtitle when `type = csp`', function () {
     const wrapper = render(
-      <TestComponent>
-        <EventOrGroupTitle
-          data={
-            {
-              ...data,
-              ...{
-                type: EventOrGroupType.CSP,
-              },
-            } as BaseGroup
-          }
-        />
-      </TestComponent>
+      <EventOrGroupTitle
+        data={
+          {
+            ...data,
+            ...{
+              type: EventOrGroupType.CSP,
+            },
+          } as BaseGroup
+        }
+      />
     );
 
     expect(wrapper.container).toSnapshot();
@@ -65,20 +49,18 @@ describe('EventOrGroupTitle', function () {
 
   it('renders with no subtitle when `type = default`', function () {
     const wrapper = render(
-      <TestComponent>
-        <EventOrGroupTitle
-          data={
-            {
-              ...data,
-              type: EventOrGroupType.DEFAULT,
-              metadata: {
-                ...data.metadata,
-                title: 'metadata title',
-              },
-            } as BaseGroup
-          }
-        />
-      </TestComponent>
+      <EventOrGroupTitle
+        data={
+          {
+            ...data,
+            type: EventOrGroupType.DEFAULT,
+            metadata: {
+              ...data.metadata,
+              title: 'metadata title',
+            },
+          } as BaseGroup
+        }
+      />
     );
 
     expect(wrapper.container).toSnapshot();
@@ -90,20 +72,18 @@ describe('EventOrGroupTitle', function () {
     ]);
 
     render(
-      <TestComponent>
-        <EventOrGroupTitle
-          data={
-            {
-              ...data,
-              type: EventOrGroupType.ERROR,
-              metadata: {
-                ...data.metadata,
-                title: 'metadata title',
-              },
-            } as BaseGroup
-          }
-        />
-      </TestComponent>,
+      <EventOrGroupTitle
+        data={
+          {
+            ...data,
+            type: EventOrGroupType.ERROR,
+            metadata: {
+              ...data.metadata,
+              title: 'metadata title',
+            },
+          } as BaseGroup
+        }
+      />,
       {context: routerContext}
     );
 
@@ -112,17 +92,15 @@ describe('EventOrGroupTitle', function () {
 
   it('does not render stack trace when issueCategory is performance', () => {
     render(
-      <TestComponent>
-        <EventOrGroupTitle
-          data={
-            {
-              ...data,
-              issueCategory: IssueCategory.PERFORMANCE,
-            } as BaseGroup
-          }
-          withStackTracePreview
-        />
-      </TestComponent>
+      <EventOrGroupTitle
+        data={
+          {
+            ...data,
+            issueCategory: IssueCategory.PERFORMANCE,
+          } as BaseGroup
+        }
+        withStackTracePreview
+      />
     );
 
     expect(screen.queryByTestId('stacktrace-preview')).not.toBeInTheDocument();
@@ -144,12 +122,7 @@ describe('EventOrGroupTitle', function () {
         {organization: TestStubs.Organization({features: ['custom-event-title']})},
       ]);
 
-      render(
-        <TestComponent>
-          <EventOrGroupTitle data={perfData} />
-        </TestComponent>,
-        {context: routerContext}
-      );
+      render(<EventOrGroupTitle data={perfData} />, {context: routerContext});
 
       expect(screen.getByText('N+1 Query')).toBeInTheDocument();
       expect(screen.getByText('transaction name')).toBeInTheDocument();

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -1,40 +1,13 @@
-import {InjectedRouter} from 'react-router';
+import {Fragment} from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import EventTagsAndScreenshot from 'sentry/components/events/eventTagsAndScreenshot';
 import GlobalModal from 'sentry/components/globalModal';
-import {EventAttachment, Organization} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
+import {EventAttachment} from 'sentry/types';
 
 import {deviceNameMapper} from '../../../../../static/app/components/deviceName';
-
-function TestComponent({
-  organization,
-  router,
-  children,
-}: {
-  children: React.ReactNode;
-  organization: Organization;
-  router: InjectedRouter;
-}) {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
 
 describe('EventTagsAndScreenshot', function () {
   const contexts = {
@@ -181,17 +154,15 @@ describe('EventTagsAndScreenshot', function () {
   describe('renders tags only', function () {
     it('not shared event - without attachments', function () {
       const {container} = render(
-        <TestComponent organization={organization} router={router}>
-          <EventTagsAndScreenshot
-            event={{...event, tags, contexts}}
-            organization={organization}
-            projectId={project.slug}
-            location={router.location}
-            attachments={[]}
-            onDeleteScreenshot={() => jest.fn()}
-            hasContext
-          />
-        </TestComponent>
+        <EventTagsAndScreenshot
+          event={{...event, tags, contexts}}
+          organization={organization}
+          projectId={project.slug}
+          location={router.location}
+          attachments={[]}
+          onDeleteScreenshot={() => jest.fn()}
+          hasContext
+        />
       );
 
       // Screenshot Container
@@ -234,18 +205,16 @@ describe('EventTagsAndScreenshot', function () {
 
     it('shared event - without attachments', function () {
       const {container} = render(
-        <TestComponent organization={organization} router={router}>
-          <EventTagsAndScreenshot
-            event={{...event, tags, contexts}}
-            organization={organization}
-            projectId={project.slug}
-            location={router.location}
-            attachments={[]}
-            onDeleteScreenshot={() => jest.fn()}
-            hasContext
-            isShare
-          />
-        </TestComponent>
+        <EventTagsAndScreenshot
+          event={{...event, tags, contexts}}
+          organization={organization}
+          projectId={project.slug}
+          location={router.location}
+          attachments={[]}
+          onDeleteScreenshot={() => jest.fn()}
+          hasContext
+          isShare
+        />
       );
 
       // Screenshot Container
@@ -259,18 +228,16 @@ describe('EventTagsAndScreenshot', function () {
 
     it('shared event - with attachments', function () {
       const {container} = render(
-        <TestComponent organization={organization} router={router}>
-          <EventTagsAndScreenshot
-            event={{...event, tags, contexts}}
-            organization={organization}
-            projectId={project.slug}
-            location={router.location}
-            attachments={attachments}
-            onDeleteScreenshot={() => jest.fn()}
-            hasContext
-            isShare
-          />
-        </TestComponent>
+        <EventTagsAndScreenshot
+          event={{...event, tags, contexts}}
+          organization={organization}
+          projectId={project.slug}
+          location={router.location}
+          attachments={attachments}
+          onDeleteScreenshot={() => jest.fn()}
+          hasContext
+          isShare
+        />
       );
 
       // Screenshot Container
@@ -301,7 +268,7 @@ describe('EventTagsAndScreenshot', function () {
 
     it('no context and no tags', async function () {
       const {container} = render(
-        <TestComponent organization={organization} router={router}>
+        <Fragment>
           <GlobalModal />
           <EventTagsAndScreenshot
             event={event}
@@ -312,7 +279,7 @@ describe('EventTagsAndScreenshot', function () {
             onDeleteScreenshot={() => jest.fn()}
             hasContext={false}
           />
-        </TestComponent>
+        </Fragment>
       );
 
       // Tags Container
@@ -353,17 +320,15 @@ describe('EventTagsAndScreenshot', function () {
   describe('renders screenshot and tags', function () {
     it('has context, tags and attachments', function () {
       const {container} = render(
-        <TestComponent organization={organization} router={router}>
-          <EventTagsAndScreenshot
-            event={{...event, tags, contexts}}
-            organization={organization}
-            projectId={project.slug}
-            location={router.location}
-            attachments={attachments}
-            onDeleteScreenshot={() => jest.fn()}
-            hasContext
-          />
-        </TestComponent>
+        <EventTagsAndScreenshot
+          event={{...event, tags, contexts}}
+          organization={organization}
+          projectId={project.slug}
+          location={router.location}
+          attachments={attachments}
+          onDeleteScreenshot={() => jest.fn()}
+          hasContext
+        />
       );
 
       // Screenshot Container
@@ -388,17 +353,15 @@ describe('EventTagsAndScreenshot', function () {
 
     it('has context and attachments only', function () {
       const {container} = render(
-        <TestComponent organization={organization} router={router}>
-          <EventTagsAndScreenshot
-            event={{...event, contexts}}
-            organization={organization}
-            projectId={project.slug}
-            location={router.location}
-            attachments={attachments}
-            onDeleteScreenshot={() => jest.fn()}
-            hasContext
-          />
-        </TestComponent>
+        <EventTagsAndScreenshot
+          event={{...event, contexts}}
+          organization={organization}
+          projectId={project.slug}
+          location={router.location}
+          attachments={attachments}
+          onDeleteScreenshot={() => jest.fn()}
+          hasContext
+        />
       );
 
       // Screenshot Container
@@ -423,17 +386,15 @@ describe('EventTagsAndScreenshot', function () {
 
     it('has tags and attachments only', function () {
       const {container} = render(
-        <TestComponent organization={organization} router={router}>
-          <EventTagsAndScreenshot
-            event={{...event, tags}}
-            organization={organization}
-            projectId={project.slug}
-            location={router.location}
-            attachments={attachments}
-            onDeleteScreenshot={() => jest.fn()}
-            hasContext={false}
-          />
-        </TestComponent>
+        <EventTagsAndScreenshot
+          event={{...event, tags}}
+          organization={organization}
+          projectId={project.slug}
+          location={router.location}
+          attachments={attachments}
+          onDeleteScreenshot={() => jest.fn()}
+          hasContext={false}
+        />
       );
 
       // Screenshot Container

--- a/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/spanEvidencePreview.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   MockSpan,
   ProblemSpan,
@@ -7,8 +6,6 @@ import {
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import * as useApi from 'sentry/utils/useApi';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 import {SpanEvidencePreview} from './spanEvidencePreview';
 
@@ -18,27 +15,19 @@ describe('SpanEvidencePreview', () => {
     jest.restoreAllMocks();
   });
 
-  const {organization, router} = initializeOrg();
-
-  const TestComponent: typeof SpanEvidencePreview = props => (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{router, location: router.location, params: {}, routes: []}}
-      >
-        <SpanEvidencePreview {...props} />
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-
   it('does not fetch before hover', () => {
     const api = new MockApiClient();
     jest.spyOn(useApi, 'default').mockReturnValue(api);
     const spy = jest.spyOn(api, 'requestPromise');
 
     render(
-      <TestComponent eventId="event-id" projectSlug="project-slug" groupId="group-id">
+      <SpanEvidencePreview
+        eventId="event-id"
+        projectSlug="project-slug"
+        groupId="group-id"
+      >
         Hover me
-      </TestComponent>
+      </SpanEvidencePreview>
     );
 
     jest.runAllTimers();
@@ -53,9 +42,13 @@ describe('SpanEvidencePreview', () => {
     });
 
     render(
-      <TestComponent eventId="event-id" projectSlug="project-slug" groupId="group-id">
+      <SpanEvidencePreview
+        eventId="event-id"
+        projectSlug="project-slug"
+        groupId="group-id"
+      >
         Hover me
-      </TestComponent>
+      </SpanEvidencePreview>
     );
 
     userEvent.hover(screen.getByText('Hover me'));
@@ -71,7 +64,7 @@ describe('SpanEvidencePreview', () => {
       body: null,
     });
 
-    render(<TestComponent groupId="group-id">Hover me</TestComponent>);
+    render(<SpanEvidencePreview groupId="group-id">Hover me</SpanEvidencePreview>);
 
     userEvent.hover(screen.getByText('Hover me'));
 
@@ -85,7 +78,7 @@ describe('SpanEvidencePreview', () => {
     jest.spyOn(useApi, 'default').mockReturnValue(api);
     jest.spyOn(api, 'requestPromise').mockRejectedValue(new Error());
 
-    render(<TestComponent groupId="group-id">Hover me</TestComponent>);
+    render(<SpanEvidencePreview groupId="group-id">Hover me</SpanEvidencePreview>);
 
     userEvent.hover(screen.getByText('Hover me'));
 
@@ -151,7 +144,7 @@ describe('SpanEvidencePreview', () => {
       body: event,
     });
 
-    render(<TestComponent groupId="group-id">Hover me</TestComponent>);
+    render(<SpanEvidencePreview groupId="group-id">Hover me</SpanEvidencePreview>);
 
     userEvent.hover(screen.getByText('Hover me'));
 

--- a/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
+++ b/static/app/components/groupPreviewTooltip/stackTracePreview.spec.tsx
@@ -1,11 +1,8 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {EventError, Organization} from 'sentry/types';
+import {EventError} from 'sentry/types';
 import {EntryType, Event, ExceptionType, ExceptionValue, Frame} from 'sentry/types/event';
 import useApi from 'sentry/utils/useApi';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 import {StackTracePreview} from './stackTracePreview';
 
@@ -17,25 +14,6 @@ const makeEvent = (event: Partial<Event> = {}): Event => {
 
   return evt;
 };
-
-function TestComponent({org, children}: {children: React.ReactNode; org?: Organization}) {
-  const {organization, router} = initializeOrg();
-
-  return (
-    <OrganizationContext.Provider value={org ?? organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
 
 jest.mock('sentry/utils/useApi');
 
@@ -51,11 +29,9 @@ describe('StackTracePreview', () => {
     useApi.mockReturnValue(api);
 
     render(
-      <TestComponent>
-        <StackTracePreview issueId="issue" eventId="event_id" projectSlug="project_slug">
-          Preview Trigger
-        </StackTracePreview>
-      </TestComponent>
+      <StackTracePreview issueId="issue" eventId="event_id" projectSlug="project_slug">
+        Preview Trigger
+      </StackTracePreview>
     );
 
     userEvent.hover(screen.getByText(/Preview Trigger/));
@@ -76,11 +52,7 @@ describe('StackTracePreview', () => {
     // @ts-ignore useApi is mocked
     useApi.mockReturnValue(api);
 
-    render(
-      <TestComponent>
-        <StackTracePreview issueId="issue">Preview Trigger</StackTracePreview>
-      </TestComponent>
-    );
+    render(<StackTracePreview issueId="issue">Preview Trigger</StackTracePreview>);
 
     userEvent.hover(screen.getByText(/Preview Trigger/));
 
@@ -100,11 +72,7 @@ describe('StackTracePreview', () => {
     // @ts-ignore useApi is mocked
     useApi.mockReturnValue(api);
 
-    render(
-      <TestComponent>
-        <StackTracePreview issueId="issue">Preview Trigger</StackTracePreview>
-      </TestComponent>
-    );
+    render(<StackTracePreview issueId="issue">Preview Trigger</StackTracePreview>);
 
     userEvent.hover(screen.getByText(/Preview Trigger/));
 
@@ -120,11 +88,7 @@ describe('StackTracePreview', () => {
     // @ts-ignore useApi is mocked
     useApi.mockReturnValue(api);
 
-    render(
-      <TestComponent>
-        <StackTracePreview issueId="issue">Preview Trigger</StackTracePreview>
-      </TestComponent>
-    );
+    render(<StackTracePreview issueId="issue">Preview Trigger</StackTracePreview>);
 
     userEvent.hover(screen.getByText(/Preview Trigger/));
 
@@ -194,11 +158,9 @@ describe('StackTracePreview', () => {
     // @ts-ignore useApi is mocked
     useApi.mockReturnValue(api);
 
-    render(
-      <TestComponent org={TestStubs.Organization({features})}>
-        <StackTracePreview issueId="issue">Preview Trigger</StackTracePreview>
-      </TestComponent>
-    );
+    render(<StackTracePreview issueId="issue">Preview Trigger</StackTracePreview>, {
+      organization: {features},
+    });
 
     userEvent.hover(screen.getByText(/Preview Trigger/));
 

--- a/static/app/components/profiling/functionsTable.spec.tsx
+++ b/static/app/components/profiling/functionsTable.spec.tsx
@@ -1,38 +1,19 @@
-import {ReactElement, useEffect, useMemo} from 'react';
+import {ReactElement, useEffect} from 'react';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {FunctionsTable} from 'sentry/components/profiling/functionsTable';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
-const organization = TestStubs.Organization();
 const project = TestStubs.Project();
 
 function TestContext({children}: {children: ReactElement}) {
-  const {router} = useMemo(() => initializeOrg({organization, project} as any), []);
-
   useEffect(() => {
     ProjectsStore.loadInitialData([project]);
     return () => ProjectsStore.reset();
   }, []);
 
-  return (
-    <RouteContext.Provider
-      value={{
-        router,
-        location: router.location,
-        params: {},
-        routes: [],
-      }}
-    >
-      <OrganizationContext.Provider value={organization}>
-        {children}
-      </OrganizationContext.Provider>
-    </RouteContext.Provider>
-  );
+  return children;
 }
 
 describe('FunctionsTable', function () {

--- a/static/app/components/profiling/profilesTable.spec.tsx
+++ b/static/app/components/profiling/profilesTable.spec.tsx
@@ -1,38 +1,19 @@
-import {ReactElement, useEffect, useMemo} from 'react';
+import {ReactElement, useEffect} from 'react';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {ProfilesTable} from 'sentry/components/profiling/profilesTable';
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
-const organization = TestStubs.Organization();
 const project = TestStubs.Project();
 
 function TestContext({children}: {children: ReactElement}) {
-  const {router} = useMemo(() => initializeOrg({organization, project} as any), []);
-
   useEffect(() => {
     ProjectsStore.loadInitialData([project]);
     return () => ProjectsStore.reset();
   }, []);
 
-  return (
-    <RouteContext.Provider
-      value={{
-        router,
-        location: router.location,
-        params: {},
-        routes: [],
-      }}
-    >
-      <OrganizationContext.Provider value={organization}>
-        {children}
-      </OrganizationContext.Provider>
-    </RouteContext.Provider>
-  );
+  return children;
 }
 
 describe('ProfilesTable', function () {

--- a/static/app/components/replays/replayTagsTableRow.spec.tsx
+++ b/static/app/components/replays/replayTagsTableRow.spec.tsx
@@ -1,8 +1,4 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
-
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 import ReplayTagsTableRow from './replayTagsTableRow';
 
@@ -16,32 +12,9 @@ const genericTag = {
   value: ['bar', 'baz'],
 };
 
-function TestComponent({children}) {
-  const {organization, router} = initializeOrg();
-
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
-
 describe('ReplayTagsTableRow', () => {
   it('Should render tag key and value correctly', () => {
-    render(
-      <TestComponent>
-        <ReplayTagsTableRow tag={genericTag} />
-      </TestComponent>
-    );
+    render(<ReplayTagsTableRow tag={genericTag} />);
 
     expect(screen.getByText('foo')).toBeInTheDocument();
     expect(screen.getByText('bar')).toBeInTheDocument();
@@ -49,11 +22,7 @@ describe('ReplayTagsTableRow', () => {
   });
 
   it('Should render release tags correctly', () => {
-    render(
-      <TestComponent>
-        <ReplayTagsTableRow tag={releaseTag} />
-      </TestComponent>
-    );
+    render(<ReplayTagsTableRow tag={releaseTag} />);
 
     expect(screen.getByText('release')).toBeInTheDocument();
     expect(screen.getByText('1.0.0')).toBeInTheDocument();
@@ -61,11 +30,7 @@ describe('ReplayTagsTableRow', () => {
   });
 
   it('Should render the tag value as a link if we get a link result from generateUrl', () => {
-    render(
-      <TestComponent>
-        <ReplayTagsTableRow tag={genericTag} generateUrl={() => 'https://foo.bar'} />
-      </TestComponent>
-    );
+    render(<ReplayTagsTableRow tag={genericTag} generateUrl={() => 'https://foo.bar'} />);
 
     expect(screen.getByText('foo')).toBeInTheDocument();
     expect(screen.getByText('bar')).toBeInTheDocument();
@@ -77,13 +42,11 @@ describe('ReplayTagsTableRow', () => {
 
   it('Should not render the tag value as a link if we get the value in the query prop', () => {
     render(
-      <TestComponent>
-        <ReplayTagsTableRow
-          tag={genericTag}
-          generateUrl={() => 'https://foo.bar'}
-          query="foo:bar"
-        />
-      </TestComponent>
+      <ReplayTagsTableRow
+        tag={genericTag}
+        generateUrl={() => 'https://foo.bar'}
+        query="foo:bar"
+      />
     );
 
     expect(screen.getByText('foo')).toBeInTheDocument();

--- a/static/app/components/sidebar/index.spec.jsx
+++ b/static/app/components/sidebar/index.spec.jsx
@@ -5,8 +5,6 @@ import * as incidentActions from 'sentry/actionCreators/serviceIncidents';
 import SidebarContainer from 'sentry/components/sidebar';
 import ConfigStore from 'sentry/stores/configStore';
 import {PersistedStoreProvider} from 'sentry/stores/persistedStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 jest.mock('sentry/actionCreators/serviceIncidents');
 
@@ -19,20 +17,9 @@ describe('Sidebar', function () {
   const location = {...router.location, ...{pathname: '/test/'}};
 
   const getElement = props => (
-    <RouteContext.Provider
-      value={{
-        location,
-        params: {},
-        router,
-        routes: [],
-      }}
-    >
-      <OrganizationContext.Provider value={organization}>
-        <PersistedStoreProvider>
-          <SidebarContainer organization={organization} location={location} {...props} />
-        </PersistedStoreProvider>
-      </OrganizationContext.Provider>
-    </RouteContext.Provider>
+    <PersistedStoreProvider>
+      <SidebarContainer organization={organization} location={location} {...props} />
+    </PersistedStoreProvider>
   );
 
   const renderSidebar = props => render(getElement(props));

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
@@ -1,33 +1,18 @@
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {SwitchOrganization} from 'sentry/components/sidebar/sidebarDropdown/switchOrganization';
-import {Organization} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('SwitchOrganization', function () {
-  function mountWithOrg(children, organization?: Organization) {
-    if (!organization) {
-      organization = TestStubs.Organization() as Organization;
-    }
-    return (
-      <OrganizationContext.Provider value={organization}>
-        {children}
-      </OrganizationContext.Provider>
-    );
-  }
-
   it('can list organizations', function () {
     jest.useFakeTimers();
     render(
-      mountWithOrg(
-        <SwitchOrganization
-          canCreateOrganization={false}
-          organizations={[
-            TestStubs.Organization({name: 'Organization 1'}),
-            TestStubs.Organization({name: 'Organization 2', slug: 'org2'}),
-          ]}
-        />
-      )
+      <SwitchOrganization
+        canCreateOrganization={false}
+        organizations={[
+          TestStubs.Organization({name: 'Organization 1'}),
+          TestStubs.Organization({name: 'Organization 2', slug: 'org2'}),
+        ]}
+      />
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -53,23 +38,21 @@ describe('SwitchOrganization', function () {
   it('uses organizationUrl when customer domain is enabled', function () {
     jest.useFakeTimers();
     render(
-      mountWithOrg(
-        <SwitchOrganization
-          canCreateOrganization={false}
-          organizations={[
-            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
-            TestStubs.Organization({
-              name: 'Organization 2',
-              slug: 'org2',
-              links: {
-                organizationUrl: 'http://org2.sentry.io',
-                regionUrl: 'http://eu.sentry.io',
-              },
-              features: ['customer-domains'],
-            }),
-          ]}
-        />
-      )
+      <SwitchOrganization
+        canCreateOrganization={false}
+        organizations={[
+          TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+          TestStubs.Organization({
+            name: 'Organization 2',
+            slug: 'org2',
+            links: {
+              organizationUrl: 'http://org2.sentry.io',
+              regionUrl: 'http://eu.sentry.io',
+            },
+            features: ['customer-domains'],
+          }),
+        ]}
+      />
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -93,23 +76,21 @@ describe('SwitchOrganization', function () {
   it('does not use organizationUrl when customer domain is disabled', function () {
     jest.useFakeTimers();
     render(
-      mountWithOrg(
-        <SwitchOrganization
-          canCreateOrganization={false}
-          organizations={[
-            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
-            TestStubs.Organization({
-              name: 'Organization 2',
-              slug: 'org2',
-              links: {
-                organizationUrl: 'http://org2.sentry.io',
-                regionUrl: 'http://eu.sentry.io',
-              },
-              features: [],
-            }),
-          ]}
-        />
-      )
+      <SwitchOrganization
+        canCreateOrganization={false}
+        organizations={[
+          TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+          TestStubs.Organization({
+            name: 'Organization 2',
+            slug: 'org2',
+            links: {
+              organizationUrl: 'http://org2.sentry.io',
+              regionUrl: 'http://eu.sentry.io',
+            },
+            features: [],
+          }),
+        ]}
+      />
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -139,16 +120,14 @@ describe('SwitchOrganization', function () {
       features: ['customer-domains'],
     });
     render(
-      mountWithOrg(
-        <SwitchOrganization
-          canCreateOrganization={false}
-          organizations={[
-            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
-            currentOrg,
-          ]}
-        />,
-        currentOrg
-      )
+      <SwitchOrganization
+        canCreateOrganization={false}
+        organizations={[
+          TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+          currentOrg,
+        ]}
+      />,
+      {organization: currentOrg}
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -186,24 +165,22 @@ describe('SwitchOrganization', function () {
       features: [],
     });
     render(
-      mountWithOrg(
-        <SwitchOrganization
-          canCreateOrganization={false}
-          organizations={[
-            TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
-            TestStubs.Organization({
-              name: 'Organization 3',
-              slug: 'org3',
-              links: {
-                organizationUrl: 'http://org3.sentry.io',
-                regionUrl: 'http://eu.sentry.io',
-              },
-              features: ['customer-domains'],
-            }),
-          ]}
-        />,
-        currentOrg
-      )
+      <SwitchOrganization
+        canCreateOrganization={false}
+        organizations={[
+          TestStubs.Organization({name: 'Organization 1', slug: 'org1'}),
+          TestStubs.Organization({
+            name: 'Organization 3',
+            slug: 'org3',
+            links: {
+              organizationUrl: 'http://org3.sentry.io',
+              regionUrl: 'http://eu.sentry.io',
+            },
+            features: ['customer-domains'],
+          }),
+        ]}
+      />,
+      {organization: currentOrg}
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -226,7 +203,7 @@ describe('SwitchOrganization', function () {
 
   it('shows "Create an Org" if they have permission', function () {
     jest.useFakeTimers();
-    render(mountWithOrg(<SwitchOrganization canCreateOrganization organizations={[]} />));
+    render(<SwitchOrganization canCreateOrganization organizations={[]} />);
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
     act(() => void jest.advanceTimersByTime(500));
@@ -241,11 +218,7 @@ describe('SwitchOrganization', function () {
 
   it('does not have "Create an Org" if they do not have permission', function () {
     jest.useFakeTimers();
-    render(
-      mountWithOrg(
-        <SwitchOrganization canCreateOrganization={false} organizations={[]} />
-      )
-    );
+    render(<SwitchOrganization canCreateOrganization={false} organizations={[]} />);
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
     act(() => void jest.advanceTimersByTime(500));
@@ -266,12 +239,9 @@ describe('SwitchOrganization', function () {
     });
 
     jest.useFakeTimers();
-    render(
-      mountWithOrg(
-        <SwitchOrganization canCreateOrganization organizations={[]} />,
-        currentOrg
-      )
-    );
+    render(<SwitchOrganization canCreateOrganization organizations={[]} />, {
+      organization: currentOrg,
+    });
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
     act(() => void jest.advanceTimersByTime(500));
@@ -292,12 +262,10 @@ describe('SwitchOrganization', function () {
 
     jest.useFakeTimers();
     render(
-      mountWithOrg(
-        <SwitchOrganization
-          canCreateOrganization
-          organizations={[TestStubs.Organization(), orgPendingDeletion]}
-        />
-      )
+      <SwitchOrganization
+        canCreateOrganization
+        organizations={[TestStubs.Organization(), orgPendingDeletion]}
+      />
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));

--- a/static/app/views/dashboardsV2/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.spec.tsx
@@ -10,7 +10,6 @@ import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhan
 import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
 import WidgetCard from 'sentry/views/dashboardsV2/widgetCard';
 import ReleaseWidgetQueries from 'sentry/views/dashboardsV2/widgetCard/releaseWidgetQueries';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/components/charts/simpleTableChart');
 jest.mock('sentry/views/dashboardsV2/widgetCard/releaseWidgetQueries');
@@ -24,12 +23,10 @@ describe('Dashboards > WidgetCard', function () {
     router: {orgId: 'orgId'},
   } as Parameters<typeof initializeOrg>[0]);
 
-  const renderWithProviders = (component, context?) =>
+  const renderWithProviders = component =>
     render(
-      <OrganizationContext.Provider value={organization}>
-        <MEPSettingProvider forceTransactions={false}>{component}</MEPSettingProvider>
-      </OrganizationContext.Provider>,
-      context
+      <MEPSettingProvider forceTransactions={false}>{component}</MEPSettingProvider>,
+      {organization, router, context: routerContext}
     );
 
   const multipleQueryWidget: Widget = {
@@ -145,8 +142,7 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />,
-      {context: routerContext}
+      />
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
@@ -184,8 +180,7 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />,
-      {context: routerContext}
+      />
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
@@ -226,8 +221,7 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />,
-      {context: routerContext}
+      />
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
@@ -265,8 +259,7 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />,
-      {context: routerContext}
+      />
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
@@ -305,8 +298,7 @@ describe('Dashboards > WidgetCard', function () {
         currentWidgetDragging={false}
         showContextMenu
         widgetLimitReached={false}
-      />,
-      {context: routerContext}
+      />
     );
 
     userEvent.click(await screen.findByLabelText('Widget actions'));
@@ -618,8 +610,7 @@ describe('Dashboards > WidgetCard', function () {
         showWidgetViewerButton
         index="10"
         isPreview
-      />,
-      {context: routerContext}
+      />
     );
 
     userEvent.click(await screen.findByLabelText('Open Widget Viewer'));
@@ -660,8 +651,7 @@ describe('Dashboards > WidgetCard', function () {
         showContextMenu
         widgetLimitReached={false}
         showStoredAlert
-      />,
-      {context: routerContext}
+      />
     );
 
     await waitFor(() => {
@@ -832,8 +822,7 @@ describe('Dashboards > WidgetCard', function () {
           showContextMenu
           widgetLimitReached={false}
           showStoredAlert
-        />,
-        {context: routerContext}
+        />
       );
 
       await waitFor(() => {
@@ -909,8 +898,7 @@ describe('Dashboards > WidgetCard', function () {
           currentWidgetDragging={false}
           showContextMenu
           widgetLimitReached={false}
-        />,
-        {context: routerContext}
+        />
       );
       await waitFor(function () {
         expect(eventsStatsMock).toHaveBeenCalled();
@@ -944,8 +932,7 @@ describe('Dashboards > WidgetCard', function () {
           showContextMenu
           widgetLimitReached={false}
           isPreview
-        />,
-        {context: routerContext}
+        />
       );
 
       expect(await screen.findByText('Indexed')).toBeInTheDocument();

--- a/static/app/views/dashboardsV2/widgetCard/widgetQueries.spec.jsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetQueries.spec.jsx
@@ -8,19 +8,13 @@ import {DashboardsMEPContext} from 'sentry/views/dashboardsV2/widgetCard/dashboa
 import WidgetQueries, {
   flattenMultiSeriesDataWithGrouping,
 } from 'sentry/views/dashboardsV2/widgetCard/widgetQueries';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('Dashboards > WidgetQueries', function () {
-  const initialData = initializeOrg({
-    organization: TestStubs.Organization(),
-  });
+  const initialData = initializeOrg();
 
-  const renderWithProviders = (component, context) =>
+  const renderWithProviders = component =>
     render(
-      <OrganizationContext.Provider value={initialData.organization}>
-        <MEPSettingProvider forceTransactions={false}>{component}</MEPSettingProvider>
-      </OrganizationContext.Provider>,
-      context
+      <MEPSettingProvider forceTransactions={false}>{component}</MEPSettingProvider>
     );
 
   const multipleQueryWidget = {
@@ -736,33 +730,31 @@ describe('Dashboards > WidgetQueries', function () {
 
     // Simulate a re-render with a new query alias
     rerender(
-      <OrganizationContext.Provider value={initialData.organization}>
-        <MEPSettingProvider forceTransactions={false}>
-          <WidgetQueries
-            api={api}
-            widget={{
-              ...lineWidget,
-              queries: [
-                {
-                  conditions: 'event.type:error',
-                  fields: ['count()'],
-                  aggregates: ['count()'],
-                  columns: [],
-                  name: 'this query alias changed',
-                  orderby: '',
-                },
-              ],
-            }}
-            organization={initialData.organization}
-            selection={selection}
-          >
-            {props => {
-              childProps = props;
-              return <div data-test-id="child" />;
-            }}
-          </WidgetQueries>
-        </MEPSettingProvider>
-      </OrganizationContext.Provider>
+      <MEPSettingProvider forceTransactions={false}>
+        <WidgetQueries
+          api={api}
+          widget={{
+            ...lineWidget,
+            queries: [
+              {
+                conditions: 'event.type:error',
+                fields: ['count()'],
+                aggregates: ['count()'],
+                columns: [],
+                name: 'this query alias changed',
+                orderby: '',
+              },
+            ],
+          }}
+          organization={initialData.organization}
+          selection={selection}
+        >
+          {props => {
+            childProps = props;
+            return <div data-test-id="child" />;
+          }}
+        </WidgetQueries>
+      </MEPSettingProvider>
     );
 
     // Did not re-query

--- a/static/app/views/eventsV2/eventDetails/index.spec.jsx
+++ b/static/app/views/eventsV2/eventDetails/index.spec.jsx
@@ -5,15 +5,6 @@ import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
 import {ALL_VIEWS, DEFAULT_EVENT_VIEW} from 'sentry/views/eventsV2/data';
 import EventDetails from 'sentry/views/eventsV2/eventDetails';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-
-const WrappedEventDetails = ({organization, ...rest}) => {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <EventDetails organization={organization} {...rest} />
-    </OrganizationContext.Provider>
-  );
-};
 
 describe('EventsV2 > EventDetails', function () {
   const allEventsView = EventView.fromSavedQuery(DEFAULT_EVENT_VIEW);
@@ -112,7 +103,7 @@ describe('EventsV2 > EventDetails', function () {
 
   it('renders', async function () {
     render(
-      <WrappedEventDetails
+      <EventDetails
         organization={TestStubs.Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{query: allEventsView.generateQueryStringObject()}}
@@ -123,7 +114,7 @@ describe('EventsV2 > EventDetails', function () {
 
   it('renders a 404', async function () {
     render(
-      <WrappedEventDetails
+      <EventDetails
         organization={TestStubs.Organization()}
         params={{eventSlug: 'project-slug:abad1'}}
         location={{query: allEventsView.generateQueryStringObject()}}
@@ -135,7 +126,7 @@ describe('EventsV2 > EventDetails', function () {
 
   it('renders a chart in grouped view', async function () {
     render(
-      <WrappedEventDetails
+      <EventDetails
         organization={TestStubs.Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{query: errorsView.generateQueryStringObject()}}
@@ -152,7 +143,7 @@ describe('EventsV2 > EventDetails', function () {
       body: {},
     });
     render(
-      <WrappedEventDetails
+      <EventDetails
         organization={TestStubs.Organization()}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{query: allEventsView.generateQueryStringObject()}}
@@ -176,7 +167,7 @@ describe('EventsV2 > EventDetails', function () {
       },
     });
     render(
-      <WrappedEventDetails
+      <EventDetails
         organization={organization}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{query: allEventsView.generateQueryStringObject()}}
@@ -215,7 +206,7 @@ describe('EventsV2 > EventDetails', function () {
       },
     });
     render(
-      <WrappedEventDetails
+      <EventDetails
         organization={organization}
         params={{eventSlug: 'project-slug:deadbeef'}}
         location={{

--- a/static/app/views/issueList/actions/index.spec.jsx
+++ b/static/app/views/issueList/actions/index.spec.jsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {
   act,
   fireEvent,
@@ -12,7 +14,6 @@ import GroupStore from 'sentry/stores/groupStore';
 import SelectedGroupStore from 'sentry/stores/selectedGroupStore';
 import {IssueCategory} from 'sentry/types';
 import {IssueListActions} from 'sentry/views/issueList/actions';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 const organization = TestStubs.Organization();
 
@@ -36,10 +37,10 @@ const defaultProps = {
 
 function WrappedComponent(props) {
   return (
-    <OrganizationContext.Provider value={organization}>
+    <Fragment>
       <GlobalModal />
       <IssueListActions {...defaultProps} {...props} />
-    </OrganizationContext.Provider>
+    </Fragment>
   );
 }
 
@@ -361,10 +362,11 @@ describe('IssueListActions', function () {
         });
 
         render(
-          <OrganizationContext.Provider value={orgWithPerformanceIssues}>
+          <Fragment>
             <GlobalModal />
             <IssueListActions {...defaultProps} query="is:unresolved" queryCount={100} />
-          </OrganizationContext.Provider>
+          </Fragment>,
+          {organization: orgWithPerformanceIssues}
         );
 
         userEvent.click(screen.getByRole('checkbox'));
@@ -406,10 +408,11 @@ describe('IssueListActions', function () {
           );
 
         render(
-          <OrganizationContext.Provider value={orgWithPerformanceIssues}>
+          <Fragment>
             <GlobalModal />
             <IssueListActions {...defaultProps} query="is:unresolved" queryCount={100} />
-          </OrganizationContext.Provider>
+          </Fragment>,
+          {organization: orgWithPerformanceIssues}
         );
 
         userEvent.click(screen.getByRole('checkbox'));

--- a/static/app/views/issueList/overview.polling.spec.jsx
+++ b/static/app/views/issueList/overview.polling.spec.jsx
@@ -5,8 +5,6 @@ import StreamGroup from 'sentry/components/stream/group';
 import TagStore from 'sentry/stores/tagStore';
 import IssueList from 'sentry/views/issueList/overview';
 
-import {OrganizationContext} from '../organizationContext';
-
 // Mock <IssueListSidebar> (need <IssueListActions> to toggling real time polling)
 jest.mock('sentry/views/issueList/sidebar', () => jest.fn(() => null));
 jest.mock('sentry/views/issueList/filters', () => jest.fn(() => null));
@@ -62,12 +60,9 @@ describe('IssueList -> Polling', function () {
       },
     };
 
-    render(
-      <OrganizationContext.Provider value={TestStubs.Organization()}>
-        <IssueList {...newRouter} {...defaultProps} {...p} />
-      </OrganizationContext.Provider>,
-      {context: routerContext}
-    );
+    render(<IssueList {...newRouter} {...defaultProps} {...p} />, {
+      context: routerContext,
+    });
 
     await Promise.resolve();
     jest.runAllTimers();

--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -4,8 +4,6 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import TagStore from 'sentry/stores/tagStore';
 import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 
-import {OrganizationContext} from '../organizationContext';
-
 describe('IssueListSearchBar', function () {
   let tagValuePromise;
   let supportedTags;
@@ -52,12 +50,9 @@ describe('IssueListSearchBar', function () {
     it('sets state with complete tag', function () {
       const loader = jest.fn();
 
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <IssueListSearchBar {...defaultProps} tagValueLoader={loader} />
-        </OrganizationContext.Provider>,
-        {context: routerContext}
-      );
+      render(<IssueListSearchBar {...defaultProps} tagValueLoader={loader} />, {
+        context: routerContext,
+      });
 
       userEvent.type(screen.getByRole('textbox'), 'url:"fu"');
 
@@ -70,12 +65,9 @@ describe('IssueListSearchBar', function () {
     it('sets state when value has colon', function () {
       const loader = jest.fn();
 
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <IssueListSearchBar {...defaultProps} tagValueLoader={loader} />
-        </OrganizationContext.Provider>,
-        {context: routerContext}
-      );
+      render(<IssueListSearchBar {...defaultProps} tagValueLoader={loader} />, {
+        context: routerContext,
+      });
 
       userEvent.type(screen.getByRole('textbox'), 'url:');
 
@@ -86,12 +78,9 @@ describe('IssueListSearchBar', function () {
       // This should never get called
       const loader = jest.fn(x => x);
 
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <IssueListSearchBar {...defaultProps} tagValueLoader={loader} />
-        </OrganizationContext.Provider>,
-        {context: routerContext}
-      );
+      render(<IssueListSearchBar {...defaultProps} tagValueLoader={loader} />, {
+        context: routerContext,
+      });
 
       userEvent.type(screen.getByRole('textbox'), 'timesSeen:');
 
@@ -110,13 +99,11 @@ describe('IssueListSearchBar', function () {
       const onSearch = jest.fn();
 
       render(
-        <OrganizationContext.Provider value={organization}>
-          <IssueListSearchBar
-            {...defaultProps}
-            tagValueLoader={loader}
-            onSearch={onSearch}
-          />
-        </OrganizationContext.Provider>,
+        <IssueListSearchBar
+          {...defaultProps}
+          tagValueLoader={loader}
+          onSearch={onSearch}
+        />,
         {context: routerContext}
       );
 
@@ -142,12 +129,7 @@ describe('IssueListSearchBar', function () {
     });
 
     it('queries for recent searches', function () {
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <IssueListSearchBar {...defaultProps} />
-        </OrganizationContext.Provider>,
-        {context: routerContext}
-      );
+      render(<IssueListSearchBar {...defaultProps} />, {context: routerContext});
 
       userEvent.type(screen.getByRole('textbox'), 'is:');
 
@@ -164,12 +146,7 @@ describe('IssueListSearchBar', function () {
     });
 
     it('cycles through keyboard navigation for selection', async function () {
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <IssueListSearchBar {...defaultProps} />
-        </OrganizationContext.Provider>,
-        {context: routerContext}
-      );
+      render(<IssueListSearchBar {...defaultProps} />, {context: routerContext});
 
       const textarea = screen.getByRole('textbox');
 
@@ -224,23 +201,15 @@ describe('IssueListSearchBar', function () {
     });
 
     it('has pin icon', function () {
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <IssueListSearchBar {...defaultProps} />
-        </OrganizationContext.Provider>,
-        {context: routerContext}
-      );
+      render(<IssueListSearchBar {...defaultProps} />, {context: routerContext});
 
       expect(screen.getByTestId('pin-icon')).toBeInTheDocument();
     });
 
     it('pins a search from the searchbar', function () {
-      render(
-        <OrganizationContext.Provider value={organization}>
-          <IssueListSearchBar {...defaultProps} query='url:"fu"' />
-        </OrganizationContext.Provider>,
-        {context: routerContext}
-      );
+      render(<IssueListSearchBar {...defaultProps} query='url:"fu"' />, {
+        context: routerContext,
+      });
 
       userEvent.click(screen.getByRole('button', {name: 'Pin this search'}));
 
@@ -259,23 +228,21 @@ describe('IssueListSearchBar', function () {
 
     it('unpins a search from the searchbar', function () {
       render(
-        <OrganizationContext.Provider value={organization}>
-          <IssueListSearchBar
-            {...defaultProps}
-            query='url:"fu"'
-            savedSearch={{
-              id: '1',
-              name: 'Saved Search',
-              isPinned: true,
-              query: 'url:"fu"',
-              sort: 'date',
-              dateCreated: '',
-              isOrgCustom: false,
-              isGlobal: false,
-              type: 0,
-            }}
-          />
-        </OrganizationContext.Provider>,
+        <IssueListSearchBar
+          {...defaultProps}
+          query='url:"fu"'
+          savedSearch={{
+            id: '1',
+            name: 'Saved Search',
+            isPinned: true,
+            query: 'url:"fu"',
+            sort: 'date',
+            dateCreated: '',
+            isOrgCustom: false,
+            isGlobal: false,
+            type: 0,
+          }}
+        />,
         {context: routerContext}
       );
 

--- a/static/app/views/onboarding/onboarding.spec.jsx
+++ b/static/app/views/onboarding/onboarding.spec.jsx
@@ -5,14 +5,13 @@ import OrganizationStore from 'sentry/stores/organizationStore';
 import {PersistedStoreProvider} from 'sentry/stores/persistedStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import Onboarding from 'sentry/views/onboarding/onboarding';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 describe('Onboarding', function () {
   afterEach(function () {
     MockApiClient.clearMockResponses();
   });
   it('renders the welcome page', function () {
-    const {organization, router, routerContext} = initializeOrg({
+    const {router, routerContext} = initializeOrg({
       router: {
         params: {
           step: 'welcome',
@@ -20,11 +19,9 @@ describe('Onboarding', function () {
       },
     });
     render(
-      <OrganizationContext.Provider value={organization}>
-        <PersistedStoreProvider>
-          <Onboarding {...router} />
-        </PersistedStoreProvider>
-      </OrganizationContext.Provider>,
+      <PersistedStoreProvider>
+        <Onboarding {...router} />
+      </PersistedStoreProvider>,
       {
         context: routerContext,
       }
@@ -46,11 +43,9 @@ describe('Onboarding', function () {
     });
     OrganizationStore.onUpdate(organization);
     render(
-      <OrganizationContext.Provider value={organization}>
-        <PersistedStoreProvider>
-          <Onboarding {...router} />
-        </PersistedStoreProvider>
-      </OrganizationContext.Provider>,
+      <PersistedStoreProvider>
+        <Onboarding {...router} />
+      </PersistedStoreProvider>,
       {
         context: routerContext,
       }
@@ -115,11 +110,9 @@ describe('Onboarding', function () {
     ProjectsStore.loadInitialData(projects);
     OrganizationStore.onUpdate(organization);
     render(
-      <OrganizationContext.Provider value={organization}>
-        <PersistedStoreProvider>
-          <Onboarding {...router} />
-        </PersistedStoreProvider>
-      </OrganizationContext.Provider>,
+      <PersistedStoreProvider>
+        <Onboarding {...router} />
+      </PersistedStoreProvider>,
       {
         context: routerContext,
       }

--- a/static/app/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -7,9 +7,7 @@ import GroupStore from 'sentry/stores/groupStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {IssueCategory} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import GroupDetails from 'sentry/views/organizationGroupDetails';
-import {RouteContext} from 'sentry/views/routeContext';
 
 jest.unmock('sentry/utils/recreateRoute');
 
@@ -67,20 +65,9 @@ describe('groupDetails', () => {
 
   const createWrapper = (props = {selection}) => {
     return render(
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        <OrganizationContext.Provider value={organization}>
-          <GroupDetails {...router} router={router} selection={props.selection}>
-            <MockComponent />
-          </GroupDetails>
-        </OrganizationContext.Provider>
-      </RouteContext.Provider>,
+      <GroupDetails {...router} router={router} selection={props.selection}>
+        <MockComponent />
+      </GroupDetails>,
       {context: routerContext}
     );
   };

--- a/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
@@ -9,7 +9,6 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {GroupEvents} from 'sentry/views/organizationGroupDetails/groupEvents';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('groupEvents', function () {
   let request;
@@ -116,15 +115,13 @@ describe('groupEvents', function () {
 
   it('renders', function () {
     const wrapper = render(
-      <RouteContext.Provider value={routerContext}>
-        <GroupEvents
-          organization={organization}
-          api={new MockApiClient()}
-          group={TestStubs.Group()}
-          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-          location={{query: {}}}
-        />
-      </RouteContext.Provider>,
+      <GroupEvents
+        organization={organization}
+        api={new MockApiClient()}
+        group={TestStubs.Group()}
+        params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+        location={{query: {}}}
+      />,
       {context: routerContext, organization}
     );
 
@@ -133,15 +130,13 @@ describe('groupEvents', function () {
 
   it('handles search', function () {
     render(
-      <RouteContext.Provider value={routerContext}>
-        <GroupEvents
-          organization={organization}
-          api={new MockApiClient()}
-          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-          group={TestStubs.Group()}
-          location={{query: {}}}
-        />
-      </RouteContext.Provider>,
+      <GroupEvents
+        organization={organization}
+        api={new MockApiClient()}
+        params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+        group={TestStubs.Group()}
+        location={{query: {}}}
+      />,
       {context: routerContext, organization}
     );
 
@@ -167,15 +162,13 @@ describe('groupEvents', function () {
 
   it('handles environment filtering', function () {
     render(
-      <RouteContext.Provider value={routerContext}>
-        <GroupEvents
-          organization={organization}
-          api={new MockApiClient()}
-          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-          group={TestStubs.Group()}
-          location={{query: {environment: ['prod', 'staging']}}}
-        />
-      </RouteContext.Provider>,
+      <GroupEvents
+        organization={organization}
+        api={new MockApiClient()}
+        params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+        group={TestStubs.Group()}
+        location={{query: {environment: ['prod', 'staging']}}}
+      />,
       {context: routerContext, organization}
     );
     expect(request).toHaveBeenCalledWith(
@@ -201,15 +194,13 @@ describe('groupEvents', function () {
       group.issueCategory = 'performance';
 
       render(
-        <RouteContext.Provider value={routerContext}>
-          <GroupEvents
-            organization={org.organization}
-            api={new MockApiClient()}
-            params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-            group={group}
-            location={{query: {environment: ['prod', 'staging']}}}
-          />
-        </RouteContext.Provider>,
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging']}}}
+        />,
         {context: routerContext, organization}
       );
       expect(discoverRequest).toHaveBeenCalledWith(
@@ -227,15 +218,13 @@ describe('groupEvents', function () {
       group.issueCategory = 'performance';
 
       render(
-        <RouteContext.Provider value={routerContext}>
-          <GroupEvents
-            organization={org.organization}
-            api={new MockApiClient()}
-            params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-            group={group}
-            location={{query: {environment: ['prod', 'staging']}}}
-          />
-        </RouteContext.Provider>,
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging']}}}
+        />,
         {context: routerContext, organization}
       );
       await waitForElementToBeRemoved(document.querySelector('div.loading-indicator'));
@@ -253,15 +242,13 @@ describe('groupEvents', function () {
 
     it('does not display attachments column with no attachments', async () => {
       render(
-        <RouteContext.Provider value={routerContext}>
-          <GroupEvents
-            organization={org.organization}
-            api={new MockApiClient()}
-            params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-            group={group}
-            location={{query: {environment: ['prod', 'staging']}}}
-          />
-        </RouteContext.Provider>,
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging']}}}
+        />,
         {context: routerContext, organization}
       );
       await waitForElementToBeRemoved(document.querySelector('div.loading-indicator'));
@@ -272,15 +259,13 @@ describe('groupEvents', function () {
 
     it('does not display minidump column with no minidumps', async () => {
       render(
-        <RouteContext.Provider value={routerContext}>
-          <GroupEvents
-            organization={org.organization}
-            api={new MockApiClient()}
-            params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-            group={group}
-            location={{query: {environment: ['prod', 'staging']}}}
-          />
-        </RouteContext.Provider>,
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging']}}}
+        />,
         {context: routerContext, organization}
       );
       await waitForElementToBeRemoved(document.querySelector('div.loading-indicator'));
@@ -309,15 +294,13 @@ describe('groupEvents', function () {
       });
 
       render(
-        <RouteContext.Provider value={routerContext}>
-          <GroupEvents
-            organization={org.organization}
-            api={new MockApiClient()}
-            params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-            group={group}
-            location={{query: {environment: ['prod', 'staging']}}}
-          />
-        </RouteContext.Provider>,
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging']}}}
+        />,
         {context: routerContext, organization}
       );
       await waitForElementToBeRemoved(document.querySelector('div.loading-indicator'));
@@ -346,15 +329,13 @@ describe('groupEvents', function () {
       });
 
       render(
-        <RouteContext.Provider value={routerContext}>
-          <GroupEvents
-            organization={org.organization}
-            api={new MockApiClient()}
-            params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-            group={group}
-            location={{query: {environment: ['prod', 'staging']}}}
-          />
-        </RouteContext.Provider>,
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging']}}}
+        />,
         {context: routerContext, organization}
       );
       await waitForElementToBeRemoved(document.querySelector('div.loading-indicator'));
@@ -367,15 +348,13 @@ describe('groupEvents', function () {
 
     it('renders new events table if error', function () {
       render(
-        <RouteContext.Provider value={routerContext}>
-          <GroupEvents
-            organization={org.organization}
-            api={new MockApiClient()}
-            params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-            group={group}
-            location={{query: {environment: ['prod', 'staging']}}}
-          />
-        </RouteContext.Provider>,
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging']}}}
+        />,
         {context: routerContext, organization}
       );
       expect(discoverRequest).toHaveBeenCalledWith(
@@ -394,15 +373,13 @@ describe('groupEvents', function () {
 
     it('removes sort if unsupported by the events table', function () {
       render(
-        <RouteContext.Provider value={routerContext}>
-          <GroupEvents
-            organization={org.organization}
-            api={new MockApiClient()}
-            params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-            group={group}
-            location={{query: {environment: ['prod', 'staging'], sort: 'user'}}}
-          />
-        </RouteContext.Provider>,
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging'], sort: 'user'}}}
+        />,
         {context: routerContext, organization}
       );
       expect(discoverRequest).toHaveBeenCalledWith(
@@ -417,15 +394,13 @@ describe('groupEvents', function () {
     const group = TestStubs.Group();
 
     render(
-      <RouteContext.Provider value={routerContext}>
-        <GroupEvents
-          organization={org.organization}
-          api={new MockApiClient()}
-          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
-          group={group}
-          location={{query: {environment: ['prod', 'staging']}}}
-        />
-      </RouteContext.Provider>,
+      <GroupEvents
+        organization={org.organization}
+        api={new MockApiClient()}
+        params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+        group={group}
+        location={{query: {environment: ['prod', 'staging']}}}
+      />,
       {context: routerContext, organization}
     );
 

--- a/static/app/views/performance/transactionDetails/index.spec.jsx
+++ b/static/app/views/performance/transactionDetails/index.spec.jsx
@@ -78,13 +78,11 @@ describe('EventDetails', () => {
     });
 
     render(
-      <OrganizationContext.Provider value={organization}>
-        <EventDetails
-          organization={organization}
-          params={{orgId: organization.slug, eventSlug: 'latest'}}
-          location={routerContext.context.location}
-        />
-      </OrganizationContext.Provider>
+      <EventDetails
+        organization={organization}
+        params={{orgId: organization.slug, eventSlug: 'latest'}}
+        location={routerContext.context.location}
+      />
     );
     expect(screen.queryByText(alertText)).not.toBeInTheDocument();
 

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.spec.jsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.spec.jsx
@@ -1,15 +1,6 @@
 import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import QuickTraceMeta from 'sentry/views/performance/transactionDetails/quickTraceMeta';
-
-const WrappedQuickTraceMeta = ({organization, ...rest}) => {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <QuickTraceMeta {...rest} />
-    </OrganizationContext.Provider>
-  );
-};
 
 describe('QuickTraceMeta', function () {
   const routerContext = TestStubs.routerContext();
@@ -32,7 +23,7 @@ describe('QuickTraceMeta', function () {
 
   it('renders basic UI', function () {
     render(
-      <WrappedQuickTraceMeta
+      <QuickTraceMeta
         event={event}
         project={project}
         organization={organization}
@@ -54,7 +45,7 @@ describe('QuickTraceMeta', function () {
 
   it('renders placeholder while loading', function () {
     render(
-      <WrappedQuickTraceMeta
+      <QuickTraceMeta
         event={event}
         project={project}
         organization={organization}
@@ -80,7 +71,7 @@ describe('QuickTraceMeta', function () {
 
   it('renders errors', function () {
     render(
-      <WrappedQuickTraceMeta
+      <QuickTraceMeta
         event={event}
         project={project}
         organization={organization}
@@ -106,7 +97,7 @@ describe('QuickTraceMeta', function () {
   it('renders missing trace when trace id is not present', function () {
     const newEvent = TestStubs.Event();
     render(
-      <WrappedQuickTraceMeta
+      <QuickTraceMeta
         event={newEvent}
         project={project}
         organization={organization}
@@ -128,7 +119,7 @@ describe('QuickTraceMeta', function () {
     const newEvent = TestStubs.Event();
     const newOrg = TestStubs.Organization();
     render(
-      <WrappedQuickTraceMeta
+      <QuickTraceMeta
         event={newEvent}
         project={project}
         organization={newOrg}
@@ -156,7 +147,7 @@ describe('QuickTraceMeta', function () {
     const newProject = TestStubs.Project();
     const newEvent = TestStubs.Event();
     const result = render(
-      <WrappedQuickTraceMeta
+      <QuickTraceMeta
         event={newEvent}
         project={newProject}
         organization={organization}

--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -1,9 +1,7 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import TransactionHeader from 'sentry/views/performance/transactionSummary/header';
 import Tab from 'sentry/views/performance/transactionSummary/tabs';
 
@@ -48,20 +46,6 @@ function initializeData(opts?: InitialOpts) {
   };
 }
 
-function ComponentProviders({
-  organization,
-  children,
-}: {
-  children: React.ReactNode;
-  organization: Organization;
-}) {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      {children}
-    </OrganizationContext.Provider>
-  );
-}
-
 describe('Performance > Transaction Summary Header', function () {
   beforeEach(function () {
     MockApiClient.clearMockResponses();
@@ -76,18 +60,16 @@ describe('Performance > Transaction Summary Header', function () {
     });
 
     render(
-      <ComponentProviders organization={organization}>
-        <TransactionHeader
-          eventView={eventView}
-          location={router.location}
-          organization={organization}
-          projects={[project]}
-          projectId={project.id}
-          transactionName="transaction_name"
-          currentTab={Tab.TransactionSummary}
-          hasWebVitals="yes"
-        />
-      </ComponentProviders>
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        projectId={project.id}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="yes"
+      />
     );
 
     expect(screen.getByRole('tab', {name: 'Web Vitals'})).toBeInTheDocument();
@@ -101,18 +83,16 @@ describe('Performance > Transaction Summary Header', function () {
       body: {measurements: true},
     });
 
-    <ComponentProviders organization={organization}>
-      <TransactionHeader
-        eventView={eventView}
-        location={router.location}
-        organization={organization}
-        projects={[project]}
-        projectId={project.id}
-        transactionName="transaction_name"
-        currentTab={Tab.TransactionSummary}
-        hasWebVitals="no"
-      />
-    </ComponentProviders>;
+    <TransactionHeader
+      eventView={eventView}
+      location={router.location}
+      organization={organization}
+      projects={[project]}
+      projectId={project.id}
+      transactionName="transaction_name"
+      currentTab={Tab.TransactionSummary}
+      hasWebVitals="no"
+    />;
 
     expect(screen.queryByRole('tab', {name: 'Web Vitals'})).not.toBeInTheDocument();
   });
@@ -128,18 +108,16 @@ describe('Performance > Transaction Summary Header', function () {
     });
 
     render(
-      <ComponentProviders organization={organization}>
-        <TransactionHeader
-          eventView={eventView}
-          location={router.location}
-          organization={organization}
-          projects={[project]}
-          projectId={project.id}
-          transactionName="transaction_name"
-          currentTab={Tab.TransactionSummary}
-          hasWebVitals="maybe"
-        />
-      </ComponentProviders>
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        projectId={project.id}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="maybe"
+      />
     );
 
     expect(screen.getByRole('tab', {name: 'Web Vitals'})).toBeInTheDocument();
@@ -154,18 +132,16 @@ describe('Performance > Transaction Summary Header', function () {
     });
 
     render(
-      <ComponentProviders organization={organization}>
-        <TransactionHeader
-          eventView={eventView}
-          location={router.location}
-          organization={organization}
-          projects={[project]}
-          projectId={project.id}
-          transactionName="transaction_name"
-          currentTab={Tab.TransactionSummary}
-          hasWebVitals="maybe"
-        />
-      </ComponentProviders>
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        projectId={project.id}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="maybe"
+      />
     );
 
     await waitFor(() => expect(eventHasMeasurementsMock).toHaveBeenCalled());
@@ -182,18 +158,16 @@ describe('Performance > Transaction Summary Header', function () {
     });
 
     render(
-      <ComponentProviders organization={organization}>
-        <TransactionHeader
-          eventView={eventView}
-          location={router.location}
-          organization={organization}
-          projects={[project]}
-          projectId={project.id}
-          transactionName="transaction_name"
-          currentTab={Tab.TransactionSummary}
-          hasWebVitals="maybe"
-        />
-      </ComponentProviders>
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        projectId={project.id}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="maybe"
+      />
     );
 
     await waitFor(() => expect(eventHasMeasurementsMock).toHaveBeenCalled());
@@ -212,18 +186,16 @@ describe('Performance > Transaction Summary Header', function () {
     });
 
     render(
-      <ComponentProviders organization={organization}>
-        <TransactionHeader
-          eventView={eventView}
-          location={router.location}
-          organization={organization}
-          projects={[project]}
-          projectId={project.id}
-          transactionName="transaction_name"
-          currentTab={Tab.TransactionSummary}
-          hasWebVitals="yes"
-        />
-      </ComponentProviders>
+      <TransactionHeader
+        eventView={eventView}
+        location={router.location}
+        organization={organization}
+        projects={[project]}
+        projectId={project.id}
+        transactionName="transaction_name"
+        currentTab={Tab.TransactionSummary}
+        hasWebVitals="yes"
+      />
     );
 
     expect(screen.getByRole('tab', {name: 'Spans'})).toBeInTheDocument();

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
@@ -1,6 +1,5 @@
 import {browserHistory} from 'react-router';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   initializeData as _initializeData,
   initializeDataSettings,
@@ -9,32 +8,18 @@ import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLi
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import TransactionEvents from 'sentry/views/performance/transactionSummary/transactionEvents';
-import {RouteContext} from 'sentry/views/routeContext';
 
 import {EVENTS_TABLE_RESPONSE_FIELDS, MOCK_EVENTS_TABLE_DATA} from './eventsTable.spec';
 
 const WrappedComponent = ({data}) => {
-  const {router} = initializeOrg();
   return (
-    <RouteContext.Provider
-      value={{
-        router,
-        location: router.location,
-        params: {},
-        routes: [],
-      }}
-    >
-      <OrganizationContext.Provider value={data.organization}>
-        <MEPSettingProvider>
-          <TransactionEvents
-            organization={data.organization}
-            location={data.router.location}
-          />
-        </MEPSettingProvider>
-      </OrganizationContext.Provider>
-    </RouteContext.Provider>
+    <MEPSettingProvider>
+      <TransactionEvents
+        organization={data.organization}
+        location={data.router.location}
+      />
+    </MEPSettingProvider>
   );
 };
 

--- a/static/app/views/projectDetail/projectFilters.spec.jsx
+++ b/static/app/views/projectDetail/projectFilters.spec.jsx
@@ -1,6 +1,5 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import ProjectFilters from 'sentry/views/projectDetail/projectFilters';
 
 describe('ProjectDetail > ProjectFilters', () => {
@@ -12,7 +11,6 @@ describe('ProjectDetail > ProjectFilters', () => {
   });
 
   it('recommends semver search tag', async () => {
-    const organization = TestStubs.Organization();
     tagValueLoader.mockResolvedValue([
       {
         count: null,
@@ -24,9 +22,7 @@ describe('ProjectDetail > ProjectFilters', () => {
       },
     ]);
     render(
-      <OrganizationContext.Provider value={organization}>
-        <ProjectFilters query="" onSearch={onSearch} tagValueLoader={tagValueLoader} />
-      </OrganizationContext.Provider>,
+      <ProjectFilters query="" onSearch={onSearch} tagValueLoader={tagValueLoader} />,
       {context: TestStubs.routerContext()}
     );
 

--- a/static/app/views/projectDetail/projectIssues.spec.jsx
+++ b/static/app/views/projectDetail/projectIssues.spec.jsx
@@ -3,8 +3,6 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectIssues from 'sentry/views/projectDetail/projectIssues';
 
-import {OrganizationContext} from '../organizationContext';
-
 describe('ProjectDetail > ProjectIssues', function () {
   let endpointMock, filteredEndpointMock;
   const {organization, router, routerContext} = initializeOrg({
@@ -40,27 +38,19 @@ describe('ProjectDetail > ProjectIssues', function () {
       url: `/organizations/org-slug/issues/?limit=5&query=error.unhandled%3Atrue%20is%3Aunresolved&sort=freq&statsPeriod=14d`,
       body: [TestStubs.Group(), TestStubs.Group({id: '2'})],
     });
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <ProjectIssues organization={organization} location={router.location} />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    render(<ProjectIssues organization={organization} location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     expect(await screen.findAllByTestId('group')).toHaveLength(2);
   });
 
   it('renders a link to Issues', function () {
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <ProjectIssues organization={organization} location={router.location} />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    render(<ProjectIssues organization={organization} location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     const link = screen.getByLabelText('Open in Issues');
     expect(link).toBeInTheDocument();
@@ -78,14 +68,10 @@ describe('ProjectDetail > ProjectIssues', function () {
   });
 
   it('renders a link to Discover', function () {
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <ProjectIssues organization={organization} location={router.location} />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    render(<ProjectIssues organization={organization} location={router.location} />, {
+      context: routerContext,
+      organization,
+    });
 
     const link = screen.getByLabelText('Open in Discover');
     expect(link).toBeInTheDocument();
@@ -106,15 +92,13 @@ describe('ProjectDetail > ProjectIssues', function () {
 
   it('changes according to global header', function () {
     render(
-      <OrganizationContext.Provider value={organization}>
-        <ProjectIssues
-          organization={organization}
-          location={{
-            query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
-          }}
-        />
-      </OrganizationContext.Provider>,
-      {context: routerContext}
+      <ProjectIssues
+        organization={organization}
+        location={{
+          query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
+        }}
+      />,
+      {context: routerContext, organization}
     );
 
     expect(endpointMock).toHaveBeenCalledTimes(0);

--- a/static/app/views/replays/detail/console/messageFormatter.spec.tsx
+++ b/static/app/views/replays/detail/console/messageFormatter.spec.tsx
@@ -1,4 +1,3 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {
@@ -7,8 +6,6 @@ import {
   BreadcrumbTypeDefault,
   Crumb,
 } from 'sentry/types/breadcrumbs';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 
 import MessageFormatter from './messageFormatter';
 
@@ -104,82 +101,39 @@ const breadcrumbs: Extract<Crumb, BreadcrumbTypeDefault>[] = [
   },
 ];
 
-function TestComponent({children}: {children: React.ReactNode}) {
-  const {organization, router} = initializeOrg();
-
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
-
 describe('MessageFormatter', () => {
   it('Should print console message with placeholders correctly', () => {
-    render(
-      <TestComponent>
-        <MessageFormatter breadcrumb={breadcrumbs[0]} />
-      </TestComponent>
-    );
+    render(<MessageFormatter breadcrumb={breadcrumbs[0]} />);
 
     expect(screen.getByRole('text')).toHaveTextContent('This is a test');
   });
 
   it('Should print console message with objects correctly', () => {
-    render(
-      <TestComponent>
-        <MessageFormatter breadcrumb={breadcrumbs[1]} />
-      </TestComponent>
-    );
+    render(<MessageFormatter breadcrumb={breadcrumbs[1]} />);
 
     expect(screen.getByRole('text')).toHaveTextContent('test 1 false {}');
   });
 
   it('Should print console message correctly when it is an Error object', () => {
-    render(
-      <TestComponent>
-        <MessageFormatter breadcrumb={breadcrumbs[2]} />
-      </TestComponent>
-    );
+    render(<MessageFormatter breadcrumb={breadcrumbs[2]} />);
 
     expect(screen.getByRole('text')).toHaveTextContent('Error: this is my error message');
   });
 
   it('Should print empty object in case there is no message prop', () => {
-    render(
-      <TestComponent>
-        <MessageFormatter breadcrumb={breadcrumbs[3]} />
-      </TestComponent>
-    );
+    render(<MessageFormatter breadcrumb={breadcrumbs[3]} />);
 
     expect(screen.getByRole('text')).toHaveTextContent('{}');
   });
 
   it('Should ignore the "%c" placheholder and print the console message correctly', () => {
-    render(
-      <TestComponent>
-        <MessageFormatter breadcrumb={breadcrumbs[4]} />
-      </TestComponent>
-    );
+    render(<MessageFormatter breadcrumb={breadcrumbs[4]} />);
 
     expect(screen.getByRole('text')).toHaveTextContent('prev state {"cart":[]}');
   });
 
   it('Should print arrays correctly', () => {
-    render(
-      <TestComponent>
-        <MessageFormatter breadcrumb={breadcrumbs[5]} />
-      </TestComponent>
-    );
+    render(<MessageFormatter breadcrumb={breadcrumbs[5]} />);
 
     expect(screen.getByRole('text')).toHaveTextContent('test ["foo","bar"]');
   });

--- a/static/app/views/replays/detail/tagPanel/index.spec.tsx
+++ b/static/app/views/replays/detail/tagPanel/index.spec.tsx
@@ -1,11 +1,8 @@
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {Provider as ReplayContextProvider} from 'sentry/components/replays/replayContext';
 import ReplayReader from 'sentry/utils/replays/replayReader';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import TagPanel from 'sentry/views/replays/detail/tagPanel';
-import {RouteContext} from 'sentry/views/routeContext';
 
 // Get replay data with the mocked replay reader params
 const replayReaderParams = TestStubs.ReplayReaderParams({
@@ -20,23 +17,10 @@ const replayReaderParams = TestStubs.ReplayReaderParams({
 const mockReplay = ReplayReader.factory(replayReaderParams);
 
 const renderComponent = (replay: ReplayReader | null) => {
-  const {router, organization} = initializeOrg();
-
   return render(
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location: router.location,
-          params: router.params,
-          routes: router.routes,
-        }}
-      >
-        <ReplayContextProvider replay={replay}>
-          <TagPanel />
-        </ReplayContextProvider>
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
+    <ReplayContextProvider replay={replay}>
+      <TagPanel />
+    </ReplayContextProvider>
   );
 };
 

--- a/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogView.spec.tsx
@@ -1,7 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import OrganizationAuditLog from 'sentry/views/settings/organizationAuditLog';
 
 // XXX(epurkhiser): This appears to also be tested by ./index.spec.tsx
@@ -25,14 +24,9 @@ describe('OrganizationAuditLog', function () {
   });
 
   it('renders', async function () {
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <OrganizationAuditLog location={router.location} />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    render(<OrganizationAuditLog location={router.location} />, {
+      context: routerContext,
+    });
 
     expect(await screen.findByRole('heading')).toHaveTextContent('Audit Log');
     expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -51,27 +45,17 @@ describe('OrganizationAuditLog', function () {
       body: {rows: [], options: TestStubs.AuditLogsApiEventNames()},
     });
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <OrganizationAuditLog location={router.location} />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    render(<OrganizationAuditLog location={router.location} />, {
+      context: routerContext,
+    });
 
     expect(await screen.findByText('No audit entries available')).toBeInTheDocument();
   });
 
   it('displays whether an action was done by a superuser', async () => {
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <OrganizationAuditLog location={router.location} />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    render(<OrganizationAuditLog location={router.location} />, {
+      context: routerContext,
+    });
 
     expect(await screen.findByText('Sentry Staff')).toBeInTheDocument();
     expect(screen.getAllByText('Foo Bar')).toHaveLength(2);

--- a/static/app/views/settings/organizationAuditLog/index.spec.tsx
+++ b/static/app/views/settings/organizationAuditLog/index.spec.tsx
@@ -3,7 +3,6 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
 import {Config, User} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import OrganizationAuditLog from 'sentry/views/settings/organizationAuditLog';
 
 describe('OrganizationAuditLog', function () {
@@ -54,7 +53,7 @@ describe('OrganizationAuditLog', function () {
       },
     });
 
-    const {routerContext, organization, router} = initializeOrg({
+    const {routerContext, router} = initializeOrg({
       ...initializeOrg(),
       projects: [],
       router: {
@@ -62,14 +61,9 @@ describe('OrganizationAuditLog', function () {
       },
     });
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <OrganizationAuditLog location={router.location} />
-      </OrganizationContext.Provider>,
-      {
-        context: routerContext,
-      }
-    );
+    render(<OrganizationAuditLog location={router.location} />, {
+      context: routerContext,
+    });
 
     expect(await screen.findByText('project.remove')).toBeInTheDocument();
     expect(screen.getByText('org.create')).toBeInTheDocument();

--- a/static/app/views/settings/organizationSecurityAndPrivacy/index.spec.tsx
+++ b/static/app/views/settings/organizationSecurityAndPrivacy/index.spec.tsx
@@ -1,61 +1,24 @@
-import {InjectedRouter} from 'react-router';
-import {Location} from 'history';
+import {Fragment} from 'react';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import GlobalModal from 'sentry/components/globalModal';
-import {Organization} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 import OrganizationSecurityAndPrivacy from 'sentry/views/settings/organizationSecurityAndPrivacy';
 
-function ComponentProviders({
-  router,
-  location,
-  organization,
-  children,
-}: {
-  children: React.ReactNode;
-  location: Location;
-  organization: Organization;
-  router: InjectedRouter;
-}) {
-  MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/auth-provider/`,
-    method: 'GET',
-    body: {},
+describe('OrganizationSecurityAndPrivacy', function () {
+  const {organization} = initializeOrg();
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/auth-provider/`,
+      method: 'GET',
+      body: {},
+    });
   });
 
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
-
-describe('OrganizationSecurityAndPrivacy', function () {
   it('shows require2fa switch', async function () {
-    const {organization, router} = initializeOrg();
-
-    render(
-      <ComponentProviders
-        organization={organization}
-        router={router}
-        location={router.location}
-      >
-        <OrganizationSecurityAndPrivacy />
-      </ComponentProviders>
-    );
+    render(<OrganizationSecurityAndPrivacy />);
 
     expect(
       await screen.findByRole('checkbox', {
@@ -65,8 +28,6 @@ describe('OrganizationSecurityAndPrivacy', function () {
   });
 
   it('returns to "off" if switch enable fails (e.g. API error)', async function () {
-    const {organization, router} = initializeOrg();
-
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,
       method: 'PUT',
@@ -74,14 +35,10 @@ describe('OrganizationSecurityAndPrivacy', function () {
     });
 
     render(
-      <ComponentProviders
-        organization={organization}
-        router={router}
-        location={router.location}
-      >
+      <Fragment>
         <GlobalModal />
         <OrganizationSecurityAndPrivacy />
-      </ComponentProviders>
+      </Fragment>
     );
 
     userEvent.click(
@@ -104,17 +61,7 @@ describe('OrganizationSecurityAndPrivacy', function () {
   });
 
   it('renders join request switch', async function () {
-    const {organization, router} = initializeOrg();
-
-    render(
-      <ComponentProviders
-        organization={organization}
-        router={router}
-        location={router.location}
-      >
-        <OrganizationSecurityAndPrivacy />
-      </ComponentProviders>
-    );
+    render(<OrganizationSecurityAndPrivacy />);
 
     expect(
       await screen.findByRole('checkbox', {
@@ -124,22 +71,16 @@ describe('OrganizationSecurityAndPrivacy', function () {
   });
 
   it('enables require2fa but cancels confirm modal', async function () {
-    const {organization, router} = initializeOrg();
-
     const mock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,
       method: 'PUT',
     });
 
     render(
-      <ComponentProviders
-        organization={organization}
-        router={router}
-        location={router.location}
-      >
+      <Fragment>
         <GlobalModal />
         <OrganizationSecurityAndPrivacy />
-      </ComponentProviders>
+      </Fragment>
     );
 
     userEvent.click(
@@ -161,22 +102,16 @@ describe('OrganizationSecurityAndPrivacy', function () {
   });
 
   it('enables require2fa with confirm modal', async function () {
-    const {organization, router} = initializeOrg();
-
     const mock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,
       method: 'PUT',
     });
 
     render(
-      <ComponentProviders
-        organization={organization}
-        router={router}
-        location={router.location}
-      >
+      <Fragment>
         <GlobalModal />
         <OrganizationSecurityAndPrivacy />
-      </ComponentProviders>
+      </Fragment>
     );
 
     userEvent.click(

--- a/static/app/views/settings/project/dynamicSampling/dynamicSampling.spec.tsx
+++ b/static/app/views/settings/project/dynamicSampling/dynamicSampling.spec.tsx
@@ -3,7 +3,6 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {Organization, Project} from 'sentry/types';
 import {DynamicSamplingBiasType} from 'sentry/types/sampling';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import DynamicSampling from '.';
 
@@ -49,11 +48,7 @@ describe('Dynamic Sampling', function () {
 
     renderMockRequests(organization.slug, project.slug);
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <DynamicSampling project={project} />
-      </OrganizationContext.Provider>
-    );
+    render(<DynamicSampling project={project} />, {organization});
 
     expect(screen.getByRole('heading', {name: /Dynamic Sampling/})).toBeInTheDocument();
 
@@ -100,11 +95,7 @@ describe('Dynamic Sampling', function () {
 
     renderMockRequests(organization.slug, project.slug);
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <DynamicSampling project={project} />
-      </OrganizationContext.Provider>
-    );
+    render(<DynamicSampling project={project} />, {organization});
 
     expect(
       screen.getByText(
@@ -152,11 +143,7 @@ describe('Dynamic Sampling', function () {
 
     const mockRequests = renderMockRequests(organization.slug, project.slug);
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <DynamicSampling project={project} />
-      </OrganizationContext.Provider>
-    );
+    render(<DynamicSampling project={project} />, {organization});
 
     userEvent.click(screen.getByRole('checkbox', {name: 'Prioritize new releases'}));
 

--- a/static/app/views/settings/projectSecurityAndPrivacy/index.spec.tsx
+++ b/static/app/views/settings/projectSecurityAndPrivacy/index.spec.tsx
@@ -1,55 +1,14 @@
-import {InjectedRouter} from 'react-router';
-import {Location} from 'history';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {Organization} from 'sentry/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
-import {RouteContext} from 'sentry/views/routeContext';
 import ProjectSecurityAndPrivacy from 'sentry/views/settings/projectSecurityAndPrivacy';
-
-function ComponentProviders({
-  router,
-  location,
-  organization,
-  children,
-}: {
-  children: React.ReactNode;
-  location: Location;
-  organization: Organization;
-  router: InjectedRouter;
-}) {
-  return (
-    <OrganizationContext.Provider value={organization}>
-      <RouteContext.Provider
-        value={{
-          router,
-          location,
-          params: {},
-          routes: [],
-        }}
-      >
-        {children}
-      </RouteContext.Provider>
-    </OrganizationContext.Provider>
-  );
-}
 
 describe('projectSecurityAndPrivacy', function () {
   it('renders form fields', function () {
-    const {organization, router} = initializeOrg();
+    const {organization} = initializeOrg();
     const project = TestStubs.ProjectDetails();
 
-    render(
-      <ComponentProviders
-        organization={organization}
-        router={router}
-        location={router.location}
-      >
-        <ProjectSecurityAndPrivacy project={project} organization={organization} />
-      </ComponentProviders>
-    );
+    render(<ProjectSecurityAndPrivacy project={project} organization={organization} />);
 
     expect(
       screen.getByRole('checkbox', {
@@ -89,7 +48,7 @@ describe('projectSecurityAndPrivacy', function () {
   });
 
   it('disables field when equivalent org setting is true', function () {
-    const {organization, router} = initializeOrg();
+    const {organization} = initializeOrg();
     const project = TestStubs.ProjectDetails();
 
     organization.dataScrubber = true;
@@ -101,15 +60,7 @@ describe('projectSecurityAndPrivacy', function () {
       body: project,
     });
 
-    render(
-      <ComponentProviders
-        organization={organization}
-        router={router}
-        location={router.location}
-      >
-        <ProjectSecurityAndPrivacy project={project} organization={organization} />
-      </ComponentProviders>
-    );
+    render(<ProjectSecurityAndPrivacy project={project} organization={organization} />);
 
     expect(
       screen.getByRole('checkbox', {

--- a/static/app/views/userFeedback/index.spec.jsx
+++ b/static/app/views/userFeedback/index.spec.jsx
@@ -2,7 +2,6 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import UserFeedback from 'sentry/views/userFeedback';
 
 describe('UserFeedback', function () {
@@ -47,12 +46,7 @@ describe('UserFeedback', function () {
       headers: {Link: pageLinks},
     });
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedback {...params} />
-      </OrganizationContext.Provider>,
-      {context: routerContext}
-    );
+    render(<UserFeedback {...params} />, {context: routerContext});
 
     expect(screen.getByText('Something bad happened')).toBeInTheDocument();
   });
@@ -67,12 +61,7 @@ describe('UserFeedback', function () {
         orgId: organization.slug,
       },
     };
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedback {...params} />
-      </OrganizationContext.Provider>,
-      {context: routerContext}
-    );
+    render(<UserFeedback {...params} />, {context: routerContext});
 
     expect(
       screen.getByText('You need at least one project to use this view')
@@ -94,12 +83,7 @@ describe('UserFeedback', function () {
         orgId: organization.slug,
       },
     };
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedback {...params} />
-      </OrganizationContext.Provider>,
-      {context: routerContext}
-    );
+    render(<UserFeedback {...params} />, {context: routerContext});
 
     expect(screen.getByTestId('user-feedback-empty')).toBeInTheDocument();
   });
@@ -119,12 +103,7 @@ describe('UserFeedback', function () {
         orgId: organization.slug,
       },
     };
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedback {...params} />
-      </OrganizationContext.Provider>,
-      {context: routerContext}
-    );
+    render(<UserFeedback {...params} />, {context: routerContext});
 
     expect(screen.getByTestId('user-feedback-empty')).toBeInTheDocument();
 
@@ -149,12 +128,7 @@ describe('UserFeedback', function () {
         orgId: organization.slug,
       },
     };
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedback {...params} />
-      </OrganizationContext.Provider>,
-      {context: routerContext}
-    );
+    render(<UserFeedback {...params} />, {context: routerContext});
 
     expect(screen.getByTestId('user-feedback-empty')).toBeInTheDocument();
 

--- a/static/app/views/userFeedback/userFeedbackEmpty.spec.tsx
+++ b/static/app/views/userFeedback/userFeedbackEmpty.spec.tsx
@@ -1,31 +1,21 @@
 import {reactHooks, render, screen} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import {UserFeedbackEmpty} from 'sentry/views/userFeedback/userFeedbackEmpty';
 
 describe('UserFeedbackEmpty', function () {
   const project = TestStubs.Project({id: '1'});
   const projectWithReports = TestStubs.Project({id: '2', hasUserReports: true});
   const projectWithoutReports = TestStubs.Project({id: '3'});
-  const organization = TestStubs.Organization();
 
   it('renders empty', function () {
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedbackEmpty />)
-      </OrganizationContext.Provider>
-    );
+    render(<UserFeedbackEmpty />);
   });
 
   it('renders landing for project with no user feedback', function () {
     reactHooks.act(() => void ProjectsStore.loadInitialData([project]));
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedbackEmpty />)
-      </OrganizationContext.Provider>
-    );
+    render(<UserFeedbackEmpty />);
 
     expect(
       screen.getByRole('heading', {name: 'What do users think?'})
@@ -35,11 +25,7 @@ describe('UserFeedbackEmpty', function () {
   it('renders warning for project with any user feedback', function () {
     reactHooks.act(() => void ProjectsStore.loadInitialData([projectWithReports]));
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedbackEmpty />)
-      </OrganizationContext.Provider>
-    );
+    render(<UserFeedbackEmpty />);
 
     expect(
       screen.getByText('Sorry, no user reports match your filters.')
@@ -51,11 +37,7 @@ describe('UserFeedbackEmpty', function () {
       () => void ProjectsStore.loadInitialData([project, projectWithReports])
     );
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedbackEmpty />)
-      </OrganizationContext.Provider>
-    );
+    render(<UserFeedbackEmpty />);
 
     expect(
       screen.getByText('Sorry, no user reports match your filters.')
@@ -67,11 +49,7 @@ describe('UserFeedbackEmpty', function () {
       () => void ProjectsStore.loadInitialData([project, projectWithReports])
     );
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedbackEmpty projectIds={[projectWithReports.id]} />)
-      </OrganizationContext.Provider>
-    );
+    render(<UserFeedbackEmpty projectIds={[projectWithReports.id]} />);
 
     expect(
       screen.getByText('Sorry, no user reports match your filters.')
@@ -83,11 +61,7 @@ describe('UserFeedbackEmpty', function () {
       () => void ProjectsStore.loadInitialData([project, projectWithReports])
     );
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedbackEmpty projectIds={[project.id]} />)
-      </OrganizationContext.Provider>
-    );
+    render(<UserFeedbackEmpty projectIds={[project.id]} />);
 
     expect(
       screen.getByRole('heading', {name: 'What do users think?'})
@@ -99,11 +73,7 @@ describe('UserFeedbackEmpty', function () {
       () => void ProjectsStore.loadInitialData([project, projectWithReports])
     );
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedbackEmpty projectIds={[project.id, projectWithReports.id]} />)
-      </OrganizationContext.Provider>
-    );
+    render(<UserFeedbackEmpty projectIds={[project.id, projectWithReports.id]} />);
 
     expect(
       screen.getByText('Sorry, no user reports match your filters.')
@@ -115,11 +85,7 @@ describe('UserFeedbackEmpty', function () {
       () => void ProjectsStore.loadInitialData([project, projectWithoutReports])
     );
 
-    render(
-      <OrganizationContext.Provider value={organization}>
-        <UserFeedbackEmpty projectIds={[project.id, projectWithoutReports.id]} />)
-      </OrganizationContext.Provider>
-    );
+    render(<UserFeedbackEmpty projectIds={[project.id, projectWithoutReports.id]} />);
 
     expect(
       screen.getByRole('heading', {name: 'What do users think?'})


### PR DESCRIPTION
This should be the rest of the tests, aside from some that I skipped due to complexity (or ones inside enzyme tests).