### PR TITLE
feat(alerts): add spike protection notification setting

### DIFF
--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -81,6 +81,8 @@ class NotificationSetting(Model):
             (NotificationSettingTypes.QUOTA_TRANSACTIONS, "quotaTransactions"),
             (NotificationSettingTypes.QUOTA_ATTACHMENTS, "quotaAttacments"),
             (NotificationSettingTypes.QUOTA_WARNINGS, "quotaWarnings"),
+            (NotificationSettingTypes.QUOTA_SPEND_ALLOCATIONS, "quotaSpendAllocations"),
+            (NotificationSettingTypes.SPIKE_PROTECTION, "spikeProtection"),
         ),
         null=False,
     )

--- a/src/sentry/notifications/defaults.py
+++ b/src/sentry/notifications/defaults.py
@@ -20,6 +20,7 @@ NOTIFICATION_SETTINGS_ALL_SOMETIMES = {
     NotificationSettingTypes.QUOTA_ATTACHMENTS: NotificationSettingOptionValues.ALWAYS,
     NotificationSettingTypes.QUOTA_WARNINGS: NotificationSettingOptionValues.ALWAYS,
     NotificationSettingTypes.QUOTA_SPEND_ALLOCATIONS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.SPIKE_PROTECTION: NotificationSettingOptionValues.ALWAYS,
 }
 
 
@@ -35,6 +36,7 @@ NOTIFICATION_SETTINGS_DEFAULT_OFF = {
     NotificationSettingTypes.QUOTA_ATTACHMENTS: NotificationSettingOptionValues.NEVER,
     NotificationSettingTypes.QUOTA_WARNINGS: NotificationSettingOptionValues.NEVER,
     NotificationSettingTypes.QUOTA_SPEND_ALLOCATIONS: NotificationSettingOptionValues.NEVER,
+    NotificationSettingTypes.SPIKE_PROTECTION: NotificationSettingOptionValues.NEVER,
 }
 
 

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -262,11 +262,12 @@ def get_scope_type(type: NotificationSettingTypes) -> NotificationScopeType:
         NotificationSettingTypes.WORKFLOW,
         NotificationSettingTypes.ISSUE_ALERTS,
         NotificationSettingTypes.ACTIVE_RELEASE,
+        NotificationSettingTypes.SPIKE_PROTECTION,
     ]:
         return NotificationScopeType.PROJECT
 
     raise Exception(
-        f"type {type}, must be alerts, deploy, workflow, approval, quota, quotaErrors, quotaTransactions, quotaAttachments, quotaWarnings, quotaSpendAllocations"
+        f"type {type}, must be alerts, deploy, workflow, approval, quota, quotaErrors, quotaTransactions, quotaAttachments, quotaWarnings, quotaSpendAllocations, spikeProtection"
     )
 
 

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -62,6 +62,9 @@ class NotificationSettingTypes(Enum):
     # Sub category of quotas for spend allocation notifications
     QUOTA_SPEND_ALLOCATIONS = 55
 
+    # Notifications about spikes
+    SPIKE_PROTECTION = 60
+
 
 NOTIFICATION_SETTING_TYPES = {
     NotificationSettingTypes.DEFAULT: "default",
@@ -76,6 +79,7 @@ NOTIFICATION_SETTING_TYPES = {
     NotificationSettingTypes.QUOTA_ATTACHMENTS: "quotaAttachments",
     NotificationSettingTypes.QUOTA_WARNINGS: "quotaWarnings",
     NotificationSettingTypes.QUOTA_SPEND_ALLOCATIONS: "quotaSpendAllocations",
+    NotificationSettingTypes.SPIKE_PROTECTION: "spikeProtection",
 }
 
 
@@ -147,6 +151,7 @@ class UserOptionsSettingsKey(Enum):
     ACTIVE_RELEASE = "activeReleaseNotifications"
     APPROVAL = "approvalNotifications"
     QUOTA = "quotaNotifications"
+    SPIKE_PROTECTION = "spikeProtectionNotifications"
 
 
 VALID_VALUES_FOR_KEY = {
@@ -193,6 +198,10 @@ VALID_VALUES_FOR_KEY = {
         NotificationSettingOptionValues.NEVER,
     },
     NotificationSettingTypes.ACTIVE_RELEASE: {
+        NotificationSettingOptionValues.ALWAYS,
+        NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.SPIKE_PROTECTION: {
         NotificationSettingOptionValues.ALWAYS,
         NotificationSettingOptionValues.NEVER,
     },


### PR DESCRIPTION
Backend part for spike protection notification settings.

Eventually should look something like this
<img width="968" alt="Screen Shot 2022-10-26 at 3 41 11 PM" src="https://user-images.githubusercontent.com/70817427/198152211-3f7afa4d-669f-46a9-9db1-907c36e167da.png">
