### PR TITLE
fix(discover-homepage): Change Build a new query to open homepage

### DIFF
--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -284,7 +284,9 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
   render() {
     const {location, organization} = this.props;
     const eventView = EventView.fromNewQueryWithLocation(DEFAULT_EVENT_VIEW, location);
-    const to = eventView.getResultsViewUrlTarget(organization.slug);
+    const to = organization.features.includes('discover-query-builder-as-landing-page')
+      ? `/organizations/${organization.slug}/discover/homepage/`
+      : eventView.getResultsViewUrlTarget(organization.slug);
 
     return (
       <Feature


### PR DESCRIPTION
If we're using the homepage as the jump off point, the Build a new query button should reflect that and bring you to the homepage