### PR TITLE
chore(hybrid-cloud): Allow anyone to use customer domains

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -4,9 +4,8 @@ from typing import Callable
 
 from django.conf import settings
 from django.contrib.auth import logout
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 from django.urls import resolve, reverse
-from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -96,17 +95,6 @@ class CustomerDomainMiddleware:
             logout_view = reverse("sentry-logout")
             redirect_url = f"{url_prefix}{logout_view}"
             return HttpResponseRedirect(redirect_url)
-
-        user = getattr(request, "user", None)
-        if user and user.is_authenticated and not user.is_staff:
-            # Kick user to sentry.io if they are not a Sentry staff
-            url_prefix = options.get("system.url-prefix")
-            qs = _query_string(request)
-            redirect_url = f"{url_prefix}{request.path}{qs}"
-            if request.method == "GET":
-                return HttpResponseRedirect(redirect_url)
-            else:
-                return HttpResponse(status=status.HTTP_400_BAD_REQUEST)
 
         activeorg = _resolve_activeorg(request)
         if not activeorg:

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -317,31 +317,30 @@ class End2EndTest(APITestCase):
                 follow=True,
             )
             assert response.status_code == 200
-            assert response.redirect_chain == [
-                ("http://testserver/api/0/albertos-apples/?querystring=value", 302)
-            ]
+            assert response.redirect_chain == []
             assert response.data == {
                 "organization_slug": "albertos-apples",
-                "subdomain": None,
-                "activeorg": None,
+                "subdomain": "albertos-apples",
+                "activeorg": "albertos-apples",
             }
-            assert "activeorg" not in self.client.session
+            assert "activeorg" in self.client.session
+            assert self.client.session["activeorg"] == "albertos-apples"
 
             # POST request
             response = self.client.post(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
                 data={"querystring": "value"},
-                HTTP_HOST="albertos-apples.testserver",
+                SERVER_NAME="albertos-apples.testserver",
             )
-            assert response.status_code == 400
+            assert response.status_code == 200
 
-            # PUT request (not-supported)
+            # # PUT request (not-supported)
             response = self.client.put(
                 reverse("org-events-endpoint", kwargs={"organization_slug": "albertos-apples"}),
                 data={"querystring": "value"},
-                HTTP_HOST="albertos-apples.testserver",
+                SERVER_NAME="albertos-apples.testserver",
             )
-            assert response.status_code == 400
+            assert response.status_code == 405
 
     def test_with_middleware_and_is_staff(self):
         self.create_organization(name="albertos-apples")

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -487,8 +487,6 @@ class AuthLoginCustomerDomainTest(TestCase):
             assert resp.status_code == 200
             assert resp.redirect_chain == [
                 (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
-                # Non-sentry staff should be kicked out of using customer domain
-                ("http://testserver/auth/login/", 302),
                 ("/organizations/albertos-apples/issues/", 302),
             ]
 


### PR DESCRIPTION
Gatekeeping customer domains to staff users has been causing issues. I'm removing this altogether to hopefully help alleviate any issues.