### PR TITLE
feat(saved-searches): Move pin search button to header [UP-194]

### DIFF
--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -50,7 +50,9 @@ function IssueListFilters({
         disabled={isSearchDisabled}
         excludedTags={['environment']}
         actionBarItems={[
-          makePinSearchAction({sort, pinnedSearch, location}),
+          ...(!organization.features.includes('issue-list-saved-searches-v2')
+            ? [makePinSearchAction({sort, pinnedSearch, location})]
+            : []),
           makeSaveSearchAction({
             sort,
             disabled: !organization.access.includes('org:write'),

--- a/static/app/views/issueList/header.tsx
+++ b/static/app/views/issueList/header.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import Badge from 'sentry/components/badge';
 import Button from 'sentry/components/button';
+import ButtonBar from 'sentry/components/buttonBar';
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
 import Link from 'sentry/components/links/link';
@@ -12,9 +13,10 @@ import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
 import {IconPause, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Organization} from 'sentry/types';
+import {Organization, SavedSearch} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import useProjects from 'sentry/utils/useProjects';
+import IssueListSetAsDefault from 'sentry/views/issueList/issueListSetAsDefault';
 
 import SavedSearchTab from './savedSearchTab';
 import {getTabs, IssueSortOptions, Query, QueryCounts, TAB_MAX_COUNT} from './utils';
@@ -27,6 +29,7 @@ type Props = {
   queryCounts: QueryCounts;
   realtimeActive: boolean;
   router: InjectedRouter;
+  savedSearch: SavedSearch | null;
   selectedProjectIds: number[];
   sort: string;
   queryCount?: number;
@@ -42,6 +45,7 @@ function IssueListHeader({
   onRealtimeChange,
   onSavedSearchSelect,
   onSavedSearchDelete,
+  savedSearch,
   savedSearchList,
   router,
   displayReprocessingTab,
@@ -83,14 +87,17 @@ function IssueListHeader({
         <StyledLayoutTitle>{t('Issues')}</StyledLayoutTitle>
       </Layout.HeaderContent>
       <Layout.HeaderActions>
-        <Button
-          size="sm"
-          data-test-id="real-time"
-          title={realtimeTitle}
-          aria-label={realtimeTitle}
-          icon={realtimeActive ? <IconPause size="xs" /> : <IconPlay size="xs" />}
-          onClick={() => onRealtimeChange(!realtimeActive)}
-        />
+        <ButtonBar gap={1}>
+          <IssueListSetAsDefault {...{sort, query, savedSearch, organization}} />
+          <Button
+            size="sm"
+            data-test-id="real-time"
+            title={realtimeTitle}
+            aria-label={realtimeTitle}
+            icon={realtimeActive ? <IconPause size="xs" /> : <IconPlay size="xs" />}
+            onClick={() => onRealtimeChange(!realtimeActive)}
+          />
+        </ButtonBar>
       </Layout.HeaderActions>
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
       <Layout.HeaderNavTabs underlined>

--- a/static/app/views/issueList/issueListSetAsDefault.spec.tsx
+++ b/static/app/views/issueList/issueListSetAsDefault.spec.tsx
@@ -1,0 +1,68 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {SavedSearchType} from 'sentry/types';
+import IssueListSetAsDefault from 'sentry/views/issueList/issueListSetAsDefault';
+
+describe('IssueListSetAsDefault', () => {
+  const organization = TestStubs.Organization({
+    features: ['issue-list-saved-searches-v2'],
+  });
+
+  const {router} = initializeOrg();
+
+  const routerProps = {
+    params: router.params,
+    location: router.location,
+  };
+
+  const defaultProps = {
+    organization,
+    savedSearch: null,
+    query: 'is:unresolved',
+    sort: 'date',
+    ...routerProps,
+  };
+
+  it('can set a search as default', () => {
+    const mockPinSearch = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/pinned-searches/',
+      method: 'PUT',
+      body: {},
+    });
+
+    render(<IssueListSetAsDefault {...defaultProps} />);
+
+    userEvent.click(screen.getByRole('button', {name: /set as default/i}));
+
+    expect(mockPinSearch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {query: 'is:unresolved', sort: 'date', type: SavedSearchType.ISSUE},
+      })
+    );
+  });
+
+  it('can remove a default search', () => {
+    const mockUnpinSearch = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/pinned-searches/',
+      method: 'DELETE',
+    });
+
+    render(
+      <IssueListSetAsDefault
+        {...defaultProps}
+        savedSearch={TestStubs.Search({isPinned: true})}
+      />
+    );
+
+    userEvent.click(screen.getByRole('button', {name: /remove default/i}));
+
+    expect(mockUnpinSearch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: {type: SavedSearchType.ISSUE},
+      })
+    );
+  });
+});

--- a/static/app/views/issueList/issueListSetAsDefault.tsx
+++ b/static/app/views/issueList/issueListSetAsDefault.tsx
@@ -1,0 +1,91 @@
+// eslint-disable-next-line no-restricted-imports
+import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import isNil from 'lodash/isNil';
+
+import {pinSearch, unpinSearch} from 'sentry/actionCreators/savedSearches';
+import Button from 'sentry/components/button';
+import {removeSpace} from 'sentry/components/smartSearchBar/utils';
+import {IconBookmark} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {Organization, SavedSearch, SavedSearchType} from 'sentry/types';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import useApi from 'sentry/utils/useApi';
+
+interface IssueListSetAsDefaultProps extends WithRouterProps {
+  organization: Organization;
+  query: string;
+  savedSearch: SavedSearch | null;
+  sort: string;
+}
+
+const IssueListSetAsDefault = ({
+  location,
+  organization,
+  savedSearch,
+  sort,
+  query,
+}: IssueListSetAsDefaultProps) => {
+  const api = useApi();
+  const pinnedSearch = savedSearch?.isPinned ? savedSearch : undefined;
+  const pinnedSearchActive = !isNil(pinnedSearch);
+
+  const onTogglePinnedSearch = async () => {
+    const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
+
+    trackAdvancedAnalyticsEvent('search.pin', {
+      organization,
+      action: pinnedSearch ? 'unpin' : 'pin',
+      search_type: 'issues',
+      query: pinnedSearch?.query ?? query,
+    });
+
+    if (pinnedSearch) {
+      await unpinSearch(api, organization.slug, SavedSearchType.ISSUE, pinnedSearch);
+      browserHistory.push({
+        ...location,
+        pathname: `/organizations/${organization.slug}/issues/`,
+        query: {
+          referrer: 'search-bar',
+          ...currentQuery,
+          query: pinnedSearch.query,
+          sort: pinnedSearch.sort,
+        },
+      });
+      return;
+    }
+
+    const resp = await pinSearch(
+      api,
+      organization.slug,
+      SavedSearchType.ISSUE,
+      removeSpace(query),
+      sort
+    );
+
+    if (!resp || !resp.id) {
+      return;
+    }
+
+    browserHistory.push({
+      ...location,
+      pathname: `/organizations/${organization.slug}/issues/searches/${resp.id}/`,
+      query: {referrer: 'search-bar', ...currentQuery},
+    });
+  };
+
+  if (!organization.features.includes('issue-list-saved-searches-v2')) {
+    return null;
+  }
+
+  return (
+    <Button
+      onClick={onTogglePinnedSearch}
+      size="sm"
+      icon={<IconBookmark isSolid={pinnedSearchActive} />}
+    >
+      {pinnedSearchActive ? t('Remove Default') : t('Set as Default')}
+    </Button>
+  );
+};
+
+export default withRouter(IssueListSetAsDefault);

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1209,6 +1209,7 @@ class IssueListOverview extends Component<Props, State> {
           onSavedSearchSelect={this.onSavedSearchSelect}
           onSavedSearchDelete={this.onSavedSearchDelete}
           displayReprocessingTab={showReprocessingTab}
+          savedSearch={savedSearch}
           selectedProjectIds={selection.projects}
         />
         <Layout.Body {...layoutProps}>


### PR DESCRIPTION
This simply moves the pin search logic to a button in the header.

Note that the behavior is already a bit unsatisfactory. When pinning a search, the whole page goes blank and shows a spinner. We will address this later, right now this should work the same as it does today. 