### PR TITLE
fix(replays): add default user_id  to first replay_event url sent

### DIFF
--- a/src/sentry/analytics/events/first_replay_sent.py
+++ b/src/sentry/analytics/events/first_replay_sent.py
@@ -8,6 +8,7 @@ class FirstReplaySentEvent(analytics.Event):
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id"),
         analytics.Attribute("platform", required=False),
+        analytics.Attribute("default_user_id", required=False),
     )
 
 

--- a/src/sentry/analytics/events/first_replay_sent.py
+++ b/src/sentry/analytics/events/first_replay_sent.py
@@ -8,7 +8,7 @@ class FirstReplaySentEvent(analytics.Event):
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id"),
         analytics.Attribute("platform", required=False),
-        analytics.Attribute("default_user_id", required=False),
+        analytics.Attribute("user_id", required=False),
     )
 
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -224,15 +224,10 @@ def record_first_profile(project, **kwargs):
 
 @first_replay_received.connect(weak=False)
 def record_first_replay(project, **kwargs):
-    try:
-        default_user_id = project.organization.get_default_owner().id
-    except IndexError:
-        default_user_id = None
-
     project.update(flags=F("flags").bitor(Project.flags.has_replays))
     analytics.record(
         "first_replay.sent",
-        default_user_id=default_user_id,
+        user_id=project.organization.default_owner_id,
         organization_id=project.organization_id,
         project_id=project.id,
         platform=project.platform,

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -224,9 +224,15 @@ def record_first_profile(project, **kwargs):
 
 @first_replay_received.connect(weak=False)
 def record_first_replay(project, **kwargs):
+    try:
+        default_user_id = project.organization.get_default_owner().id
+    except IndexError:
+        default_user_id = None
+
     project.update(flags=F("flags").bitor(Project.flags.has_replays))
     analytics.record(
         "first_replay.sent",
+        default_user_id=default_user_id,
         organization_id=project.organization_id,
         project_id=project.id,
         platform=project.platform,

--- a/tests/sentry/replays/consumers/recording_consumer/test_consumer.py
+++ b/tests/sentry/replays/consumers/recording_consumer/test_consumer.py
@@ -89,6 +89,7 @@ class TestRecordingsConsumerEndToEnd(TransactionTestCase):
             organization_id=self.organization.id,
             project_id=self.project.id,
             platform=self.project.platform,
+            user_id=self.organization.default_owner_id,
         )
 
     def test_duplicate_segment_flow(self):


### PR DESCRIPTION
events need user_id to be considered valid for analytics.