### PR TITLE
ref(mep): Add flag to introduce transaction-search on indexed

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1149,6 +1149,8 @@ SENTRY_FEATURES = {
     "organizations:performance-onboarding-checklist": False,
     # Enable transaction name only search
     "organizations:performance-transaction-name-only-search": False,
+    # Enable transaction name only search on indexed
+    "organizations:performance-transaction-name-only-search-indexed": False,
     # Re-enable histograms for Metrics Enhanced Performance Views
     "organizations:performance-mep-reintroduce-histograms": False,
     # Enable showing INP web vital in default views

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -133,6 +133,7 @@ default_manager.add("organizations:performance-onboarding-checklist", Organizati
 default_manager.add("organizations:performance-span-histogram-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-suspect-spans-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-transaction-name-only-search", OrganizationFeature, True)
+default_manager.add("organizations:performance-transaction-name-only-search-indexed", OrganizationFeature, True)
 default_manager.add("organizations:performance-use-metrics", OrganizationFeature, True)
 default_manager.add("organizations:performance-vitals-inp", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, True)


### PR DESCRIPTION
### Summary
We plan to rollout transaction search on indexed views as part of the MEP/DS rollout but we can try this out ahead of time to minimize technical/product risk on launch.
