### PR TITLE
feat(commit-context): Add caching to GroupOwner lookups

### DIFF
--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -13,6 +13,9 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.group import Group
 from sentry.models.release import Release
 from sentry.models.releasecommit import ReleaseCommit
+from sentry.utils.cache import cache
+
+READ_CACHE_DURATION = 3600
 
 
 class GroupOwnerType(Enum):
@@ -91,6 +94,44 @@ class GroupOwner(Model):
         from sentry.models import ActorTuple
 
         return ActorTuple.from_actor_identifier(self.owner_id())
+
+    @classmethod
+    def get_autoassigned_owner_cache_key(self, group_id, project_id, autoassignment_types):
+        if not len(autoassignment_types):
+            raise Exception("Requires the autoassignment types")
+        return f"groupowner_id:{group_id}:{project_id}:{':'.join([str(t) for t in autoassignment_types])}"
+
+    @classmethod
+    def get_autoassigned_owner_cached(cls, group_id, project_id, autoassignment_types):
+        """
+        Cached read access to find the autoassigned GroupOwner.
+        """
+        cache_key = cls.get_autoassigned_owner_cache_key(group_id, project_id, autoassignment_types)
+        issue_owner = cache.get(cache_key)
+        if issue_owner is None:
+            issue_owner = (
+                cls.objects.filter(
+                    group_id=group_id, project_id=project_id, type__in=autoassignment_types
+                )
+                .order_by("type")
+                .first()
+            )
+            if issue_owner is None:
+                issue_owner = False
+            # Store either the GroupOwner if exists or False for no owners
+            cache.set(cache_key, issue_owner, READ_CACHE_DURATION)
+
+        return issue_owner
+
+    @classmethod
+    def invalidate_autoassigned_owner_cache(cls, project_id, autoassignment_types):
+        group_ids = Group.objects.filter(project_id=project_id).values_list("id", flat=True)
+
+        cache_keys = [
+            cls.get_autoassigned_owner_cache_key(group_id, project_id, autoassignment_types)
+            for group_id in group_ids
+        ]
+        cache.delete_many(cache_keys)
 
 
 def get_owner_details(group_list: List[Group], user: Any) -> List[OwnersSerialized]:

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -832,13 +832,29 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
             },
             project_id=self.project.id,
         )
+        event_2 = self.store_event(
+            data={
+                "message": "Exception",
+                "platform": "python",
+                "stacktrace": {"frames": [{"filename": "src/app/integration.py"}]},
+            },
+            project_id=self.project.id,
+        )
         cache_key = write_event_to_cache(event)
+        cache_key_2 = write_event_to_cache(event_2)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
             cache_key=cache_key,
             group_id=event.group_id,
+        )
+        self.call_post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key_2,
+            group_id=event_2.group_id,
         )
         assignee = event.group.assignee_set.first()
         assert assignee.user == self.user
@@ -858,12 +874,20 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         self.prj_ownership.save()
 
         cache_key = write_event_to_cache(event)
+        cache_key_2 = write_event_to_cache(event_2)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
             cache_key=cache_key,
             group_id=event.group_id,
+        )
+        self.call_post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key_2,
+            group_id=event_2.group_id,
         )
 
         # Group should be re-assigned to the new group owner
@@ -892,12 +916,20 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         )
 
         cache_key = write_event_to_cache(event)
+        cache_key_2 = write_event_to_cache(event_2)
         self.call_post_process_group(
             is_new=False,
             is_regression=False,
             is_new_group_environment=False,
             cache_key=cache_key,
             group_id=event.group_id,
+        )
+        self.call_post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key_2,
+            group_id=event_2.group_id,
         )
 
         # Group should be re-assigned to the new group owner

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -870,6 +870,40 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         assignee = event.group.assignee_set.first()
         assert assignee.user == user_3
 
+        # De-assign group assignees
+        GroupAssignee.objects.deassign(event.group, assignee.user)
+        assert event.group.assignee_set.first() is None
+
+        user_4 = self.create_user()
+        self.create_team_membership(self.team, user=user_4)
+        self.prj_ownership.schema = dump_schema([])
+        self.prj_ownership.save()
+
+        code_owners_rule = Rule(
+            Matcher("codeowners", "*.py"),
+            [Owner("user", user_4.email)],
+        )
+
+        self.code_mapping = self.create_code_mapping(project=self.project)
+        self.code_owners = self.create_codeowners(
+            self.project,
+            self.code_mapping,
+            schema=dump_schema([code_owners_rule]),
+        )
+
+        cache_key = write_event_to_cache(event)
+        self.call_post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            cache_key=cache_key,
+            group_id=event.group_id,
+        )
+
+        # Group should be re-assigned to the new group owner
+        assignee = event.group.assignee_set.first()
+        assert assignee.user == user_4
+
     def test_ensure_when_assignees_and_owners_are_cached_does_not_cause_unbound_errors(self):
         self.make_ownership()
         event = self.store_event(


### PR DESCRIPTION
## Objective:

Follow up from https://github.com/getsentry/sentry/pull/40424

Added more specific db query during GroupOwner cache invalidation