### PR TITLE
feat(analytics): adds referrer to event toolbar

### DIFF
--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -169,13 +169,22 @@ class GroupEventToolbar extends Component<Props> {
             hasPrevious={!!evt.previousEventID}
             hasNext={!!evt.nextEventID}
             links={[
-              {pathname: `${baseEventsPath}oldest/`, query: location.query},
+              {
+                pathname: `${baseEventsPath}oldest/`,
+                query: {...location.query, referrer: 'oldest-event'},
+              },
               {
                 pathname: `${baseEventsPath}${evt.previousEventID}/`,
-                query: location.query,
+                query: {...location.query, referrer: 'previous-event'},
               },
-              {pathname: `${baseEventsPath}${evt.nextEventID}/`, query: location.query},
-              {pathname: `${baseEventsPath}latest/`, query: location.query},
+              {
+                pathname: `${baseEventsPath}${evt.nextEventID}/`,
+                query: {...location.query, referrer: 'next-event'},
+              },
+              {
+                pathname: `${baseEventsPath}latest/`,
+                query: {...location.query, referrer: 'latest-event'},
+              },
             ]}
             onOldestClick={() => this.handleNavigationClick('oldest')}
             onOlderClick={() => this.handleNavigationClick('older')}


### PR DESCRIPTION
This PR adds a `referrer` for the links on the event toolbar to oldest/older/newer/newest events. This will help with analytics.