### PR TITLE
feat(ecosystem): Display in-app frames as owner suggestions

### DIFF
--- a/static/app/views/settings/project/projectOwnership/modal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.spec.tsx
@@ -68,5 +68,6 @@ describe('Project Ownership', () => {
     expect(screen.getByText(/Match against Issue Data/)).toBeInTheDocument();
     // First in-app frame is suggested
     expect(screen.getByText('raven/base.py')).toBeInTheDocument();
+    expect(screen.getByText('https://example.com/path')).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/project/projectOwnership/modal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.spec.tsx
@@ -5,7 +5,6 @@ import ProjectOwnershipModal from './modal';
 describe('Project Ownership', () => {
   const org = TestStubs.Organization();
   const project = TestStubs.ProjectDetails();
-  const onSave = jest.fn();
   const issueId = '1234';
 
   beforeEach(() => {
@@ -54,7 +53,6 @@ describe('Project Ownership', () => {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
-    jest.clearAllMocks();
   });
 
   it('renders stacktrace suggestions', () => {
@@ -63,7 +61,7 @@ describe('Project Ownership', () => {
         issueId={issueId}
         organization={org}
         project={project}
-        onSave={onSave}
+        onSave={() => {}}
       />
     );
 

--- a/static/app/views/settings/project/projectOwnership/modal.spec.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.spec.tsx
@@ -1,0 +1,74 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ProjectOwnershipModal from './modal';
+
+describe('Project Ownership', () => {
+  const org = TestStubs.Organization();
+  const project = TestStubs.ProjectDetails();
+  const onSave = jest.fn();
+  const issueId = '1234';
+
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: `/issues/${issueId}/tags/url/`,
+      body: {
+        key: 'url',
+        name: 'URL',
+        uniqueValues: 1,
+        totalValues: 1,
+        topValues: [
+          {
+            key: 'url',
+            name: 'https://example.com/path',
+            value: 'https://example.com/path',
+            count: 1,
+            lastSeen: '2022-08-27T03:24:53Z',
+            firstSeen: '2022-08-27T03:24:53Z',
+          },
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/ownership/`,
+      body: {
+        fallthrough: false,
+        autoAssignment: 'Auto Assign to Suspect Commits',
+        codeownersAutoSync: false,
+        raw: null,
+      },
+    });
+    const stacktrace = TestStubs.EventEntryStacktrace();
+    // Set one frame to in-app
+    stacktrace.data.frames[0].inApp = true;
+    MockApiClient.addMockResponse({
+      url: `/issues/${issueId}/events/latest/`,
+      body: TestStubs.Event({
+        entries: [stacktrace],
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/members/`,
+      body: TestStubs.Members(),
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+  });
+
+  it('renders stacktrace suggestions', () => {
+    render(
+      <ProjectOwnershipModal
+        issueId={issueId}
+        organization={org}
+        project={project}
+        onSave={onSave}
+      />
+    );
+
+    expect(screen.getByText(/Match against Issue Data/)).toBeInTheDocument();
+    // First in-app frame is suggested
+    expect(screen.getByText('raven/base.py')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/settings/project/projectOwnership/modal.tsx
+++ b/static/app/views/settings/project/projectOwnership/modal.tsx
@@ -61,7 +61,7 @@ class ProjectOwnershipModal extends AsyncComponent<Props, State> {
       : [];
 
     // pull frame data out of exception or the stacktrace
-    const entry = (eventData?.entries as Entry[]).find(({type}) =>
+    const entry = (eventData?.entries as Entry[])?.find(({type}) =>
       ['exception', 'stacktrace'].includes(type)
     );
 
@@ -73,11 +73,8 @@ class ProjectOwnershipModal extends AsyncComponent<Props, State> {
       frames = entry?.data?.frames ?? [];
     }
 
-    // filter frames by inApp unless there would be 0
-    const inAppFrames = frames.filter(frame => frame.inApp);
-    if (inAppFrames.length > 0) {
-      frames = inAppFrames;
-    }
+    // Only display in-app frames
+    frames = frames.filter(frame => frame.inApp);
 
     const paths = uniq(frames.map(frame => frame.filename || frame.absPath || ''))
       .filter(i => i)


### PR DESCRIPTION
Do not show out of app paths as these are usually not helpful like node_modules

fixes https://getsentry.atlassian.net/browse/WOR-2253