### PR TITLE
fix(restore): Organization restore endpoint should not bork if the org no longer exists

### DIFF
--- a/src/sentry/web/frontend/restore_organization.py
+++ b/src/sentry/web/frontend/restore_organization.py
@@ -37,7 +37,7 @@ class RestoreOrganizationView(OrganizationView):
         organization = organization_service.get_organization_by_slug(
             user_id=request.user.id, slug=organization_slug, only_visible=False, allow_stale=False
         )
-        if organization.member:
+        if organization and organization.member:
             self.active_organization = organization
         else:
             self.active_organization = None


### PR DESCRIPTION

Fixes SENTRY-WCD
