### PR TITLE
chore: Add DS flag checks for latest release boost logic

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -525,7 +525,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         if "hasAlertIntegration" in expand:
             data["hasAlertIntegrationInstalled"] = has_alert_integration(project)
 
-        ds_feature_multiplexer = DynamicSamplingFeatureMultiplexer(project, request.user)
+        ds_feature_multiplexer = DynamicSamplingFeatureMultiplexer(project)
 
         # Dynamic Sampling Logic
         if ds_feature_multiplexer.is_on_dynamic_sampling:
@@ -585,7 +585,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
         result = serializer.validated_data
 
-        ds_flags_multiplexer = DynamicSamplingFeatureMultiplexer(project, request.user)
+        ds_flags_multiplexer = DynamicSamplingFeatureMultiplexer(project)
         if result.get("dynamicSamplingBiases") and not ds_flags_multiplexer.is_on_dynamic_sampling:
             return Response(
                 {"detail": ["dynamicSamplingBiases is not a valid field"]},

--- a/src/sentry/dynamic_sampling/feature_multiplexer.py
+++ b/src/sentry/dynamic_sampling/feature_multiplexer.py
@@ -3,7 +3,6 @@ from typing import List, Optional, Set
 from sentry import features
 from sentry.dynamic_sampling.utils import DEFAULT_BIASES, Bias
 from sentry.models import Project
-from sentry.models.user import User
 
 
 class DynamicSamplingFeatureMultiplexer:
@@ -17,18 +16,18 @@ class DynamicSamplingFeatureMultiplexer:
     - The `organizations:dynamic-sampling` feature flag is the flag that enables the new adaptive sampling
     """
 
-    def __init__(self, project: Project, user: User):
+    def __init__(self, project: Project):
         # Feature flag that informs us that relay is handling DS rules
         self.allow_dynamic_sampling = features.has(
-            "organizations:server-side-sampling", project.organization, actor=user
+            "organizations:server-side-sampling", project.organization
         )
         # Feature flag that informs us that the org is on the new AM2 plan and thereby have adaptive sampling enabled
         self.current_dynamic_sampling = features.has(
-            "organizations:dynamic-sampling", project.organization, actor=user
+            "organizations:dynamic-sampling", project.organization
         )
         # Flag responsible to inform us if the org was in the original LA/EA Dynamic Sampling
         self.deprecated_dynamic_sampling = features.has(
-            "organizations:dynamic-sampling-deprecated", project.organization, actor=user
+            "organizations:dynamic-sampling-deprecated", project.organization
         )
 
     @property

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -39,11 +39,9 @@ from sentry.constants import (
     DataCategory,
 )
 from sentry.culprit import generate_culprit
-from sentry.dynamic_sampling.latest_release_booster import (
-    TooManyBoostedReleasesException,
-    add_boosted_release,
-    observe_release,
-)
+from sentry.dynamic_sampling import DynamicSamplingFeatureMultiplexer
+from sentry.dynamic_sampling.latest_release_booster import (add_boosted_release, observe_release,
+    TooManyBoostedReleasesException)
 from sentry.eventstore.processing import event_processing_store
 from sentry.grouping.api import (
     BackgroundGroupingConfigLoader,
@@ -835,6 +833,9 @@ def _get_or_create_release_many(jobs, projects):
                 # Dynamic Sampling - Boosting latest release functionality
                 if (
                     options.get("dynamic-sampling:boost-latest-release")
+                    and DynamicSamplingFeatureMultiplexer(
+                        project=projects[project_id]
+                    ).is_on_dynamic_sampling
                     and data.get("type") == "transaction"
                 ):
                     with sentry_sdk.start_span(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -40,8 +40,11 @@ from sentry.constants import (
 )
 from sentry.culprit import generate_culprit
 from sentry.dynamic_sampling import DynamicSamplingFeatureMultiplexer
-from sentry.dynamic_sampling.latest_release_booster import (add_boosted_release, observe_release,
-    TooManyBoostedReleasesException)
+from sentry.dynamic_sampling.latest_release_booster import (
+    TooManyBoostedReleasesException,
+    add_boosted_release,
+    observe_release,
+)
 from sentry.eventstore.processing import event_processing_store
 from sentry.grouping.api import (
     BackgroundGroupingConfigLoader,

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -156,7 +156,7 @@ def get_project_config(project, full_config=True, project_keys=None):
 
 
 def get_dynamic_sampling_config(project) -> Optional[Mapping[str, Any]]:
-    feature_multiplexer = DynamicSamplingFeatureMultiplexer(project, None)
+    feature_multiplexer = DynamicSamplingFeatureMultiplexer(project)
 
     # In this case we should override old conditionnal rules if they exists
     # or just return uniform rule

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -73,7 +73,7 @@ from sentry.testutils import (
     TransactionTestCase,
     assert_mock_called_once_with_partial,
 )
-from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers import apply_feature_flag_on_cls, override_options
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
@@ -2705,6 +2705,8 @@ class ReleaseIssueTest(TestCase):
 
 
 @region_silo_test
+@apply_feature_flag_on_cls("organizations:server-side-sampling")
+@apply_feature_flag_on_cls("organizations:dynamic-sampling")
 class DSLatestReleaseBoostTest(TestCase):
     def setUp(self):
         self.project = self.create_project()


### PR DESCRIPTION
This handles only running the latest release caching logic
if the new dynamic sampling feature flags are set