### PR TITLE
feat(replays): Replay Index searchbox implements onGetTagValues

### DIFF
--- a/static/app/views/replays/replaySearchBar.tsx
+++ b/static/app/views/replays/replaySearchBar.tsx
@@ -1,8 +1,20 @@
+import {useCallback} from 'react';
+
+import {fetchTagValues} from 'sentry/actionCreators/tags';
 import SmartSearchBar from 'sentry/components/smartSearchBar';
 import {MAX_QUERY_LENGTH, NEGATION_OPERATOR, SEARCH_WILDCARD} from 'sentry/constants';
 import {t} from 'sentry/locale';
-import {Organization, PageFilters, SavedSearchType, TagCollection} from 'sentry/types';
+import {
+  Organization,
+  PageFilters,
+  SavedSearchType,
+  Tag,
+  TagCollection,
+  TagValue,
+} from 'sentry/types';
+import {isAggregateField} from 'sentry/utils/discover/fields';
 import {getFieldDefinition, REPLAY_FIELDS} from 'sentry/utils/fields';
+import useApi from 'sentry/utils/useApi';
 
 const SEARCH_SPECIAL_CHARS_REGEXP = new RegExp(
   `^${NEGATION_OPERATOR}|\\${SEARCH_WILDCARD}`,
@@ -38,10 +50,39 @@ type Props = React.ComponentProps<typeof SmartSearchBar> & {
 };
 
 function ReplaySearchBar(props: Props) {
+  const {organization, pageFilters} = props;
+  const api = useApi();
+  const projectIdStrings = pageFilters.projects?.map(String);
+
+  const getTagValues = useCallback(
+    (tag: Tag, searchQuery: string, _params: object): Promise<string[]> => {
+      if (isAggregateField(tag.key)) {
+        // We can't really auto suggest values for aggregate fields
+        // or measurements, so we simply don't
+        return Promise.resolve([]);
+      }
+
+      return fetchTagValues({
+        api,
+        orgSlug: organization.slug,
+        tagKey: tag.key,
+        search: searchQuery,
+        projectIds: projectIdStrings,
+        includeReplays: true,
+      }).then(
+        tagValues => (tagValues as TagValue[]).map(({value}) => value),
+        () => {
+          throw new Error('Unable to fetch event field values');
+        }
+      );
+    },
+    [api, organization.slug, projectIdStrings]
+  );
+
   return (
     <SmartSearchBar
       {...props}
-      onGetTagValues={undefined}
+      onGetTagValues={getTagValues}
       supportedTags={REPLAY_TAGS}
       placeholder={t('Search for users, duration, count_errors, and more')}
       prepareQuery={prepareQuery}


### PR DESCRIPTION
Show suggested values when using the Replay search type-ahead:

<img width="657" alt="SCR-20230201-lks" src="https://user-images.githubusercontent.com/187460/216191916-27e488a5-83f7-4424-9705-cbc3d0f93120.png">

In my testing all the suggested values for `browser.name` are valid -> some replays showup in the last 90days.  

Doing the same test against `os.name` `Chomecast` appeared in the suggested list, but there are no replays matching that in the last 90days. I wonder if it's from a deleted replay, or an indexed value in tagstore, but the replay has become expired and puged.

Fixes #37968