### PR TITLE
feat(metrics): Add `transform_null_to_unparameterized` filter capability [TET-503]

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -1563,6 +1563,7 @@ DERIVED_OPS: Mapping[MetricOperationType, DerivedOp] = {
         ),
         DerivedOp(
             op="transform_null_to_unparameterized",
+            can_orderby=False,
             can_groupby=True,
             can_filter=True,
             snql_func=transform_null_to_unparameterized_snql,

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -1563,8 +1563,8 @@ DERIVED_OPS: Mapping[MetricOperationType, DerivedOp] = {
         ),
         DerivedOp(
             op="transform_null_to_unparameterized",
-            can_orderby=False,  # TODO: a better and more comprehensive
             can_groupby=True,
+            can_filter=True,
             snql_func=transform_null_to_unparameterized_snql,
             default_null_value=0,
         ),

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -1567,7 +1567,6 @@ DERIVED_OPS: Mapping[MetricOperationType, DerivedOp] = {
             can_groupby=True,
             can_filter=True,
             snql_func=transform_null_to_unparameterized_snql,
-            default_null_value=0,
         ),
     ]
 }

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -539,7 +539,7 @@ class SnubaQueryBuilder:
                                 alias=condition.lhs.alias,
                             )[0],
                             op=condition.op,
-                            rhs=resolve_weak(self._use_case_id, self._org_id, condition.rhs)
+                            rhs=resolve_tag_value(self._use_case_id, self._org_id, condition.rhs)
                             if requires_rhs_condition_resolution(condition.lhs.op)
                             else condition.rhs,
                         )

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -73,6 +73,7 @@ from sentry.snuba.metrics.utils import (
     DerivedMetricParseException,
     MetricDoesNotExistException,
     get_intervals,
+    requires_rhs_condition_resolution,
 )
 from sentry.snuba.sessions_v2 import finite_or_none
 from sentry.utils.dates import parse_stats_period, to_datetime
@@ -538,7 +539,9 @@ class SnubaQueryBuilder:
                                 alias=condition.lhs.alias,
                             )[0],
                             op=condition.op,
-                            rhs=condition.rhs,
+                            rhs=resolve_weak(self._use_case_id, self._org_id, condition.rhs)
+                            if requires_rhs_condition_resolution(condition.lhs.op)
+                            else condition.rhs,
                         )
                     )
                 except IndexError:

--- a/src/sentry/snuba/metrics/query_builder.py
+++ b/src/sentry/snuba/metrics/query_builder.py
@@ -73,7 +73,7 @@ from sentry.snuba.metrics.utils import (
     DerivedMetricParseException,
     MetricDoesNotExistException,
     get_intervals,
-    requires_rhs_condition_resolution,
+    require_rhs_condition_resolution,
 )
 from sentry.snuba.sessions_v2 import finite_or_none
 from sentry.utils.dates import parse_stats_period, to_datetime
@@ -540,7 +540,7 @@ class SnubaQueryBuilder:
                             )[0],
                             op=condition.op,
                             rhs=resolve_tag_value(self._use_case_id, self._org_id, condition.rhs)
-                            if requires_rhs_condition_resolution(condition.lhs.op)
+                            if require_rhs_condition_resolution(condition.lhs.op)
                             else condition.rhs,
                         )
                     )

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -144,15 +144,15 @@ GENERIC_OP_TO_SNUBA_FUNCTION = {
     "generic_metrics_sets": OP_TO_SNUBA_FUNCTION["metrics_sets"],
 }
 
-# This list contains all the operations that require the "rhs" condition to be resolved
+# This set contains all the operations that require the "rhs" condition to be resolved
 # in a "MetricConditionField". This solution is the simplest one and doesn't require any
 # changes in the transformer, however it requires this list to be discovered and updated
 # in case new operations are added, which is not ideal but given the fact that we already
 # define operations in this file, it is not a deal-breaker.
-REQUIRES_RHS_CONDITION_RESOLUTION = ["transform_null_to_unparameterized"]
+REQUIRES_RHS_CONDITION_RESOLUTION = {"transform_null_to_unparameterized"}
 
 
-def requires_rhs_condition_resolution(op: MetricOperationType) -> bool:
+def require_rhs_condition_resolution(op: MetricOperationType) -> bool:
     """
     Checks whether a given operation requires its right operand to be resolved.
     """

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -144,6 +144,14 @@ GENERIC_OP_TO_SNUBA_FUNCTION = {
     "generic_metrics_sets": OP_TO_SNUBA_FUNCTION["metrics_sets"],
 }
 
+# This list contains all the operations that require the "rhs" condition to be resolved
+# in a "MetricConditionField".
+REQUIRES_RHS_CONDITION_RESOLUTION = ["transform_null_to_unparameterized"]
+
+
+def requires_rhs_condition_resolution(op: MetricOperationType) -> bool:
+    return op in REQUIRES_RHS_CONDITION_RESOLUTION
+
 
 def generate_operation_regex():
     """

--- a/src/sentry/snuba/metrics/utils.py
+++ b/src/sentry/snuba/metrics/utils.py
@@ -145,11 +145,17 @@ GENERIC_OP_TO_SNUBA_FUNCTION = {
 }
 
 # This list contains all the operations that require the "rhs" condition to be resolved
-# in a "MetricConditionField".
+# in a "MetricConditionField". This solution is the simplest one and doesn't require any
+# changes in the transformer, however it requires this list to be discovered and updated
+# in case new operations are added, which is not ideal but given the fact that we already
+# define operations in this file, it is not a deal-breaker.
 REQUIRES_RHS_CONDITION_RESOLUTION = ["transform_null_to_unparameterized"]
 
 
 def requires_rhs_condition_resolution(op: MetricOperationType) -> bool:
+    """
+    Checks whether a given operation requires its right operand to be resolved.
+    """
     return op in REQUIRES_RHS_CONDITION_RESOLUTION
 
 


### PR DESCRIPTION
This PR aims at adding the capability to use `transform_null_to_unparameterized` in the `where` clause of a `MetricQuery`.

_In order to make this work, I had to introduce a new check in the query builder which checks whether a certain `MetricField` in the `MetricConditionField` requires the `rhs` operand to be resolved._