### PR TITLE
ref(js): Remove deprecated `Form` from window global

### DIFF
--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -28,7 +28,6 @@ const globals = {
 // modules that are not compiled with the sentry bundle.
 const SentryApp = {
   // The following components are used in sentry-plugins.
-  Form: require('sentry/components/deprecatedforms/form').TrackedDeprecatedForm,
   FormState: require('sentry/components/forms/state').default,
   LoadingIndicator: require('sentry/components/loadingIndicator').default,
   plugins: {


### PR DESCRIPTION
We began tracking usage of this in GH-40628. We have not seen any usage of it. I believe it is safe to remove.