### PR TITLE
feat(derived_code_mappings): Enable task with only one project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -242,6 +242,7 @@ yarn.lock           @getsentry/owners-js-deps
 /src/sentry/tasks/commits.py                  @getsentry/ecosystem
 /src/sentry/tasks/commit_context.py           @getsentry/ecosystem
 /src/sentry/tasks/digests.py                  @getsentry/ecosystem
+/src/sentry/tasks/derive_code_mappings.py     @getsentry/ecosystem
 /src/sentry/tasks/email.py                    @getsentry/ecosystem
 /src/sentry/tasks/integrations/               @getsentry/ecosystem
 /src/sentry/tasks/reports.py                  @getsentry/ecosystem

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -605,6 +605,7 @@ CELERY_IMPORTS = (
     "sentry.release_health.tasks",
     "sentry.utils.suspect_resolutions.get_suspect_resolutions",
     "sentry.utils.suspect_resolutions_releases.get_suspect_resolutions_releases",
+    "sentry.tasks.derive_code_mappings",
 )
 CELERY_QUEUES = [
     Queue("activity.notify", routing_key="activity.notify"),
@@ -827,6 +828,11 @@ CELERYBEAT_SCHEDULE = {
         "task": "sentry.snuba.tasks.subscription_checker",
         "schedule": timedelta(minutes=20),
         "options": {"expires": 20 * 60},
+    },
+    "derive-code-mappings": {
+        "task": "sentry.tasks.derive_code_mappings.process_organizations",
+        "schedule": timedelta(minutes=1),
+        "options": {"expires": 3600},
     },
 }
 

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -34,7 +34,11 @@ def derive_missing_codemappings(dry_run=False) -> None:
     """
     Queue tasks to process each organization to derive missing codemappings.
     """
-    organizations = Organization.objects.filter(status=OrganizationStatus.ACTIVE)
+    organizations = Organization.objects.filter(
+        status=OrganizationStatus.ACTIVE,
+        # Temporary change in order to enable the task until we fix perf issues
+        name__in=["sentry-test", "Sentry", "sentry", "Foo_org"],
+    )
     for _, organization in enumerate(
         RangeQuerySetWrapper(organizations, step=1000, result_value_getter=lambda item: item.id)
     ):
@@ -80,6 +84,8 @@ def identify_stacktrace_paths(organization: Organization) -> Mapping[Project, Li
     projects = Project.objects.filter(
         organization=organization,
         first_event__isnull=False,
+        # This is temporary in order to enable the task while fixing perf issues
+        name__in=["sentry-github-actions-app", "foo"],
     )
     projects = [
         project

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -115,6 +115,8 @@ SAMPLED_TASKS = {
     "sentry.tasks.weekly_reports.schedule_organizations": settings.SAMPLED_DEFAULT_RATE,
     "sentry.tasks.weekly_reports.prepare_organization_report": 0.1,
     "sentry.profiles.task.process_profile": 0.01,
+    "sentry.tasks.derive_code_mappings.process_organizations": settings.SAMPLED_DEFAULT_RATE,
+    "sentry.tasks.derive_code_mappings.derive_code_mappings": settings.SAMPLED_DEFAULT_RATE,
 }
 
 if settings.ADDITIONAL_SAMPLED_TASKS:

--- a/tests/sentry/tasks/test_derive_code_mappings.py
+++ b/tests/sentry/tasks/test_derive_code_mappings.py
@@ -17,9 +17,11 @@ from sentry.testutils.helpers.features import with_feature
 class TestIdentfiyStacktracePaths(TestCase):
     def setUp(self):
         self.organization = self.create_organization(
+            name="sentry-test",  # Temp change
             status=OrganizationStatus.ACTIVE,
         )
         self.project = self.create_project(
+            name="sentry-github-actions-app",  # Temp change
             organization=self.organization,
             platform="python",
         )
@@ -68,6 +70,7 @@ class TestIdentfiyStacktracePaths(TestCase):
 
     def test_finds_stacktrace_paths_multiple_projects(self):
         project_2 = self.create_project(
+            name="foo",  # Temp change
             organization=self.organization,
             platform="python",
         )
@@ -182,7 +185,7 @@ class TestIdentfiyStacktracePaths(TestCase):
     @patch("sentry.tasks.derive_code_mappings.derive_code_mappings.delay")
     @with_feature("organizations:derive-code-mappings")
     def test_derive_missing_code_mappings(self, mock_derive_code_mappings):
-        self.create_organization()
+        self.create_organization(name="Foo_org")
         with self.tasks():
             derive_missing_codemappings(self)
 


### PR DESCRIPTION
We have some perf issues that we're investigating, however, we can enable this for just a project with few issues.

This is based on the work from #40717 