### PR TITLE
ref(mep): Re-add histograms to UI

### DIFF
--- a/static/app/views/performance/landing/widgets/utils.tsx
+++ b/static/app/views/performance/landing/widgets/utils.tsx
@@ -136,6 +136,9 @@ export function filterAllowedChartsMetrics(
 ) {
   if (
     !canUseMetricsData(organization) ||
+    organization.features.includes(
+      'organizations:performance-mep-reintroduce-histograms'
+    ) ||
     mepSetting.metricSettingState === MEPState.transactionsOnly
   ) {
     return allowedCharts;


### PR DESCRIPTION
### Summary
This uses a new flag to let us roll histograms back out for processed event views. There still might be issues with outlier data since the histograms are backed by a probabilistic data structure, so the flag will act as a switch in case visualization quality isn't high enough.



