### PR TITLE
ref(self-hosted): Add note to separate self-hosted error reporting and beacon reporting

### DIFF
--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -261,7 +261,7 @@ const definitions: Field[] = [
       ['true', 'Please keep my usage information anonymous'],
     ],
     help: tct(
-      'If enabled, any stats reported to sentry.io will exclude identifying information (such as your administrative email address). By anonymizing your installation the Sentry team will be unable to contact you about security updates. For more information on what data is sent to Sentry, see the [link:documentation].',
+      'If enabled, any stats reported to sentry.io will exclude identifying information (such as your administrative email address). By anonymizing your installation the Sentry team will be unable to contact you about security updates. For more information on what data is sent to Sentry, see the [link:documentation]. Note: This is separate from error-reporting for the self-hosted installer.',
       {
         link: <a href="https://develop.sentry.dev/self-hosted/" />,
       }

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -261,7 +261,7 @@ const definitions: Field[] = [
       ['true', 'Please keep my usage information anonymous'],
     ],
     help: tct(
-      'If enabled, any stats reported to sentry.io will exclude identifying information (such as your administrative email address). By anonymizing your installation the Sentry team will be unable to contact you about security updates. For more information on what data is sent to Sentry, see the [link:documentation]. Note: This is separate from error-reporting for the self-hosted installer.',
+      'If enabled, any stats reported to sentry.io will exclude identifying information (such as your administrative email address). By anonymizing your installation the Sentry team will be unable to contact you about security updates. For more information on what data is sent to Sentry, see the [link:documentation]. Note: This is separate from error-reporting for the self-hosted installer. The data reported to the beacon only includes usage stats from your running self-hosted instance.',
       {
         link: <a href="https://develop.sentry.dev/self-hosted/" />,
       }


### PR DESCRIPTION
Adds a note so that users know that the self-hosted beacon is completely separate from self-hosted error reporting

Develop docs also updated here:
https://github.com/getsentry/develop/pull/734