### PR TITLE
bug(replays): Make the sort props on ReplayTable optional

### DIFF
--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
+import first from 'lodash/first';
 
 import Pagination from 'sentry/components/pagination';
 import {PageContent} from 'sentry/styles/organization';
@@ -49,7 +50,7 @@ const GroupReplays = ({group, replayIds}: Props) => {
         isFetching={isFetching}
         replays={replays}
         showProjectColumn={false}
-        sort={eventView.sorts[0]}
+        sort={first(eventView.sorts)}
         fetchError={fetchError}
       />
       <Pagination pageLinks={pageLinks} />

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -31,7 +31,7 @@ type Props = {
   isFetching: boolean;
   replays: undefined | ReplayListRecord[] | ReplayListRecordWithTx[];
   showProjectColumn: boolean;
-  sort: Sort;
+  sort: Sort | undefined;
   fetchError?: Error;
   showSlowestTxColumn?: boolean;
 };
@@ -57,19 +57,19 @@ function SortableHeader({
 }: {
   fieldName: string;
   label: string;
-  sort: Sort;
+  sort: Props['sort'];
 }) {
   const location = useLocation<ReplayListLocationQuery>();
 
-  const arrowDirection = sort.kind === 'asc' ? 'up' : 'down';
+  const arrowDirection = sort?.kind === 'asc' ? 'up' : 'down';
   const sortArrow = <IconArrow color="gray300" size="xs" direction={arrowDirection} />;
 
   return (
     <SortLink
       role="columnheader"
       aria-sort={
-        sort.field.endsWith(fieldName)
-          ? sort.kind === 'asc'
+        sort?.field.endsWith(fieldName)
+          ? sort?.kind === 'asc'
             ? 'ascending'
             : 'descending'
           : 'none'
@@ -78,15 +78,15 @@ function SortableHeader({
         pathname: location.pathname,
         query: {
           ...location.query,
-          sort: sort.field.endsWith(fieldName)
-            ? sort.kind === 'desc'
+          sort: sort?.field.endsWith(fieldName)
+            ? sort?.kind === 'desc'
               ? fieldName
               : '-' + fieldName
             : '-' + fieldName,
         },
       }}
     >
-      {label} {sort.field === fieldName && sortArrow}
+      {label} {sort?.field === fieldName && sortArrow}
     </SortLink>
   );
 }


### PR DESCRIPTION
When we pass in the sort props it can come from something like: `sort={eventView.sorts[0]}`, which is not typesafe in our tsconfig. So i added a call to `first()` which is typesafe, and updated the callsites to match.

Fixes #40807