### PR TITLE
feat(replays): Allow replay as a search type

### DIFF
--- a/src/sentry/models/search_common.py
+++ b/src/sentry/models/search_common.py
@@ -5,3 +5,4 @@ class SearchType(IntEnum):
     ISSUE = 0
     EVENT = 1
     SESSION = 2
+    REPLAY = 3


### PR DESCRIPTION
This will allow us to have our own list from `/recent-searches/` for example.

This is the backend change, the front-end is updated in https://github.com/getsentry/sentry/pull/40677 to match.