### PR TITLE
fix(span-tree): Fix bug where out of view spans were not rendering properly

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -132,11 +132,13 @@ class SpanTree extends Component<PropType> {
       return null;
     }
 
+    const isClickable = focusedSpanIds && showFilteredSpansMessage;
+
     return (
       <MessageRow
         key={`message-row-${firstHiddenSpanId}`}
         onClick={
-          focusedSpanIds
+          isClickable
             ? () => {
                 trackAdvancedAnalyticsEvent(
                   'issue_details.performance.hidden_spans_expanded',
@@ -146,7 +148,7 @@ class SpanTree extends Component<PropType> {
               }
             : undefined
         }
-        cursor={focusedSpanIds ? 'pointer' : 'default'}
+        cursor={isClickable ? 'pointer' : 'default'}
       >
         {messages}
       </MessageRow>

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -75,11 +75,11 @@ class SpanTree extends Component<PropType> {
     filteredSpansAbove: EnhancedProcessedSpanType[];
     isCurrentSpanFilteredOut: boolean;
     isCurrentSpanHidden: boolean;
-    numOfSpansOutOfViewAbove: number;
+    outOfViewSpansAbove: EnhancedProcessedSpanType[];
   }): React.ReactNode {
     const {
       isCurrentSpanHidden,
-      numOfSpansOutOfViewAbove,
+      outOfViewSpansAbove,
       isCurrentSpanFilteredOut,
       filteredSpansAbove,
     } = input;
@@ -87,14 +87,13 @@ class SpanTree extends Component<PropType> {
     const {focusedSpanIds, waterfallModel, organization} = this.props;
 
     const messages: React.ReactNode[] = [];
+    let firstHiddenSpanId = '0';
 
+    const numOfSpansOutOfViewAbove = outOfViewSpansAbove.length;
     const showHiddenSpansMessage = !isCurrentSpanHidden && numOfSpansOutOfViewAbove > 0;
 
-    const firstHiddenSpanId = filteredSpansAbove[0]
-      ? getSpanID(filteredSpansAbove[0].span)
-      : '0';
-
     if (showHiddenSpansMessage) {
+      firstHiddenSpanId = getSpanID(outOfViewSpansAbove[0].span);
       messages.push(
         <span key={`spans-out-of-view-${firstHiddenSpanId}`}>
           <strong>{numOfSpansOutOfViewAbove}</strong> {t('spans out of view')}
@@ -103,11 +102,11 @@ class SpanTree extends Component<PropType> {
     }
 
     const numOfFilteredSpansAbove = filteredSpansAbove.length;
-
     const showFilteredSpansMessage =
       !isCurrentSpanFilteredOut && numOfFilteredSpansAbove > 0;
 
     if (showFilteredSpansMessage) {
+      firstHiddenSpanId = getSpanID(filteredSpansAbove[0].span);
       if (!isCurrentSpanHidden) {
         if (numOfFilteredSpansAbove === 1) {
           messages.push(
@@ -197,7 +196,7 @@ class SpanTree extends Component<PropType> {
 
     type AccType = {
       filteredSpansAbove: EnhancedProcessedSpanType[];
-      numOfSpansOutOfViewAbove: number;
+      outOfViewSpansAbove: EnhancedProcessedSpanType[];
       spanNumber: number;
       spanTree: React.ReactNode[];
     };
@@ -218,7 +217,7 @@ class SpanTree extends Component<PropType> {
 
     const isEmbeddedSpanTree = waterfallModel.isEmbeddedSpanTree;
 
-    const {spanTree, numOfSpansOutOfViewAbove, filteredSpansAbove} = spans.reduce(
+    const {spanTree, outOfViewSpansAbove, filteredSpansAbove} = spans.reduce(
       (acc: AccType, payload: EnhancedProcessedSpanType) => {
         const {type} = payload;
 
@@ -228,7 +227,7 @@ class SpanTree extends Component<PropType> {
             return acc;
           }
           case 'out_of_view': {
-            acc.numOfSpansOutOfViewAbove += 1;
+            acc.outOfViewSpansAbove.push(payload);
             return acc;
           }
           default: {
@@ -237,13 +236,13 @@ class SpanTree extends Component<PropType> {
         }
 
         const previousSpanNotDisplayed =
-          acc.filteredSpansAbove.length > 0 || acc.numOfSpansOutOfViewAbove > 0;
+          acc.filteredSpansAbove.length > 0 || acc.outOfViewSpansAbove.length > 0;
 
         if (previousSpanNotDisplayed) {
           const infoMessage = this.generateInfoMessage({
             isCurrentSpanHidden: false,
             filteredSpansAbove: acc.filteredSpansAbove,
-            numOfSpansOutOfViewAbove: acc.numOfSpansOutOfViewAbove,
+            outOfViewSpansAbove: acc.outOfViewSpansAbove,
             isCurrentSpanFilteredOut: false,
           });
           acc.spanTree.push(infoMessage);
@@ -270,7 +269,7 @@ class SpanTree extends Component<PropType> {
           );
           acc.spanNumber = spanNumber + 1;
 
-          acc.numOfSpansOutOfViewAbove = 0;
+          acc.outOfViewSpansAbove = [];
           acc.filteredSpansAbove = [];
 
           return acc;
@@ -297,7 +296,7 @@ class SpanTree extends Component<PropType> {
           );
           acc.spanNumber = spanNumber + 1;
 
-          acc.numOfSpansOutOfViewAbove = 0;
+          acc.outOfViewSpansAbove = [];
           acc.filteredSpansAbove = [];
 
           return acc;
@@ -309,7 +308,7 @@ class SpanTree extends Component<PropType> {
         const spanBarColor: string = pickBarColor(getSpanOperation(span));
         const numOfSpanChildren = payload.numOfSpanChildren;
 
-        acc.numOfSpansOutOfViewAbove = 0;
+        acc.outOfViewSpansAbove = [];
         acc.filteredSpansAbove = [];
 
         let toggleSpanGroup: (() => void) | undefined = undefined;
@@ -394,7 +393,7 @@ class SpanTree extends Component<PropType> {
       },
       {
         filteredSpansAbove: [],
-        numOfSpansOutOfViewAbove: 0,
+        outOfViewSpansAbove: [],
         spanTree: [],
         spanNumber: 1, // 1-based indexing
       }
@@ -402,7 +401,7 @@ class SpanTree extends Component<PropType> {
 
     const infoMessage = this.generateInfoMessage({
       isCurrentSpanHidden: false,
-      numOfSpansOutOfViewAbove,
+      outOfViewSpansAbove,
       isCurrentSpanFilteredOut: false,
       filteredSpansAbove,
     });


### PR DESCRIPTION
This fixes a bug where the span tree would render the `X spans out of view` message repeatedly if you resized the span tree minimap. 

The reason why this was happening was because of the way I was previously assigning the `key` prop to these messages. I was only using the ID of the first span that is "filtered out", and '0' as a backup. However, when you adjust the minimap, there won't ever be any spans that are "filtered out", they are "out of view", so we'd have multiple messages with the key prop set to `spans-out-of-view-0`, violating the unique key prop constraint and confusing React when rendering the tree.

### Example demonstration of the bug:

https://user-images.githubusercontent.com/16740047/197877725-120cb61e-f2e8-47a4-a616-ecf837ac43fe.mp4


