### PR TITLE
perf(issues): Load environments earlier

### DIFF
--- a/static/app/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -116,6 +116,10 @@ describe('groupDetails', () => {
         ],
       },
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/environments/`,
+      body: TestStubs.Environments(),
+    });
   });
 
   afterEach(() => {

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/react';
 import omit from 'lodash/omit';
 import * as PropTypes from 'prop-types';
 
+import {fetchOrganizationEnvironments} from 'sentry/actionCreators/environments';
 import {Client} from 'sentry/api';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -117,6 +118,9 @@ class GroupDetails extends Component<Props, State> {
       this.fetchReplayIds();
     }
     this.updateReprocessingProgress();
+
+    // Fetch environments early - used in GroupEventDetailsContainer
+    fetchOrganizationEnvironments(this.props.api, this.props.organization.slug);
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {

--- a/static/app/views/organizationGroupDetails/groupEventDetails/index.spec.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/index.spec.tsx
@@ -1,5 +1,7 @@
 import {render, screen, waitForElementToBeRemoved} from 'sentry-test/reactTestingLibrary';
 
+import {fetchOrganizationEnvironments} from 'sentry/actionCreators/environments';
+import {Client} from 'sentry/api';
 import OrganizationEnvironmentsStore from 'sentry/stores/organizationEnvironmentsStore';
 import GroupEventDetailsContainer, {
   GroupEventDetailsProps,
@@ -41,6 +43,7 @@ describe('groupEventDetailsContainer', () => {
       body: TestStubs.Environments(),
     });
 
+    fetchOrganizationEnvironments(new Client(), organization.slug);
     render(<GroupEventDetailsContainer {...makeProps({organization})} />);
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
@@ -53,6 +56,7 @@ describe('groupEventDetailsContainer', () => {
       statusCode: 400,
     });
 
+    fetchOrganizationEnvironments(new Client(), organization.slug);
     render(<GroupEventDetailsContainer {...makeProps({organization})} />);
 
     expect(
@@ -68,6 +72,7 @@ describe('groupEventDetailsContainer', () => {
       url: `/organizations/${organization.slug}/environments/`,
       body: null,
     });
+    fetchOrganizationEnvironments(new Client(), organization.slug);
     render(<GroupEventDetailsContainer {...makeProps({organization})} />);
 
     expect(
@@ -88,6 +93,7 @@ describe('groupEventDetailsContainer', () => {
       url: `/organizations/${organization.slug}/environments/`,
       body: TestStubs.Environments(),
     });
+    fetchOrganizationEnvironments(new Client(), organization.slug);
     const {unmount} = render(
       <GroupEventDetailsContainer {...makeProps({organization})} />
     );

--- a/static/app/views/organizationGroupDetails/groupEventDetails/index.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/index.tsx
@@ -1,7 +1,5 @@
-import {useEffect} from 'react';
 import {RouteComponentProps} from 'react-router';
 
-import {fetchOrganizationEnvironments} from 'sentry/actionCreators/environments';
 import {Client} from 'sentry/api';
 import LoadingError from 'sentry/components/loadingError';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -32,15 +30,10 @@ export interface GroupEventDetailsProps
   selection: PageFilters;
 }
 
+// Blocks rendering of the event until the environment is loaded
 export function GroupEventDetailsContainer(props: GroupEventDetailsProps) {
+  // fetchOrganizationEnvironments is called in groupDetails.tsx
   const state = useLegacyStore(OrganizationEnvironmentsStore);
-
-  useEffect(() => {
-    if (!state.environments && !state.error) {
-      fetchOrganizationEnvironments(props.api, props.organization.slug);
-    }
-    // XXX: Missing dependencies, but it reflects the old of componentDidMount
-  }, [props.api]);
 
   if (state.error) {
     return (


### PR DESCRIPTION
We're blocking the event details component until the environments load. Load them as early as possible so that we don't have to wait for them to load later.

The next requests don't start until environments has loaded
![image](https://user-images.githubusercontent.com/1400464/197917885-b15300ae-6502-4f02-b20e-b04b80ade659.png)

This might start loading the environments on pages that didn't need them before, but it shouldn't hurt anything.