### PR TITLE
bug(replays): Stop calling getBoundingClientRect when it does not exist

### DIFF
--- a/static/app/utils/replays/highlightNode.tsx
+++ b/static/app/utils/replays/highlightNode.tsx
@@ -65,7 +65,11 @@ export function highlightNode({
 
   // TODO(replays): There is some sort of race condition here when you "rewind" a replay,
   // mirror will be empty and highlight does not get added because node is null
-  if (!node || !replayer.iframe.contentDocument?.body?.contains(node)) {
+  if (
+    !node ||
+    !('getBoundingClientRect' in node) ||
+    !replayer.iframe.contentDocument?.body?.contains(node)
+  ) {
     return null;
   }
 


### PR DESCRIPTION
Fixes #40811