### PR TITLE
feat(replays): Add Replay column to new all-events table

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -413,7 +413,7 @@ const SPECIAL_FIELDS: SpecialFields = {
     renderFunc: data => {
       const id: string | unknown = data?.trace;
       if (typeof id !== 'string') {
-        return null;
+        return emptyValue;
       }
 
       return <Container>{getShortEventId(id)}</Container>;
@@ -440,7 +440,7 @@ const SPECIAL_FIELDS: SpecialFields = {
     renderFunc: data => {
       const replayId = data?.replayId;
       if (typeof replayId !== 'string' || !replayId) {
-        return null;
+        return emptyValue;
       }
 
       return (

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -30,6 +30,8 @@ const AllEventsTable = (props: Props) => {
   } = props;
   const [error, setError] = useState<string>('');
   const routes = useRoutes();
+
+  const isReplayEnabled = organization.features.includes('session-replay-ui');
   const fields: string[] = [
     'id',
     'transaction',
@@ -39,6 +41,7 @@ const AllEventsTable = (props: Props) => {
     'user.display',
     ...(isPerfIssue ? ['transaction.duration'] : []),
     'timestamp',
+    ...(isReplayEnabled ? ['replayId'] : []),
   ];
 
   const eventView: EventView = EventView.fromLocation(props.location);
@@ -65,6 +68,7 @@ const AllEventsTable = (props: Props) => {
     t('user'),
     ...(isPerfIssue ? [t('total duration')] : []),
     t('timestamp'),
+    ...(isReplayEnabled ? [t('replay')] : []),
     t('minidump'),
   ];
 


### PR DESCRIPTION
Make sure the replay column exists on the new All Events table. The old table had the column, but it wasn't brought over here yet.

Also, show `(no value)` when there is no Trace Id or Replay associated (instead of leaving the cell empty)

<img width="1237" alt="Screen Shot 2022-10-27 at 1 24 37 PM" src="https://user-images.githubusercontent.com/187460/198391197-3942c494-a026-4879-a853-08c1daef1d19.png">
<img width="149" alt="Screen Shot 2022-10-27 at 1 25 03 PM" src="https://user-images.githubusercontent.com/187460/198391204-741d8d0f-df61-436d-8351-d4bc2208923d.png">
