### PR TITLE
feat(analytics): adds analytics event for first event for project

### DIFF
--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -1,6 +1,7 @@
 from sentry import analytics
 
 
+# first error for that organization
 class FirstEventSentEvent(analytics.Event):
     type = "first_event.sent"
 
@@ -12,4 +13,10 @@ class FirstEventSentEvent(analytics.Event):
     )
 
 
+# first error for that project
+class FirstEventSentEventForProject(FirstEventSentEvent):
+    type = "first_event_for_project.sent"
+
+
 analytics.register(FirstEventSentEvent)
+analytics.register(FirstEventSentEventForProject)

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -142,7 +142,7 @@ def record_first_event(project, event, **kwargs):
         )
         return
 
-    # thise event fires once per project
+    # this event fires once per project
     analytics.record(
         "first_event_for_project.sent",
         user_id=user.id,

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -142,7 +142,17 @@ def record_first_event(project, event, **kwargs):
         )
         return
 
+    # thise event fires once per project
+    analytics.record(
+        "first_event_for_project.sent",
+        user_id=user.id,
+        organization_id=project.organization_id,
+        project_id=project.id,
+        platform=event.platform,
+    )
+
     if rows_affected or created:
+        # this event only fires once per org
         analytics.record(
             "first_event.sent",
             user_id=user.id,


### PR DESCRIPTION
This PR adds a new analytics event (`first_event_for_project.sent`) that fires whenever a project gets a first event. Note we already have the `first_event.sent` event but that only fires at most once per organization.