### PR TITLE
fix(perf): Allow transaction tokens in queries

### DIFF
--- a/static/app/views/performance/data.spec.jsx
+++ b/static/app/views/performance/data.spec.jsx
@@ -121,6 +121,6 @@ describe('generatePerformanceEventView()', function () {
       [],
       {withStaticFilters: true}
     );
-    expect(result.query).toEqual('');
+    expect(result.query).toEqual('transaction:*auth*');
   });
 });

--- a/static/app/views/performance/data.spec.jsx
+++ b/static/app/views/performance/data.spec.jsx
@@ -1,3 +1,7 @@
+import {
+  MEPState,
+  METRIC_SEARCH_SETTING_PARAM,
+} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {generatePerformanceEventView} from 'sentry/views/performance/data';
 
 describe('generatePerformanceEventView()', function () {
@@ -104,5 +108,19 @@ describe('generatePerformanceEventView()', function () {
     expect(result.fields).toEqual(
       expect.arrayContaining([expect.objectContaining({field: 'apdex()'})])
     );
+  });
+
+  it('removes unsupported tokens for limited search', function () {
+    const result = generatePerformanceEventView(
+      {
+        query: {
+          query: 'tag:value transaction:*auth*',
+          [METRIC_SEARCH_SETTING_PARAM]: MEPState.metricsOnly,
+        },
+      },
+      [],
+      {withStaticFilters: true}
+    );
+    expect(result.query).toEqual('');
   });
 });

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -471,8 +471,8 @@ function generateGenericPerformanceEventView(
     conditions.freeText = [];
   }
   if (isLimitedSearch) {
-    conditions.tokens = conditions.tokens.filter(token =>
-      TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key || '')
+    conditions.tokens = conditions.tokens.filter(
+      token => token.key && TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key)
     );
   }
   savedQuery.query = conditions.formatString();

--- a/static/app/views/performance/data.tsx
+++ b/static/app/views/performance/data.tsx
@@ -38,6 +38,8 @@ export const COLUMN_TITLES = [
   'user misery',
 ];
 
+const TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH = ['transaction'];
+
 export enum PERFORMANCE_TERM {
   TPM = 'tpm',
   THROUGHPUT = 'throughput',
@@ -469,7 +471,9 @@ function generateGenericPerformanceEventView(
     conditions.freeText = [];
   }
   if (isLimitedSearch) {
-    conditions.tokens = [];
+    conditions.tokens = conditions.tokens.filter(token =>
+      TOKEN_KEYS_SUPPORTED_IN_LIMITED_SEARCH.includes(token.key || '')
+    );
   }
   savedQuery.query = conditions.formatString();
 


### PR DESCRIPTION
Fixes PERF-1778, introduced in #39457. We were aggressively dropping all query tokens from the URL, but we _need_ the transaction query tokens because the transaction name search toolbar works by appending the transaction to the URL query string.
