### PR TITLE
fix(perf_issues): Set `is_new` correctly when we fail to create a perf issue due to a race condition

### DIFF
--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2896,10 +2896,13 @@ class TestSaveGroupHashAndGroup(TransactionTestCase):
         perf_data = load_data("transaction-n-plus-one", timestamp=before_now(minutes=10))
         event = _get_event_instance(perf_data, project_id=self.project.id)
         group_hash = "some_group"
-        group = _save_grouphash_and_group(self.project, event, group_hash)
-        group_2 = _save_grouphash_and_group(self.project, event, group_hash)
+        group, created = _save_grouphash_and_group(self.project, event, group_hash)
+        assert created
+        group_2, created = _save_grouphash_and_group(self.project, event, group_hash)
         assert group.id == group_2.id
+        assert not created
         assert Group.objects.filter(grouphash__hash=group_hash).count() == 1
-        group_3 = _save_grouphash_and_group(self.project, event, "new_hash")
+        group_3, created = _save_grouphash_and_group(self.project, event, "new_hash")
+        assert created
         assert group_2.id != group_3.id
         assert Group.objects.filter(grouphash__hash=group_hash).count() == 1


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/40431 fixed a race condition when creating performance issues. 
However we would always set `is_new=True` for these issues, which could result in us sending duplicate 
notifications on some rule types.

Fixing this here by storing the creation status as `is_new` instead of hardcoding.