### PR TITLE
fix(hc) Fix typings of model annotations

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -202,7 +202,7 @@ class ModelSiloLimit(SiloLimit):
 
         return handle
 
-    def __call__(self, model_class: ModelClass) -> ModelClass:
+    def __call__(self, model_class: ModelClass) -> Type[ModelClass]:
         if not (isinstance(model_class, type) and issubclass(model_class, BaseModel)):
             raise TypeError("`@ModelSiloLimit ` must decorate a Model class")
         assert isinstance(model_class.objects, BaseManager)

--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable, Mapping, Tuple, Type, cast
+from typing import Any, Callable, Iterable, Mapping, Tuple, Type, TypeVar, cast
 
 from django.apps.config import AppConfig
 from django.db import models
@@ -162,6 +162,9 @@ def get_model_if_available(app_config: AppConfig, model_name: str) -> Type[model
     return model
 
 
+ModelClass = TypeVar("ModelClass")
+
+
 class ModelSiloLimit(SiloLimit):
     def __init__(
         self,
@@ -199,7 +202,7 @@ class ModelSiloLimit(SiloLimit):
 
         return handle
 
-    def __call__(self, model_class: Any) -> type:
+    def __call__(self, model_class: ModelClass) -> ModelClass:
         if not (isinstance(model_class, type) and issubclass(model_class, BaseModel)):
             raise TypeError("`@ModelSiloLimit ` must decorate a Model class")
         assert isinstance(model_class.objects, BaseManager)


### PR DESCRIPTION
Without the generic typevar, annotations for model classes were all 'type' causing warnings in both sentry and getsentry for functions that want to typehint on a model class.

Using a TypeVar results in the class type being preserved by the decorator.

Fixes HC-428
