### PR TITLE
ref(ui): Remove deprecatedforms from AdminQuotas

### DIFF
--- a/static/app/views/admin/adminQuotas.tsx
+++ b/static/app/views/admin/adminQuotas.tsx
@@ -1,5 +1,9 @@
-import TextField from 'sentry/components/deprecatedforms/textField';
+import {Fragment} from 'react';
+
+import TextField from 'sentry/components/forms/fields/textField';
 import InternalStatChart from 'sentry/components/internalStatChart';
+import {Panel, PanelBody, PanelHeader} from 'sentry/components/panels';
+import {t} from 'sentry/locale';
 import AsyncView from 'sentry/views/asyncView';
 
 type Config = {
@@ -29,49 +33,55 @@ export default class AdminQuotas extends AsyncView<{}, State> {
   renderBody() {
     const {config} = this.state;
     return (
-      <div>
+      <Fragment>
         <h3>Quotas</h3>
 
-        <div className="box">
-          <div className="box-header">
-            <h4>Config</h4>
-          </div>
-
-          <div className="box-content with-padding">
-            <TextField name="backend" value={config.backend} label="Backend" disabled />
+        <Panel>
+          <PanelHeader>{t('Config')}</PanelHeader>
+          <PanelBody withPadding>
+            <TextField
+              name="backend"
+              value={config.backend}
+              label="Backend"
+              disabled
+              inline={false}
+              stacked
+            />
             <TextField
               name="rateLimit"
               value={config.options['system.rate-limit']}
               label="Rate Limit"
               disabled
+              inline={false}
+              stacked
             />
-          </div>
-        </div>
+          </PanelBody>
+        </Panel>
 
-        <div className="box">
-          <div className="box-header">
-            <h4>Total Events</h4>
-          </div>
-          <InternalStatChart
-            since={this.state.since}
-            resolution={this.state.resolution}
-            stat="events.total"
-            label="Events"
-          />
-        </div>
+        <Panel>
+          <PanelHeader>{t('Total Events')}</PanelHeader>
+          <PanelBody withPadding>
+            <InternalStatChart
+              since={this.state.since}
+              resolution={this.state.resolution}
+              stat="events.total"
+              label="Events"
+            />
+          </PanelBody>
+        </Panel>
 
-        <div className="box">
-          <div className="box-header">
-            <h4>Dropped Events</h4>
-          </div>
-          <InternalStatChart
-            since={this.state.since}
-            resolution={this.state.resolution}
-            stat="events.dropped"
-            label="Events"
-          />
-        </div>
-      </div>
+        <Panel>
+          <PanelHeader>{t('Dropped Events')}</PanelHeader>
+          <PanelBody withPadding>
+            <InternalStatChart
+              since={this.state.since}
+              resolution={this.state.resolution}
+              stat="events.dropped"
+              label="Events"
+            />
+          </PanelBody>
+        </Panel>
+      </Fragment>
     );
   }
 }


### PR DESCRIPTION
Also switches over to using Panels instead of box classes

Before
<img width="1652" alt="image" src="https://user-images.githubusercontent.com/1421724/198192505-1c02dac3-92a8-498e-91b8-10c3f26e4716.png">

After
<img width="1652" alt="image" src="https://user-images.githubusercontent.com/1421724/198192533-559b2004-df70-42c0-bac4-64242b06e072.png">
