### PR TITLE
fix(dashboards): Restrict POST and PUT to <=30 widgets

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -319,6 +319,11 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
         if start and end and start >= end:
             raise serializers.ValidationError("start must be before end")
 
+        if len(data.get("widgets", [])) > Dashboard.MAX_WIDGETS:
+            raise serializers.ValidationError(
+                f"Number of widgets must be less than {Dashboard.MAX_WIDGETS}"
+            )
+
         return data
 
     def update_dashboard_filters(self, instance, validated_data):

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -36,6 +36,8 @@ class Dashboard(Model):
     projects = models.ManyToManyField("sentry.Project", through=DashboardProject)
     filters = JSONField(null=True)
 
+    MAX_WIDGETS = 30
+
     class Meta:
         app_label = "sentry"
         db_table = "sentry_dashboard"


### PR DESCRIPTION
We impose a 30 widget limit in the frontend, but not through the API. We should also have validation in the API.
