### PR TITLE
feat(ui): Add minWidth option to DropdownMenuControl

### DIFF
--- a/static/app/components/dropdownMenu.tsx
+++ b/static/app/components/dropdownMenu.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useMemo, useRef} from 'react';
-import {useTheme} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 import {useKeyboard} from '@react-aria/interactions';
@@ -40,6 +40,7 @@ type Props = {
    * Title to display on top of the menu
    */
   menuTitle?: string;
+  minWidth?: number;
   onClose?: () => void;
   size?: MenuItemProps['size'];
   /**
@@ -60,6 +61,7 @@ function DropdownMenu({
   closeRootMenu,
   closeCurrentSubmenu,
   overlayPositionProps,
+  minWidth,
   ...props
 }: Props) {
   const state = useTreeState<MenuItemProps>({...props, selectionMode: 'single'});
@@ -193,7 +195,7 @@ function DropdownMenu({
   return (
     <FocusScope restoreFocus autoFocus>
       <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayPositionProps}>
-        <StyledOverlay>
+        <StyledOverlay minWidth={minWidth}>
           <MenuWrap
             ref={menuRef}
             {...mergeProps(modifiedMenuProps, keyboardProps)}
@@ -213,7 +215,12 @@ function DropdownMenu({
 
 export default DropdownMenu;
 
-const StyledOverlay = styled(Overlay)`
+const StyledOverlay = styled(Overlay)<{minWidth?: number}>`
+  ${p =>
+    p.minWidth &&
+    css`
+      min-width: ${p.minWidth}px;
+    `}
   max-width: 24rem;
   @media only screen and (max-width: calc(24rem + ${space(2)} * 2)) {
     max-width: calc(100vw - ${space(2)} * 2);

--- a/static/app/components/dropdownMenuControl.tsx
+++ b/static/app/components/dropdownMenuControl.tsx
@@ -80,6 +80,10 @@ interface Props
    */
   menuTitle?: string;
   /**
+   * Minimum menu width. By default, expands to content.
+   */
+  minWidth?: number;
+  /**
    * Tag name for the outer wrap, defaults to `div`
    */
   renderWrapAs?: React.ElementType;


### PR DESCRIPTION
The dropdown menu can be very small if you have very short options, so I added a an optional `minWidth` prop.

This is the design I'm trying to create and cannot with the current options (the menu will be very tiny):

![image](https://user-images.githubusercontent.com/10888943/199126390-66f00f70-e3d0-4bc8-8eae-fd781830091a.png)
 