### PR TITLE
fix(tests): Remove `mockRouterPush` import

### DIFF
--- a/tests/js/sentry-test/index.jsx
+++ b/tests/js/sentry-test/index.jsx
@@ -1,3 +1,2 @@
 export * from './charts';
 export * from './initializeOrg';
-export * from './mockRouterPush';


### PR DESCRIPTION
The FE test suite has been failing as of #40479 which removed `mockRouterPush`. There's still one reference remaining, apparently!
