### PR TITLE
ref(forms): Avoid InputField indirection

### DIFF
--- a/static/app/components/forms/fields/booleanField.tsx
+++ b/static/app/components/forms/fields/booleanField.tsx
@@ -1,9 +1,11 @@
 import {Component} from 'react';
 
 import Confirm from 'sentry/components/confirm';
+import FormField from 'sentry/components/forms/formField';
 import Switch from 'sentry/components/switchButton';
 
-import InputField, {InputFieldProps, OnEvent} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps, OnEvent} from './inputField';
 
 export interface BooleanFieldProps extends InputFieldProps {
   confirm?: {
@@ -33,10 +35,9 @@ export default class BooleanField extends Component<BooleanFieldProps> {
     const {confirm, ...fieldProps} = this.props;
 
     return (
-      <InputField
-        {...fieldProps}
-        resetOnError
-        field={({
+      <FormField {...fieldProps} resetOnError>
+        {({
+          children: _children,
           onChange,
           onBlur,
           value,
@@ -48,6 +49,7 @@ export default class BooleanField extends Component<BooleanFieldProps> {
           onChange: OnEvent;
           type: string;
           value: any;
+          children?: React.ReactNode;
         }) => {
           // Create a function with required args bound
           const handleChange = this.handleChange.bind(this, value, onChange, onBlur);
@@ -89,7 +91,7 @@ export default class BooleanField extends Component<BooleanFieldProps> {
 
           return <Switch {...switchProps} />;
         }}
-      />
+      </FormField>
     );
   }
 }

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -8,12 +8,14 @@ import DropdownButton from 'sentry/components/dropdownButton';
 import SelectControl, {
   ControlProps,
 } from 'sentry/components/forms/controls/selectControl';
+import FormField from 'sentry/components/forms/formField';
 import {IconAdd, IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {defined, objectIsEmpty} from 'sentry/utils';
 
-import InputField, {InputFieldProps} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps} from './inputField';
 
 interface DefaultProps {
   /**
@@ -246,11 +248,12 @@ export default class ChoiceMapperField extends Component<ChoiceMapperFieldProps>
 
   render() {
     return (
-      <InputField
+      <FormField
         {...this.props}
         inline={({model}) => !this.hasValue(model.getValue(this.props.name))}
-        field={this.renderField}
-      />
+      >
+        {this.renderField}
+      </FormField>
     );
   }
 }

--- a/static/app/components/forms/fields/datePickerField.tsx
+++ b/static/app/components/forms/fields/datePickerField.tsx
@@ -5,12 +5,14 @@ import {FocusScope} from '@react-aria/focus';
 import moment from 'moment';
 
 import {DatePicker} from 'sentry/components/calendar';
+import FormField from 'sentry/components/forms/formField';
 import Input from 'sentry/components/input';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import {IconCalendar} from 'sentry/icons';
 import useOverlay from 'sentry/utils/useOverlay';
 
-import InputField, {InputFieldProps, OnEvent} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps, OnEvent} from './inputField';
 
 interface DatePickerFieldProps extends Omit<InputFieldProps, 'field'> {}
 
@@ -37,9 +39,8 @@ export default function DatePickerField(props: DatePickerFieldProps) {
   const theme = useTheme();
 
   return (
-    <InputField
-      {...props}
-      field={({onChange, onBlur, value, id, size, ...inputProps}) => {
+    <FormField {...props}>
+      {({children: _children, onChange, onBlur, value, id, size, ...inputProps}) => {
         const dateObj = new Date(value);
         const inputValue = !isNaN(dateObj.getTime()) ? dateObj : new Date();
         const dateString = moment(inputValue).format('LL');
@@ -74,7 +75,7 @@ export default function DatePickerField(props: DatePickerFieldProps) {
           </div>
         );
       }}
-    />
+    </FormField>
   );
 }
 

--- a/static/app/components/forms/fields/fileField.tsx
+++ b/static/app/components/forms/fields/fileField.tsx
@@ -1,9 +1,11 @@
 import {Fragment, useState} from 'react';
 import omit from 'lodash/omit';
 
+import FormField from 'sentry/components/forms/formField';
 import Input from 'sentry/components/input';
 
-import InputField, {InputFieldProps} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps} from './inputField';
 
 export interface FileFieldProps extends Omit<InputFieldProps, 'type' | 'accept'> {
   accept?: string[];
@@ -39,25 +41,22 @@ export default function FileField({accept, ...props}: FileFieldProps) {
   };
 
   return (
-    <InputField
-      {...props}
-      accept={accept?.join(', ')}
-      field={({onChange, ...fieldProps}) => {
-        return (
-          <Fragment>
-            <Input
-              {...omit(fieldProps, 'value', 'onBlur', 'onKeyDown')}
-              type="file"
-              onChange={e => handleFile(onChange, e)}
-            />
-            {isUploading ? (
-              <div>This is a janky upload indicator. Wait to hit save!</div>
-            ) : (
-              ''
-            )}
-          </Fragment>
-        );
-      }}
-    />
+    <FormField {...props}>
+      {({children: _children, onChange, ...fieldProps}) => (
+        <Fragment>
+          <Input
+            {...omit(fieldProps, 'value', 'onBlur', 'onKeyDown')}
+            type="file"
+            accept={accept?.join(', ')}
+            onChange={e => handleFile(onChange, e)}
+          />
+          {isUploading ? (
+            <div>This is a janky upload indicator. Wait to hit save!</div>
+          ) : (
+            ''
+          )}
+        </Fragment>
+      )}
+    </FormField>
   );
 }

--- a/static/app/components/forms/fields/projectMapperField.tsx
+++ b/static/app/components/forms/fields/projectMapperField.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import Button from 'sentry/components/button';
 import SelectControl from 'sentry/components/forms/controls/selectControl';
 import FieldErrorReason from 'sentry/components/forms/field/fieldErrorReason';
+import FormField from 'sentry/components/forms/formField';
 import FormFieldControlState from 'sentry/components/forms/formField/controlState';
 import FormModel from 'sentry/components/forms/model';
 import {ProjectMapperType} from 'sentry/components/forms/types';
@@ -24,7 +25,8 @@ import space from 'sentry/styles/space';
 import {safeGetQsParam} from 'sentry/utils/integrationUtil';
 import {removeAtArrayIndex} from 'sentry/utils/removeAtArrayIndex';
 
-import InputField, {InputFieldProps} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps} from './inputField';
 
 export interface ProjectMapperProps extends Omit<InputFieldProps, 'type'> {}
 
@@ -312,14 +314,15 @@ export class RenderField extends Component<RenderProps, State> {
 
 function ProjectMapperField(props: InputFieldProps) {
   return (
-    <StyledInputField
+    <StyledFormField
       {...props}
       resetOnError
       inline={false}
       stacked={false}
       hideControlState
-      field={(renderProps: RenderProps) => <RenderField {...renderProps} />}
-    />
+    >
+      {(renderProps: RenderProps) => <RenderField {...renderProps} />}
+    </StyledFormField>
   );
 }
 
@@ -379,7 +382,7 @@ const OptionLabelWrapper = styled('div')`
   margin-left: ${space(0.5)};
 `;
 
-const StyledInputField = styled(InputField)`
+const StyledFormField = styled(FormField)`
   padding: 0;
 `;
 

--- a/static/app/components/forms/fields/radioField.tsx
+++ b/static/app/components/forms/fields/radioField.tsx
@@ -1,6 +1,8 @@
 import RadioGroup, {RadioGroupProps} from 'sentry/components/forms/controls/radioGroup';
+import FormField from 'sentry/components/forms/formField';
 
-import InputField, {InputFieldProps, OnEvent} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps, OnEvent} from './inputField';
 
 export interface RadioFieldProps extends Omit<InputFieldProps, 'type'> {
   choices?: RadioGroupProps<any>['choices'];
@@ -19,9 +21,8 @@ function handleChange(
 
 function RadioField(props: RadioFieldProps) {
   return (
-    <InputField
-      {...props}
-      field={({id, onChange, onBlur, value, disabled, orientInline, ...fieldProps}) => (
+    <FormField {...props}>
+      {({id, onChange, onBlur, value, disabled, orientInline, ...fieldProps}) => (
         // XXX: The label must be present on the role="radiogroup" element. The
         // `htmlFor` attribute on the Field label does NOT link to the group.
         <RadioGroup
@@ -34,7 +35,7 @@ function RadioField(props: RadioFieldProps) {
           onChange={(v, e) => handleChange(v, onChange, onBlur, e)}
         />
       )}
-    />
+    </FormField>
   );
 }
 

--- a/static/app/components/forms/fields/rangeField.tsx
+++ b/static/app/components/forms/fields/rangeField.tsx
@@ -1,6 +1,8 @@
 import RangeSlider from 'sentry/components/forms/controls/rangeSlider';
+import FormField from 'sentry/components/forms/formField';
 
-import InputField, {InputFieldProps, OnEvent} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps, OnEvent} from './inputField';
 
 type DisabledFunction = (props: Omit<RangeFieldProps, 'formatMessageValue'>) => boolean;
 type PlaceholderFunction = (props: any) => React.ReactNode;
@@ -54,9 +56,8 @@ function RangeField({
   };
 
   return (
-    <InputField
-      {...props}
-      field={({onChange: fieldOnChange, onBlur, value, ...fieldProps}) => (
+    <FormField {...props}>
+      {({children: _children, onChange: fieldOnChange, onBlur, value, ...fieldProps}) => (
         <RangeSlider
           {...fieldProps}
           value={value}
@@ -64,7 +65,7 @@ function RangeField({
           onChange={(val, event) => onChange(fieldOnChange, val, event)}
         />
       )}
-    />
+    </FormField>
   );
 }
 

--- a/static/app/components/forms/fields/selectAsyncField.tsx
+++ b/static/app/components/forms/fields/selectAsyncField.tsx
@@ -6,8 +6,10 @@ import SelectAsyncControl, {
 } from 'sentry/components/forms/controls/selectAsyncControl';
 // projects can be passed as a direct prop as well
 import {GeneralSelectValue} from 'sentry/components/forms/controls/selectControl';
+import FormField from 'sentry/components/forms/formField';
 
-import InputField, {InputFieldProps} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps} from './inputField';
 
 export interface SelectAsyncFieldProps
   extends Omit<InputFieldProps, 'highlighted' | 'visible' | 'required' | 'value'>,
@@ -77,9 +79,16 @@ class SelectAsyncField extends Component<SelectAsyncFieldProps, SelectAsyncField
   render() {
     const {onChangeOption, ...otherProps} = this.props;
     return (
-      <InputField
-        {...otherProps}
-        field={({onBlur, onChange, required: _required, onResults, value, ...props}) => (
+      <FormField {...otherProps}>
+        {({
+          required: _required,
+          children: _children,
+          onBlur,
+          onChange,
+          onResults,
+          value,
+          ...props
+        }) => (
           <SelectAsyncControl
             {...props}
             onChange={this.handleChange.bind(this, onBlur, onChange, onChangeOption)}
@@ -97,7 +106,7 @@ class SelectAsyncField extends Component<SelectAsyncFieldProps, SelectAsyncField
             value={this.findValue(value)}
           />
         )}
-      />
+      </FormField>
     );
   }
 }

--- a/static/app/components/forms/fields/selectField.tsx
+++ b/static/app/components/forms/fields/selectField.tsx
@@ -5,10 +5,12 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import SelectControl, {
   ControlProps,
 } from 'sentry/components/forms/controls/selectControl';
+import FormField from 'sentry/components/forms/formField';
 import {t} from 'sentry/locale';
 import {Choices, SelectValue} from 'sentry/types';
 
-import InputField, {InputFieldProps} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps} from './inputField';
 
 export interface SelectFieldProps<OptionType extends OptionTypeBase>
   extends InputFieldProps,
@@ -97,9 +99,8 @@ export default class SelectField<OptionType extends SelectValue<any>> extends Co
   render() {
     const {allowClear, confirm, multiple, ...otherProps} = this.props;
     return (
-      <InputField
-        {...otherProps}
-        field={({id, onChange, onBlur, required: _required, ...props}) => (
+      <FormField {...otherProps}>
+        {({id, onChange, onBlur, required: _required, children: _children, ...props}) => (
           <SelectControl
             {...props}
             inputId={id}
@@ -145,7 +146,7 @@ export default class SelectField<OptionType extends SelectValue<any>> extends Co
             }}
           />
         )}
-      />
+      </FormField>
     );
   }
 }

--- a/static/app/components/forms/fields/sentryProjectSelectorField.tsx
+++ b/static/app/components/forms/fields/sentryProjectSelectorField.tsx
@@ -1,11 +1,13 @@
 import {Component} from 'react';
 
 import SelectControl from 'sentry/components/forms/controls/selectControl';
+import FormField from 'sentry/components/forms/formField';
 import IdBadge from 'sentry/components/idBadge';
 import {t} from 'sentry/locale';
 import {Project} from 'sentry/types';
 
-import InputField, {InputFieldProps} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps} from './inputField';
 
 const defaultProps = {
   avatarSize: 20,
@@ -39,7 +41,14 @@ class RenderField extends Component<RenderProps> {
   };
 
   render() {
-    const {projects, avatarSize, onChange, onBlur, ...rest} = this.props;
+    const {
+      children: _children,
+      projects,
+      avatarSize,
+      onChange,
+      onBlur,
+      ...rest
+    } = this.props;
 
     const projectOptions = projects.map(project => ({
       value: project.id,
@@ -65,10 +74,7 @@ class RenderField extends Component<RenderProps> {
 }
 
 const SentryProjectSelectorField = (props: RenderFieldProps) => (
-  <InputField
-    {...props}
-    field={(renderProps: RenderProps) => <RenderField {...renderProps} />}
-  />
+  <FormField {...props}>{fieldProps => <RenderField {...fieldProps} />}</FormField>
 );
 
 export default SentryProjectSelectorField;

--- a/static/app/components/forms/fields/tableField.tsx
+++ b/static/app/components/forms/fields/tableField.tsx
@@ -5,6 +5,7 @@ import flatten from 'lodash/flatten';
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
+import FormField from 'sentry/components/forms/formField';
 import {TableType} from 'sentry/components/forms/types';
 import Input from 'sentry/components/input';
 import {IconAdd, IconDelete} from 'sentry/icons';
@@ -13,7 +14,8 @@ import space from 'sentry/styles/space';
 import {defined, objectIsEmpty} from 'sentry/utils';
 import {singleLineRenderer} from 'sentry/utils/marked';
 
-import InputField, {InputFieldProps} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps} from './inputField';
 
 interface DefaultProps {
   /**
@@ -182,12 +184,13 @@ export default class TableField extends Component<InputFieldProps> {
     // change within the toast. Just turn off displaying the from/to portion of
     // the message
     return (
-      <InputField
+      <FormField
         {...this.props}
         formatMessageValue={false}
         inline={({model}) => !this.hasValue(model.getValue(this.props.name))}
-        field={this.renderField}
-      />
+      >
+        {this.renderField}
+      </FormField>
     );
   }
 }

--- a/static/app/components/forms/fields/textareaField.tsx
+++ b/static/app/components/forms/fields/textareaField.tsx
@@ -1,8 +1,10 @@
 import omit from 'lodash/omit';
 
 import Textarea, {TextAreaProps} from 'sentry/components/forms/controls/textarea';
+import FormField from 'sentry/components/forms/formField';
 
-import InputField, {InputFieldProps} from './inputField';
+// XXX(epurkhiser): This is wrong, it should not be inheriting these props
+import {InputFieldProps} from './inputField';
 
 export interface TextareaFieldProps
   extends Omit<InputFieldProps, 'field'>,
@@ -10,16 +12,15 @@ export interface TextareaFieldProps
 
 function TextareaField({monospace, rows, autosize, ...props}: TextareaFieldProps) {
   return (
-    <InputField
-      {...props}
-      field={fieldProps => (
+    <FormField {...props}>
+      {({children: _children, ...fieldProps}) => (
         <Textarea
           {...{monospace, rows, autosize}}
           // Do not forward required to `textarea` to avoid default browser behavior
           {...omit(fieldProps, ['onKeyDown', 'children', 'required'])}
         />
       )}
-    />
+    </FormField>
   );
 }
 


### PR DESCRIPTION
The InputField did nothing for all of these other field types. The extra level of indirection of having to go and read the InputField and understand what that did just to understand these was unnecessary.

Unfortunately many field still inherit / use the InputFieldProps.

Due to how incorrect most of the types are in the forms, I'll get rid of these in a later commit.