### PR TITLE
bug(replays): Do not double-encode replay `?referrer=` query param - again

### DIFF
--- a/static/app/components/eventsTable/eventsTableRow.spec.jsx
+++ b/static/app/components/eventsTable/eventsTableRow.spec.jsx
@@ -100,7 +100,7 @@ describe('EventsTableRow', function () {
       'href',
       `/organizations/org-slug/replays/projectId:test-replay-id/?event_t=${new Date(
         event.dateCreated
-      ).getTime()}&referrer=%252Forganizations%252F%253AorgId%252Fissues%252F%253AgroupId%252Fevents%252F`
+      ).getTime()}&referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Fevents%2F`
     );
   });
 });

--- a/static/app/components/eventsTable/eventsTableRow.tsx
+++ b/static/app/components/eventsTable/eventsTableRow.tsx
@@ -56,7 +56,7 @@ function EventsTableRow({
   const fullReplayUrl = {
     pathname: `/organizations/${organization.slug}/replays/${projectId}:${tagMap.replayId}/`,
     query: {
-      referrer: encodeURIComponent(getRouteStringFromRoutes(routes)),
+      referrer: getRouteStringFromRoutes(routes),
       event_t: event.dateCreated ? new Date(event.dateCreated).getTime() : undefined,
     },
   };


### PR DESCRIPTION
A new spot got added after #40455, squashing it.