### PR TITLE
feat(issue-alerts): detect incompatible rules

### DIFF
--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -528,6 +528,11 @@ describe('ProjectAlertsCreate', function () {
       )
     ).toBeInTheDocument();
 
+    expect(screen.getByRole('button', {name: 'Save Rule'})).toHaveAttribute(
+      'aria-disabled',
+      'true'
+    );
+
     userEvent.click(screen.getAllByLabelText('Delete Node')[0]);
     expect(
       screen.queryByText(

--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -510,4 +510,29 @@ describe('ProjectAlertsCreate', function () {
       expect(screen.getByText('No preview available')).toBeInTheDocument();
     });
   });
+
+  it('shows error for incompatible conditions', async () => {
+    const organization = TestStubs.Organization({
+      features: ['issue-alert-incompatible-rules'],
+    });
+    createWrapper({organization});
+    await selectEvent.select(screen.getByText('Add optional trigger...'), [
+      'A new issue is created',
+    ]);
+    await selectEvent.select(screen.getByText('Add optional trigger...'), [
+      'The issue changes state from resolved to unresolved',
+    ]);
+    expect(
+      screen.getByText(
+        'This condition conflicts with other condition(s) above. Please select a different condition'
+      )
+    ).toBeInTheDocument();
+
+    userEvent.click(screen.getAllByLabelText('Delete Node')[0]);
+    expect(
+      screen.queryByText(
+        'This condition conflicts with other condition(s) above. Please select a different condition'
+      )
+    ).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1121,10 +1121,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       <Access access={['alerts:write']}>
         {({hasAccess}) => {
           // check if superuser or if user is on the alert's team
-          const disabled =
-            loading ||
-            !(isActiveSuperuser() || hasAccess) ||
-            incompatibleCondition !== null;
+          const disabled = loading || !(isActiveSuperuser() || hasAccess);
 
           return (
             <Main fullWidth>
@@ -1143,7 +1140,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                 extraButton={
                   isSavedAlertRule(rule) ? (
                     <Confirm
-                      disabled={disabled}
+                      disabled={disabled || incompatibleCondition !== null}
                       priority="danger"
                       confirmText={t('Delete Rule')}
                       onConfirm={this.handleDeleteRule}

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -419,8 +419,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     const {rule} = this.state;
     if (
       !rule ||
-      false
-      // !this.props.organization.features.includes('issue-alert-incompatible-rules')
+      !this.props.organization.features.includes('issue-alert-incompatible-rules')
     ) {
       return;
     }

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -416,6 +416,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     const {rule} = this.state;
     if (
       !rule ||
+      rule.actionMatch !== 'all' ||
       !this.props.organization.features.includes('issue-alert-incompatible-rules')
     ) {
       return;

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -419,7 +419,8 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     const {rule} = this.state;
     if (
       !rule ||
-      !this.props.organization.features.includes('issue-alert-incompatible-rules')
+      false
+      // !this.props.organization.features.includes('issue-alert-incompatible-rules')
     ) {
       return;
     }
@@ -1163,16 +1164,16 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                   frequency: `${frequency}`,
                   projectId: project.id,
                 }}
-                submitDisabled={disabled}
+                submitDisabled={
+                  disabled ||
+                  incompatibleCondition !== null ||
+                  incompatibleFilter !== null
+                }
                 submitLabel={t('Save Rule')}
                 extraButton={
                   isSavedAlertRule(rule) ? (
                     <Confirm
-                      disabled={
-                        disabled ||
-                        incompatibleCondition !== null ||
-                        incompatibleFilter !== null
-                      }
+                      disabled={disabled}
                       priority="danger"
                       confirmText={t('Delete Rule')}
                       onConfirm={this.handleDeleteRule}

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -456,7 +456,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     if (
       firstSeen &&
       (rule.actionMatch === 'all' || conditions.length === 1) &&
-      (rule.filterMatch === 'all' || filters.length === 1)
+      (rule.filterMatch === 'all' || (rule.filterMatch === 'any' && filters.length === 1))
     ) {
       for (let i = 0; i < filters.length; i++) {
         const id = filters[i].id;

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -229,6 +229,7 @@ interface Props {
   onReset: (rowIndex: number, name: string, value: string) => void;
   organization: Organization;
   project: Project;
+  incompatibleRule?: boolean;
   node?: IssueAlertRuleActionTemplate | IssueAlertRuleConditionTemplate | null;
   ownership?: null | IssueOwnership;
 }
@@ -244,6 +245,7 @@ function RuleNode({
   onPropertyChange,
   onReset,
   ownership,
+  incompatibleRule,
 }: Props) {
   const handleDelete = useCallback(() => {
     onDelete(index);
@@ -447,6 +449,19 @@ function RuleNode({
     return null;
   }
 
+  function renderIncompatibleRuleBanner() {
+    if (!incompatibleRule) {
+      return null;
+    }
+    return (
+      <MarginlessAlert type="error" showIcon>
+        {t(
+          'This condition conflicts with other condition(s) above. Please select a different condition'
+        )}
+      </MarginlessAlert>
+    );
+  }
+
   /**
    * Update all the AlertRuleAction's fields from the TicketRuleModal together
    * only after the user clicks "Apply Changes".
@@ -562,6 +577,7 @@ function RuleNode({
           icon={<IconDelete />}
         />
       </RuleRow>
+      {renderIncompatibleRuleBanner()}
       {conditionallyRenderHelpfulBanner()}
     </RuleRowContainer>
   );

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -45,6 +45,7 @@ type Props = {
    */
   placeholder: string;
   project: Project;
+  incompatibleRule?: number | null;
   ownership?: null | IssueOwnership;
   selectType?: 'grouped';
 };
@@ -152,6 +153,7 @@ class RuleNodeList extends Component<Props> {
       disabled,
       error,
       selectType,
+      incompatibleRule,
     } = this.props;
 
     const enabledNodes = nodes ? nodes.filter(({enabled}) => enabled) : [];
@@ -244,6 +246,7 @@ class RuleNodeList extends Component<Props> {
               project={project}
               disabled={disabled}
               ownership={ownership}
+              incompatibleRule={incompatibleRule === idx}
             />
           ))}
         </RuleNodes>


### PR DESCRIPTION
Adds a banner below incompatible rule.
![Screen Shot 2022-10-28 at 10 52 28 AM](https://user-images.githubusercontent.com/39287272/198700926-f2082e3c-ef4a-4099-aa83-8169a255facc.png)

The logic behind detecting these incompatible rules is still very simple and can be expanded on later if the function gets too complicated. An idea for this is in the [doc](https://www.notion.so/sentry/Issue-Alert-Previews-Testing-ba0d8a43ea564ab9ba6c72b1814274f4#ec0bd3e95e4c4ab29285f6cebb7c5d8a) (still might be overkill)