### PR TITLE
ref(perf): Remove autogroup flag from BE code

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1143,8 +1143,6 @@ SENTRY_FEATURES = {
     "organizations:performance-anomaly-detection-ui": False,
     # Enable histogram view in span details
     "organizations:performance-span-histogram-view": False,
-    # Enable autogrouping of sibling spans
-    "organizations:performance-autogroup-sibling-spans": False,
     # Enable performance on-boarding checklist
     "organizations:performance-onboarding-checklist": False,
     # Enable transaction name only search

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -120,7 +120,6 @@ default_manager.add("organizations:notification-all-recipients", OrganizationFea
 default_manager.add("organizations:onboarding", OrganizationFeature)  # Only enabled in sentry.io to enable onboarding flows.
 default_manager.add("organizations:org-subdomains", OrganizationFeature)
 default_manager.add("organizations:performance-anomaly-detection-ui", OrganizationFeature, True)
-default_manager.add("organizations:performance-autogroup-sibling-spans", OrganizationFeature, True)
 default_manager.add("organizations:performance-chart-interpolation", OrganizationFeature, True)
 default_manager.add("organizations:performance-dry-run-mep", OrganizationFeature, True)
 default_manager.add("organizations:performance-frontend-use-events-endpoint", OrganizationFeature, True)

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -483,7 +483,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         child_event["spans"] = child_event["spans"][0:3]
         self.store_event(data=child_event, project_id=self.project.id, assert_no_errors=True)
 
-        with self.feature(FEATURE_NAMES + ["organizations:performance-autogroup-sibling-spans"]):
+        with self.feature(FEATURE_NAMES):
             # Get the list page
             self.browser.get(self.result_path + "?" + transactions_sorted_query())
             self.wait_until_loaded()


### PR DESCRIPTION
Removes this flag from the code as it is no longer necessary.

FE PR: https://github.com/getsentry/sentry/pull/40735