### PR TITLE
feat(replays): allow searchable url field

### DIFF
--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -50,8 +50,9 @@ def generate_normalized_output(
             "family": item.pop("device_family"),
         }
 
-        item["urls"] = list(generate_sorted_urls(item.pop("agg_urls")))
-        item["countUrls"] = len(item["urls"])
+        item.pop("agg_urls")
+        item["countUrls"] = len(item["urls_sorted"])
+        item["urls"] = item.pop("urls_sorted")
 
         item.pop("isArchived")
 

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -279,14 +279,18 @@ def _sorted_aggregated_urls(agg_urls_column, alias):
     mapped_urls = Function(
         "arrayMap",
         parameters=[
-            Lambda(["x"], Function("tupleElement", parameters=[Identifier("x"), 2])),
+            Lambda(
+                ["url_tuple"], Function("tupleElement", parameters=[Identifier("url_tuple"), 2])
+            ),
             agg_urls_column,
         ],
     )
     mapped_sequence_ids = Function(
         "arrayMap",
         parameters=[
-            Lambda(["x"], Function("tupleElement", parameters=[Identifier("x"), 1])),
+            Lambda(
+                ["url_tuple"], Function("tupleElement", parameters=[Identifier("url_tuple"), 1])
+            ),
             agg_urls_column,
         ],
     )
@@ -296,7 +300,10 @@ def _sorted_aggregated_urls(agg_urls_column, alias):
             Function(
                 "arraySort",
                 parameters=[
-                    Lambda(["x", "y"], Function("identity", parameters=[Identifier("y")])),
+                    Lambda(
+                        ["urls", "sequence_id"],
+                        Function("identity", parameters=[Identifier("sequence_id")]),
+                    ),
                     mapped_urls,
                     mapped_sequence_ids,
                 ],

--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -230,6 +230,7 @@ def make_select_statement() -> List[Union[Column, Function]]:
             parameters=[Function("tuple", parameters=[Column("segment_id"), Column("urls")])],
             alias="agg_urls",
         ),
+        _sorted_aggregated_urls(Column("agg_urls"), "urls_sorted"),
         Function("count", parameters=[Column("segment_id")], alias="countSegments"),
         Function(
             "uniqArray",
@@ -274,6 +275,37 @@ def _grouped_unique_scalar_value(
     )
 
 
+def _sorted_aggregated_urls(agg_urls_column, alias):
+    mapped_urls = Function(
+        "arrayMap",
+        parameters=[
+            Lambda(["x"], Function("tupleElement", parameters=[Identifier("x"), 2])),
+            agg_urls_column,
+        ],
+    )
+    mapped_sequence_ids = Function(
+        "arrayMap",
+        parameters=[
+            Lambda(["x"], Function("tupleElement", parameters=[Identifier("x"), 1])),
+            agg_urls_column,
+        ],
+    )
+    return Function(
+        "arrayFlatten",
+        parameters=[
+            Function(
+                "arraySort",
+                parameters=[
+                    Lambda(["x", "y"], Function("identity", parameters=[Identifier("y")])),
+                    mapped_urls,
+                    mapped_sequence_ids,
+                ],
+            )
+        ],
+        alias=alias,
+    )
+
+
 # Filter
 
 replay_url_parser_config = SearchConfig(
@@ -293,6 +325,7 @@ class ReplayQueryConfig(QueryConfig):
     agg_environment = String(field_alias="environment")
     releases = ListField()
     dist = String()
+    urls = ListField(query_alias="urls_sorted")
     user_id = String(field_alias="user.id")
     user_email = String(field_alias="user.email")
     user_name = String(field_alias="user.name")

--- a/src/sentry/replays/testutils.py
+++ b/src/sentry/replays/testutils.py
@@ -55,7 +55,7 @@ def assert_expected_response(
             assert response_value == value, f'"{key}, {response_value}" "{value}"'
 
     # Ensure no lingering unexpected keys exist.
-    assert list(response.keys()) == []
+    assert list(response.keys()) == [], response.keys()
 
 
 def mock_expected_response(
@@ -121,7 +121,6 @@ def mock_replay(
 ) -> typing.Dict[str, typing.Any]:
     tags = kwargs.pop("tags", {})
     tags.update({"transaction": kwargs.pop("title", "Title")})
-
     return {
         "type": "replay_event",
         "start_time": sec(timestamp),

--- a/tests/sentry/replays/test_organization_replay_index.py
+++ b/tests/sentry/replays/test_organization_replay_index.py
@@ -344,6 +344,7 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 device_family="Macintosh",
                 device_model="10",
                 tags={"a": "m", "b": "q"},
+                urls=["example.com"],
             )
         )
         self.store_replays(
@@ -400,6 +401,8 @@ class OrganizationReplayIndexTest(APITestCase, ReplaysSnubaTestCase):
                 # Tag filters.
                 "a:m",
                 "a:[n,o]",
+                # # url filter
+                "urls:example.com",
             ]
 
             for query in queries:


### PR DESCRIPTION
- add a new field to the query `sorted_urls`, which does the sorting/flattening in clickhouse
- use this field to with our `ListField` Field, which allows for searching within a list in a replay row
- replace the sorting/flattening of `agg_urls` in our post_process with simply the `sorted_urls` field

The other option considered was creating a new Field to do a Lambda search on the `agg_url` Array of Tuples, but this seemed cleaner. 

Also, maybe one day `GroupArraySorted` will be a thing and we can use that instead

closes https://github.com/getsentry/replay-backend/issues/175