### PR TITLE
ref(mep): Add flag to reintroduce histograms

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1147,6 +1147,8 @@ SENTRY_FEATURES = {
     "organizations:performance-span-tree-autoscroll": False,
     # Enable transaction name only search
     "organizations:performance-transaction-name-only-search": False,
+    # Re-enable histograms for Metrics Enhanced Performance Views
+    "organizations:performance-mep-reintroduce-histograms": False,
     # Enable showing INP web vital in default views
     "organizations:performance-vitals-inp": False,
     # Enable processing transactions in post_process_group

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -135,6 +135,7 @@ default_manager.add("organizations:performance-suspect-spans-view", Organization
 default_manager.add("organizations:performance-transaction-name-only-search", OrganizationFeature, True)
 default_manager.add("organizations:performance-use-metrics", OrganizationFeature, True)
 default_manager.add("organizations:performance-vitals-inp", OrganizationFeature, True)
+default_manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, True)
 default_manager.add("organizations:profiling", OrganizationFeature)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)
 default_manager.add("organizations:project-stats", OrganizationFeature, True)


### PR DESCRIPTION
### Summary
This will let us try out histograms again for various accounts, and disable them if they still don't high enough fidelity with 
processed events.

