### PR TITLE
fix(ds): Fix relay test for Dynamic Sampling Feature Multiplexer call

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -156,7 +156,7 @@ def get_project_config(project, full_config=True, project_keys=None):
 
 
 def get_dynamic_sampling_config(project) -> Optional[Mapping[str, Any]]:
-    feature_multiplexer = DynamicSamplingFeatureMultiplexer(project, None)
+    feature_multiplexer = DynamicSamplingFeatureMultiplexer(project)
 
     # In this case we should override old conditionnal rules if they exists
     # or just return uniform rule


### PR DESCRIPTION
This fixes an incorrect function invocation where the dynamic sampling feature multiplexer was sending an extra arg to
the multiplexer


