### PR TITLE
feat(analytics): disable route analytics for issue list and performance home page

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -194,8 +194,8 @@ class IssueListOverview extends Component<Props, State> {
     this.fetchSavedSearches();
     this.fetchTags();
     this.fetchMemberList();
-    // let custom anaylytics take control
-    this.props.setDisableRouteAnalytics();
+    // let custom analytics take control
+    this.props.setDisableRouteAnalytics?.();
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -50,6 +50,9 @@ import parseApiError from 'sentry/utils/parseApiError';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {decodeScalar} from 'sentry/utils/queryString';
+import withRouteAnalytics, {
+  WithRouteAnalyticsProps,
+} from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import withApi from 'sentry/utils/withApi';
 import withIssueTags from 'sentry/utils/withIssueTags';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -93,7 +96,8 @@ type Props = {
   savedSearches: SavedSearch[];
   selection: PageFilters;
   tags: TagCollection;
-} & RouteComponentProps<{searchId?: string}, {}>;
+} & RouteComponentProps<{searchId?: string}, {}> &
+  WithRouteAnalyticsProps;
 
 type State = {
   actionTaken: boolean;
@@ -190,6 +194,8 @@ class IssueListOverview extends Component<Props, State> {
     this.fetchSavedSearches();
     this.fetchTags();
     this.fetchMemberList();
+    // let custom anaylytics take control
+    this.props.setDisableRouteAnalytics();
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
@@ -1289,9 +1295,11 @@ class IssueListOverview extends Component<Props, State> {
   }
 }
 
-export default withApi(
-  withPageFilters(
-    withSavedSearches(withOrganization(withIssueTags(withProfiler(IssueListOverview))))
+export default withRouteAnalytics(
+  withApi(
+    withPageFilters(
+      withSavedSearches(withOrganization(withIssueTags(withProfiler(IssueListOverview))))
+    )
   )
 );
 

--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -17,6 +17,7 @@ import {
   METRIC_SEARCH_SETTING_PARAM,
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {PerformanceEventViewProvider} from 'sentry/utils/performance/contexts/performanceEventViewContext';
+import useDisableRouteAnalytics from 'sentry/utils/routeAnalytics/useDisableRouteAnalytics';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
@@ -48,6 +49,8 @@ function PerformanceContent({selection, location, demoMode, router}: Props) {
   const {projects} = useProjects();
   const mounted = useRef(false);
   const previousDateTime = usePrevious(selection.datetime);
+  // TODO: remove the trackAdvancedAnalyticsEvent call and use useRouteAnalyticsParams instead
+  useDisableRouteAnalytics();
 
   const [state, setState] = useState<State>({error: undefined});
   const withStaticFilters = canUseMetricsData(organization);


### PR DESCRIPTION
The page view events for the issue list and performance home page are very high volume. In order to reduce the impact of turning on the feature flag for route analytics, I am disabling route analytics for these very high volume events. The rest are low enough volume that we can tackle after we turn the feature flag to 100%.