### PR TITLE
feat(replays): Allow replay as a search type, ex for /recent-searches/

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -40,6 +40,7 @@ export enum SavedSearchType {
   ISSUE = 0,
   EVENT = 1,
   SESSION = 2,
+  REPLAY = 3,
 }
 
 export enum IssueCategory {


### PR DESCRIPTION
This will allow us to have our own list from `/recent-searches/` for example.

This is the front-end change
Depends on: https://github.com/getsentry/sentry/pull/40676
Will be put to use in https://github.com/getsentry/sentry/pull/40683