### PR TITLE
ref(issue-alerts): alert form ui changes

### DIFF
--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -121,7 +121,7 @@ describe('ProjectAlertsCreate', function () {
         expect(screen.getAllByDisplayValue('all')).toHaveLength(2);
       });
       await waitFor(() => {
-        expect(screen.getByText('30 minutes')).toBeInTheDocument();
+        expect(screen.getByText('24 hours')).toBeInTheDocument();
       });
     });
 
@@ -155,7 +155,7 @@ describe('ProjectAlertsCreate', function () {
               conditions: [],
               filterMatch: 'all',
               filters: [],
-              frequency: 30,
+              frequency: 60 * 24,
               name: 'My Rule Name',
               owner: null,
             },
@@ -209,7 +209,7 @@ describe('ProjectAlertsCreate', function () {
               conditions: [],
               filterMatch: 'all',
               filters: [],
-              frequency: 30,
+              frequency: 60 * 24,
               name: 'My Rule Name',
               owner: null,
             },
@@ -251,7 +251,7 @@ describe('ProjectAlertsCreate', function () {
               conditions: [],
               filterMatch: 'all',
               filters: [],
-              frequency: 30,
+              frequency: 60 * 24,
               name: 'My Rule Name',
               owner: null,
             },
@@ -305,7 +305,7 @@ describe('ProjectAlertsCreate', function () {
               actions: [],
               filters: [],
               environment: 'production',
-              frequency: 30,
+              frequency: 60 * 24,
               name: 'My Rule Name',
               owner: null,
             },
@@ -353,7 +353,7 @@ describe('ProjectAlertsCreate', function () {
                   value: 'conditionValue',
                 },
               ],
-              frequency: 30,
+              frequency: 60 * 24,
               name: 'My Rule Name',
               owner: null,
             },
@@ -398,7 +398,7 @@ describe('ProjectAlertsCreate', function () {
               ],
               actions: [],
               conditions: [],
-              frequency: 30,
+              frequency: 60 * 24,
               name: 'My Rule Name',
               owner: null,
             },
@@ -425,7 +425,7 @@ describe('ProjectAlertsCreate', function () {
         ]);
 
         // Update action interval
-        await selectEvent.select(screen.getByText('30 minutes'), ['60 minutes']);
+        await selectEvent.select(screen.getByText('24 hours'), ['60 minutes']);
 
         userEvent.click(screen.getByText('Save Rule'));
 
@@ -482,7 +482,7 @@ describe('ProjectAlertsCreate', function () {
               conditions: [],
               filterMatch: 'all',
               filters: [],
-              frequency: 30,
+              frequency: 60 * 24,
             },
           })
         );

--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -540,11 +540,9 @@ describe('ProjectAlertsCreate', function () {
     await selectEvent.select(screen.getByText('Add optional trigger...'), [
       'The issue changes state from resolved to unresolved',
     ]);
-    expect(
-      screen.getByText(
-        'This condition conflicts with other condition(s) above. Please select a different condition'
-      )
-    ).toBeInTheDocument();
+    const errorText =
+      'This condition conflicts with other condition(s) above. Please select a different condition.';
+    expect(screen.getByText(errorText)).toBeInTheDocument();
 
     expect(screen.getByRole('button', {name: 'Save Rule'})).toHaveAttribute(
       'aria-disabled',
@@ -552,10 +550,6 @@ describe('ProjectAlertsCreate', function () {
     );
 
     userEvent.click(screen.getAllByLabelText('Delete Node')[0]);
-    expect(
-      screen.queryByText(
-        'This condition conflicts with other condition(s) above. Please select a different condition'
-      )
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(errorText)).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -104,7 +104,7 @@ const defaultRule: UnsavedIssueAlertRule = {
   conditions: [],
   filters: [],
   name: '',
-  frequency: 30,
+  frequency: 60 * 24,
   environment: ALL_ENVIRONMENTS_KEY,
 };
 
@@ -880,13 +880,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     const ownerId = rule?.owner?.split(':')[1];
 
     return (
-      <StyledField
-        extraMargin
-        label={null}
-        help={null}
-        disabled={disabled}
-        flexibleControlStateSize
-      >
+      <StyledField label={null} help={null} disabled={disabled} flexibleControlStateSize>
         <TeamSelector
           value={this.getTeamId()}
           project={project}
@@ -1188,7 +1182,9 @@ class IssueRuleEditor extends AsyncView<Props, State> {
               >
                 <List symbol="colored-numeric">
                   {loading && <SemiTransparentLoadingMask data-test-id="loading-mask" />}
-                  <StyledListItem>{t('Add alert settings')}</StyledListItem>
+                  <StyledListItem>
+                    {t('Select an environment and project')}
+                  </StyledListItem>
                   <SettingsContainer>
                     {this.renderEnvironmentSelect(disabled)}
                     {this.renderProjectSelect(disabled)}
@@ -1400,7 +1396,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                                     rule?.actions.length === 0
                                   }
                                 >
-                                  {t('Test Notifications')}
+                                  {t('Send Test Notification')}
                                 </Button>
                               </TestButtonWrapper>
                             </Feature>
@@ -1427,9 +1423,19 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                     </StyledListItem>
                     {this.renderPreviewTable()}
                   </Feature>
-                  <StyledListItem>{t('Establish ownership')}</StyledListItem>
-                  {this.renderRuleName(disabled)}
-                  {this.renderTeamSelect(disabled)}
+                  <StyledListItem>
+                    {t('Add a name and owner')}
+                    <StyledFieldHelp>
+                      {t(
+                        'This name will show up in notifications and the owner will give permissions to your whole team to edit and view this alert.'
+                      )}
+                    </StyledFieldHelp>
+                  </StyledListItem>
+
+                  <StyledFieldWrapper>
+                    {this.renderRuleName(disabled)}
+                    {this.renderTeamSelect(disabled)}
+                  </StyledFieldWrapper>
                 </List>
               </StyledForm>
             </Main>
@@ -1554,11 +1560,7 @@ const SettingsContainer = styled('div')`
   gap: ${space(1)};
 `;
 
-const StyledField = styled(Field)<{extraMargin?: boolean}>`
-  :last-child {
-    padding-bottom: ${space(2)};
-  }
-
+const StyledField = styled(Field)`
   border-bottom: none;
   padding: 0;
 
@@ -1566,8 +1568,16 @@ const StyledField = styled(Field)<{extraMargin?: boolean}>`
     padding: 0;
     width: 100%;
   }
+  margin-bottom: ${space(1)};
+`;
 
-  margin-bottom: ${p => `${p.extraMargin ? '60px' : space(1)}`};
+const StyledFieldWrapper = styled('div')`
+  @media (min-width: ${p => p.theme.breakpoints.small}) {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: ${space(1)};
+  }
+  margin-bottom: 60px;
 `;
 
 const Main = styled(Layout.Main)`

--- a/static/app/views/alerts/rules/issue/previewTable.tsx
+++ b/static/app/views/alerts/rules/issue/previewTable.tsx
@@ -80,18 +80,27 @@ const PreviewTable = ({
     return tct(`Showing [pageIssues] of [issueCount] issues`, {pageIssues, issueCount});
   };
 
-  return (
-    <Fragment>
-      <Panel>
-        <GroupListHeader withChart={false} />
-        <PanelBody>{renderBody()}</PanelBody>
-      </Panel>
+  const renderPagination = () => {
+    if (error) {
+      return null;
+    }
+    return (
       <StyledPagination
         pageLinks={pageLinks}
         onCursor={onCursor}
         caption={renderCaption()}
         disabled={loading}
       />
+    );
+  };
+
+  return (
+    <Fragment>
+      <Panel>
+        <GroupListHeader withChart={false} />
+        <PanelBody>{renderBody()}</PanelBody>
+      </Panel>
+      {renderPagination()}
     </Fragment>
   );
 };

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -456,7 +456,7 @@ function RuleNode({
     return (
       <MarginlessAlert type="error" showIcon>
         {t(
-          'This condition conflicts with other condition(s) above. Please select a different condition'
+          'This condition conflicts with other condition(s) above. Please select a different condition.'
         )}
       </MarginlessAlert>
     );


### PR DESCRIPTION
Puts the alert name and owner selectors side by side when screen size > small

Before:
![Screen Shot 2022-10-31 at 1 12 03 PM](https://user-images.githubusercontent.com/39287272/199101488-7ee4c2f1-de51-4d35-8033-c25b39da54a0.png)
![Screen Shot 2022-10-31 at 11 51 54 AM](https://user-images.githubusercontent.com/39287272/199101354-9b7f37fc-bb9c-44d7-9f8f-161456681bce.png)

After:
![Screen Shot 2022-10-31 at 1 07 07 PM](https://user-images.githubusercontent.com/39287272/199101317-fc4fb33f-bdbd-4992-beb3-e13e86e5a945.png)
![Screen Shot 2022-10-31 at 1 06 36 PM](https://user-images.githubusercontent.com/39287272/199101294-b3c9479c-175c-4aed-b11b-36887616714d.png)

Other changes:

`Add alert settings` -> `Select an environment and project`
`Establish ownership` -> `Add a name and owner` + help blurb
`Test Notifications` -> `Send Test Notifications`
defulat actionInterval 30 minutes -> 24 hours
adds a period to incompatible rule error text
removes pagination buttons if there's an error