### PR TITLE
feat(discover-homepage): Add breadcrumb for saved queries

### DIFF
--- a/static/app/views/eventsV2/breadcrumb.tsx
+++ b/static/app/views/eventsV2/breadcrumb.tsx
@@ -46,6 +46,12 @@ function DiscoverBreadcrumb({
   });
 
   if (!isHomepage && eventView && eventView.isValid()) {
+    if (organization.features.includes('discover-query-builder-as-landing-page')) {
+      crumbs.push({
+        to: `/organizations/${organization.slug}/discover/queries/`,
+        label: t('Saved Queries'),
+      });
+    }
     crumbs.push({
       to: eventView.getResultsViewUrlTarget(organization.slug, isHomepage),
       label: eventView.name || '',

--- a/static/app/views/eventsV2/results.spec.jsx
+++ b/static/app/views/eventsV2/results.spec.jsx
@@ -1295,6 +1295,38 @@ describe('Results', function () {
     );
   });
 
+  it('links back to the Saved Queries through the Saved Queries breadcrumb', () => {
+    const organization = TestStubs.Organization({
+      features: [
+        'discover-basic',
+        'discover-query',
+        'discover-query-builder-as-landing-page',
+        'discover-frontend-use-events-endpoint',
+      ],
+    });
+
+    const initialData = initializeOrg({
+      organization,
+      router: {
+        location: {query: {id: '1'}},
+      },
+    });
+
+    render(
+      <Results
+        organization={organization}
+        location={initialData.router.location}
+        router={initialData.router}
+      />,
+      {context: initialData.routerContext, organization}
+    );
+
+    expect(screen.getByRole('link', {name: 'Saved Queries'})).toHaveAttribute(
+      'href',
+      expect.stringMatching(new RegExp('^/organizations/org-slug/discover/queries/'))
+    );
+  });
+
   it('allows users to Set As Default on the All Events query', () => {
     const organization = TestStubs.Organization({
       features: [


### PR DESCRIPTION
Adds a breadcrumb on saved queries to navigate back to the Saved Queries. We have the button but this is because semantically, we've arrived at the current query builder from the Saved Queries page, so there should be a breadcrumb linking back.

<img width="1422" alt="Screen Shot 2022-10-31 at 12 17 18 PM" src="https://user-images.githubusercontent.com/22846452/199078206-1a7dfffb-3fa9-4baf-9cdd-2053a1e2e23a.png">