### PR TITLE
ref: expand timeouts

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -67,7 +67,7 @@ jobs:
     needs: files-changed
     name: backend test
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)
@@ -112,7 +112,7 @@ jobs:
     needs: files-changed
     name: backend test (snuba contains metrics tag values)
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
+    timeout-minutes: 40
     strategy:
       # This helps not having to run multiple jobs because one fails, thus, reducing resource usage
       # and reducing the risk that one of many runs would turn red again (read: intermittent tests)


### PR DESCRIPTION
right now timeouts are within ~5% of expected meaning a small change in runner performance can waste a lot of dev time




<!-- Describe your PR here. -->