### PR TITLE
feat(devx): Enable --pretty by default in devserver

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -94,7 +94,7 @@ def _get_daemon(name: str, *args: str, **kwargs: str) -> tuple[str, list[str]]:
     "--prefix/--no-prefix", default=True, help="Show the service name prefix and timestamp"
 )
 @click.option(
-    "--pretty/--no-pretty", default=False, help="Stylize various outputs from the devserver"
+    "--pretty/--no-pretty", default=True, help="Stylize various outputs from the devserver"
 )
 @click.option(
     "--styleguide/--no-styleguide",


### PR DESCRIPTION
A few nice features

* **Tells you when the devserver is ready again** 

   <img width="995" alt="image" src="https://user-images.githubusercontent.com/1421724/198822681-c11ff06f-2104-4227-b0de-2bf105b9f986.png">

* **Highlights HTTP requests and status code**

  <img width="987" alt="image" src="https://user-images.githubusercontent.com/1421724/198822715-12cae363-09c3-4c02-949b-d0fd5d816dbc.png">

* **Marks tracebacks clearly**

  <img width="1452" alt="image" src="https://user-images.githubusercontent.com/1421724/198822797-bbc7c23b-dff3-4b7b-8599-d0b19945f091.png">
