### PR TITLE
feat(releases): writes user agent when creating a release

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -475,6 +475,7 @@ class OrganizationReleasesEndpoint(
                             "owner": result.get("owner"),
                             "date_released": result.get("dateReleased"),
                             "status": new_status or ReleaseStatus.OPEN,
+                            "user_agent": request.META.get("HTTP_USER_AGENT", ""),
                         },
                     )
                 except IntegrityError:

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -475,7 +475,7 @@ class OrganizationReleasesEndpoint(
                             "owner": result.get("owner"),
                             "date_released": result.get("dateReleased"),
                             "status": new_status or ReleaseStatus.OPEN,
-                            "user_agent": request.META.get("HTTP_USER_AGENT", ""),
+                            "user_agent": request.META.get("HTTP_USER_AGENT", "")[:256],
                         },
                     )
                 except IntegrityError:

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -131,6 +131,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                                 owner=result.get("owner"),
                                 date_released=result.get("dateReleased"),
                                 status=new_status or ReleaseStatus.OPEN,
+                                user_agent=request.META.get("HTTP_USER_AGENT", ""),
                             ),
                             True,
                         )

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -182,7 +182,7 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                     user_id=request.user.id if request.user and request.user.id else None,
                     organization_id=project.organization_id,
                     project_ids=[project.id],
-                    user_agent=request.META.get("HTTP_USER_AGENT", ""),
+                    user_agent=request.META.get("HTTP_USER_AGENT", "")[:256],
                     created_status=status,
                 )
                 scope.set_tag("success_status", status)

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1130,7 +1130,7 @@ class OrganizationReleaseCreateTest(APITestCase):
             HTTP_USER_AGENT="sentry-cli/2.77.4",
         )
 
-        assert response.status_code == 201, response.contentpy
+        assert response.status_code == 201, response.content
         assert response.data["version"]
 
         release = Release.objects.get(

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1125,13 +1125,17 @@ class OrganizationReleaseCreateTest(APITestCase):
 
         url = reverse("sentry-api-0-organization-releases", kwargs={"organization_slug": org.slug})
         response = self.client.post(
-            url, data={"version": "1.2.1", "projects": [project.slug, project2.slug]}
+            url,
+            data={"version": "1.2.1", "projects": [project.slug, project2.slug]},
+            HTTP_USER_AGENT="sentry-cli/2.77.4",
         )
 
-        assert response.status_code == 201, response.content
+        assert response.status_code == 201, response.contentpy
         assert response.data["version"]
 
-        release = Release.objects.get(version=response.data["version"])
+        release = Release.objects.get(
+            version=response.data["version"], user_agent="sentry-cli/2.77.4"
+        )
         assert not release.owner
         assert release.organization == org
         assert ReleaseProject.objects.filter(release=release, project=project).exists()

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -325,12 +325,19 @@ class ProjectReleaseCreateTest(APITestCase):
             "sentry-api-0-project-releases",
             kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
         )
-        response = self.client.post(url, data={"version": "1.2.1"})
+        response = self.client.post(
+            url,
+            data={"version": "1.2.1"},
+            HTTP_USER_AGENT="sentry-cli/2.77.4",
+        )
 
         assert response.status_code == 201, response.content
         assert response.data["version"]
 
-        release = Release.objects.get(version=response.data["version"])
+        release = Release.objects.get(
+            version=response.data["version"],
+            user_agent="sentry-cli/2.77.4",
+        )
         assert not release.owner
         assert release.organization == project.organization
         assert release.projects.first() == project


### PR DESCRIPTION
This PR starts writing the new `user_agent` column using the user agent that created the release.