### PR TITLE
chore(migrations): Improve message for adding a not null column with a default

### DIFF
--- a/src/sentry/db/postgres/schema.py
+++ b/src/sentry/db/postgres/schema.py
@@ -11,8 +11,8 @@ from django_zero_downtime_migrations.backends.postgres.schema import (
 
 unsafe_mapping = {
     Unsafe.ADD_COLUMN_DEFAULT: (
-        "Adding {}.{} as column with a default is unsafe.\n"
-        "More info: https://develop.sentry.dev/database-migrations/#adding-columns-with-a-default"
+        "Adding {}.{} as column with a default is safe, but you need to take additional steps.\n"
+        "Follow this guide: https://develop.sentry.dev/database-migrations/#adding-columns-with-a-default"
     ),
     Unsafe.ADD_COLUMN_NOT_NULL: (
         "Adding {}.{} as a not null column is unsafe.\n"

--- a/tests/sentry/db/postgres/schema/safe_migrations/integration/test_migrations.py
+++ b/tests/sentry/db/postgres/schema/safe_migrations/integration/test_migrations.py
@@ -38,7 +38,7 @@ class AddColWithDefaultTest(BaseSafeMigrationTest):
     def test(self):
         with pytest.raises(
             UnsafeOperationException,
-            match="Adding TestTable.field as column with a default is unsafe.",
+            match="Adding TestTable.field as column with a default is safe, but you need to take additional steps.",
         ):
             self.run_migration()
 
@@ -51,7 +51,7 @@ class AddColWithNotNullDefaultTest(BaseSafeMigrationTest):
     def test(self):
         with pytest.raises(
             UnsafeOperationException,
-            match="Adding TestTable.field as column with a default is unsafe.",
+            match="Adding TestTable.field as column with a default is safe, but you need to take additional steps.",
         ):
             self.run_migration()
 


### PR DESCRIPTION
I've noticed a few people getting this message and changing their migration to have a nullable column instead.
Just improving this message to make it clearer how to add a not null col with a default.
