### PR TITLE
feat(suspect-spans): Add CLI script for testing hashing output

### DIFF
--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -72,6 +72,8 @@ for cmd in map(
         "sentry.runner.commands.devservices.devservices",
         "sentry.runner.commands.performance.performance",
         "sentry.runner.commands.performance.detect",
+        "sentry.runner.commands.spans.spans",
+        "sentry.runner.commands.spans.write_hashes",
     ),
 ):
     cli.add_command(cmd)

--- a/src/sentry/runner/commands/spans.py
+++ b/src/sentry/runner/commands/spans.py
@@ -21,7 +21,9 @@ def spans() -> None:
 @configuration
 def write_hashes(filename):
     """
-    Given a JSON file, runs span groupings on it, and writes to the file.
+    Runs span hash grouping on event data in the supplied filename using the
+    default grouping strategy. Write the results to a copy of the file.
+    Filename should be a path to a JSON event data file.
     """
 
     [head, tail] = os.path.split(filename)

--- a/src/sentry/runner/commands/spans.py
+++ b/src/sentry/runner/commands/spans.py
@@ -1,0 +1,46 @@
+import os
+import shutil
+
+import click
+
+from sentry.runner.decorators import configuration
+from sentry.spans.grouping.api import load_span_grouping_config
+from sentry.spans.grouping.strategy.config import DEFAULT_CONFIG_ID
+from sentry.utils import json
+
+
+@click.group()
+def spans() -> None:
+    """
+    Span utilities
+    """
+
+
+@spans.command()
+@click.argument("filename", type=click.Path(exists=True))
+@configuration
+def write_hashes(filename):
+    """
+    Given a JSON file, runs span groupings on it, and writes to the file.
+    """
+
+    [head, tail] = os.path.split(filename)
+    new_filename = f"{head}/hashed-{tail}"
+
+    shutil.copy(filename, new_filename)
+
+    with open(filename) as in_file:
+        data = json.loads(in_file.read())
+
+    click.echo(f"Event ID: {data['event_id']}")
+    click.echo("Writing span hashes")
+
+    config = load_span_grouping_config({"id": DEFAULT_CONFIG_ID})
+    results = config.execute_strategy(data)
+
+    with open(new_filename, "w") as out_file:
+        results.write_to_event(data)
+        out_file.write(json.dumps(data, indent=4))
+
+    click.echo("Done")
+    click.echo("\n")


### PR DESCRIPTION
Adds a CLI script for testing our spans hashes. Given a file, runs grouping, and writes the result to a new JSON file.

**e.g.,**
```bash
~/C/s/sentry (feat/add-cli-detector-tooling) sentry spans write-hashes ~/Desktop/fc6ef7f890b84657a6c575c06ff9caef.json
```
