### PR TITLE
fix(jira): Handle perf issue title

### DIFF
--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -54,7 +54,7 @@ class IssueBasicMixin:
             issue_type = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
             transaction = get_performance_issue_alert_subtitle(event)
             description = f"{issue_type}: {transaction}"
-            # Jira API will not accept a description field over 255 chars
+            # Jira API will not accept a summary field over 255 chars
             return (description[:253] + "..") if len(description) > 255 else description
         else:
             return event.title

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -53,7 +53,9 @@ class IssueBasicMixin:
         if group.issue_category == GroupCategory.PERFORMANCE:
             issue_type = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
             transaction = get_performance_issue_alert_subtitle(event)
-            return f"{issue_type}: {transaction}"
+            description = f"{issue_type}: {transaction}"
+            # Jira API will not accept a description field over 255 chars
+            return (description[:253] + "..") if len(description) > 255 else description
         else:
             return event.title
 

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -53,9 +53,9 @@ class IssueBasicMixin:
         if group.issue_category == GroupCategory.PERFORMANCE:
             issue_type = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
             transaction = get_performance_issue_alert_subtitle(event)
-            description = f"{issue_type}: {transaction}"
+            title = f"{issue_type}: {transaction}"
             # Jira API will not accept a summary field over 255 chars
-            return (description[:253] + "..") if len(description) > 255 else description
+            return (title[:253] + "..") if len(title) > 255 else title
         else:
             return event.title
 

--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -89,7 +89,7 @@ def create_issue(event: GroupEvent, futures: Sequence[RuleFuture]) -> None:
             return
 
         installation = integration.get_installation(organization.id)
-        data["title"] = event.title
+        data["title"] = installation.get_group_title(event.group, event)
         data["description"] = build_description(event, rule_id, installation, generate_footer)
 
         if data.get("dynamic_form_fields"):

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -1,11 +1,16 @@
 import responses
 
 from fixtures.integrations.mock_service import StubService
+from sentry.event_manager import EventManager
 from sentry.integrations.jira import JiraCreateTicketAction
 from sentry.models import ExternalIssue, GroupLink, Integration, Rule
 from sentry.testutils.cases import RuleTestCase
+from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.datetime import before_now
+from sentry.types.issues import GroupType
 from sentry.types.rules import RuleFuture
 from sentry.utils import json
+from sentry.utils.samples import load_data
 
 
 class JiraCreateTicketActionTest(RuleTestCase):
@@ -87,6 +92,98 @@ class JiraCreateTicketActionTest(RuleTestCase):
         data = json.loads(responses.calls[1].request.body)
         assert data["fields"]["summary"] == event.title
         assert event.message in data["fields"]["description"]
+        assert data["fields"]["issuetype"]["id"] == "1"
+
+        external_issue = ExternalIssue.objects.get(key="APP-123")
+        assert external_issue
+
+    @responses.activate
+    def test_creates_performance_issue(self):
+        """Test that a performance issue properly creates a Jira ticket"""
+        event_data = load_data(
+            "transaction-n-plus-one",
+            timestamp=before_now(minutes=10),
+            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE.value}-group1"],
+        )
+        perf_event_manager = EventManager(event_data)
+        perf_event_manager.normalize()
+        with override_options(
+            {
+                "performance.issues.all.problem-creation": 1.0,
+                "performance.issues.all.problem-detection": 1.0,
+                "performance.issues.n_plus_one_db.problem-creation": 1.0,
+            }
+        ), self.feature(
+            [
+                "organizations:performance-issues-ingest",
+                "projects:performance-suspect-spans-ingestion",
+            ]
+        ):
+            event = perf_event_manager.save(self.project.id)
+        event = event.for_group(event.groups[0])
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project",
+            body=StubService.get_stub_json("jira", "project_list_response.json"),
+            content_type="application/json",
+        )
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/issue/createmeta",
+            body=StubService.get_stub_json("jira", "createmeta_response.json"),
+            content_type="json",
+        )
+        jira_rule = self.get_rule(
+            data={
+                "issuetype": "1",
+                "labels": "bunnies",
+                "customfield_10200": "sad",
+                "customfield_10300": ["Feature 1", "Feature 2"],
+                "project": "10000",
+                "integration": self.integration.id,
+                "jira_project": "10000",
+                "issue_type": "Bug",
+                "fixVersions": "[10000]",
+            }
+        )
+        jira_rule.rule = Rule.objects.create(
+            project=self.project,
+            label="test rule",
+        )
+
+        jira_rule.data["key"] = "APP-123"
+
+        # Add two mocks: one for POSTing the issue and a GET to confirm it's there.
+        responses.add(
+            method=responses.POST,
+            url="https://example.atlassian.net/rest/api/2/issue",
+            json=jira_rule.data,
+            status=202,
+            content_type="application/json",
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/issue/APP-123",
+            body=StubService.get_stub_json("jira", "get_issue_response.json"),
+            content_type="application/json",
+        )
+
+        results = list(jira_rule.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+
+        # Trigger rule callback
+        rule_future = RuleFuture(rule=jira_rule, kwargs=results[0].kwargs)
+        results[0].callback(event, futures=[rule_future])
+
+        # Make assertions about what would be POSTed to api/2/issue.
+        data = json.loads(responses.calls[1].request.body)
+        assert (
+            data["fields"]["summary"]
+            == 'N+1 Query: SELECT "books_author"."id", "books_author"."name" FROM "books_author" WHERE "books_author"."id" = %s LIMIT 21'
+        )
+        assert event.message in data["fields"]["description"]  # TODO add span evidence
         assert data["fields"]["issuetype"]["id"] == "1"
 
         external_issue = ExternalIssue.objects.get(key="APP-123")


### PR DESCRIPTION
Handle the title of a Jira ticket created from a performance issue. The issue `title` isn't always available as it is for error issues and renders as "untitled". This adds the type of issue to the title (called the summary in Jira) e.g. `N+1 Query: SELECT "books_author"."id", ... ` to match what we render for error issues.

In the near future I want to add the span evidence as a table to the Jira ticket description field, but that will be in a [follow up PR](https://github.com/getsentry/sentry/pull/40535). 