### PR TITLE
fix(release): Escape releases with quotes

### DIFF
--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -37,7 +37,7 @@ import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import AsyncView from 'sentry/views/asyncView';
 
-import {getReleaseBounds, ReleaseBounds} from '../utils';
+import {getReleaseBounds, ReleaseBounds, searchReleaseVersion} from '../utils';
 
 import ReleaseHeader from './header/releaseHeader';
 
@@ -143,11 +143,14 @@ class ReleasesDetail extends AsyncView<Props, State> {
         query: {
           project: location.query.project,
           environment: location.query.environment ?? [],
-          query: `release:"${params.release}"`,
+          query: searchReleaseVersion(params.release),
           field: 'sum(session)',
           statsPeriod: '90d',
           interval: '1d',
         },
+      },
+      {
+        allowError: error => error.status === 400,
       },
     ]);
 

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -48,7 +48,12 @@ import {
   PROJECT_PERFORMANCE_TYPE,
 } from 'sentry/views/performance/utils';
 
-import {getReleaseParams, isReleaseArchived, ReleaseBounds} from '../../utils';
+import {
+  getReleaseParams,
+  isReleaseArchived,
+  ReleaseBounds,
+  searchReleaseVersion,
+} from '../../utils';
 import {ReleaseContext} from '..';
 
 import CommitAuthorBreakdown from './sidebar/commitAuthorBreakdown';
@@ -127,7 +132,7 @@ class ReleaseOverview extends AsyncView<Props> {
       id: undefined,
       version: 2,
       name: `Release ${formatVersion(version)}`,
-      query: `event.type:transaction release:${version}`,
+      query: `event.type:transaction ${searchReleaseVersion(version)}`,
       fields: ['transaction', 'failure_count()', 'epm()', 'p50()'],
       orderby: '-failure_count',
       range: statsPeriod || undefined,
@@ -438,7 +443,10 @@ class ReleaseOverview extends AsyncView<Props> {
                 errored: allReleasesErrored,
                 response: allReleases,
               }) => (
-                <SessionsRequest {...sessionsRequestProps} query={`release:"${version}"`}>
+                <SessionsRequest
+                  {...sessionsRequestProps}
+                  query={searchReleaseVersion(version)}
+                >
                   {({
                     loading: thisReleaseLoading,
                     reloading: thisReleaseReloading,

--- a/static/app/views/releases/utils/index.spec.tsx
+++ b/static/app/views/releases/utils/index.spec.tsx
@@ -1,6 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
-import {getReleaseBounds, getReleaseParams} from 'sentry/views/releases/utils';
+import {getReleaseBounds, getReleaseParams, searchReleaseVersion} from './index';
 
 describe('releases/utils', () => {
   describe('getReleaseBounds', () => {
@@ -148,5 +148,13 @@ describe('releases/utils', () => {
         end: '2022-03-23T01:02:30.000',
       });
     });
+  });
+});
+
+describe('searchReleaseVersion()', function () {
+  it('should escape quotes', function () {
+    expect(searchReleaseVersion('com.sentry.go_app@"1.0.0-chore"')).toBe(
+      'release:"com.sentry.go_app@\\"1.0.0-chore\\""'
+    );
   });
 });

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -235,3 +235,12 @@ export const ADOPTION_STAGE_LABELS: Record<
 
 export const isMobileRelease = (releaseProjectPlatform: PlatformKey) =>
   ([...mobile, ...desktop] as string[]).includes(releaseProjectPlatform);
+
+/**
+ * Helper that escapes quotes and formats release version into release search
+ * ex - com.sentry.go_app@"1.0.0-chore"
+ */
+export function searchReleaseVersion(version: string): string {
+  // Wrap with quotes and escape any quotes inside
+  return `release:"${version.replace(/"/g, '\\"')}"`;
+}


### PR DESCRIPTION
We searched for releases like `release:"${version}"` but if the release also included double quotes it would fail to load. This escapes the quotes.

I have an example setup on my test org https://sentry.io/organizations/scooper/releases/com.fleetio.go_app%40%224.8.1-chore-GO-1396%22/?project=4504000181567488