### PR TITLE
ref(feature-flag): Remove feature flag for span tree autoscrolling in BE

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1141,8 +1141,6 @@ SENTRY_FEATURES = {
     "organizations:performance-autogroup-sibling-spans": False,
     # Enable performance on-boarding checklist
     "organizations:performance-onboarding-checklist": False,
-    # Enable automatic horizontal scrolling on the span tree
-    "organizations:performance-span-tree-autoscroll": False,
     # Enable transaction name only search
     "organizations:performance-transaction-name-only-search": False,
     # Enable showing INP web vital in default views

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -129,7 +129,6 @@ default_manager.add("organizations:performance-issues-dev", OrganizationFeature,
 default_manager.add("organizations:performance-issues-all-events-tab", OrganizationFeature, True)
 default_manager.add("organizations:performance-onboarding-checklist", OrganizationFeature, True)
 default_manager.add("organizations:performance-span-histogram-view", OrganizationFeature, True)
-default_manager.add("organizations:performance-span-tree-autoscroll", OrganizationFeature, True)
 default_manager.add("organizations:performance-suspect-spans-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-transaction-name-only-search", OrganizationFeature, True)
 default_manager.add("organizations:performance-use-metrics", OrganizationFeature, True)


### PR DESCRIPTION
Forgot to remove this earlier, this feature flag enabled the autoscroll feature on the span tree. The related code on the frontend had already been removed.