### PR TITLE
ref(issue-stream): Refactor IssueListSearchBar to be more reusable

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/issuesSearchBar.tsx
@@ -1,13 +1,9 @@
 import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 
-import {fetchTagValues} from 'sentry/actionCreators/tags';
 import {SearchBarProps} from 'sentry/components/events/searchBar';
 import {t} from 'sentry/locale';
-import {Organization, PageFilters, SavedSearchType, TagCollection} from 'sentry/types';
-import {getUtcDateString} from 'sentry/utils/dates';
-import useApi from 'sentry/utils/useApi';
-import withIssueTags from 'sentry/utils/withIssueTags';
+import {Organization} from 'sentry/types';
 import {WidgetQuery} from 'sentry/views/dashboardsV2/types';
 import {
   MAX_MENU_HEIGHT,
@@ -18,46 +14,20 @@ import IssueListSearchBar from 'sentry/views/issueList/searchBar';
 interface Props {
   onClose: SearchBarProps['onClose'];
   organization: Organization;
-  pageFilters: PageFilters;
-  tags: TagCollection;
   widgetQuery: WidgetQuery;
 }
 
-function IssuesSearchBarContainer({
-  tags,
-  onClose,
-  widgetQuery,
-  organization,
-  pageFilters,
-}: Props) {
-  const api = useApi();
-  function tagValueLoader(key: string, search: string) {
-    const orgId = organization.slug;
-    const projectIds = pageFilters.projects.map(id => id.toString());
-    const endpointParams = {
-      start: getUtcDateString(pageFilters.datetime.start),
-      end: getUtcDateString(pageFilters.datetime.end),
-      statsPeriod: pageFilters.datetime.period,
-    };
-
-    return fetchTagValues(api, orgId, key, search, projectIds, endpointParams);
-  }
-
+function IssuesSearchBar({onClose, widgetQuery, organization}: Props) {
   return (
     <ClassNames>
       {({css}) => (
         <StyledIssueListSearchBar
           searchSource="widget_builder"
+          organization={organization}
           query={widgetQuery.conditions || ''}
-          sort=""
           onClose={onClose}
-          excludedTags={['environment']}
-          supportedTags={tags}
           placeholder={t('Search for issues, status, assigned, and more')}
-          tagValueLoader={tagValueLoader}
-          onSidebarToggle={() => undefined}
           maxSearchItems={MAX_SEARCH_ITEMS}
-          savedSearchType={SavedSearchType.ISSUE}
           dropdownClassName={css`
             max-height: ${MAX_MENU_HEIGHT}px;
             overflow-y: auto;
@@ -67,8 +37,6 @@ function IssuesSearchBarContainer({
     </ClassNames>
   );
 }
-
-const IssuesSearchBar = withIssueTags(IssuesSearchBarContainer);
 
 export {IssuesSearchBar};
 

--- a/static/app/views/issueList/filters.spec.tsx
+++ b/static/app/views/issueList/filters.spec.tsx
@@ -1,0 +1,116 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import TagStore from 'sentry/stores/tagStore';
+
+import IssueListFilters from './filters';
+
+describe('IssueListFilters', function () {
+  const {organization, routerContext} = initializeOrg();
+  const defaultProps = {
+    isSearchDisabled: false,
+    organization,
+    query: '',
+    onSearch: jest.fn(),
+    sort: 'date',
+    savedSearch: null,
+  };
+
+  beforeEach(function () {
+    TagStore.reset();
+    TagStore.loadTagsSuccess(TestStubs.Tags());
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      method: 'GET',
+      body: [],
+    });
+  });
+
+  afterEach(function () {
+    MockApiClient.clearMockResponses();
+  });
+
+  describe('Pinned Searches', function () {
+    let pinSearch;
+    let unpinSearch;
+
+    beforeEach(function () {
+      MockApiClient.clearMockResponses();
+      pinSearch = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/pinned-searches/',
+        method: 'PUT',
+        body: {},
+      });
+      unpinSearch = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/pinned-searches/',
+        method: 'DELETE',
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/recent-searches/',
+        method: 'GET',
+        body: [],
+      });
+    });
+
+    it('has pin icon', function () {
+      render(<IssueListFilters {...defaultProps} />, {context: routerContext});
+
+      expect(screen.getByTestId('pin-icon')).toBeInTheDocument();
+    });
+
+    it('pins a search from the searchbar', function () {
+      render(<IssueListFilters {...defaultProps} query='url:"fu"' />, {
+        context: routerContext,
+      });
+
+      userEvent.click(screen.getByRole('button', {name: 'Pin this search'}));
+
+      expect(pinSearch).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          method: 'PUT',
+          data: {
+            query: 'url:"fu"',
+            sort: 'date',
+            type: 0,
+          },
+        })
+      );
+    });
+
+    it('unpins a search from the searchbar', function () {
+      render(
+        <IssueListFilters
+          {...defaultProps}
+          query='url:"fu"'
+          savedSearch={{
+            id: '1',
+            name: 'Saved Search',
+            isPinned: true,
+            query: 'url:"fu"',
+            sort: 'date',
+            dateCreated: '',
+            isOrgCustom: false,
+            isGlobal: false,
+            type: 0,
+          }}
+        />,
+        {context: routerContext}
+      );
+
+      userEvent.click(screen.getByRole('button', {name: 'Unpin this search'}));
+
+      expect(unpinSearch).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          method: 'DELETE',
+          data: {
+            type: 0,
+          },
+        })
+      );
+    });
+  });
+});

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -1,26 +1,28 @@
+// eslint-disable-next-line no-restricted-imports
+import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
 import EnvironmentPageFilter from 'sentry/components/environmentPageFilter';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
+import {
+  makePinSearchAction,
+  makeSaveSearchAction,
+} from 'sentry/components/smartSearchBar/actions';
 import space from 'sentry/styles/space';
-import {Organization, SavedSearch, TagCollection} from 'sentry/types';
+import {Organization, SavedSearch} from 'sentry/types';
 
 import IssueListSearchBar from './searchBar';
-import {TagValueLoader} from './types';
 
-type Props = {
+interface Props extends WithRouterProps {
   isSearchDisabled: boolean;
   onSearch: (query: string) => void;
-  onSidebarToggle: () => void;
   organization: Organization;
   query: string;
-  savedSearch: SavedSearch;
+  savedSearch: SavedSearch | null;
   sort: string;
-  tagValueLoader: TagValueLoader;
-  tags: TagCollection;
-};
+}
 
 function IssueListFilters({
   organization,
@@ -28,11 +30,11 @@ function IssueListFilters({
   query,
   isSearchDisabled,
   sort,
-  onSidebarToggle,
   onSearch,
-  tagValueLoader,
-  tags,
+  location,
 }: Props) {
+  const pinnedSearch = savedSearch?.isPinned ? savedSearch : undefined;
+
   return (
     <SearchContainer>
       <PageFilterBar>
@@ -41,16 +43,19 @@ function IssueListFilters({
         <DatePageFilter alignDropdown="left" />
       </PageFilterBar>
       <IssueListSearchBar
+        searchSource="main_search"
         organization={organization}
         query={query || ''}
-        sort={sort}
         onSearch={onSearch}
         disabled={isSearchDisabled}
         excludedTags={['environment']}
-        supportedTags={tags}
-        tagValueLoader={tagValueLoader}
-        savedSearch={savedSearch}
-        onSidebarToggle={onSidebarToggle}
+        actionBarItems={[
+          makePinSearchAction({sort, pinnedSearch, location}),
+          makeSaveSearchAction({
+            sort,
+            disabled: !organization.access.includes('org:write'),
+          }),
+        ]}
       />
     </SearchContainer>
   );
@@ -68,4 +73,4 @@ const SearchContainer = styled('div')`
   }
 `;
 
-export default IssueListFilters;
+export default withRouter(IssueListFilters);

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1213,10 +1213,7 @@ class IssueListOverview extends Component<Props, State> {
               savedSearch={savedSearch}
               sort={this.getSort()}
               onSearch={this.onSearch}
-              onSidebarToggle={this.onSidebarToggle}
               isSearchDisabled={isSidebarVisible}
-              tagValueLoader={this.tagValueLoader}
-              tags={tags}
             />
 
             <Panel>


### PR DESCRIPTION
`<IssueListSearchBar />` is being used on the issue stream, in dashboards, and (soon) the create saved search modal.

Instead of having to define `tagValueLoader` in 3 places, this puts the logic in `<IssueListSearchBar />`. Props that are specific to the issue list were moved to `<IssueListFilters />`.