### PR TITLE
fix(dashboards): Some dashboard widgets error out when generating ARIA labels

### DIFF
--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -1,9 +1,4 @@
-import type {
-  BarSeriesOption,
-  EChartsOption,
-  LegendComponentOption,
-  LineSeriesOption,
-} from 'echarts';
+import type {EChartsOption, LegendComponentOption, LineSeriesOption} from 'echarts';
 import type {Location} from 'history';
 import moment from 'moment';
 

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -291,8 +291,8 @@ export function useEchartsAriaLabels(
   {series, useUTC}: Omit<EChartsOption, 'series'>,
   isGroupedByDate: boolean
 ) {
-  const filteredSeries: (LineSeriesOption | BarSeriesOption)[] = Array.isArray(series)
-    ? series.filter(s => !!s.data && s.data.length > 0)
+  const filteredSeries = Array.isArray(series)
+    ? series.filter(s => s && !!s.data && s.data.length > 0)
     : [series];
 
   const dateFormat = useShortInterval({


### PR DESCRIPTION
Closes JAVASCRIPT-2AXR and JAVASCRIPT-2AYQ. tl;dr sometimes the `series` is `undefined`, and in those cases the ARIA label generation fails and the widget is fully broken.

## Discussion

You may have questions like "okay but why is the series `undefined`" or "how come the typing system didn't catch this" and so on. Good questions neither of which I chose to address with the fix. Read on for details.

A series might be `undefined` because of this code: https://github.com/getsentry/sentry/blob/aae57229ffeb6c85bdeda528fa70d5db83a12086/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx#L329-L347 If there are multiple queries where the results are of _different length_ (e.g., query 1 is transformed into 1 row, and query 2 is transformed into three rows) this code creates a sparse array (e.g., `[series1, undefined, undefined, series2, series3, series4]` because it uses the length of the _current_ transformed set in the iteration. I don't think TypeScript is clever enough to catch this, but the type of `transformedTimeseriesResults` is actually `Array<Series | undefined>` as far as I can tell. Should it create sparse arrays? Seems like no, but I'm not sure.

The typing system didn't catch this because as far as I can tell the typing of `useEchartsAriaLabels` is also incorrect. Using `Omit` there types both `series` and `useUTC` as `unknown` which is surely wrong. The right type is probably `SeriesOption`, but it mysteriously types `data` as `{}`. Unsure what the right move is there either.
