### PR TITLE
feat(dashboards): hides indexed and processed events alerts/banners/badges

### DIFF
--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -323,43 +323,44 @@ class WidgetCard extends Component<Props, State> {
               )}
               {this.renderToolbar()}
             </WidgetCardPanel>
-            {(organization.features.includes('dashboards-mep') ||
-              organization.features.includes('mep-rollout-flag')) && (
-              <MEPConsumer>
-                {metricSettingContext => {
-                  return (
-                    <DashboardsMEPConsumer>
-                      {({isMetricsData}) => {
-                        if (
-                          showStoredAlert &&
-                          isMetricsData === false &&
-                          widget.widgetType === WidgetType.DISCOVER &&
-                          metricSettingContext &&
-                          metricSettingContext.metricSettingState !==
-                            MEPState.transactionsOnly
-                        ) {
-                          if (!widgetContainsErrorFields) {
-                            return (
-                              <StoredDataAlert showIcon>
-                                {tct(
-                                  "Your selection is only applicable to [indexedData: indexed event data]. We've automatically adjusted your results.",
-                                  {
-                                    indexedData: (
-                                      <ExternalLink href="https://docs.sentry.io/product/dashboards/widget-builder/#errors--transactions" />
-                                    ),
-                                  }
-                                )}
-                              </StoredDataAlert>
-                            );
+            {!organization.features.includes('performance-mep-bannerless-ui') &&
+              (organization.features.includes('dashboards-mep') ||
+                organization.features.includes('mep-rollout-flag')) && (
+                <MEPConsumer>
+                  {metricSettingContext => {
+                    return (
+                      <DashboardsMEPConsumer>
+                        {({isMetricsData}) => {
+                          if (
+                            showStoredAlert &&
+                            isMetricsData === false &&
+                            widget.widgetType === WidgetType.DISCOVER &&
+                            metricSettingContext &&
+                            metricSettingContext.metricSettingState !==
+                              MEPState.transactionsOnly
+                          ) {
+                            if (!widgetContainsErrorFields) {
+                              return (
+                                <StoredDataAlert showIcon>
+                                  {tct(
+                                    "Your selection is only applicable to [indexedData: indexed event data]. We've automatically adjusted your results.",
+                                    {
+                                      indexedData: (
+                                        <ExternalLink href="https://docs.sentry.io/product/dashboards/widget-builder/#errors--transactions" />
+                                      ),
+                                    }
+                                  )}
+                                </StoredDataAlert>
+                              );
+                            }
                           }
-                        }
-                        return null;
-                      }}
-                    </DashboardsMEPConsumer>
-                  );
-                }}
-              </MEPConsumer>
-            )}
+                          return null;
+                        }}
+                      </DashboardsMEPConsumer>
+                    );
+                  }}
+                </MEPConsumer>
+              )}
           </React.Fragment>
         )}
       </ErrorBoundary>

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardContextMenu.tsx
@@ -95,8 +95,9 @@ function WidgetCardContextMenu({
           <MEPConsumer>
             {metricSettingContext => (
               <ContextWrapper>
-                {(organization.features.includes('dashboards-mep') ||
-                  organization.features.includes('mep-rollout-flag')) &&
+                {!organization.features.includes('performance-mep-bannerless-ui') &&
+                  (organization.features.includes('dashboards-mep') ||
+                    organization.features.includes('mep-rollout-flag')) &&
                   isMetricsData === false &&
                   metricSettingContext &&
                   metricSettingContext.metricSettingState !==
@@ -237,8 +238,9 @@ function WidgetCardContextMenu({
         <MEPConsumer>
           {metricSettingContext => (
             <ContextWrapper>
-              {(organization.features.includes('dashboards-mep') ||
-                organization.features.includes('mep-rollout-flag')) &&
+              {!organization.features.includes('performance-mep-bannerless-ui') &&
+                (organization.features.includes('dashboards-mep') ||
+                  organization.features.includes('mep-rollout-flag')) &&
                 isMetricsData === false &&
                 metricSettingContext &&
                 metricSettingContext.metricSettingState !== MEPState.transactionsOnly && (

--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -512,7 +512,11 @@ export class Results extends Component<Props, State> {
   };
 
   renderMetricsFallbackBanner() {
-    if (this.state.showMetricsAlert) {
+    const {organization} = this.props;
+    if (
+      !organization.features.includes('performance-mep-bannerless-ui') &&
+      this.state.showMetricsAlert
+    ) {
       return (
         <Alert type="info" showIcon>
           {t(


### PR DESCRIPTION
Hides several alerts/banners/badges referring to indexed and processed events in the discover and dashboards ui if using performance-mep-bannerless-ui feature flag:
![image](https://user-images.githubusercontent.com/83961295/199032241-6dbe9cec-295a-4180-a481-293ae2fb0e61.png)
![image](https://user-images.githubusercontent.com/83961295/199032331-435df91b-784a-4037-9cec-e5019ad15c51.png)
![image](https://user-images.githubusercontent.com/83961295/199032464-26eb6a5a-8443-4e86-8d9f-7786a9beff79.png)
