### PR TITLE
ref(jest): safer test check

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -133,6 +133,13 @@ function getTestsForGroup(
     throw new Error('All tests should be accounted for');
   }
 
+  // We need to ensure that everything from jest --listTests is accounted for.
+  for (const test of allTests) {
+    if (!tests.has(test)) {
+      throw new Error(`Test ${test} is not accounted for`);
+    }
+  }
+
   if (!groups[nodeIndex]) {
     throw new Error(`No tests found for node ${nodeIndex}`);
   }


### PR DESCRIPTION
We were already checking that allTests.length is not < final test map and that all tests have been consumed, but I want to be more exhaustive and check that every test that was listed by jest --listTests is actually in the map. #paranoid 😂 