### PR TITLE
ref(js): Remove unused fetchProjectSavedSearches

### DIFF
--- a/static/app/actionCreators/savedSearches.tsx
+++ b/static/app/actionCreators/savedSearches.tsx
@@ -30,17 +30,6 @@ export function fetchSavedSearches(api: Client, orgSlug: string): Promise<SavedS
   return promise;
 }
 
-export function fetchProjectSavedSearches(
-  api: Client,
-  orgSlug: string,
-  projectId: string
-): Promise<SavedSearch[]> {
-  const url = `/projects/${orgSlug}/${projectId}/searches/`;
-  return api.requestPromise(url, {
-    method: 'GET',
-  });
-}
-
 const getRecentSearchUrl = (orgSlug: string): string =>
   `/organizations/${orgSlug}/recent-searches/`;
 


### PR DESCRIPTION
We do not use project level saved searches any longer. This was deprecated in Sentry 9.

I'll be attempting to remove this from the backend as well. This is the first step to ensure nothing on the frontend is using it (it's not)