### PR TITLE
fix(discover-homepage): Use the homepage target in event details page

### DIFF
--- a/static/app/components/events/eventCustomPerformanceMetrics.tsx
+++ b/static/app/components/events/eventCustomPerformanceMetrics.tsx
@@ -28,6 +28,7 @@ type Props = {
   event: Event;
   location: Location;
   organization: Organization;
+  isHomepage?: boolean;
   source?: EventDetailPageSource;
 };
 
@@ -40,6 +41,7 @@ export default function EventCustomPerformanceMetrics({
   location,
   organization,
   source,
+  isHomepage,
 }: Props) {
   const measurementNames = Object.keys(event.measurements ?? {})
     .filter(name => isCustomMeasurement(`measurements.${name}`))
@@ -63,6 +65,7 @@ export default function EventCustomPerformanceMetrics({
               location={location}
               organization={organization}
               source={source}
+              isHomepage={isHomepage}
             />
           );
         })}
@@ -100,6 +103,7 @@ function EventCustomPerformanceMetric({
   location,
   organization,
   source,
+  isHomepage,
 }: EventCustomPerformanceMetricProps) {
   const {value, unit} = event.measurements?.[name] ?? {};
   if (value === null) {
@@ -129,7 +133,7 @@ function EventCustomPerformanceMetric({
         });
       case EventDetailPageSource.DISCOVER:
       default:
-        return eventView.getResultsViewUrlTarget(organization.slug);
+        return eventView.getResultsViewUrlTarget(organization.slug, isHomepage);
     }
   }
 

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -73,6 +73,7 @@ function generateDiscoverEventTarget(
     orgSlug: organization.slug,
     eventSlug,
     eventView: EventView.fromLocation(newLocation),
+    isHomepage: location.query.homepage === 'true' || undefined,
   });
 }
 

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -271,6 +271,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                   event={event}
                   location={location}
                   organization={organization}
+                  isHomepage={isHomepage}
                 />
               )}
               {event.groupID && (

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -100,7 +100,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
   }
 
   generateTagUrl = (tag: EventTag) => {
-    const {eventView, organization} = this.props;
+    const {eventView, organization, isHomepage} = this.props;
     const {event} = this.state;
     if (!event) {
       return '';
@@ -111,7 +111,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     }
     const tagKey = formatTagKey(tag.key);
     const nextView = getExpandedResults(eventView, {[tagKey]: tag.value}, eventReference);
-    return nextView.getResultsViewUrlTarget(organization.slug);
+    return nextView.getResultsViewUrlTarget(organization.slug, isHomepage);
   };
 
   renderBody() {

--- a/static/app/views/eventsV2/eventDetails/index.spec.jsx
+++ b/static/app/views/eventsV2/eventDetails/index.spec.jsx
@@ -195,6 +195,45 @@ describe('EventsV2 > EventDetails', function () {
     );
   });
 
+  it('navigates to homepage when tag values are clicked', async function () {
+    const {organization, routerContext, router} = initializeOrg({
+      organization: TestStubs.Organization(),
+      router: {
+        location: {
+          pathname: '/organizations/org-slug/discover/project-slug:deadbeef',
+          query: {...allEventsView.generateQueryStringObject(), homepage: 'true'},
+        },
+      },
+    });
+    render(
+      <EventDetails
+        organization={organization}
+        params={{eventSlug: 'project-slug:deadbeef'}}
+        location={router.location}
+      />,
+      {context: routerContext}
+    );
+
+    // Get the first link as we wrap react-router's link
+    expect(await screen.findByText('Firefox')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Firefox'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/discover/homepage/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All%20Events&query=browser%3AFirefox%20title%3A%22Oh%20no%20something%20bad%22&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29'
+    );
+
+    // Get the second link
+    expect(screen.getByRole('link', {name: 'test-uuid'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/discover/homepage/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All%20Events&query=tags%5Bdevice.uuid%5D%3Atest-uuid%20title%3A%22Oh%20no%20something%20bad%22&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29'
+    );
+
+    // Get the third link
+    expect(screen.getByRole('link', {name: '82ebf297206a'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/discover/homepage/?field=title&field=event.type&field=project&field=user.display&field=timestamp&name=All%20Events&query=release%3A82ebf297206a%20title%3A%22Oh%20no%20something%20bad%22&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29'
+    );
+  });
+
   it('appends tag value to existing query when clicked', async function () {
     const {organization, routerContext} = initializeOrg({
       organization: TestStubs.Organization(),


### PR DESCRIPTION
You can apply tag filters by clicking links in the Tag Details sidebar on the Event Detail page. This needs to target the homepage query or else it'll error.

Also updated the Custom Performance Metrics links while we're making this change