### PR TITLE
ref(mep): Remove dynamic sampling rule check from UI

### DIFF
--- a/static/app/utils/performance/contexts/metricsCardinality.tsx
+++ b/static/app/utils/performance/contexts/metricsCardinality.tsx
@@ -131,10 +131,6 @@ function getMetricsOutcome(
     return fallbackOutcome;
   }
 
-  if (checkForSamplingRules(dataCounts)) {
-    return fallbackOutcome;
-  }
-
   if (checkNoDataFallback(dataCounts)) {
     return fallbackOutcome;
   }
@@ -164,21 +160,6 @@ function getMetricsOutcome(
   }
 
   return successOutcome;
-}
-
-/**
- * Fallback if very similar amounts of metrics and transactions are found.
- * No projects with dynamic sampling means no rules have been enabled yet.
- */
-function checkForSamplingRules(dataCounts: MergedMetricsData) {
-  const counts = normalizeCounts(dataCounts);
-  if (!dataCounts.dynamic_sampling_projects?.length) {
-    return true;
-  }
-  if (counts.metricsCount === 0) {
-    return true;
-  }
-  return false;
 }
 
 /**

--- a/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuery.tsx
+++ b/static/app/utils/performance/metricsEnhanced/metricsCompatibilityQuery.tsx
@@ -8,7 +8,6 @@ import GenericDiscoverQuery, {
 
 export interface MetricsCompatibilityData {
   compatible_projects?: number[];
-  dynamic_sampling_projects?: number[];
 }
 
 type QueryProps = Omit<DiscoverQueryProps, 'eventView' | 'api'> & {

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/visualizationStep.spec.tsx
@@ -48,7 +48,6 @@ function mockRequests(orgSlug: Organization['slug']) {
     body: {
       incompatible_projects: [],
       compatible_projects: [1],
-      dynamic_sampling_projects: [1],
     },
   });
 

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -246,7 +246,6 @@ describe('WidgetBuilder', function () {
       body: {
         incompatible_projects: [],
         compatible_projects: [1],
-        dynamic_sampling_projects: [1],
       },
     });
 


### PR DESCRIPTION
We are removing DS rules so we no longer should check for them to fallback to indexed events if they don't exist. This should still be behind the feature flag for metrics so no one aside from EA customers will see their processed events.
