### PR TITLE
fix(grouping): fix mobile grouping for empty frames [INGEST-1626]

### DIFF
--- a/src/sentry/grouping/strategies/hierarchical.py
+++ b/src/sentry/grouping/strategies/hierarchical.py
@@ -85,7 +85,7 @@ def get_stacktrace_hierarchy(
             id="stacktrace", values=layer, tree_label=tree_label
         )
 
-    if not all_variants and components:
+    if components and not all_variants:
         # In case we haven't found any sentinel frames, start grouping by
         # application frames.
         all_variants = _build_fallback_tree(main_variant, components, frames, inverted_hierarchy)

--- a/src/sentry/grouping/strategies/hierarchical.py
+++ b/src/sentry/grouping/strategies/hierarchical.py
@@ -27,7 +27,7 @@ def get_stacktrace_hierarchy(
         assert key not in all_variants
 
         found_sentinel = False
-
+        component = None
         for frame, component in frames_iter:
             if not component.contributes:
                 continue
@@ -85,7 +85,7 @@ def get_stacktrace_hierarchy(
             id="stacktrace", values=layer, tree_label=tree_label
         )
 
-    if not all_variants:
+    if not all_variants and components:
         # In case we haven't found any sentinel frames, start grouping by
         # application frames.
         all_variants = _build_fallback_tree(main_variant, components, frames, inverted_hierarchy)

--- a/tests/sentry/grouping/grouping_inputs/frame-empty-list.json
+++ b/tests/sentry/grouping/grouping_inputs/frame-empty-list.json
@@ -1,0 +1,7 @@
+{
+    "event_id": "10a940c671e347d5861c7296b490aa63",
+    "platform": "csharp",
+    "stacktrace": {
+      "frames": []
+    }
+}

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/frame_empty_list.pysnap
@@ -1,0 +1,15 @@
+---
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/frame_empty_list.pysnap
@@ -1,0 +1,15 @@
+---
+source: tests/sentry/grouping/test_variants.py
+---
+app-depth-max:
+  hash: null
+  component:
+    app-depth-max
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/frame_empty_list.pysnap
@@ -1,0 +1,15 @@
+---
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/frame_empty_list.pysnap
@@ -1,0 +1,15 @@
+---
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/frame_empty_list.pysnap
@@ -1,0 +1,15 @@
+---
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/frame_empty_list.pysnap
@@ -1,0 +1,15 @@
+---
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/frame_empty_list.pysnap
@@ -1,0 +1,15 @@
+---
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: null
+  component:
+    app
+--------------------------------------------------------------------------
+fallback:
+  hash: "d41d8cd98f00b204e9800998ecf8427e"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system


### PR DESCRIPTION
This change fixes index out of range for mobile grouping strategy when the list of the incoming frames is empty. 

Fixes SENTRY-W23