### PR TITLE
ref(feature-flag): Remove feature flag FE code for ops breakdown

### DIFF
--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -377,19 +377,13 @@ class TableView extends Component<TableViewProps & WithRouterProps> {
       customMeasurements,
     } = this.props;
 
-    const hasBreakdownFeature = organization.features.includes(
-      'performance-ops-breakdown'
-    );
-
     openModal(
       modalProps => (
         <ColumnEditModal
           {...modalProps}
           organization={organization}
           measurementKeys={measurementKeys}
-          spanOperationBreakdownKeys={
-            hasBreakdownFeature ? spanOperationBreakdownKeys : undefined
-          }
+          spanOperationBreakdownKeys={spanOperationBreakdownKeys}
           columns={eventView.getColumns().map(col => col.column)}
           onApply={this.handleUpdateColumns}
           customMeasurements={customMeasurements}

--- a/static/app/views/performance/transactionSummary/filter.tsx
+++ b/static/app/views/performance/transactionSummary/filter.tsx
@@ -50,11 +50,7 @@ type Props = {
 };
 
 function Filter(props: Props) {
-  const {currentFilter, onChangeFilter, organization} = props;
-
-  if (!organization.features.includes('performance-ops-breakdown')) {
-    return null;
-  }
+  const {currentFilter, onChangeFilter} = props;
 
   const menuOptions = OPTIONS.map(operationName => ({
     value: operationName,

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -18,7 +18,7 @@ import {RouteContext} from 'sentry/views/routeContext';
 
 function initializeData() {
   const organization = TestStubs.Organization({
-    features: ['discover-basic', 'performance-view', 'performance-ops-breakdown'],
+    features: ['discover-basic', 'performance-view'],
     projects: [TestStubs.Project()],
     apdexThreshold: 400,
   });

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.spec.tsx
@@ -4,7 +4,7 @@ import {
   initializeData as _initializeData,
   initializeDataSettings,
 } from 'sentry-test/performance/initializePerformanceData';
-import {act, render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -162,8 +162,9 @@ describe('Performance > Transaction Summary > Transaction Events > Index', () =>
     const data = initializeData();
 
     render(<WrappedComponent data={data} />, {context: data.routerContext});
-    const percentileContainer = await screen.findByRole('presentation');
-    const percentileButton = await within(percentileContainer).findByRole('button');
+    const percentileButton = await screen.findByRole('button', {
+      name: /percentile p100/i,
+    });
 
     userEvent.click(percentileButton);
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -223,53 +223,51 @@ function SummaryContent({
 
   let transactionsListEventView = eventView.clone();
 
-  if (organization.features.includes('performance-ops-breakdown')) {
-    // update search conditions
+  // update search conditions
 
-    const spanOperationBreakdownConditions = filterToSearchConditions(
-      spanOperationBreakdownFilter,
-      location
-    );
+  const spanOperationBreakdownConditions = filterToSearchConditions(
+    spanOperationBreakdownFilter,
+    location
+  );
 
-    if (spanOperationBreakdownConditions) {
-      eventView = eventView.clone();
-      eventView.query = `${eventView.query} ${spanOperationBreakdownConditions}`.trim();
-      transactionsListEventView = eventView.clone();
-    }
-
-    // update header titles of transactions list
-
-    const operationDurationTableTitle =
-      spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None
-        ? t('operation duration')
-        : `${spanOperationBreakdownFilter} duration`;
-
-    // add ops breakdown duration column as the 3rd column
-    transactionsListTitles.splice(2, 0, operationDurationTableTitle);
-
-    // span_ops_breakdown.relative is a preserved name and a marker for the associated
-    // field renderer to be used to generate the relative ops breakdown
-    let durationField = SPAN_OP_RELATIVE_BREAKDOWN_FIELD;
-
-    if (spanOperationBreakdownFilter !== SpanOperationBreakdownFilter.None) {
-      durationField = filterToField(spanOperationBreakdownFilter)!;
-    }
-
-    const fields = [...transactionsListEventView.fields];
-
-    // add ops breakdown duration column as the 3rd column
-    fields.splice(2, 0, {field: durationField});
-
-    if (spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None) {
-      fields.push(
-        ...SPAN_OP_BREAKDOWN_FIELDS.map(field => {
-          return {field};
-        })
-      );
-    }
-
-    transactionsListEventView.fields = fields;
+  if (spanOperationBreakdownConditions) {
+    eventView = eventView.clone();
+    eventView.query = `${eventView.query} ${spanOperationBreakdownConditions}`.trim();
+    transactionsListEventView = eventView.clone();
   }
+
+  // update header titles of transactions list
+
+  const operationDurationTableTitle =
+    spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None
+      ? t('operation duration')
+      : `${spanOperationBreakdownFilter} duration`;
+
+  // add ops breakdown duration column as the 3rd column
+  transactionsListTitles.splice(2, 0, operationDurationTableTitle);
+
+  // span_ops_breakdown.relative is a preserved name and a marker for the associated
+  // field renderer to be used to generate the relative ops breakdown
+  let durationField = SPAN_OP_RELATIVE_BREAKDOWN_FIELD;
+
+  if (spanOperationBreakdownFilter !== SpanOperationBreakdownFilter.None) {
+    durationField = filterToField(spanOperationBreakdownFilter)!;
+  }
+
+  const fields = [...transactionsListEventView.fields];
+
+  // add ops breakdown duration column as the 3rd column
+  fields.splice(2, 0, {field: durationField});
+
+  if (spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None) {
+    fields.push(
+      ...SPAN_OP_BREAKDOWN_FIELDS.map(field => {
+        return {field};
+      })
+    );
+  }
+
+  transactionsListEventView.fields = fields;
 
   const openAllEventsProps = {
     generatePerformanceTransactionEventsView: () => {

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -428,7 +428,12 @@ describe('Performance > TransactionSummary', function () {
       expect(screen.getByRole('button', {name: 'Open in Issues'})).toBeInTheDocument();
 
       // Ensure transaction filter button exists
-      expect(screen.getByText('Filter').closest('button')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Filter Slow Transactions (p95)'})
+      ).toBeInTheDocument();
+
+      // Ensure ops breakdown filter exists
+      expect(screen.getByTestId('span-operation-breakdown-filter')).toBeInTheDocument();
 
       // Ensure create alert from discover is hidden without metric alert
       expect(
@@ -835,7 +840,9 @@ describe('Performance > TransactionSummary', function () {
       expect(screen.getByRole('button', {name: 'Open in Issues'})).toBeInTheDocument();
 
       // Ensure transaction filter button exists
-      expect(screen.getByText('Filter').closest('button')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Filter Slow Transactions (p95)'})
+      ).toBeInTheDocument();
 
       // Ensure create alert from discover is hidden without metric alert
       expect(


### PR DESCRIPTION
This feature is fully rolled out so we no longer need the flag

BE PR: https://github.com/getsentry/sentry/pull/40605
