### PR TITLE
feat(metrics-layer): Switch to transform function

### DIFF
--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -412,8 +412,6 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
 
     # Field Aliases
     def _resolve_transaction_alias(self, alias: str) -> SelectType:
-        return AliasedExpression(Column(self.builder.resolve_column_name("transaction")), alias)
-        # TODO: 4 tests still failing with the transform
         return Function(
             "transform_null_to_unparameterized",
             [Column("d:transactions/duration@millisecond"), "transaction"],

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -1912,15 +1912,3 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     @pytest.mark.xfail(reason="Metrics layer failing to support ordering by apdex")
     def test_apdex_transaction_threshold(self):
         super().test_apdex_transaction_threshold()
-
-    @pytest.mark.xfail(reason="Metrics layer failing to support group by transaction")
-    def test_environment_param(self):
-        super().test_environment_param()
-
-    @pytest.mark.xfail(reason="Metrics layer failing to support group by transaction")
-    def test_has_transaction(self):
-        super().test_has_transaction()
-
-    @pytest.mark.xfail(reason="Metrics layer failing to support group by transaction")
-    def test_merge_null_unparam(self):
-        super().test_merge_null_unparam()


### PR DESCRIPTION
- Change the transaction alias to the transform function, so we can un-xfail some tests