### PR TITLE
feat(monitors): Restrict monitor actions to organization admin properly

### DIFF
--- a/static/app/views/monitors/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/monitorHeaderActions.tsx
@@ -6,6 +6,7 @@ import {
   addLoadingMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
+import Access from 'sentry/components/acl/access';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Confirm from 'sentry/components/confirm';
@@ -22,6 +23,10 @@ type Props = {
   onUpdate: (data: Monitor) => void;
   orgId: string;
 };
+
+const DISABLED_TOOLTIP_TEXT = t(
+  'You must be an organization admin to perform this action'
+);
 
 const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
   const api = useApi();
@@ -65,31 +70,46 @@ const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
     });
 
   return (
-    <ButtonContainer>
-      <ButtonBar gap={1}>
-        <Button
-          size="sm"
-          icon={<IconEdit size="xs" />}
-          to={`/organizations/${orgId}/monitors/${monitor.id}/edit/`}
-        >
-          &nbsp;
-          {t('Edit')}
-        </Button>
-        <Button size="sm" onClick={toggleStatus}>
-          {monitor.status !== 'disabled' ? t('Pause') : t('Enable')}
-        </Button>
-        <Confirm
-          onConfirm={handleDelete}
-          message={t(
-            'Deleting this monitor is permanent. Are you sure you wish to continue?'
-          )}
-        >
-          <Button size="sm" icon={<IconDelete size="xs" />}>
-            {t('Delete')}
-          </Button>
-        </Confirm>
-      </ButtonBar>
-    </ButtonContainer>
+    <Access access={['project:write']}>
+      {({hasAccess}) => (
+        <ButtonContainer>
+          <ButtonBar gap={1}>
+            <Button
+              size="sm"
+              icon={<IconEdit size="xs" />}
+              to={`/organizations/${orgId}/monitors/${monitor.id}/edit/`}
+            >
+              {hasAccess ? t('Edit') : t('View Config')}
+            </Button>
+            <Button
+              size="sm"
+              onClick={toggleStatus}
+              disabled={!hasAccess}
+              title={DISABLED_TOOLTIP_TEXT}
+              tooltipProps={{disabled: hasAccess}}
+            >
+              {monitor.status !== 'disabled' ? t('Pause') : t('Enable')}
+            </Button>
+            <Confirm
+              onConfirm={handleDelete}
+              message={t(
+                'Deleting this monitor is permanent. Are you sure you wish to continue?'
+              )}
+              disabled={!hasAccess}
+            >
+              <Button
+                size="sm"
+                icon={<IconDelete size="xs" />}
+                title={DISABLED_TOOLTIP_TEXT}
+                tooltipProps={{disabled: hasAccess}}
+              >
+                {t('Delete')}
+              </Button>
+            </Confirm>
+          </ButtonBar>
+        </ButtonContainer>
+      )}
+    </Access>
   );
 };
 

--- a/static/app/views/monitors/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/monitorHeaderActions.tsx
@@ -25,7 +25,7 @@ type Props = {
 };
 
 const DISABLED_TOOLTIP_TEXT = t(
-  'You must be an organization admin to perform this action'
+  'These settings can only be edited by users with the organization owner, manager, or admin role.'
 );
 
 const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {


### PR DESCRIPTION
What admin sees:
<img width="1199" alt="image" src="https://user-images.githubusercontent.com/9372512/198154011-917e2e46-09ba-427c-8e48-709259c59b0b.png">

What member sees:
<img width="1191" alt="image" src="https://user-images.githubusercontent.com/9372512/198154085-d3f602c8-9eac-43f2-95e7-3bd51ef24079.png">
