### PR TITLE
feat(growth): modifies guide assistant endpoint

### DIFF
--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -88,14 +88,14 @@ class AssistantEndpoint(Endpoint):
         useful = data.get("useful")
 
         fields = {}
-        if status == Status.RESTART:
+        if status == Status.RESTART.value:
             AssistantActivity.objects.filter(user=request.user, guide_id=guide_id).delete()
         else:
             if useful is not None:
                 fields["useful"] = useful
-            if status == Status.VIEWED:
+            if status == Status.VIEWED.value:
                 fields["viewed_ts"] = timezone.now()
-            elif status == Status.DISMISSED:
+            elif status == Status.DISMISSED.value:
                 fields["dismissed_ts"] = timezone.now()
 
             try:

--- a/tests/sentry/api/endpoints/test_assistant.py
+++ b/tests/sentry/api/endpoints/test_assistant.py
@@ -88,3 +88,13 @@ class AssistantActivityUpdateTest(APITestCase):
         activity = AssistantActivity.objects.get(user=self.user, guide_id=self.guides[guide])
         assert activity.viewed_ts
         assert not activity.dismissed_ts
+
+    def test_restart(self):
+        guide = "issue_stream"
+        resp = self.get_response(guide=guide, status="viewed")
+        assert resp.status_code == 201
+
+        self.get_response(guide=guide, status="restart")
+        assert not AssistantActivity.objects.filter(
+            user=self.user, guide_id=self.guides[guide]
+        ).exists()


### PR DESCRIPTION
this PR modifies the assistant endpoint so that guides can be restarted for the new sandbox walkthrough project. allows for the restart tour button in the end modal in https://github.com/getsentry/sentry/pull/40687 to work