### PR TITLE
perf(issues): Remove duplicate fetch on latest/oldest event

### DIFF
--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -5,11 +5,11 @@ from typing import TYPE_CHECKING
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api import client
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
+from sentry.api.endpoints.project_event_details import wrap_event_response
 from sentry.api.helpers.environments import get_environments
-from sentry.api.serializers import EventSerializer, serialize
+from sentry.api.serializers import DetailedEventSerializer, EventSerializer, serialize
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 if TYPE_CHECKING:
@@ -47,11 +47,6 @@ class GroupEventsLatestEndpoint(GroupEndpoint):  # type: ignore
         if "stacktraceOnly" in collapse:
             return Response(serialize(event, request.user, EventSerializer()))
 
-        try:
-            return client.get(
-                f"/projects/{event.organization.slug}/{event.project.slug}/events/{event.event_id}/",
-                request=request,
-                data={"environment": environments, "group_id": event.group_id},
-            )
-        except client.ApiError as e:
-            return Response(e.body, status=e.status_code)
+        event_data = serialize(event, request.user, DetailedEventSerializer())
+        data = wrap_event_response(request.user, event, event_data, event.project, environments)
+        return Response(data)

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -9,7 +9,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.endpoints.project_event_details import wrap_event_response
 from sentry.api.helpers.environments import get_environments
-from sentry.api.serializers import DetailedEventSerializer, EventSerializer, serialize
+from sentry.api.serializers import EventSerializer, serialize
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 if TYPE_CHECKING:
@@ -47,6 +47,5 @@ class GroupEventsLatestEndpoint(GroupEndpoint):  # type: ignore
         if "stacktraceOnly" in collapse:
             return Response(serialize(event, request.user, EventSerializer()))
 
-        event_data = serialize(event, request.user, DetailedEventSerializer())
-        data = wrap_event_response(event, event_data, event.project, environments)
+        data = wrap_event_response(request.user, event, event.project, environments)
         return Response(data)

--- a/src/sentry/api/endpoints/group_events_latest.py
+++ b/src/sentry/api/endpoints/group_events_latest.py
@@ -48,5 +48,5 @@ class GroupEventsLatestEndpoint(GroupEndpoint):  # type: ignore
             return Response(serialize(event, request.user, EventSerializer()))
 
         event_data = serialize(event, request.user, DetailedEventSerializer())
-        data = wrap_event_response(request.user, event, event_data, event.project, environments)
+        data = wrap_event_response(event, event_data, event.project, environments)
         return Response(data)

--- a/src/sentry/api/endpoints/group_events_oldest.py
+++ b/src/sentry/api/endpoints/group_events_oldest.py
@@ -9,7 +9,6 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.endpoints.project_event_details import wrap_event_response
 from sentry.api.helpers.environments import get_environments
-from sentry.api.serializers import DetailedEventSerializer, serialize
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
@@ -34,6 +33,5 @@ class GroupEventsOldestEndpoint(GroupEndpoint):  # type: ignore
         if not event:
             return Response({"detail": "No events found for group"}, status=404)
 
-        event_data = serialize(event, request.user, DetailedEventSerializer())
-        data = wrap_event_response(event, event_data, event.project, environments)
+        data = wrap_event_response(request.user, event, event.project, environments)
         return Response(data)

--- a/src/sentry/api/endpoints/group_events_oldest.py
+++ b/src/sentry/api/endpoints/group_events_oldest.py
@@ -35,5 +35,5 @@ class GroupEventsOldestEndpoint(GroupEndpoint):  # type: ignore
             return Response({"detail": "No events found for group"}, status=404)
 
         event_data = serialize(event, request.user, DetailedEventSerializer())
-        data = wrap_event_response(request.user, event, event_data, event.project, environments)
+        data = wrap_event_response(event, event_data, event.project, environments)
         return Response(data)

--- a/src/sentry/api/endpoints/project_event_details.py
+++ b/src/sentry/api/endpoints/project_event_details.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from datetime import datetime
+from typing import Any, List
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -8,10 +9,14 @@ from sentry import eventstore, features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import DetailedEventSerializer, serialize
+from sentry.eventstore.models import Event
 from sentry.issues.query import apply_performance_conditions
+from sentry.models.project import Project
 
 
-def wrap_event_response(event, event_data, project, requested_environments):
+def wrap_event_response(
+    event: Event, event_data: Any, project: Project, requested_environments: List[str]
+):
     # Used for paginating through events of a single issue in group details
     # Skip next/prev for issueless events
     next_event_id = None


### PR DESCRIPTION
Instead of making an additional fetch that re-loads the event by id, return the event we have already loaded in the `latest` and `oldest` api endpoints.