### PR TITLE
perf(issues): Load group event earlier using project id

### DIFF
--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -207,9 +207,9 @@ class GroupDetails extends Component<Props, State> {
   /**
    * Fetching a event by ID requires a project slug.
    * We can get the project slug from the group and wait for that request to finish
-   * or we could get the project slug via the projectId in the URL
+   * or we could get the project slug via the projectId in the URL.
    *
-   * In the future, we could make a events endpoint that does not require the project slug.
+   * In the future, we could make an events endpoint that does not require the project slug.
    */
   canLoadEventEarly(props: Props): boolean {
     const hasProject = this.props.projects.some(

--- a/static/app/views/organizationGroupDetails/utils.tsx
+++ b/static/app/views/organizationGroupDetails/utils.tsx
@@ -13,7 +13,7 @@ import {Event} from 'sentry/types/event';
  * @param groupId groupId
  * @param eventId eventId or "latest" or "oldest"
  * @param envNames
- * @param projectId project slug required for eventId that is not latest or oldest
+ * @param projectSlug required for eventId that is not latest or oldest
  */
 export async function fetchGroupEvent(
   api: Client,
@@ -21,12 +21,12 @@ export async function fetchGroupEvent(
   groupId: string,
   eventId: string,
   envNames: string[],
-  projectId?: string
+  projectSlug?: string
 ): Promise<Event> {
   const url =
     eventId === 'latest' || eventId === 'oldest'
       ? `/issues/${groupId}/events/${eventId}/`
-      : `/projects/${orgId}/${projectId}/events/${eventId}/?group_id=${groupId}`;
+      : `/projects/${orgId}/${projectSlug}/events/${eventId}/?group_id=${groupId}`;
 
   const query: {environment?: string[]} = {};
   if (envNames.length !== 0) {

--- a/static/app/views/organizationGroupDetails/utils.tsx
+++ b/static/app/views/organizationGroupDetails/utils.tsx
@@ -9,7 +9,7 @@ import {Event} from 'sentry/types/event';
 /**
  * Fetches group data and mark as seen
  *
- * @param orgId organization slug
+ * @param orgSlug
  * @param groupId groupId
  * @param eventId eventId or "latest" or "oldest"
  * @param envNames
@@ -17,7 +17,7 @@ import {Event} from 'sentry/types/event';
  */
 export async function fetchGroupEvent(
   api: Client,
-  orgId: string,
+  orgSlug: string,
   groupId: string,
   eventId: string,
   envNames: string[],
@@ -26,7 +26,7 @@ export async function fetchGroupEvent(
   const url =
     eventId === 'latest' || eventId === 'oldest'
       ? `/issues/${groupId}/events/${eventId}/`
-      : `/projects/${orgId}/${projectSlug}/events/${eventId}/?group_id=${groupId}`;
+      : `/projects/${orgSlug}/${projectSlug}/events/${eventId}/?group_id=${groupId}`;
 
   const query: {environment?: string[]} = {};
   if (envNames.length !== 0) {


### PR DESCRIPTION
This change is specific to the `/organizations/:orgId/issues/:groupId/events/:eventId/` route.

Instead of waiting for the group to finish loading before loading the event, load the event details earlier using the project store. This would be better fixed in the backend via an api that didn't require the project slug. Savings would be ~0.5-1 second.

the highlighted request is blocking other requests and is made after the first blocking request. After this change the highlighted request would be made at the same time as the first request.
![image](https://user-images.githubusercontent.com/1400464/197901906-aee341b4-5b0e-46e8-900e-85b19ec9919d.png)
