### PR TITLE
fix(code_mappings): Use organization ID consistently

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -157,7 +157,7 @@ def get_installation(organization: Organization) -> Tuple[Integration, Organizat
         return None, None
 
     organization_integration = organization_integration.first()
-    return integration.get_installation(organization), organization_integration
+    return integration.get_installation(organization.id), organization_integration
 
 
 def set_project_codemappings(

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -50,10 +50,11 @@ def derive_missing_codemappings(dry_run=False) -> None:
     queue="derive_code_mappings",
     max_retries=0,  # if we don't backfill it this time, we'll get it the next time
 )
-def derive_code_mappings(organization: Organization, dry_run=False) -> None:
+def derive_code_mappings(organization_id: int, dry_run=False) -> None:
     """
     Derive code mappings for an organization and save the derived code mappings.
     """
+    organization: Organization = Organization.objects.get(id=organization_id)
     project_stacktrace_paths = identify_stacktrace_paths(organization)
     if not project_stacktrace_paths:
         return
@@ -156,7 +157,7 @@ def get_installation(organization: Organization) -> Tuple[Integration, Organizat
         return None, None
 
     organization_integration = organization_integration.first()
-    return integration.get_installation(organization.id), organization_integration
+    return integration.get_installation(organization), organization_integration
 
 
 def set_project_codemappings(

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -139,7 +139,7 @@ def get_installation(organization: Organization) -> Tuple[Integration, Organizat
     integration = None
     try:
         integration = Integration.objects.filter(
-            organizations=organization.id,
+            organizations=organization,
             provider="github",
         )
     except Integration.DoesNotExist:

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -170,7 +170,7 @@ class TestIdentfiyStacktracePaths(TestCase):
                 self.project: ["sentry/models/release.py", "sentry/tasks.py"],
             },
         ) as mock_identify_stacktraces, self.tasks():
-            derive_code_mappings(self.organization)
+            derive_code_mappings(self.organization.id)
 
         assert mock_identify_stacktraces.call_count == 1
         assert mock_get_trees_for_org.call_count == 1


### PR DESCRIPTION
Fix for #40271 and SENTRY-WC8