### PR TITLE
feat(replays): Allow organization-tagkey-values endpoint to lookup from Replay dataset

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -45,6 +45,7 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
                     order_by=validate_sort_field(request.GET.get("sort", "-last_seen")),
                     include_transactions=request.GET.get("includeTransactions") == "1",
                     include_sessions=request.GET.get("includeSessions") == "1",
+                    include_replays=request.GET.get("includeReplays") == "1",
                 )
 
         return self.paginate(

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -985,6 +985,7 @@ class SnubaTagStorage(TagStorage):
         order_by="-last_seen",
         include_transactions=False,
         include_sessions=False,
+        include_replays=False,
     ):
         from sentry.api.paginator import SequencePaginator
 
@@ -999,6 +1000,8 @@ class SnubaTagStorage(TagStorage):
         dataset = Dataset.Events
         if include_transactions:
             dataset = Dataset.Discover
+        if include_replays:
+            dataset = Dataset.Replays
 
         snuba_key = snuba.get_snuba_column_name(key, dataset=dataset)
 


### PR DESCRIPTION
This is the backend setup. The frontend is keeping up with https://github.com/getsentry/sentry/pull/40679