### PR TITLE
feat(ds): Limit the amount of boosted releases to 10

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -839,15 +839,31 @@ def _get_or_create_release_many(jobs, projects):
                 ):
                     with sentry_sdk.start_span(
                         op="event_manager.dynamic_sampling_observe_latest_release"
-                    ), metrics.timer("event_manager.dynamic_sampling_observe_latest_release"):
+                    ) as span, metrics.timer(
+                        "event_manager.dynamic_sampling_observe_latest_release"
+                    ) as metrics_tags:
                         try:
                             release_observed_in_last_24h = observe_release(project_id, release.id)
                             if not release_observed_in_last_24h:
+                                span.set_tag(
+                                    "dynamic_sampling.observe_release_status",
+                                    f"New release observed {release.id}",
+                                )
+                                metrics_tags[
+                                    "dynamic_sampling.observe_release_status"
+                                ] = f"New release observed {release.id}"
                                 add_boosted_release(project_id, release.id)
                                 schedule_invalidate_project_config(
                                     project_id=project_id, trigger="dynamic_sampling:boost_release"
                                 )
                         except TooManyBoostedReleasesException:
+                            span.set_tag(
+                                "dynamic_sampling.observe_release_status",
+                                "Too many boosted releases",
+                            )
+                            metrics_tags[
+                                "dynamic_sampling.observe_release_status"
+                            ] = "Too many boosted releases"
                             pass
                         except Exception:
                             sentry_sdk.capture_exception()

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -39,7 +39,11 @@ from sentry.constants import (
     DataCategory,
 )
 from sentry.culprit import generate_culprit
-from sentry.dynamic_sampling.latest_release_booster import add_boosted_release, observe_release
+from sentry.dynamic_sampling.latest_release_booster import (
+    TooManyBoostedReleasesException,
+    add_boosted_release,
+    observe_release,
+)
 from sentry.eventstore.processing import event_processing_store
 from sentry.grouping.api import (
     BackgroundGroupingConfigLoader,
@@ -843,6 +847,8 @@ def _get_or_create_release_many(jobs, projects):
                                 schedule_invalidate_project_config(
                                     project_id=project_id, trigger="dynamic_sampling:boost_release"
                                 )
+                        except TooManyBoostedReleasesException:
+                            pass
                         except Exception:
                             sentry_sdk.capture_exception()
 

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2852,6 +2852,42 @@ class DSLatestReleaseBoostTest(TestCase):
                 for o in mocked_invalidate.mock_calls
             )
 
+    @freeze_time()
+    @mock.patch("sentry.dynamic_sampling.latest_release_booster.BOOSTED_RELEASES_LIMIT", 2)
+    def test_too_many_boosted_releases_do_not_boost_anymore(self):
+        """
+        This test tests the case when we have already too many boosted releases, in this case we want to skip the
+        boosting of anymore releases
+        """
+        release_2 = Release.get_or_create(self.project, "2.0")
+        release_3 = Release.get_or_create(self.project, "3.0")
+
+        for release_id in (self.release.id, release_2.id):
+            self.redis_client.set(f"ds::p:{self.project.id}:r:{release_id}", 1, 60 * 60 * 24)
+            self.redis_client.hset(
+                f"ds::p:{self.project.id}:boosted_releases",
+                release_id,
+                time(),
+            )
+
+        with self.options(
+            {
+                "dynamic-sampling:boost-latest-release": True,
+            }
+        ):
+            self.make_release_transaction(
+                release_version=release_3.version,
+                environment_name=self.environment1.name,
+                project_id=self.project.id,
+                checksum="b" * 32,
+                timestamp=self.timestamp,
+            )
+            assert self.redis_client.hgetall(f"ds::p:{self.project.id}:boosted_releases") == {
+                str(self.release.id): str(time()),
+                str(release_2.id): str(time()),
+            }
+            assert self.redis_client.get(f"ds::p:{self.project.id}:r:{release_3.id}") is None
+
 
 class TestSaveGroupHashAndGroup(TransactionTestCase):
     def test(self):


### PR DESCRIPTION
Limits amount of boosted releases to 10 releases
otherwise do not add any more releases to hash set of listed releases

