### PR TITLE
fix(replays): Replay Index header css tweak

### DIFF
--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -56,9 +56,7 @@ function Replays({location}: Props) {
     <Fragment>
       <StyledPageHeader>
         <HeaderTitle>
-          <div>
-            {t('Replays')} <ReplaysFeatureBadge />
-          </div>
+          {t('Replays')} <ReplaysFeatureBadge space={1} />
         </HeaderTitle>
       </StyledPageHeader>
       <PageFiltersContainer>
@@ -112,8 +110,6 @@ const StyledPageContent = styled(PageContent)`
 
 const HeaderTitle = styled(PageHeading)`
   display: flex;
-  align-items: center;
-  justify-content: space-between;
   flex: 1;
 `;
 


### PR DESCRIPTION
Checkout the visual snapshot differences... just sucking in some extra spacing between the title and badge.

**Before** there was weird extra space inside, and the extra `<div>`
<img width="227" alt="Screen Shot 2022-10-27 at 1 46 16 PM" src="https://user-images.githubusercontent.com/187460/198394700-ba3c7716-10f4-47b7-9c41-837012bb72f3.png">

**After**
<img width="422" alt="Screen Shot 2022-10-27 at 1 46 03 PM" src="https://user-images.githubusercontent.com/187460/198394688-e5116f82-b0c1-4337-bd42-d588ca1220b2.png">
