### PR TITLE
test(ui): Extend newsletter consent timeout

### DIFF
--- a/static/app/views/app/index.spec.jsx
+++ b/static/app/views/app/index.spec.jsx
@@ -49,7 +49,9 @@ describe('App', function () {
     );
 
     const updatesViaEmail = await screen.findByText(
-      'Yes, I would like to receive updates via email'
+      'Yes, I would like to receive updates via email',
+      undefined,
+      {timeout: 2000, interval: 100}
     );
     expect(updatesViaEmail).toBeInTheDocument();
 


### PR DESCRIPTION
seems to flake in ci https://sentry.io/organizations/sentry/performance/summary/?environment=ci&project=4857230&query=transaction.status%3Ainternal_error&referrer=performance-transaction-summary&statsPeriod=7d&transaction=App+%3E+renders+NewsletterConsent&unselectedSeries=p100%28%29&unselectedSeries=Releases
