### PR TITLE
fix(sidebar): strip off query params for route checking

### DIFF
--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -109,9 +109,14 @@ const SidebarItem = ({
   if (isValidElement(label)) {
     labelString = label?.props?.children ?? label;
   }
+  // take off the query params for matching
+  const toPathWithourReferrer = to?.split('?')[0];
   // If there is no active panel open and if path is active according to react-router
   const isActiveRouter =
-    (!hasPanel && router && to && location.pathname.startsWith(to)) ||
+    (!hasPanel &&
+      router &&
+      toPathWithourReferrer &&
+      location.pathname.startsWith(toPathWithourReferrer)) ||
     (labelString === 'Discover' && location.pathname.includes('/discover/')) ||
     (labelString === 'Dashboards' &&
       (location.pathname.includes('/dashboards/') ||


### PR DESCRIPTION
This fixes a bug where we don't show the issues tab as being highlighted because the `to` URL contains a query param. This PR strips out the query param when performing matching logic.