### PR TITLE
feat(derived_code_mappings): Better instrumentation of task 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -242,6 +242,7 @@ yarn.lock           @getsentry/owners-js-deps
 /src/sentry/tasks/commits.py                  @getsentry/ecosystem
 /src/sentry/tasks/commit_context.py           @getsentry/ecosystem
 /src/sentry/tasks/digests.py                  @getsentry/ecosystem
+/src/sentry/tasks/derive_code_mappings.py     @getsentry/ecosystem
 /src/sentry/tasks/email.py                    @getsentry/ecosystem
 /src/sentry/tasks/integrations/               @getsentry/ecosystem
 /src/sentry/tasks/reports.py                  @getsentry/ecosystem

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -829,11 +829,6 @@ CELERYBEAT_SCHEDULE = {
         "schedule": timedelta(minutes=20),
         "options": {"expires": 20 * 60},
     },
-    "derive-code-mappings": {
-        "task": "sentry.tasks.derive_code_mappings.process_organizations",
-        "schedule": timedelta(minutes=1),
-        "options": {"expires": 3600},
-    },
 }
 
 BGTASKS = {

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -605,6 +605,7 @@ CELERY_IMPORTS = (
     "sentry.release_health.tasks",
     "sentry.utils.suspect_resolutions.get_suspect_resolutions",
     "sentry.utils.suspect_resolutions_releases.get_suspect_resolutions_releases",
+    "sentry.tasks.derive_code_mappings",
 )
 CELERY_QUEUES = [
     Queue("activity.notify", routing_key="activity.notify"),
@@ -827,6 +828,11 @@ CELERYBEAT_SCHEDULE = {
         "task": "sentry.snuba.tasks.subscription_checker",
         "schedule": timedelta(minutes=20),
         "options": {"expires": 20 * 60},
+    },
+    "derive-code-mappings": {
+        "task": "sentry.tasks.derive_code_mappings.process_organizations",
+        "schedule": timedelta(minutes=1),
+        "options": {"expires": 3600},
     },
 }
 

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from typing import Any, List, Mapping, Set, Tuple
 
 from django.utils import timezone
+from sentry_sdk import set_tag, set_user
 
 from sentry import features
 from sentry.db.models.fields.node import NodeData
@@ -55,6 +56,9 @@ def derive_code_mappings(organization_id: int, dry_run=False) -> None:
     Derive code mappings for an organization and save the derived code mappings.
     """
     organization: Organization = Organization.objects.get(id=organization_id)
+    set_tag("organization.slug", organization.slug)
+    # When you look at the performance page the user is a default column
+    set_user({"username": organization.slug})
     project_stacktrace_paths = identify_stacktrace_paths(organization)
     if not project_stacktrace_paths:
         return

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -115,6 +115,8 @@ SAMPLED_TASKS = {
     "sentry.tasks.weekly_reports.schedule_organizations": settings.SAMPLED_DEFAULT_RATE,
     "sentry.tasks.weekly_reports.prepare_organization_report": 0.1,
     "sentry.profiles.task.process_profile": 0.01,
+    "sentry.tasks.derive_code_mappings.process_organizations": settings.SAMPLED_DEFAULT_RATE,
+    "sentry.tasks.derive_code_mappings.derive_code_mappings": settings.SAMPLED_DEFAULT_RATE,
 }
 
 if settings.ADDITIONAL_SAMPLED_TASKS:


### PR DESCRIPTION
This allows differentiating Celery tasks by setting the org as the user as well as adding a tag.

This also adds the queue which allows for easier local testing without scheduling the tasks in production.

Once this merges, we can use `SENTRY_DSN` with `sentry shell -c "from sentry.tasks.derive_code_mappings import derive_missing_codemappings; derive_missing_codemappings.delay(dry_run=True)"` in order to allow reporting performance transactions from your localhost.

For instance, [this](https://sentry.io/organizations/sentry-test/performance/trace/eb357d2499b84af399e1bf82ca697579/?pageEnd=2022-11-01T07%3A43%3A59.347&pageStart=2022-10-31T07%3A43%3A58.957) shows the 10 GH paginated requests to my GH user:
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/44410/199097231-e9c45691-9f7a-4277-beca-d44f5a00cb20.png">
