### PR TITLE
feat(replays): add count number to Replays tab inside Transaction Summary

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -239,9 +239,13 @@ function TransactionHeader({
               </Item>
               <Item key={Tab.Replays} textValue={t('Replays')} hidden={!hasSessionReplay}>
                 {t('Replays')}
-                {defined(replaysCount) && !Number.isNaN(replaysCount) ? (
-                  <Badge text={replaysCount} />
-                ) : null}
+                <Badge
+                  text={
+                    defined(replaysCount) && !Number.isNaN(replaysCount)
+                      ? replaysCount
+                      : null
+                  }
+                />
                 <ReplaysFeatureBadge noTooltip />
               </Item>
             </TabList>

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -1,9 +1,11 @@
-import {useCallback} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 
 import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
+import Badge from 'sentry/components/badge';
 import ButtonBar from 'sentry/components/buttonBar';
 import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import FeatureBadge from 'sentry/components/featureBadge';
@@ -14,10 +16,14 @@ import {Item, TabList} from 'sentry/components/tabs';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
+import {defined} from 'sentry/utils';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import {TableData} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
+import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {MetricsCardinalityContext} from 'sentry/utils/performance/contexts/metricsCardinality';
 import HasMeasurementsQuery from 'sentry/utils/performance/vitals/hasMeasurementsQuery';
+import useApi from 'sentry/utils/useApi';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 
 import {getCurrentLandingDisplay, LandingDisplayField} from '../landing/utils';
@@ -59,6 +65,8 @@ function TransactionHeader({
       organization_id: organization.id,
     });
   }
+  const api = useApi();
+  const [replaysCount, setReplaysCount] = useState<number>();
 
   const project = projects.find(p => p.id === projectId);
 
@@ -98,6 +106,41 @@ function TransactionHeader({
     },
     [hasWebVitals, location, projects, eventView]
   );
+
+  const fetchReplaysCount = useCallback(async () => {
+    if (hasSessionReplay) {
+      const replayEventView = EventView.fromNewQueryWithLocation(
+        {
+          id: '',
+          name: `Replay events count within a transaction`,
+          version: 2,
+          fields: ['count_unique(replayId)'],
+          query: `event.type:transaction transaction:${transactionName}`,
+          projects: [],
+        },
+        location
+      );
+
+      try {
+        const [data] = await doDiscoverQuery<TableData>(
+          api,
+          `/organizations/${organization.slug}/events/`,
+          replayEventView.getEventsAPIPayload(location)
+        );
+
+        setReplaysCount(Number(data.data[0]['count_unique(replayId)']));
+      } catch (err) {
+        Sentry.captureException(err);
+        return null;
+      }
+    }
+
+    return null;
+  }, [api, hasSessionReplay, location, organization.slug, transactionName]);
+
+  useEffect(() => {
+    fetchReplaysCount();
+  }, [fetchReplaysCount]);
 
   return (
     <Layout.Header>
@@ -196,6 +239,9 @@ function TransactionHeader({
               </Item>
               <Item key={Tab.Replays} textValue={t('Replays')} hidden={!hasSessionReplay}>
                 {t('Replays')}
+                {defined(replaysCount) && !Number.isNaN(replaysCount) ? (
+                  <Badge text={replaysCount} />
+                ) : null}
                 <ReplaysFeatureBadge noTooltip />
               </Item>
             </TabList>


### PR DESCRIPTION
<!-- Describe your PR here. -->
### Changes
- Added a fetch call to get the count number of replays of the transaction in order to add the value to the Replays tab inside Transaction Summary

Closes #40731 

### Test notes

- Made sure tests were passing
- Tested it with different transactions with/without replays

Loom videos: 

https://user-images.githubusercontent.com/39612839/199111548-c7c84bb7-3f49-4612-a79a-0625d95a8ae6.mp4


https://user-images.githubusercontent.com/39612839/199546303-bc80579f-4029-4332-8e90-4d4b264432e2.mp4



### Additional notes

- The header component is being unmounted and mounted every time the user changes tabs, this result in the fetch call to be called again on every tab change, making the number appear and disappear inside the Replay tab.

- The count number will be slight off as this are counting replays that are under 5 seconds which are being hidden in the table at the Replays Tab. There are solutions for this but none of them are particularly easy.
<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
