### PR TITLE
fix(webpack): Use 127.0.0.1 loopback over locahost

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -520,7 +520,7 @@ if (
 
   if (!IS_UI_DEV_ONLY) {
     // This proxies to local backend server
-    const backendAddress = `http://localhost:${SENTRY_BACKEND_PORT}/`;
+    const backendAddress = `http://127.0.0.1:${SENTRY_BACKEND_PORT}/`;
     const relayAddress = 'http://127.0.0.1:7899';
 
     appConfig.devServer = {
@@ -603,7 +603,7 @@ if (IS_UI_DEV_ONLY || IS_DEPLOY_PREVIEW) {
     new HtmlWebpackPlugin({
       // Local dev vs vercel slightly differs...
       ...(IS_UI_DEV_ONLY
-        ? {devServer: `https://localhost:${SENTRY_WEBPACK_PROXY_PORT}`}
+        ? {devServer: `https://127.0.0.1:${SENTRY_WEBPACK_PROXY_PORT}`}
         : {}),
       favicon: path.resolve(sentryDjangoAppPath, 'images', 'favicon_dev.png'),
       template: path.resolve(staticPrefix, 'index.ejs'),


### PR DESCRIPTION
This fixes a problem with webpack devserver where localhost will now
sometimes fail to resolve to the IPv4 127.0.0.1 (and instead resolve to ::1)

This is because of Node 18, which we recently bumped to

> Node.js 17+ no longer prefers IPv4 over IPv6 for DNS lookups. E.g.
> It's not guaranteed that localhost will be resolved to 127.0.0.1 – it
> might just as well be ::1 (or some other IP address).

See: https://github.com/chimurai/http-proxy-middleware#nodejs-17-econnrefused-issue-with-ipv6-and-localhost-705