### PR TITLE
fix: Fix streaming post process forwarder

### DIFF
--- a/src/sentry/eventstream/kafka/consumer_strategy.py
+++ b/src/sentry/eventstream/kafka/consumer_strategy.py
@@ -46,8 +46,8 @@ def dispatch_post_process_group_task(
         is_new,
         is_regression,
         is_new_group_environment,
-        queue,
         primary_hash,
+        queue,
         skip_consume,
         group_states,
     )

--- a/src/sentry/eventstream/kafka/consumer_strategy.py
+++ b/src/sentry/eventstream/kafka/consumer_strategy.py
@@ -34,8 +34,8 @@ def dispatch_post_process_group_task(
     is_new: bool,
     is_regression: Optional[bool],
     is_new_group_environment: bool,
-    queue: str,
     primary_hash: Optional[str],
+    queue: str,
     skip_consume: bool = False,
     group_states: Optional[GroupStates] = None,
 ) -> None:


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/40239 introduced a bug where the arguments were called in the wrong order. Since the postprocessworker.py file is not being type checked this was not caught in CI.

This code will eventually be removed and only exists temporarily to support our two side by side post process forwarder implementations.
