### PR TITLE
perf(QueryBuilder): Spread dataset config imports over multiple calls

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -269,23 +269,27 @@ class QueryBuilder:
         Mapping[str, Callable[[SearchFilter], Optional[WhereType]]],
         Mapping[str, Callable[[Direction], OrderBy]],
     ]:
-        from sentry.search.events.datasets.discover import DiscoverDatasetConfig
-        from sentry.search.events.datasets.metrics import MetricsDatasetConfig
-        from sentry.search.events.datasets.metrics_layer import MetricsLayerDatasetConfig
-        from sentry.search.events.datasets.profiles import ProfilesDatasetConfig
-        from sentry.search.events.datasets.sessions import SessionsDatasetConfig
-
         self.config: DatasetConfig
         if self.dataset in [Dataset.Discover, Dataset.Transactions, Dataset.Events]:
+            from sentry.search.events.datasets.discover import DiscoverDatasetConfig
+
             self.config = DiscoverDatasetConfig(self)
         elif self.dataset == Dataset.Sessions:
+            from sentry.search.events.datasets.sessions import SessionsDatasetConfig
+
             self.config = SessionsDatasetConfig(self)
         elif self.dataset in [Dataset.Metrics, Dataset.PerformanceMetrics]:
             if self.use_metrics_layer:
+                from sentry.search.events.datasets.metrics_layer import MetricsLayerDatasetConfig
+
                 self.config = MetricsLayerDatasetConfig(self)
             else:
+                from sentry.search.events.datasets.metrics import MetricsDatasetConfig
+
                 self.config = MetricsDatasetConfig(self)
         elif self.dataset == Dataset.Profiles:
+            from sentry.search.events.datasets.profiles import ProfilesDatasetConfig
+
             self.config = ProfilesDatasetConfig(self)
         else:
             raise NotImplementedError(f"Data Set configuration not found for {self.dataset}.")


### PR DESCRIPTION
Due to a circular dependency, `load_config` is dynamically importing the various dataset configs into the query builder. This incurs a runtime cost when `load_config` is first called that it needs to import the various dataset configs. In the worst case, this can take a few hundred milliseconds. To alleviate this, this change delegates the import to just before it is needed inside each if branch. This way, the impact is minimized by only importing a single dataset each time. This means we're spreading the cost of loading the various configs to the first time each config is loaded instead of all at once.

Looking at the self time for the `MetricQueryBuilder` span, you can see that there's the random spikes in span durations.

![image](https://user-images.githubusercontent.com/10239353/199093857-4312fe0e-c10e-4924-88e2-62e1bb245350.png)

When examining a matching profile, you can see the `load_config` call in the query builder taking a long time importing the various dataset configs.

![image](https://user-images.githubusercontent.com/10239353/199094157-a382e7d8-0fb2-435e-962d-4fd49c7b334a.png)
