### PR TITLE
fix(widget-builder): Update text to clarify why filters are disabled

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -107,9 +107,11 @@ export function FilterResultsStep({
       description={
         canAddSearchConditions
           ? t(
-              'This is how you filter down your search. You can add multiple queries to compare data for each overlay.'
+              'Projects, environments, and date range have been preselected at the dashboard level. Filter down your search here. You can add multiple queries to compare data for each overlay.'
             )
-          : t('This is how you filter down your search.')
+          : t(
+              'Projects, environments, and date range have been preselected at the dashboard level. Filter down your search here.'
+            )
       }
     >
       <Feature features={['dashboards-top-level-filter']}>


### PR DESCRIPTION
A number of people have commented on not understanding why the page filters appear disabled. Updating the text copy to make this clearer.
