### PR TITLE
feat(issue-alert): add filter logic to previews

### DIFF
--- a/src/sentry/rules/filters/age_comparison.py
+++ b/src/sentry/rules/filters/age_comparison.py
@@ -59,7 +59,7 @@ class AgeComparisonFilter(EventFilter):
     label = "The issue is {comparison_type} than {value} {time}"
     prompt = "The issue is older or newer than..."
 
-    def _passes(self, first_seen: datetime) -> bool:
+    def _passes(self, first_seen: datetime, current_time: datetime) -> bool:
         comparison_type = self.get_option("comparison_type")
         time = self.get_option("time")
 
@@ -82,12 +82,12 @@ class AgeComparisonFilter(EventFilter):
         _, delta_time = timeranges[time]
 
         passes_: bool = age_comparison_map[comparison_type](
-            first_seen + (value * delta_time), timezone.now()
+            first_seen + (value * delta_time), current_time
         )
         return passes_
 
     def passes(self, event: GroupEvent, state: EventState) -> bool:
-        return self._passes(event.group.first_seen)
+        return self._passes(event.group.first_seen, timezone.now())
 
     def passes_activity(self, condition_activity: ConditionActivity) -> bool:
         try:
@@ -95,4 +95,4 @@ class AgeComparisonFilter(EventFilter):
         except Group.DoesNotExist:
             return False
 
-        return self._passes(group.first_seen)
+        return self._passes(group.first_seen, condition_activity.timestamp)

--- a/src/sentry/rules/filters/base.py
+++ b/src/sentry/rules/filters/base.py
@@ -2,6 +2,7 @@ import abc
 
 from sentry.eventstore.models import GroupEvent
 from sentry.rules.base import EventState, RuleBase
+from sentry.types.condition_activity import ConditionActivity
 
 
 class EventFilter(RuleBase, abc.ABC):
@@ -10,3 +11,6 @@ class EventFilter(RuleBase, abc.ABC):
     @abc.abstractmethod
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         pass
+
+    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+        raise NotImplementedError

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -4,8 +4,10 @@ from typing import Any
 from django import forms
 
 from sentry.eventstore.models import GroupEvent
+from sentry.models import Group
 from sentry.rules import EventState
 from sentry.rules.filters import EventFilter
+from sentry.types.condition_activity import ConditionActivity
 from sentry.types.issues import GroupCategory
 
 CATEGORY_CHOICES = OrderedDict([(f"{gc.value}", str(gc.name).title()) for gc in GroupCategory])
@@ -23,13 +25,24 @@ class IssueCategoryFilter(EventFilter):
     label = "The issue's category is equal to {value}"
     prompt = "The issue's category is ..."
 
-    def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
+    def _passes(self, group: Group) -> bool:
         try:
             value: GroupCategory = GroupCategory(int(self.get_option("value")))
         except (TypeError, ValueError):
             return False
 
-        if event.group and event.group.issue_category:
-            return bool(value == event.group.issue_category)
+        if group and group.issue_category:
+            return bool(value == group.issue_category)
 
         return False
+
+    def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
+        return self._passes(event.group)
+
+    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+        try:
+            group = Group.objects.get_from_cache(id=condition_activity.group_id)
+        except Group.DoesNotExist:
+            return False
+
+        return self._passes(group)

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -1,8 +1,11 @@
 from django import forms
+from django.utils import timezone
 
 from sentry.eventstore.models import GroupEvent
+from sentry.models import Group
 from sentry.rules import EventState
 from sentry.rules.filters.base import EventFilter
+from sentry.types.condition_activity import ConditionActivity
 
 
 class IssueOccurrencesForm(forms.Form):  # type: ignore
@@ -25,4 +28,27 @@ class IssueOccurrencesFilter(EventFilter):
         # This value is slightly delayed due to us batching writes to times_seen. We attempt to work
         # around this by including pending updates from buffers to improve accuracy.
         issue_occurrences: int = event.group.times_seen_with_pending
-        return issue_occurrences >= value
+        return bool(issue_occurrences >= value)
+
+    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+        try:
+            value = int(self.get_option("value"))
+        except (TypeError, ValueError):
+            return False
+
+        try:
+            group = Group.objects.get_from_cache(id=condition_activity.group_id)
+        except Group.DoesNotExist:
+            return False
+
+        now = timezone.now()
+        if now == group.first_seen:
+            return bool(group.times_seen >= value)
+        # assumes uniform distribution of error occurrences between first_seen and now
+        guess = (
+            (condition_activity.timestamp - group.first_seen)
+            / (now - group.first_seen)
+            * group.times_seen
+        )
+
+        return bool(guess >= value)

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from sentry.db.models import BaseQuerySet
 from sentry.models import Group, Project
 from sentry.rules import rules
+from sentry.rules.processor import get_match_function
 
 PREVIEW_TIME_RANGE = timedelta(weeks=2)
 # limit on number of ConditionActivity's a condition will return
@@ -26,8 +27,8 @@ def preview(
     end = timezone.now()
     start = end - PREVIEW_TIME_RANGE
 
-    # must have at least one condition to filter activity. Filters currently not supported
-    if len(conditions) == 0 or len(filters):
+    # must have at least one condition to filter activity
+    if len(conditions) == 0:
         return None
     # all the currently supported conditions are mutually exclusive
     elif len(conditions) > 1 and condition_match == "all":
@@ -48,13 +49,27 @@ def preview(
     k = lambda a: a.timestamp
     activity.sort(key=k)
 
+    filter_objects = []
+    for filter in filters:
+        filter_cls = rules.get(filter["id"])
+        if filter_cls is None:
+            return None
+        filter_objects.append(filter_cls(project, data=filter))
+
+    filter_func = get_match_function(filter_match)
+    if filter_func is None:
+        return None
+
     frequency = timedelta(minutes=frequency_minutes)
     group_last_fire: Dict[str, datetime] = {}
     group_ids = set()
     for event in activity:
-        # TODO: check conditions and filters to see if event passes
+        try:
+            passes = [f.passes_activity(event) for f in filter_objects]
+        except NotImplementedError:
+            return None
         last_fire = group_last_fire.get(event.group_id, event.timestamp - frequency)
-        if last_fire <= event.timestamp - frequency:
+        if last_fire <= event.timestamp - frequency and filter_func(passes):
             group_ids.add(event.group_id)
             group_last_fire[event.group_id] = event.timestamp
 

--- a/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
@@ -53,9 +53,9 @@ class ProjectRulePreviewEndpointTest(APITestCase):
             assert resp.status_code == 400
 
     def test_invalid_filters(self):
-        # No filters are currently supported
-        invalid_filter = [{"id": "anything"}]
+        invalid_filter = [{"id": "sentry.rules.filters.latest_release.LatestReleaseFilter"}]
         condition = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
+        Group.objects.create(project=self.project, first_seen=timezone.now() - timedelta(hours=1))
         resp = self.get_response(
             self.organization.slug,
             self.project.slug,

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -8,6 +8,7 @@ from sentry.rules.history.preview import PREVIEW_TIME_RANGE, preview
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
+from sentry.types.issues import GroupType
 
 
 def get_hours(time: timedelta) -> int:
@@ -63,6 +64,99 @@ class ProjectRulePreviewTest(TestCase):
             hours,
         )
 
+    def test_age_comparison(self):
+        hours = get_hours(PREVIEW_TIME_RANGE)
+        conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
+        threshold = 24
+        filters = [
+            {
+                "id": "sentry.rules.filters.age_comparison.AgeComparisonFilter",
+                "comparison_type": "newer",
+                "time": "hour",
+                "value": threshold,
+            }
+        ]
+        groups = []
+        for i in range(hours):
+            groups.append(
+                Group.objects.create(
+                    id=i, project=self.project, first_seen=timezone.now() - timedelta(hours=i + 1)
+                )
+            )
+
+        result = preview(self.project, conditions, filters, "all", "all", 0)
+        # this filter is strictly older/newer
+        for i in range(threshold - 1):
+            assert groups[i] in result
+        for i in range(threshold - 1, hours):
+            assert groups[i] not in result
+
+    def test_occurrences(self):
+        hours = get_hours(PREVIEW_TIME_RANGE)
+        groups = []
+        for i in range(hours):
+            groups.append(
+                Group.objects.create(
+                    project=self.project,
+                    first_seen=timezone.now() - timedelta(hours=i + 1),
+                    times_seen=i,
+                )
+            )
+        # regression events to trigger conditions
+        for group in groups:
+            Activity.objects.create(
+                project=self.project,
+                group=group,
+                type=ActivityType.SET_REGRESSION.value,
+                datetime=timezone.now() - timedelta(hours=1),
+            )
+        conditions = [{"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"}]
+        threshold = 24
+        filters = [
+            {
+                "id": "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
+                "value": threshold,  # issue has occurred at least 24 times
+            }
+        ]
+
+        result = preview(self.project, conditions, filters, "all", "all", 0)
+        for i in range(threshold + 1):
+            assert groups[i] not in result
+        for i in range(threshold + 1, hours):
+            assert groups[i] in result
+
+    def test_issue_category(self):
+        hours = get_hours(PREVIEW_TIME_RANGE)
+        prev_hour = timezone.now() - timedelta(hours=1)
+        errors = []
+        n_plus_one = []
+        for i in range(hours):
+            if i % 2:
+                errors.append(
+                    Group.objects.create(
+                        project=self.project, first_seen=prev_hour, type=GroupType.ERROR.value
+                    )
+                )
+            else:
+                n_plus_one.append(
+                    Group.objects.create(
+                        project=self.project,
+                        first_seen=prev_hour,
+                        type=GroupType.PERFORMANCE_N_PLUS_ONE.value,
+                    )
+                )
+
+        conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
+        filters = [
+            {
+                "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
+                "value": GroupType.ERROR.value,
+            }
+        ]
+        result = preview(self.project, conditions, filters, "all", "all", 0)
+        assert all(group in result for group in errors)
+        assert all(group not in result for group in n_plus_one)
+
     def test_unsupported_conditions(self):
         self._set_up_first_seen()
         # conditions with no immediate plan to support
@@ -79,15 +173,6 @@ class ProjectRulePreviewTest(TestCase):
 
         # empty condition
         assert None is preview(self.project, [], [], "all", "all", 60)
-        # filters
-        assert None is preview(
-            self.project,
-            [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}],
-            [{"id": "anything"}],
-            "all",
-            "all",
-            60,
-        )
 
     def test_mutually_exclusive_conditions(self):
         mutually_exclusive = [


### PR DESCRIPTION
Adds filter logic to previews. This pr adds `age_comparison`, `issue_occurrences`, and `issue_category`. the other filter that we currently have plans to support is `assigned_to`, but that requires some more complicated assignee logic so it'll be added in a separate pr.

Filters have a `passes` method that is used to check if an incoming `GroupEvent` will pass the filter. For previews we similarly have a `passes_activity` method that checks if the filter passes a `ConditionActivity`.