### PR TITLE
ref(api): Remove deprecated savedsearch serializer attributes

### DIFF
--- a/src/sentry/api/serializers/models/savedsearch.py
+++ b/src/sentry/api/serializers/models/savedsearch.py
@@ -1,40 +1,17 @@
 from sentry.api.serializers import Serializer, register
-from sentry.models import SavedSearch, SavedSearchUserDefault
+from sentry.models import SavedSearch
 
 
 @register(SavedSearch)
 class SavedSearchSerializer(Serializer):
-    def get_attrs(self, item_list, user):
-        if user.is_authenticated:
-            user_defaults = tuple(
-                SavedSearchUserDefault.objects.filter(
-                    savedsearch__in=item_list, user=user
-                ).values_list("savedsearch", flat=True)
-            )
-        else:
-            user_defaults = ()
-
-        attrs = {}
-        for item in item_list:
-            attrs[item] = {"isUserDefault": item.id in user_defaults}
-        return attrs
-
     def serialize(self, obj, attrs, user):
         return {
             "id": str(obj.id),
-            # TODO: Remove once we've completely deprecated Sentry 9
-            "projectId": str(obj.project_id) if obj.project_id else None,
             "type": obj.type,
             "name": obj.name,
             "query": obj.query,
             "sort": obj.sort,
-            # TODO: Remove once we've completely deprecated Sentry 9
-            "isDefault": obj.is_default,
-            # TODO: Remove once we've completely deprecated Sentry 9
-            "isUserDefault": attrs["isUserDefault"],
             "dateCreated": obj.date_added,
-            # TODO: Remove once we've completely deprecated Sentry 9
-            "isPrivate": bool(obj.owner),
             "isGlobal": obj.is_global,
             "isPinned": obj.is_pinned,
             "isOrgCustom": obj.is_org_custom_search,

--- a/tests/sentry/api/serializers/test_saved_search.py
+++ b/tests/sentry/api/serializers/test_saved_search.py
@@ -5,20 +5,14 @@ from sentry.testutils import TestCase
 
 class SavedSearchSerializerTest(TestCase):
     def test_simple(self):
-        search = SavedSearch.objects.create(
-            project=self.project, name="Something", query="some query"
-        )
+        search = SavedSearch.objects.create(name="Something", query="some query")
         result = serialize(search)
 
         assert result["id"] == str(search.id)
-        assert result["projectId"] == str(search.project_id)
         assert result["type"] == search.type
         assert result["name"] == search.name
         assert result["query"] == search.query
-        assert result["isDefault"] == search.is_default
-        assert result["isUserDefault"] == search.is_default
         assert result["dateCreated"] == search.date_added
-        assert not result["isPrivate"]
         assert not result["isGlobal"]
         assert not result["isPinned"]
 
@@ -27,14 +21,10 @@ class SavedSearchSerializerTest(TestCase):
         result = serialize(search)
 
         assert result["id"] == str(search.id)
-        assert result["projectId"] is None
         assert result["type"] == search.type
         assert result["name"] == search.name
         assert result["query"] == search.query
-        assert not result["isDefault"]
-        assert not result["isUserDefault"]
         assert result["dateCreated"] == search.date_added
-        assert not result["isPrivate"]
         assert result["isGlobal"]
         assert not result["isPinned"]
 
@@ -45,14 +35,10 @@ class SavedSearchSerializerTest(TestCase):
         result = serialize(search)
 
         assert result["id"] == str(search.id)
-        assert result["projectId"] is None
         assert result["type"] == search.type
         assert result["name"] == search.name
         assert result["query"] == search.query
-        assert not result["isDefault"]
-        assert not result["isUserDefault"]
         assert result["dateCreated"] == search.date_added
-        assert not result["isPrivate"]
         assert not result["isGlobal"]
         assert not result["isPinned"]
 
@@ -63,13 +49,9 @@ class SavedSearchSerializerTest(TestCase):
         result = serialize(search)
 
         assert result["id"] == str(search.id)
-        assert result["projectId"] is None
         assert result["type"] == search.type
         assert result["name"] == search.name
         assert result["query"] == search.query
-        assert not result["isDefault"]
-        assert not result["isUserDefault"]
         assert result["dateCreated"] == search.date_added
-        assert result["isPrivate"]
         assert not result["isGlobal"]
         assert result["isPinned"]


### PR DESCRIPTION
This removes 3 attributes from the resulting dict

 * `projectId`

   Saved searches are no longer associated to projects. As noted in GH-40751 where the ProjectSearchesEndpoint API endpoint is removed, we have not created any new project savedsearch since October 2020.

   I've checked through the frontend code, this was not being used anywhere. The SavedSearch types [0] do not include the deprecated attributes.

 * `isUserDefault`

   Another easy to grep for attribute. This was not used anywhere. It was powered by the old SavedSearchUserDefault model, which is also not used and will be removed in a near future migration.

 * `isDefault`

   Similar to projectId, this has not been set to `true` since October 2022. Notably there are NO rows in the sentry.io production database with this set to true AND that have an organization_id.

   ```sql
   select *
   from sentry_savedsearch
   where is_default = true and organization_id is not null
   order by date_added desc
   limit 100
   ```

   This was not used in the frontend

 * `isPrivate`

   This was a derived attribute from `owner`. This was not used in the frontend. There are no instances of the string `isPrivate` in sentry.

[0]: https://github.com/getsentry/sentry/blob/4be98deb27375dac541740b9c8d7ce871ff2bc99/static/app/types/group.tsx#L26-L37