### PR TITLE
ref(searchBar): Account for controlled query values

### DIFF
--- a/static/app/components/searchBar.tsx
+++ b/static/app/components/searchBar.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
@@ -17,7 +17,7 @@ interface SearchBarProps extends Omit<InputProps, 'onChange'> {
 }
 
 function SearchBar({
-  query: controlledQuery,
+  query: queryProp,
   defaultQuery = '',
   onChange,
   onSearch,
@@ -28,16 +28,16 @@ function SearchBar({
 }: SearchBarProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const [uncontrolledQuery, setUncontrolledQuery] = useState(defaultQuery);
-  const query = useMemo(
-    () => controlledQuery ?? uncontrolledQuery,
-    [controlledQuery, uncontrolledQuery]
-  );
+  const [query, setQuery] = useState(queryProp ?? defaultQuery);
+
+  useEffect(() => {
+    setQuery(queryProp ?? '');
+  }, [queryProp]);
 
   const onQueryChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const {value} = e.target;
-      setUncontrolledQuery(value);
+      setQuery(value);
       onChange?.(value);
     },
     [onChange]
@@ -53,7 +53,7 @@ function SearchBar({
   );
 
   const clearSearch = useCallback(() => {
-    setUncontrolledQuery('');
+    setQuery('');
     onChange?.('');
     onSearch?.('');
   }, [onChange, onSearch]);

--- a/static/app/components/searchBar.tsx
+++ b/static/app/components/searchBar.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useRef, useState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
@@ -17,7 +17,7 @@ interface SearchBarProps extends Omit<InputProps, 'onChange'> {
 }
 
 function SearchBar({
-  query: queryProp,
+  query: controlledQuery,
   defaultQuery = '',
   onChange,
   onSearch,
@@ -28,12 +28,16 @@ function SearchBar({
 }: SearchBarProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const [query, setQuery] = useState(queryProp ?? defaultQuery);
+  const [uncontrolledQuery, setUncontrolledQuery] = useState(defaultQuery);
+  const query = useMemo(
+    () => controlledQuery ?? uncontrolledQuery,
+    [controlledQuery, uncontrolledQuery]
+  );
 
   const onQueryChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const {value} = e.target;
-      setQuery(value);
+      setUncontrolledQuery(value);
       onChange?.(value);
     },
     [onChange]
@@ -49,7 +53,7 @@ function SearchBar({
   );
 
   const clearSearch = useCallback(() => {
-    setQuery('');
+    setUncontrolledQuery('');
     onChange?.('');
     onSearch?.('');
   }, [onChange, onSearch]);


### PR DESCRIPTION
With the way it's currently implemented, `SearchBar`'s `query` prop acts more as a default value rather than a controlled value. If we change the value passed through `query` after `SearchBar` has mounted, `SearchBar` will not be updated with the new value ([suspect PR](https://github.com/getsentry/sentry/pull/37955)). This PR fixes that.