### PR TITLE
ref: Fix typing of base eventstream class

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -172,6 +172,7 @@ class EventStream(Service):
         commit_batch_timeout_ms: int,
         concurrency: int,
         initial_offset_reset: Union[Literal["latest"], Literal["earliest"]],
+        strict_offset_reset: bool,
         use_streaming_consumer: bool,
     ) -> None:
         assert not self.requires_post_process_forwarder()


### PR DESCRIPTION
Fix the typing of the base class to match actual usage and the backend implementation.