### PR TITLE
fix(perf-issue): fix search query logic for !issue.category filters

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -176,12 +176,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         group_categories: Set[GroupCategory] = set()
         for search_filter in search_filters or ():
             if search_filter.key.name in ("issue.category", "issue.type"):
-                if not search_filter.is_negation:
-                    group_categories.update(
-                        GROUP_TYPE_TO_CATEGORY[GroupType(value)]
-                        for value in search_filter.value.raw_value
-                    )
-                else:
+                if search_filter.is_negation:
                     group_categories.update(
                         GROUP_TYPE_TO_CATEGORY[GroupType(value)]
                         for value in list(
@@ -191,6 +186,12 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                             )
                         )
                     )
+                else:
+                    group_categories.update(
+                        GROUP_TYPE_TO_CATEGORY[GroupType(value)]
+                        for value in search_filter.value.raw_value
+                    )
+
             if (
                 # Don't filter on postgres fields here, they're not available
                 search_filter.key.name in self.postgres_only_fields

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -43,6 +43,8 @@ from sentry.utils import json, metrics, snuba
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.snuba import SnubaQueryParams, aliased_query_params, bulk_raw_query
 
+ALL_ISSUE_TYPES = {gt.value for gt in GroupType}
+
 
 def get_search_filter(
     search_filters: Optional[Sequence[SearchFilter]], name: str, operator: str
@@ -181,7 +183,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                         GROUP_TYPE_TO_CATEGORY[GroupType(value)]
                         for value in list(
                             filter(
-                                lambda x: x not in {gt.value for gt in GroupType},
+                                lambda x: x not in ALL_ISSUE_TYPES,
                                 search_filter.value.raw_value,
                             )
                         )

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -416,6 +416,15 @@ class EventsSnubaSearchTest(SharedSnubaTest):
             with self.feature("organizations:performance-issues"):
                 self.make_query(search_filter_query="issue.category:hellboy")
 
+    def test_not_perf_category(self):
+        with self.feature("organizations:performance-issues"):
+            results = self.make_query(search_filter_query="issue.category:error foo")
+        assert set(results) == {self.group1}
+
+        with self.feature("organizations:performance-issues"):
+            not_results = self.make_query(search_filter_query="!issue.category:performance foo")
+        assert set(not_results) == {self.group1}
+
     def test_type(self):
         with self.feature("organizations:performance-issues"):
             results = self.make_query(search_filter_query="issue.type:error")


### PR DESCRIPTION
Fixes a bug where we queried the wrong data source when the search query included negation logic like `!issue.category: performance`. 

Fixes ISP-50