### PR TITLE
fix(all-events) add event.type:transaction to performance issue id request

### DIFF
--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -51,7 +51,7 @@ const AllEventsTable = (props: Props) => {
   }
 
   const idQuery = isPerfIssue
-    ? `performance.issue_ids:${issueId}`
+    ? `performance.issue_ids:${issueId} event.type:transaction`
     : `issue.id:${issueId}`;
   eventView.query = `${idQuery} ${props.location.query.query || ''}`;
   eventView.statsPeriod = '90d';

--- a/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
@@ -215,7 +215,9 @@ describe('groupEvents', function () {
       expect(discoverRequest).toHaveBeenCalledWith(
         '/organizations/org-slug/events/',
         expect.objectContaining({
-          query: expect.objectContaining({query: 'performance.issue_ids:1 '}),
+          query: expect.objectContaining({
+            query: 'performance.issue_ids:1 event.type:transaction ',
+          }),
         })
       );
       const perfEventsColumn = screen.getByText('transaction');


### PR DESCRIPTION
fixes PERF-1773

In this case, we can speed up the query by specifying the event type as a transaction.

I wonder if this can be added server side? (As performance issues are always associated with transaction events? something i'll look into).