### PR TITLE
feat(alerts): spike protection notification setting frontend

### DIFF
--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -33,6 +33,16 @@ const PanelBodyLineItem = styled(PanelBody)`
   }
 `;
 
+const accountNotifications = [
+  'alerts',
+  'deploy',
+  'workflow',
+  'activeRelease',
+  'approval',
+  'quota',
+  'spikeProtection',
+];
+
 type ANBPProps = {
   field: FineTuneField;
   projects: Project[];
@@ -129,8 +139,8 @@ type State = AsyncView['state'] & {
 
 class AccountNotificationFineTuning extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {fineTuneType: param} = this.props.params;
-    const fineTuneType = getNotificationTypeFromPathname(param);
+    const {fineTuneType: pathnameType} = this.props.params;
+    const fineTuneType = getNotificationTypeFromPathname(pathnameType);
     const endpoints = [
       ['notifications', '/users/me/notifications/'],
       ['fineTuneData', `/users/me/notifications/${fineTuneType}/`],
@@ -169,20 +179,10 @@ class AccountNotificationFineTuning extends AsyncView<Props, State> {
 
   renderBody() {
     const {params} = this.props;
-    const {fineTuneType: param} = params;
-    const fineTuneType = getNotificationTypeFromPathname(param);
+    const {fineTuneType: pathnameType} = params;
+    const fineTuneType = getNotificationTypeFromPathname(pathnameType);
 
-    if (
-      [
-        'alerts',
-        'deploy',
-        'workflow',
-        'activeRelease',
-        'approval',
-        'quota',
-        'spikeProtection',
-      ].includes(fineTuneType)
-    ) {
+    if (accountNotifications.includes(fineTuneType)) {
       return <NotificationSettingsByType notificationType={fineTuneType} />;
     }
 

--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -19,6 +19,7 @@ import {
 } from 'sentry/views/settings/account/notifications/fields';
 import NotificationSettingsByType from 'sentry/views/settings/account/notifications/notificationSettingsByType';
 import {
+  getNotificationTypeFromPathname,
   groupByOrganization,
   isGroupedByProject,
 } from 'sentry/views/settings/account/notifications/utils';
@@ -128,7 +129,8 @@ type State = AsyncView['state'] & {
 
 class AccountNotificationFineTuning extends AsyncView<Props, State> {
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {fineTuneType} = this.props.params;
+    const {fineTuneType: param} = this.props.params;
+    const fineTuneType = getNotificationTypeFromPathname(param);
     const endpoints = [
       ['notifications', '/users/me/notifications/'],
       ['fineTuneData', `/users/me/notifications/${fineTuneType}/`],
@@ -167,12 +169,19 @@ class AccountNotificationFineTuning extends AsyncView<Props, State> {
 
   renderBody() {
     const {params} = this.props;
-    const {fineTuneType} = params;
+    const {fineTuneType: param} = params;
+    const fineTuneType = getNotificationTypeFromPathname(param);
 
     if (
-      ['alerts', 'deploy', 'workflow', 'activeRelease', 'approval', 'quota'].includes(
-        fineTuneType
-      )
+      [
+        'alerts',
+        'deploy',
+        'workflow',
+        'activeRelease',
+        'approval',
+        'quota',
+        'spikeProtection',
+      ].includes(fineTuneType)
     ) {
       return <NotificationSettingsByType notificationType={fineTuneType} />;
     }

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -37,14 +37,17 @@ export const NOTIFICATION_SETTINGS_TYPES = [
   'reports',
   'email',
   'spikeProtection',
-];
+] as const;
 
 export const SELF_NOTIFICATION_SETTINGS_TYPES = [
   'personalActivityNotifications',
   'selfAssignOnResolve',
 ];
 
-export const NOTIFICATION_SETTINGS_PATHNAMES = {
+// 'alerts' | 'activeRelease' | 'workflow' ...
+export type NotificationSettingsType = typeof NOTIFICATION_SETTINGS_TYPES[number];
+
+export const NOTIFICATION_SETTINGS_PATHNAMES: Record<NotificationSettingsType, string> = {
   alerts: 'alerts',
   activeRelease: 'activeRelease',
   workflow: 'workflow',

--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -36,12 +36,25 @@ export const NOTIFICATION_SETTINGS_TYPES = [
   'quota',
   'reports',
   'email',
+  'spikeProtection',
 ];
 
 export const SELF_NOTIFICATION_SETTINGS_TYPES = [
   'personalActivityNotifications',
   'selfAssignOnResolve',
 ];
+
+export const NOTIFICATION_SETTINGS_PATHNAMES = {
+  alerts: 'alerts',
+  activeRelease: 'activeRelease',
+  workflow: 'workflow',
+  deploy: 'deploy',
+  approval: 'approval',
+  quota: 'quota',
+  reports: 'reports',
+  email: 'email',
+  spikeProtection: 'spike-protection',
+};
 
 export const CONFIRMATION_MESSAGE = (
   <div>

--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -97,6 +97,19 @@ export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
     // No choices here because it's going to have dynamic content
     // Component will create choices,
   },
+  spikeProtection: {
+    title: t('Spike Protection Notifications'),
+    description: t(
+      'Notifications about spikes on projects that you have enabled spike protection for.'
+    ),
+    type: 'select',
+    defaultValue: '1',
+    options: [
+      {value: '1', label: t('On')},
+      {value: '0', label: t('Off')},
+    ],
+    defaultFieldName: 'spikeProtection',
+  },
   email: {
     title: t('Email Routing'),
     description: t(

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -104,6 +104,16 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, Field> = {
     label: t('Email Routing'),
     help: t('Change the email address that receives notifications.'),
   },
+  spikeProtection: {
+    name: 'spikeProtection',
+    type: 'select',
+    label: t('Spike Protection'),
+    choices: [
+      ['always', t('On')],
+      ['never', t('Off')],
+    ],
+    help: t('Notifications about spikes on a per project basis.'),
+  },
   personalActivityNotifications: {
     name: 'personalActivityNotifications',
     type: 'select',

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -14,6 +14,7 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import withOrganizations from 'sentry/utils/withOrganizations';
 import {
   CONFIRMATION_MESSAGE,
+  NOTIFICATION_SETTINGS_PATHNAMES,
   NOTIFICATION_SETTINGS_TYPES,
   NotificationSettingsObject,
   SELF_NOTIFICATION_SETTINGS_TYPES,
@@ -147,7 +148,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
               &nbsp;
               <Link
                 data-test-id="fine-tuning"
-                to={`/settings/account/notifications/${notificationType}`}
+                to={`/settings/account/notifications/${NOTIFICATION_SETTINGS_PATHNAMES[notificationType]}`}
               >
                 Fine tune
               </Link>

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -17,10 +17,16 @@ import ParentLabel from 'sentry/views/settings/account/notifications/parentLabel
 /**
  * Which fine-tuning parts are grouped by project
  */
+const notificationsByProject = [
+  'alerts',
+  'email',
+  'workflow',
+  'activeRelease',
+  'spikeProtection',
+];
+
 export const isGroupedByProject = (notificationType: string): boolean =>
-  ['alerts', 'email', 'workflow', 'activeRelease', 'spikeProtection'].includes(
-    notificationType
-  );
+  notificationsByProject.includes(notificationType);
 
 export const getParentKey = (notificationType: string): string => {
   return isGroupedByProject(notificationType) ? 'project' : 'organization';
@@ -440,10 +446,12 @@ export function getDocsLinkForEventType(event: 'error' | 'transaction' | 'attach
   }
 }
 
-export function getNotificationTypeFromPathname(name: string) {
+/**
+ * Returns the corresponding notification type name from the router path name
+ */
+export function getNotificationTypeFromPathname(routerPathname: string) {
   const result = Object.entries(NOTIFICATION_SETTINGS_PATHNAMES).find(
-    ([_, pathname]) => pathname === name
-  );
-
-  return result ? result[0] : '';
+    ([_, pathname]) => pathname === routerPathname
+  ) ?? [routerPathname];
+  return result[0];
 }

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -6,6 +6,7 @@ import {OrganizationSummary, Project} from 'sentry/types';
 import {
   ALL_PROVIDERS,
   MIN_PROJECTS_FOR_CONFIRMATION,
+  NOTIFICATION_SETTINGS_PATHNAMES,
   NotificationSettingsByProviderObject,
   NotificationSettingsObject,
   VALUE_MAPPING,
@@ -17,7 +18,9 @@ import ParentLabel from 'sentry/views/settings/account/notifications/parentLabel
  * Which fine-tuning parts are grouped by project
  */
 export const isGroupedByProject = (notificationType: string): boolean =>
-  ['alerts', 'email', 'workflow', 'activeRelease'].includes(notificationType);
+  ['alerts', 'email', 'workflow', 'activeRelease', 'spikeProtection'].includes(
+    notificationType
+  );
 
 export const getParentKey = (notificationType: string): string => {
   return isGroupedByProject(notificationType) ? 'project' : 'organization';
@@ -435,4 +438,12 @@ export function getDocsLinkForEventType(event: 'error' | 'transaction' | 'attach
     default:
       return 'https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#common-workflows-for-managing-your-event-stream';
   }
+}
+
+export function getNotificationTypeFromPathname(name: string) {
+  const result = Object.entries(NOTIFICATION_SETTINGS_PATHNAMES).find(
+    ([_, pathname]) => pathname === name
+  );
+
+  return result ? result[0] : '';
 }


### PR DESCRIPTION
Adds spike protection as a notification setting with fine tuning `/settings/account/notifications/spike-protection/`

I had to add some logic to make `spikeProtection` camel case into `spike-protection` kebab case for the URL, and vice versa when pulling the name of the setting from the URL back into the appropriate camel case for sending a PUT request to edit the setting.


https://user-images.githubusercontent.com/70817427/199110102-a7048032-96e9-4cfe-860d-d4bc84bc4f21.mov