### PR TITLE
fix(searchbar): Search bar button needs type=button

### DIFF
--- a/static/app/components/searchBar.tsx
+++ b/static/app/components/searchBar.tsx
@@ -80,6 +80,7 @@ function SearchBar({
         <InputTrailingItems>
           {!!query && (
             <SearchClearButton
+              type="button"
               size="zero"
               borderless
               onClick={clearSearch}


### PR DESCRIPTION
The button is inside a form so it implicitly has a type=submit. This means input enter, the button gets clicked which triggers the clear search.

Seems to have regressed in #40663 cc @vuluongj20 