### PR TITLE
ci: Enable noUncheckedIndexedAccess in tsconfig

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -42,6 +42,7 @@
     "strict": true,
     "strictBindCallApply": false,
     "useUnknownInCatchVariables": false,
+    "noUncheckedIndexedAccess": true,
 
     // We do not configure these, but are left here for documentation purposes
     //
@@ -50,7 +51,6 @@
     // exactOptionalPropertyTypes
     // noImplicitOverride
     // noPropertyAccessFromIndexSignature
-    // noUncheckedIndexedAccess
     // strictFunctionTypes
     // strictNullChecks
     // strictPropertyInitialization

--- a/docs-ui/stories/assets/icons/searchPanel.tsx
+++ b/docs-ui/stories/assets/icons/searchPanel.tsx
@@ -67,6 +67,7 @@ const enumerateIconVariants = (iconData: ExtendedIconData[]): ExtendedIconData[]
 const addIconNames = (iconData: IconData[]): ExtendedIconData[] =>
   iconData.map(icon => {
     const nameString = icon.id.split('-')[0];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const name = nameString.charAt(0).toUpperCase() + nameString.slice(1);
     return {...icon, name};
   });

--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -25,6 +25,7 @@ export function fetchDashboards(api: Client, orgSlug: string) {
 
     if (errorResponse) {
       const errors = flattenErrors(errorResponse, {});
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       addErrorMessage(errors[Object.keys(errors)[0]]);
     } else {
       addErrorMessage(t('Unable to fetch dashboards'));
@@ -70,6 +71,7 @@ export function createDashboard(
 
     if (errorResponse) {
       const errors = flattenErrors(errorResponse, {});
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       addErrorMessage(errors[Object.keys(errors)[0]]);
     } else {
       addErrorMessage(t('Unable to create dashboard'));
@@ -111,6 +113,7 @@ export function fetchDashboard(
 
     if (errorResponse) {
       const errors = flattenErrors(errorResponse, {});
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       addErrorMessage(errors[Object.keys(errors)[0]]);
     } else {
       addErrorMessage(t('Unable to load dashboard'));
@@ -154,6 +157,7 @@ export function updateDashboard(
 
     if (errorResponse) {
       const errors = flattenErrors(errorResponse, {});
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       addErrorMessage(errors[Object.keys(errors)[0]]);
     } else {
       addErrorMessage(t('Unable to update dashboard'));
@@ -180,6 +184,7 @@ export function deleteDashboard(
 
     if (errorResponse) {
       const errors = flattenErrors(errorResponse, {});
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       addErrorMessage(errors[Object.keys(errors)[0]]);
     } else {
       addErrorMessage(t('Unable to delete dashboard'));

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -44,6 +44,7 @@ export function redirectToRemainingOrganization({
 
   // Let's be smart and select the best org to redirect to
   const firstRemainingOrg = allOrgs[0];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   browserHistory.push(`/${firstRemainingOrg.slug}/`);
 
   // Remove org from SidebarDropdown

--- a/static/app/actionCreators/pageFilters.tsx
+++ b/static/app/actionCreators/pageFilters.tsx
@@ -228,6 +228,7 @@ export function initializeUrlState({
     if (projects && projects.length > 0) {
       // If there is a list of projects from URL params, select first project
       // from that list
+      // @ts-expect-error TS(2322) FIXME: Type '(number | undefined)[]' is not assignable to... Remove this comment to see the full error message
       newProject = typeof projects === 'string' ? [Number(projects)] : [projects[0]];
     } else {
       // When we have finished loading the organization into the props,  i.e.

--- a/static/app/chartcuterie/discover.tsx
+++ b/static/app/chartcuterie/discover.tsx
@@ -344,6 +344,7 @@ discoverCharts.push({
       const previousPeriod = LineSeries({
         name: t('previous %s', data.seriesName),
         data: previous.map(([_, countsForTimestamp], i) => [
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           current[i][0] * 1000,
           countsForTimestamp.reduce((acc, {count}) => acc + count, 0),
         ]),

--- a/static/app/components/acl/feature.tsx
+++ b/static/app/components/acl/feature.tsx
@@ -132,10 +132,12 @@ class Feature extends Component<Props> {
     }
 
     if (shouldMatchOnlyProject) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       return project.includes(shouldMatchOnlyProject[1]);
     }
 
     if (shouldMatchOnlyOrg) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       return organization.includes(shouldMatchOnlyOrg[1]);
     }
 
@@ -173,6 +175,7 @@ class Feature extends Component<Props> {
       const hooks = HookStore.get(hookName);
 
       if (hooks.length > 0) {
+        // @ts-expect-error TS(2322) FIXME: Type 'FeatureDisabledHook | undefined' is not assi... Remove this comment to see the full error message
         customDisabledRender = hooks[0];
       }
     }
@@ -184,6 +187,7 @@ class Feature extends Component<Props> {
     };
 
     if (!hasFeature && customDisabledRender !== false) {
+      // @ts-expect-error TS(2349) FIXME: This expression is not callable.
       return customDisabledRender({children, ...renderProps});
     }
 

--- a/static/app/components/arithmeticInput/parser.tsx
+++ b/static/app/components/arithmeticInput/parser.tsx
@@ -54,6 +54,7 @@ export class TokenConverter {
 
   tokenTerm = (maybeFactor: Expression, remainingAdds: Array<Operation>): Expression => {
     if (remainingAdds.length > 0) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       remainingAdds[0].lhs = maybeFactor;
       return flatten(remainingAdds);
     }
@@ -75,6 +76,7 @@ export class TokenConverter {
   };
 
   tokenFactor = (primary: Expression, remaining: Array<Operation>): Operation => {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     remaining[0].lhs = primary;
     return flatten(remaining);
   };

--- a/static/app/components/assigneeSelector.tsx
+++ b/static/app/components/assigneeSelector.tsx
@@ -69,14 +69,18 @@ function AssigneeSelector({noDropdown, ...props}: AssigneeSelectorProps) {
             <div>
               {tct('Suggestion: [name]', {
                 name:
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   suggestedActors[0].type === 'team'
-                    ? `#${suggestedActors[0].name}`
-                    : suggestedActors[0].name,
+                    ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+                      `#${suggestedActors[0].name}`
+                    : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+                      suggestedActors[0].name,
               })}
               {suggestedActors.length > 1 &&
                 tn(' + %s other', ' + %s others', suggestedActors.length - 1)}
             </div>
             <TooltipSubtext>
+              {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
               {suggestedReasons[suggestedActors[0].suggestedReason]}
             </TooltipSubtext>
           </TooltipWrapper>

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -400,6 +400,7 @@ export class AssigneeSelectorDropdown extends Component<
 
     const assignableTeams = this.assignableTeams();
     const memberList = this.memberList() ?? [];
+    // @ts-expect-error TS(2322) FIXME: Type '({ type: "user"; id: string | undefined; nam... Remove this comment to see the full error message
     const suggestedAssignees: Array<SuggestedAssignee | null> = suggestedOwners.map(
       owner => {
         // converts a backend suggested owner to a suggested assignee
@@ -505,6 +506,7 @@ export function putSessionUserFirst(members: User[] | undefined): User[] {
   arrangedMembers.push(...members.slice(0, sessionUserIndex));
   arrangedMembers.push(...members.slice(sessionUserIndex + 1));
 
+  // @ts-expect-error TS(2322) FIXME: Type '(User | undefined)[]' is not assignable to t... Remove this comment to see the full error message
   return arrangedMembers;
 }
 

--- a/static/app/components/assistant/guideAnchor.tsx
+++ b/static/app/components/assistant/guideAnchor.tsx
@@ -156,6 +156,7 @@ class BaseGuideAnchor extends Component<Props, State> {
         onClick={this.handleDismiss}
         priority="link"
       >
+        {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
         {currentStep.dismissText || t('Dismiss')}
       </DismissButton>
     );
@@ -163,7 +164,9 @@ class BaseGuideAnchor extends Component<Props, State> {
     return (
       <GuideContainer data-test-id="guide-container">
         <GuideContent>
+          {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
           {currentStep.title && <GuideTitle>{currentStep.title}</GuideTitle>}
+          {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
           <GuideDescription>{currentStep.description}</GuideDescription>
         </GuideContent>
         <GuideAction>
@@ -176,9 +179,11 @@ class BaseGuideAnchor extends Component<Props, State> {
                   to={to}
                   onClick={this.handleFinish}
                 >
+                  {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                   {currentStep.nextText ||
                     (hasManySteps ? t('Enough Already') : t('Got It'))}
                 </StyledButton>
+                {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                 {currentStep.hasNextGuide && dismissButton}
               </Fragment>
             ) : (
@@ -189,8 +194,10 @@ class BaseGuideAnchor extends Component<Props, State> {
                   onClick={this.handleNextStep}
                   to={to}
                 >
+                  {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                   {currentStep.nextText || t('Next')}
                 </StyledButton>
+                {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                 {!currentStep.cantDismiss && dismissButton}
               </Fragment>
             )}

--- a/static/app/components/asyncComponent.tsx
+++ b/static/app/components/asyncComponent.tsx
@@ -368,6 +368,7 @@ class AsyncComponent<
     const urlOrDefault = url || (firstEndpoint && firstEndpoint[1]);
     return (
       <AsyncComponentSearchInput
+        // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         url={urlOrDefault}
         {...props}
         api={this.api}

--- a/static/app/components/avatar/actorAvatar.tsx
+++ b/static/app/components/avatar/actorAvatar.tsx
@@ -40,6 +40,7 @@ function ActorAvatar({size = 24, hasTooltip = true, actor, ...props}: Props) {
       <Teams ids={[actor.id]}>
         {({initiallyLoaded, teams}) =>
           initiallyLoaded ? (
+            // @ts-expect-error TS(2322) FIXME: Type 'Team | undefined' is not assignable to type ... Remove this comment to see the full error message
             <TeamAvatar team={teams[0]} {...otherProps} />
           ) : (
             <LoadingIndicator mini />

--- a/static/app/components/avatar/suggestedAvatarStack.tsx
+++ b/static/app/components/avatar/suggestedAvatarStack.tsx
@@ -22,6 +22,7 @@ const SuggestedAvatarStack = ({owners, tooltip, tooltipOptions, ...props}: Props
         <Avatar
           {...props}
           suggested
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           round={firstSuggestion.type === 'user'}
           actor={owner}
           key={i}
@@ -32,6 +33,7 @@ const SuggestedAvatarStack = ({owners, tooltip, tooltipOptions, ...props}: Props
       <Avatar
         {...props}
         suggested
+        // @ts-expect-error TS(2322) FIXME: Type 'Actor | undefined' is not assignable to type... Remove this comment to see the full error message
         actor={firstSuggestion}
         index={numAvatars - 1}
         tooltip={tooltip}

--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -88,7 +88,9 @@ const Breadcrumbs = ({crumbs, linkLastItem = false, ...props}: Props) => {
 
   if (!linkLastItem) {
     const lastCrumb = crumbs[crumbs.length - 1];
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'Crumb | CrumbDropdown | undefine... Remove this comment to see the full error message
     if (!isCrumbDropdown(lastCrumb)) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       lastCrumb.to = null;
     }
   }

--- a/static/app/components/charts/barChartZoom.tsx
+++ b/static/app/components/charts/barChartZoom.tsx
@@ -108,7 +108,9 @@ class BarChartZoom extends Component<Props> {
     if (startValue !== null && endValue !== null) {
       const {buckets, location, paramStart, paramEnd, minZoomWidth, onHistoryPush} =
         this.props;
+      // @ts-expect-error TS(2339) FIXME: Property 'start' does not exist on type 'BarChartB... Remove this comment to see the full error message
       const {start} = buckets[startValue];
+      // @ts-expect-error TS(2339) FIXME: Property 'end' does not exist on type 'BarChartBuc... Remove this comment to see the full error message
       const {end} = buckets[endValue];
 
       if (minZoomWidth === undefined || end - start > minZoomWidth) {

--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -365,6 +365,7 @@ function BaseChartUnwrapped({
     resolveColors ||
     (series.length ? theme.charts.getColorPalette(series.length) : theme.charts.colors);
   const previousPeriodColors =
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string[] | undefined' is not ass... Remove this comment to see the full error message
     previousPeriod && previousPeriod.length > 1 ? lightenHexToRgb(color) : undefined;
 
   const transformedSeries =
@@ -468,8 +469,10 @@ function BaseChartUnwrapped({
     : [XAxis(defaultAxesProps), XAxis(defaultAxesProps)];
 
   const seriesData =
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     Array.isArray(series?.[0]?.data) && series[0].data.length > 1
-      ? series[0].data
+      ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        series[0].data
       : undefined;
   const bucketSize = seriesData ? seriesData[1][0] - seriesData[0][0] : undefined;
 

--- a/static/app/components/charts/chartZoom.tsx
+++ b/static/app/components/charts/chartZoom.tsx
@@ -197,6 +197,7 @@ class ChartZoom extends Component<Props> {
       return;
     }
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'Period | undefined' is not assig... Remove this comment to see the full error message
     this.setPeriod(this.history[0]);
 
     // reset history

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -231,6 +231,7 @@ function getFormatter({
                 `<div><span class="tooltip-label tooltip-label-indent"><strong>${
                   subLabel.label
                 }</strong></span> ${valueFormatter(
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   subLabel.data[s.dataIndex].value
                 )}</div>`
               );

--- a/static/app/components/charts/eventsChart.tsx
+++ b/static/app/components/charts/eventsChart.tsx
@@ -334,6 +334,7 @@ class Chart extends React.Component<ChartProps, State> {
                 new Set(Object.values(timeseriesResultsTypes)).size === 1
                   ? timeseriesResultsTypes[yAxis]
                   : 'number';
+              // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
               return axisLabelFormatterUsingAggregateOutputType(value, outputType);
             }
             return axisLabelFormatter(value, aggregateOutputType(yAxis));
@@ -618,6 +619,7 @@ class EventsChart extends React.Component<EventsChartProps> {
             additionalSeries={additionalSeries}
             previousSeriesTransformer={previousSeriesTransformer}
             stacked={this.isStacked()}
+            // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             yAxis={yAxisArray[0]}
             showDaily={showDaily}
             colors={colors}

--- a/static/app/components/charts/eventsRequest.tsx
+++ b/static/app/components/charts/eventsRequest.tsx
@@ -398,6 +398,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
       seriesName: seriesName ?? 'Previous',
       data: this.calculateTotalsPerTimestamp(
         previous,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         (_timestamp, _countArray, i) => current[i][0] * 1000
       ),
       stack: 'previous',
@@ -545,6 +546,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
             seriesName: string,
             index: number
           ): [number, Series, Series | null, AdditionalSeriesInfo] => {
+            // @ts-expect-error TS(2322) FIXME: Type 'EventsStats | undefined' is not assignable t... Remove this comment to see the full error message
             const seriesData: EventsStats = timeseriesData[seriesName];
             const processedData = this.processData(
               seriesData,
@@ -561,6 +563,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
             }
             return [
               seriesData.order || 0,
+              // @ts-expect-error TS(2322) FIXME: Type 'Series | undefined' is not assignable to typ... Remove this comment to see the full error message
               processedData.data[0],
               processedData.previousData,
               {isMetricsData: processedData.isMetricsData},
@@ -570,6 +573,7 @@ class EventsRequest extends PureComponent<EventsRequestProps, EventsRequestState
         .sort((a, b) => a[0] - b[0]);
       const timeseriesResultsTypes: Record<string, AggregationOutputType> = {};
       Object.keys(timeseriesData).forEach(key => {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const fieldsMeta = timeseriesData[key].meta?.fields[getAggregateAlias(key)];
         if (fieldsMeta) {
           timeseriesResultsTypes[key] = fieldsMeta;

--- a/static/app/components/charts/intervalSelector.tsx
+++ b/static/app/components/charts/intervalSelector.tsx
@@ -124,10 +124,13 @@ function formatHoursToInterval(hours: number): [number, IntervalUnits] {
 function getIntervalOption(rangeHours: number): IntervalOption {
   for (const index in INTERVAL_OPTIONS) {
     const currentOption = INTERVAL_OPTIONS[index];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (currentOption.rangeStart <= rangeHours) {
+      // @ts-expect-error TS(2322) FIXME: Type 'IntervalOption | undefined' is not assignabl... Remove this comment to see the full error message
       return currentOption;
     }
   }
+  // @ts-expect-error TS(2322) FIXME: Type 'IntervalOption | undefined' is not assignabl... Remove this comment to see the full error message
   return INTERVAL_OPTIONS[0];
 }
 
@@ -196,6 +199,7 @@ export default function IntervalSelector({
         makeItem(
           amount,
           unit,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           SUPPORTED_RELATIVE_PERIOD_UNITS[unit].label,
           results.length + 1
         )

--- a/static/app/components/charts/percentageAreaChart.tsx
+++ b/static/app/components/charts/percentageAreaChart.tsx
@@ -40,8 +40,10 @@ export default class PercentageAreaChart extends Component<Props> {
     const {series, getDataItemName, getValue} = this.props;
 
     const totalsArray: [string | number, number][] = series.length
-      ? series[0].data.map(({name}, i) => [
+      ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        series[0].data.map(({name}, i) => [
           name,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           series.reduce((sum, {data}) => sum + data[i].value, 0),
         ])
       : [];

--- a/static/app/components/charts/pieChart.tsx
+++ b/static/app/components/charts/pieChart.tsx
@@ -76,6 +76,7 @@ class PieChart extends Component<Props> {
       .reduce(
         (acc, [name, value]) => ({
           ...acc,
+          // @ts-expect-error TS(2464) FIXME: A computed property name must be of type 'string',... Remove this comment to see the full error message
           [name]: value,
         }),
         {}
@@ -94,6 +95,7 @@ class PieChart extends Component<Props> {
 
     // Note, we only take the first series unit!
     const [firstSeries] = series;
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'PieChartSeries | undefined' is n... Remove this comment to see the full error message
     const seriesPercentages = this.getSeriesPercentages(firstSeries);
 
     return (
@@ -108,6 +110,7 @@ class PieChart extends Component<Props> {
           if (
             !this.isInitialSelected ||
             !name ||
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             firstSeries.data[this.selected].name === name
           ) {
             return;
@@ -159,7 +162,9 @@ class PieChart extends Component<Props> {
         }}
         series={[
           PieSeries({
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             name: firstSeries.seriesName,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             data: firstSeries.data,
             avoidLabelOverlap: false,
             label: {

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -173,6 +173,7 @@ class ReleaseSeries extends Component<Props, State> {
         if (pageLinks) {
           const paginationObject = parseLinkHeader(pageLinks);
           hasMore = paginationObject?.next?.results ?? false;
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           conditions.cursor = paginationObject.next.cursor;
         } else {
           hasMore = false;

--- a/static/app/components/charts/sessionsRequest.tsx
+++ b/static/app/components/charts/sessionsRequest.tsx
@@ -118,6 +118,7 @@ class SessionsRequest extends Component<Props, State> {
 
       this.setState({
         reloading: false,
+        // @ts-expect-error TS(2322) FIXME: Type '{ start: string | undefined; end: string | u... Remove this comment to see the full error message
         response: shouldFilterSessionsInTimeWindow
           ? filterSessionsInTimeWindow(
               response,

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -251,6 +251,7 @@ export const processTableResults = (tableResults?: TableDataWithTitle[]) => {
 
   const tableResult = tableResults[0];
 
+  // @ts-expect-error TS(2339) FIXME: Property 'data' does not exist on type 'TableDataW... Remove this comment to see the full error message
   const {data} = tableResult;
 
   if (!data || !data.length) {
@@ -266,6 +267,7 @@ export const processTableResults = (tableResults?: TableDataWithTitle[]) => {
   }
 
   return {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     title: tableResult.title ?? '',
     data: data.map(row => {
       return {

--- a/static/app/components/compositeSelect.tsx
+++ b/static/app/components/compositeSelect.tsx
@@ -105,6 +105,7 @@ function CompositeSelect<OptionType extends GeneralSelectValue = GeneralSelectVa
 
       // If the section allows multiple selection, then add the value to the
       // list of selected values
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (parentSection.multiple) {
         if (!newValues[parentSectionIndex]) {
           newValues[parentSectionIndex] = [];
@@ -132,6 +133,7 @@ function CompositeSelect<OptionType extends GeneralSelectValue = GeneralSelectVa
 
       // Trigger the onChange callback for sections whose values have changed.
       if (!valueIsEqual(values[i], newValues[i])) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         sections[i].onChange?.(newValues[i]);
       }
     });

--- a/static/app/components/contextData/index.tsx
+++ b/static/app/components/contextData/index.tsx
@@ -149,11 +149,13 @@ function walk({
         <span className="val-dict-col">{': '}</span>
         <span className="val-dict-value">
           {walk({
+            // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
             value: value[key],
             depth: depth + 1,
             preserveQuotes,
             withAnnotatedText,
             jsonConsts,
+            // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
             meta: meta?.[key]?.[''] ?? meta?.[key] ?? meta?.[''] ?? meta,
           })}
           {i < keys.length - 1 ? <span className="val-dict-sep">{', '}</span> : null}

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -146,6 +146,7 @@ class ContextPickerModal extends Component<Props> {
       this.onFinishTimeout =
         onFinish(
           replaceRouterParams(nextPath, {
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             orgId: organizations[0].slug,
           })
         ) ?? undefined;
@@ -155,6 +156,7 @@ class ContextPickerModal extends Component<Props> {
     // Use latest org or if only 1 org, use that
     let org = latestOrg;
     if (!org && organizations.length === 1) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       org = organizations[0].slug;
     }
 
@@ -162,7 +164,9 @@ class ContextPickerModal extends Component<Props> {
       onFinish(
         replaceRouterParams(nextPath, {
           orgId: org,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           projectId: projects[0].slug,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           project: this.props.projects.find(p => p.slug === projects[0].slug)?.id,
         })
       ) ?? undefined;
@@ -270,6 +274,7 @@ class ContextPickerModal extends Component<Props> {
     const projectOptions = [
       {
         label: t('My Projects'),
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         options: memberProjects.map(p => ({
           value: p.slug,
           label: p.slug,
@@ -278,6 +283,7 @@ class ContextPickerModal extends Component<Props> {
       },
       {
         label: t('All Projects'),
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         options: nonMemberProjects.map(p => ({
           value: p.slug,
           label: p.slug,
@@ -322,6 +328,7 @@ class ContextPickerModal extends Component<Props> {
     const options = [
       {
         label: tct('[providerName] Configurations', {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           providerName: integrationConfigs[0].provider.name,
         }),
         options: integrationConfigs.map(config => ({

--- a/static/app/components/deviceName.tsx
+++ b/static/app/components/deviceName.tsx
@@ -15,6 +15,7 @@ export function deviceNameMapper(model: string | undefined): string | null {
 
   const [identifier, ...rest] = model.split(' ');
 
+  // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
   const modelName = iOSDeviceMapping[identifier];
   return modelName === undefined ? model : `${modelName} ${rest.join(' ')}`;
 }

--- a/static/app/components/discover/transactionsTable.tsx
+++ b/static/app/components/discover/transactionsTable.tsx
@@ -62,8 +62,10 @@ class TransactionsTable extends PureComponent<Props> {
 
     const headers = tableTitles.map((title, index) => {
       const column = columnOrder[index];
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const align: Alignments = fieldAlignment(column.name, column.type, tableMeta);
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (column.key === 'span_ops_breakdown.relative') {
         return (
           <HeadCellContainer key={index}>
@@ -150,6 +152,7 @@ class TransactionsTable extends PureComponent<Props> {
         );
       }
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       const isNumeric = ['integer', 'number', 'duration'].includes(fieldType);
       const key = `${rowIndex}:${column.key}:${index}`;
       rendered = isNumeric ? (

--- a/static/app/components/dropdownAutoComplete/list.tsx
+++ b/static/app/components/dropdownAutoComplete/list.tsx
@@ -82,6 +82,7 @@ const List = ({
             onScroll={onScroll}
             rowCount={items.length}
             rowHeight={({index}) =>
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               items[index].groupLabel && virtualizedLabelHeight
                 ? virtualizedLabelHeight
                 : virtualizedHeight
@@ -90,7 +91,9 @@ const List = ({
               <Row
                 key={key}
                 style={style}
+                // @ts-expect-error TS(2322) FIXME: Type '({ index: number; label: ReactNode | ((value... Remove this comment to see the full error message
                 item={items[index]}
+                // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                 isHighlighted={items[index].index === highlightedIndex}
                 {...rowProps}
               />

--- a/static/app/components/environmentPageFilter.spec.tsx
+++ b/static/app/components/environmentPageFilter.spec.tsx
@@ -56,9 +56,11 @@ describe('EnvironmentPageFilter', function () {
 
     // Click the first environment's checkbox
     const envOptions = screen.getAllByTestId('checkbox-fancy');
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(envOptions[0]);
 
     // Close the dropdown
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(screen.getAllByText('prod')[0]);
 
     // Verify we were redirected

--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -58,6 +58,7 @@ function EnvironmentPageFilter({
     value,
   }) => {
     const environmentsToShow =
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       value[0]?.length + value[1]?.length <= maxTitleLength - 2
         ? value.slice(0, 2)
         : value.slice(0, 1);

--- a/static/app/components/events/contextSummary/index.tsx
+++ b/static/app/components/events/contextSummary/index.tsx
@@ -104,6 +104,7 @@ function ContextSummary({event}: Props) {
       data,
       unknownTitle,
       omitUnknownVersion,
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       meta: event._meta?.contexts?.[key] ?? {},
     };
 

--- a/static/app/components/events/contextSummary/utils.tsx
+++ b/static/app/components/events/contextSummary/utils.tsx
@@ -64,6 +64,7 @@ export function generateIconName(
     return 'google';
   }
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const formattedName = name
     .split(/\d/)[0]
     .toLowerCase()
@@ -73,6 +74,7 @@ export function generateIconName(
 
   if (formattedName === 'edge' && version) {
     const majorVersion = version.split('.')[0];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const isLegacyEdge = majorVersion >= '12' && majorVersion <= '18';
 
     return isLegacyEdge ? 'legacy-edge' : 'edge';

--- a/static/app/components/events/contexts/gpu/index.spec.tsx
+++ b/static/app/components/events/contexts/gpu/index.spec.tsx
@@ -49,6 +49,7 @@ describe('gpu event context', function () {
     });
 
     expect(screen.getByText('API Type')).toBeInTheDocument(); // subject
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByText(/redacted/)[0]);
     expect(
       await screen.findByText(
@@ -59,6 +60,7 @@ describe('gpu event context', function () {
     ).toBeInTheDocument(); // tooltip description
 
     expect(screen.getByText('Name')).toBeInTheDocument(); // subject
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByText(/redacted/)[1]);
     expect(
       await screen.findByText(

--- a/static/app/components/events/errorItem.spec.tsx
+++ b/static/app/components/events/errorItem.spec.tsx
@@ -50,6 +50,7 @@ describe('Issue error item', function () {
     expect(screen.getByText('File Path')).toBeInTheDocument();
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByText(/redacted/)[0]);
 
     expect(

--- a/static/app/components/events/eventAttachments.tsx
+++ b/static/app/components/events/eventAttachments.tsx
@@ -107,6 +107,7 @@ class EventAttachments extends Component<Props, State> {
 
     const lastAttachmentPreviewed =
       attachments.length > 0 &&
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'IssueAttachment | undefined' is ... Remove this comment to see the full error message
       this.attachmentPreviewIsOpen(attachments[attachments.length - 1]);
 
     return (

--- a/static/app/components/events/eventExtraData/index.spec.tsx
+++ b/static/app/components/events/eventExtraData/index.spec.tsx
@@ -178,6 +178,7 @@ describe('EventExtraData', function () {
 
     expect(await screen.findAllByText(/redacted/)).toHaveLength(10);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByText(/redacted/)[0]);
 
     expect(

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -174,6 +174,7 @@ describe('EventTagsAndScreenshot', function () {
       expect(contextItems).toHaveLength(Object.keys(contexts).length);
 
       // Context Item 1
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       const contextItem1 = within(contextItems[0]);
       expect(contextItem1.getByRole('heading')).toHaveTextContent(user.email);
       expect(contextItem1.getByTestId('context-sub-title')).toHaveTextContent(
@@ -181,6 +182,7 @@ describe('EventTagsAndScreenshot', function () {
       );
 
       // Context Item 2
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       const contextItem2 = within(contextItems[1]);
       expect(contextItem2.getByRole('heading')).toHaveTextContent(contexts.os.name);
       expect(contextItem2.getByTestId('context-sub-title')).toHaveTextContent(
@@ -188,6 +190,7 @@ describe('EventTagsAndScreenshot', function () {
       );
 
       // Context Item 3
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       const contextItem3 = within(contextItems[2]);
       expect(contextItem3.getByRole('heading')).toHaveTextContent(
         deviceNameMapper(contexts.device.model)?.trim() ?? ''
@@ -290,7 +293,12 @@ describe('EventTagsAndScreenshot', function () {
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByTestId('image-viewer')).toHaveAttribute(
         'src',
-        `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1].id}/?download`
+        `/api/0/projects/${organization.slug}/${project.slug}/events/${
+          event.id
+        }/attachments/${
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          attachments[1].id
+        }/?download`
       );
 
       // Display help text when hovering question element
@@ -336,7 +344,12 @@ describe('EventTagsAndScreenshot', function () {
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByTestId('image-viewer')).toHaveAttribute(
         'src',
-        `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1].id}/?download`
+        `/api/0/projects/${organization.slug}/${project.slug}/events/${
+          event.id
+        }/attachments/${
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          attachments[1].id
+        }/?download`
       );
 
       // Tags Container
@@ -369,7 +382,12 @@ describe('EventTagsAndScreenshot', function () {
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByTestId('image-viewer')).toHaveAttribute(
         'src',
-        `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1].id}/?download`
+        `/api/0/projects/${organization.slug}/${project.slug}/events/${
+          event.id
+        }/attachments/${
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          attachments[1].id
+        }/?download`
       );
 
       // Tags Container
@@ -402,7 +420,12 @@ describe('EventTagsAndScreenshot', function () {
       expect(screen.getByText('View screenshot')).toBeInTheDocument();
       expect(screen.getByTestId('image-viewer')).toHaveAttribute(
         'src',
-        `/api/0/projects/${organization.slug}/${project.slug}/events/${event.id}/attachments/${attachments[1].id}/?download`
+        `/api/0/projects/${organization.slug}/${project.slug}/events/${
+          event.id
+        }/attachments/${
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          attachments[1].id
+        }/?download`
       );
 
       // Tags Container

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -99,6 +99,7 @@ function Modal({
         return;
       }
       setCurrentAttachmentIndex(newAttachmentIndex);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'IssueAttachment | undefined' is ... Remove this comment to see the full error message
       setCurrentAttachment(memoizedAttachments[newAttachmentIndex]);
     }
   };

--- a/static/app/components/events/eventVitals.tsx
+++ b/static/app/components/events/eventVitals.tsx
@@ -119,6 +119,7 @@ type EventVitalProps = Props & {
 };
 
 function EventVital({event, name, vital}: EventVitalProps) {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const value = event.measurements?.[name].value ?? null;
   if (value === null || !vital) {
     return null;

--- a/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/breadcrumbs.tsx
@@ -92,6 +92,7 @@ function Breadcrumbs({
 
   function renderRow({index, key, parent, style}: ListRowProps) {
     const breadcrumb = breadcrumbs[index];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const isLastItem = breadcrumbs[breadcrumbs.length - 1].id === breadcrumb.id;
     const {height} = style;
     return (
@@ -109,6 +110,7 @@ function Breadcrumbs({
             onLoad={measure}
             organization={organization}
             searchTerm={searchTerm}
+            // @ts-expect-error TS(2322) FIXME: Type 'Crumb | undefined' is not assignable to type... Remove this comment to see the full error message
             breadcrumb={breadcrumb}
             meta={event._meta?.entries?.[entryIndex]?.data?.values?.[index]}
             event={event}

--- a/static/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -134,13 +134,17 @@ function BreadcrumbsContainer({
     for (const index in crumbs) {
       const breadcrumb = crumbs[index];
       const foundFilterType = filterTypes.findIndex(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         f => f.value === `type-${breadcrumb.type}`
       );
 
       if (foundFilterType === -1) {
         filterTypes.push({
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           value: `type-${breadcrumb.type}`,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           leadingItems: <Type type={breadcrumb.type} color={breadcrumb.color} />,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           label: breadcrumb.description,
           levels: breadcrumb?.level ? [breadcrumb.level] : [],
         });
@@ -149,8 +153,10 @@ function BreadcrumbsContainer({
 
       if (
         breadcrumb?.level &&
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         !filterTypes[foundFilterType].levels?.includes(breadcrumb.level)
       ) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         filterTypes[foundFilterType].levels?.push(breadcrumb.level);
       }
     }
@@ -162,7 +168,9 @@ function BreadcrumbsContainer({
     const filterLevels: FilterOptions = [];
 
     for (const indexType in types) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       for (const indexLevel in types[indexType].levels) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const level = types[indexType].levels?.[indexLevel];
 
         if (filterLevels.some(f => f.value === `level-${level}`)) {

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -120,6 +120,7 @@ describe('Exception Content', function () {
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByText(/redacted/)[0]);
 
     expect(

--- a/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/stackTrace.spec.tsx
@@ -124,6 +124,7 @@ describe('ExceptionStacktraceContent', function () {
     render(
       <ExceptionStacktraceContent
         {...props}
+        // @ts-expect-error TS(2322) FIXME: Type '{ inApp: true; } | { inApp: true; function: ... Remove this comment to see the full error message
         stacktrace={{...stacktrace, frames: [{...frames[0], inApp: true}, frames[1]]}}
       />
     );
@@ -150,6 +151,7 @@ describe('ExceptionStacktraceContent', function () {
     render(
       <ExceptionStacktraceContent
         {...props}
+        // @ts-expect-error TS(2322) FIXME: Type '{ inApp: true; } | { inApp: true; function: ... Remove this comment to see the full error message
         stacktrace={{...stacktrace, frames: [{...frames[0], inApp: true}, frames[1]]}}
         chainedException
       />

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.spec.tsx
@@ -81,6 +81,7 @@ describe('StackTrace', function () {
     const frameTitles = screen.getAllByTestId('title');
 
     // collapse the expanded frame (by default)
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(frameTitles[0]);
 
     // all frames are now collapsed
@@ -88,7 +89,9 @@ describe('StackTrace', function () {
     expect(screen.getAllByTestId('toggle-button-collapsed')).toHaveLength(5);
 
     // expand penultimate and last frame
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(frameTitles[frameTitles.length - 2]);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(frameTitles[frameTitles.length - 1]);
 
     // two frames are now collapsed
@@ -119,7 +122,9 @@ describe('StackTrace', function () {
     const collapsedToggleButtons = screen.getAllByTestId('toggle-button-collapsed');
 
     // expand penultimate and last frame
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(collapsedToggleButtons[collapsedToggleButtons.length - 2]);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(collapsedToggleButtons[collapsedToggleButtons.length - 1]);
 
     // two frames are now collapsed
@@ -149,6 +154,7 @@ describe('StackTrace', function () {
       };
 
       renderedComponent({
+        // @ts-expect-error TS(2322) FIXME: Type '{ hasSystemFrames: boolean; frames: { inApp:... Remove this comment to see the full error message
         data: newData,
         event: {...event, entries: [{...event.entries[0], stacktrace: newData.frames}]},
         includeSystemFrames: false,
@@ -180,6 +186,7 @@ describe('StackTrace', function () {
       };
 
       renderedComponent({
+        // @ts-expect-error TS(2322) FIXME: Type '{ hasSystemFrames: boolean; registers: {}; f... Remove this comment to see the full error message
         data: newData,
         event: {...event, entries: [{...event.entries[0], stacktrace: newData.frames}]},
         includeSystemFrames: false,
@@ -213,6 +220,7 @@ describe('StackTrace', function () {
       };
 
       renderedComponent({
+        // @ts-expect-error TS(2322) FIXME: Type '{ hasSystemFrames: boolean; frames: { inApp:... Remove this comment to see the full error message
         data: newData,
         event: {...event, entries: [{...event.entries[0], stacktrace: newData.frames}]},
         includeSystemFrames: false,

--- a/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/content.tsx
@@ -70,6 +70,7 @@ class Content extends Component<Props, State> {
     const lastFrame = frames[frames.length - 1];
     const penultimateFrame = frames[frames.length - 2];
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return penultimateFrame.inApp && !lastFrame.inApp;
   }
 
@@ -204,6 +205,7 @@ class Content extends Component<Props, State> {
         nRepeats++;
       }
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'Frame | undefined' is not assign... Remove this comment to see the full error message
       if (this.frameIsVisible(frame, nextFrame) && !repeatedFrame) {
         const image = this.findImageForAddress(frame.instructionAddr, frame.addrMode);
 
@@ -247,6 +249,7 @@ class Content extends Component<Props, State> {
 
     if (frames.length > 0 && data.registers) {
       const lastFrame = frames.length - 1;
+      // @ts-expect-error TS(2769) FIXME: No overload matches this call.
       frames[lastFrame] = cloneElement(frames[lastFrame], {
         registers: data.registers,
       });

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV2.tsx
@@ -225,6 +225,7 @@ function Content({
 
     if (convertedFrames.length > 0 && registers) {
       const lastFrame = convertedFrames.length - 1;
+      // @ts-expect-error TS(2769) FIXME: No overload matches this call.
       convertedFrames[lastFrame] = cloneElement(convertedFrames[lastFrame], {
         registers,
       });

--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -215,6 +215,7 @@ function Content({
 
   if (convertedFrames.length > 0 && registers) {
     const lastFrame = convertedFrames.length - 1;
+    // @ts-expect-error TS(2769) FIXME: No overload matches this call.
     convertedFrames[lastFrame] = cloneElement(convertedFrames[lastFrame], {
       registers,
     });

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -179,6 +179,7 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
       const needle = parseAddress(searchTerm);
       if (needle > 0 && image.image_addr !== '0x0') {
         const [startAddress, endAddress] = getImageRange(image as any); // TODO(PRISCILA): remove any
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         return needle >= startAddress && needle < endAddress;
       }
     }
@@ -324,6 +325,7 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
     const filteredImages = [...usedImages, ...unusedImages];
 
     const filterOptions = this.getFilterOptions(filteredImages);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const defaultFilterSelections = (filterOptions[0].options ?? []).filter(
       opt => opt.value !== ImageStatus.UNUSED
     );
@@ -436,6 +438,7 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
       >
         <DebugImage
           style={style}
+          // @ts-expect-error TS(2322) FIXME: Type '(Image & { status: ImageStatus; }) | undefin... Remove this comment to see the full error message
           image={images[index]}
           onOpenImageDetailsModal={this.handleOpenImageDetailsModal}
         />

--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -67,6 +67,7 @@ const Context = ({
     ? frame.context
     : frame.context.filter(l => l[0] === frame.lineNo);
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const startLineNo = hasContextSource ? frame.context[0][0] : undefined;
 
   return (

--- a/static/app/components/events/interfaces/frame/contextLine.tsx
+++ b/static/app/components/events/interfaces/frame/contextLine.tsx
@@ -13,6 +13,7 @@ const ContextLine = function ({line, isActive, children, className}: Props) {
   let lineWs = '';
   let lineCode = '';
   if (typeof line[1] === 'string') {
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     [, lineWs, lineCode] = line[1].match(/^(\s*)(.*?)$/m)!;
   }
   const Component = !children ? Fragment : Context;

--- a/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
@@ -70,6 +70,7 @@ describe('Frame Variables', function () {
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByText(/redacted/)[0]);
 
     expect(

--- a/static/app/components/events/interfaces/keyValueList/index.spec.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.spec.tsx
@@ -14,10 +14,12 @@ describe('KeyValueList', function () {
     const rows = screen.getAllByRole('row');
     expect(rows).toHaveLength(2);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const firstColumn = within(rows[0]).getAllByRole('cell');
     expect(firstColumn[0]).toHaveTextContent('a');
     expect(firstColumn[1]).toHaveTextContent('x');
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const secondColumn = within(rows[1]).getAllByRole('cell');
     expect(secondColumn[0]).toHaveTextContent('b');
     expect(secondColumn[1]).toHaveTextContent('y');
@@ -33,10 +35,12 @@ describe('KeyValueList', function () {
 
     const rows = screen.getAllByRole('row');
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const firstColumn = within(rows[0]).getAllByRole('cell');
     expect(firstColumn[0]).toHaveTextContent('a');
     expect(firstColumn[1]).toHaveTextContent('x');
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const secondColumn = within(rows[1]).getAllByRole('cell');
     expect(secondColumn[0]).toHaveTextContent('b');
     expect(secondColumn[1]).toHaveTextContent('y');
@@ -52,10 +56,12 @@ describe('KeyValueList', function () {
 
     const rows = screen.getAllByRole('row');
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const firstColumn = within(rows[0]).getAllByRole('cell');
     expect(firstColumn[0]).toHaveTextContent('a');
     expect(firstColumn[1]).toHaveTextContent(''); // empty string
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const secondColumn = within(rows[1]).getAllByRole('cell');
     expect(secondColumn[0]).toHaveTextContent('b');
     expect(secondColumn[1]).toHaveTextContent('y');
@@ -72,9 +78,11 @@ describe('KeyValueList', function () {
     const rows = screen.getAllByRole('row');
 
     // Ignore values, more interested in if keys rendered + are sorted
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const firstColumn = within(rows[0]).getAllByRole('cell');
     expect(firstColumn[0]).toHaveTextContent('a');
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const secondColumn = within(rows[1]).getAllByRole('cell');
     expect(secondColumn[0]).toHaveTextContent('b');
   });

--- a/static/app/components/events/interfaces/performance/durationChart.tsx
+++ b/static/app/components/events/interfaces/performance/durationChart.tsx
@@ -164,7 +164,8 @@ function Content({affectedEvents, allEvents, errored, loading}: ContentProps) {
             value,
             aggregateOutputType(
               affectedEvents && affectedEvents.length
-                ? affectedEvents[0].seriesName
+                ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+                  affectedEvents[0].seriesName
                 : seriesName
             )
           );

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -93,7 +93,9 @@ export function getSpanInfoFromTransactionEvent(
   }
   const spansById = keyBy(spans, 'span_id');
 
+  // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
   const parentSpan = spansById[event.perfProblem.parentSpanIds[0]];
+  // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
   const repeatingSpan = spansById[event.perfProblem.offenderSpanIds[0]];
 
   const affectedSpanIds = [parentSpan.span_id, ...event.perfProblem.offenderSpanIds];

--- a/static/app/components/events/interfaces/request/index.spec.tsx
+++ b/static/app/components/events/interfaces/request/index.spec.tsx
@@ -171,6 +171,7 @@ describe('Request entry', function () {
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(7);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByText(/redacted/)[0]);
 
     expect(

--- a/static/app/components/events/interfaces/searchBarAction.spec.tsx
+++ b/static/app/components/events/interfaces/searchBarAction.spec.tsx
@@ -119,6 +119,7 @@ describe('SearchBarAction', () => {
     const typeOptions = options[0];
     render(
       <SearchBarAction
+        // @ts-expect-error TS(2322) FIXME: Type '(GeneralSelectValue & { options?: GeneralSel... Remove this comment to see the full error message
         filterOptions={[typeOptions]}
         onFilterChange={handleFilter}
         onChange={() => null}
@@ -145,6 +146,7 @@ describe('SearchBarAction', () => {
     const httpRequestItem = screen.getByText('HTTP request');
     userEvent.click(httpRequestItem);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const httpRequestOption = (typeOptions.options ?? []).find(
       opt => opt.label === 'HTTP request'
     );
@@ -155,6 +157,7 @@ describe('SearchBarAction', () => {
     const levelOptions = options[1];
     render(
       <SearchBarAction
+        // @ts-expect-error TS(2322) FIXME: Type '(GeneralSelectValue & { options?: GeneralSel... Remove this comment to see the full error message
         filterOptions={[levelOptions]}
         onFilterChange={handleFilter}
         onChange={() => null}
@@ -178,6 +181,7 @@ describe('SearchBarAction', () => {
     const infoItem = screen.getByText('info');
     userEvent.click(infoItem);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const infoOption = (levelOptions.options ?? []).find(opt => opt.label === 'info');
     expect(handleFilter).toHaveBeenCalledWith([infoOption]);
   });

--- a/static/app/components/events/interfaces/spans/measurementsPanel.tsx
+++ b/static/app/components/events/interfaces/spans/measurementsPanel.tsx
@@ -40,6 +40,7 @@ function MeasurementsPanel(props: Props) {
     >
       {Array.from(measurements.values()).map(verticalMark => {
         const mark = Object.values(verticalMark.marks)[0];
+        // @ts-expect-error TS(2339) FIXME: Property 'timestamp' does not exist on type '{ fai... Remove this comment to see the full error message
         const {timestamp} = mark;
         const bounds = getMeasurementBounds(timestamp, generateBounds);
 
@@ -51,6 +52,7 @@ function MeasurementsPanel(props: Props) {
 
         const vitalLabels: VitalLabel[] = Object.keys(verticalMark.marks).map(name => ({
           vital: WEB_VITAL_DETAILS[`measurements.${name}`],
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           isPoorValue: verticalMark.marks[name].failedThreshold,
         }));
 
@@ -68,6 +70,7 @@ function MeasurementsPanel(props: Props) {
           <LabelContainer
             key={String(timestamp)}
             left={toPercent(bounds.left || 0)}
+            // @ts-expect-error TS(2769) FIXME: No overload matches this call.
             vitalLabel={vitalLabels[0]}
           />
         );

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -335,6 +335,7 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
       <Fragment>
         {Array.from(measurements.values()).map(verticalMark => {
           const mark = Object.values(verticalMark.marks)[0];
+          // @ts-expect-error TS(2339) FIXME: Property 'timestamp' does not exist on type '{ fai... Remove this comment to see the full error message
           const {timestamp} = mark;
           const bounds = getMeasurementBounds(timestamp, generateBounds);
 
@@ -849,7 +850,9 @@ class SpanBar extends Component<SpanBarProps, SpanBarState> {
                 toggleEmbeddedChildren({
                   orgSlug: organization.slug,
                   eventSlug: generateEventSlug({
+                    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                     id: transaction.event_id,
+                    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                     project: transaction.project_slug,
                   }),
                 });

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -174,9 +174,13 @@ class SpanDetail extends Component<Props, State> {
     const childTransaction = childTransactions[0];
 
     const transactionResult: TransactionResult = {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       'project.name': childTransaction.project_slug,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       transaction: childTransaction.transaction,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       'trace.span': childTransaction.span_id,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       id: childTransaction.event_id,
     };
 
@@ -198,6 +202,7 @@ class SpanDetail extends Component<Props, State> {
             orgSlug: organization.slug,
             transaction: transactionResult.transaction,
             query: omit(location.query, Object.values(PAGE_URL_PARAM)),
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             projectID: String(childTransaction.project_id),
           });
 

--- a/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanSiblingGroupBar.tsx
@@ -62,7 +62,9 @@ export default function SpanSiblingGroupBar(props: Props) {
       return '';
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const operation = spanGrouping[0].span.op;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const description = spanGrouping[0].span.description;
 
     if (!description || !operation) {
@@ -122,6 +124,7 @@ export default function SpanSiblingGroupBar(props: Props) {
           <SpanRectangle
             key={index}
             spanGrouping={spanGrouping}
+            // @ts-expect-error TS(2322) FIXME: Type 'EnhancedSpan | undefined' is not assignable ... Remove this comment to see the full error message
             bounds={getSpanGroupBounds([spanGrouping[index]], generateBounds)}
           />
         ))}
@@ -142,6 +145,7 @@ export default function SpanSiblingGroupBar(props: Props) {
       spanNumber={spanNumber}
       generateBounds={generateBounds}
       toggleSpanGroup={() => {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         toggleSiblingSpanGroup?.(spanGrouping[0].span, occurrence);
         isEmbeddedSpanTree &&
           trackAdvancedAnalyticsEvent(

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -93,6 +93,7 @@ class SpanTree extends Component<PropType> {
     const showHiddenSpansMessage = !isCurrentSpanHidden && numOfSpansOutOfViewAbove > 0;
 
     if (showHiddenSpansMessage) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       firstHiddenSpanId = getSpanID(outOfViewSpansAbove[0].span);
       messages.push(
         <span key={`spans-out-of-view-${firstHiddenSpanId}`}>
@@ -106,6 +107,7 @@ class SpanTree extends Component<PropType> {
       !isCurrentSpanFilteredOut && numOfFilteredSpansAbove > 0;
 
     if (showFilteredSpansMessage) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       firstHiddenSpanId = getSpanID(filteredSpansAbove[0].span);
       if (!isCurrentSpanHidden) {
         if (numOfFilteredSpansAbove === 1) {

--- a/static/app/components/events/interfaces/spans/spanTreeModel.spec.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.spec.tsx
@@ -443,11 +443,15 @@ describe('SpanTreeModel', () => {
       }
     );
 
+    // @ts-expect-error TS(2322) FIXME: Type '{} | { span: SpanType; type: "root_span"; co... Remove this comment to see the full error message
     fullWaterfallExpected[0] = {
       ...fullWaterfallExpected[0],
     };
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     assert(fullWaterfallExpected[0].type === 'span');
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     fullWaterfallExpected[0].numOfSpanChildren += 1;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     fullWaterfallExpected[0].showEmbeddedChildren = true;
 
     expect(spans).toEqual(fullWaterfallExpected);
@@ -551,6 +555,7 @@ describe('SpanTreeModel', () => {
     };
 
     for (let i = 0; i < 5; i++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       event2.entries[0].data.push(spanTemplate);
     }
 
@@ -592,6 +597,7 @@ describe('SpanTreeModel', () => {
     expect(spans[1].type).toEqual('span_group_siblings');
 
     // If statement here is required to avoid TS linting issues
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (spans[1].type === 'span_group_siblings') {
       expect(spans[1].spanSiblingGrouping!.length).toEqual(5);
     }
@@ -628,6 +634,7 @@ describe('SpanTreeModel', () => {
     };
 
     for (let i = 0; i < 4; i++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       event2.entries[0].data.push(spanTemplate);
     }
 
@@ -719,13 +726,16 @@ describe('SpanTreeModel', () => {
     };
 
     for (let i = 0; i < 7; i++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       event2.entries[0].data.push(groupableSpanTemplate);
     }
 
     // This span should not get grouped with the others
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     event2.entries[0].data.push(normalSpanTemplate);
 
     for (let i = 0; i < 5; i++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       event2.entries[0].data.push(groupableSpanTemplate);
     }
 

--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -256,10 +256,14 @@ class SpanTreeModel {
       // we will need to reconstruct the tree depth information. This is only neccessary
       // when the span group chain is hidden/collapsed.
       if (spanNestedGrouping.length === 1) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const treeDepthEntry = isOrphanSpan(spanNestedGrouping[0].span)
-          ? ({type: 'orphan', depth: spanNestedGrouping[0].treeDepth} as OrphanTreeDepth)
-          : spanNestedGrouping[0].treeDepth;
+          ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+            ({type: 'orphan', depth: spanNestedGrouping[0].treeDepth} as OrphanTreeDepth)
+          : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+            spanNestedGrouping[0].treeDepth;
 
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (!spanNestedGrouping[0].isLastSibling) {
           continuingTreeDepths = [...continuingTreeDepths, treeDepthEntry];
         }
@@ -354,16 +358,22 @@ class SpanTreeModel {
 
         // We want to group siblings only if they share the same op and description, and if they have no children
         if (
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           prevSpanModel.span.op === currSpanModel.span.op &&
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           prevSpanModel.span.description === currSpanModel.span.description &&
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           currSpanModel.children.length === 0
         ) {
           currentGroup.push(currSpanModel);
         } else {
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'SpanTreeModel | undefined' is no... Remove this comment to see the full error message
           addGroupToMap(prevSpanModel, currentGroup);
 
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           if (currSpanModel.children.length) {
             currentGroup = [currSpanModel];
+            // @ts-expect-error TS(2322) FIXME: Type '(SpanTreeModel | undefined)[]' is not assign... Remove this comment to see the full error message
             groupedDescendants.push({group: currentGroup});
             currentGroup = [];
           } else {
@@ -374,6 +384,7 @@ class SpanTreeModel {
         prevSpanModel = currSpanModel;
       }
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'SpanTreeModel | undefined' is no... Remove this comment to see the full error message
       addGroupToMap(prevSpanModel, currentGroup);
     } else if (descendantsSource.length >= 1) {
       groupedDescendants.push({group: descendantsSource});
@@ -432,6 +443,7 @@ class SpanTreeModel {
           return acc;
         }
 
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const key = getSiblingGroupKey(group[0].span, occurrence);
         if (this.expandedSiblingGroups.has(key)) {
           // This check is needed here, since it is possible that a user could be filtering for a specific span ID.
@@ -482,6 +494,7 @@ class SpanTreeModel {
         // if the spans are filtered or out of bounds here
 
         if (
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'SpanTreeModel | undefined' is no... Remove this comment to see the full error message
           this.isSpanFilteredOut(props, group[0]) ||
           groupShouldBeHidden(group, focusedSpanIds)
         ) {
@@ -495,7 +508,9 @@ class SpanTreeModel {
         }
 
         const bounds = generateBounds({
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           startTimestamp: group[0].span.start_timestamp,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           endTimestamp: group[group.length - 1].span.timestamp,
         });
 
@@ -548,6 +563,7 @@ class SpanTreeModel {
         };
 
         acc.previousSiblingEndTimestamp =
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           wrappedSiblings[wrappedSiblings.length - 1].span.timestamp;
 
         acc.descendants.push(groupedSiblingsSpan);
@@ -636,6 +652,7 @@ class SpanTreeModel {
       spanNestedGrouping.length === 1
     ) {
       if (!isNestedSpanGroupExpanded) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const parentSpan = spanNestedGrouping[0].span;
         const parentSpanBounds = generateBounds({
           startTimestamp: parentSpan.start_timestamp,
@@ -643,6 +660,7 @@ class SpanTreeModel {
         });
         const isParentSpanOutOfView = !parentSpanBounds.isSpanVisibleInView;
         if (!isParentSpanOutOfView) {
+          // @ts-expect-error TS(2322) FIXME: Type 'EnhancedSpan | undefined' is not assignable ... Remove this comment to see the full error message
           return [spanNestedGrouping[0], wrappedSpan, ...descendants];
         }
       }

--- a/static/app/components/events/interfaces/spans/traceView.spec.tsx
+++ b/static/app/components/events/interfaces/spans/traceView.spec.tsx
@@ -349,6 +349,7 @@ describe('TraceView', () => {
       expect(screen.queryAllByText('group me')).toHaveLength(2);
 
       const firstGroup = screen.queryAllByText('Autogrouped — http —')[0];
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(firstGroup);
       expect(await screen.findAllByText('group me')).toHaveLength(6);
 
@@ -357,6 +358,7 @@ describe('TraceView', () => {
       expect(await screen.findAllByText('group me')).toHaveLength(10);
 
       const firstRegroup = screen.queryAllByText('Regroup')[0];
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(firstRegroup);
       expect(await screen.findAllByText('group me')).toHaveLength(6);
 

--- a/static/app/components/events/interfaces/spans/utils.tsx
+++ b/static/app/components/events/interfaces/spans/utils.tsx
@@ -532,6 +532,7 @@ function hasFailedThreshold(marks: Measurements): boolean {
   );
 
   return records.some(record => {
+    // @ts-expect-error TS(2339) FIXME: Property 'value' does not exist on type '{ failedT... Remove this comment to see the full error message
     const {value} = marks[record.slug];
     if (typeof value === 'number' && typeof record.poorThreshold === 'number') {
       return value >= record.poorThreshold;
@@ -566,6 +567,7 @@ export function getMeasurements(
       return {
         name,
         // Time timestamp is in seconds, but the measurement value is given in ms so convert it here
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         timestamp: startTimestamp + associatedMeasurement.value / 1000,
         value: associatedMeasurement ? associatedMeasurement.value : undefined,
       };
@@ -752,7 +754,9 @@ export function getSpanGroupTimestamps(spanGroup: EnhancedSpan[]) {
       };
     },
     {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       startTimestamp: spanGroup[0].span.start_timestamp,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       endTimestamp: spanGroup[0].span.timestamp,
     }
   );
@@ -929,21 +933,27 @@ export function getFormattedTimeRangeWithLeadingAndTrailingZero(
 
   const newTimestamps = startStrings.reduce(
     (acc, startString, index) => {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (startString.length > endStrings[index].length) {
         acc.start.push(startString);
         acc.end.push(
           index === 0
-            ? endStrings[index].padStart(startString.length, '0')
-            : endStrings[index].padEnd(startString.length, '0')
+            ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+              endStrings[index].padStart(startString.length, '0')
+            : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+              endStrings[index].padEnd(startString.length, '0')
         );
         return acc;
       }
 
       acc.start.push(
         index === 0
-          ? startString.padStart(endStrings[index].length, '0')
-          : startString.padEnd(endStrings[index].length, '0')
+          ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+            startString.padStart(endStrings[index].length, '0')
+          : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+            startString.padEnd(endStrings[index].length, '0')
       );
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       acc.end.push(endStrings[index]);
       return acc;
     },

--- a/static/app/components/events/interfaces/spans/waterfallModel.spec.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.spec.tsx
@@ -662,11 +662,13 @@ describe('WaterfallModel', () => {
 
     expected[1] = {
       type: 'out_of_view',
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       span: fullWaterfall[1].span,
     } as EnhancedProcessedSpanType;
 
     expected[4] = {
       type: 'out_of_view',
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       span: fullWaterfall[4].span,
     } as EnhancedProcessedSpanType;
 
@@ -680,50 +682,62 @@ describe('WaterfallModel', () => {
     });
 
     assert(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       fullWaterfall[10].type === 'span_group_chain' &&
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         fullWaterfall[10].spanNestedGrouping
     );
     expected = [
       {
         type: 'filtered_out',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[0].span,
       },
       {
         type: 'out_of_view',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[1].span,
       },
       fullWaterfall[2],
       fullWaterfall[3],
       {
         type: 'filtered_out',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[4].span,
       },
       {
         type: 'filtered_out',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[5].span,
       },
       {
         type: 'filtered_out',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[6].span,
       },
       {
         type: 'filtered_out',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[7].span,
       },
       {
         type: 'filtered_out',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[9].span,
       },
       {
         type: 'filtered_out',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[10].spanNestedGrouping[0].span,
       },
       {
         type: 'filtered_out',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[10].spanNestedGrouping[1].span,
       },
       {
         type: 'filtered_out',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         span: fullWaterfall[11].span,
       },
     ] as EnhancedProcessedSpanType[];
@@ -740,6 +754,7 @@ describe('WaterfallModel', () => {
       viewEnd: 0.65,
     });
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     expected[1].type = 'filtered_out';
 
     expect(spans).toEqual(expected);
@@ -808,6 +823,7 @@ describe('WaterfallModel', () => {
       ...event,
       entries: [
         {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           data: [event.entries[0].data[0]],
           type: EntryType.SPANS,
         },
@@ -842,9 +858,12 @@ describe('WaterfallModel', () => {
       entries: [
         {
           data: [
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             event.entries[0].data[0],
             {
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               ...event.entries[0].data[0],
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               parent_span_id: event.entries[0].data[0].span_id,
               span_id: 'foo',
             },
@@ -878,7 +897,9 @@ describe('WaterfallModel', () => {
       {
         ...fullWaterfall[1],
         span: {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           ...fullWaterfall[1].span,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           parent_span_id: event.entries[0].data[0].span_id,
           span_id: 'foo',
         },
@@ -896,13 +917,17 @@ describe('WaterfallModel', () => {
       entries: [
         {
           data: [
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             event.entries[0].data[0],
             {
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               ...event.entries[0].data[0],
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               parent_span_id: event.entries[0].data[0].span_id,
               span_id: 'foo',
             },
             {
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               ...event.entries[0].data[0],
               parent_span_id: 'foo',
               span_id: 'bar',
@@ -922,6 +947,7 @@ describe('WaterfallModel', () => {
     // expect 1 or more spans are grouped
     expect(spans).toHaveLength(3);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     assert(fullWaterfall[1].type === 'span');
     const collapsedWaterfallExpected = [
       {
@@ -932,8 +958,10 @@ describe('WaterfallModel', () => {
       {
         type: 'span_group_chain',
         treeDepth: 1,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         continuingTreeDepths: fullWaterfall[1].continuingTreeDepths,
         span: {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           ...fullWaterfall[1].span,
           parent_span_id: 'foo',
           span_id: 'bar',
@@ -948,7 +976,9 @@ describe('WaterfallModel', () => {
           {
             ...fullWaterfall[1],
             span: {
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               ...fullWaterfall[1].span,
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               parent_span_id: event.entries[0].data[0].span_id,
               span_id: 'foo',
             },
@@ -963,6 +993,7 @@ describe('WaterfallModel', () => {
       {
         ...fullWaterfall[1],
         span: {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           ...fullWaterfall[1].span,
           parent_span_id: 'foo',
           span_id: 'bar',
@@ -977,7 +1008,9 @@ describe('WaterfallModel', () => {
     expect(spans).toEqual(collapsedWaterfallExpected);
 
     // Expand span group
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     assert(spans[1].type === 'span' && spans[1].toggleNestedSpanGroup);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     spans[1].toggleNestedSpanGroup();
 
     spans = waterfallModel.getWaterfall({
@@ -1005,7 +1038,9 @@ describe('WaterfallModel', () => {
       {
         ...fullWaterfall[1],
         span: {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           ...fullWaterfall[1].span,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           parent_span_id: event.entries[0].data[0].span_id,
           span_id: 'foo',
         },
@@ -1017,6 +1052,7 @@ describe('WaterfallModel', () => {
       {
         ...fullWaterfall[1],
         span: {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           ...fullWaterfall[1].span,
           parent_span_id: 'foo',
           span_id: 'bar',
@@ -1029,7 +1065,9 @@ describe('WaterfallModel', () => {
     ]);
 
     // Collapse span group
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     assert(spans[1].type === 'span' && spans[1].toggleNestedSpanGroup);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     spans[1].toggleNestedSpanGroup();
 
     spans = waterfallModel.getWaterfall({

--- a/static/app/components/events/interfaces/spans/waterfallModel.tsx
+++ b/static/app/components/events/interfaces/spans/waterfallModel.tsx
@@ -265,7 +265,9 @@ class WaterfallModel {
         };
       },
       {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         traceStartTimestamp: this.traceBounds[0].traceStartTimestamp,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         traceEndTimestamp: this.traceBounds[0].traceEndTimestamp,
       }
     );

--- a/static/app/components/events/interfaces/threads/threadSelector/getThreadException.tsx
+++ b/static/app/components/events/interfaces/threads/threadSelector/getThreadException.tsx
@@ -6,6 +6,7 @@ function getException(
   exceptionDataValues: ExceptionValue[],
   thread: Thread
 ) {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   if (exceptionDataValues.length === 1 && !exceptionDataValues[0].stacktrace) {
     return {
       ...exceptionData,
@@ -52,6 +53,7 @@ function getThreadException(
   );
 
   if (matchedStacktraceAndExceptionThread) {
+    // @ts-expect-error TS(2322) FIXME: Type '{ values: { stacktrace: StacktraceType | nul... Remove this comment to see the full error message
     return getException(exceptionData, exceptionDataValues, thread);
   }
 
@@ -61,6 +63,7 @@ function getThreadException(
     ) &&
     thread.crashed
   ) {
+    // @ts-expect-error TS(2322) FIXME: Type '{ values: { stacktrace: StacktraceType | nul... Remove this comment to see the full error message
     return getException(exceptionData, exceptionDataValues, thread);
   }
 

--- a/static/app/components/events/interfaces/threadsV2.spec.tsx
+++ b/static/app/components/events/interfaces/threadsV2.spec.tsx
@@ -195,6 +195,7 @@ describe('ThreadsV2', function () {
       };
 
       const props: React.ComponentProps<typeof ThreadsV2> = {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         data: event.entries[1].data as React.ComponentProps<typeof ThreadsV2>['data'],
         event,
         groupingCurrentLevel: 0,
@@ -253,6 +254,7 @@ describe('ThreadsV2', function () {
         render(<ThreadsV2 {...props} />, {organization: org});
 
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
             'sentry/controllers/welcome_controller.rb'
           )
@@ -272,6 +274,7 @@ describe('ThreadsV2', function () {
 
         // Last frame is the first on the list
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
             'puma (3.12.6) lib/puma/server.rb'
           )
@@ -283,6 +286,7 @@ describe('ThreadsV2', function () {
 
         // First frame is the first on the list
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
             'sentry/controllers/welcome_controller.rb'
           )
@@ -855,6 +859,7 @@ describe('ThreadsV2', function () {
       };
 
       const props: React.ComponentProps<typeof ThreadsV2> = {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         data: event.entries[1].data as React.ComponentProps<typeof ThreadsV2>['data'],
         event,
         groupingCurrentLevel: 0,
@@ -912,6 +917,7 @@ describe('ThreadsV2', function () {
         render(<ThreadsV2 {...props} />, {organization: org});
 
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
             '-[SentryClient crash]'
           )
@@ -937,6 +943,7 @@ describe('ThreadsV2', function () {
 
         // Last frame is the first on the list
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[0]).getByText('UIKit')
         ).toBeInTheDocument();
 
@@ -946,6 +953,7 @@ describe('ThreadsV2', function () {
 
         // First frame is the first on the list
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[0]).getByText(
             '-[SentryClient crash]'
           )
@@ -981,6 +989,7 @@ describe('ThreadsV2', function () {
 
         // Function name is not verbose
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[1]).getByText(
             'ViewController.causeCrash'
           )
@@ -991,6 +1000,7 @@ describe('ThreadsV2', function () {
 
         // Function name is now verbose
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[1]).getByText(
             'ViewController.causeCrash(Any) -> ()'
           )
@@ -998,6 +1008,7 @@ describe('ThreadsV2', function () {
 
         // Address is not absolute
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[1]).getByText('+0x085ac')
         ).toBeInTheDocument();
 
@@ -1006,6 +1017,7 @@ describe('ThreadsV2', function () {
 
         // Address is now absolute
         expect(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
           within(screen.getAllByTestId('stack-trace-frame')[1]).getByText('0x10008c5ac')
         ).toBeInTheDocument();
 

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -83,6 +83,7 @@ export function stringifyQueryList(query: string | [key: string, value: string][
       const [key, value] = kv;
       if (value !== null) {
         if (Array.isArray(queryObj[key])) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           queryObj[key].push(value);
         } else {
           queryObj[key] = [value];
@@ -190,8 +191,11 @@ export function parseAssembly(assembly: string | null) {
 
   if (pieces.length === 4) {
     name = pieces[0];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     version = pieces[1].split('Version=')[1];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     culture = pieces[2].split('Culture=')[1];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     publicKeyToken = pieces[3].split('PublicKeyToken=')[1];
   }
 
@@ -204,6 +208,7 @@ export function stackTracePlatformIcon(platform: PlatformType, frames: Frame[]) 
   );
 
   if (fileExtensions.length === 1) {
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     const newPlatform = fileExtensionToPlatform(fileExtensions[0]);
 
     return newPlatform ?? platform;

--- a/static/app/components/events/opsBreakdown.tsx
+++ b/static/app/components/events/opsBreakdown.tsx
@@ -375,6 +375,7 @@ function mergeInterval(intervals: TimeWindowSpan[]): TimeWindowSpan[] {
     }
 
     const lastInterval = merged[merged.length - 1];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const lastIntervalEnd = lastInterval[1];
 
     const [currentIntervalStart, currentIntervalEnd] = currentInterval;
@@ -390,6 +391,7 @@ function mergeInterval(intervals: TimeWindowSpan[]): TimeWindowSpan[] {
 
     // invariant: lastIntervalStart <= currentIntervalStart
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     lastInterval[1] = Math.max(lastIntervalEnd, currentIntervalEnd);
   }
 

--- a/static/app/components/eventsTable/eventsTableRow.tsx
+++ b/static/app/components/eventsTable/eventsTableRow.tsx
@@ -99,6 +99,7 @@ function EventsTableRow({
         <td key={tag.key}>
           <div>
             {tag.key === 'device' ? (
+              // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               <DeviceName value={tagMap[tag.key]} />
             ) : tag.key === 'replayId' ? (
               hasReplay ? (

--- a/static/app/components/forms/controls/selectControl.tsx
+++ b/static/app/components/forms/controls/selectControl.tsx
@@ -34,6 +34,7 @@ function isGroupedOptions<OptionType extends OptionTypeBase>(
   if (!maybe || maybe.length === 0) {
     return false;
   }
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   return (maybe as GroupedOptionsType<OptionType>)[0].options !== undefined;
 }
 

--- a/static/app/components/forms/fields/choiceMapperField.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.tsx
@@ -219,7 +219,8 @@ export default class ChoiceMapperField extends Component<ChoiceMapperFieldProps>
                 <Control>
                   <SelectControl
                     {...(perItemMapping
-                      ? mappedSelectors[itemKey][fieldKey]
+                      ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+                        mappedSelectors[itemKey][fieldKey]
                       : mappedSelectors[fieldKey])}
                     height={30}
                     disabled={disabled}

--- a/static/app/components/forms/fields/projectMapperField.spec.tsx
+++ b/static/app/components/forms/fields/projectMapperField.spec.tsx
@@ -73,6 +73,7 @@ describe('ProjectMapperField', () => {
         ]}
       />
     );
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(screen.getAllByLabelText('Delete')[0]);
 
     expect(defaultProps.onBlur).toHaveBeenCalledWith([[24, 1]], []);

--- a/static/app/components/forms/jsonForm.spec.tsx
+++ b/static/app/components/forms/jsonForm.spec.tsx
@@ -83,6 +83,7 @@ describe('JsonForm', function () {
     const jsonFormFields = [fields.name, fields.platform];
 
     it('default', function () {
+      // @ts-expect-error TS(2322) FIXME: Type '((CustomType & BaseField) | ({ type: "select... Remove this comment to see the full error message
       const {container} = render(<JsonForm fields={jsonFormFields} />);
       expect(container).toSnapshot();
     });
@@ -93,6 +94,7 @@ describe('JsonForm', function () {
       try {
         render(
           <JsonForm
+            // @ts-expect-error TS(2322) FIXME: Type '{ visible: ({ test }: any) => boolean; } | {... Remove this comment to see the full error message
             fields={[{...jsonFormFields[0], visible: ({test}) => !!test.email}]}
           />
         );
@@ -105,6 +107,7 @@ describe('JsonForm', function () {
 
     it('should NOT hide panel, if at least one field has visible set to true - no visible prop', function () {
       // slug and platform have no visible prop, that means they will be always visible
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       render(<JsonForm title={accountDetailsFields[0].title} fields={jsonFormFields} />);
 
       expect(screen.getByText('Account Details')).toBeInTheDocument();
@@ -115,7 +118,9 @@ describe('JsonForm', function () {
       // slug and platform have no visible prop, that means they will be always visible
       render(
         <JsonForm
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           title={accountDetailsFields[0].title}
+          // @ts-expect-error TS(2322) FIXME: Type '({ visible: true; } | { visible: true; Compo... Remove this comment to see the full error message
           fields={jsonFormFields.map(field => ({...field, visible: true}))}
         />
       );
@@ -128,7 +133,9 @@ describe('JsonForm', function () {
       // slug and platform have no visible prop, that means they will be always visible
       render(
         <JsonForm
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           title={accountDetailsFields[0].title}
+          // @ts-expect-error TS(2322) FIXME: Type '({ visible: () => true; } | { visible: () =>... Remove this comment to see the full error message
           fields={jsonFormFields.map(field => ({...field, visible: () => true}))}
         />
       );
@@ -141,7 +148,9 @@ describe('JsonForm', function () {
       // slug and platform have no visible prop, that means they will be always visible
       render(
         <JsonForm
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           title={accountDetailsFields[0].title}
+          // @ts-expect-error TS(2322) FIXME: Type '({ visible: false; } | { visible: false; Com... Remove this comment to see the full error message
           fields={jsonFormFields.map(field => ({...field, visible: false}))}
         />
       );
@@ -153,7 +162,9 @@ describe('JsonForm', function () {
       // slug and platform have no visible prop, that means they will be always visible
       render(
         <JsonForm
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           title={accountDetailsFields[0].title}
+          // @ts-expect-error TS(2322) FIXME: Type '({ visible: () => false; } | { visible: () =... Remove this comment to see the full error message
           fields={jsonFormFields.map(field => ({...field, visible: () => false}))}
         />
       );

--- a/static/app/components/forms/model.tsx
+++ b/static/app/components/forms/model.tsx
@@ -430,6 +430,7 @@ class FormModel {
     }
 
     this.snapshots.shift();
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'Snapshot | undefined' is not ass... Remove this comment to see the full error message
     this.fields.replace(this.snapshots[0]);
 
     return true;

--- a/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
+++ b/static/app/components/globalAppStoreConnectUpdateAlert/updateAlert.tsx
@@ -19,6 +19,7 @@ function UpdateAlert({Wrapper, project, className}: Props) {
     !project ||
     !appStoreConnectContext ||
     !Object.keys(appStoreConnectContext).some(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       key => !!appStoreConnectContext[key].updateAlertMessage
     )
   ) {
@@ -28,6 +29,7 @@ function UpdateAlert({Wrapper, project, className}: Props) {
   const notices = (
     <Notices className={className}>
       {Object.keys(appStoreConnectContext).map(key => {
+        // @ts-expect-error TS(2339) FIXME: Property 'updateAlertMessage' does not exist on ty... Remove this comment to see the full error message
         const {updateAlertMessage} = appStoreConnectContext[key];
         if (!updateAlertMessage) {
           return null;

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -164,6 +164,7 @@ class GridEditable<
 
   clearWindowLifecycleEvents() {
     Object.keys(this.resizeWindowLifecycleEvents).forEach(e => {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       this.resizeWindowLifecycleEvents[e].forEach(c => window.removeEventListener(e, c));
       this.resizeWindowLifecycleEvents[e] = [];
     });
@@ -173,6 +174,7 @@ class GridEditable<
     e.stopPropagation();
 
     const nextColumnOrder = [...this.props.columnOrder];
+    // @ts-expect-error TS(2322) FIXME: Type '{ width: number; key?: ColumnKey | undefined... Remove this comment to see the full error message
     nextColumnOrder[i] = {
       ...nextColumnOrder[i],
       width: COL_WIDTH_UNDEFINED,
@@ -181,6 +183,7 @@ class GridEditable<
 
     const onResizeColumn = this.props.grid.onResizeColumn;
     if (onResizeColumn) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type '{ width: number; key?: ColumnKey... Remove this comment to see the full error message
       onResizeColumn(i, {
         ...nextColumnOrder[i],
         width: COL_WIDTH_UNDEFINED,
@@ -210,9 +213,11 @@ class GridEditable<
     };
 
     window.addEventListener('mousemove', this.onResizeMouseMove);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     this.resizeWindowLifecycleEvents.mousemove.push(this.onResizeMouseMove);
 
     window.addEventListener('mouseup', this.onResizeMouseUp);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     this.resizeWindowLifecycleEvents.mouseup.push(this.onResizeMouseUp);
   };
 
@@ -224,6 +229,7 @@ class GridEditable<
       const {columnOrder} = this.props;
       const widthChange = e.clientX - metadata.cursorX;
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type '{ width: number; key?: ColumnKey... Remove this comment to see the full error message
       onResizeColumn(metadata.columnIndex, {
         ...columnOrder[metadata.columnIndex],
         width: metadata.columnWidth + widthChange,
@@ -252,6 +258,7 @@ class GridEditable<
     const widthChange = e.clientX - metadata.cursorX;
 
     const nextColumnOrder = [...this.props.columnOrder];
+    // @ts-expect-error TS(2322) FIXME: Type '{ width: number; key?: ColumnKey | undefined... Remove this comment to see the full error message
     nextColumnOrder[metadata.columnIndex] = {
       ...nextColumnOrder[metadata.columnIndex],
       width: Math.max(metadata.columnWidth + widthChange, 0),

--- a/static/app/components/group/externalIssueActions.tsx
+++ b/static/app/components/group/externalIssueActions.tsx
@@ -45,6 +45,7 @@ const ExternalIssueActions = ({configurations, group, onChange}: Props) => {
     // Currently we do not support a case where there is multiple external issues.
     // For example, we shouldn't have more than 1 jira ticket created for an issue for each jira configuration.
     const issue = externalIssues[0];
+    // @ts-expect-error TS(2339) FIXME: Property 'id' does not exist on type 'IntegrationE... Remove this comment to see the full error message
     const {id} = issue;
     const endpoint = `/groups/${group.id}/integrations/${integration.id}/?externalIssue=${id}`;
 
@@ -75,18 +76,26 @@ const ExternalIssueActions = ({configurations, group, onChange}: Props) => {
         const issue = externalIssues[0];
         return (
           <IssueSyncListElement
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             key={issue.id}
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             externalIssueLink={issue.url}
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             externalIssueId={issue.id}
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             externalIssueKey={issue.key}
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             externalIssueDisplayName={issue.displayName}
             onClose={() => deleteIssue(config)}
             integrationType={provider.key}
             hoverCardHeader={t('%s Integration', provider.name)}
             hoverCardBody={
               <div>
+                {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                 <IssueTitle>{issue.title}</IssueTitle>
+                {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                 {issue.description && (
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   <IssueDescription>{issue.description}</IssueDescription>
                 )}
               </div>
@@ -97,7 +106,9 @@ const ExternalIssueActions = ({configurations, group, onChange}: Props) => {
 
       {unlinked.length > 0 && (
         <IssueSyncListElement
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           integrationType={unlinked[0].provider.key}
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           hoverCardHeader={t('%s Integration', unlinked[0].provider.name)}
           hoverCardBody={
             <Container>
@@ -108,6 +119,7 @@ const ExternalIssueActions = ({configurations, group, onChange}: Props) => {
               ))}
             </Container>
           }
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'GroupIntegration | undefined' is... Remove this comment to see the full error message
           onOpen={unlinked.length === 1 ? () => doOpenModal(unlinked[0]) : undefined}
         />
       )}

--- a/static/app/components/group/ownedBy.tsx
+++ b/static/app/components/group/ownedBy.tsx
@@ -36,6 +36,7 @@ function OwnedBy({group, project, organization}: OwnedByProps) {
       if (member) {
         currentOwner = {
           type: 'user',
+          // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           id,
           name: member.name,
         };
@@ -46,6 +47,7 @@ function OwnedBy({group, project, organization}: OwnedByProps) {
       if (team) {
         currentOwner = {
           type: 'team',
+          // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           id,
           name: team.slug,
         };

--- a/static/app/components/group/releaseChart.tsx
+++ b/static/app/components/group/releaseChart.tsx
@@ -45,6 +45,7 @@ export function getGroupReleaseChartMarkers(
 ): BarChartSeries['markPoint'] {
   const markers: Marker[] = [];
   // Get the timestamp of the first point.
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const firstGraphTime = stats[0][0] * 1000;
 
   const firstSeenX = new Date(firstSeen ?? 0).getTime();
@@ -65,8 +66,10 @@ export function getGroupReleaseChartMarkers(
     let bucketStart: number | undefined;
     if (firstBucket > 0) {
       // The size of the data interval in ms
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const halfBucketSize = ((stats[1][0] - stats[0][0]) * 1000) / 2;
       // Display the marker in front of the first bucket
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       bucketStart = stats[firstBucket - 1][0] * 1000 - halfBucketSize;
     }
 
@@ -154,6 +157,7 @@ function GroupReleaseChart(props: Props) {
 
   series.push({
     seriesName: t('Events in %s', environmentLabel),
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     data: environmentStats[statsPeriod].map(point => ({
       name: point[0] * 1000,
       value: point[1],
@@ -163,6 +167,7 @@ function GroupReleaseChart(props: Props) {
   if (release && releaseStats) {
     series.push({
       seriesName: t('Events in release %s', formatVersion(release.version)),
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       data: releaseStats[statsPeriod].map(point => ({
         name: point[0] * 1000,
         value: point[1],
@@ -172,7 +177,9 @@ function GroupReleaseChart(props: Props) {
 
   const totalSeries =
     environment && environmentStats ? environmentStats[statsPeriod] : stats;
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const totalEvents = totalSeries.reduce((acc, current) => acc + current[1], 0);
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   series[0].markPoint = getGroupReleaseChartMarkers(theme, stats, firstSeen, lastSeen);
 
   return (

--- a/static/app/components/group/releaseStats.tsx
+++ b/static/app/components/group/releaseStats.tsx
@@ -40,7 +40,8 @@ const GroupReleaseStats = ({
     environments.length > 1
       ? t('selected environments')
       : environments.length === 1
-      ? environments[0].displayName
+      ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        environments[0].displayName
       : undefined;
 
   const projectId = project.id;

--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -154,7 +154,9 @@ class SuggestedOwnerHovercard extends Component<Props, State> {
                             <CommitLink
                               inline
                               showIcon={false}
+                              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                               commitId={commits[0].id}
+                              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                               repository={commits[0].repository}
                             />
                           ),

--- a/static/app/components/group/tagFacets.tsx
+++ b/static/app/components/group/tagFacets.tsx
@@ -24,6 +24,7 @@ export function MOBILE_TAGS_FORMATTER(tagsData: Record<string, TagWithTopValues>
     if (tagKey === 'release') {
       transformedTagsData[tagKey] = {
         ...tagsData[tagKey],
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         topValues: tagsData[tagKey].topValues.map(topValue => {
           return {
             ...topValue,
@@ -69,6 +70,7 @@ export function TagFacets({
 }: Props) {
   const [state, setState] = useState<State>({
     tagsData: {},
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     selectedTag: tagKeys.length > 0 ? tagKeys[0] : '',
     loading: true,
     showMore: false,

--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -92,6 +92,7 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
     const errorKey = `missing_external_${type}s`;
     const unassociatedMappings = Object.values(associationMappings).reduce(
       (map, {errors}) => {
+        // @ts-expect-error TS(2488) FIXME: Type 'string | undefined' must have a '[Symbol.ite... Remove this comment to see the full error message
         return new Set<string>([...map, ...errors[errorKey]]);
       },
       new Set<string>()

--- a/static/app/components/lastCommit.tsx
+++ b/static/app/components/lastCommit.tsx
@@ -31,7 +31,9 @@ function LastCommit({commit, className}: Props) {
     }
 
     const firstLine = message.split(/\n/)[0];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (firstLine.length > 100) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       let truncated = firstLine.substr(0, 90);
       const words = truncated.split(/ /);
       // try to not have ellipsis mid-word

--- a/static/app/components/letterAvatar.tsx
+++ b/static/app/components/letterAvatar.tsx
@@ -37,6 +37,7 @@ function getColor(identifier: string | undefined): Color {
   }
 
   const id = hashIdentifier(identifier);
+  // @ts-expect-error TS(2322) FIXME: Type '"#4674ca" | "#315cac" | "#57be8c" | "#3fa372... Remove this comment to see the full error message
   return COLORS[id % COLORS.length];
 }
 
@@ -46,10 +47,13 @@ function getInitials(displayName: string | undefined) {
   );
   // Use Array.from as slicing and substring() work on ucs2 segments which
   // results in only getting half of any 4+ byte character.
+  // @ts-expect-error TS(2769) FIXME: No overload matches this call.
   let initials = Array.from(names[0])[0];
   if (names.length > 1) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     initials += Array.from(names[names.length - 1])[0];
   }
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   return initials.toUpperCase();
 }
 

--- a/static/app/components/modals/commandPalette.spec.tsx
+++ b/static/app/components/modals/commandPalette.spec.tsx
@@ -118,6 +118,7 @@ describe('Command Palette Modal', function () {
     expect(badges[0]).toHaveTextContent('billy-org Dashboard');
     expect(badges[1]).toHaveTextContent('billy-org Settings');
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(badges[0]);
 
     expect(navigateTo).toHaveBeenCalledWith('/billy-org/', expect.anything(), undefined);

--- a/static/app/components/modals/debugFileCustomRepository/appStoreConnect/utils.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/appStoreConnect/utils.tsx
@@ -74,7 +74,9 @@ export function getAppStoreErrorMessage(
       const field = Object.keys(fieldErrorMessage)[0];
 
       const errorMessages: string[] = errorResponse[serverSideField].map(errorMessage => {
+        // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
         if (fieldErrorMessage[field][errorMessage]) {
+          // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
           return fieldErrorMessage[field][errorMessage];
         }
 
@@ -92,6 +94,7 @@ export function getAppStoreErrorMessage(
       });
 
       // the UI only displays one error message at a time
+      // @ts-expect-error TS(2464) FIXME: A computed property name must be of type 'string',... Remove this comment to see the full error message
       return {...acc, [field]: errorMessages[0]};
     },
     {}

--- a/static/app/components/modals/featureTourModal.tsx
+++ b/static/app/components/modals/featureTourModal.tsx
@@ -168,10 +168,14 @@ class ModalContents extends Component<ContentsProps, ContentsState> {
           aria-label={t('Close tour')}
         />
         <TourContent>
+          {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
           {step.image}
+          {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
           <TourHeader>{step.title}</TourHeader>
+          {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
           {step.body}
           <TourButtonBar gap={1}>
+            {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
             {step.actions && step.actions}
             {hasNext && (
               <Button priority="primary" onClick={this.handleAdvance}>

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -174,6 +174,7 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
   setEmails(emails: string[], index: number) {
     this.setState(state => {
       const pendingInvites = [...state.pendingInvites];
+      // @ts-expect-error TS(2322) FIXME: Type '{ emails: Set<string>; role?: string | undef... Remove this comment to see the full error message
       pendingInvites[index] = {...pendingInvites[index], emails: new Set(emails)};
 
       return {pendingInvites};
@@ -183,6 +184,7 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
   setTeams(teams: string[], index: number) {
     this.setState(state => {
       const pendingInvites = [...state.pendingInvites];
+      // @ts-expect-error TS(2322) FIXME: Type '{ teams: Set<string>; emails?: Set<string> |... Remove this comment to see the full error message
       pendingInvites[index] = {...pendingInvites[index], teams: new Set(teams)};
 
       return {pendingInvites};
@@ -192,6 +194,7 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
   setRole(role: string, index: number) {
     this.setState(state => {
       const pendingInvites = [...state.pendingInvites];
+      // @ts-expect-error TS(2322) FIXME: Type '{ role: string; emails?: Set<string> | undef... Remove this comment to see the full error message
       pendingInvites[index] = {...pendingInvites[index], role};
 
       return {pendingInvites};

--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -38,6 +38,7 @@ function ValueComponent(
   props: MultiValueProps<SelectOption>,
   inviteStatus: Props['inviteStatus']
 ) {
+  // @ts-expect-error TS(2345) FIXME: Argument of type '{ sent: boolean; error?: string ... Remove this comment to see the full error message
   return renderEmailValue(inviteStatus[props.data.value], props);
 }
 

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -148,7 +148,9 @@ function AddToDashboardModal({
       return;
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     let orderby = widget.queries[0].orderby;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!(DisplayType.AREA && widget.queries[0].columns.length)) {
       orderby = ''; // Clear orderby if its not a top n visualization.
     }
@@ -166,6 +168,7 @@ function AddToDashboardModal({
         widgets: [...selectedDashboard.widgets, newWidget],
       };
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type '{ widgets: { title: string; quer... Remove this comment to see the full error message
       await updateDashboard(api, organization.slug, newDashboard);
 
       closeModal();
@@ -228,6 +231,7 @@ function AddToDashboardModal({
             organization={organization}
             eventView={eventViewFromWidget(
               widget.title,
+              // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
               widget.queries[0],
               selection,
               widget.displayType

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -259,13 +259,17 @@ function WidgetViewerModal(props: Props) {
     ...cloneDeep({...widget, queries: [sortedQueries[selectedQueryIndex]]}),
     displayType: DisplayType.TABLE,
   };
+  // @ts-expect-error TS(2339) FIXME: Property 'aggregates' does not exist on type 'Widg... Remove this comment to see the full error message
   const {aggregates, columns} = tableWidget.queries[0];
+  // @ts-expect-error TS(2339) FIXME: Property 'orderby' does not exist on type 'WidgetQ... Remove this comment to see the full error message
   const {orderby} = widget.queries[0];
   const order = orderby.startsWith('-');
   const rawOrderby = trimStart(orderby, '-');
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const fields = defined(tableWidget.queries[0].fields)
-    ? tableWidget.queries[0].fields
+    ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+      tableWidget.queries[0].fields
     : [...columns, ...aggregates];
 
   // Some Discover Widgets (Line, Area, Bar) allow the user to specify an orderby
@@ -282,13 +286,17 @@ function WidgetViewerModal(props: Props) {
     [tableWidget, primaryWidget].forEach(aggregatesAndColumns => {
       if (isAggregateField(rawOrderby) || isEquation(rawOrderby)) {
         aggregatesAndColumns.queries.forEach(query => {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           if (!query.aggregates.includes(rawOrderby)) {
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             query.aggregates.push(rawOrderby);
           }
         });
       } else {
         aggregatesAndColumns.queries.forEach(query => {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           if (!query.columns.includes(rawOrderby)) {
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             query.columns.push(rawOrderby);
           }
         });
@@ -298,7 +306,9 @@ function WidgetViewerModal(props: Props) {
 
   // Need to set the orderby of the eventsv2 query to equation[index] format
   // since eventsv2 does not accept the raw equation as a valid sort payload
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   if (isEquation(rawOrderby) && tableWidget.queries[0].orderby === orderby) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     tableWidget.queries[0].orderby = `${order ? '-' : ''}equation[${
       getNumEquations(fields) - 1
     }]`;
@@ -348,7 +358,9 @@ function WidgetViewerModal(props: Props) {
     switch (widget.widgetType) {
       case WidgetType.DISCOVER:
         if (fields.length === 1) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           tableWidget.queries[0].orderby =
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             tableWidget.queries[0].orderby || `-${fields[0]}`;
         }
         fields.unshift('title');
@@ -365,6 +377,7 @@ function WidgetViewerModal(props: Props) {
 
   const eventView = eventViewFromWidget(
     tableWidget.title,
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
     tableWidget.queries[0],
     modalTableSelection,
     tableWidget.displayType
@@ -379,6 +392,7 @@ function WidgetViewerModal(props: Props) {
   const columnSortBy = eventView.getSorts();
   columnOrder = columnOrder.map((column, index) => ({
     ...column,
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     width: parseInt(widths[index], 10) || -1,
   }));
 
@@ -467,6 +481,7 @@ function WidgetViewerModal(props: Props) {
           grid={{
             renderHeadCell: renderDiscoverGridHeaderCell({
               ...props,
+              // @ts-expect-error TS(2322) FIXME: Type '{ displayType: DisplayType; queries: (Widget... Remove this comment to see the full error message
               widget: tableWidget,
               tableData: tableResults?.[0],
               onHeaderClick: () => {
@@ -538,6 +553,7 @@ function WidgetViewerModal(props: Props) {
               location,
               organization,
               selection,
+              // @ts-expect-error TS(2322) FIXME: Type '{ displayType: DisplayType; queries: (Widget... Remove this comment to see the full error message
               widget: tableWidget,
               onHeaderClick: () => {
                 setChartUnmodified(false);
@@ -547,6 +563,7 @@ function WidgetViewerModal(props: Props) {
               location,
               organization,
               selection,
+              // @ts-expect-error TS(2322) FIXME: Type '{ displayType: DisplayType; queries: (Widget... Remove this comment to see the full error message
               widget: tableWidget,
             }),
             onResizeColumn,
@@ -608,6 +625,7 @@ function WidgetViewerModal(props: Props) {
           grid={{
             renderHeadCell: renderReleaseGridHeaderCell({
               ...props,
+              // @ts-expect-error TS(2322) FIXME: Type '{ displayType: DisplayType; queries: (Widget... Remove this comment to see the full error message
               widget: tableWidget,
               tableData: tableResults?.[0],
               onHeaderClick: () => {
@@ -628,6 +646,7 @@ function WidgetViewerModal(props: Props) {
           }}
           location={location}
         />
+        {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
         {!tableWidget.queries[0].orderby.match(/^-?release$/) &&
           (links?.previous?.results || links?.next?.results) && (
             <Pagination
@@ -715,6 +734,7 @@ function WidgetViewerModal(props: Props) {
           <IssueWidgetQueries
             api={api}
             organization={organization}
+            // @ts-expect-error TS(2322) FIXME: Type '{ displayType: DisplayType; queries: (Widget... Remove this comment to see the full error message
             widget={tableWidget}
             selection={modalTableSelection}
             limit={
@@ -739,6 +759,7 @@ function WidgetViewerModal(props: Props) {
           <ReleaseWidgetQueries
             api={api}
             organization={organization}
+            // @ts-expect-error TS(2769) FIXME: No overload matches this call.
             widget={tableWidget}
             selection={modalTableSelection}
             limit={
@@ -766,6 +787,7 @@ function WidgetViewerModal(props: Props) {
           <WidgetQueries
             api={api}
             organization={organization}
+            // @ts-expect-error TS(2322) FIXME: Type '{ displayType: DisplayType; queries: (Widget... Remove this comment to see the full error message
             widget={tableWidget}
             selection={modalTableSelection}
             limit={
@@ -856,6 +878,7 @@ function WidgetViewerModal(props: Props) {
             )}
           </Alert>
         )}
+        {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
         {(widget.queries.length > 1 || widget.queries[0].conditions) && (
           <QueryContainer>
             <SelectControl
@@ -895,9 +918,11 @@ function WidgetViewerModal(props: Props) {
                         padding: `0 ${space(0.5)}`,
                       })}
                     >
+                      {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                       {queryOptions[selectedQueryIndex].getHighlightedQuery({
                         display: 'block',
                       }) ??
+                        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                         (queryOptions[selectedQueryIndex].label || (
                           <EmptyQueryContainer>{EMPTY_QUERY_NAME}</EmptyQueryContainer>
                         ))}
@@ -1042,6 +1067,7 @@ function OpenButton({
     default:
       openLabel = t('Open in Discover');
       path = getWidgetDiscoverUrl(
+        // @ts-expect-error TS(2322) FIXME: Type 'WidgetQuery | undefined' is not assignable t... Remove this comment to see the full error message
         {...widget, queries: [widget.queries[selectedQueryIndex]]},
         selection,
         organization,

--- a/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
+++ b/static/app/components/modals/widgetViewerModal/widgetViewerTableCell.tsx
@@ -62,6 +62,7 @@ export const renderIssueGridHeaderCell =
       <SortLink
         align={align}
         title={<StyledTooltip title={column.name}>{column.name}</StyledTooltip>}
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         direction={widget.queries[0].orderby === sortField ? 'desc' : undefined}
         canSort={!!sortField}
         generateSortLink={() => ({
@@ -98,6 +99,7 @@ export const renderDiscoverGridHeaderCell =
     isMetricsData,
   }: Props) =>
   (column: TableColumn<keyof TableDataRow>, _columnIndex: number): React.ReactNode => {
+    // @ts-expect-error TS(2339) FIXME: Property 'orderby' does not exist on type 'WidgetQ... Remove this comment to see the full error message
     const {orderby} = widget.queries[0];
     // Need to convert orderby to aggregate alias because eventView still uses aggregate alias format
     const aggregateAliasOrderBy = `${
@@ -105,6 +107,7 @@ export const renderDiscoverGridHeaderCell =
     }${getAggregateAlias(trimStart(orderby, '-'))}`;
     const eventView = eventViewFromWidget(
       widget.title,
+      // @ts-expect-error TS(2345) FIXME: Argument of type '{ orderby: string; aggregates?: ... Remove this comment to see the full error message
       {...widget.queries[0], orderby: aggregateAliasOrderBy},
       selection,
       widget.displayType
@@ -271,6 +274,7 @@ export const renderReleaseGridHeaderCell =
   (column: TableColumn<keyof TableDataRow>, _columnIndex: number): React.ReactNode => {
     const tableMeta = tableData?.meta;
     const align = fieldAlignment(column.name, column.type, tableMeta);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const widgetOrderBy = widget.queries[0].orderby;
     const sort: Sort = {
       kind: widgetOrderBy.startsWith('-') ? 'desc' : 'asc',

--- a/static/app/components/multiPlatformPicker.tsx
+++ b/static/app/components/multiPlatformPicker.tsx
@@ -85,6 +85,7 @@ function PlatformPicker(props: PlatformPickerProps) {
     props.defaultCategory ?? PLATFORM_CATEGORIES[0].id
   );
   const [filter, setFilter] = useState<string>(
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     props.noAutoFilter ? '' : (props.platforms[0] || '').split('-')[0]
   );
 

--- a/static/app/components/onboardingWizard/task.tsx
+++ b/static/app/components/onboardingWizard/task.tsx
@@ -113,6 +113,7 @@ function Task(props: Props) {
     <Tooltip
       containerDisplayMode="block"
       title={tct('[requisite] before completing this task', {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         requisite: task.requisiteTasks[0].title,
       })}
     >

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -54,6 +54,7 @@ function getIssueAlertUrl({projects, organization}: Options) {
   // pick the first project with events if we have that, otherwise just pick the first project
   const firstProjectWithEvents = projects.find(project => !!project.firstEvent);
   const project = firstProjectWithEvents ?? projects[0];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   return `/organizations/${organization.slug}/alerts/${project.slug}/wizard/`;
 }
 
@@ -66,6 +67,7 @@ function getMetricAlertUrl({projects, organization}: Options) {
     project => !!project.firstTransactionEvent
   );
   const project = firstProjectWithEvents ?? projects[0];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   return `/organizations/${organization.slug}/alerts/${project.slug}/wizard/?alert_option=trans_duration`;
 }
 
@@ -103,6 +105,7 @@ export function getOnboardingTasks({
           <EventWaiter
             api={api}
             organization={organization}
+            // @ts-expect-error TS(2322) FIXME: Type 'Project | undefined' is not assignable to ty... Remove this comment to see the full error message
             project={projects[0]}
             eventType="error"
             onIssueReceived={() => !taskIsDone(task) && onCompleteTask()}
@@ -183,14 +186,20 @@ export function getOnboardingTasks({
 
         if (projectsForOnboarding.length) {
           navigateTo(
-            `/organizations/${organization.slug}/performance/?project=${projectsForOnboarding[0].id}#performance-sidequest`,
+            `/organizations/${organization.slug}/performance/?project=${
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+              projectsForOnboarding[0].id
+            }#performance-sidequest`,
             router
           );
           return;
         }
 
         navigateTo(
-          `/organizations/${organization.slug}/performance/?project=${projectsWithoutFirstTransactionEvent[0].id}#performance-sidequest`,
+          `/organizations/${organization.slug}/performance/?project=${
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+            projectsWithoutFirstTransactionEvent[0].id
+          }#performance-sidequest`,
           router
         );
       },
@@ -200,6 +209,7 @@ export function getOnboardingTasks({
           <EventWaiter
             api={api}
             organization={organization}
+            // @ts-expect-error TS(2322) FIXME: Type 'Project | undefined' is not assignable to ty... Remove this comment to see the full error message
             project={projects[0]}
             eventType="transaction"
             onIssueReceived={() => !taskIsDone(task) && onCompleteTask()}

--- a/static/app/components/organizations/environmentSelector.spec.tsx
+++ b/static/app/components/organizations/environmentSelector.spec.tsx
@@ -82,6 +82,7 @@ describe('EnvironmentSelector', function () {
     renderSelector();
     await clickMenu();
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(screen.queryAllByRole('checkbox')[0]);
     expect(onUpdate).not.toHaveBeenCalled();
 

--- a/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
@@ -28,12 +28,14 @@ function getReadableDesyncedFilterList(desyncedFilters: Set<PinnedPageFilter>) {
   const filters = [...desyncedFilters];
 
   if (filters.length === 1) {
+    // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
     return `${filterNameMap[filters[0]]} filter`;
   }
 
   return `${filters
     .slice(0, -1)
     .map(value => filterNameMap[value])
+    // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
     .join(', ')} and ${filterNameMap[filters[filters.length - 1]]} filters`;
 }
 

--- a/static/app/components/organizations/timeRangeSelector/utils.tsx
+++ b/static/app/components/organizations/timeRangeSelector/utils.tsx
@@ -61,6 +61,7 @@ const parseStatsPeriodString = (statsPeriodString: string) => {
     throw new Error('Invalid stats period');
   }
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const value = parseInt(result[1], 10);
   const unit = result[2] as RelativePeriodUnit;
 
@@ -86,6 +87,7 @@ export function parseStatsPeriod(
 ): {end: string; start: string} {
   const {value, unit} = parseStatsPeriodString(statsPeriod);
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const momentUnit = SUPPORTED_RELATIVE_PERIOD_UNITS[unit].momentUnit;
 
   const format = outputFormat === null ? undefined : outputFormat;
@@ -118,6 +120,7 @@ export function getRelativeSummary(
 
     const {value, unit} = parseStatsPeriodString(relative);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return SUPPORTED_RELATIVE_PERIOD_UNITS[unit].label(value);
   } catch {
     return 'Invalid period';
@@ -154,6 +157,7 @@ function timePeriodIsWithinLimit<T extends RelativeUnitsMapping>({
     return true;
   }
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const daysMultiplier = supportedPeriods[unit].convertToDaysMultiplier;
 
   return daysMultiplier * amount <= maxDays;
@@ -208,6 +212,7 @@ export const _timeRangeAutoCompleteFilter = function <T extends RelativeUnitsMap
         })
       )
       .map((unit, index) =>
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         makeItem(userSuppliedAmount, unit, supportedPeriods[unit].label, index)
       );
   }
@@ -219,6 +224,7 @@ export const _timeRangeAutoCompleteFilter = function <T extends RelativeUnitsMap
         return unit === userSuppliedUnits;
       }
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       return supportedPeriods[unit].searchKey.startsWith(userSuppliedUnits);
     });
 
@@ -235,6 +241,7 @@ export const _timeRangeAutoCompleteFilter = function <T extends RelativeUnitsMap
         makeItem(
           userSuppliedAmount,
           matchingUnit,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           supportedPeriods[matchingUnit].label,
           0
         ),

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -89,11 +89,13 @@ function SearchBar(props: SearchBarProps) {
       isDropdownOpen &&
       transactionCount > 0
     ) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const currentHighlightedItem = searchResults[0].children[highlightedItemIndex];
       const nextHighlightedItemIndex =
         (highlightedItemIndex + transactionCount + (key === 'ArrowUp' ? -1 : 1)) %
         transactionCount;
       setHighlightedItemIndex(nextHighlightedItemIndex);
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const nextHighlightedItem = searchResults[0].children[nextHighlightedItemIndex];
 
       let newSearchResults = searchResults;
@@ -119,6 +121,7 @@ function SearchBar(props: SearchBarProps) {
 
     if (key === 'Enter') {
       event.preventDefault();
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const currentItem = searchResults[0].children[highlightedItemIndex];
       if (!currentItem?.value) {
         return;

--- a/static/app/components/performance/waterfall/utils.tsx
+++ b/static/app/components/performance/waterfall/utils.tsx
@@ -230,12 +230,17 @@ const getLetterIndex = (letter: string): number => {
   return index === -1 ? 0 : index;
 };
 
+// @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
 const colorsAsArray = Object.keys(CHART_PALETTE).map(key => CHART_PALETTE[17][key]);
 
 export const barColors = {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   default: CHART_PALETTE[17][4],
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   transaction: CHART_PALETTE[17][8],
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   http: CHART_PALETTE[17][10],
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   db: CHART_PALETTE[17][17],
 };
 
@@ -244,6 +249,7 @@ export const pickBarColor = (input: string | undefined): string => {
   // That way colors stay consistent between transactions.
 
   if (!input || input.length < 3) {
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     return CHART_PALETTE[17][4];
   }
 

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -70,6 +70,7 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
       // Among the project selection, find a project that has performance onboarding docs support, and has not sent
       // a first transaction event.
       const maybeProject = projectSelection.find(project =>
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Project | undefined' is not assi... Remove this comment to see the full error message
         projectsForOnboarding.includes(project)
       );
       if (maybeProject) {
@@ -79,6 +80,7 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
 
       // Among the project selection, find a project that has not sent a first transaction event
       const maybeProjectFallback = projectSelection.find(project =>
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Project | undefined' is not assi... Remove this comment to see the full error message
         projectsWithoutFirstTransactionEvent.includes(project)
       );
       if (maybeProjectFallback) {

--- a/static/app/components/pickProjectToContinue.tsx
+++ b/static/app/components/pickProjectToContinue.tsx
@@ -47,6 +47,7 @@ function PickProjectToContinue({
 
   // if the project in URL is missing, but this release belongs to only one project, redirect there
   if (projects.length === 1) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     router.replace(path + projects[0].id);
     return null;
   }

--- a/static/app/components/platformPicker.tsx
+++ b/static/app/components/platformPicker.tsx
@@ -53,6 +53,7 @@ class PlatformPicker extends Component<PlatformPickerProps, State> {
 
   state: State = {
     category: this.props.defaultCategory ?? PLATFORM_CATEGORIES[0].id,
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     filter: this.props.noAutoFilter ? '' : (this.props.platform || '').split('-')[0],
   };
 

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
@@ -19,6 +19,7 @@ function selectProject(project: Project) {
     throw new Error(`Selected project requires a name, received ${project.slug}`);
   }
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
   userEvent.click(screen.getAllByRole('textbox')[0]);
   userEvent.click(screen.getByText(project.slug));
 }
@@ -71,11 +72,13 @@ describe('ProfilingOnboarding', function () {
     selectProject(project);
     await act(async () => {
       await screen.findByText(/options\.dsn/);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByText('Next')[0]);
     });
     expect(screen.getByText(/Step 2 of 2/i)).toBeInTheDocument();
 
     act(() => {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByText('Back')[0]);
     });
     expect(screen.getByText(/Select a Project/i)).toBeInTheDocument();
@@ -99,6 +102,7 @@ describe('ProfilingOnboarding', function () {
       <ProfilingOnboardingModal organization={organization} {...MockRenderModalProps} />
     );
     selectProject(TestStubs.Project({name: 'javascript'}));
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(screen.getAllByText('Next')[0]);
 
     expect(screen.getByRole('button', {name: /Next/i})).toBeDisabled();

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.tsx
@@ -213,6 +213,7 @@ function SelectProjectStep({
               sdkUpdates={sdkUpdates}
               project={project}
               organization={organization}
+              // @ts-expect-error TS(2322) FIXME: Type 'InitialState | LoadingState | ErroredState |... Remove this comment to see the full error message
               publicDSN={publicDSN}
             />
           ) : null}
@@ -221,6 +222,7 @@ function SelectProjectStep({
               sdkUpdates={sdkUpdates}
               project={project}
               organization={organization}
+              // @ts-expect-error TS(2322) FIXME: Type 'InitialState | LoadingState | ErroredState |... Remove this comment to see the full error message
               publicDSN={publicDSN}
             />
           ) : null}

--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -554,11 +554,17 @@ function FlamegraphZoomView({
       const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
 
       const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m00,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m01,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m02,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m10,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m11,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m12,
         0,
         0,
@@ -651,11 +657,17 @@ function FlamegraphZoomView({
       const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
 
       const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m00,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m01,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m02,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m10,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m11,
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         m12,
         0,
         0,

--- a/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
@@ -287,11 +287,17 @@ function FlamegraphZoomViewMinimap({
         const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
 
         const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
+          // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
           m00,
+          // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
           m01,
+          // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
           m02,
+          // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
           m10,
+          // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
           m11,
+          // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
           m12,
           0,
           0,

--- a/static/app/components/profiling/profileDragDropImport.tsx
+++ b/static/app/components/profiling/profileDragDropImport.tsx
@@ -28,6 +28,7 @@ function ProfileDragDropImport({
       evt.preventDefault();
       evt.stopPropagation();
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const file = evt.dataTransfer.items[0].getAsFile();
 
       if (file) {

--- a/static/app/components/projectPageFilter.spec.tsx
+++ b/static/app/components/projectPageFilter.spec.tsx
@@ -58,12 +58,14 @@ describe('ProjectPageFilter', function () {
 
     // Click the first project's checkbox
     const projectOptions = screen.getAllByTestId('checkbox-fancy');
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(projectOptions[0]);
 
     // Confirm the selection changed the visible text
     expect(screen.queryByText('My Projects')).not.toBeInTheDocument();
 
     // Close the dropdown
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(screen.getAllByText('project-2')[0]);
 
     // Verify we were redirected

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -142,6 +142,7 @@ function ProjectPageFilter({
     // Show 2 projects only if the combined string does not exceed maxTitleLength.
     // Otherwise show only 1 project.
     const projectsToShow =
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       selectedProjects[0]?.slug?.length + selectedProjects[1]?.slug?.length <=
       maxTitleLength - 2
         ? selectedProjects.slice(0, 2)

--- a/static/app/components/projects/appStoreConnectContext.tsx
+++ b/static/app/components/projects/appStoreConnectContext.tsx
@@ -124,6 +124,7 @@ const Provider = ({children, project, organization}: ProviderProps) => {
                       name: appStoreConnectSymbolSources[key].name,
                       link: `/settings/${organization.slug}/projects/${project.slug}/debug-symbols/?customRepository=${key}`,
                     },
+                    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                     appStoreConnect.credentials
                   ),
                 },

--- a/static/app/components/projects/missingProjectMembership.tsx
+++ b/static/app/components/projects/missingProjectMembership.tsx
@@ -134,6 +134,7 @@ class MissingProjectMembership extends Component<Props, State> {
     const teamAccess = [
       {
         label: t('Request Access'),
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         options: this.getTeamsForAccess()[0].map(request => ({
           value: request,
           label: `#${request}`,
@@ -141,6 +142,7 @@ class MissingProjectMembership extends Component<Props, State> {
       },
       {
         label: t('Pending Requests'),
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         options: this.getTeamsForAccess()[1].map(pending =>
           this.getPendingTeamOption(pending)
         ),

--- a/static/app/components/quickTrace/index.spec.tsx
+++ b/static/app/components/quickTrace/index.spec.tsx
@@ -415,6 +415,7 @@ describe('Quick Trace', function () {
         makeTransactionHref('p4', 'e4', 't4', '4'),
         makeTransactionHref('p5', 'e5', 't5', '5'),
       ].forEach((target, i) => {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const linkNode = nodes[i].children[0];
         if (target) {
           expect(linkNode).toHaveAttribute('href', target);

--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -322,11 +322,14 @@ function EventNodeSelector({
     const hoverText = errors.length ? (
       t('View the error for this Transaction')
     ) : (
+      // @ts-expect-error TS(2322) FIXME: Type 'QuickTraceEvent | undefined' is not assignab... Remove this comment to see the full error message
       <SingleEventHoverText event={events[0]} />
     );
     const target = errors.length
-      ? generateSingleErrorTarget(errors[0], organization, location, errorDest)
+      ? // @ts-expect-error TS(2345) FIXME: Argument of type 'TraceError | undefined' is not a... Remove this comment to see the full error message
+        generateSingleErrorTarget(errors[0], organization, location, errorDest)
       : generateSingleTransactionTarget(
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'QuickTraceEvent | undefined' is ... Remove this comment to see the full error message
           events[0],
           organization,
           location,

--- a/static/app/components/radioGroupRating.spec.tsx
+++ b/static/app/components/radioGroupRating.spec.tsx
@@ -44,9 +44,11 @@ describe('RadioGroupRating', function () {
     Object.keys(options).forEach((key, index) => {
       expect(screen.getByText(index + 1)).toBeInTheDocument();
       expect(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         screen.getByLabelText(`Select option ${options[key].label}`)
       ).toBeInTheDocument();
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const description = options[key].description;
       if (description) {
         expect(screen.getByText(description)).toBeInTheDocument();
@@ -54,6 +56,7 @@ describe('RadioGroupRating', function () {
     });
 
     // Click on the first option
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     userEvent.click(screen.getByLabelText(`Select option ${options[0].label}`));
     expect(handleChange).toHaveBeenCalledWith('0');
   });

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -105,6 +105,7 @@ function Event({
     if (crumbs.length === 1) {
       const crumb = crumbs[0];
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       switch (crumb.type) {
         case 'navigation':
         case 'debug':

--- a/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
@@ -92,7 +92,9 @@ const Span = styled('li')<{startPct: number; widthPct: number}>`
   min-width: 1px;
   width: ${p => p.widthPct * 100}%;
   height: 100%;
-  background: ${p => p.theme.charts.colors[0]};
+  background: ${p =>
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+    p.theme.charts.colors[0]};
   border-radius: 2px;
   pointer-events: auto;
 `;

--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -23,6 +23,7 @@ function ReplayCurrentUrl() {
 
   return (
     <UrlCopyInput size="sm">
+      {/* @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message */}
       {getCurrentUrl(replayRecord, crumbs, currentTime)}
     </UrlCopyInput>
   );

--- a/static/app/components/replays/replayHighlight.tsx
+++ b/static/app/components/replays/replayHighlight.tsx
@@ -6,6 +6,7 @@ interface Props {
   replay: undefined | Pick<ReplayListRecord, 'countErrors' | 'duration' | 'urls'>;
 }
 
+// @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
 const palette = new Array(10).fill([CHART_PALETTE[0][0]]);
 
 function ReplayHighlight({replay}: Props) {

--- a/static/app/components/replays/utils.tsx
+++ b/static/app/components/replays/utils.tsx
@@ -214,11 +214,16 @@ export function flattenSpans(rawSpans: ReplaySpan[]): FlattenedSpanRange[] {
   for (const span of restSpans) {
     let overlap = false;
     for (const fspan of flatSpans) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'FlattenedSpanRange | undefined' ... Remove this comment to see the full error message
       if (doesOverlap(fspan, span)) {
         overlap = true;
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         fspan.spanCount += 1;
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         fspan.startTimestamp = Math.min(fspan.startTimestamp, span.startTimestamp);
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         fspan.endTimestamp = Math.max(fspan.endTimestamp, span.endTimestamp);
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         fspan.duration = fspan.endTimestamp - fspan.startTimestamp;
         break;
       }
@@ -227,6 +232,7 @@ export function flattenSpans(rawSpans: ReplaySpan[]): FlattenedSpanRange[] {
       flatSpans.push(span);
     }
   }
+  // @ts-expect-error TS(2322) FIXME: Type '(FlattenedSpanRange | undefined)[]' is not a... Remove this comment to see the full error message
   return flatSpans;
 }
 

--- a/static/app/components/resultGrid.tsx
+++ b/static/app/components/resultGrid.tsx
@@ -198,6 +198,7 @@ class ResultGrid extends Component<Props, State> {
     this.setState(
       {
         query: queryParams.query ?? '',
+        // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         sortBy: queryParams.sortBy ?? this.props.defaultSort,
         filters: {...queryParams},
         pageLinks: null,
@@ -352,6 +353,7 @@ class ResultGrid extends Component<Props, State> {
             <Filter
               key={filterKey}
               queryKey={filterKey}
+              // @ts-expect-error TS(2769) FIXME: No overload matches this call.
               value={this.state.filters[filterKey]}
               path={path ?? ''}
               location={location}

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -438,6 +438,7 @@ class ApiSource extends Component<Props, State> {
         sentryApps,
         docIntegrations,
       ]),
+      // @ts-expect-error TS(2322) FIXME: Type 'Promise<Result | null> | undefined' is not a... Remove this comment to see the full error message
       this.getDirectResults([shortIdLookup, eventIdLookup]),
     ]);
 
@@ -493,7 +494,9 @@ class ApiSource extends Component<Props, State> {
 
     const directResults = (
       await Promise.all([
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Promise<any> | undefined' is not... Remove this comment to see the full error message
         createShortIdLookupResult(shortIdLookup),
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Promise<any> | undefined' is not... Remove this comment to see the full error message
         createEventIdLookupResult(eventIdLookup),
       ])
     ).filter(defined);

--- a/static/app/components/search/sources/helpSource.tsx
+++ b/static/app/components/search/sources/helpSource.tsx
@@ -115,7 +115,9 @@ function mapSearchResults(results: SearchResult[]) {
 
     // The first element should indicate the section.
     if (sectionItems.length > 0) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       sectionItems[0].item.sectionHeading = section.name;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       sectionItems[0].item.sectionCount = sectionItems.length;
 
       items.push(...sectionItems);

--- a/static/app/components/search/sources/index.tsx
+++ b/static/app/components/search/sources/index.tsx
@@ -52,6 +52,7 @@ class SearchSources extends Component<Props> {
     }
     const Source = sources[idx];
     return (
+      // @ts-expect-error TS(2604) FIXME: JSX element type 'Source' does not have any constr... Remove this comment to see the full error message
       <Source {...this.props}>
         {(args: SourceResult) => {
           // Mutate the array instead of pushing because we don't know how often

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -932,7 +932,8 @@ export function joinQuery(
   return (
     (leadingSpace ? ' ' : '') +
     (parsedTerms.length === 1
-      ? parsedTerms[0].text
+      ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        parsedTerms[0].text
       : parsedTerms.map(p => p.text).join(additionalSpaceBetween ? ' ' : ''))
   );
 }

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -372,6 +372,7 @@ function Sidebar({location, organization}: Props) {
 
           <SidebarSection>
             {HookStore.get('sidebar:bottom-items').length > 0 &&
+              // @ts-expect-error TS(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
               HookStore.get('sidebar:bottom-items')[0]({
                 orientation,
                 collapsed,

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -429,6 +429,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     }
 
     const entry = entries[0];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const {width} = entry.contentRect;
     const actionCount = this.props.actionBarItems?.length ?? 0;
 
@@ -502,10 +503,12 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     if (this.searchInput.current && filterTokens.length > 0) {
       this.searchInput.current.focus();
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       let offset = filterTokens[0].location.end.offset;
       if (token) {
         const tokenIndex = filterTokens.findIndex(tok => tok === token);
         if (tokenIndex !== -1 && tokenIndex + 1 < filterTokens.length) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           offset = filterTokens[tokenIndex + 1].location.end.offset;
         }
       }
@@ -774,10 +777,12 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
 
       // Clear previous selection
       const prevItem = flatSearchItems[currIndex];
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'SearchItem | undefined' is not a... Remove this comment to see the full error message
       searchGroups = getSearchGroupWithItemMarkedActive(searchGroups, prevItem, false);
 
       // Set new selection
       const activeItem = flatSearchItems[nextActiveSearchItem];
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'SearchItem | undefined' is not a... Remove this comment to see the full error message
       searchGroups = getSearchGroupWithItemMarkedActive(searchGroups, activeItem, true);
 
       this.setState({searchGroups, activeSearchItem: nextActiveSearchItem});
@@ -870,6 +875,7 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     if (isSelectingDropdownItems) {
       searchGroups = getSearchGroupWithItemMarkedActive(
         searchGroups,
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'SearchItem | undefined' is not a... Remove this comment to see the full error message
         flatSearchItems[activeSearchItem],
         false
       );
@@ -1015,12 +1021,14 @@ class SmartSearchBar extends Component<DefaultProps & Props, State> {
     const innerStart = cursorPosition - cursorToken.location.start.offset;
 
     let tokenStart = innerStart;
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     while (tokenStart > 0 && !LIMITER_CHARS.includes(cursorToken.text[tokenStart - 1])) {
       tokenStart--;
     }
     let tokenEnd = innerStart;
     while (
       tokenEnd < cursorToken.text.length &&
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       !LIMITER_CHARS.includes(cursorToken.text[tokenEnd])
     ) {
       tokenEnd++;

--- a/static/app/components/smartSearchBar/searchDropdown.tsx
+++ b/static/app/components/smartSearchBar/searchDropdown.tsx
@@ -21,6 +21,7 @@ import {getSearchConfigFromCustomPerformanceMetrics} from './utils';
 
 const getDropdownItemKey = (item: SearchItem) =>
   `${item.value || item.desc || item.title}-${
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'SearchItem | undefined' is not a... Remove this comment to see the full error message
     item.children && item.children.length > 0 ? getDropdownItemKey(item.children[0]) : ''
   }`;
 
@@ -199,7 +200,8 @@ const ItemTitle = ({item, searchSubstring, isChild}: ItemTitleProps) => {
   if (searchSubstring) {
     const idx =
       restWords.length === 0
-        ? fullWord.toLowerCase().indexOf(searchSubstring.split('.')[0])
+        ? // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
+          fullWord.toLowerCase().indexOf(searchSubstring.split('.')[0])
         : fullWord.toLowerCase().indexOf(searchSubstring);
 
     // Below is the logic to make the current query bold inside the result.
@@ -208,13 +210,17 @@ const ItemTitle = ({item, searchSubstring, isChild}: ItemTitleProps) => {
         <SearchItemTitleWrapper hasSingleField={hasSingleField}>
           {!isFirstWordHidden && (
             <FirstWordWrapper>
+              {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
               {firstWord.slice(0, idx)}
+              {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
               <strong>{firstWord.slice(idx, idx + searchSubstring.length)}</strong>
+              {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
               {firstWord.slice(idx + searchSubstring.length)}
             </FirstWordWrapper>
           )}
           {combinedRestWords && (
             <HighlightedRestOfWords
+              // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               firstWord={firstWord}
               isFirstWordHidden={isFirstWordHidden}
               searchSubstring={searchSubstring}

--- a/static/app/components/smartSearchBar/utils.tsx
+++ b/static/app/components/smartSearchBar/utils.tsx
@@ -398,7 +398,8 @@ export const getTagItemsFromKeys = (
 
     const definition =
       supportedTags[key]?.kind === FieldKind.FUNCTION
-        ? fieldDefinitionGetter(key.split('(')[0])
+        ? // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
+          fieldDefinitionGetter(key.split('(')[0])
         : fieldDefinitionGetter(key);
     const kind = supportedTags[key]?.kind ?? definition?.kind ?? FieldKind.FIELD;
 
@@ -610,18 +611,23 @@ export const getSearchConfigFromCustomPerformanceMetrics = (
   };
   if (customPerformanceMetrics) {
     Object.keys(customPerformanceMetrics).forEach(metricName => {
+      // @ts-expect-error TS(2339) FIXME: Property 'fieldType' does not exist on type 'Custo... Remove this comment to see the full error message
       const {fieldType} = customPerformanceMetrics[metricName];
       switch (fieldType) {
         case 'size':
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           searchConfigMap.sizeKeys.push(metricName);
           break;
         case 'duration':
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           searchConfigMap.durationKeys.push(metricName);
           break;
         case 'percentage':
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           searchConfigMap.percentageKeys.push(metricName);
           break;
         default:
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           searchConfigMap.numericKeys.push(metricName);
       }
     });

--- a/static/app/components/stream/groupChart.tsx
+++ b/static/app/components/stream/groupChart.tsx
@@ -23,12 +23,14 @@ function GroupChart({
   height = 24,
   showMarkLine = false,
 }: Props) {
+  // @ts-expect-error TS(2322) FIXME: Type 'TimeseriesValue[] | undefined' is not assign... Remove this comment to see the full error message
   const stats: TimeseriesValue[] = statsPeriod
     ? data.filtered
       ? data.filtered.stats[statsPeriod]
       : data.stats[statsPeriod]
     : [];
 
+  // @ts-expect-error TS(2322) FIXME: Type 'TimeseriesValue[] | null | undefined' is not... Remove this comment to see the full error message
   const secondaryStats: TimeseriesValue[] | null =
     statsPeriod && data.filtered ? data.stats[statsPeriod] : null;
 

--- a/static/app/components/tagDistributionMeter.tsx
+++ b/static/app/components/tagDistributionMeter.tsx
@@ -52,6 +52,7 @@ function TagDistributionMeter({
     }
 
     const largestSegment = segments[0];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const pct = percent(largestSegment.count, totalValues);
     const pctLabel = Math.floor(pct);
     const renderLabel = () => {
@@ -60,6 +61,7 @@ function TagDistributionMeter({
           return (
             <Label>
               <Version
+                // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                 version={largestSegment.name}
                 anchor={false}
                 tooltipRawVersion
@@ -69,6 +71,7 @@ function TagDistributionMeter({
             </Label>
           );
         default:
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           return <Label>{largestSegment.name || t('n/a')}</Label>;
       }
     };

--- a/static/app/components/truncate.tsx
+++ b/static/app/components/truncate.tsx
@@ -82,7 +82,8 @@ class Truncate extends Component<Props, State> {
       } else if (trimRegex && !leftTrim) {
         const matches = slicedValue.match(trimRegex);
         let lastIndex = matches
-          ? slicedValue.lastIndexOf(matches[matches.length - 1]) + 1
+          ? // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
+            slicedValue.lastIndexOf(matches[matches.length - 1]) + 1
           : slicedValue.length;
         if (lastIndex <= minLength) {
           lastIndex = slicedValue.length;

--- a/static/app/components/userMisery.tsx
+++ b/static/app/components/userMisery.tsx
@@ -21,6 +21,7 @@ function UserMisery(props: Props) {
   // 0 User Misery while still preserving the actual value for sorting purposes.
   const adjustedMisery = userMisery > 0.05 ? userMisery : 0;
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const palette = new Array(bars).fill([CHART_PALETTE[0][0]]);
   const score = Math.round(adjustedMisery * palette.length);
 

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -201,8 +201,10 @@ export function parseComponentTemplate(template: string): ParsedTemplate {
       if (closeBraceOrValueSeparator === ']') {
         pos = regex.lastIndex;
       } else {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
         pos = regex.lastIndex = process(regex.lastIndex, groupName, true);
       }
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       buf.push({group: groupName});
     }
 

--- a/static/app/plugins/registry.tsx
+++ b/static/app/plugins/registry.tsx
@@ -33,6 +33,7 @@ export default class Registry {
         }
       }
       console.info(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         '[plugins] Loaded ' + data.id + ' as {' + this.plugins[data.id].name + '}'
       );
       callback(this.get(data));

--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -57,6 +57,7 @@ const storeConfig: AlertStoreDefinition = {
         // Remove any objects that have passed their mute duration.
         const now = Math.floor(new Date().valueOf() / 1000);
         for (const key in expirations) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           if (expirations.hasOwnProperty(key) && expirations[key] < now) {
             delete expirations[key];
           }

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -188,6 +188,7 @@ const storeConfig: GroupStoreDefinition = {
     if (this.statuses[id] === undefined) {
       this.statuses[id] = {};
     }
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     this.statuses[id][status] = true;
   },
 
@@ -195,6 +196,7 @@ const storeConfig: GroupStoreDefinition = {
     if (this.statuses[id] === undefined) {
       return;
     }
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     this.statuses[id][status] = false;
   },
 
@@ -209,6 +211,7 @@ const storeConfig: GroupStoreDefinition = {
     }
 
     for (let i = 0; i < group.activity.length; i++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (group.activity[i].id === id) {
         return i;
       }
@@ -249,6 +252,7 @@ const storeConfig: GroupStoreDefinition = {
     // Here, we want to merge the new `data` being passed in
     // into the existing `data` object. This effectively
     // allows passing in an object of only changes.
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     group.activity[index].data = Object.assign(group.activity[index].data, data);
     this.updateItems([group.id]);
   },
@@ -266,6 +270,7 @@ const storeConfig: GroupStoreDefinition = {
 
     const activity = group.activity.splice(index, 1);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (activity[0].type === 'note') {
       group.numComments--;
     }
@@ -300,6 +305,7 @@ const storeConfig: GroupStoreDefinition = {
         ? item
         : {
             ...item,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             ...pendingById[item.id].reduce((a, change) => ({...a, ...change.data}), {}),
           }
     );

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -307,10 +307,12 @@ const storeConfig: GroupingStoreDefinition = {
           const {childId, childLabel, eventCount, lastSeen, latestEvent} = item;
 
           if (eventCount) {
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             newItem.eventCount += eventCount;
           }
 
           if (childId) {
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             newItem.children.push({
               childId,
               childLabel,
@@ -336,9 +338,12 @@ const storeConfig: GroupingStoreDefinition = {
             // v1 layout: '<interface>:...'
             const [interfaceName] = String(scoreKey).split(':');
 
+            // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
             if (!acc[interfaceName]) {
+              // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
               acc[interfaceName] = [];
             }
+            // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
             acc[interfaceName].push([scoreKey, score]);
 
             return acc;
@@ -440,6 +445,7 @@ const storeConfig: GroupingStoreDefinition = {
     }
 
     // Update "checked" state for row
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     this.setStateForId(this.unmergeState, fingerprint, {
       checked,
     });

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -256,6 +256,7 @@ const storeConfig: GuideStoreDefinition = {
       guideOptions.length > 0
         ? {
             ...guideOptions[0],
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             steps: guideOptions[0].steps.filter(
               step =>
                 anchors.has(step.target) ||
@@ -264,6 +265,7 @@ const storeConfig: GuideStoreDefinition = {
           }
         : null;
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type '{ steps: GuideStep[]; guide?: st... Remove this comment to see the full error message
     this.updatePrevGuide(nextGuide);
     this.state.currentStep =
       this.state.currentGuide &&
@@ -271,8 +273,10 @@ const storeConfig: GuideStoreDefinition = {
       this.state.currentGuide.guide === nextGuide.guide
         ? this.state.currentStep
         : 0;
+    // @ts-expect-error TS(2322) FIXME: Type '{ steps: GuideStep[]; guide?: string | undef... Remove this comment to see the full error message
     this.state.currentGuide = nextGuide;
     this.trigger(this.state);
+    // @ts-expect-error TS(2345) FIXME: Argument of type '{ steps: GuideStep[]; guide?: st... Remove this comment to see the full error message
     HookStore.get('callback:on-guide-update').map(cb => cb(nextGuide, {dismissed}));
   },
 };

--- a/static/app/stores/memberListStore.tsx
+++ b/static/app/stores/memberListStore.tsx
@@ -43,6 +43,7 @@ const storeConfig: MemberListStoreDefinition = {
 
     id = '' + id;
     for (let i = 0; i < this.state.length; i++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (this.state[i].id === id) {
         return this.state[i];
       }

--- a/static/app/stores/projectsStatsStore.tsx
+++ b/static/app/stores/projectsStatsStore.tsx
@@ -98,6 +98,7 @@ const storeConfig: ProjectsStatsStoreDefinition = {
     return this.itemsBySlug;
   },
 
+  // @ts-expect-error TS(2322) FIXME: Type '(slug: string) => Project | undefined' is no... Remove this comment to see the full error message
   getBySlug(slug) {
     return this.itemsBySlug[slug];
   },

--- a/static/app/stores/projectsStore.tsx
+++ b/static/app/stores/projectsStore.tsx
@@ -114,6 +114,7 @@ const storeConfig: ProjectsStoreDefinition = {
 
     // Assign stats into projects
     entries.forEach(([projectId, stats]) => {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       this.itemsById[projectId].stats = stats;
     });
 

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -85,9 +85,11 @@ export function sortArray<T>(arr: Array<T>, score_fn: (entry: T) => string): Arr
       b_score = score_fn(b);
 
     for (let i = 0; i < a_score.length; i++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (a_score[i] > b_score[i]) {
         return 1;
       }
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (a_score[i] < b_score[i]) {
         return -1;
       }

--- a/static/app/utils/consolidatedScopes.tsx
+++ b/static/app/utils/consolidatedScopes.tsx
@@ -41,6 +41,7 @@ type PermissionLevelResources = {
  */
 const permissionLevel = (scope: string): number => {
   const permission = scope.split(':')[1];
+  // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
   return PERMISSION_LEVELS[permission];
 };
 
@@ -92,6 +93,7 @@ function toResourcePermissions(scopes: string[]): Permissions {
   topScopes(filteredScopes).forEach((scope: string | undefined) => {
     if (scope) {
       const [resource, permission] = scope.split(':');
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       permissions[HUMAN_RESOURCE_NAMES[resource]] = permission;
     }
   });

--- a/static/app/utils/cursorPoller.tsx
+++ b/static/app/utils/cursorPoller.tsx
@@ -90,6 +90,7 @@ class CursorPoller {
 
         const linksHeader = resp?.getResponseHeader('Link') ?? null;
         const links = parseLinkHeader(linksHeader);
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         this.setEndpoint(links.previous.href);
 
         this.options.success(data, linksHeader);

--- a/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
+++ b/static/app/utils/customMeasurements/customMeasurementsProvider.tsx
@@ -74,8 +74,11 @@ export function CustomMeasurementsProvider({
             acc[customMeasurement] = {
               key: customMeasurement,
               name: customMeasurement,
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               functions: response[customMeasurement].functions,
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               unit: response[customMeasurement].unit,
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               fieldType: getFieldTypeFromUnit(response[customMeasurement].unit),
             };
             return acc;

--- a/static/app/utils/dates.tsx
+++ b/static/app/utils/dates.tsx
@@ -71,8 +71,10 @@ export function setDateToTime(
   const date = new Date(+dateObj);
 
   if (local) {
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
     date.setHours(hours, minutes);
   } else {
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
     date.setUTCHours(hours, minutes);
   }
 
@@ -173,6 +175,7 @@ export function intervalToMilliseconds(interval: string): number {
     h: 60 * 60,
     m: 60,
   };
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   return parseInt(value, 10) * multipliers[unit] * 1000;
 }
 
@@ -189,6 +192,7 @@ export function parsePeriodToHours(str: string): number {
 
   const {period, periodLength} = result;
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const periodNumber = parseInt(period, 10);
 
   switch (periodLength) {

--- a/static/app/utils/discover/arrayValue.tsx
+++ b/static/app/utils/discover/arrayValue.tsx
@@ -34,6 +34,7 @@ class ArrayValue extends Component<Props, State> {
             .map((item, i) => (
               <ArrayItem key={`${i}:${item}`}>{nullableValue(item)}</ArrayItem>
             ))}
+        {/* @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message */}
         <ArrayItem>{nullableValue(value.slice(-1)[0])}</ArrayItem>
         {value.length > 1 ? (
           <ButtonContainer>

--- a/static/app/utils/discover/charts.tsx
+++ b/static/app/utils/discover/charts.tsx
@@ -150,6 +150,7 @@ export function findRangeOfMultiSeries(series: Series[], legend?: LegendComponen
     let maxSeries;
     series.forEach(({seriesName, data}, idx) => {
       if (legend?.selected?.[seriesName] !== false && data.length) {
+        // @ts-expect-error TS(2322) FIXME: Type 'Series | undefined' is not assignable to typ... Remove this comment to see the full error message
         minSeries = series[idx];
         maxSeries ??= series[idx];
       }

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -798,8 +798,10 @@ class EventView {
         // their old widths.
         const existing = newEventView.fields[i];
         const width =
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           existing.field === field && existing.width !== undefined
-            ? existing.width
+            ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+              existing.width
             : COL_WIDTH_UNDEFINED;
         return {field, width};
       });
@@ -867,6 +869,7 @@ class EventView {
     const columnToBeUpdated = this.fields[columnIndex];
     const fieldAsString = generateFieldAsString(updatedColumn);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const updateField = columnToBeUpdated.field !== fieldAsString;
     if (!updateField) {
       return this;
@@ -890,6 +893,7 @@ class EventView {
     // if the updated column is one of the sorted columns, we may need to remove
     // it from the list of sorts
     const needleSortIndex = this.sorts.findIndex(sort =>
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'Field | undefined' is not assign... Remove this comment to see the full error message
       isSortEqualToField(sort, columnToBeUpdated, tableMeta)
     );
 
@@ -897,6 +901,7 @@ class EventView {
       const needleSort = this.sorts[needleSortIndex];
 
       const numOfColumns = this.fields.reduce((sum, currentField) => {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Sort | undefined' is not assigna... Remove this comment to see the full error message
         if (isSortEqualToField(needleSort, currentField, tableMeta)) {
           return sum + 1;
         }
@@ -912,6 +917,7 @@ class EventView {
           const sort = fieldToSort(updatedField, tableMeta)!;
 
           // preserve the sort kind
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           sort.kind = needleSort.kind;
 
           const sorts = [...newEventView.sorts];
@@ -932,6 +938,7 @@ class EventView {
           const sort = fieldToSort(updatedField, tableMeta)!;
 
           // preserve the sort kind
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           sort.kind = needleSort.kind;
 
           newEventView.sorts = [sort];
@@ -941,6 +948,7 @@ class EventView {
           );
           if (sortableFieldIndex >= 0) {
             const fieldToBeSorted = newEventView.fields[sortableFieldIndex];
+            // @ts-expect-error TS(2345) FIXME: Argument of type 'Field | undefined' is not assign... Remove this comment to see the full error message
             const sort = fieldToSort(fieldToBeSorted, tableMeta)!;
             newEventView.sorts = [sort];
           }
@@ -972,6 +980,7 @@ class EventView {
     // To ensure a well formed table results.
     const hasAutoIndex = fields.find(field => field.width === COL_WIDTH_UNDEFINED);
     if (!hasAutoIndex) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       newEventView.fields[0].width = COL_WIDTH_UNDEFINED;
     }
 
@@ -979,6 +988,7 @@ class EventView {
     // it from the list of sorts
     const columnToBeDeleted = this.fields[columnIndex];
     const needleSortIndex = this.sorts.findIndex(sort =>
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'Field | undefined' is not assign... Remove this comment to see the full error message
       isSortEqualToField(sort, columnToBeDeleted, tableMeta)
     );
 
@@ -986,6 +996,7 @@ class EventView {
       const needleSort = this.sorts[needleSortIndex];
 
       const numOfColumns = this.fields.reduce((sum, field) => {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Sort | undefined' is not assigna... Remove this comment to see the full error message
         if (isSortEqualToField(needleSort, field, tableMeta)) {
           return sum + 1;
         }
@@ -1008,6 +1019,7 @@ class EventView {
 
           if (sortableFieldIndex >= 0) {
             const fieldToBeSorted = newEventView.fields[sortableFieldIndex];
+            // @ts-expect-error TS(2345) FIXME: Argument of type 'Field | undefined' is not assign... Remove this comment to see the full error message
             const sort = fieldToSort(fieldToBeSorted, tableMeta)!;
             newEventView.sorts = [sort];
           }
@@ -1134,7 +1146,8 @@ class EventView {
         ? undefined
         : this.sorts.length > 1
         ? encodeSorts(this.sorts)
-        : encodeSort(this.sorts[0]);
+        : // @ts-expect-error TS(2345) FIXME: Argument of type 'Sort | undefined' is not assigna... Remove this comment to see the full error message
+          encodeSort(this.sorts[0]);
     const fields = this.getFields();
     const team = this.team.map(proj => String(proj));
     const project = this.project.map(proj => String(proj));
@@ -1257,10 +1270,12 @@ class EventView {
       const sorts = [...newEventView.sorts];
       sorts[needleIndex] = kind
         ? setSortOrder(
+            // @ts-expect-error TS(2345) FIXME: Argument of type '{ field?: string | undefined; ki... Remove this comment to see the full error message
             {...currentSort, ...(useFunctionFormat ? {field: field.field} : {})},
             kind
           )
-        : reverseSort({
+        : // @ts-expect-error TS(2345) FIXME: Argument of type '{ field?: string | undefined; ki... Remove this comment to see the full error message
+          reverseSort({
             ...currentSort,
             ...(useFunctionFormat ? {field: field.field} : {}),
           });
@@ -1304,6 +1319,7 @@ class EventView {
     const yAxisOptions = this.getYAxisOptions();
 
     const yAxis = this.yAxis;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const defaultOption = yAxisOptions[0].value;
 
     if (!yAxis) {

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -747,6 +747,7 @@ export function getSortField(
   }
 
   const fieldType = tableMeta[field];
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
     return FIELD_FORMATTERS[fieldType as keyof typeof FIELD_FORMATTERS].isSortable
       ? field
@@ -910,7 +911,9 @@ export function getFieldRenderer(
     }
   }
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
+    // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
     return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);
   }
   return partial(FIELD_FORMATTERS.string.renderFunc, fieldName);
@@ -938,7 +941,9 @@ export function getFieldFormatter(
   const fieldName = isAlias ? getAggregateAlias(field) : field;
   const fieldType = meta[fieldName];
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
+    // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
     return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);
   }
   return partial(FIELD_FORMATTERS.string.renderFunc, fieldName);

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -234,6 +234,7 @@ export const AGGREGATIONS = {
         kind: 'dropdown',
         options: CONDITIONS_ARGUMENTS,
         dataType: 'string',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         defaultValue: CONDITIONS_ARGUMENTS[0].value,
         required: true,
       },
@@ -266,6 +267,7 @@ export const AGGREGATIONS = {
         kind: 'dropdown',
         options: WEB_VITALS_QUALITY,
         dataType: 'string',
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         defaultValue: WEB_VITALS_QUALITY[0].value,
         required: true,
       },
@@ -648,6 +650,7 @@ export function measurementType(field: string): MeasurementType {
 export function getMeasurementSlug(field: string): string | null {
   const results = field.match(MEASUREMENT_PATTERN);
   if (results && results.length >= 2) {
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     return results[1];
   }
   return null;
@@ -662,6 +665,7 @@ export function getAggregateArg(field: string): string | null {
   const result = parseFunction(field);
 
   if (result && result.arguments.length > 0) {
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     return result.arguments[0];
   }
 
@@ -672,7 +676,9 @@ export function parseFunction(field: string): ParsedFunction | null {
   const results = field.match(AGGREGATE_PATTERN);
   if (results && results.length === 3) {
     return {
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       name: results[1],
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       arguments: parseArguments(results[1], results[2]),
     };
   }
@@ -767,6 +773,7 @@ export function getEquationAliasIndex(field: string): number {
   const results = field.match(EQUATION_ALIAS_PATTERN);
 
   if (results && results.length === 2) {
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     return parseInt(results[1], 10);
   }
   return -1;
@@ -1191,6 +1198,7 @@ export function isLegalYAxisType(match: ColumnType | MetricsType) {
 export function getSpanOperationName(field: string): string | null {
   const results = field.match(SPAN_OP_BREAKDOWN_PATTERN);
   if (results && results.length >= 2) {
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     return results[1];
   }
   return null;

--- a/static/app/utils/discover/teamKeyTransactionField.spec.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.spec.tsx
@@ -195,6 +195,7 @@ describe('TeamKeyTransactionField', function () {
 
     expect(teamOneCheckbox).not.toBeChecked();
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(teamOneCheckbox);
     expect(postTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
     await waitFor(() => {
@@ -251,6 +252,7 @@ describe('TeamKeyTransactionField', function () {
 
     expect(teamOneCheckbox).toBeChecked();
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(teamOneCheckbox);
     expect(deleteTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
     await waitFor(() => {
@@ -309,6 +311,7 @@ describe('TeamKeyTransactionField', function () {
       screen.getAllByRole('checkbox');
 
     expect(allTeamsCheckbox).not.toBeChecked();
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(allTeamsCheckbox);
 
     expect(postTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);
@@ -370,6 +373,7 @@ describe('TeamKeyTransactionField', function () {
       screen.getAllByRole('checkbox');
 
     expect(allTeamsCheckbox).toBeChecked();
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(allTeamsCheckbox);
 
     expect(deleteTeamKeyTransactionsMock).toHaveBeenCalledTimes(1);

--- a/static/app/utils/formatters.tsx
+++ b/static/app/utils/formatters.tsx
@@ -217,6 +217,7 @@ export function formatAbbreviatedNumber(number: number | string) {
 
   let lookup: typeof numberFormats[number];
 
+  // @ts-expect-error TS(2322) FIXME: Type 'readonly [1000000000, "b"] | readonly [10000... Remove this comment to see the full error message
   // eslint-disable-next-line no-cond-assign
   for (let i = 0; (lookup = numberFormats[i]); i++) {
     const [suffixNum, suffix] = lookup;

--- a/static/app/utils/getPeriod.tsx
+++ b/static/app/utils/getPeriod.tsx
@@ -48,6 +48,7 @@ export function getPeriod(
     }
     const [, periodNumber, periodLength] = period.match(/([0-9]+)([mhdw])/)!;
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     return {statsPeriod: `${parseInt(periodNumber, 10) * 2}${periodLength}`};
   }
 

--- a/static/app/utils/highlightFuseMatches.tsx
+++ b/static/app/utils/highlightFuseMatches.tsx
@@ -46,6 +46,7 @@ const getFuseMatches = ({value, indices}: Match): MatchResult => {
 
   indices.forEach(([start, end]) => {
     // Unhighlighted string before the match
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const stringBeforeMatch = value.substring(prev[1] + 1, start);
 
     // Only add to result if non-empty string
@@ -67,6 +68,7 @@ const getFuseMatches = ({value, indices}: Match): MatchResult => {
   });
 
   // The rest of the string starting from the last match index
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const restOfString = value.substring(prev[1] + 1, strLength);
   // Only add to result if non-empty string
   if (restOfString) {

--- a/static/app/utils/metrics/transformMetricsResponseToSeries.tsx
+++ b/static/app/utils/metrics/transformMetricsResponseToSeries.tsx
@@ -18,6 +18,7 @@ export function transformMetricsResponseToSeries(
           .join('')}`,
         data: response.intervals.map((interval, index) => ({
           name: interval,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           value: group.series ? group.series[field][index] ?? 0 : 0,
         })),
       }));

--- a/static/app/utils/parseLinkHeader.tsx
+++ b/static/app/utils/parseLinkHeader.tsx
@@ -16,6 +16,7 @@ export default function parseLinkHeader(header: string | null): Result {
       );
     const hasResults = match![3] === 'true' ? true : match![3] === 'false' ? false : null;
 
+    // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
     links[match![2]] = {
       href: match![1],
       results: hasResults,

--- a/static/app/utils/performance/contexts/genericQueryBatcher.tsx
+++ b/static/app/utils/performance/contexts/genericQueryBatcher.tsx
@@ -56,6 +56,7 @@ function queriesToMap(collectedQueries: Record<symbol, BatchQueryDefinition>) {
   keys.forEach(key => {
     const query = collectedQueries[key];
     mergeMap[mergeKey(query)] = mergeMap[mergeKey(query)] || [];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     mergeMap[mergeKey(query)].push(query);
     delete collectedQueries[key];
   });
@@ -82,7 +83,9 @@ function _handleUnmergeableQueries(mergeMap: MergeMap) {
     // Using async forEach to ensure calls start in parallel.
     const mergeList = mergeMap[k];
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (mergeList.length === 1) {
+      // @ts-expect-error TS(2488) FIXME: Type 'BatchQueryDefinition[] | undefined' must hav... Remove this comment to see the full error message
       const [queryDefinition] = mergeList;
       queriesSent++;
       _handleUnmergeableQuery(queryDefinition);
@@ -97,6 +100,7 @@ function _handleMergeableQueries(mergeMap: MergeMap) {
   Object.keys(mergeMap).forEach(async k => {
     const mergeList = mergeMap[k];
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (mergeList.length <= 1) {
       return;
     }
@@ -108,6 +112,7 @@ function _handleMergeableQueries(mergeMap: MergeMap) {
 
     const batchValues: string[] = [];
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     mergeList.forEach(q => {
       const batchFieldValue = q.requestQueryObject.query[batchProperty];
       if (Array.isArray(batchFieldValue)) {
@@ -136,6 +141,7 @@ function _handleMergeableQueries(mergeMap: MergeMap) {
     try {
       const result = await requestPromise;
       // Unmerge back into individual results
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       mergeList.forEach(queryDefinition => {
         queryDefinition.resolve(
           (queryDefinition.transform || identity)(result, queryDefinition)
@@ -143,6 +149,7 @@ function _handleMergeableQueries(mergeMap: MergeMap) {
       });
     } catch (e) {
       // On error fail all requests relying on this merged query (for now)
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       mergeList.forEach(q => q.reject(e));
     }
   });

--- a/static/app/utils/performance/histogram/index.tsx
+++ b/static/app/utils/performance/histogram/index.tsx
@@ -42,7 +42,8 @@ class Histogram extends Component<Props> {
 
     const dataFilter = location.query.dataFilter
       ? decodeScalar(location.query.dataFilter)
-      : FILTER_OPTIONS[0].value;
+      : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        FILTER_OPTIONS[0].value;
     return FILTER_OPTIONS.find(item => item.value === dataFilter) || FILTER_OPTIONS[0];
   }
 
@@ -66,6 +67,7 @@ class Histogram extends Component<Props> {
       handleFilterChange: this.handleFilterChange,
       filterOptions: FILTER_OPTIONS,
     };
+    // @ts-expect-error TS(2345) FIXME: Argument of type '{ isZoomed: boolean; handleReset... Remove this comment to see the full error message
     return this.props.children(childrenProps);
   }
 }

--- a/static/app/utils/performance/histogram/utils.tsx
+++ b/static/app/utils/performance/histogram/utils.tsx
@@ -7,6 +7,7 @@ export function getBucketWidth(data: HistogramData) {
   // We can assume that all buckets are of equal width, use the first two
   // buckets to get the width. The value of each histogram function indicates
   // the beginning of the bucket.
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   return data.length >= 2 ? data[1].bin - data[0].bin : 0;
 }
 

--- a/static/app/utils/profiling/filterFlamegraphTree.spec.tsx
+++ b/static/app/utils/profiling/filterFlamegraphTree.spec.tsx
@@ -30,6 +30,7 @@ function assertImmutability(baseNode: FlamegraphFrame, newNode: FlamegraphFrame)
       map.set(n.key, n);
 
       for (let i = 0; i < n.children.length; i++) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
         stack.push(n.children[i]);
       }
     }
@@ -80,6 +81,7 @@ describe('filterFlamegraphTree', () => {
 
     const result = filterFlamegraphTree([root], skipFn);
     expect(result).toEqual([{...child1, parent: null}]);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
     assertImmutability(root, result[0]);
   });
 
@@ -108,6 +110,7 @@ describe('filterFlamegraphTree', () => {
     const result = filterFlamegraphTree([root], skipFn);
     expect(result[0].children.map(c => c.key)).toEqual([1, 2]);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
     assertImmutability(root, result[0]);
   });
 
@@ -141,6 +144,7 @@ describe('filterFlamegraphTree', () => {
     expect(result[0].key).toBe(0);
     expect(result[0].children[0].key).toBe(2);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
     assertImmutability(root, result[0]);
   });
 
@@ -175,6 +179,7 @@ describe('filterFlamegraphTree', () => {
     expect(result[0].children[0].key).toBe(1);
     expect(result[0].children[0].children[0].key).toBe(2);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
     assertImmutability(root, result[0]);
   });
 
@@ -215,6 +220,7 @@ describe('filterFlamegraphTree', () => {
     expect(result[0].children[0].children[0].key).toBe(3);
     expect(result[0].children[0].children[1].key).toBe(2);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
     assertImmutability(root, result[0]);
   });
 });

--- a/static/app/utils/profiling/filterFlamegraphTree.tsx
+++ b/static/app/utils/profiling/filterFlamegraphTree.tsx
@@ -38,6 +38,7 @@ export function filterFlamegraphTree(
 
       // enqueue children
       for (let i = 0; i < node.children.length; i++) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
         stack.push(node.children[node.children.length - i - 1]);
       }
     }

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -251,18 +251,24 @@ export class Flamegraph {
     if (typeof frameOrName === 'string') {
       for (let i = 0; i < this.frames.length; i++) {
         if (
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           this.frames[i].frame.name === frameOrName &&
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           this.frames[i].frame.image === packageName
         ) {
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
           matches.push(this.frames[i]);
         }
       }
     } else {
       for (let i = 0; i < this.frames.length; i++) {
         if (
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           this.frames[i].frame.name === frameOrName.node.frame.name &&
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           this.frames[i].frame.image === frameOrName.node.frame.image
         ) {
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
           matches.push(this.frames[i]);
         }
       }

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
@@ -43,6 +43,7 @@ function scoreFlamegraph(
     }
 
     for (let i = 0; i < frame.children.length; i++) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
       frames.push(frame.children[i]);
     }
   }
@@ -144,6 +145,7 @@ export function FlamegraphStateProvider(
         typeof profileGroup.data.activeProfileIndex === 'number'
       ) {
         const threadID =
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           profileGroup.data.profiles[profileGroup.data.activeProfileIndex].threadId;
 
         if (defined(threadID)) {

--- a/static/app/utils/profiling/hooks/useContextMenu.tsx
+++ b/static/app/utils/profiling/hooks/useContextMenu.tsx
@@ -135,6 +135,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
     }
 
     const resizeObserver = new window.ResizeObserver(entries => {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const contentRect = entries[0].contentRect;
       setMenuCoordinates(new Rect(0, 0, contentRect.width, contentRect.height));
     });
@@ -153,6 +154,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
     }
 
     const resizeObserver = new window.ResizeObserver(entries => {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const contentRect = entries[0].contentRect;
       setContainerCoordinates(new Rect(0, 0, contentRect.width, contentRect.height));
     });

--- a/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
+++ b/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
@@ -76,6 +76,7 @@ export function useKeyboardNavigation() {
           if (tabIndex === idx) {
             node?.focus();
           }
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           items[idx].node = node;
         }
       },

--- a/static/app/utils/profiling/hooks/useResizableDrawer.tsx
+++ b/static/app/utils/profiling/hooks/useResizableDrawer.tsx
@@ -60,11 +60,13 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
             Math.max(
               options.min[0],
               dimensionsRef.current[0] +
+                // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                 distance[0] * (options.direction === 'horizontal-ltr' ? -1 : 1)
             )
           ),
           // Round to 1px precision
           Math.round(
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             Math.max(options.min[1] ?? 0, dimensionsRef.current[1] + distance[1])
           ),
         ];

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.spec.tsx
@@ -12,11 +12,13 @@ function toFlattenedList(tree: VirtualizedTree<any>): VirtualizedTreeNode<any>[]
     list.push(node);
 
     for (let i = 0; i < node.children.length; i++) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       visit(node.children[i]);
     }
   }
 
   for (let i = 0; i < tree.roots.length; i++) {
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
     visit(tree.roots[i]);
   }
 
@@ -31,6 +33,7 @@ describe('VirtualizedTree', () => {
       root.children = [child1];
 
       const tree = VirtualizedTree.fromRoots([root]);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       tree.expandNode(tree.roots[0], true, {expandChildren: true});
 
       expect(tree.flattened).toHaveLength(2);
@@ -48,6 +51,7 @@ describe('VirtualizedTree', () => {
         return node.node.id === 'child1';
       });
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       tree.expandNode(tree.roots[0], true, {expandChildren: true});
       expect(tree.flattened).toHaveLength(2);
 
@@ -62,6 +66,7 @@ describe('VirtualizedTree', () => {
       root.children = [child1];
 
       const tree = VirtualizedTree.fromRoots([root]);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       const addedNodes = tree.expandNode(tree.roots[0], true);
 
       expect(addedNodes.length).toBe(1);
@@ -78,9 +83,11 @@ describe('VirtualizedTree', () => {
       const tree = VirtualizedTree.fromRoots([root]);
 
       // Expand all
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       tree.expandNode(tree.roots[0], true, {expandChildren: true});
 
       // Close root
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       const removedNodes = tree.expandNode(tree.roots[0], false);
       expect(removedNodes.length).toBe(1);
 
@@ -97,6 +104,7 @@ describe('VirtualizedTree', () => {
       root.children = [child1];
       const tree = VirtualizedTree.fromRoots([root]);
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       tree.roots[0].setExpanded(false);
 
       expect(VirtualizedTree.toExpandedList(tree.roots).map(i => i.node.id)).toEqual([

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTree.tsx
@@ -52,6 +52,7 @@ export class VirtualizedTree<T extends TreeLike> {
     }
 
     for (let i = 0; i < items.length; i++) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'T | undefined' is not assignable... Remove this comment to see the full error message
       toTreeNode(items[i], null, roots, 0);
     }
 
@@ -72,11 +73,13 @@ export class VirtualizedTree<T extends TreeLike> {
       }
 
       for (let i = 0; i < node.children.length; i++) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
         visit(node.children[i]);
       }
     }
 
     for (let i = 0; i < nodes.length; i++) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
       visit(nodes[i]);
     }
 
@@ -117,12 +120,14 @@ export class VirtualizedTree<T extends TreeLike> {
     function visit(node: VirtualizedTreeNode<T>) {
       const sortedChildren = node.children.sort(sortFn);
       for (let i = 0; i < sortedChildren.length; i++) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
         visit(sortedChildren[i]);
       }
     }
 
     const sortedRoots = this.roots.sort(sortFn);
     for (let i = 0; i < sortedRoots.length; i++) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
       visit(sortedRoots[i]);
     }
 
@@ -138,11 +143,13 @@ export class VirtualizedTree<T extends TreeLike> {
       }
 
       for (let i = 0; i < node.children.length; i++) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
         visit(node.children[i]);
       }
     }
 
     for (let i = 0; i < this.roots.length; i++) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
       visit(this.roots[i]);
     }
 

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/VirtualizedTreeNode.tsx
@@ -34,6 +34,7 @@ export class VirtualizedTreeNode<T> {
 
       if (next.expanded) {
         for (let i = 0; i < next.children.length; i++) {
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
           queue.push(next.children[i]);
         }
       }
@@ -73,11 +74,13 @@ export class VirtualizedTreeNode<T> {
       }
 
       for (let i = 0; i < node.children.length; i++) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
         visit(node.children[i]);
       }
     }
 
     for (let i = 0; i < this.children.length; i++) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
       visit(this.children[i]);
     }
 

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.spec.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.spec.tsx
@@ -75,6 +75,7 @@ describe('useVirtualizedTree', () => {
     });
 
     reactHooks.act(() => {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       result.current.handleExpandTreeNode(result.current.tree.roots[0], {
         expandChildren: true,
       });
@@ -102,6 +103,7 @@ describe('useVirtualizedTree', () => {
     });
 
     reactHooks.act(() => {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       result.current.handleExpandTreeNode(result.current.tree.roots[0], {
         expandChildren: true,
       });
@@ -133,6 +135,7 @@ describe('useVirtualizedTree', () => {
     });
 
     reactHooks.act(() => {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       result.current.handleExpandTreeNode(result.current.tree.roots[0], {
         expandChildren: true,
       });
@@ -164,6 +167,7 @@ describe('useVirtualizedTree', () => {
     });
 
     reactHooks.act(() => {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       result.current.handleExpandTreeNode(result.current.tree.roots[0], {
         expandChildren: true,
       });
@@ -193,6 +197,7 @@ describe('useVirtualizedTree', () => {
     });
 
     reactHooks.act(() => {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<any> | undef... Remove this comment to see the full error message
       result.current.handleExpandTreeNode(result.current.tree.roots[0], {
         expandChildren: true,
       });
@@ -212,6 +217,7 @@ describe('useVirtualizedTree', () => {
 
     // Last item should be different
     expect(result.current.items[result.current.items.length - 1].key).toBe(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       stableKeys[stableKeys.length - 1] + 1
     );
   });

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -214,6 +214,7 @@ function findVisibleItems<T extends TreeLike>({
         key: indexPointer,
         ref: null,
         styles: {position: 'absolute', top: elementTop},
+        // @ts-expect-error TS(2322) FIXME: Type 'VirtualizedTreeNode<T> | undefined' is not a... Remove this comment to see the full error message
         item: items[indexPointer],
       };
 
@@ -651,6 +652,7 @@ export function useVirtualizedTree<T extends TreeLike>(
       }
 
       if (event.key === 'Enter') {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'VirtualizedTreeNode<T> | undefin... Remove this comment to see the full error message
         handleExpandTreeNode(tree.flattened[latestStateRef.current.tabIndexKey], {
           expandChildren: true,
         });
@@ -692,16 +694,20 @@ export function useVirtualizedTree<T extends TreeLike>(
             return;
           }
 
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           dispatch({type: 'set tab index key', payload: items[nextIndex].key});
           updateGhostRow({
             ref: clickedGhostRowRef,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             tabIndexKey: items[nextIndex].key,
             scrollTop: latestStateRef.current.scrollTop,
             rowHeight: props.rowHeight,
             interaction: 'active',
             theme,
           });
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           items[nextIndex].ref?.focus({preventScroll: true});
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           items[nextIndex].ref?.scrollIntoView({block: 'nearest'});
         }
       }
@@ -737,16 +743,20 @@ export function useVirtualizedTree<T extends TreeLike>(
             return;
           }
 
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           dispatch({type: 'set tab index key', payload: items[nextIndex].key});
           updateGhostRow({
             ref: clickedGhostRowRef,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             tabIndexKey: items[nextIndex].key,
             scrollTop: latestStateRef.current.scrollTop,
             rowHeight: props.rowHeight,
             interaction: 'active',
             theme,
           });
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           items[nextIndex].ref?.focus({preventScroll: true});
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           items[nextIndex].ref?.scrollIntoView({block: 'nearest'});
         }
       }
@@ -842,10 +852,13 @@ export function useVirtualizedTree<T extends TreeLike>(
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
       renderered.push(
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'VisibleItem<T> | undefined' is n... Remove this comment to see the full error message
         renderRow(item, {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           handleRowClick: handleRowClick(item.key),
           handleExpandTreeNode,
           handleRowKeyDown,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           handleRowMouseEnter: handleRowMouseEnter(item.key),
           tabIndexKey: state.tabIndexKey,
         })

--- a/static/app/utils/profiling/jsSelfProfiling.tsx
+++ b/static/app/utils/profiling/jsSelfProfiling.tsx
@@ -51,6 +51,7 @@ export function resolveJSSelfProfilingStack(
       return callStack;
     }
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'Frame | undefined' is not assign... Remove this comment to see the full error message
     callStack.unshift(frameIndex[stack.frameId]);
 
     if (stack.parentId !== undefined) {

--- a/static/app/utils/profiling/profile/chromeTraceProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.spec.tsx
@@ -64,6 +64,7 @@ describe('parseTypescriptChromeTraceArrayFormat', () => {
 
   it('marks process name', () => {
     expect(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       parseTypescriptChromeTraceArrayFormat(
         [
           {
@@ -92,6 +93,7 @@ describe('parseTypescriptChromeTraceArrayFormat', () => {
 
   it('marks thread name', () => {
     expect(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       parseTypescriptChromeTraceArrayFormat(
         [
           {

--- a/static/app/utils/profiling/profile/chromeTraceProfile.tsx
+++ b/static/app/utils/profiling/profile/chromeTraceProfile.tsx
@@ -146,7 +146,9 @@ function buildProfile(
     throw new Error('Profile does not contain any frame events');
   }
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const firstTimestamp = beginQueue[beginQueue.length - 1].ts;
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const lastTimestamp = endQueue[0]?.ts ?? beginQueue[0].ts;
 
   if (typeof firstTimestamp !== 'number') {
@@ -201,20 +203,25 @@ function buildProfile(
           )}`
         );
       }
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'Event | undefined' is not assign... Remove this comment to see the full error message
       const topFrameInfo = createFrameInfoFromEvent(stack[stack.length - 1]);
 
       // We check frames with the same ts and look for a match. We do this because
       // chronological sort will not break ties on frames that end at the same time,
       // but may not be in the same order as they were opened.
       for (let i = endQueue.length - 2; i > 0; i--) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (endQueue[i].ts > endQueue[endQueue.length - 1].ts) {
           break;
         }
 
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Event | undefined' is not assign... Remove this comment to see the full error message
         const nextEndInfo = createFrameInfoFromEvent(endQueue[i]);
         if (topFrameInfo.key === nextEndInfo.key) {
           const tmp = endQueue[endQueue.length - 1];
+          // @ts-expect-error TS(2322) FIXME: Type 'Event | undefined' is not assignable to type... Remove this comment to see the full error message
           endQueue[endQueue.length - 1] = endQueue[i];
+          // @ts-expect-error TS(2322) FIXME: Type 'Event | undefined' is not assignable to type... Remove this comment to see the full error message
           endQueue[i] = tmp;
 
           frameInfo = nextEndInfo;
@@ -327,12 +334,14 @@ function collectEventsByProfile(input: ChromeTrace.ArrayFormat): {
   for (let i = 0; i < sorted.length; i++) {
     const event = sorted[i];
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'Event | ProfileEvent | undefined... Remove this comment to see the full error message
     if (isThreadmetaData(event)) {
       threadNames.set(`${event.pid}:${event.tid}`, event.args.name);
       continue;
     }
 
     // A profile entry will happen before we see any ProfileChunks, so the order here matters
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'Event | ProfileEvent | undefined... Remove this comment to see the full error message
     if (isProfileEvent(event)) {
       profileIdToProcessAndThreadIds.set(event.id, [event.pid, event.tid]);
 
@@ -357,6 +366,7 @@ function collectEventsByProfile(input: ChromeTrace.ArrayFormat): {
       continue;
     }
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'Event | undefined' is not assign... Remove this comment to see the full error message
     if (isProfileChunk(event)) {
       const profile = cpuProfiles.get(event.id);
 
@@ -404,13 +414,16 @@ function createFramesIndex(
   const frames: Map<number, ChromeTrace.ProfileNode> = new Map();
 
   for (let i = 0; i < profile.nodes.length; i++) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     frames.set(profile.nodes[i].id, {...profile.nodes[i]});
   }
 
   for (let i = 0; i < profile.nodes.length; i++) {
     const profileNode = profile.nodes[i];
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (typeof profileNode.parent === 'number') {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const parent = frames.get(profileNode.parent);
 
       if (parent === undefined) {
@@ -418,11 +431,14 @@ function createFramesIndex(
       }
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!profileNode.children) {
       continue;
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     for (let j = 0; j < profileNode.children.length; j++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const child = frames.get(profileNode.children[j]);
 
       if (child === undefined) {
@@ -464,11 +480,13 @@ export function collapseSamples(profile: ChromeTrace.CpuProfile): {
   }
 
   if (profile.samples.length === 1 && profile.timeDeltas.length === 1) {
+    // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
     return {samples: [profile.samples[0]], sampleTimes: [profile.timeDeltas[0]]};
   }
 
   // First delta is relative to profile start
   // https://github.com/v8/v8/blob/44bd8fd7/src/inspector/js_protocol.json#L1485
+  // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
   let elapsed: number = profile.timeDeltas[0];
 
   // This is quite significantly changed from speedscope's implementation.
@@ -487,6 +505,7 @@ export function collapseSamples(profile: ChromeTrace.CpuProfile): {
       // Update the delta and advance j. In some cases, v8 reports deltas
       // as negative. We will just ignore these deltas and make sure that
       // we never go back in time when updating the delta.
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       delta = Math.max(delta + profile.timeDeltas[j + 1], delta);
       j++;
     }
@@ -496,19 +515,23 @@ export function collapseSamples(profile: ChromeTrace.CpuProfile): {
       // We skipped more than 1 element, so we should collapse the samples,
       // push the first element where we started with the elapsed time
       // and last element where we started with the elapsed time + delta
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
       samples.push(nodeId);
       sampleTimes.push(elapsed);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
       samples.push(nodeId);
       sampleTimes.push(elapsed + delta);
       elapsed += delta;
       i = j;
     } else {
       // If we have not skipped samples, then we just push the sample and the delta to the list
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
       samples.push(nodeId);
       sampleTimes.push(elapsed);
 
       // In some cases, v8 reports deltas as negative. We will just ignore
       // these deltas and make sure that we never go back in time when updating the delta.
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       elapsed = Math.max(elapsed + profile.timeDeltas[i + 1], elapsed);
     }
   }

--- a/static/app/utils/profiling/profile/eventedProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.spec.tsx
@@ -101,6 +101,7 @@ describe('EventedProfile', () => {
     expect(openSpy).toHaveBeenCalledTimes(2);
     expect(closeSpy).toHaveBeenCalledTimes(2);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'CallTreeNode | undefined' is not... Remove this comment to see the full error message
     const root = firstCallee(profile.appendOrderStack[0]);
 
     expect(root.totalWeight).toEqual(4);
@@ -158,6 +159,7 @@ describe('EventedProfile', () => {
     );
 
     expect(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       firstCallee(firstCallee(firstCallee(profile.appendOrderTree))).isRecursive()
     ).toBe(true);
   });

--- a/static/app/utils/profiling/profile/eventedProfile.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.tsx
@@ -126,9 +126,12 @@ export class EventedProfile extends Profile {
       // We check the stack in a top-down order to find the first recursive frame.
       let start = this.appendOrderStack.length - 1;
       while (start >= 0) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (this.appendOrderStack[start].frame === node.frame) {
           // The recursion edge is bidirectional
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           this.appendOrderStack[start].setRecursiveThroughNode(node);
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'CallTreeNode | undefined' is not... Remove this comment to see the full error message
           node.setRecursiveThroughNode(this.appendOrderStack[start]);
           break;
         }

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -156,13 +156,17 @@ function importSentrySampledProfile(
 
   for (let i = 0; i < input.profile.samples.length; i++) {
     const sample = input.profile.samples[i];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!samplesByThread[sample.thread_id]) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       samplesByThread[sample.thread_id] = [];
     }
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     samplesByThread[sample.thread_id].push(sample);
   }
 
   for (const key in samplesByThread) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     samplesByThread[key].sort(
       (a, b) =>
         parseInt(a.elapsed_since_start_ns, 10) - parseInt(b.elapsed_since_start_ns, 10)
@@ -176,6 +180,7 @@ function importSentrySampledProfile(
       ...input,
       profile: {
         ...input.profile,
+        // @ts-expect-error TS(2322) FIXME: Type 'SentrySampledProfileSample[] | undefined' is... Remove this comment to see the full error message
         samples: samplesByThread[key],
       },
     };
@@ -210,6 +215,7 @@ function importSentrySampledProfile(
       deviceOSName: input.os.name,
       deviceOSVersion: input.os.version,
       durationNS: parseInt(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         input.profile.samples[input.profile.samples.length - 1].elapsed_since_start_ns,
         10
       ),

--- a/static/app/utils/profiling/profile/jsSelfProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.spec.tsx
@@ -248,6 +248,7 @@ describe('jsSelfProfile', () => {
     );
 
     expect(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       firstCallee(firstCallee(firstCallee(profile.appendOrderTree))).isRecursive()
     ).toBe(true);
   });

--- a/static/app/utils/profiling/profile/jsSelfProfile.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.tsx
@@ -36,6 +36,7 @@ export class JSSelfProfile extends Profile {
       );
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const startedAt = profile.samples[0].timestamp;
     const endedAt = lastOfArray(profile.samples).timestamp;
 
@@ -54,8 +55,10 @@ export class JSSelfProfile extends Profile {
     jsSelfProfile.appendSample(
       resolveJSSelfProfilingStack(
         profile,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         profile.samples[0].stackId,
         frameIndex,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         profile.samples[0].marker
       ),
       0
@@ -67,25 +70,32 @@ export class JSSelfProfile extends Profile {
       // When gc is triggered, the stack may be indicated as empty. In that case, the thread was not idle
       // and we should append gc to the top of the previous stack.
       // https://github.com/WICG/js-self-profiling/issues/59
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (profile.samples[i].marker === 'gc') {
         jsSelfProfile.appendSample(
           resolveJSSelfProfilingStack(
             profile,
             // use the previous sample
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             profile.samples[i - 1].stackId,
             frameIndex,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             profile.samples[i].marker
           ),
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           profile.samples[i].timestamp - profile.samples[i - 1].timestamp
         );
       } else {
         jsSelfProfile.appendSample(
           resolveJSSelfProfilingStack(
             profile,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             profile.samples[i].stackId,
             frameIndex,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             profile.samples[i].marker
           ),
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           profile.samples[i].timestamp - profile.samples[i - 1].timestamp
         );
       }
@@ -119,9 +129,12 @@ export class JSSelfProfile extends Profile {
       let stackHeight = framesInStack.length - 1;
 
       while (stackHeight >= 0) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (framesInStack[stackHeight].frame === node.frame) {
           // The recursion edge is bidirectional
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           framesInStack[stackHeight].setRecursiveThroughNode(node);
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'CallTreeNode | undefined' is not... Remove this comment to see the full error message
           node.setRecursiveThroughNode(framesInStack[stackHeight]);
           break;
         }

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -124,10 +124,12 @@ export class Profile {
       }
 
       prevStack = prevStack.concat(toOpen);
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       value += this.weights[sampleIndex++];
     }
 
     for (let i = prevStack.length - 1; i >= 0; i--) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'CallTreeNode | undefined' is not... Remove this comment to see the full error message
       closeFrame(prevStack[i], value);
     }
   }

--- a/static/app/utils/profiling/profile/sampledProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.spec.tsx
@@ -143,6 +143,7 @@ describe('SampledProfile', () => {
     );
 
     expect(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       firstCallee(firstCallee(firstCallee(profile.appendOrderTree))).isRecursive()
     ).toBe(true);
   });

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -34,6 +34,7 @@ export class SampledProfile extends Profile {
       const weight = sampledProfile.weights[i];
 
       profile.appendSampleWithWeight(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         stack.map(n => {
           if (!frameIndex[n]) {
             throw new Error(`Could not resolve frame ${n} in frame index`);
@@ -78,9 +79,12 @@ export class SampledProfile extends Profile {
       // We check the stack in a top-down order to find the first recursive frame.
       let start = framesInStack.length - 1;
       while (start >= 0) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (framesInStack[start].frame === node.frame) {
           // The recursion edge is bidirectional
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           framesInStack[start].setRecursiveThroughNode(node);
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'CallTreeNode | undefined' is not... Remove this comment to see the full error message
           node.setRecursiveThroughNode(framesInStack[start]);
           break;
         }

--- a/static/app/utils/profiling/profile/sentrySampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sentrySampledProfile.tsx
@@ -15,13 +15,17 @@ export class SentrySampledProfile extends Profile {
     frameIndex: ReturnType<typeof createSentrySampleProfileFrameIndex>
   ): Profile {
     const {samples, stacks, thread_metadata = {}} = sampledProfile.profile;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const startedAt = parseInt(samples[0].elapsed_since_start_ns, 10);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const endedAt = parseInt(samples[samples.length - 1].elapsed_since_start_ns, 10);
     if (Number.isNaN(startedAt) || Number.isNaN(endedAt)) {
       throw TypeError('startedAt or endedAt is NaN');
     }
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const threadId = parseInt(samples[0].thread_id, 10);
     const threadName = `thread: ${
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       thread_metadata[samples[0].thread_id]?.name || threadId
     }`;
     const profileTransactionName = sampledProfile.transactions?.[0]?.name;
@@ -40,10 +44,13 @@ export class SentrySampledProfile extends Profile {
 
     for (let i = 0; i < samples.length; i++) {
       const sample = samples[i];
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const stack = stacks[sample.stack_id];
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const sampleWeight = parseInt(sample.elapsed_since_start_ns, 10);
 
       profile.appendSampleWithWeight(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         stack.map(n => {
           if (!frameIndex[n]) {
             throw new Error(`Could not resolve frame ${n} in frame index`);
@@ -81,6 +88,7 @@ export class SentrySampledProfile extends Profile {
         node = last;
       } else {
         const parent = node;
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Frame | undefined' is not assign... Remove this comment to see the full error message
         node = new CallTreeNode(frame, node);
         parent.children.push(node);
       }
@@ -92,9 +100,12 @@ export class SentrySampledProfile extends Profile {
       // We check the stack in a top-down order to find the first recursive frame.
       let start = framesInStack.length - 1;
       while (start >= 0) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (framesInStack[start].frame === node.frame) {
           // The recursion edge is bidirectional
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           framesInStack[start].setRecursiveThroughNode(node);
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'CallTreeNode | undefined' is not... Remove this comment to see the full error message
           node.setRecursiveThroughNode(framesInStack[start]);
           break;
         }

--- a/static/app/utils/profiling/profile/utils.tsx
+++ b/static/app/utils/profiling/profile/utils.tsx
@@ -18,8 +18,11 @@ export function createSentrySampleProfileFrameIndex(
 
     frameIndex[i] = new Frame({
       key: i,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       name: frame.function ?? 'unknown',
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       line: frame.lineno,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       column: frame.colno,
     });
   }
@@ -176,17 +179,23 @@ function indexNodeToParents(
   // Begin in each root node
   for (let i = 0; i < roots.length; i++) {
     // If the root is a leaf node, push it to the leafs array
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!roots[i].children?.length) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
       leafs.push(roots[i]);
     }
 
     // Init the map for the root in case we havent yet
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!map[roots[i].key]) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       map[roots[i].key] = [];
     }
 
     // descend down to each child and index them
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     for (let j = 0; j < roots[i].children.length; j++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       indexNode(roots[i].children[j], roots[i]);
     }
   }

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
@@ -131,7 +131,9 @@ describe('flamegraphRenderer', () => {
     expect(
       renderer.getColorForFrame({
         key: 20,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         frame: flamegraph.frames[0].frame,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         node: flamegraph.frames[0].node,
         parent: null,
         children: [],

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -113,9 +113,13 @@ class FlamegraphRenderer {
     for (let index = 0; index < length; index++) {
       const frame = this.frames[index];
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const x1 = frame.start;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const x2 = frame.end;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const y1 = frame.depth;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const y2 = frame.depth + 1;
 
       // top left -> top right -> bottom left ->
@@ -379,11 +383,13 @@ class FlamegraphRenderer {
 
       // Descend into the rest of the children
       for (let i = 0; i < frame.children.length; i++) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
         findHoveredNode(frame.children[i], depth + 1);
       }
     };
 
     for (let i = 0; i < this.roots.length; i++) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
       findHoveredNode(this.roots[i], 0);
     }
 
@@ -443,10 +449,12 @@ class FlamegraphRenderer {
     // This is an optimization to avoid setting uniform1i for each draw call when user is not searching
     if (searchResults.size > 0) {
       for (let i = 0; i < length; i++) {
+        // @ts-expect-error TS(2322) FIXME: Type 'FlamegraphFrame | undefined' is not assignab... Remove this comment to see the full error message
         frame = this.frames[i];
         const vertexOffset = i * VERTICES;
         this.gl.uniform1i(
           this.uniforms.u_is_search_result,
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | null' is not a... Remove this comment to see the full error message
           searchResults.has(getFlamegraphFrameSearchId(frame)) ? 1 : 0
         );
         this.gl.drawArrays(this.gl.TRIANGLES, vertexOffset, VERTICES);

--- a/static/app/utils/profiling/renderers/flamegraphRenderer2D.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer2D.tsx
@@ -8,7 +8,9 @@ import {Rect} from 'sentry/utils/profiling/gl/utils';
 
 // Convert color component from 0-1 to 0-255 range
 function colorComponentsToRgba(color: number[]): string {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   return `rgba(${Math.floor(color[0] * 255)}, ${Math.floor(color[1] * 255)}, ${Math.floor(
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     color[2] * 255
   )}, ${color[3] ?? 1})`;
 }
@@ -95,6 +97,7 @@ export class FlamegraphRenderer2d {
       );
 
       for (let i = 0; i < frame.children.length; i++) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
         queue.push(frame.children[i]);
       }
     }

--- a/static/app/utils/profiling/renderers/gridRenderer.tsx
+++ b/static/app/utils/profiling/renderers/gridRenderer.tsx
@@ -103,10 +103,12 @@ class GridRenderer {
     for (let i = 0; i < intervals.length; i++) {
       // Compute the x position of our interval from config space to physical
       const physicalIntervalPosition = Math.round(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         intervals[i] * configViewToPhysicalSpace[0] + configViewToPhysicalSpace[6]
       );
 
       // Format the label text
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
       const labelText = this.formatter(intervals[i]);
 
       context.fillStyle = this.theme.COLORS.LABEL_FONT_COLOR;

--- a/static/app/utils/profiling/renderers/selectedFrameRenderer.tsx
+++ b/static/app/utils/profiling/renderers/selectedFrameRenderer.tsx
@@ -23,6 +23,7 @@ class SelectedFrameRenderer {
     context.lineWidth = style.BORDER_WIDTH;
 
     for (let i = 0; i < frames.length; i++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const frameInPhysicalSpace = frames[i].transformRect(configViewToPhysicalSpace);
 
       // We draw the border in the center of the flamegraph, so we need to increase

--- a/static/app/utils/profiling/renderers/textRenderer.tsx
+++ b/static/app/utils/profiling/renderers/textRenderer.tsx
@@ -36,9 +36,11 @@ class TextRenderer {
 
   measureAndCacheText(text: string): TextMetrics {
     if (this.textCache[text]) {
+      // @ts-expect-error TS(2322) FIXME: Type 'TextMetrics | undefined' is not assignable t... Remove this comment to see the full error message
       return this.textCache[text];
     }
     this.textCache[text] = this.context.measureText(text);
+    // @ts-expect-error TS(2322) FIXME: Type 'TextMetrics | undefined' is not assignable t... Remove this comment to see the full error message
     return this.textCache[text];
   }
 
@@ -119,6 +121,7 @@ class TextRenderer {
       }
 
       for (let i = 0; i < frame.children.length; i++) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'FlamegraphFrame | undefined' is ... Remove this comment to see the full error message
         frames.push(frame.children[i]);
       }
 

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -520,7 +520,9 @@ async function fetchProjects(
     const paginationObject = parseLinkHeader(pageLinks);
     hasMore =
       paginationObject &&
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       (paginationObject.next.results || paginationObject.previous.results);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     nextCursor = paginationObject.next.cursor;
   }
 

--- a/static/app/utils/recreateRoute.spec.tsx
+++ b/static/app/utils/recreateRoute.spec.tsx
@@ -42,6 +42,7 @@ describe('recreateRoute', function () {
     );
 
     expect(
+      // @ts-expect-error TS(2345) FIXME: Argument of type '{ path: string; childRoutes: nev... Remove this comment to see the full error message
       recreateRoute(projectRoutes[5], {routes: projectRoutes, location, params})
     ).toBe('/settings/org-slug/project-slug/alerts/');
   });

--- a/static/app/utils/replays/getCurrentUrl.tsx
+++ b/static/app/utils/replays/getCurrentUrl.tsx
@@ -25,6 +25,7 @@ function getCurrentUrl(
   ) as BreadcrumbTypeNavigation[];
 
   const initialUrl = replayRecord.urls[0];
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
   const origin = parseUrl(initialUrl)?.origin || initialUrl;
 
   const mostRecentNavigation = last(

--- a/static/app/utils/replays/getReplayEvent.spec.tsx
+++ b/static/app/utils/replays/getReplayEvent.spec.tsx
@@ -87,6 +87,7 @@ describe('getNextReplayEvent', () => {
   it('should return the next crumb when the the list is not sorted', () => {
     const [one, two, three, four, five] = createCrumbs();
     const results = getNextReplayEvent({
+      // @ts-expect-error TS(2322) FIXME: Type 'Crumb | undefined' is not assignable to type... Remove this comment to see the full error message
       items: [one, four, five, three, two],
       targetTimestampMs: START_TIMESTAMP_SEC * 1000 + CURRENT_TIME_MS,
     });
@@ -151,6 +152,7 @@ describe('getPrevReplayEvent', () => {
   it('should return the previous crumb when the list is not sorted', () => {
     const [one, two, three, four, five] = createCrumbs();
     const results = getPrevReplayEvent({
+      // @ts-expect-error TS(2322) FIXME: Type 'Crumb | undefined' is not assignable to type... Remove this comment to see the full error message
       items: [one, four, five, three, two],
       targetTimestampMs: START_TIMESTAMP_SEC * 1000 + CURRENT_TIME_MS,
     });

--- a/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
@@ -222,19 +222,26 @@ function removeNodesAtLevel(html: string, level: number) {
       for (let i = 0; i < collection.length; i++) {
         const child = collection[i];
 
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (child.nodeName === 'STYLE') {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           child.textContent = '/* Inline CSS */';
         }
 
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (child.nodeName === 'svg') {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           child.innerHTML = '<!-- SVG -->';
         }
 
         if (max <= current) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           if (child.childElementCount > 0) {
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             child.innerHTML = `<!-- ${child.childElementCount} descendents -->`;
           }
         } else {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           removeChildLevel(max, child.children, current + 1);
         }
       }

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -155,6 +155,7 @@ function useReplayData({replaySlug, orgSlug}: Options): Result {
       });
       segmentRanges.push(data);
       const links = parseLinkHeader(resp?.getResponseHeader('Link') ?? '');
+      // @ts-expect-error TS(2322) FIXME: Type 'ParsedHeader | undefined' is not assignable ... Remove this comment to see the full error message
       next = links.next;
     }
 

--- a/static/app/utils/sessions.tsx
+++ b/static/app/utils/sessions.tsx
@@ -25,6 +25,7 @@ export function getCount(
   groups: SessionApiResponse['groups'] = [],
   field: SessionFieldWithOperation
 ) {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   return groups.reduce((acc, group) => acc + group.totals[field], 0);
 }
 
@@ -33,6 +34,7 @@ export function getCountAtIndex(
   field: SessionFieldWithOperation,
   index: number
 ) {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   return groups.reduce((acc, group) => acc + group.series[field][index], 0);
 }
 
@@ -67,6 +69,7 @@ export function getSeriesSum(
   const groupSeries = groups.map(group => group.series[field]);
 
   groupSeries.forEach(series => {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     series.forEach((dataPoint, idx) => (dataPointsSums[idx] += dataPoint));
   });
 
@@ -132,11 +135,13 @@ export function getSessionStatusRateSeries(
   return compact(
     intervals.map((interval, i) => {
       const intervalTotalSessions = groups.reduce(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         (acc, group) => acc + group.series[field][i],
         0
       );
 
       const intervalStatusSessions =
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         groups.find(group => group.by['session.status'] === status)?.series[field][i] ??
         0;
 
@@ -166,6 +171,7 @@ export function getSessionP50Series(
   return compact(
     intervals.map((interval, i) => {
       const meanValue = mean(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         groups.map(group => group.series[field][i]).filter(v => !!v)
       );
 
@@ -214,6 +220,7 @@ export function getCountSeries(
 ): SeriesDataUnit[] {
   return intervals.map((interval, index) => ({
     name: interval,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     value: group?.series[field][index] ?? 0,
   }));
 }
@@ -350,6 +357,7 @@ export function filterSessionsInTimeWindow(
     const totals = {};
     Object.keys(group.series).forEach(field => {
       totals[field] = 0;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       series[field] = group.series[field].filter((value, index) => {
         const isBetween = filteredIndexes.includes(index);
         if (isBetween) {

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -340,9 +340,13 @@ const generateAliases = (colors: BaseColors) => ({
 });
 
 const dataCategory = {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   [DataCategory.ERRORS]: CHART_PALETTE[4][3],
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   [DataCategory.TRANSACTIONS]: CHART_PALETTE[4][2],
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   [DataCategory.ATTACHMENTS]: CHART_PALETTE[4][1],
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   [DataCategory.DEFAULT]: CHART_PALETTE[4][0],
 };
 
@@ -350,8 +354,11 @@ const dataCategory = {
  * Default colors for data usage outcomes
  */
 const outcome = {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   [Outcome.ACCEPTED]: CHART_PALETTE[0][0],
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   [Outcome.FILTERED]: CHART_PALETTE[1][1],
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   [Outcome.DROPPED]: CHART_PALETTE[5][3],
 };
 

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -62,6 +62,7 @@ export class MutableSearch {
       if (token.startsWith('(')) {
         const parenMatch = token.match(/^\(+/g);
         if (parenMatch) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           parenMatch[0].split('').map(paren => this.addOp(paren));
           token = token.replace(/^\(+/g, '');
         }
@@ -91,6 +92,7 @@ export class MutableSearch {
       if (token.endsWith(')') && !token.includes('(')) {
         const parenMatch = token.match(/\)+$/g);
         if (parenMatch) {
+          // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           trailingParen = parenMatch[0];
           token = token.replace(/\)+$/g, '');
         }
@@ -137,6 +139,7 @@ export class MutableSearch {
 
   addStringFilter(filter: string, shouldEscape = true) {
     const [key, value] = parseFilter(filter);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     this.addFilterValues(key, [value], shouldEscape);
     return this;
   }
@@ -196,6 +199,7 @@ export class MutableSearch {
           const token = this.tokens[i];
           const prev = this.tokens[i - 1];
           const next = this.tokens[i + 1];
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'Token | undefined' is not assign... Remove this comment to see the full error message
           if (isOp(token) && isBooleanOp(token.value)) {
             if (prev === undefined || isOp(prev) || next === undefined || isOp(next)) {
               // Want to avoid removing `(term) OR (term)` and `term OR (term)`
@@ -235,6 +239,7 @@ export class MutableSearch {
 
       for (let i = 0; i < this.tokens.length; i++) {
         const token = this.tokens[i];
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Token | undefined' is not assign... Remove this comment to see the full error message
         if (!isOp(token) || token.value !== '(') {
           continue;
         }
@@ -242,17 +247,20 @@ export class MutableSearch {
         let alreadySeen = false;
         for (let j = i + 1; j < this.tokens.length; j++) {
           const nextToken = this.tokens[j];
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'Token | undefined' is not assign... Remove this comment to see the full error message
           if (isOp(nextToken) && nextToken.value === '(') {
             // Continue down to the nested parens. We can skip i forward since we know
             // everything between i and j is NOT an open paren.
             i = j - 1;
             break;
+            // @ts-expect-error TS(2345) FIXME: Argument of type 'Token | undefined' is not assign... Remove this comment to see the full error message
           } else if (!isOp(nextToken)) {
             if (alreadySeen) {
               // This has more than one term, no need to delete
               break;
             }
             alreadySeen = true;
+            // @ts-expect-error TS(2345) FIXME: Argument of type 'Token | undefined' is not assign... Remove this comment to see the full error message
           } else if (isOp(nextToken) && nextToken.value === ')') {
             // We found another paren with zero or one terms inside. Delete the pair.
             parensToDelete = [i, j];
@@ -339,18 +347,23 @@ function splitSearchIntoTokens(query: string) {
     const nextChar = queryChars.length - 1 > idx ? queryChars[idx + 1] : null;
     token += char;
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     if (nextChar !== null && !isSpace(char) && isSpace(nextChar)) {
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       endOfPrevWord = char;
     }
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     if (isSpace(char) && !quoteEnclosed && endOfPrevWord !== ':' && !isSpace(token)) {
       tokens.push(token.trim());
       token = '';
     }
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     if (["'", '"'].includes(char) && (!quoteEnclosed || quoteType === char)) {
       quoteEnclosed = !quoteEnclosed;
       if (quoteEnclosed) {
+        // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         quoteType = char;
       }
     }

--- a/static/app/utils/touch.tsx
+++ b/static/app/utils/touch.tsx
@@ -15,6 +15,7 @@ export function getPointerPosition(
 ): number {
   const actual = isReactEvent(event) ? event.nativeEvent : event;
   if (window.TouchEvent && actual instanceof TouchEvent) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return actual.targetTouches[0][property];
   }
   if (actual instanceof MouseEvent) {

--- a/static/app/utils/trimSlug.tsx
+++ b/static/app/utils/trimSlug.tsx
@@ -51,9 +51,12 @@ export function trimSlug(slug: string, maxLength: number = 20) {
   // from the middle.
   const debt = getLength(words) - maxLength;
   const toTrimFromLeftWord = Math.ceil(debt / 2);
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const leftWordLength = Math.max(words[0].length - toTrimFromLeftWord, 3);
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const leftWord = words[0].slice(0, leftWordLength);
   const rightWordLength = maxLength - leftWord.length;
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const rightWord = words[1].slice(-rightWordLength);
 
   return `${leftWord}\u2026${rightWord}`;

--- a/static/app/utils/useCombinedReducer.tsx
+++ b/static/app/utils/useCombinedReducer.tsx
@@ -37,6 +37,7 @@ export function makeCombinedReducers<M extends ReducersObject>(
     const nextState = {} as ReducersState<M>;
 
     for (const key of keys) {
+      // @ts-expect-error TS(2722) FIXME: Cannot invoke an object which is possibly 'undefin... Remove this comment to see the full error message
       nextState[key] = reducers[key](state[key], action);
     }
 

--- a/static/app/utils/useProjects.tsx
+++ b/static/app/utils/useProjects.tsx
@@ -131,7 +131,9 @@ async function fetchProjects(
   const pageLinks = resp?.getResponseHeader('Link');
   if (pageLinks) {
     const paginationObject = parseLinkHeader(pageLinks);
+    // @ts-expect-error TS(2322) FIXME: Type 'boolean | null | undefined' is not assignabl... Remove this comment to see the full error message
     hasMore = paginationObject?.next?.results || paginationObject?.previous?.results;
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     nextCursor = paginationObject?.next?.cursor;
   }
 

--- a/static/app/utils/useTeams.tsx
+++ b/static/app/utils/useTeams.tsx
@@ -135,7 +135,9 @@ async function fetchTeams(
   const pageLinks = resp?.getResponseHeader('Link');
   if (pageLinks) {
     const paginationObject = parseLinkHeader(pageLinks);
+    // @ts-expect-error TS(2322) FIXME: Type 'boolean | null | undefined' is not assignabl... Remove this comment to see the full error message
     hasMore = paginationObject?.next?.results;
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     nextCursor = paginationObject?.next?.cursor;
   }
 

--- a/static/app/utils/withIssueTags.spec.tsx
+++ b/static/app/utils/withIssueTags.spec.tsx
@@ -16,6 +16,7 @@ const MyComponent = (props: MyComponentProps) => {
       {'mechanism: ' + props.tags?.mechanism?.values?.join(', ')}
       {'bookmarks: ' + props.tags?.bookmarks?.values?.join(', ')}
       {'assigned: ' + props.tags?.assigned?.values?.join(', ')}
+      {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
       {'stack filename: ' + props.tags?.['stack.filename'].name}
     </div>
   );

--- a/static/app/utils/withIssueTags.tsx
+++ b/static/app/utils/withIssueTags.tsx
@@ -40,6 +40,7 @@ function withIssueTags<Props extends WithIssueTagsProps>(
     });
 
     const setAssigned = useCallback((newState: Partial<WrappedComponentState>) => {
+      // @ts-expect-error TS(2345) FIXME: Argument of type '(oldState: WrappedComponentState... Remove this comment to see the full error message
       setState(oldState => {
         const usernames: string[] = newState.users
           ? newState.users.map(getUsername)

--- a/static/app/views/admin/adminOverview/apiChart.tsx
+++ b/static/app/views/admin/adminOverview/apiChart.tsx
@@ -98,16 +98,19 @@ class ApiChart extends Component<Props, State> {
     return [
       {
         seriesName: '2xx',
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'TimeseriesValue[] | undefined' i... Remove this comment to see the full error message
         data: this.processRawSeries(rawData['client-api.all-versions.responses.2xx']),
         color: theme.green200,
       },
       {
         seriesName: '4xx',
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'TimeseriesValue[] | undefined' i... Remove this comment to see the full error message
         data: this.processRawSeries(rawData['client-api.all-versions.responses.4xx']),
         color: theme.blue300,
       },
       {
         seriesName: '5xx',
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'TimeseriesValue[] | undefined' i... Remove this comment to see the full error message
         data: this.processRawSeries(rawData['client-api.all-versions.responses.5xx']),
         color: theme.red200,
       },

--- a/static/app/views/admin/adminOverview/eventChart.tsx
+++ b/static/app/views/admin/adminOverview/eventChart.tsx
@@ -90,15 +90,19 @@ class EventChart extends Component<Props, State> {
     const sRejected: Record<string, number> = {};
     const aReceived = [0, 0]; // received, points
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     rawData['events.total'].forEach((point, idx) => {
       const dReceived = point[1];
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const dRejected = rawData['events.dropped'][idx]?.[1];
       const ts = point[0];
       if (sReceived[ts] === undefined) {
         sReceived[ts] = dReceived;
+        // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
         sRejected[ts] = dRejected;
       } else {
         sReceived[ts] += dReceived;
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         sRejected[ts] += dRejected;
       }
       if (dReceived > 0) {
@@ -115,6 +119,7 @@ class EventChart extends Component<Props, State> {
         })),
         accepted: Object.keys(sReceived).map(ts =>
           // total number of events accepted (received - rejected)
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           ({name: parseInt(ts, 10) * 1000, value: sReceived[ts] - sRejected[ts]})
         ),
       },
@@ -151,6 +156,7 @@ class EventChart extends Component<Props, State> {
     const colors = series.map(({color}) => color);
     return (
       <MiniBarChart
+        // @ts-expect-error TS(2322) FIXME: Type '{ seriesName: string; data: SeriesDataUnit[]... Remove this comment to see the full error message
         series={series}
         colors={colors}
         height={110}

--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -64,6 +64,7 @@ export default class AdminSettings extends AsyncView<{}, State> {
       } else {
         initialData[key] = option.value;
       }
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'Field | {}' is not assignable to... Remove this comment to see the full error message
       fields[key] = getOptionField(key, option.field);
     }
 

--- a/static/app/views/admin/installWizard/index.tsx
+++ b/static/app/views/admin/installWizard/index.tsx
@@ -121,6 +121,7 @@ export default class InstallWizard extends AsyncView<Props, State> {
     return (
       <ApiForm
         apiMethod="PUT"
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         apiEndpoint={this.getEndpoints()[0][1]}
         submitLabel={t('Continue')}
         initialData={this.getInitialData()}

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -324,6 +324,7 @@ const disabledReasons = {
 };
 
 export function getOption(option: string): Field {
+  // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
   return definitionsMap[option];
 }
 
@@ -368,6 +369,7 @@ export function getForm(fieldMap: Record<string, Field>) {
 
     for (const option of optionsForSection(section)) {
       if (fieldMap[option.key]) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Field | undefined' is not assign... Remove this comment to see the full error message
         set.push(fieldMap[option.key]);
       }
     }

--- a/static/app/views/alerts/list/incidents/row.tsx
+++ b/static/app/views/alerts/list/incidents/row.tsx
@@ -66,6 +66,7 @@ function AlertListRow({incident, projectsLoaded, projects, organization}: Props)
         )}
       </NoWrapNumeric>
 
+      {/* @ts-expect-error TS(2322) FIXME: Type 'Project | { slug: string | undefined; } | un... Remove this comment to see the full error message */}
       <ProjectBadge avatarSize={18} project={!projectsLoaded ? {slug} : project} />
       <NoWrapNumeric>#{incident.id}</NoWrapNumeric>
 

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -226,6 +226,7 @@ function RuleListRow({
       priority: 'danger',
       onAction: () => {
         openConfirmModal({
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
           onConfirm: () => onDelete(slug, rule),
           header: t('Delete Alert Rule?'),
           message: tct(
@@ -242,6 +243,7 @@ function RuleListRow({
   function handleOwnerChange({value}: {value: string}) {
     const ownerValue = value && `team:${value}`;
     setAssignee(ownerValue);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     onOwnerChange(slug, rule, ownerValue);
   }
 
@@ -259,6 +261,7 @@ function RuleListRow({
   };
 
   const projectRow = projects.filter(project => project.slug === slug);
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const projectRowTeams = projectRow[0].teams;
   const filteredProjectTeams = projectRowTeams?.filter(projTeam => {
     return userTeams.has(projTeam.id);
@@ -291,6 +294,7 @@ function RuleListRow({
 
   const avatarElement = assigneeTeamActor ? (
     <ActorAvatar
+      // @ts-expect-error TS(2322) FIXME: Type '{ type: "team" | "user"; id: string | undefi... Remove this comment to see the full error message
       actor={assigneeTeamActor}
       className="avatar"
       size={24}
@@ -341,6 +345,7 @@ function RuleListRow({
         <ProjectBadgeContainer>
           <ProjectBadge
             avatarSize={18}
+            // @ts-expect-error TS(2322) FIXME: Type 'Project | { slug: string | undefined; } | un... Remove this comment to see the full error message
             project={!projectsLoaded ? {slug} : getProject(slug, projects)}
           />
         </ProjectBadgeContainer>

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -653,6 +653,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       const clonedState = cloneDeep(prevState);
 
       // Set initial configuration, but also set
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const id = (clonedState.rule as IssueAlertRule)[type][idx].id;
       const newRule = {
         ...this.getInitialValue(type, id),
@@ -1002,6 +1003,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                     undefined &&
                   nextSelectedProject.teams.length
                 ) {
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   this.handleOwnerChange({value: nextSelectedProject.teams[0].id});
                 }
 
@@ -1192,6 +1194,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                               error={
                                 this.hasError('conditions') && (
                                   <StyledAlert type="error">
+                                    {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                                     {detailedError?.conditions[0]}
                                   </StyledAlert>
                                 )
@@ -1262,6 +1265,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                               error={
                                 this.hasError('filters') && (
                                   <StyledAlert type="error">
+                                    {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                                     {detailedError?.filters[0]}
                                   </StyledAlert>
                                 )
@@ -1304,6 +1308,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                               error={
                                 this.hasError('actions') && (
                                   <StyledAlert type="error">
+                                    {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                                     {detailedError?.actions[0]}
                                   </StyledAlert>
                                 )

--- a/static/app/views/alerts/rules/metric/constants.tsx
+++ b/static/app/views/alerts/rules/metric/constants.tsx
@@ -189,6 +189,7 @@ export function createRuleFromEventView(eventView: EventView): UnsavedMetricRule
     ...datasetAndEventtypes,
     query: parsedQuery?.query ?? eventView.query,
     aggregate,
+    // @ts-expect-error TS(2322) FIXME: Type 'string | null | undefined' is not assignable... Remove this comment to see the full error message
     environment: eventView.environment.length ? eventView.environment[0] : null,
   };
 }

--- a/static/app/views/alerts/rules/metric/details/index.tsx
+++ b/static/app/views/alerts/rules/metric/details/index.tsx
@@ -125,6 +125,7 @@ class MetricAlertDetails extends Component<Props, State> {
     const timeOption =
       TIME_OPTIONS.find(item => item.value === period) ?? TIME_OPTIONS[1];
     const start = getUtcDateString(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       moment(moment.utc().diff(TIME_WINDOWS[timeOption.value]))
     );
     const end = getUtcDateString(moment.utc());
@@ -134,7 +135,9 @@ class MetricAlertDetails extends Component<Props, State> {
       end,
       period,
       usingPeriod: true,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       label: timeOption.label as string,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       display: timeOption.label as string,
     };
   }

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -102,11 +102,14 @@ function getRuleChangeSeries(
   data: AreaChartSeries[]
 ): LineSeriesOption[] {
   const {dateModified} = rule;
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   if (!data.length || !data[0].data.length || !dateModified) {
     return [];
   }
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const seriesData = data[0].data;
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const seriesStart = new Date(seriesData[0].name).getTime();
   const ruleChanged = new Date(dateModified).getTime();
 
@@ -371,6 +374,7 @@ class MetricChart extends PureComponent<Props, State> {
                         };
                         const endTime = formatTooltipDate(
                           moment(pointX).add(
+                            // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
                             parseInt(period, 10),
                             periodLength as StatsPeriodType
                           ),

--- a/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChartOption.tsx
@@ -170,9 +170,12 @@ export function getMetricAlertChartOption({
   const series: AreaChartSeries[] = [...timeseriesData];
   const areaSeries: AreaChartSeries[] = [];
   // Ensure series data appears below incident/mark lines
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   series[0].z = 1;
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   series[0].color = CHART_PALETTE[0][0];
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const dataArr = timeseriesData[0].data;
   const maxSeriesValue = dataArr.reduce(
     (currMax, coord) => Math.max(currMax, coord.value),
@@ -193,7 +196,9 @@ export function getMetricAlertChartOption({
         ) / ALERT_CHART_MIN_MAX_BUFFER
       )
     : 0;
+  // @ts-expect-error TS(2769) FIXME: No overload matches this call.
   const firstPoint = new Date(dataArr[0]?.name).getTime();
+  // @ts-expect-error TS(2769) FIXME: No overload matches this call.
   const lastPoint = new Date(dataArr[dataArr.length - 1]?.name).getTime();
   const totalDuration = lastPoint - firstPoint;
   let criticalDuration = 0;
@@ -245,6 +250,7 @@ export function getMetricAlertChartOption({
             incidentColor,
             incidentStartDate,
             incidentStartValue,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             series[0].seriesName,
             rule.aggregate,
             handleIncidentClick
@@ -252,8 +258,10 @@ export function getMetricAlertChartOption({
         );
         const areaStart = Math.max(new Date(incident.dateStarted).getTime(), firstPoint);
         const areaEnd = Math.min(
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           statusChanges.length && statusChanges[0].dateCreated
-            ? new Date(statusChanges[0].dateCreated).getTime() - timeWindowMs
+            ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+              new Date(statusChanges[0].dateCreated).getTime() - timeWindowMs
             : new Date(incidentEnd).getTime(),
           lastPoint
         );
@@ -278,7 +286,8 @@ export function getMetricAlertChartOption({
           const statusAreaEnd = Math.min(
             idx === statusChanges.length - 1
               ? new Date(incidentEnd).getTime()
-              : new Date(statusChanges[idx + 1].dateCreated).getTime() - timeWindowMs,
+              : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+                new Date(statusChanges[idx + 1].dateCreated).getTime() - timeWindowMs,
             lastPoint
           );
           const statusAreaColor =
@@ -349,6 +358,7 @@ export function getMetricAlertChartOption({
   const yAxis: YAXisComponentOption = {
     axisLabel: {
       formatter: (value: number) =>
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         alertAxisFormatter(value, timeseriesData[0].seriesName, rule.aggregate),
     },
     max: isCrashFreeAlert(rule.dataset)

--- a/static/app/views/alerts/rules/metric/details/metricHistory.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricHistory.tsx
@@ -53,15 +53,17 @@ function MetricAlertActivity({organization, incident}: MetricAlertActivityProps)
   const triggeredActivity = criticalActivity.length
     ? criticalActivity[0]
     : warningActivity[0];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const currentTrigger = getTriggerName(triggeredActivity.value);
 
   const nextActivity = activities.find(
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     ({previousValue}) => previousValue === triggeredActivity.value
   );
 
-  const activityDuration = (
-    nextActivity ? moment(nextActivity.dateCreated) : moment()
-  ).diff(moment(triggeredActivity.dateCreated), 'milliseconds');
+  const activityDuration = (nextActivity ? moment(nextActivity.dateCreated) : moment())
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+    .diff(moment(triggeredActivity.dateCreated), 'milliseconds');
 
   const threshold =
     activityDuration !== null &&

--- a/static/app/views/alerts/rules/metric/details/relatedTransactions.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedTransactions.tsx
@@ -161,6 +161,7 @@ class Table extends Component<TableProps, TableState> {
                 onResizeColumn: this.handleResizeColumn,
                 renderHeadCell: this.renderHeadCellWithMeta(
                   tableData?.meta,
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   columnOrder[2].name as string
                 ) as any,
                 renderBodyCell: this.renderBodyCellWithData(tableData) as any,

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -84,6 +84,7 @@ export default class Sidebar extends PureComponent<Props> {
             threshold,
             comparisonType: thresholdTypeText,
             timeWindow: this.getTimeWindow(),
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             comparisonDelta: (
               COMPARISON_DELTA_OPTIONS.find(
                 ({value}) => value === rule.comparisonDelta

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -329,6 +329,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                     undefined &&
                   nextSelectedProject.teams.length
                 ) {
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   model.setValue('owner', `team:${nextSelectedProject.teams[0].id}`);
                 }
                 onChange(value, {});

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -416,8 +416,11 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     const criticalTrigger = triggers[criticalTriggerIndex];
     const warningTrigger = triggers[warningTriggerIndex];
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const isEmptyWarningThreshold = isEmpty(warningTrigger.alertThreshold);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const warningThreshold = warningTrigger.alertThreshold ?? 0;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const criticalThreshold = criticalTrigger.alertThreshold ?? 0;
 
     const hasError =

--- a/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/actionsPanel/index.tsx
@@ -129,6 +129,7 @@ class ActionsPanel extends PureComponent<Props> {
     value: string
   ) {
     const {triggers, onChange} = this.props;
+    // @ts-expect-error TS(2339) FIXME: Property 'actions' does not exist on type 'Trigger... Remove this comment to see the full error message
     const {actions} = triggers[triggerIndex];
     const newAction = {
       ...actions[index],
@@ -140,6 +141,7 @@ class ActionsPanel extends PureComponent<Props> {
 
   conditionallyRenderHelpfulBanner(triggerIndex: number, index: number) {
     const {triggers} = this.props;
+    // @ts-expect-error TS(2339) FIXME: Property 'actions' does not exist on type 'Trigger... Remove this comment to see the full error message
     const {actions} = triggers[triggerIndex];
     const newAction = {...actions[index]};
     if (newAction.type !== 'slack') {
@@ -182,6 +184,7 @@ class ActionsPanel extends PureComponent<Props> {
 
   handleDeleteAction = (triggerIndex: number, index: number) => {
     const {triggers, onChange} = this.props;
+    // @ts-expect-error TS(2339) FIXME: Property 'actions' does not exist on type 'Trigger... Remove this comment to see the full error message
     const {actions} = triggers[triggerIndex];
 
     onChange(triggerIndex, triggers, removeAtArrayIndex(actions, index));
@@ -194,9 +197,12 @@ class ActionsPanel extends PureComponent<Props> {
   ) => {
     const {triggers, onChange} = this.props;
     // Convert saved action to unsaved by removing id
+    // @ts-expect-error TS(2339) FIXME: Property 'id' does not exist on type 'Action | und... Remove this comment to see the full error message
     const {id: _, ...action} = triggers[triggerIndex].actions[index];
     action.unsavedId = uniqueId();
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     triggers[value.value].actions.push(action);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     onChange(value.value, triggers, triggers[value.value].actions);
     this.handleDeleteAction(triggerIndex, index);
   };
@@ -207,6 +213,7 @@ class ActionsPanel extends PureComponent<Props> {
     value: SelectValue<ActionType>
   ) => {
     const {triggers, onChange, availableActions} = this.props;
+    // @ts-expect-error TS(2339) FIXME: Property 'actions' does not exist on type 'Trigger... Remove this comment to see the full error message
     const {actions} = triggers[triggerIndex];
     const actionConfig = availableActions?.find(
       availableAction => getActionUniqueKey(availableAction) === value.value
@@ -229,6 +236,7 @@ class ActionsPanel extends PureComponent<Props> {
     value: SelectValue<keyof typeof TargetLabel>
   ) => {
     const {triggers, onChange} = this.props;
+    // @ts-expect-error TS(2339) FIXME: Property 'actions' does not exist on type 'Trigger... Remove this comment to see the full error message
     const {actions} = triggers[triggerIndex];
     const newAction = {
       ...actions[index],
@@ -250,6 +258,7 @@ class ActionsPanel extends PureComponent<Props> {
     formData: {[key: string]: string}
   ): void => {
     const {triggers, onChange} = this.props;
+    // @ts-expect-error TS(2339) FIXME: Property 'actions' does not exist on type 'Trigger... Remove this comment to see the full error message
     const {actions} = triggers[triggerIndex];
     const newAction = {
       ...actions[actionIndex],
@@ -312,6 +321,7 @@ class ActionsPanel extends PureComponent<Props> {
         {loading && <LoadingIndicator />}
         {actions.map(({action, actionIdx, triggerIndex, availableAction}) => {
           const actionDisabled =
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             triggers[triggerIndex].actions[actionIdx]?.disabled || disabled;
           return (
             <div key={action.id ?? action.unsavedId}>
@@ -385,6 +395,7 @@ class ActionsPanel extends PureComponent<Props> {
                                   actionIdx
                                 )}
                                 resetValues={
+                                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                                   triggers[triggerIndex].actions[actionIdx] || {}
                                 }
                               />

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -280,6 +280,7 @@ class TriggersChart extends PureComponent<Props, State> {
                 value: timePeriod,
                 disabled: isLoading || isReloading,
               }))}
+              // @ts-expect-error TS(2322) FIXME: Type 'import("/Users/ryan/code/sentry/static/app/v... Remove this comment to see the full error message
               selected={period}
               onChange={this.handleStatsPeriodChange}
               title={t('Display')}

--- a/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/thresholdsChart.tsx
@@ -364,9 +364,11 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
             ? seriesParamsOrParam
             : [seriesParamsOrParam];
 
-          const pointY = (
-            seriesParams.length > 1 ? seriesParams[0].data[1] : undefined
-          ) as number | undefined;
+          const pointY =
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+            (seriesParams.length > 1 ? seriesParams[0].data[1] : undefined) as
+              | number
+              | undefined;
 
           const comparisonSeries =
             seriesParams.length > 1
@@ -405,6 +407,7 @@ export default class ThresholdsChart extends PureComponent<Props, State> {
         max: this.state.yAxisMax ?? undefined,
         axisLabel: {
           formatter: (value: number) =>
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             alertAxisFormatter(value, data[0].seriesName, aggregate),
         },
       },

--- a/static/app/views/alerts/rules/metric/triggers/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/index.tsx
@@ -67,11 +67,13 @@ class Triggers extends Component<Props> {
   handleAddAction = (triggerIndex: number, action: Action) => {
     const {onChange, triggers} = this.props;
     const trigger = triggers[triggerIndex];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const actions = [...trigger.actions, action];
     const updatedTriggers = replaceAtArrayIndex(triggers, triggerIndex, {
       ...trigger,
       actions,
     });
+    // @ts-expect-error TS(2345) FIXME: Argument of type '{ actions: Action[]; label?: Ale... Remove this comment to see the full error message
     onChange(updatedTriggers, triggerIndex, {actions});
   };
 
@@ -86,6 +88,7 @@ class Triggers extends Component<Props> {
       ...trigger,
       actions,
     });
+    // @ts-expect-error TS(2345) FIXME: Argument of type '{ actions: Action[]; label?: Ale... Remove this comment to see the full error message
     onChange(updatedTriggers, triggerIndex, {actions});
   };
 

--- a/static/app/views/alerts/utils/getComparisonMarkLines.tsx
+++ b/static/app/views/alerts/utils/getComparisonMarkLines.tsx
@@ -31,8 +31,10 @@ export const getComparisonMarkLines = (
 
     if (triggers.some(({alertThreshold}) => typeof alertThreshold === 'number')) {
       const lastPointLimit =
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         (baseData[changeData.length - 1].name as number) - timeWindow * MINUTE;
       changeData.forEach(({name, value: comparisonValue}, idx) => {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const baseValue = baseData[idx].value;
         const comparisonPercentage =
           comparisonValue === 0
@@ -44,6 +46,7 @@ export const getComparisonMarkLines = (
         if (
           idx === 0 ||
           idx === changeData.length - 1 ||
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           status !== changeStatuses[changeStatuses.length - 1].status
         ) {
           changeStatuses.push({name, status});
@@ -70,6 +73,7 @@ export const getComparisonMarkLines = (
               {coord: [name, 0]},
               {
                 coord: [
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   Math.min(changeStatuses[idx + 1].name as number, lastPointLimit),
                   0,
                 ],

--- a/static/app/views/alerts/utils/index.tsx
+++ b/static/app/views/alerts/utils/index.tsx
@@ -22,8 +22,10 @@ import {AlertRuleStatus, Incident, IncidentStats} from '../types';
  * Gets start and end date query parameters from stats
  */
 export function getStartEndFromStats(stats: IncidentStats) {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const start = getUtcDateString(stats.eventStats.data[0][0] * 1000);
   const end = getUtcDateString(
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     stats.eventStats.data[stats.eventStats.data.length - 1][0] * 1000
   );
 
@@ -107,13 +109,17 @@ export function getQueryDatasource(
       return null;
     }
 
+    // @ts-expect-error TS(2769) FIXME: No overload matches this call.
     return {source: Datasource.ERROR_DEFAULT, query: query.replace(match[0], '').trim()};
   }
 
   match = query.match(/(^|\s)event\.type:(error|default|transaction)/i);
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   if (match && Datasource[match[2].toUpperCase()]) {
     return {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       source: Datasource[match[2].toUpperCase()],
+      // @ts-expect-error TS(2769) FIXME: No overload matches this call.
       query: query.replace(match[0], '').trim(),
     };
   }

--- a/static/app/views/dashboardsV2/dashboard.tsx
+++ b/static/app/views/dashboardsV2/dashboard.tsx
@@ -372,7 +372,9 @@ class Dashboard extends Component<Props, State> {
     const {dashboard, onUpdate} = this.props;
     const isNotAddButton = ({i}) => i !== ADD_WIDGET_BUTTON_DRAG_ID;
     const newLayouts = {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       [DESKTOP]: allLayouts[DESKTOP].filter(isNotAddButton),
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       [MOBILE]: allLayouts[MOBILE].filter(isNotAddButton),
     };
 
@@ -442,6 +444,7 @@ class Dashboard extends Component<Props, State> {
         isMobile: true,
         layouts: {
           ...layouts,
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'Layout[] | undefined' is not ass... Remove this comment to see the full error message
           [MOBILE]: getMobileLayout(layouts[DESKTOP], widgets),
         },
       });
@@ -454,6 +457,7 @@ class Dashboard extends Component<Props, State> {
     const {isMobile, layouts} = this.state;
     let position: Position = BOTTOM_MOBILE_VIEW_POSITION;
     if (!isMobile) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'Layout[] | undefined' is not ass... Remove this comment to see the full error message
       const columnDepths = calculateColumnDepths(layouts[DESKTOP]);
       const [nextPosition] = getNextAvailablePosition(columnDepths, 1);
       position = nextPosition;
@@ -479,6 +483,7 @@ class Dashboard extends Component<Props, State> {
       return true;
     });
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'Layout[] | undefined' is not ass... Remove this comment to see the full error message
     const columnDepths = calculateColumnDepths(layouts[DESKTOP]);
     const widgetsWithLayout = assignDefaultLayout(widgets, columnDepths);
 

--- a/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/errorsAndTransactions.tsx
@@ -365,6 +365,7 @@ function transformEventsResponseToSeries(
     } else {
       seriesWithOrdering = Object.keys(data).map((seriesName: string) => {
         const prefixedName = queryAlias ? `${queryAlias} : ${seriesName}` : seriesName;
+        // @ts-expect-error TS(2322) FIXME: Type 'EventsStats | undefined' is not assignable t... Remove this comment to see the full error message
         const seriesData: EventsStats = data[seriesName];
         return [
           seriesData.order || 0,
@@ -381,6 +382,7 @@ function transformEventsResponseToSeries(
   } else {
     const field = widgetQuery.aggregates[0];
     const prefixedName = queryAlias ? `${queryAlias} : ${field}` : field;
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     const transformed = transformSeries(data, prefixedName, field);
     output.push(transformed);
   }
@@ -398,9 +400,11 @@ function getSeriesResultType(
   // Need to use getAggregateAlias since events-stats still uses aggregate alias format
   if (isMultiSeriesStats(data)) {
     Object.keys(data).forEach(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       key => (resultTypes[key] = data[key].meta?.fields[getAggregateAlias(key)])
     );
   } else {
+    // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
     resultTypes[field] = data.meta?.fields[getAggregateAlias(field)];
   }
   return resultTypes;
@@ -556,17 +560,22 @@ function getEventsSeriesRequest(
       project: projects,
       environment: environments,
       period: statsPeriod,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       query: widgetQuery.conditions,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       yAxis: widgetQuery.aggregates[widgetQuery.aggregates.length - 1],
       includePrevious: false,
       referrer,
       partial: true,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       field: [...widgetQuery.columns, ...widgetQuery.aggregates],
       queryExtras: getDashboardsMEPQueryParams(isMEPEnabled),
       includeAllArgs: true,
       topEvents: TOP_N,
     };
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (widgetQuery.orderby) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       requestData.orderby = widgetQuery.orderby;
     }
   } else {
@@ -578,8 +587,11 @@ function getEventsSeriesRequest(
       project: projects,
       environment: environments,
       period: statsPeriod,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       query: widgetQuery.conditions,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       yAxis: widgetQuery.aggregates,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       orderby: widgetQuery.orderby,
       includePrevious: false,
       referrer,
@@ -587,15 +599,19 @@ function getEventsSeriesRequest(
       queryExtras: getDashboardsMEPQueryParams(isMEPEnabled),
       includeAllArgs: true,
     };
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (widgetQuery.columns?.length !== 0) {
       requestData.topEvents = limit ?? TOP_N;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       requestData.field = [...widgetQuery.columns, ...widgetQuery.aggregates];
 
       // Compare field and orderby as aliases to ensure requestData has
       // the orderby selected
       // If the orderby is an equation alias, do not inject it
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const orderby = trimStart(widgetQuery.orderby, '-');
       if (
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         widgetQuery.orderby &&
         !isEquationAlias(orderby) &&
         !requestData.field.includes(orderby)
@@ -606,18 +622,25 @@ function getEventsSeriesRequest(
       // The "Other" series is only included when there is one
       // y-axis and one widgetQuery
       requestData.excludeOther =
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         widgetQuery.aggregates.length !== 1 || widget.queries.length !== 1;
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (isEquation(trimStart(widgetQuery.orderby, '-'))) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const nextEquationIndex = getNumEquations(widgetQuery.aggregates);
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const isDescending = widgetQuery.orderby.startsWith('-');
         const prefix = isDescending ? '-' : '';
 
         // Construct the alias form of the equation and inject it into the request
         requestData.orderby = `${prefix}equation[${nextEquationIndex}]`;
         requestData.field = [
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           ...widgetQuery.columns,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           ...widgetQuery.aggregates,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           trimStart(widgetQuery.orderby, '-'),
         ];
       }

--- a/static/app/views/dashboardsV2/datasetConfig/releases.tsx
+++ b/static/app/views/dashboardsV2/datasetConfig/releases.tsx
@@ -194,8 +194,10 @@ function getReleasesSeriesRequest(
   const {datetime} = pageFilters;
   const {start, end, period} = datetime;
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
   const isCustomReleaseSorting = requiresCustomReleaseSorting(query);
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const includeTotals = query.columns.length > 0 ? 1 : 0;
   const interval = getWidgetInterval(
     displayType,
@@ -209,6 +211,7 @@ function getReleasesSeriesRequest(
     1,
     includeTotals,
     api,
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
     query,
     organization,
     pageFilters,

--- a/static/app/views/dashboardsV2/layoutUtils.tsx
+++ b/static/app/views/dashboardsV2/layoutUtils.tsx
@@ -142,6 +142,7 @@ export function getNextAvailablePosition(
   // we get the top-most available spot
   for (let currDepth = 0; currDepth <= maxColumnDepth; currDepth++) {
     for (let start = 0; start <= columnDepths.length - DEFAULT_WIDGET_WIDTH; start++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (columnDepths[start] > currDepth) {
         // There are potentially widgets in the way here, so skip
         continue;

--- a/static/app/views/dashboardsV2/manage/index.tsx
+++ b/static/app/views/dashboardsV2/manage/index.tsx
@@ -74,6 +74,7 @@ class ManageDashboards extends AsyncView<Props, State> {
         {
           query: {
             ...pick(location.query, ['cursor', 'query']),
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             sort: this.getActiveSort().value,
             per_page: '9',
           },
@@ -170,6 +171,7 @@ class ManageDashboards extends AsyncView<Props, State> {
         />
         <CompactSelect
           triggerProps={{prefix: t('Sort By')}}
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           value={activeSort.value}
           options={SORT_OPTIONS}
           onChange={opt => this.handleSortChange(opt.value)}

--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -120,6 +120,7 @@ export function constructWidgetFromQuery(query?: Query): Widget | undefined {
       const {columns, aggregates} = getColumnsAndAggregates(queryFields);
       queryConditions.forEach((condition, index) => {
         queries.push({
+          // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           name: queryNames[index],
           conditions: condition,
           fields: queryFields,
@@ -225,6 +226,7 @@ export function getWidgetDiscoverUrl(
 ) {
   const eventView = eventViewFromWidget(
     widget.title,
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
     widget.queries[index],
     selection,
     widget.displayType
@@ -235,6 +237,7 @@ export function getWidgetDiscoverUrl(
   const yAxisOptions = eventView.getYAxisOptions().map(({value}) => value);
   discoverLocation.query.yAxis = [
     ...new Set(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       widget.queries[0].aggregates.filter(aggregate => yAxisOptions.includes(aggregate))
     ),
   ].slice(0, 3);
@@ -250,8 +253,10 @@ export function getWidgetDiscoverUrl(
     case DisplayType.TOP_N:
       discoverLocation.query.display = DisplayModes.TOP5;
       // Last field is used as the yAxis
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const aggregates = widget.queries[0].aggregates;
       discoverLocation.query.yAxis = aggregates[aggregates.length - 1];
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       if (aggregates.slice(0, -1).includes(aggregates[aggregates.length - 1])) {
         discoverLocation.query.field = aggregates.slice(0, -1);
       }
@@ -263,9 +268,12 @@ export function getWidgetDiscoverUrl(
   // Equation fields need to have their terms explicitly selected as columns in the discover table
   const fields = discoverLocation.query.field;
   const query = widget.queries[0];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const queryFields = defined(query.fields)
-    ? query.fields
-    : [...query.columns, ...query.aggregates];
+    ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+      query.fields
+    : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+      [...query.columns, ...query.aggregates];
   const equationFields = getFieldsFromEquations(queryFields);
   // Updates fields by adding any individual terms from equation fields as a column
   equationFields.forEach(term => {

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/columnsStep/columnFields.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/columnsStep/columnFields.tsx
@@ -60,6 +60,7 @@ export function ColumnFields({
         <ColumnCollectionEdit
           columns={fields.slice(0, fields.length - 1)}
           onChange={newColumns => {
+            // @ts-expect-error TS(2322) FIXME: Type 'QueryFieldValue | undefined' is not assignab... Remove this comment to see the full error message
             onChange([...newColumns, fields[fields.length - 1]]);
           }}
           fieldOptions={fieldOptions}

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/filterResultsStep/index.tsx
@@ -65,6 +65,7 @@ export function FilterResultsStep({
   const handleSearch = useCallback(
     (queryIndex: number) => {
       return (field: string) => {
+        // @ts-expect-error TS(2322) FIXME: Type '{ conditions: string; aggregates?: string[] ... Remove this comment to see the full error message
         const newQuery: WidgetQuery = {
           ...queries[queryIndex],
           conditions: field,
@@ -82,6 +83,7 @@ export function FilterResultsStep({
         queryConditionValidity[queryIndex] = validSearch;
         setQueryConditionValidity(queryConditionValidity);
         onQueryConditionChange(!queryConditionValidity.some(validity => !validity));
+        // @ts-expect-error TS(2322) FIXME: Type '{ conditions: string; aggregates?: string[] ... Remove this comment to see the full error message
         const newQuery: WidgetQuery = {
           ...queries[queryIndex],
           conditions: field,
@@ -159,6 +161,7 @@ export function FilterResultsStep({
                     value={query.name}
                     placeholder={t('Legend Alias')}
                     onChange={event => {
+                      // @ts-expect-error TS(2322) FIXME: Type '{ name: string; aggregates?: string[] | unde... Remove this comment to see the full error message
                       const newQuery: WidgetQuery = {
                         ...queries[queryIndex],
                         name: event.target.value,

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -55,7 +55,9 @@ export function GroupBySelector({fieldOptions, columns = [], onChange}: Props) {
 
   const hasOnlySingleColumnWithValue =
     columns.length === 1 &&
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     columns[0].kind === FieldValueKind.FIELD &&
+    // @ts-expect-error TS(2339) FIXME: Property 'field' does not exist on type 'QueryFiel... Remove this comment to see the full error message
     columns[0]?.field !== '';
 
   const canDrag = columns.length > 1;
@@ -67,12 +69,15 @@ export function GroupBySelector({fieldOptions, columns = [], onChange}: Props) {
       (acc, key) => {
         const value = fieldOptions[key];
         const optionInColumnsIndex = columnFieldsAsString.findIndex(
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           column => column === value.value.meta.name
         );
         if (optionInColumnsIndex === -1) {
+          // @ts-expect-error TS(2322) FIXME: Type 'SelectValue<FieldValue> | undefined' is not ... Remove this comment to see the full error message
           acc.filteredFieldOptions[key] = value;
           return acc;
         }
+        // @ts-expect-error TS(2322) FIXME: Type '{ [x: string]: SelectValue<FieldValue> | und... Remove this comment to see the full error message
         acc.columnsAsFieldOptions[optionInColumnsIndex] = {[key]: value};
         return acc;
       },
@@ -131,6 +136,7 @@ export function GroupBySelector({fieldOptions, columns = [], onChange}: Props) {
                 {columns.map((column, index) => (
                   <SortableQueryField
                     key={items[index]}
+                    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                     dragId={items[index]}
                     value={column}
                     fieldOptions={{
@@ -149,6 +155,7 @@ export function GroupBySelector({fieldOptions, columns = [], onChange}: Props) {
               {activeId ? (
                 <Ghost>
                   <QueryField
+                    // @ts-expect-error TS(2322) FIXME: Type 'QueryFieldValue | undefined' is not assignab... Remove this comment to see the full error message
                     value={columns[Number(activeId)]}
                     fieldOptions={{
                       ...filteredFieldOptions,

--- a/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/buildSteps/sortByStep/index.tsx
@@ -53,11 +53,14 @@ export function SortByStep({
 
   if (datasetConfig.disableSortOptions) {
     ({disableSort, disableSortDirection, disableSortReason} =
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
       datasetConfig.disableSortOptions(queries[0]));
   }
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const orderBy = queries[0].orderby;
   const strippedOrderBy = trimStart(orderBy, '-');
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const maxLimit = getResultsLimit(queries.length, queries[0].aggregates.length);
 
   const isTimeseriesChart = [
@@ -113,10 +116,12 @@ export function SortByStep({
           <SortBySelectors
             displayType={displayType}
             widgetType={widgetType}
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             hasGroupBy={isTimeseriesChart && !!queries[0].columns.length}
             disableSortReason={disableSortReason}
             disableSort={disableSort}
             disableSortDirection={disableSortDirection}
+            // @ts-expect-error TS(2322) FIXME: Type 'WidgetQuery | undefined' is not assignable t... Remove this comment to see the full error message
             widgetQuery={queries[0]}
             values={{
               sortDirection:

--- a/static/app/views/dashboardsV2/widgetBuilder/issueWidget/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/issueWidget/utils.tsx
@@ -13,6 +13,7 @@ export function generateIssueWidgetFieldOptions(
   fieldKeys.forEach(field => {
     fieldOptions[`field:${field}`] = {
       label: field,
+      // @ts-expect-error TS(2322) FIXME: Type '{ kind: FieldValueKind.FIELD; meta: { name: ... Remove this comment to see the full error message
       value: {
         kind: FieldValueKind.FIELD,
         meta: {

--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -170,8 +170,10 @@ export function normalizeQueries({
 
     const queryOrderBy =
       widgetType === WidgetType.RELEASE
-        ? stripDerivedMetricsPrefix(queries[0].orderby)
-        : queries[0].orderby;
+        ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          stripDerivedMetricsPrefix(queries[0].orderby)
+        : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          queries[0].orderby;
     const rawOrderBy = trimStart(queryOrderBy, '-');
 
     const resetOrderBy =
@@ -189,9 +191,12 @@ export function normalizeQueries({
       (!resetOrderBy && trimStart(queryOrderBy, '-')) ||
       (widgetType === WidgetType.ISSUE
         ? queryOrderBy ?? IssueSortOptions.DATE
-        : generateOrderOptions({
+        : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          generateOrderOptions({
             widgetType: widgetType ?? WidgetType.DISCOVER,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             columns: queries[0].columns,
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             aggregates: queries[0].aggregates,
           })[0].value);
 
@@ -238,6 +243,7 @@ export function normalizeQueries({
   if (isTimeseriesChart) {
     // For timeseries widget, all queries must share identical set of fields.
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const referenceAggregates = [...queries[0].aggregates];
 
     queryLoop: for (const query of queries) {

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.spec.tsx
@@ -478,6 +478,7 @@ describe('WidgetBuilder', function () {
       // EditableText and chart title
       expect(customWidgetLabels).toHaveLength(2);
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(customWidgetLabels[0]);
       userEvent.clear(screen.getByRole('textbox', {name: 'Widget title'}));
       userEvent.paste(
@@ -548,6 +549,7 @@ describe('WidgetBuilder', function () {
       const countFields = screen.getAllByText('count()');
       expect(countFields).toHaveLength(3);
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(countFields[1], ['last_seen()']);
 
       userEvent.click(screen.getByText('Add Widget'));
@@ -671,6 +673,7 @@ describe('WidgetBuilder', function () {
       // EditableText and chart title
       expect(customWidgetLabels).toHaveLength(2);
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(customWidgetLabels[0]);
       userEvent.clear(screen.getByRole('textbox', {name: 'Widget title'}));
 
@@ -795,6 +798,7 @@ describe('WidgetBuilder', function () {
       const customWidgetLabels = screen.getAllByText(widget.title);
       // EditableText and chart title
       expect(customWidgetLabels).toHaveLength(2);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(customWidgetLabels[0]);
 
       userEvent.clear(screen.getByRole('textbox', {name: 'Widget title'}));
@@ -1160,6 +1164,7 @@ describe('WidgetBuilder', function () {
 
       // Triggering the onBlur of the new field should not error
       userEvent.click(
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
         screen.getAllByPlaceholderText('Search for events, users, tags, and more')[1]
       );
       userEvent.keyboard('{esc}');
@@ -1229,6 +1234,7 @@ describe('WidgetBuilder', function () {
       await selectEvent.select(screen.getByText('Select group'), /project/);
 
       // Change the y-axis
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[0], 'eps()');
 
       await waitFor(() => {
@@ -1360,6 +1366,7 @@ describe('WidgetBuilder', function () {
       expect(customWidgetLabels).toHaveLength(2);
 
       // Change title text
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(customWidgetLabels[0]);
       userEvent.clear(screen.getByRole('textbox', {name: 'Widget title'}));
       userEvent.paste(
@@ -1572,6 +1579,7 @@ describe('WidgetBuilder', function () {
 
       userEvent.click(screen.getByLabelText('Add a Column'));
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.paste(screen.getAllByPlaceholderText('Alias')[1], 'Second Alias');
 
       userEvent.click(screen.getByText('Add Widget'));
@@ -1593,7 +1601,9 @@ describe('WidgetBuilder', function () {
       });
 
       userEvent.click(screen.getByText('Add an Equation'));
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.paste(screen.getAllByPlaceholderText('Alias')[1], 'This should persist');
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.type(screen.getAllByPlaceholderText('Alias')[0], 'A');
 
       expect(await screen.findByText('This should persist')).toBeInTheDocument();
@@ -1605,10 +1615,12 @@ describe('WidgetBuilder', function () {
       });
 
       userEvent.click(screen.getByText('Add an Equation'));
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.paste(screen.getAllByPlaceholderText('Alias')[1], 'This should persist');
 
       // 1 for the table, 1 for the the column selector, 1 for the sort
       await waitFor(() => expect(screen.getAllByText('count()')).toHaveLength(3));
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], /count_unique/);
 
       expect(screen.getByText('This should persist')).toBeInTheDocument();
@@ -1622,6 +1634,7 @@ describe('WidgetBuilder', function () {
       userEvent.click(await screen.findByText('Table'));
       userEvent.click(screen.getByText('Line Chart'));
       await selectEvent.select(screen.getByText('Select group'), 'project');
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'count_unique(…)');
 
       MockApiClient.clearMockResponses();
@@ -1686,6 +1699,7 @@ describe('WidgetBuilder', function () {
         // Confirm modal doesn't open because no changes were made
         expect(mockModal).not.toHaveBeenCalled();
 
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
         userEvent.click(screen.getAllByLabelText('Remove this Y-Axis')[0]);
         userEvent.click(screen.getByText('High Throughput Transactions'));
 
@@ -1727,6 +1741,7 @@ describe('WidgetBuilder', function () {
         });
 
         await selectEvent.select(await screen.findByText('Select group'), 'project');
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
         userEvent.click(screen.getAllByText('count()')[0], undefined, {skipHover: true});
         userEvent.click(screen.getByText(/count_unique/), undefined, {skipHover: true});
 
@@ -1782,6 +1797,7 @@ describe('WidgetBuilder', function () {
         userEvent.click(await screen.findByText('Add Group'));
         expect(screen.getAllByLabelText('Remove group')).toHaveLength(2);
 
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
         userEvent.click(screen.getAllByLabelText('Remove group')[1]);
         await waitFor(() =>
           expect(screen.queryByLabelText('Remove group')).not.toBeInTheDocument()

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -228,7 +228,8 @@ function WidgetBuilder({
           orderby:
             defaultWidgetQuery.orderby ||
             (datasetConfig.getTableSortOptions
-              ? datasetConfig.getTableSortOptions(organization, defaultWidgetQuery)[0]
+              ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+                datasetConfig.getTableSortOptions(organization, defaultWidgetQuery)[0]
                   .value
               : ''),
         },
@@ -238,9 +239,11 @@ function WidgetBuilder({
         ![DisplayType.TABLE, DisplayType.TOP_N].includes(defaultState.displayType) &&
         !(
           getIsTimeseriesChart(defaultState.displayType) &&
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           defaultState.queries[0].columns.length
         )
       ) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         defaultState.queries[0].orderby = '';
       }
     } else {
@@ -276,15 +279,20 @@ function WidgetBuilder({
       const widgetFromDashboard = filteredDashboardWidgets[widgetIndexNum];
 
       let queries;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       let newDisplayType = widgetFromDashboard.displayType;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       let newLimit = widgetFromDashboard.limit;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (widgetFromDashboard.displayType === DisplayType.TOP_N) {
         newLimit = DEFAULT_RESULTS_LIMIT;
         newDisplayType = DisplayType.AREA;
 
         queries = normalizeQueries({
           displayType: newDisplayType,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           queries: widgetFromDashboard.queries,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           widgetType: widgetFromDashboard.widgetType ?? WidgetType.DISCOVER,
         }).map(query => ({
           ...query,
@@ -296,27 +304,35 @@ function WidgetBuilder({
       } else {
         queries = normalizeQueries({
           displayType: newDisplayType,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           queries: widgetFromDashboard.queries,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           widgetType: widgetFromDashboard.widgetType ?? WidgetType.DISCOVER,
         });
       }
 
       setState({
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         title: widgetFromDashboard.title,
         displayType: newDisplayType,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         interval: widgetFromDashboard.interval,
         queries,
         errors: undefined,
         loading: false,
         userHasModified: false,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         dataSet: widgetFromDashboard.widgetType
-          ? WIDGET_TYPE_TO_DATA_SET[widgetFromDashboard.widgetType]
+          ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+            WIDGET_TYPE_TO_DATA_SET[widgetFromDashboard.widgetType]
           : DataSet.EVENTS,
         limit: newLimit,
         prebuiltWidgetId: null,
         queryConditionsValid: true,
       });
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       setDataSetConfig(getDatasetConfig(widgetFromDashboard.widgetType));
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'Widget | undefined' is not assig... Remove this comment to see the full error message
       setWidgetToBeUpdated(widgetFromDashboard);
     }
     // This should only run once on mount
@@ -441,6 +457,7 @@ function WidgetBuilder({
 
       if (
         getIsTimeseriesChart(newDisplayType) &&
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         normalized[0].columns.filter(column => !!column).length
       ) {
         // If a limit already exists (i.e. going between timeseries) then keep it,
@@ -448,6 +465,7 @@ function WidgetBuilder({
         newState.limit =
           prevState.limit ??
           Math.min(
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             getResultsLimit(normalized.length, normalized[0].columns.length),
             DEFAULT_RESULTS_LIMIT
           );
@@ -542,9 +560,13 @@ function WidgetBuilder({
       const newState = cloneDeep(prevState);
       const config = getDatasetConfig(DATA_SET_TO_WIDGET_TYPE[prevState.dataSet]);
       const query = cloneDeep(config.defaultWidgetQuery);
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       query.fields = prevState.queries[0].fields;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       query.aggregates = prevState.queries[0].aggregates;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       query.columns = prevState.queries[0].columns;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       query.orderby = prevState.queries[0].orderby;
       newState.queries.push(query);
       return newState;
@@ -574,12 +596,17 @@ function WidgetBuilder({
       const newState = cloneDeep(state);
       let newQuery = cloneDeep(newState.queries[0]);
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       newQuery.fields = fieldStrings;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       newQuery.aggregates = splitFields.aggregates;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       newQuery.columns = splitFields.columns;
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       newQuery.fieldAliases = splitFields.fieldAliases;
 
       if (datasetConfig.handleColumnFieldChangeOverride) {
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
         newQuery = datasetConfig.handleColumnFieldChangeOverride(newQuery);
       }
 
@@ -593,12 +620,14 @@ function WidgetBuilder({
           )
         ) {
           newQuery = datasetConfig.handleOrderByReset(
+            // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
             newQuery,
             fieldStrings.filter(
               fieldString => !['transaction', 'title'].includes(fieldString)
             )
           );
         } else {
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
           newQuery = datasetConfig.handleOrderByReset(newQuery, fieldStrings);
         }
       }
@@ -642,6 +671,7 @@ function WidgetBuilder({
     set(newState, 'queries', newQueries);
     set(newState, 'userHasModified', true);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const groupByFields = newState.queries[0].columns.filter(
       field => !(field === 'equation|')
     );
@@ -653,6 +683,7 @@ function WidgetBuilder({
         'limit',
         Math.min(
           newState.limit ?? DEFAULT_RESULTS_LIMIT,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           getResultsLimit(newQueries.length, newQueries[0].aggregates.length)
         )
       );
@@ -684,6 +715,7 @@ function WidgetBuilder({
         if (!orderOptions.length) {
           newQuery.orderby = '';
         } else {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           orderOption = orderOptions[0].value;
           newQuery.orderby = `-${orderOption}`;
         }
@@ -694,6 +726,7 @@ function WidgetBuilder({
     set(newState, 'userHasModified', true);
     set(newState, 'queries', newQueries);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const groupByFields = newState.queries[0].columns.filter(
       field => !(field === 'equation|')
     );
@@ -706,6 +739,7 @@ function WidgetBuilder({
         'limit',
         Math.min(
           newState.limit ?? DEFAULT_RESULTS_LIMIT,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           getResultsLimit(newQueries.length, newQueries[0].aggregates.length)
         )
       );
@@ -837,9 +871,12 @@ function WidgetBuilder({
       queryNames: [],
       queryConditions: [],
       queryFields: [
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         ...widgetData.queries[0].columns,
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         ...widgetData.queries[0].aggregates,
       ],
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       queryOrderby: widgetData.queries[0].orderby,
     };
 
@@ -914,6 +951,7 @@ function WidgetBuilder({
 
   // Tabular visualizations will always have only one query and that query cannot be deleted,
   // so we will always have the first query available to get data from.
+  // @ts-expect-error TS(2339) FIXME: Property 'columns' does not exist on type 'WidgetQ... Remove this comment to see the full error message
   const {columns, aggregates, fields, fieldAliases = []} = state.queries[0];
 
   const explodedColumns = useMemo(() => {

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderDataset.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderDataset.spec.tsx
@@ -404,6 +404,7 @@ describe('WidgetBuilder', function () {
       expect(screen.getByText('High to low')).toBeInTheDocument();
 
       // Selector "sortBy"
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByText('crash_free_rate(session)')[1]);
 
       // release exists in sort by selector
@@ -724,7 +725,9 @@ describe('WidgetBuilder', function () {
       expect(screen.getAllByLabelText('Remove column')).toHaveLength(2);
       expect(screen.getAllByLabelText('Drag to reorder')).toHaveLength(3);
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByLabelText('Remove column')[1]);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByLabelText('Remove column')[0]);
 
       expect(screen.getByText('issue')).toBeInTheDocument();
@@ -776,6 +779,7 @@ describe('WidgetBuilder', function () {
 
       userEvent.click(screen.getByText('Issues (States, Assignment, Time, etc.)'));
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.paste(screen.getAllByPlaceholderText('Alias')[0], 'First Alias');
 
       userEvent.click(screen.getByText('Add Widget'));
@@ -827,6 +831,7 @@ describe('WidgetBuilder', function () {
         const countFields = screen.getAllByText('count()');
         expect(countFields).toHaveLength(3);
 
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
         await selectEvent.select(countFields[1], ['p99(…)']);
         await selectEvent.select(screen.getByText('transaction.duration'), [
           'measurements.custom.measurement',
@@ -1033,12 +1038,14 @@ describe('WidgetBuilder', function () {
 
         expect(await screen.findAllByText('Custom Widget')).toHaveLength(2);
 
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
         await selectEvent.select(screen.getAllByText('count()')[1], ['p99(…)']);
         userEvent.click(screen.getByText('transaction.duration'));
         screen.getByText('measurements.custom.measurement');
         expect(
           screen.queryByText('measurements.another.custom.measurement')
         ).not.toBeInTheDocument();
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
         await selectEvent.select(screen.getAllByText('p99(…)')[0], ['p95(…)']);
         userEvent.click(screen.getByText('transaction.duration'));
         screen.getByText('measurements.another.custom.measurement');
@@ -1260,6 +1267,7 @@ describe('WidgetBuilder', function () {
           orgFeatures: [...defaultOrgFeatures, 'discover-frontend-use-events-endpoint'],
         });
         await screen.findByText('transaction');
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
         userEvent.click(screen.getAllByText('count()')[1]);
         expect(screen.getByText('measurements.custom.measurement')).toBeInTheDocument();
       });
@@ -1302,6 +1310,7 @@ describe('WidgetBuilder', function () {
           await screen.findByText('p99(measurements.custom.measurement)')
         ).toBeInTheDocument();
         // Delete p99(measurements.custom.measurement) column
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
         userEvent.click(screen.getAllByLabelText('Remove column')[0]);
         expect(
           screen.queryByText('p99(measurements.custom.measurement)')

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderSortBy.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetBuilderSortBy.spec.tsx
@@ -348,6 +348,7 @@ describe('WidgetBuilder', function () {
       // Selector "sortBy"
       expect(screen.getAllByText('count()')).toHaveLength(3);
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[2], 'count_unique(id)');
 
       // Wait for the Builder update the widget values
@@ -432,12 +433,14 @@ describe('WidgetBuilder', function () {
       expect(screen.queryByText('Sort by a y-axis')).not.toBeInTheDocument();
 
       // Select GroupBy value
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('Select group')[0], 'project');
 
       // Now that at least one groupBy value is selected, the SortBy step shall be visible
       expect(screen.getByText('Sort by a y-axis')).toBeInTheDocument();
 
       // Remove selected GroupBy value
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByLabelText('Remove group')[0]);
 
       // SortBy step shall no longer be visible
@@ -454,6 +457,7 @@ describe('WidgetBuilder', function () {
 
       await selectEvent.select(await screen.findByText('Select group'), 'project');
       expect(screen.getAllByText('count()')).toHaveLength(2);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'Custom Equation');
       userEvent.paste(
         screen.getByPlaceholderText('Enter Equation'),
@@ -484,6 +488,7 @@ describe('WidgetBuilder', function () {
 
       await selectEvent.select(await screen.findByText('Select group'), 'project');
       expect(screen.getAllByText('count()')).toHaveLength(2);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'Custom Equation');
       userEvent.paste(
         screen.getByPlaceholderText('Enter Equation'),
@@ -497,6 +502,7 @@ describe('WidgetBuilder', function () {
       expect(screen.getAllByText('project')).toHaveLength(2);
 
       // Switch back, the equation should still be visible
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('project')[1], 'Custom Equation');
       expect(screen.getByPlaceholderText('Enter Equation')).toHaveValue(
         'count_unique(user) * 2'
@@ -513,6 +519,7 @@ describe('WidgetBuilder', function () {
 
       await selectEvent.select(await screen.findByText('Select group'), 'project');
       expect(screen.getAllByText('count()')).toHaveLength(2);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'Custom Equation');
       userEvent.paste(
         screen.getByPlaceholderText('Enter Equation'),
@@ -574,6 +581,7 @@ describe('WidgetBuilder', function () {
 
       await selectEvent.select(await screen.findByText('Select group'), 'project');
       expect(screen.getAllByText('count()')).toHaveLength(2);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'Custom Equation');
       selectEvent.openMenu(screen.getByPlaceholderText('Enter Equation'));
 
@@ -591,6 +599,7 @@ describe('WidgetBuilder', function () {
 
       await selectEvent.select(await screen.findByText('Select group'), 'project');
       expect(screen.getAllByText('count()')).toHaveLength(2);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'Custom Equation');
       userEvent.paste(
         screen.getByPlaceholderText('Enter Equation'),
@@ -627,6 +636,7 @@ describe('WidgetBuilder', function () {
 
       await selectEvent.select(await screen.findByText('Select group'), 'project');
       userEvent.click(screen.getByText('Add an Equation'));
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByLabelText('Remove this Y-Axis')[0]);
 
       expect(screen.queryByPlaceholderText('Enter Equation')).not.toBeInTheDocument();
@@ -644,7 +654,9 @@ describe('WidgetBuilder', function () {
       expect(screen.getAllByText('count()')).toHaveLength(2);
 
       // Change the sort option to a grouping field, and then change a y-axis
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'project');
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[0], /count_unique/);
 
       // project should appear in the group by field, as well as the sort field
@@ -663,6 +675,7 @@ describe('WidgetBuilder', function () {
       await selectEvent.select(screen.getByText('Select group'), 'project');
 
       // Change the sort by to count_unique
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], /count_unique/);
 
       // Change the grouping
@@ -682,6 +695,7 @@ describe('WidgetBuilder', function () {
       });
 
       await selectEvent.select(await screen.findByText('Select group'), 'project');
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'Custom Equation');
       userEvent.paste(
         screen.getByPlaceholderText('Enter Equation'),
@@ -783,6 +797,7 @@ describe('WidgetBuilder', function () {
 
       await selectEvent.select(await screen.findByText('Select group'), 'project');
       expect(screen.getAllByText('count()')).toHaveLength(2);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], /count_unique/);
 
       userEvent.click(screen.getByText('Line Chart'));
@@ -807,6 +822,7 @@ describe('WidgetBuilder', function () {
 
       await selectEvent.select(screen.getByText('Select group'), 'project');
       expect(screen.getAllByText('count()')).toHaveLength(2);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'count() * 100');
     });
 
@@ -882,6 +898,7 @@ describe('WidgetBuilder', function () {
       });
 
       const projectElements = screen.getAllByText('project');
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(projectElements[projectElements.length - 1], 'count()');
 
       await waitFor(() => {
@@ -907,6 +924,7 @@ describe('WidgetBuilder', function () {
 
       await selectEvent.select(await screen.findByText('Select group'), 'project');
       expect(screen.getAllByText('count()')).toHaveLength(2);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       await selectEvent.select(screen.getAllByText('count()')[1], 'Custom Equation');
       userEvent.paste(
         screen.getByPlaceholderText('Enter Equation'),

--- a/static/app/views/dashboardsV2/widgetBuilder/widgetLibrary/index.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/widgetLibrary/index.tsx
@@ -86,8 +86,10 @@ export function WidgetLibrary({
             <CardHoverWrapper
               selected={selectedWidgetId === widget.id}
               key={widget.title}
+              // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
               onClick={getLibrarySelectionHandler(newWidget, iconColor)}
             >
+              {/* @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message */}
               <Card widget={newWidget} iconColor={iconColor} />
             </CardHoverWrapper>
           );

--- a/static/app/views/dashboardsV2/widgetCard/chart.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/chart.tsx
@@ -157,6 +157,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       const fieldAliases = widget.queries[i]?.fieldAliases ?? [];
       const eventView = eventViewFromWidget(
         widget.title,
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
         widget.queries[0],
         selection,
         widget.displayType
@@ -212,8 +213,10 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
       const field = fields[0];
 
       // Change tableMeta for the field from integer to string since we will be rendering with toLocaleString
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       const shouldExpandInteger = !!expandNumbers && tableMeta[field] === 'integer';
       if (shouldExpandInteger) {
+        // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
         tableMeta[field] = 'string';
       }
 
@@ -226,6 +229,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
 
       const unit = tableMeta.units?.[field];
       const rendered = fieldRenderer(
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'TableDataRow | { [x: string]: st... Remove this comment to see the full error message
         shouldExpandInteger ? {[field]: dataRow[field].toLocaleString()} : dataRow,
         {location, organization, unit}
       );
@@ -262,6 +266,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
 
   chartComponent(chartProps): React.ReactNode {
     const {widget} = this.props;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const stacked = widget.queries[0]?.columns.length > 0;
 
     switch (widget.displayType) {
@@ -425,6 +430,7 @@ class WidgetCardChart extends Component<WidgetCardChartProps, State> {
                 new Set(Object.values(timeseriesResultsTypes)).size === 1
                   ? timeseriesResultsTypes[axisLabel]
                   : 'number';
+              // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
               return axisLabelFormatterUsingAggregateOutputType(value, outputType);
             }
             return axisLabelFormatter(value, aggregateOutputType(axisLabel));

--- a/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/genericWidgetQueries.tsx
@@ -183,6 +183,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       this.setState(prevState => {
         const timeseriesResults = widget.queries.reduce((acc: Series[], query, index) => {
           return acc.concat(
+            // @ts-expect-error TS(2345) FIXME: Argument of type 'SeriesResponse | undefined' is n... Remove this comment to see the full error message
             config.transformSeries!(prevState.rawResults![index], query, organization)
           );
         }, []);
@@ -271,6 +272,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       // Cast so we can add the title.
       const transformedData = config.transformTable(
         data,
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
         widget.queries[0],
         organization,
         selection
@@ -331,6 +333,7 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
       rawResultsClone[requestIndex] = data;
       const transformedResult = config.transformSeries!(
         data,
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
         widget.queries[requestIndex],
         organization
       );
@@ -349,7 +352,9 @@ class GenericWidgetQueries<SeriesResponse, TableResponse> extends Component<
     // Get series result type
     // Only used by custom measurements in errorsAndTransactions at the moment
     const timeseriesResultsTypes = config.getSeriesResultType?.(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       responses[0][0],
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
       widget.queries[0]
     );
 

--- a/static/app/views/dashboardsV2/widgetCard/index.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.spec.tsx
@@ -131,6 +131,7 @@ describe('Dashboards > WidgetCard', function () {
       <WidgetCard
         api={api}
         organization={organization}
+        // @ts-expect-error TS(2322) FIXME: Type 'WidgetQuery | undefined' is not assignable t... Remove this comment to see the full error message
         widget={{...multipleQueryWidget, queries: [multipleQueryWidget.queries[0]]}}
         selection={selection}
         isEditing={false}
@@ -162,6 +163,7 @@ describe('Dashboards > WidgetCard', function () {
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
           queries: [
+            // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates: string[]; co... Remove this comment to see the full error message
             {
               ...multipleQueryWidget.queries[0],
               fields: ['count()'],
@@ -199,6 +201,7 @@ describe('Dashboards > WidgetCard', function () {
         widget={{
           ...multipleQueryWidget,
           queries: [
+            // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; columns: never[]; aggreg... Remove this comment to see the full error message
             {
               ...multipleQueryWidget.queries[0],
               fields: [
@@ -241,6 +244,7 @@ describe('Dashboards > WidgetCard', function () {
           ...multipleQueryWidget,
           displayType: DisplayType.TOP_N,
           queries: [
+            // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; columns: string[]; aggre... Remove this comment to see the full error message
             {
               ...multipleQueryWidget.queries[0],
               fields: ['transaction', 'count()'],
@@ -279,6 +283,7 @@ describe('Dashboards > WidgetCard', function () {
           ...multipleQueryWidget,
           displayType: DisplayType.LINE,
           queries: [
+            // @ts-expect-error TS(2322) FIXME: Type '{ conditions: string; fields: never[]; colum... Remove this comment to see the full error message
             {
               ...multipleQueryWidget.queries[0],
               conditions: '',
@@ -318,6 +323,7 @@ describe('Dashboards > WidgetCard', function () {
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
+          // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates?: string[] | ... Remove this comment to see the full error message
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
@@ -348,6 +354,7 @@ describe('Dashboards > WidgetCard', function () {
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
+          // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates?: string[] | ... Remove this comment to see the full error message
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
@@ -378,6 +385,7 @@ describe('Dashboards > WidgetCard', function () {
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
+          // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates?: string[] | ... Remove this comment to see the full error message
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
@@ -408,6 +416,7 @@ describe('Dashboards > WidgetCard', function () {
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.WORLD_MAP,
+          // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates?: string[] | ... Remove this comment to see the full error message
           queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
         }}
         selection={selection}
@@ -445,6 +454,7 @@ describe('Dashboards > WidgetCard', function () {
           widget={{
             ...multipleQueryWidget,
             displayType: DisplayType.TABLE,
+            // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates?: string[] | ... Remove this comment to see the full error message
             queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
           }}
           selection={selection}
@@ -482,6 +492,7 @@ describe('Dashboards > WidgetCard', function () {
           widget={{
             ...multipleQueryWidget,
             displayType: DisplayType.TABLE,
+            // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates?: string[] | ... Remove this comment to see the full error message
             queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
           }}
           selection={selection}
@@ -638,6 +649,7 @@ describe('Dashboards > WidgetCard', function () {
         widget={{
           ...multipleQueryWidget,
           displayType: DisplayType.TABLE,
+          // @ts-expect-error TS(2322) FIXME: Type '{ aggregates?: string[] | undefined; columns... Remove this comment to see the full error message
           queries: [{...multipleQueryWidget.queries[0]}],
         }}
         selection={selection}
@@ -683,6 +695,7 @@ describe('Dashboards > WidgetCard', function () {
             widget={{
               ...multipleQueryWidget,
               displayType: DisplayType.TABLE,
+              // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates?: string[] | ... Remove this comment to see the full error message
               queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
             }}
             selection={selection}
@@ -720,6 +733,7 @@ describe('Dashboards > WidgetCard', function () {
             widget={{
               ...multipleQueryWidget,
               displayType: DisplayType.TABLE,
+              // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates?: string[] | ... Remove this comment to see the full error message
               queries: [{...multipleQueryWidget.queries[0], fields: ['count()']}],
             }}
             selection={selection}
@@ -809,6 +823,7 @@ describe('Dashboards > WidgetCard', function () {
           widget={{
             ...multipleQueryWidget,
             displayType: DisplayType.TABLE,
+            // @ts-expect-error TS(2322) FIXME: Type '{ aggregates?: string[] | undefined; columns... Remove this comment to see the full error message
             queries: [{...multipleQueryWidget.queries[0]}],
           }}
           selection={selection}

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -245,6 +245,7 @@ class WidgetCard extends Component<Props, State> {
           ? [query.aggregates[query.aggregates.length - 1]]
           : [],
       }));
+      // @ts-expect-error TS(2322) FIXME: Type '{ aggregates: (string | undefined)[]; column... Remove this comment to see the full error message
       widget.queries = queries;
       widget.limit = DEFAULT_RESULTS_LIMIT;
     }

--- a/static/app/views/dashboardsV2/widgetCard/issueWidgetCard.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/issueWidgetCard.spec.tsx
@@ -201,6 +201,7 @@ describe('Dashboards > IssueWidgetCard', function () {
         widget={{
           ...widget,
           queries: [
+            // @ts-expect-error TS(2322) FIXME: Type '{ fields: string[]; aggregates?: string[] | ... Remove this comment to see the full error message
             {
               ...widget.queries[0],
               fields: ['issue', 'assignee', 'title', 'lifetimeEvents', 'lifetimeUsers'],

--- a/static/app/views/dashboardsV2/widgetCard/issueWidgetCard.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/issueWidgetCard.tsx
@@ -50,12 +50,17 @@ export function IssueWidgetCard({
   }
 
   const query = widget.queries[0];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const queryFields = defined(query.fields)
-    ? query.fields
-    : [...query.columns, ...query.aggregates];
+    ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+      query.fields
+    : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+      [...query.columns, ...query.aggregates];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const fieldAliases = query.fieldAliases ?? [];
   const eventView = eventViewFromWidget(
     widget.title,
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
     widget.queries[0],
     selection,
     widget.displayType

--- a/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.spec.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.spec.tsx
@@ -765,9 +765,11 @@ describe('Dashboards > ReleaseWidgetQueries', function () {
         widget={{
           ...singleQueryWidget,
           queries: [
+            // @ts-expect-error TS(2769) FIXME: No overload matches this call.
             {
               ...singleQueryWidget.queries[0],
               name: 'New Legend Alias',
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               fields: [...singleQueryWidget.queries[0].fields, ''],
             },
           ],

--- a/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/releaseWidgetQueries.tsx
@@ -71,10 +71,14 @@ function getReleasesQuery(releases: Release[]): {
 } {
   let releaseCondition = '';
   const releasesArray: string[] = [];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   releaseCondition += 'release:[' + releases[0].version;
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   releasesArray.push(releases[0].version);
   for (let i = 1; i < releases.length; i++) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     releaseCondition += ',' + releases[i].version;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     releasesArray.push(releases[i].version);
   }
   releaseCondition += ']';
@@ -158,6 +162,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
 
   componentDidMount() {
     this._isMounted = true;
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
     if (requiresCustomReleaseSorting(this.props.widget.queries[0])) {
       this.fetchReleases();
       return;
@@ -281,15 +286,20 @@ class ReleaseWidgetQueries extends Component<Props, State> {
     const {releases} = this.state;
     const widget = cloneDeep(initialWidget);
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
     const isCustomReleaseSorting = requiresCustomReleaseSorting(widget.queries[0]);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const isDescending = widget.queries[0].orderby.startsWith('-');
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const useSessionAPI = widget.queries[0].columns.includes('session.status');
 
     let releaseCondition = '';
     const releasesArray: string[] = [];
     if (isCustomReleaseSorting) {
       if (releases && releases.length === 1) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         releaseCondition += `release:${releases[0].version}`;
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         releasesArray.push(releases[0].version);
       }
       if (releases && releases.length > 1) {
@@ -317,11 +327,14 @@ class ReleaseWidgetQueries extends Component<Props, State> {
     const {widget} = this.props;
     const {releases} = this.state;
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const isDescending = widget.queries[0].orderby.startsWith('-');
 
     const releasesArray: string[] = [];
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
     if (requiresCustomReleaseSorting(widget.queries[0])) {
       if (releases && releases.length === 1) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         releasesArray.push(releases[0].version);
       }
       if (releases && releases.length > 1) {
@@ -372,6 +385,7 @@ class ReleaseWidgetQueries extends Component<Props, State> {
         limit={this.limit}
         onDataFetched={onDataFetched}
         loading={
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'WidgetQuery | undefined' is not ... Remove this comment to see the full error message
           requiresCustomReleaseSorting(widget.queries[0])
             ? !this.state.releases
             : undefined

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -91,6 +91,7 @@ export function WidgetCardChartContainer({
                 : null}
               <LoadingScreen loading={loading} />
               <IssueWidgetCard
+                // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                 transformedResults={tableResults?.[0].data ?? []}
                 loading={loading}
                 errorMessage={errorMessage}

--- a/static/app/views/eventsV2/chartFooter.tsx
+++ b/static/app/views/eventsV2/chartFooter.tsx
@@ -162,6 +162,7 @@ export default function ChartFooter({
         {TOP_EVENT_MODES.includes(displayMode) ? (
           <OptionSelector
             title={t('Y-Axis')}
+            // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             selected={yAxisValue[0]}
             options={yAxisOptions}
             onChange={yAxis => onAxisChange([yAxis])}

--- a/static/app/views/eventsV2/eventDetails/content.tsx
+++ b/static/app/views/eventsV2/eventDetails/content.tsx
@@ -191,6 +191,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
               {hasProfilingFeature && event.type === 'transaction' && (
                 <TransactionToProfileButton
                   orgId={organization.slug}
+                  // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                   projectId={this.projectId}
                   transactionId={event.eventID}
                 />
@@ -218,6 +219,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
               meta={metaResults?.meta ?? null}
               event={event}
               organization={organization}
+              // @ts-expect-error TS(2769) FIXME: No overload matches this call.
               projectId={this.projectId}
               location={location}
               errorDest="discover"
@@ -225,6 +227,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
             />
           </Layout.Main>
           <Layout.Main fullWidth={!isSidebarVisible}>
+            {/* @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message */}
             <Projects orgId={organization.slug} slugs={[this.projectId]}>
               {({projects, initiallyLoaded}) =>
                 initiallyLoaded ? (

--- a/static/app/views/eventsV2/landing.tsx
+++ b/static/app/views/eventsV2/landing.tsx
@@ -122,6 +122,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
       cursor,
       query: `version:2 name:"${searchQuery}"`,
       per_page: perPage.toString(),
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       sortBy: this.getActiveSort().value,
     };
     if (!cursor) {
@@ -219,6 +220,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
         </PrebuiltSwitch>
         <CompactSelect
           triggerProps={{prefix: t('Sort By')}}
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           value={activeSort.value}
           options={SORT_OPTIONS}
           onChange={opt => this.handleSortChange(opt.value)}

--- a/static/app/views/eventsV2/metricsBaselineContainer.tsx
+++ b/static/app/views/eventsV2/metricsBaselineContainer.tsx
@@ -183,6 +183,7 @@ export function MetricsBaselineContainer({
 
           seriesWithOrdering = Object.keys(response).map((seriesName: string) => {
             const prefixedName = `processed events: ${seriesName}`;
+            // @ts-expect-error TS(2322) FIXME: Type 'EventsStats | undefined' is not assignable t... Remove this comment to see the full error message
             const seriesData: EventsStats = response[seriesName];
             return [
               seriesData.order || 0,
@@ -199,6 +200,7 @@ export function MetricsBaselineContainer({
                 name: series.seriesName,
                 data: series.data.map(({name, value}) => [name, value]),
                 stack:
+                  // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
                   aggregateMultiPlotType(yAxis[order]) === 'area'
                     ? 'processed'
                     : undefined,
@@ -218,6 +220,7 @@ export function MetricsBaselineContainer({
         } else {
           const field = yAxis[0];
           const prefixedName = `processed events: ${field}`;
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
           const transformed = transformSeries(response, prefixedName, field);
           additionalSeries.push(
             LineSeries({

--- a/static/app/views/eventsV2/miniGraph.tsx
+++ b/static/app/views/eventsV2/miniGraph.tsx
@@ -234,6 +234,7 @@ class MiniGraph extends Component<Props> {
               ? display
               : this.getChartType({
                   showDaily,
+                  // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                   yAxis: Array.isArray(yAxis) ? yAxis[0] : yAxis,
                   timeseriesData: allSeries,
                 });

--- a/static/app/views/eventsV2/resultsChart.tsx
+++ b/static/app/views/eventsV2/resultsChart.tsx
@@ -104,6 +104,7 @@ class ResultsChart extends Component<ResultsChartProps> {
     const isPrevious = display === DisplayModes.PREVIOUS;
     const referrer = `api.discover.${display}-chart`;
     const topEvents = eventView.topEvents ? parseInt(eventView.topEvents, 10) : TOP_N;
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     const aggregateParam = getAggregateArg(yAxisValue[0]) || '';
     const customPerformanceMetricFieldType = isCustomMeasurement(aggregateParam)
       ? customMeasurements

--- a/static/app/views/eventsV2/table/arithmeticInput.tsx
+++ b/static/app/views/eventsV2/table/arithmeticInput.tsx
@@ -107,6 +107,7 @@ export default class ArithmeticInput extends PureComponent<Props, State> {
 
     const matches = [...query.substring(0, currentPosition).matchAll(/\s|^/g)];
     const match = matches[matches.length - 1];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const startOfTerm = match[0] === '' ? 0 : (match.index || 0) + 1;
 
     const cursorOffset = query.slice(currentPosition).search(/\s|$/);
@@ -148,6 +149,7 @@ export default class ArithmeticInput extends PureComponent<Props, State> {
         continue;
       }
 
+      // @ts-expect-error TS(2322) FIXME: Type 'DropdownOption | undefined' is not assignabl... Remove this comment to see the full error message
       return group.options[selection];
     }
 
@@ -182,6 +184,7 @@ export default class ArithmeticInput extends PureComponent<Props, State> {
       }
       // This is modifying the `active` value of the references so make sure to
       // use `newOptionGroups` at the end.
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       flattenedOptions[newSelection].active = true;
 
       this.setState({

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -49,6 +49,7 @@ export function updateQuery(
   if (Array.isArray(value)) {
     value = [...new Set(value)];
     if (value.length === 1) {
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       value = value[0];
     }
   }
@@ -180,6 +181,7 @@ function makeCellActions({
       <ActionItem
         key="add-to-filter"
         data-test-id="add-to-filter"
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
         onClick={() => handleCellAction(Actions.ADD, value)}
       >
         {t('Add to filter')}
@@ -192,6 +194,7 @@ function makeCellActions({
         <ActionItem
           key="exclude-from-filter"
           data-test-id="exclude-from-filter"
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
           onClick={() => handleCellAction(Actions.EXCLUDE, value)}
         >
           {t('Exclude from filter')}
@@ -209,6 +212,7 @@ function makeCellActions({
       <ActionItem
         key="show-values-greater-than"
         data-test-id="show-values-greater-than"
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
         onClick={() => handleCellAction(Actions.SHOW_GREATER_THAN, value)}
       >
         {t('Show values greater than')}
@@ -220,6 +224,7 @@ function makeCellActions({
       <ActionItem
         key="show-values-less-than"
         data-test-id="show-values-less-than"
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
         onClick={() => handleCellAction(Actions.SHOW_LESS_THAN, value)}
       >
         {t('Show values less than')}
@@ -233,6 +238,7 @@ function makeCellActions({
       <ActionItem
         key="transaction-summary"
         data-test-id="transaction-summary"
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
         onClick={() => handleCellAction(Actions.TRANSACTION, value)}
       >
         {t('Go to summary')}
@@ -246,6 +252,7 @@ function makeCellActions({
       <ActionItem
         key="release"
         data-test-id="release"
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
         onClick={() => handleCellAction(Actions.RELEASE, value)}
       >
         {t('Go to release')}
@@ -259,6 +266,7 @@ function makeCellActions({
       <ActionItem
         key="drilldown"
         data-test-id="per-cell-drilldown"
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
         onClick={() => handleCellAction(Actions.DRILLDOWN, value)}
       >
         {t('View Stacks')}
@@ -276,6 +284,7 @@ function makeCellActions({
       <ActionItem
         key="edit_threshold"
         data-test-id="edit-threshold"
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
         onClick={() => handleCellAction(Actions.EDIT_THRESHOLD, value)}
       >
         {tct('Edit threshold ([threshold]ms)', {

--- a/static/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/static/app/views/eventsV2/table/columnEditCollection.tsx
@@ -107,7 +107,9 @@ class ColumnEditCollection extends Component<Props, State> {
     const error = new Map();
     for (let i = 0; i < columns.length; i += 1) {
       const column = columns[i];
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (column.kind === 'equation') {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const result = parseArithmetic(column.field);
         if (result.error) {
           error.set(i, result.error);
@@ -173,8 +175,10 @@ class ColumnEditCollection extends Component<Props, State> {
 
   updateEquationFields = (newColumns: Column[], index: number, updatedColumn: Column) => {
     const oldColumn = newColumns[index];
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'QueryFieldValue | undefined' is ... Remove this comment to see the full error message
     const existingColumn = generateFieldAsString(newColumns[index]);
     const updatedColumnString = generateFieldAsString(updatedColumn);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'QueryFieldValue | undefined' is ... Remove this comment to see the full error message
     if (!isLegalEquationColumn(updatedColumn) || hasDuplicate(newColumns, oldColumn)) {
       return;
     }
@@ -182,7 +186,9 @@ class ColumnEditCollection extends Component<Props, State> {
     for (let i = 0; i < newColumns.length; i++) {
       const newColumn = newColumns[i];
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (newColumn.kind === 'equation') {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const result = parseArithmetic(newColumn.field);
         let newEquation = '';
         // Track where to continue from, not reconstructing from result so we don't have to worry
@@ -191,6 +197,7 @@ class ColumnEditCollection extends Component<Props, State> {
 
         // the parser separates fields & functions, so we only need to check one
         const fields =
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           oldColumn.kind === 'function' ? result.tc.functions : result.tc.fields;
 
         // for each field, add the text before it, then the new function and update index
@@ -198,6 +205,7 @@ class ColumnEditCollection extends Component<Props, State> {
         for (const field of fields) {
           if (field.term === existingColumn && lastIndex !== field.location.end.offset) {
             newEquation +=
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               newColumn.field.substring(lastIndex, field.location.start.offset) +
               updatedColumnString;
             lastIndex = field.location.end.offset;
@@ -206,10 +214,12 @@ class ColumnEditCollection extends Component<Props, State> {
 
         // Add whatever remains to be added from the equation, if existing field wasn't found
         // add the entire equation
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         newEquation += newColumn.field.substring(lastIndex);
         newColumns[i] = {
           kind: 'equation',
           field: newEquation,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           alias: newColumns[i].alias,
         };
       }
@@ -323,7 +333,9 @@ class ColumnEditCollection extends Component<Props, State> {
     return (
       issueFieldColumnCount <= 1 &&
       source === WidgetType.ISSUE &&
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       column.kind === 'field' &&
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       column.field === FieldKey.ISSUE
     );
   };
@@ -337,6 +349,7 @@ class ColumnEditCollection extends Component<Props, State> {
     return (
       aggregateCount <= 1 &&
       source === WidgetType.RELEASE &&
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       column.kind === FieldValueKind.FUNCTION
     );
   };
@@ -364,6 +377,7 @@ class ColumnEditCollection extends Component<Props, State> {
     // Reorder columns and trigger change.
     const newColumns = [...this.props.columns];
     const removed = newColumns.splice(sourceIndex, 1);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'QueryFieldValue | undefined' is ... Remove this comment to see the full error message
     newColumns.splice(targetIndex, 0, removed[0]);
     this.checkColumnErrors(newColumns);
     this.props.onChange(newColumns);
@@ -398,6 +412,7 @@ class ColumnEditCollection extends Component<Props, State> {
     };
     const ghost = (
       <Ghost ref={this.dragGhostRef} style={style}>
+        {/* @ts-expect-error TS(2345) FIXME: Argument of type 'QueryFieldValue | undefined' is ... Remove this comment to see the full error message */}
         {this.renderItem(col, index, {
           singleColumn,
           isGhost: true,

--- a/static/app/views/eventsV2/table/index.tsx
+++ b/static/app/views/eventsV2/table/index.tsx
@@ -211,7 +211,8 @@ class Table extends PureComponent<TableProps, TableState> {
     const {pageLinks, tableData, isLoading, error} = this.state;
 
     const isFirstPage = pageLinks
-      ? parseLinkHeader(pageLinks).previous.results === false
+      ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        parseLinkHeader(pageLinks).previous.results === false
       : false;
 
     return (

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -288,21 +288,25 @@ class QueryField extends Component<Props> {
 
     const fieldName = `field:${name}`;
     if (fieldOptions[fieldName]) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       return fieldOptions[fieldName].value;
     }
 
     const measurementName = `measurement:${name}`;
     if (fieldOptions[measurementName]) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       return fieldOptions[measurementName].value;
     }
 
     const spanOperationBreakdownName = `span_op_breakdown:${name}`;
     if (fieldOptions[spanOperationBreakdownName]) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       return fieldOptions[spanOperationBreakdownName].value;
     }
 
     const equationName = `equation:${name}`;
     if (fieldOptions[equationName]) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       return fieldOptions[equationName].value;
     }
 
@@ -312,6 +316,7 @@ class QueryField extends Component<Props> {
         : `tag:${name}`;
 
     if (fieldOptions[tagName]) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       return fieldOptions[tagName].value;
     }
 
@@ -351,6 +356,7 @@ class QueryField extends Component<Props> {
     if (fieldValue?.kind === 'function') {
       const funcName = `function:${fieldValue.function[0]}`;
       if (fieldOptions[funcName] !== undefined) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         field = fieldOptions[funcName].value;
       }
     }

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -226,6 +226,7 @@ class TableView extends Component<TableViewProps & WithRouterProps> {
 
     const title = (
       <StyledTooltip title={titleText}>
+        {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
         <Truncate value={titleText} maxLength={60} expandable={false} />
       </StyledTooltip>
     );

--- a/static/app/views/eventsV2/tags.tsx
+++ b/static/app/views/eventsV2/tags.tsx
@@ -105,7 +105,8 @@ class Tags extends Component<Props, State> {
     // endpoint and the totals endpoint
     const maxTotalValues =
       segments.length > 0
-        ? Math.max(Number(totalValues), segments[0].count)
+        ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          Math.max(Number(totalValues), segments[0].count)
         : totalValues;
     return (
       <TagDistributionMeter

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -373,6 +373,7 @@ function generateAdditionalConditions(
           ? `tags[${column.field}]`
           : column.field;
 
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const tagValue = dataRow.tags[tagIndex].value;
         conditions[key] = tagValue;
       }
@@ -391,6 +392,7 @@ export function usesTransactionsDataset(eventView: EventView, yAxisValue: string
   const parsedQuery = new MutableSearch(eventView.query);
   for (let index = 0; index < yAxisValue.length; index++) {
     const yAxis = yAxisValue[index];
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     const aggregateArg = getAggregateArg(yAxis) ?? '';
     if (isMeasurement(aggregateArg) || aggregateArg === 'transaction.duration') {
       usesTransactions = true;
@@ -441,11 +443,14 @@ function generateExpandedConditions(
     }
 
     if (key === 'project.id') {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       eventView.project = [...eventView.project, parseInt(value, 10)];
       continue;
     }
     if (key === 'environment') {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       if (!eventView.environment.includes(value)) {
+        // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         eventView.environment = [...eventView.environment, value];
       }
       continue;
@@ -456,6 +461,7 @@ function generateExpandedConditions(
       continue;
     }
 
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     parsedQuery.setFilterValues(key, [value]);
   }
 
@@ -494,7 +500,9 @@ export function generateFieldOptions({
   // function names. Having a mapping makes finding the value objects easier
   // later as well.
   functions.forEach(func => {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const ellipsis = aggregations[func].parameters.length ? '\u2026' : '';
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const parameters = aggregations[func].parameters.map(param => {
       const overrides = AGGREGATIONS[func].getFieldOverrides;
       if (typeof overrides === 'undefined') {
@@ -628,7 +636,9 @@ export function eventViewToWidgetQuery({
     let orderbyFunction = '';
     const aggregateFields = [...queryYAxis, ...aggregates];
     for (let i = 0; i < aggregateFields.length; i++) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       if (sort.field === getAggregateAlias(aggregateFields[i])) {
+        // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         orderbyFunction = aggregateFields[i];
         break;
       }

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -202,12 +202,15 @@ function ActionSet({
                 anySelected={anySelected}
                 orgSlug={organization.slug}
                 params={{
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   hasReleases: selectedProject.hasOwnProperty('features')
                     ? (selectedProject as Project).features.includes('releases')
                     : false,
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   latestRelease: selectedProject.hasOwnProperty('latestRelease')
                     ? (selectedProject as Project).latestRelease
                     : undefined,
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   projectId: selectedProject.slug,
                   confirm,
                   label,

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -185,6 +185,7 @@ class IssueListOverview extends Component<Props, State> {
 
   componentDidMount() {
     this._poller = new CursorPoller({
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       linkPreviousHref: parseLinkHeader(this.state.pageLinks)?.previous?.href,
       success: this.onRealtimePoll,
     });
@@ -708,6 +709,7 @@ class IssueListOverview extends Component<Props, State> {
 
     // Only resume polling if we're on the first page of results
     const links = parseLinkHeader(this.state.pageLinks);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (links && !links.previous.results && this.state.realtimeActive) {
       this._poller.setEndpoint(links?.previous?.href);
       this._poller.enable();
@@ -891,6 +893,7 @@ class IssueListOverview extends Component<Props, State> {
     }
 
     const links = parseLinkHeader(this.state.pageLinks);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return links && !links.previous.results && !links.next.results;
   }
 

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -18,6 +18,7 @@ const getSupportedTags = (supportedTags: TagCollection) =>
         ...supportedTags[key],
         kind:
           getFieldDefinition(key)?.kind ??
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           (supportedTags[key].predefined ? FieldKind.FIELD : FieldKind.TAG),
       },
     ])
@@ -77,6 +78,7 @@ function IssueListSearchBar({organization, tags, ...props}: Props) {
       onGetTagValues={getTagValues}
       excludedTags={EXCLUDED_TAGS}
       maxMenuHeight={500}
+      // @ts-expect-error TS(2322) FIXME: Type '{ [k: string]: { kind: FieldKind; key?: stri... Remove this comment to see the full error message
       supportedTags={getSupportedTags(tags)}
       {...props}
     />

--- a/static/app/views/issueList/sidebar.tsx
+++ b/static/app/views/issueList/sidebar.tsx
@@ -68,6 +68,7 @@ class IssueListSidebar extends Component<Props, State> {
     const parsedResult: TokenResult<Token.Filter>[] = (
       parseSearch(`${tag.key}:${value}`) ?? []
     ).filter((p): p is TokenResult<Token.Filter> => p.type === Token.Filter);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (parsedResult.length !== 1 || parsedResult[0].type !== Token.Filter) {
       return;
     }

--- a/static/app/views/issueList/tagFilter.spec.tsx
+++ b/static/app/views/issueList/tagFilter.spec.tsx
@@ -65,6 +65,7 @@ describe('IssueListTagFilter', function () {
 
     // selects menu option
     const menuOptionFoo = allFoo[1];
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(menuOptionFoo);
 
     expect(selectMock).toHaveBeenCalledWith(tag, 'foo');

--- a/static/app/views/onboarding/components/createProjectsFooter.tsx
+++ b/static/app/views/onboarding/components/createProjectsFooter.tsx
@@ -58,6 +58,7 @@ export default function CreateProjectsFooter({
         platforms
           .filter(platform => !persistedOnboardingState.platformToProjectIdMap[platform])
           .map(platform =>
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             createProject(api, organization.slug, teams[0].slug, platform, platform, {
               defaultRules: false,
             })

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -115,9 +115,11 @@ function Onboarding(props: Props) {
   const goNextStep = (step: StepDescriptor) => {
     const currentStepIndex = onboardingSteps.findIndex(s => s.id === step.id);
     const nextStep = onboardingSteps[currentStepIndex + 1];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (step.cornerVariant !== nextStep.cornerVariant) {
       cornerVariantControl.start('none');
     }
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     browserHistory.push(`/onboarding/${props.params.orgId}/${nextStep.id}/`);
   };
 
@@ -162,6 +164,7 @@ function Onboarding(props: Props) {
   };
 
   if (!stepObj || stepIndex === -1) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return <Redirect to={`/onboarding/${organization.slug}/${onboardingSteps[0].id}/`} />;
   }
   return (
@@ -173,6 +176,7 @@ function Onboarding(props: Props) {
           <StyledStepper
             numSteps={onboardingSteps.length}
             currentStepIndex={stepIndex}
+            // @ts-expect-error TS(2345) FIXME: Argument of type 'StepDescriptor | undefined' is n... Remove this comment to see the full error message
             onClick={i => goToStep(onboardingSteps[i])}
           />
         )}

--- a/static/app/views/organizationGroupDetails/groupActivityItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupActivityItem.tsx
@@ -185,6 +185,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
               break: <br />,
               release: (
                 <Version
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   version={deployedReleases[0].version}
                   projectId={projectId}
                   tooltipRawVersion
@@ -209,6 +210,7 @@ function GroupActivityItem({activity, orgSlug, projectId, author}: Props) {
               break: <br />,
               release: (
                 <Version
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   version={deployedReleases[0].version}
                   projectId={projectId}
                   tooltipRawVersion

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -260,6 +260,7 @@ class GroupDetails extends Component<Props, State> {
       currentTab = Tab.TAGS;
     } else {
       currentTab =
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         Object.values(Tab).find(tab => currentRoute.path === TabPaths[tab]) ??
         Tab.DETAILS;
     }
@@ -713,6 +714,7 @@ class GroupDetails extends Component<Props, State> {
               <StyledLoadingError message={t('Error loading the specified project')} />
             ) : (
               // TODO(ts): Update renderContent function to deal with empty group
+              // @ts-expect-error TS(2345) FIXME: Argument of type 'AvatarProject | Project | undefi... Remove this comment to see the full error message
               this.renderContent(projects[0], group!)
             )
           ) : (

--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.tsx
@@ -49,6 +49,7 @@ const GroupReplays = ({group, replayIds}: Props) => {
         isFetching={isFetching}
         replays={replays}
         showProjectColumn={false}
+        // @ts-expect-error TS(2322) FIXME: Type 'Sort | undefined' is not assignable to type ... Remove this comment to see the full error message
         sort={eventView.sorts[0]}
         fetchError={fetchError}
       />

--- a/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -145,6 +145,7 @@ class SimilarStackTrace extends Component<Props, State> {
     GroupingStore.onMerge({
       params,
       query,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       projectId: firstIssue.issue.project.slug,
     });
   };

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -192,10 +192,12 @@ function Grouping({api, groupId, location, organization, router, projSlug}: Prop
     }
 
     if (groupingLevels.length > 1) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       setActiveGroupingLevel(groupingLevels[1].id);
       return;
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     setActiveGroupingLevel(groupingLevels[0].id);
   }
 

--- a/static/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -78,6 +78,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
       showIcon: true,
     }));
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!provider.canAdd && metadata.aspects.externalInstall) {
       alerts.push({
         type: 'warning',
@@ -97,6 +98,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get metadata() {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return this.provider.metadata;
   }
 
@@ -115,6 +117,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get integrationName() {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return this.provider.name;
   }
 
@@ -191,6 +194,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   renderTopButton(disabledFromFeatures: boolean, userHasAccess: boolean) {
     const {organization} = this.props;
     const provider = this.provider;
+    // @ts-expect-error TS(2339) FIXME: Property 'metadata' does not exist on type 'Integr... Remove this comment to see the full error message
     const {metadata} = provider;
 
     const size = 'sm' as const;
@@ -209,9 +213,11 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
       return this.renderRequestIntegrationButton();
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (provider.canAdd) {
       return (
         <AddIntegrationButton
+          // @ts-expect-error TS(2322) FIXME: Type 'IntegrationProvider | undefined' is not assi... Remove this comment to see the full error message
           provider={provider}
           onAddIntegration={this.onInstall}
           analyticsParams={{
@@ -263,6 +269,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
             <PanelItem key={integration.id}>
               <InstalledIntegration
                 organization={organization}
+                // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                 provider={provider}
                 integration={integration}
                 onRemove={this.onRemove}

--- a/static/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/static/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -302,6 +302,7 @@ export class IntegrationListDirectory extends AsyncComponent<
     const selectedCategory = Array.isArray(category) ? category[0] : category || '';
     const searchInput = Array.isArray(search) ? search[0] : search || '';
 
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     return {searchInput, selectedCategory};
   };
 

--- a/static/app/views/organizationIntegrations/integrationServerlessFunctions.tsx
+++ b/static/app/views/organizationIntegrations/integrationServerlessFunctions.tsx
@@ -62,6 +62,7 @@ class IntegrationServerlessFunctions extends AsyncComponent<Props, State> {
       ...serverlessFunctions[index],
       ...serverlessFunctionUpdate,
     };
+    // @ts-expect-error TS(2322) FIXME: Type '{ enabled?: boolean | undefined; name?: stri... Remove this comment to see the full error message
     serverlessFunctions[index] = serverlessFunction;
     this.setState({serverlessFunctions});
   };

--- a/static/app/views/organizationIntegrations/pluginDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/pluginDetailedView.tsx
@@ -40,31 +40,38 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
   }
 
   get description() {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return this.plugin.description || '';
   }
 
   get author() {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return this.plugin.author?.name;
   }
 
   get resourceLinks() {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return this.plugin.resourceLinks || [];
   }
 
   get installationStatus() {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return this.plugin.projectList.length > 0 ? 'Installed' : 'Not Installed';
   }
 
   get integrationName() {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return `${this.plugin.name}${this.plugin.isHidden ? ' (Legacy)' : ''}`;
   }
 
   get featureData() {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return this.plugin.featureDescriptions;
   }
 
   handleResetConfiguration = (projectId: string) => {
     // make a copy of our project list
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const projectList = this.plugin.projectList.slice();
     // find the index of the project
     const index = projectList.findIndex(item => item.projectId === projectId);
@@ -76,12 +83,14 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
     projectList.splice(index, 1);
     // update state
     this.setState({
+      // @ts-expect-error TS(2322) FIXME: Type '{ projectList: PluginProjectItem[]; assets?:... Remove this comment to see the full error message
       plugins: [{...this.state.plugins[0], projectList}],
     });
   };
 
   handlePluginEnableStatus = (projectId: string, enable: boolean = true) => {
     // make a copy of our project list
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const projectList = this.plugin.projectList.slice();
     // find the index of the project
     const index = projectList.findIndex(item => item.projectId === projectId);
@@ -91,6 +100,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
     }
 
     // update item in array
+    // @ts-expect-error TS(2322) FIXME: Type '{ enabled: boolean; configured?: boolean | u... Remove this comment to see the full error message
     projectList[index] = {
       ...projectList[index],
       enabled: enable,
@@ -98,6 +108,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
 
     // update state
     this.setState({
+      // @ts-expect-error TS(2322) FIXME: Type '{ projectList: PluginProjectItem[]; assets?:... Remove this comment to see the full error message
       plugins: [{...this.state.plugins[0], projectList}],
     });
   };
@@ -110,6 +121,7 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
       modalProps => (
         <ContextPickerModal
           {...modalProps}
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           nextPath={`/settings/${organization.slug}/projects/:projectId/plugins/${plugin.id}/`}
           needProject
           needOrg={false}
@@ -153,15 +165,19 @@ class PluginDetailedView extends AbstractIntegrationDetailedView<
     const plugin = this.plugin;
     const {organization} = this.props;
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (plugin.projectList.length) {
       return (
         <Fragment>
+          {/* @ts-expect-error TS(2769) FIXME: No overload matches this call. */}
           <PluginDeprecationAlert organization={organization} plugin={plugin} />
           <div>
+            {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
             {plugin.projectList.map((projectItem: PluginProjectItem) => (
               <InstalledPlugin
                 key={projectItem.projectId}
                 organization={organization}
+                // @ts-expect-error TS(2322) FIXME: Type 'PluginWithProjectList | undefined' is not as... Remove this comment to see the full error message
                 plugin={plugin}
                 projectItem={projectItem}
                 onResetConfiguration={this.handleResetConfiguration}

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -122,6 +122,7 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
         }
 
         for (const key of keys) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           projectTotals[projectId][key] += counts[key];
         }
 
@@ -129,9 +130,12 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
           allReviewedByDay[projectId] = {};
         }
 
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (allReviewedByDay[projectId][bucket] === undefined) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           allReviewedByDay[projectId][bucket] = counts.total;
         } else {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           allReviewedByDay[projectId][bucket] += counts.total;
         }
       }
@@ -144,6 +148,7 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
     const allSeries = Object.keys(allReviewedByDay).map(
       (projectId, idx): BarChartSeries => ({
         seriesName: ProjectsStore.getById(projectId)?.slug ?? projectId,
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'Record<string, number> | undefin... Remove this comment to see the full error message
         data: sortSeriesByDay(convertDayValueObjectToSeries(allReviewedByDay[projectId])),
         animationDuration: 500,
         animationDelay: idx * 500,
@@ -200,9 +205,11 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
                       </ProjectBadgeContainer>
                       {statuses.map(action => (
                         <AlignRight key={action}>
+                          {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                           {projectTotals[projectId][action]}
                         </AlignRight>
                       ))}
+                      {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                       <AlignRight>{projectTotals[projectId].total}</AlignRight>
                     </Fragment>
                   );

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -104,7 +104,8 @@ class TeamReleases extends AsyncComponent<Props, State> {
       dataset === 'week' ? weekReleases?.last_week_totals : periodReleases?.project_avgs;
 
     const count = releasesPeriod?.[projectId]
-      ? Math.ceil(releasesPeriod?.[projectId])
+      ? // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
+        Math.ceil(releasesPeriod?.[projectId])
       : 0;
 
     return count;

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -159,9 +159,11 @@ class TeamStability extends AsyncComponent<Props, State> {
     sumSessions.forEach((s, idx) => (sumSessionsWeeklyTotals[Math.floor(idx / 7)] += s));
 
     const data = countSeriesWeeklyTotals.map((value, idx) => ({
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       name: countSeries[idx * 7].name,
       value: sumSessionsWeeklyTotals[idx]
-        ? formatFloat((value / sumSessionsWeeklyTotals[idx]) * 100, 2)
+        ? // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          formatFloat((value / sumSessionsWeeklyTotals[idx]) * 100, 2)
         : 0,
     }));
 

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -200,23 +200,29 @@ class TeamUnresolvedIssues extends AsyncComponent<Props, State> {
                         <ProjectBadge avatarSize={18} project={project} />
                       </ProjectBadgeContainer>
 
+                      {/* @ts-expect-error TS(2339) FIXME: Property 'periodAvg' does not exist on type '{}'. */}
                       <ScoreWrapper>{totals.periodAvg}</ScoreWrapper>
+                      {/* @ts-expect-error TS(2339) FIXME: Property 'today' does not exist on type '{}'. */}
                       <ScoreWrapper>{totals.today}</ScoreWrapper>
                       <ScoreWrapper>
                         <SubText
                           color={
+                            // @ts-expect-error TS(2339) FIXME: Property 'percentChange' does not exist on type '{... Remove this comment to see the full error message
                             totals.percentChange === 0
                               ? 'gray300'
-                              : totals.percentChange > 0
+                              : // @ts-expect-error TS(2339) FIXME: Property 'percentChange' does not exist on type '{... Remove this comment to see the full error message
+                              totals.percentChange > 0
                               ? 'red300'
                               : 'green300'
                           }
                         >
                           {formatPercentage(
+                            // @ts-expect-error TS(2339) FIXME: Property 'percentChange' does not exist on type '{... Remove this comment to see the full error message
                             Number.isNaN(totals.percentChange) ? 0 : totals.percentChange,
                             0
                           )}
                           <PaddedIconArrow
+                            // @ts-expect-error TS(2339) FIXME: Property 'percentChange' does not exist on type '{... Remove this comment to see the full error message
                             direction={totals.percentChange > 0 ? 'up' : 'down'}
                             size="xs"
                           />

--- a/static/app/views/organizationStats/usageChart/utils.tsx
+++ b/static/app/views/organizationStats/usageChart/utils.tsx
@@ -110,7 +110,9 @@ function getLabelIntervalLongPeriod(dataPeriod: number, numBars: number) {
   const daysBetweenTicks = [1, 2, 7, 7];
 
   for (let i = 0; i < daysBetweenLabels.length && numLabels > MAX_NUMBER_OF_LABELS; i++) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     numLabels = numTicks / daysBetweenLabels[i];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     numTicks = days / daysBetweenTicks[i];
   }
 

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -256,20 +256,25 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
         }
 
         if (outcome !== Outcome.CLIENT_DISCARD) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           count.total += group.totals['sum(quantity)'];
         }
 
+        // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
         count[outcome] += group.totals['sum(quantity)'];
 
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         group.series['sum(quantity)'].forEach((stat, i) => {
           switch (outcome) {
             case Outcome.ACCEPTED:
             case Outcome.FILTERED:
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               usageStats[i][outcome] += stat;
               return;
             case Outcome.DROPPED:
             case Outcome.RATE_LIMITED:
             case Outcome.INVALID:
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               usageStats[i].dropped.total += stat;
               // TODO: add client discards to dropped?
               return;

--- a/static/app/views/organizationStats/usageStatsPerMin.tsx
+++ b/static/app/views/organizationStats/usageStatsPerMin.tsx
@@ -66,6 +66,7 @@ class UsageStatsPerMin extends AsyncComponent<Props, State> {
         return count;
       }
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       count += group.series['sum(quantity)'][lastMin];
       return count;
     }, 0);

--- a/static/app/views/organizationStats/usageStatsProjects.tsx
+++ b/static/app/views/organizationStats/usageStatsProjects.tsx
@@ -327,25 +327,31 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
         const {outcome, project: projectId} = group.by;
         // Backend enum is singlar. Frontend enum is plural.
 
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         if (!projectSet.has(projectId.toString())) {
           return;
         }
 
+        // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
         if (!stats[projectId]) {
+          // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
           stats[projectId] = {...baseStat};
         }
 
         if (outcome !== Outcome.CLIENT_DISCARD) {
+          // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
           stats[projectId].total += group.totals['sum(quantity)'];
         }
 
         if (outcome === Outcome.ACCEPTED || outcome === Outcome.FILTERED) {
+          // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
           stats[projectId][outcome] += group.totals['sum(quantity)'];
         } else if (
           outcome === Outcome.RATE_LIMITED ||
           outcome === Outcome.INVALID ||
           outcome === Outcome.DROPPED
         ) {
+          // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
           stats[projectId][SortBy.DROPPED] += group.totals['sum(quantity)'];
         }
       });

--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -117,6 +117,7 @@ function Chart({
             formatter(value: number) {
               return axisLabelFormatter(
                 value,
+                // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                 aggregateOutputType(data[0].seriesName),
                 undefined,
                 durationUnit
@@ -136,6 +137,7 @@ function Chart({
             formatter(value: number) {
               return axisLabelFormatter(
                 value,
+                // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                 aggregateOutputType(data[0].seriesName),
                 undefined,
                 durationUnit
@@ -153,6 +155,7 @@ function Chart({
             formatter(value: number) {
               return axisLabelFormatter(
                 value,
+                // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                 aggregateOutputType(data[1].seriesName),
                 undefined,
                 durationUnit
@@ -200,6 +203,7 @@ function Chart({
       valueFormatter: (value, seriesName) => {
         return tooltipFormatter(
           value,
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           aggregateOutputType(data && data.length ? data[0].seriesName : seriesName)
         );
       },

--- a/static/app/views/performance/charts/index.tsx
+++ b/static/app/views/performance/charts/index.tsx
@@ -81,6 +81,7 @@ class Container extends Component<Props> {
           showLoading={false}
           query={apiPayload.query}
           includePrevious={false}
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           yAxis={axisOptions.map(opt => opt.value)}
           partial
         >
@@ -97,12 +98,15 @@ class Container extends Component<Props> {
               <Fragment>
                 <DoubleHeaderContainer>
                   {axisOptions.map((option, i) => (
+                    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                     <div key={`${option.label}:${i}`}>
                       <HeaderTitle>
+                        {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                         {option.label}
                         <QuestionTooltip
                           position="top"
                           size="sm"
+                          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                           title={option.tooltip}
                         />
                       </HeaderTitle>
@@ -133,7 +137,9 @@ class Container extends Component<Props> {
         </EventsRequest>
         <Footer
           api={api}
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           leftAxis={axisOptions[0].value}
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           rightAxis={axisOptions[1].value}
           organization={organization}
           eventView={eventView}

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -129,6 +129,7 @@ export function PerformanceLanding(props: Props) {
 
   const derivedQuery = getTransactionSearchQuery(location, eventView.query);
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const ViewComponent = fieldToViewMap[landingDisplay.field];
 
   let pageFilters: React.ReactNode = (
@@ -156,6 +157,7 @@ export function PerformanceLanding(props: Props) {
     <StyledPageContent data-test-id="performance-landing-v3">
       <PageErrorProvider>
         <Tabs
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           value={landingDisplay.field}
           onChange={field =>
             handleLandingDisplayChange(field, location, projects, organization, eventView)
@@ -190,6 +192,7 @@ export function PerformanceLanding(props: Props) {
           <Layout.Body data-test-id="performance-landing-body">
             <Layout.Main fullWidth>
               <TabPanels>
+                {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                 <Item key={landingDisplay.field}>
                   <MetricsCardinalityProvider
                     organization={organization}
@@ -249,6 +252,7 @@ export function PerformanceLanding(props: Props) {
                                               metricSettingState ?? undefined
                                             );
                                           }}
+                                          // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                                           query={searchQuery}
                                         />
                                       ) : (

--- a/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
+++ b/static/app/views/performance/landing/metricsDataSwitcherAlert.tsx
@@ -68,11 +68,13 @@ export function MetricsDataSwitcherAlert(
     }
 
     const platform = platforms[0];
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     if (UNSUPPORTED_TRANSACTION_NAME_DOCS.includes(platform)) {
       return null;
     }
 
     const supportedPlatform = SUPPORTED_TRANSACTION_NAME_DOCS.find(platformBase =>
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       platform.includes(platformBase)
     );
 

--- a/static/app/views/performance/landing/samplingModal.tsx
+++ b/static/app/views/performance/landing/samplingModal.tsx
@@ -30,6 +30,7 @@ const SamplingModal = (props: Props) => {
     ['false', t('Always show sampled data')],
   ];
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const [choice, setChoice] = useState(choices[isMEPEnabled ? 0 : 1][0]);
 
   return (

--- a/static/app/views/performance/landing/utils.tsx
+++ b/static/app/views/performance/landing/utils.tsx
@@ -104,6 +104,7 @@ export function getCurrentLandingDisplay(
     return display;
   }
 
+  // @ts-expect-error TS(2322) FIXME: Type '{ label: string; field: LandingDisplayField;... Remove this comment to see the full error message
   return getDefaultDisplayForPlatform(projects, eventView);
 }
 

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -41,6 +41,7 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
       const _widgetData = widgetDataRef.current;
       const newWidgetData = {..._widgetData, [dataKey]: result};
       widgetDataRef.current = newWidgetData;
+      // @ts-expect-error TS(2345) FIXME: Argument of type '{ [x: string]: {}; }' is not ass... Remove this comment to see the full error message
       setWidgetData({[props.chartSetting]: newWidgetData});
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -52,6 +53,7 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
       const newWidgetData = {..._widgetData};
       delete newWidgetData[dataKey];
       widgetDataRef.current = newWidgetData;
+      // @ts-expect-error TS(2345) FIXME: Argument of type '{ [x: string]: {}; }' is not ass... Remove this comment to see the full error message
       setWidgetData({[props.chartSetting]: newWidgetData});
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -73,6 +75,7 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
       <MEPDataProvider chartSetting={props.chartSetting}>
         <QueryHandler
           eventView={props.eventView}
+          // @ts-expect-error TS(2322) FIXME: Type '{}' is not assignable to type 'T'.
           widgetData={widgetData}
           setWidgetDataForKey={setWidgetDataForKey}
           removeWidgetDataForKey={removeWidgetDataForKey}
@@ -80,6 +83,7 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
           queries={queries}
           api={api}
         />
+        {/* @ts-expect-error TS(2322) FIXME: Type '{ totalHeight: number; widgetData: {}; setWi... Remove this comment to see the full error message */}
         <_DataDisplay<T> {...props} {...widgetProps} totalHeight={totalHeight} />
       </MEPDataProvider>
     </Fragment>

--- a/static/app/views/performance/landing/widgets/components/queryHandler.tsx
+++ b/static/app/views/performance/landing/widgets/components/queryHandler.tsx
@@ -96,6 +96,7 @@ function QueryResultSaver<T extends WidgetDataConstraint>(
 
   useEffect(() => {
     const isMetricsData =
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       results?.seriesAdditionalInfo?.[props.queryProps.fields[0]]?.isMetricsData ??
       results?.histograms?.meta?.isMetricsData ??
       results?.tableData?.meta?.isMetricsData;

--- a/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetChartRow.tsx
@@ -29,11 +29,10 @@ function getInitialChartSettings(
   performanceType: PROJECT_PERFORMANCE_TYPE,
   allowedCharts: PerformanceWidgetSetting[]
 ) {
-  return new Array(chartCount)
-    .fill(0)
-    .map((_, index) =>
-      getChartSetting(index, chartHeight, performanceType, allowedCharts[index])
-    );
+  return new Array(chartCount).fill(0).map((_, index) =>
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'PerformanceWidgetSetting | undef... Remove this comment to see the full error message
+    getChartSetting(index, chartHeight, performanceType, allowedCharts[index])
+  );
 }
 
 const ChartRow = (props: ChartRowProps) => {
@@ -59,6 +58,7 @@ const ChartRow = (props: ChartRowProps) => {
           index={index}
           chartHeight={chartHeight}
           chartColor={palette[index]}
+          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           defaultChartSetting={allowedCharts[index]}
           rowChartSettings={chartSettings}
           setRowChartSettings={setChartSettings}

--- a/static/app/views/performance/landing/widgets/transforms/transformEventsToArea.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformEventsToArea.tsx
@@ -19,6 +19,7 @@ export function transformEventsRequestToArea<T extends WidgetDataConstraint>(
     ...results,
     isLoading: results.loading || results.reloading,
     isErrored: results.errored,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     hasData: defined(data) && !!data.length && !!data[0].data.length,
     data,
     previousData: results.previousTimeseriesData ?? undefined,

--- a/static/app/views/performance/landing/widgets/transforms/transformEventsToVitals.tsx
+++ b/static/app/views/performance/landing/widgets/transforms/transformEventsToVitals.tsx
@@ -19,6 +19,7 @@ export function transformEventsRequestToVitals<T extends WidgetDataConstraint>(
     ...results,
     isLoading: results.loading || results.reloading,
     isErrored: results.errored,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     hasData: defined(data) && !!data.length && !!data[0].data.length,
     data,
 

--- a/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
+++ b/static/app/views/performance/landing/widgets/widgetDefinitions.tsx
@@ -71,6 +71,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
     fields: ['transaction.duration'],
     dataType: GenericPerformanceWidgetDataType.histogram,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[5],
   },
   [PerformanceWidgetSetting.LCP_HISTOGRAM]: {
@@ -78,6 +79,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
     fields: ['measurements.lcp'],
     dataType: GenericPerformanceWidgetDataType.histogram,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[5],
   },
   [PerformanceWidgetSetting.FCP_HISTOGRAM]: {
@@ -85,6 +87,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
     fields: ['measurements.fcp'],
     dataType: GenericPerformanceWidgetDataType.histogram,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[5],
   },
   [PerformanceWidgetSetting.FID_HISTOGRAM]: {
@@ -92,6 +95,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.DURATION_DISTRIBUTION),
     fields: ['measurements.fid'],
     dataType: GenericPerformanceWidgetDataType.histogram,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[5],
   },
   [PerformanceWidgetSetting.WORST_LCP_VITALS]: {
@@ -139,6 +143,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.TPM),
     fields: ['tpm()'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[1],
     allowsOpenInDiscover: true,
   },
@@ -147,6 +152,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.APDEX),
     fields: ['apdex()'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[4],
     allowsOpenInDiscover: true,
   },
@@ -155,6 +161,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P50),
     fields: ['p50(transaction.duration)'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[3],
     allowsOpenInDiscover: true,
   },
@@ -163,6 +170,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P75),
     fields: ['p75(transaction.duration)'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[3],
     allowsOpenInDiscover: true,
   },
@@ -171,6 +179,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P95),
     fields: ['p95(transaction.duration)'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[3],
     allowsOpenInDiscover: true,
   },
@@ -179,6 +188,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P99),
     fields: ['p99(transaction.duration)'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[3],
     allowsOpenInDiscover: true,
   },
@@ -187,6 +197,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.P75),
     fields: ['p75(measurements.lcp)'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[1],
     allowsOpenInDiscover: true,
   },
@@ -195,6 +206,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FAILURE_RATE),
     fields: ['failure_rate()'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[2],
     allowsOpenInDiscover: true,
   },
@@ -203,6 +215,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.USER_MISERY),
     fields: [`user_misery()`],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
     allowsOpenInDiscover: true,
   },
@@ -211,6 +224,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_COLD),
     fields: ['p75(measurements.app_start_cold)'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[4],
     allowsOpenInDiscover: true,
   },
@@ -219,6 +233,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.APP_START_WARM),
     fields: ['p75(measurements.app_start_warm)'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[3],
     allowsOpenInDiscover: true,
   },
@@ -227,6 +242,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_FRAMES),
     fields: ['p75(measurements.frames_slow_rate)'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
     allowsOpenInDiscover: true,
   },
@@ -235,6 +251,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FROZEN_FRAMES),
     fields: ['p75(measurements.frames_frozen_rate)'],
     dataType: GenericPerformanceWidgetDataType.area,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[5],
     allowsOpenInDiscover: true,
   },
@@ -243,6 +260,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.MOST_ERRORS),
     fields: [`failure_count()`],
     dataType: GenericPerformanceWidgetDataType.line_list,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.MOST_RELATED_ISSUES]: {
@@ -250,6 +268,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.MOST_ISSUES),
     fields: [`count()`],
     dataType: GenericPerformanceWidgetDataType.line_list,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.SLOW_HTTP_OPS]: {
@@ -257,6 +276,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_HTTP_SPANS),
     fields: [`p75(spans.http)`],
     dataType: GenericPerformanceWidgetDataType.line_list,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.SLOW_BROWSER_OPS]: {
@@ -264,6 +284,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_HTTP_SPANS),
     fields: [`p75(spans.browser)`],
     dataType: GenericPerformanceWidgetDataType.line_list,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.SLOW_RESOURCE_OPS]: {
@@ -271,6 +292,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_HTTP_SPANS),
     fields: [`p75(spans.resource)`],
     dataType: GenericPerformanceWidgetDataType.line_list,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.SLOW_DB_OPS]: {
@@ -278,6 +300,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_HTTP_SPANS),
     fields: [`p75(spans.db)`],
     dataType: GenericPerformanceWidgetDataType.line_list,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.MOST_SLOW_FRAMES]: {
@@ -285,6 +308,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.SLOW_FRAMES),
     fields: ['avg(measurements.frames_slow)'],
     dataType: GenericPerformanceWidgetDataType.line_list,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.MOST_FROZEN_FRAMES]: {
@@ -292,6 +316,7 @@ export const WIDGET_DEFINITIONS: ({
     titleTooltip: getTermHelp(organization, PERFORMANCE_TERM.FROZEN_FRAMES),
     fields: ['avg(measurements.frames_frozen)'],
     dataType: GenericPerformanceWidgetDataType.line_list,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     chartColor: WIDGET_PALETTE[0],
   },
   [PerformanceWidgetSetting.MOST_IMPROVED]: {

--- a/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
@@ -67,7 +67,9 @@ export function HistogramWidget(props: PerformanceWidgetProps) {
               isLoading={false}
               isErrored={false}
               onFilterChange={onFilterChange}
+              // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               field={props.fields[0]}
+              // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
               chartData={provided.widgetData.chart?.data?.[props.fields[0]]}
               disableXAxis
               disableZoom

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -81,10 +81,12 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
 
   const listQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       fields: field,
       component: provided => {
         const eventView = provided.eventView.clone();
 
+        // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         eventView.sorts = [{kind: 'desc', field}];
         if (props.chartSetting === PerformanceWidgetSetting.MOST_RELATED_ISSUES) {
           eventView.fields = [
@@ -92,6 +94,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
             {field: 'transaction'},
             {field: 'title'},
             {field: 'project.id'},
+            // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             {field},
           ];
           eventView.additionalConditions.setFilterValues('event.type', ['error']);
@@ -116,9 +119,11 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
           ];
         } else {
           // Most related errors
+          // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           eventView.fields = [{field: 'transaction'}, {field: 'project.id'}, {field}];
         }
         // Don't retrieve list items with 0 in the field.
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
         eventView.additionalConditions.setFilterValues(field, ['>0']);
         return (
           <DiscoverQuery
@@ -140,6 +145,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
   );
 
   const chartQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
+    // @ts-expect-error TS(2345) FIXME: Argument of type '() => { enabled: (widgetData: Da... Remove this comment to see the full error message
     () => {
       return {
         enabled: widgetData => {
@@ -152,6 +158,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
             return null;
           }
           eventView.additionalConditions.setFilterValues('transaction', [
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             provided.widgetData.list.data[selectedListIndex].transaction as string,
           ]);
           if (props.chartSetting === PerformanceWidgetSetting.MOST_RELATED_ISSUES) {
@@ -162,9 +169,11 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
               {field: 'issue'},
               {field: 'issue.id'},
               {field: 'transaction'},
+              // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               {field},
             ];
             eventView.additionalConditions.setFilterValues('issue', [
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               provided.widgetData.list.data[selectedListIndex].issue as string,
             ]);
             eventView.additionalConditions.setFilterValues('event.type', ['error']);
@@ -181,6 +190,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
             mutableSearch.removeFilter('transaction.duration');
             eventView.query = mutableSearch.formatString();
           } else {
+            // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             eventView.fields = [{field: 'transaction'}, {field}];
           }
           return (
@@ -190,6 +200,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
               includePrevious
               includeTransformedData
               partial
+              // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               currentSeriesNames={[field]}
               query={eventView.getQueryWithAdditionalConditions()}
               interval={getInterval(
@@ -277,15 +288,18 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                   additionalQuery,
                 });
 
+                // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
                 const fieldString = useEvents ? field : getAggregateAlias(field);
 
                 const valueMap = {
                   [PerformanceWidgetSetting.MOST_RELATED_ERRORS]: listItem.failure_count,
                   [PerformanceWidgetSetting.MOST_RELATED_ISSUES]: listItem.issue,
+                  // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
                   slowest: getPerformanceDuration(listItem[fieldString] as number),
                 };
                 const rightValue =
                   valueMap[isSlowestType ? 'slowest' : props.chartSetting] ??
+                  // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
                   listItem[fieldString];
 
                 switch (props.chartSetting) {
@@ -308,6 +322,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                           <ListClose
                             setSelectListIndex={setSelectListIndex}
                             onClick={() =>
+                              // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
                               excludeTransaction(listItem.transaction, props)
                             }
                           />
@@ -329,6 +344,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                           <ListClose
                             setSelectListIndex={setSelectListIndex}
                             onClick={() =>
+                              // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
                               excludeTransaction(listItem.transaction, props)
                             }
                           />
@@ -349,6 +365,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                             <ListClose
                               setSelectListIndex={setSelectListIndex}
                               onClick={() =>
+                                // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
                                 excludeTransaction(listItem.transaction, props)
                               }
                             />
@@ -366,6 +383,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                           <ListClose
                             setSelectListIndex={setSelectListIndex}
                             onClick={() =>
+                              // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
                               excludeTransaction(listItem.transaction, props)
                             }
                           />

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -43,6 +43,7 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
 
   const chartQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       fields: props.fields[0],
       component: provided => (
         <QueryBatchNode batchProperty="yAxis" transform={unmergeIntoIndividualResults}>
@@ -54,7 +55,9 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
               includePrevious
               includeTransformedData
               partial
+              // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               currentSeriesNames={[field]}
+              // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
               previousSeriesNames={[getPreviousSeriesName(field)]}
               query={provided.eventView.getQueryWithAdditionalConditions()}
               interval={getInterval(
@@ -80,6 +83,7 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
 
   const overallQuery = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       fields: field,
       component: provided => {
         const eventView = provided.eventView.clone();

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -101,6 +101,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
   const pageError = usePageError();
 
   const {fieldsList, vitalFields, sortField} = transformFieldsWithStops({
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     field,
     fields: props.fields,
     vitalStops: props.chartDefinition.vitalStops,
@@ -109,6 +110,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
   const Queries = {
     list: useMemo<QueryDefinition<DataType, WidgetDataResult>>(
       () => ({
+        // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
         fields: sortField,
         component: provided => {
           const _eventView = provided.eventView.clone();
@@ -117,6 +119,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
             field: propField,
           }));
 
+          // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           _eventView.sorts = [{kind: 'desc', field: sortField}];
           if (canUseMetricsData(organization)) {
             _eventView.additionalConditions.setFilterValues('!transaction', [
@@ -167,6 +170,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
             <EventsRequest
               {...pick(provided, eventsRequestQueryProps)}
               limit={1}
+              // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               currentSeriesNames={[sortField]}
               includePrevious={false}
               partial={false}
@@ -217,8 +221,10 @@ export function VitalWidget(props: PerformanceWidgetProps) {
         const vital = settingToVital[props.chartSetting];
 
         const data = {
+          // @ts-expect-error TS(2464) FIXME: A computed property name must be of type 'string',... Remove this comment to see the full error message
           [settingToVital[props.chartSetting]]: getVitalDataForListItem(
             listItem,
+            // @ts-expect-error TS(2345) FIXME: Argument of type 'WebVital | undefined' is not ass... Remove this comment to see the full error message
             vital,
             !useEvents
           ),
@@ -228,6 +234,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
           <Subtitle>
             <VitalBar
               isLoading={provided.widgetData.list?.isLoading}
+              // @ts-expect-error TS(2322) FIXME: Type 'WebVital | undefined' is not assignable to t... Remove this comment to see the full error message
               vital={settingToVital[props.chartSetting]}
               data={data}
               showBar={false}
@@ -243,6 +250,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
         const target = vitalDetailRouteWithQuery({
           orgSlug: organization.slug,
           query: eventView.generateQueryStringObject(),
+          // @ts-expect-error TS(2322) FIXME: Type 'import("/Users/ryan/code/sentry/static/app/u... Remove this comment to see the full error message
           vitalName: vital,
           projectID: decodeList(location.query.project),
         });
@@ -270,6 +278,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
             <_VitalChart
               {...provided.widgetData.chart}
               {...provided}
+              // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
               field={field}
               vitalFields={vitalFields}
               grid={provided.grid}
@@ -296,13 +305,16 @@ export function VitalWidget(props: PerformanceWidgetProps) {
                 const target = vitalDetailRouteWithQuery({
                   orgSlug: organization.slug,
                   query: _eventView.generateQueryStringObject(),
+                  // @ts-expect-error TS(2322) FIXME: Type 'import("/Users/ryan/code/sentry/static/app/u... Remove this comment to see the full error message
                   vitalName: vital,
                   projectID: decodeList(location.query.project),
                 });
 
                 const data = {
+                  // @ts-expect-error TS(2464) FIXME: A computed property name must be of type 'string',... Remove this comment to see the full error message
                   [settingToVital[props.chartSetting]]: getVitalDataForListItem(
                     listItem,
+                    // @ts-expect-error TS(2345) FIXME: Argument of type 'WebVital | undefined' is not ass... Remove this comment to see the full error message
                     vital,
                     !useEvents
                   ),
@@ -316,6 +328,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
                     <VitalBarCell>
                       <VitalBar
                         isLoading={provided.widgetData.list?.isLoading}
+                        // @ts-expect-error TS(2322) FIXME: Type 'WebVital | undefined' is not assignable to t... Remove this comment to see the full error message
                         vital={settingToVital[props.chartSetting]}
                         data={data}
                         showBar
@@ -328,6 +341,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
                     {!props.withStaticFilters && (
                       <ListClose
                         setSelectListIndex={setSelectListIndex}
+                        // @ts-expect-error TS(2345) FIXME: Argument of type 'ReactText | undefined' is not as... Remove this comment to see the full error message
                         onClick={() => excludeTransaction(listItem.transaction, props)}
                       />
                     )}

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -116,11 +116,15 @@ class _Table extends Component<Props, State> {
               transactionName={transactionName}
               eventView={eventView}
               project={projectID}
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               transactionThreshold={project_threshold[1]}
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               transactionThresholdMetric={project_threshold[0]}
               onApply={(threshold, metric) => {
                 if (
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   threshold !== project_threshold[1] ||
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   metric !== project_threshold[0]
                 ) {
                   this.setState({
@@ -302,6 +306,7 @@ class _Table extends Component<Props, State> {
     const aggregateAliasTableMeta: MetaType = {};
     if (tableMeta) {
       Object.keys(tableMeta).forEach(key => {
+        // @ts-expect-error TS(2322) FIXME: Type '"string" | "number" | "boolean" | "size" | "... Remove this comment to see the full error message
         aggregateAliasTableMeta[getAggregateAlias(key)] = tableMeta[key];
       });
     }

--- a/static/app/views/performance/traceDetails/content.spec.tsx
+++ b/static/app/views/performance/traceDetails/content.spec.tsx
@@ -58,16 +58,20 @@ describe('TraceDetailsContent', () => {
 
       const errorList = await screen.findByTestId('trace-view-errors');
       expect(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         await within(errorList).findByText(SAMPLE_ERROR_DATA.data[0].title)
       ).toBeInTheDocument();
       expect(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         await within(errorList).findByText(SAMPLE_ERROR_DATA.data[1].title)
       ).toBeInTheDocument();
 
       expect(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         await within(errorList).findByText(SAMPLE_ERROR_DATA.data[0].level)
       ).toBeInTheDocument();
       expect(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         await within(errorList).findByText(SAMPLE_ERROR_DATA.data[1].level)
       ).toBeInTheDocument();
     });

--- a/static/app/views/performance/traceDetails/traceView.tsx
+++ b/static/app/views/performance/traceDetails/traceView.tsx
@@ -228,6 +228,7 @@ export default function TraceView({
       const isLastTransaction = index === traces.length - 1;
       const hasChildren = trace.children.length > 0;
       const isNextChildOrphaned =
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         !isLastTransaction && traces[index + 1].parent_span_id !== null;
 
       const result = renderTransaction(trace, {

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -145,6 +145,7 @@ class TransactionDetail extends Component<Props> {
             key={measurement}
             title={WEB_VITAL_DETAILS[`measurements.${measurement}`]?.name}
           >
+            {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
             {`${Number(measurements[measurement].value.toFixed(3)).toLocaleString()}ms`}
           </Row>
         ))}

--- a/static/app/views/performance/transactionDetails/content.tsx
+++ b/static/app/views/performance/transactionDetails/content.tsx
@@ -117,6 +117,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     return (
       <Fragment>
         {isSampleTransaction && (
+          // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
           <FinishSetupAlert organization={organization} projectId={this.projectId} />
         )}
         {this.renderContent(event)}
@@ -189,6 +190,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                       {hasProfilingFeature && (
                         <TransactionToProfileButton
                           orgId={organization.slug}
+                          // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                           projectId={this.projectId}
                           transactionId={event.eventID}
                         />
@@ -204,6 +206,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                         meta={metaResults?.meta ?? null}
                         event={event}
                         organization={organization}
+                        // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                         projectId={this.projectId}
                         location={location}
                         errorDest="issue"
@@ -212,6 +215,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                     </Layout.Main>
                   )}
                   <Layout.Main fullWidth={!isSidebarVisible}>
+                    {/* @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message */}
                     <Projects orgId={organization.slug} slugs={[this.projectId]}>
                       {({projects: _projects}) => (
                         <SpanEntryContext.Provider
@@ -249,6 +253,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                           <EventMetadata
                             event={event}
                             organization={organization}
+                            // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                             projectId={this.projectId}
                           />
                           <RootSpanStatus event={event} />

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/content.tsx
@@ -78,6 +78,7 @@ const transformAnomalyData = (
 
   data.push({
     seriesName: 'tpm()',
+    // @ts-expect-error TS(2339) FIXME: Property 'count' does not exist on type '{ count: ... Remove this comment to see the full error message
     data: resultData.y.data.map(([name, [{count}]]) => ({
       name,
       value: count,
@@ -85,6 +86,7 @@ const transformAnomalyData = (
   });
   data.push({
     seriesName: 'tpm() lower bound',
+    // @ts-expect-error TS(2339) FIXME: Property 'count' does not exist on type '{ count: ... Remove this comment to see the full error message
     data: resultData.yhat_lower.data.map(([name, [{count}]]) => ({
       name,
       value: count,
@@ -92,6 +94,7 @@ const transformAnomalyData = (
   });
   data.push({
     seriesName: 'tpm() upper bound',
+    // @ts-expect-error TS(2339) FIXME: Property 'count' does not exist on type '{ count: ... Remove this comment to see the full error message
     data: resultData.yhat_upper.data.map(([name, [{count}]]) => ({
       name,
       value: count,
@@ -191,6 +194,7 @@ type DataType = {
 
 function Anomalies(props: AnomaliesSectionProps) {
   const height = 250;
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const chartColor = theme.charts.colors[0];
 
   const chart = useMemo<QueryDefinition<DataType, WidgetDataResult>>(() => {

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -458,6 +458,7 @@ class EventsTable extends Component<Props, State> {
                   })
                 : undefined;
             if (shouldFetchAttachments) {
+              // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
               fetchAttachments(tableData, cursor);
             }
             joinCustomData(tableData);

--- a/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/index.tsx
@@ -82,6 +82,7 @@ function EventsContentWrapper(props: ChildProps) {
     const filteredEventView = eventView?.clone();
     if (filteredEventView && filter?.query) {
       const query = new MutableSearch(filteredEventView.query);
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       filter.query.forEach(item => query.setFilterValues(item[0], [item[1]]));
       filteredEventView.query = query.formatString();
     }

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -134,10 +134,12 @@ function TransactionSummaryCharts({
   let display = decodeScalar(location.query.display, DisplayModes.DURATION);
   let trendFunction = decodeScalar(
     location.query.trendFunction,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     TREND_FUNCTIONS_OPTIONS[0].value
   ) as TrendFunctionField;
   let trendColumn = decodeScalar(
     location.query.trendColumn,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     TREND_PARAMETERS_OPTIONS[0].value
   );
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/content.tsx
@@ -310,6 +310,7 @@ function SummaryContent({
           organization={organization}
           location={location}
           eventView={eventView}
+          // @ts-expect-error TS(2322) FIXME: Type 'number | null | undefined' is not assignable... Remove this comment to see the full error message
           totalValues={totalCount}
           currentFilter={spanOperationBreakdownFilter}
           withoutZerofill={hasPerformanceChartInterpolation}
@@ -429,6 +430,7 @@ function SummaryContent({
         <SidebarSpacer />
         <Tags
           generateUrl={generateTagUrl}
+          // @ts-expect-error TS(2322) FIXME: Type 'number | null | undefined' is not assignable... Remove this comment to see the full error message
           totalValues={totalCount}
           eventView={eventView}
           organization={organization}
@@ -510,6 +512,7 @@ function getTransactionsListSort(
     TransactionFilterOptions.SLOW
   );
   const selectedSort = sortOptions.find(opt => opt.value === urlParam) || sortOptions[0];
+  // @ts-expect-error TS(2322) FIXME: Type 'DropdownOption | undefined' is not assignabl... Remove this comment to see the full error message
   return {selected: selectedSort, options: sortOptions};
 }
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/content.tsx
@@ -119,6 +119,7 @@ class Content extends AsyncComponent<Props, State> {
 
     return (
       <Chart
+        // @ts-expect-error TS(2322) FIXME: Type '{ seriesName: string; data: { value: number ... Remove this comment to see the full error message
         series={transformData(
           chartData.data,
           !organization.features.includes('performance-frontend-use-events-endpoint')

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationPercentileChart/utils.tsx
@@ -10,6 +10,7 @@ export function transformData(
   data: Record<string, number>[],
   useAggregateAlias: boolean = true
 ) {
+  // @ts-expect-error TS(2769) FIXME: No overload matches this call.
   const extractedData = Object.keys(data[0])
     .map((key: string) => {
       const nameMatch = (
@@ -24,14 +25,18 @@ export function transformData(
       if (nameValue > 100) {
         nameValue /= 10;
       }
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       return [nameValue, data[0][key]];
     })
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     .filter(i => i[0] > 0);
 
   extractedData.sort((a, b) => {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (a[0] > b[0]) {
       return 1;
     }
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (a[0] < b[0]) {
       return -1;
     }
@@ -41,6 +46,7 @@ export function transformData(
   return [
     {
       seriesName: t('Duration'),
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       data: extractedData.map(i => ({value: i[1], name: `${i[0].toLocaleString()}%`})),
     },
   ];

--- a/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/index.spec.tsx
@@ -630,6 +630,7 @@ describe('Performance > TransactionSummary', function () {
         screen.getByRole('button', {name: 'Filter Slow Transactions (p95)'})
       );
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByText('Slow Transactions (p95)')[1]);
 
       // Check the navigation.
@@ -1052,6 +1053,7 @@ describe('Performance > TransactionSummary', function () {
         screen.getByRole('button', {name: 'Filter Slow Transactions (p95)'})
       );
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByText('Slow Transactions (p95)')[1]);
 
       // Check the navigation.

--- a/static/app/views/performance/transactionSummary/transactionOverview/metricEvents/metricsEventsDropdown.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/metricEvents/metricsEventsDropdown.tsx
@@ -64,7 +64,9 @@ function InnerDropdown() {
 
   return (
     <CompactSelect
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       triggerProps={{prefix: currentOption.prefix}}
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       value={currentOption.value}
       options={options}
       onChange={opt => mepSetting.setMetricSettingState(opt.value)}

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -106,7 +106,8 @@ function SidebarCharts({
           error={error}
           value={
             totals
-              ? formatFloat(useAggregateAlias ? totals.apdex : totals['apdex()'], 4)
+              ? // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
+                formatFloat(useAggregateAlias ? totals.apdex : totals['apdex()'], 4)
               : null
           }
         />
@@ -128,6 +129,7 @@ function SidebarCharts({
           value={
             totals
               ? formatPercentage(
+                  // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
                   useAggregateAlias ? totals.failure_rate : totals['failure_rate()']
                 )
               : null
@@ -151,6 +153,7 @@ function SidebarCharts({
           value={
             totals
               ? tct('[tpm] tpm', {
+                  // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
                   tpm: formatFloat(useAggregateAlias ? totals.tpm : totals['tpm()'], 4),
                 })
               : null
@@ -340,6 +343,7 @@ function SidebarChartsContainer({
     utc,
     isGroupedByDate: true,
     showTimeInTooltip: true,
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     colors: [colors[0], colors[1], colors[2]],
     tooltip: {
       trigger: 'axis',

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarMEPCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarMEPCharts.tsx
@@ -218,7 +218,8 @@ function ChartLabels({
           error={error}
           value={
             totals
-              ? formatFloat(useAggregateAlias ? totals.apdex : totals['apdex()'], 4)
+              ? // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
+                formatFloat(useAggregateAlias ? totals.apdex : totals['apdex()'], 4)
               : null
           }
         />
@@ -240,6 +241,7 @@ function ChartLabels({
           value={
             totals
               ? formatPercentage(
+                  // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
                   useAggregateAlias ? totals.failure_rate : totals['failure_rate()']
                 )
               : null
@@ -319,6 +321,7 @@ function getSideChartsOptions({
       utc,
       isGroupedByDate: true,
       showTimeInTooltip: true,
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       colors: [colors[0], theme.gray300],
       tooltip: {
         trigger: 'axis',
@@ -385,6 +388,7 @@ function getSideChartsOptions({
     utc,
     isGroupedByDate: true,
     showTimeInTooltip: true,
+    // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
     colors: [colors[1], colors[2]],
     tooltip: {
       trigger: 'axis',
@@ -414,6 +418,7 @@ function trimLeadingTrailingZeroCounts(series: Series | undefined) {
 
   if (
     series.data[series.data.length - 1] &&
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     series.data[series.data.length - 1].value === 0
   ) {
     series.data.pop();
@@ -576,6 +581,7 @@ function SidebarChartsContainer({
                       metricSeries[0] = {...metricsCountSeries, ...trimmed};
                     }
                   }
+                  // @ts-expect-error TS(2345) FIXME: Argument of type '{ yAxisIndex: number; xAxisIndex... Remove this comment to see the full error message
                   series.push(metricsCountSeries);
                 }
               }

--- a/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/tagExplorer.tsx
@@ -263,6 +263,7 @@ export class TagExplorer extends Component<Props> {
     columns: TagColumn[]
   ) => {
     return (column: TableColumn<ColumnKeys>, index: number): React.ReactNode =>
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'TagColumn | undefined' is not as... Remove this comment to see the full error message
       this.renderHeadCell(sortedEventView, tableMeta, column, columns[index]);
   };
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userStats.tsx
@@ -47,10 +47,12 @@ function UserStats({
   let userMisery = error !== null ? <div>{'\u2014'}</div> : <Placeholder height="34px" />;
 
   if (!isLoading && error === null && totals) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const threshold: number | undefined = totals.project_threshold_config[1];
     const miserableUsers: number | undefined = useAggregateAlias
       ? totals.count_miserable_user
       : totals['count_miserable_user()'];
+    // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
     const userMiseryScore: number = useAggregateAlias
       ? totals.user_misery
       : totals['user_misery()'];

--- a/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/useReplaysFromTransaction.tsx
@@ -112,6 +112,7 @@ function useReplaysFromTransaction({
           if (
             event.replayId === replay.id &&
             (!slowestEvent ||
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               event['transaction.duration'] > slowestEvent['transaction.duration'])
           ) {
             slowestEvent = event;
@@ -213,6 +214,7 @@ function getFilteredEventView({
   const filteredEventView = eventView.clone();
   if (filteredEventView && filter?.query) {
     const query = new MutableSearch(filteredEventView.query);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     filter.query.forEach(item => query.setFilterValues(item[0], [item[1]]));
     filteredEventView.query = query.formatString();
   }

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/index.spec.tsx
@@ -141,6 +141,7 @@ describe('Performance > Transaction Spans > Span Summary', function () {
 
       // just want to get one span in the response
       const badExamples = [generateSuspectSpansResponse({examplesOnly: true})[0]];
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       for (const example of badExamples[0].examples) {
         // make sure that the spans array is empty
         example.spans = [];

--- a/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/suspectSpansTable.spec.tsx
@@ -21,6 +21,7 @@ const initializeData = () => {
 describe('SuspectSpansTable', () => {
   it('should not calculate frequency percentages above 100%', async () => {
     const initialData = initializeData();
+    // @ts-expect-error TS(2345) FIXME: Argument of type '{ op: string; group: string; des... Remove this comment to see the full error message
     const suspectSpan = makeSuspectSpan(SAMPLE_SPANS[0]);
     suspectSpan.frequency = 120;
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/utils.tsx
@@ -112,6 +112,7 @@ export function getSuspectSpanSortFromLocation(
 }
 
 export function getSuspectSpanSortFromEventView(eventView: EventView): SpanSortOption {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const sort = eventView.sorts.length ? eventView.sorts[0].field : DEFAULT_SORT;
   return getSuspectSpanSort(sort);
 }

--- a/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagValueTable.tsx
@@ -106,6 +106,7 @@ export class TagValueTable extends Component<Props, State> {
     columns: TagsTableColumn[]
   ) => {
     return (column: TableColumn<TagsTableColumnKeys>, index: number): React.ReactNode =>
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'TagsTableColumn | undefined' is ... Remove this comment to see the full error message
       this.renderHeadCell(sortedEventView, tableMeta, column, columns[index]);
   };
 

--- a/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/tagsHeatMap.tsx
@@ -133,6 +133,7 @@ const TagsHeatMap = (
   const tagData =
     tableData && tableData.tags && tableData.tags.data ? tableData.tags.data : undefined;
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'TableDataRow | undefined' is not... Remove this comment to see the full error message
   const rowKey = histogramData && findRowKey(histogramData[0]);
 
   // Reverse since e-charts takes the axis labels in the opposite order.
@@ -156,6 +157,7 @@ const TagsHeatMap = (
 
   _data?.sort((a, b) => {
     const i = b[0] === a[0] ? 1 : 0;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return b[i] - a[i];
   });
 
@@ -253,7 +255,10 @@ const TagsHeatMap = (
     if (histogramBucketInfo && histogramData) {
       const row = histogramData[bucket.dataIndex];
       const currentBucketStart = parseInt(
-        `${row[histogramBucketInfo.histogramField]}`,
+        `${
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+          row[histogramBucketInfo.histogramField]
+        }`,
         10
       );
       const currentBucketEnd = currentBucketStart + histogramBucketInfo.bucketSize;
@@ -391,6 +396,7 @@ const TagsHeatMap = (
       </PositionWrapper>
     );
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'TableDataRow | undefined' is not... Remove this comment to see the full error message
   const histogramBucketInfo = histogramData && parseHistogramBucketInfo(histogramData[0]);
 
   return (

--- a/static/app/views/performance/transactionSummary/transactionTags/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionTags/utils.tsx
@@ -70,8 +70,11 @@ export function parseHistogramBucketInfo(row: {[key: string]: React.ReactText}) 
   const parts = field.split('_');
   return {
     histogramField: field,
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     bucketSize: parseInt(parts[parts.length - 3], 10),
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     offset: parseInt(parts[parts.length - 2], 10),
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     multiplier: parseInt(parts[parts.length - 1], 10),
   };
 }

--- a/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/utils.tsx
@@ -54,13 +54,16 @@ export function findNearestBucketIndex(
 ): number | null {
   const width = getBucketWidth(chartData);
   // it's possible that the data is not available yet or the x axis is out of range
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   if (!chartData.length || xAxis >= chartData[chartData.length - 1].bin + width) {
     return null;
   }
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   if (xAxis < chartData[0].bin) {
     return -1;
   }
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   return Math.floor((xAxis - chartData[0].bin) / width);
 }
 
@@ -82,9 +85,12 @@ export function getRefRect(chartData: HistogramData): Rectangle | null {
     for (let j = i + 1; j < chartData.length; j++) {
       const data2 = chartData[j];
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (data1.bin !== data2.bin && data1.count !== data2.count) {
         return {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           point1: {x: i, y: Math.min(data1.count, data2.count)},
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           point2: {x: j, y: Math.max(data1.count, data2.count)},
         };
       }
@@ -109,6 +115,7 @@ export function asPixelRect(chartRef: ECharts, dataRect: Rectangle): Rectangle |
     dataRect.point1.y,
   ]);
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
   if (isNaN(point1?.[0]) || isNaN(point1?.[1])) {
     return null;
   }
@@ -118,12 +125,15 @@ export function asPixelRect(chartRef: ECharts, dataRect: Rectangle): Rectangle |
     dataRect.point2.y,
   ]);
 
+  // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
   if (isNaN(point2?.[0]) || isNaN(point2?.[1])) {
     return null;
   }
 
   return {
+    // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
     point1: {x: point1[0], y: point1[1]},
+    // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
     point2: {x: point2[0], y: point2[1]},
   };
 }

--- a/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/vitalCard.tsx
@@ -372,6 +372,7 @@ class VitalCard extends Component<Props, State> {
     // We can assume that all buckets are of equal width, use the first two
     // buckets to get the width. The value of each histogram function indicates
     // the beginning of the bucket.
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return chartData.length >= 2 ? chartData[1].bin - chartData[0].bin : 0;
   }
 

--- a/static/app/views/performance/transactionSummary/transactionVitals/vitalsPanel.tsx
+++ b/static/app/views/performance/transactionSummary/transactionVitals/vitalsPanel.tsx
@@ -131,6 +131,7 @@ class VitalsPanel extends Component<Props> {
                       error,
                       data,
                       histogram,
+                      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                       [colors[index]],
                       parseBound(start, precision),
                       parseBound(end, precision),

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -98,11 +98,14 @@ function getIntervalLine(
   intervalRatio: number,
   transaction?: NormalizedTrendsTransaction
 ): LineChartSeries[] {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   if (!transaction || !series.length || !series[0].data || !series[0].data.length) {
     return [];
   }
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const seriesStart = parseInt(series[0].data[0].name as string, 10);
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const seriesEnd = parseInt(series[0].data.slice(-1)[0].name as string, 10);
 
   if (seriesEnd < seriesStart) {

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -121,6 +121,7 @@ function _initializeData(
     newSettings.selectedProject = selectedProject.id;
   }
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   newSettings.selectedProject = settings.selectedProject ?? newSettings.projects[0].id;
   const data = initializeData(newSettings);
 
@@ -136,6 +137,7 @@ function _initializeData(
   PageFiltersStore.updateDateTime(defaultTrendsSelectionDate);
   if (!options?.selectedProjectId) {
     PageFiltersStore.updateProjects(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       settings.selectedProject ? [Number(newSettings.projects[0].id)] : [],
       []
     );
@@ -325,6 +327,7 @@ describe('Performance > Trends', function () {
     expect(transactions).toHaveLength(2);
     const firstTransaction = transactions[0];
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const summaryLink = within(firstTransaction).getByTestId('item-transaction-name');
 
     expect(summaryLink.closest('a')).toHaveAttribute(
@@ -349,6 +352,7 @@ describe('Performance > Trends', function () {
     expect(transactions).toHaveLength(2);
     const firstTransaction = transactions[0];
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const menuActions = within(firstTransaction).getAllByTestId('menu-action');
     expect(menuActions).toHaveLength(3);
 
@@ -405,6 +409,7 @@ describe('Performance > Trends', function () {
     expect(transactions).toHaveLength(2);
     const firstTransaction = transactions[0];
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const menuActions = within(firstTransaction).getAllByTestId('menu-action');
     expect(menuActions).toHaveLength(3);
 
@@ -435,6 +440,7 @@ describe('Performance > Trends', function () {
     expect(transactions).toHaveLength(2);
     const firstTransaction = transactions[0];
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     const menuActions = within(firstTransaction).getAllByTestId('menu-action');
     expect(menuActions).toHaveLength(3);
 

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -144,6 +144,7 @@ export function getCurrentTrendFunction(
   const trendFunctionField =
     _trendFunctionField ?? decodeScalar(location?.query?.trendFunction);
   const trendFunction = TRENDS_FUNCTIONS.find(({field}) => field === trendFunctionField);
+  // @ts-expect-error TS(2322) FIXME: Type 'TrendFunction | undefined' is not assignable... Remove this comment to see the full error message
   return trendFunction || TRENDS_FUNCTIONS[0];
 }
 

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -248,6 +248,7 @@ class Table extends Component<Props, State> {
       : undefined;
     if (tableMeta) {
       Object.keys(tableMeta).forEach(key => {
+        // @ts-expect-error TS(2322) FIXME: Type '"string" | "number" | "boolean" | "size" | "... Remove this comment to see the full error message
         aggregateAliasTableMeta![getAggregateAlias(key)] = tableMeta[key];
       });
     }

--- a/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
@@ -103,6 +103,7 @@ function VitalChartMetrics({
               seriesName: field,
               data: response.intervals.map((intervalValue, intervalIndex) => ({
                 name: moment(intervalValue).valueOf(),
+                // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                 value: group.series ? group.series[field][intervalIndex] : 0,
               })),
             })) as Series[] | undefined;

--- a/static/app/views/projectDetail/charts/projectSessionsChartRequest.tsx
+++ b/static/app/views/projectDetail/charts/projectSessionsChartRequest.tsx
@@ -125,8 +125,10 @@ class ProjectSessionsChartRequest extends Component<Props, State> {
 
       const {timeseriesData, previousTimeseriesData, totalSessions} =
         displayMode === DisplayModes.SESSIONS
-          ? this.transformSessionCountData(filteredResponse)
-          : this.transformData(filteredResponse, {
+          ? // @ts-expect-error TS(2345) FIXME: Argument of type '{ start: string | undefined; end... Remove this comment to see the full error message
+            this.transformSessionCountData(filteredResponse)
+          : // @ts-expect-error TS(2345) FIXME: Argument of type '{ start: string | undefined; end... Remove this comment to see the full error message
+            this.transformData(filteredResponse, {
               fetchedWithPrevious: shouldFetchWithPrevious,
             });
 
@@ -136,6 +138,7 @@ class ProjectSessionsChartRequest extends Component<Props, State> {
 
       this.setState({
         reloading: false,
+        // @ts-expect-error TS(2322) FIXME: Type 'Series[] | { data: SeriesDataUnit[]; seriesN... Remove this comment to see the full error message
         timeseriesData,
         previousTimeseriesData,
         totalSessions,
@@ -211,6 +214,7 @@ class ProjectSessionsChartRequest extends Component<Props, State> {
     const totalSessions = responseData.groups.reduce(
       (acc, group) =>
         acc +
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         group.series[field]
           .slice(fetchedWithPrevious ? dataMiddleIndex : 0)
           .reduce((value, groupAcc) => groupAcc + value, 0),
@@ -221,6 +225,7 @@ class ProjectSessionsChartRequest extends Component<Props, State> {
       ? responseData.groups.reduce(
           (acc, group) =>
             acc +
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             group.series[field]
               .slice(0, dataMiddleIndex)
               .reduce((value, groupAcc) => groupAcc + value, 0),
@@ -239,11 +244,13 @@ class ProjectSessionsChartRequest extends Component<Props, State> {
             const totalIntervalSessions = responseData.groups.reduce(
               (acc, group) =>
                 acc +
+                // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                 group.series[field].slice(fetchedWithPrevious ? dataMiddleIndex : 0)[i],
               0
             );
 
             const intervalCrashedSessions =
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               responseData.groups
                 .find(group => group.by['session.status'] === 'crashed')
                 ?.series[field].slice(fetchedWithPrevious ? dataMiddleIndex : 0)[i] ?? 0;
@@ -271,11 +278,13 @@ class ProjectSessionsChartRequest extends Component<Props, State> {
           seriesName: t('Previous Period'),
           data: responseData.intervals.slice(0, dataMiddleIndex).map((_interval, i) => {
             const totalIntervalSessions = responseData.groups.reduce(
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               (acc, group) => acc + group.series[field].slice(0, dataMiddleIndex)[i],
               0
             );
 
             const intervalCrashedSessions =
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               responseData.groups
                 .find(group => group.by['session.status'] === 'crashed')
                 ?.series[field].slice(0, dataMiddleIndex)[i] ?? 0;

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -105,6 +105,7 @@ class ProjectCharts extends Component<Props, State> {
       .map(urlKey => {
         return decodeScalar(
           location.query[urlKey],
+          // @ts-expect-error TS(2345) FIXME: Argument of type 'import("/Users/ryan/code/sentry/... Remove this comment to see the full error message
           this.defaultDisplayModes[visibleCharts.findIndex(value => value === urlKey)]
         );
       });
@@ -303,6 +304,7 @@ class ProjectCharts extends Component<Props, State> {
                   router={router}
                   organization={organization}
                   onTotalValuesChange={this.handleTotalValuesChange}
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   colors={[CHART_PALETTE[0][0], theme.purple200]}
                 />
               )}
@@ -441,6 +443,7 @@ class ProjectCharts extends Component<Props, State> {
               <InlineContainer>
                 <OptionSelector
                   title={t('Display')}
+                  // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
                   selected={displayMode}
                   options={this.displayModes}
                   onChange={this.handleDisplayModeChange}

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -302,6 +302,7 @@ class ProjectDetail extends AsyncView<Props, State> {
                     <ProjectIssues
                       organization={organization}
                       location={location}
+                      // @ts-expect-error TS(2322) FIXME: Type 'number | undefined' is not assignable to typ... Remove this comment to see the full error message
                       projectId={selection.projects[0]}
                       query={query}
                       api={this.api}

--- a/static/app/views/projectDetail/projectLatestReleases.tsx
+++ b/static/app/views/projectDetail/projectLatestReleases.tsx
@@ -116,6 +116,7 @@ class ProjectLatestReleases extends AsyncComponent<Props, State> {
       org_id: parseInt(organization.id, 10),
       project_id: projectId && parseInt(projectId, 10),
       step_id: index,
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       step_title: RELEASES_TOUR_STEPS[index].title,
     });
   };

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -177,6 +177,7 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
     }
 
     const totalSessions = data.groups.reduce(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       (acc, group) => acc + group.totals[field],
       0
     );

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -126,6 +126,7 @@ class ProjectVelocityScoreCard extends AsyncComponent<Props, State> {
     const hasOlderReleases = await fetchAnyReleaseExistence(
       this.api,
       organization.slug,
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
       selection.projects[0]
     );
 

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -57,6 +57,7 @@ class CreateProject extends Component<Props, State> {
     const {query} = location;
     const accessTeams = teams.filter((team: Team) => team.hasAccess);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const team = query.team || (accessTeams.length && accessTeams[0].slug);
     const platform = getPlatformName(query.platform) ? query.platform : '';
 

--- a/static/app/views/projectInstall/overview.tsx
+++ b/static/app/views/projectInstall/overview.tsx
@@ -72,6 +72,7 @@ class ProjectInstallOverview extends AsyncComponent<Props, State> {
           <DsnInfo>
             <DsnContainer>
               <strong>{t('DSN')}</strong>
+              {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
               <DsnValue>{keyList?.[0].dsn.public}</DsnValue>
             </DsnContainer>
 

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -79,6 +79,7 @@ function Dashboard({teams, organization, loadingTeams, error, router, location}:
   const favorites = projects.filter(project => project.isBookmarked);
 
   const showEmptyMessage = projects.length === 0 && favorites.length === 0;
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const showResources = projects.length === 1 && !projects[0].firstEvent;
 
   function handleSearch(searchQuery: string) {

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -276,6 +276,7 @@ class ProjectCardContainer extends Component<ContainerProps, ContainerState> {
     }
 
     this.setState({
+      // @ts-expect-error TS(2322) FIXME: Type 'Project | undefined' is not assignable to ty... Remove this comment to see the full error message
       projectDetails: itemsBySlug[project.slug],
     });
   }

--- a/static/app/views/releases/detail/commitsAndFiles/filesChanged.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/filesChanged.tsx
@@ -107,6 +107,7 @@ class FilesChanged extends AsyncView<Props, State> {
       <Fragment>
         {reposToRender.map(repoName => {
           const repoData = filesByRepository[repoName];
+          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           const files = Object.keys(repoData);
           const fileCount = files.length;
           return (
@@ -117,6 +118,7 @@ class FilesChanged extends AsyncView<Props, State> {
               </PanelHeader>
               <PanelBody>
                 {files.map(filename => {
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   const {authors} = repoData[filename];
                   return (
                     <StyledFileChange

--- a/static/app/views/releases/detail/commitsAndFiles/withReleaseRepos.tsx
+++ b/static/app/views/releases/detail/commitsAndFiles/withReleaseRepos.tsx
@@ -81,6 +81,7 @@ function withReleaseRepos<P extends DependentProps>(
 
       if (!activeCommitRepo) {
         this.setState({
+          // @ts-expect-error TS(2322) FIXME: Type 'Repository | null' is not assignable to type... Remove this comment to see the full error message
           activeReleaseRepo: releaseRepos[0] ?? null,
         });
         return;

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -81,6 +81,7 @@ const ReleaseHeader = ({
       return activeTab.to;
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return tabs[0].to; // default to 'Overview'
   };
 

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -360,7 +360,9 @@ class ReleasesDetailContainer extends AsyncComponent<
     return (
       <PageFiltersContainer
         shouldForceProject={projects.length === 1}
+        // @ts-expect-error TS(2769) FIXME: No overload matches this call.
         forceProject={
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           projects.length === 1 ? {...projects[0], id: String(projects[0].id)} : undefined
         }
         specificProjectSlugs={projects.map(p => p.slug)}

--- a/static/app/views/releases/detail/overview/index.tsx
+++ b/static/app/views/releases/detail/overview/index.tsx
@@ -716,6 +716,7 @@ function getTransactionsListSort(location: Location): {
     TransactionsListOption.FAILURE_COUNT
   );
   const selectedSort = sortOptions.find(opt => opt.value === urlParam) || sortOptions[0];
+  // @ts-expect-error TS(2322) FIXME: Type 'DropdownOption | undefined' is not assignabl... Remove this comment to see the full error message
   return {selectedSort, sortOptions};
 }
 

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -909,6 +909,7 @@ function ReleaseComparisonChart({
 
   if (!chart) {
     chart = charts[0];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     activeChart = charts[0].type;
   }
 

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -167,6 +167,7 @@ function ReleaseEventsChart({
           query={getQuery()}
           yAxis={getYAxis()}
           field={getField()}
+          // @ts-expect-error TS(2769) FIXME: No overload matches this call.
           colors={getColors()}
           api={api}
           router={router}

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -638,6 +638,7 @@ class ReleaseSessionsChart extends Component<Props> {
           {zoomRenderProps => (
             <Chart
               legend={legend}
+              // @ts-expect-error TS(2322) FIXME: Type '(Series | { seriesName: string; connectNulls... Remove this comment to see the full error message
               series={[...(series ?? []), ...(markLines ?? [])]}
               previousPeriod={previousSeries ?? []}
               {...zoomRenderProps}
@@ -650,6 +651,7 @@ class ReleaseSessionsChart extends Component<Props> {
               minutesThresholdToDisplaySeconds={MINUTES_THRESHOLD_TO_DISPLAY_SECONDS}
               yAxis={this.getYAxis()}
               tooltip={{valueFormatter: this.formatTooltipValue}}
+              // @ts-expect-error TS(2322) FIXME: Type '(string | undefined)[] | undefined' is not a... Remove this comment to see the full error message
               colors={this.getColors()}
               transformSinglePointToBar
               height={240}

--- a/static/app/views/releases/detail/overview/sidebar/commitAuthorBreakdown.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/commitAuthorBreakdown.tsx
@@ -59,6 +59,7 @@ class CommitAuthorBreakdown extends AsyncComponent<Props, State> {
         const email = commit.author?.email ?? 'unknown';
 
         if (authorCommitsAccumulator.hasOwnProperty(email)) {
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           authorCommitsAccumulator[email].commitCount += 1;
         } else {
           authorCommitsAccumulator[email] = {

--- a/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/totalCrashFreeUsers.tsx
@@ -75,7 +75,8 @@ class TotalCrashFreeUsers extends AsyncComponent<Props, State> {
         const dateLabel =
           index === 0
             ? t('Release created')
-            : `${moment(data[0].date).from(date, true)} ${t('later')}`;
+            : // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+              `${moment(data[0].date).from(date, true)} ${t('later')}`;
 
         return {date: moment(date), dateLabel, crashFreeUsers, crashFreeUserCount};
       })

--- a/static/app/views/releases/detail/utils.tsx
+++ b/static/app/views/releases/detail/utils.tsx
@@ -37,7 +37,9 @@ export function getFilesByRepository(fileList: CommitFile[]) {
       filesByRepository[repoName] = {};
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!filesByRepository[repoName].hasOwnProperty(filename)) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       filesByRepository[repoName][filename] = {
         authors: {},
         types: new Set(),
@@ -45,9 +47,11 @@ export function getFilesByRepository(fileList: CommitFile[]) {
     }
 
     if (author.email) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       filesByRepository[repoName][filename].authors[author.email] = author;
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     filesByRepository[repoName][filename].types.add(type);
 
     return filesByRepository;

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -482,6 +482,7 @@ class ReleasesList extends AsyncView<Props, State> {
 
               {releases.map((release, index) => (
                 <ReleaseCard
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   key={`${release.version}-${release.projects[0].slug}`}
                   activeDisplay={activeDisplay}
                   release={release}

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -27,12 +27,14 @@ import ReleaseCardStatsPeriod from './releaseCardStatsPeriod';
 function getReleaseProjectId(release: Release, selection: PageFilters) {
   // if a release has only one project
   if (release.projects.length === 1) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return release.projects[0].id;
   }
 
   // if only one project is selected in global header and release has it (second condition will prevent false positives like -1)
   if (
     selection.projects.length === 1 &&
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
     release.projects.map(p => p.id).includes(selection.projects[0])
   ) {
     return selection.projects[0];

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -101,6 +101,7 @@ function ReleaseCardProjectRow({
   const adoptionStage =
     showReleaseAdoptionStages &&
     adoptionStages?.[project.slug] &&
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     adoptionStages?.[project.slug].stage;
 
   const adoptionStageLabel =

--- a/static/app/views/releases/list/releasesAdoptionChart.tsx
+++ b/static/app/views/releases/list/releasesAdoptionChart.tsx
@@ -91,6 +91,7 @@ class ReleasesAdoptionChart extends Component<Props> {
       response?.groups.map(group => group.by.release as string) ?? [];
     if (response?.groups && response.groups.length > 50) {
       releases = response!.groups
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         .sort((a, b) => b.totals['sum(session)'] - a.totals['sum(session)'])
         .slice(0, 50)
         .map(group => group.by.release as string);
@@ -170,10 +171,13 @@ class ReleasesAdoptionChart extends Component<Props> {
             return null;
           }
 
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           const numDataPoints = releasesSeries[0].data.length;
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           const xAxisData = releasesSeries[0].data.map(point => point.name);
           const hideLastPoint =
             releasesSeries.findIndex(
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               series => series.data[numDataPoints - 1].value > 0
             ) === -1;
 
@@ -254,6 +258,7 @@ class ReleasesAdoptionChart extends Component<Props> {
                               series[0].dataIndex === numDataPoints - 1
                                 ? moment(response?.end)
                                 : moment(timestamp).add(
+                                    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
                                     parseInt(periodObj.period, 10),
                                     periodObj.periodLength as StatsPeriodType
                                   )

--- a/static/app/views/releases/list/releasesRequest.tsx
+++ b/static/app/views/releases/list/releasesRequest.tsx
@@ -205,11 +205,17 @@ class ReleasesRequest extends Component<Props, State> {
 
       this.setState({
         loading: false,
+        // @ts-expect-error TS(2322) FIXME: Type 'SessionApiResponse | undefined' is not assig... Remove this comment to see the full error message
         statusCountByReleaseInPeriod,
+        // @ts-expect-error TS(2322) FIXME: Type 'SessionApiResponse | undefined' is not assig... Remove this comment to see the full error message
         totalCountByReleaseIn24h,
+        // @ts-expect-error TS(2322) FIXME: Type 'SessionApiResponse | undefined' is not assig... Remove this comment to see the full error message
         totalCountByProjectIn24h,
+        // @ts-expect-error TS(2322) FIXME: Type 'SessionApiResponse | undefined' is not assig... Remove this comment to see the full error message
         statusCountByProjectInPeriod,
+        // @ts-expect-error TS(2322) FIXME: Type 'SessionApiResponse | undefined' is not assig... Remove this comment to see the full error message
         totalCountByReleaseInPeriod,
+        // @ts-expect-error TS(2322) FIXME: Type 'SessionApiResponse | undefined' is not assig... Remove this comment to see the full error message
         totalCountByProjectInPeriod,
       });
     } catch (error) {
@@ -362,6 +368,7 @@ class ReleasesRequest extends Component<Props, State> {
 
     const totalCount = statusCountByReleaseInPeriod?.groups
       .filter(({by}) => by.release === version && by.project === project)
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       ?.reduce((acc, group) => acc + group.totals[field], 0);
 
     const crashedCount = this.getCrashCount(version, project, display);
@@ -379,9 +386,12 @@ class ReleasesRequest extends Component<Props, State> {
     const {totalCountByReleaseIn24h} = this.state;
     const field = sessionDisplayToField(display);
 
-    return totalCountByReleaseIn24h?.groups
-      .filter(({by}) => by.release === version && by.project === project)
-      ?.reduce((acc, group) => acc + group.totals[field], 0);
+    return (
+      totalCountByReleaseIn24h?.groups
+        .filter(({by}) => by.release === version && by.project === project)
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        ?.reduce((acc, group) => acc + group.totals[field], 0)
+    );
   };
 
   getPeriodCountByRelease = (
@@ -392,27 +402,36 @@ class ReleasesRequest extends Component<Props, State> {
     const {totalCountByReleaseInPeriod} = this.state;
     const field = sessionDisplayToField(display);
 
-    return totalCountByReleaseInPeriod?.groups
-      .filter(({by}) => by.release === version && by.project === project)
-      ?.reduce((acc, group) => acc + group.totals[field], 0);
+    return (
+      totalCountByReleaseInPeriod?.groups
+        .filter(({by}) => by.release === version && by.project === project)
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        ?.reduce((acc, group) => acc + group.totals[field], 0)
+    );
   };
 
   get24hCountByProject = (project: number, display: ReleasesDisplayOption) => {
     const {totalCountByProjectIn24h} = this.state;
     const field = sessionDisplayToField(display);
 
-    return totalCountByProjectIn24h?.groups
-      .filter(({by}) => by.project === project)
-      ?.reduce((acc, group) => acc + group.totals[field], 0);
+    return (
+      totalCountByProjectIn24h?.groups
+        .filter(({by}) => by.project === project)
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        ?.reduce((acc, group) => acc + group.totals[field], 0)
+    );
   };
 
   getPeriodCountByProject = (project: number, display: ReleasesDisplayOption) => {
     const {totalCountByProjectInPeriod} = this.state;
     const field = sessionDisplayToField(display);
 
-    return totalCountByProjectInPeriod?.groups
-      .filter(({by}) => by.project === project)
-      ?.reduce((acc, group) => acc + group.totals[field], 0);
+    return (
+      totalCountByProjectInPeriod?.groups
+        .filter(({by}) => by.project === project)
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        ?.reduce((acc, group) => acc + group.totals[field], 0)
+    );
   };
 
   getTimeSeries = (version: string, project: number, display: ReleasesDisplayOption) => {

--- a/static/app/views/replays/detail/console/messageFormatter.spec.tsx
+++ b/static/app/views/replays/detail/console/messageFormatter.spec.tsx
@@ -103,36 +103,42 @@ const breadcrumbs: Extract<Crumb, BreadcrumbTypeDefault>[] = [
 
 describe('MessageFormatter', () => {
   it('Should print console message with placeholders correctly', () => {
+    // @ts-expect-error TS(2322) FIXME: Type 'DefaultCrumb | undefined' is not assignable ... Remove this comment to see the full error message
     render(<MessageFormatter breadcrumb={breadcrumbs[0]} />);
 
     expect(screen.getByText('This is a test')).toBeInTheDocument();
   });
 
   it('Should print console message with objects correctly', () => {
+    // @ts-expect-error TS(2322) FIXME: Type 'DefaultCrumb | undefined' is not assignable ... Remove this comment to see the full error message
     render(<MessageFormatter breadcrumb={breadcrumbs[1]} />);
 
     expect(screen.getByText('test 1 false {}')).toBeInTheDocument();
   });
 
   it('Should print console message correctly when it is an Error object', () => {
+    // @ts-expect-error TS(2322) FIXME: Type 'DefaultCrumb | undefined' is not assignable ... Remove this comment to see the full error message
     render(<MessageFormatter breadcrumb={breadcrumbs[2]} />);
 
     expect(screen.getByText('Error: this is my error message')).toBeInTheDocument();
   });
 
   it('Should print empty object in case there is no message prop', () => {
+    // @ts-expect-error TS(2322) FIXME: Type 'DefaultCrumb | undefined' is not assignable ... Remove this comment to see the full error message
     render(<MessageFormatter breadcrumb={breadcrumbs[3]} />);
 
     expect(screen.getByText('{}')).toBeInTheDocument();
   });
 
   it('Should ignore the "%c" placheholder and print the console message correctly', () => {
+    // @ts-expect-error TS(2322) FIXME: Type 'DefaultCrumb | undefined' is not assignable ... Remove this comment to see the full error message
     render(<MessageFormatter breadcrumb={breadcrumbs[4]} />);
 
     expect(screen.getByText('prev state {"cart":[]}')).toBeInTheDocument();
   });
 
   it('Should print arrays correctly', () => {
+    // @ts-expect-error TS(2322) FIXME: Type 'DefaultCrumb | undefined' is not assignable ... Remove this comment to see the full error message
     render(<MessageFormatter breadcrumb={breadcrumbs[5]} />);
 
     expect(screen.getByText('test ["foo","bar"]')).toBeInTheDocument();

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -73,6 +73,7 @@ function DomMutations({replay}: Props) {
 
   const renderRow = ({index, key, style, parent}: ListRowProps) => {
     const mutation = items[index];
+    // @ts-expect-error TS(2339) FIXME: Property 'html' does not exist on type 'Extraction... Remove this comment to see the full error message
     const {html, crumb} = mutation;
     const {title} = getDetails(crumb);
 

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -277,7 +277,8 @@ function NetworkList({replayRecord, networkSpans}: Props) {
         <div key={key} style={style}>
           {rowIndex === 0
             ? columns[columnIndex]
-            : getNetworkColumnValue(network, columnIndex)}
+            : // @ts-expect-error TS(2345) FIXME: Argument of type 'NetworkSpan | undefined' is not ... Remove this comment to see the full error message
+              getNetworkColumnValue(network, columnIndex)}
         </div>
       </CellMeasurer>
     );

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -66,6 +66,7 @@ function Replays({location}: Props) {
             fetchError={fetchError}
             replays={replays}
             showProjectColumn={minWidthIsSmall}
+            // @ts-expect-error TS(2322) FIXME: Type 'Sort | undefined' is not assignable to type ... Remove this comment to see the full error message
             sort={eventView.sorts[0]}
           />
           <Pagination

--- a/static/app/views/sentryAppExternalInstallation.tsx
+++ b/static/app/views/sentryAppExternalInstallation.tsx
@@ -254,6 +254,7 @@ export default class SentryAppExternalInstallation extends AsyncView<Props, Stat
   renderSingleOrgView() {
     const {organizations, sentryApp} = this.state;
     // pull the name out of organizations since state.organization won't be loaded initially
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const organizationName = organizations[0].name;
     return (
       <div>

--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -181,13 +181,16 @@ class AccountNotificationFineTuning extends AsyncView<Props, State> {
 
     const isProject = isGroupedByProject(fineTuneType);
     const field = ACCOUNT_NOTIFICATION_FIELDS[fineTuneType];
+    // @ts-expect-error TS(2339) FIXME: Property 'title' does not exist on type 'FineTuneF... Remove this comment to see the full error message
     const {title, description} = field;
 
+    // @ts-expect-error TS(2488) FIXME: Type '[string, string, any?, any?] | [] | undefine... Remove this comment to see the full error message
     const [stateKey, url] = isProject ? this.getEndpoints()[2] : [];
     const hasProjects = !!projects?.length;
 
     if (fineTuneType === 'email') {
       // Fetch verified email addresses
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       field.options = this.emailChoices.map(({email}) => ({value: email, label: email}));
     }
 
@@ -212,6 +215,7 @@ class AccountNotificationFineTuning extends AsyncView<Props, State> {
             >
               <JsonForm
                 title={`Default ${title}`}
+                // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
                 fields={[fields[field.defaultFieldName]]}
               />
             </Form>
@@ -237,6 +241,7 @@ class AccountNotificationFineTuning extends AsyncView<Props, State> {
               initialData={fineTuneData}
             >
               {isProject && hasProjects && (
+                // @ts-expect-error TS(2322) FIXME: Type 'FineTuneField | undefined' is not assignable... Remove this comment to see the full error message
                 <AccountNotificationsByProject projects={projects!} field={field} />
               )}
 
@@ -245,6 +250,7 @@ class AccountNotificationFineTuning extends AsyncView<Props, State> {
               )}
 
               {!isProject && (
+                // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                 <AccountNotificationsByOrganizationContainer field={field} />
               )}
             </Form>

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -100,8 +100,11 @@ const getFields = ({
   if (authenticator.id === 'sms') {
     // Ideally we would have greater flexibility when rendering footer
     return [
+      // @ts-expect-error TS(2322) FIXME: Type '{ disabled: boolean; } | { disabled: boolean... Remove this comment to see the full error message
       {...form[0], disabled: sendingCode || hasSentCode},
+      // @ts-expect-error TS(2322) FIXME: Type '{ required: boolean; } | { required: boolean... Remove this comment to see the full error message
       ...(hasSentCode ? [{...form[1], required: true}] : []),
+      // @ts-expect-error TS(2322) FIXME: Type '(() => Element) | { required: boolean; } | {... Remove this comment to see the full error message
       () => (
         <Actions key="sms-footer">
           <ButtonBar gap={1}>

--- a/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.spec.tsx
@@ -57,6 +57,7 @@ describe('NotificationSettings', function () {
       ...SELF_NOTIFICATION_SETTINGS_TYPES,
     ].forEach(field => {
       expect(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         screen.getByText(String(NOTIFICATION_SETTING_FIELDS[field].label))
       ).toBeInTheDocument();
     });
@@ -97,6 +98,7 @@ describe('NotificationSettings', function () {
       ...SELF_NOTIFICATION_SETTINGS_TYPES,
     ].forEach(field => {
       expect(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         screen.getByText(String(NOTIFICATION_SETTING_FIELDS[field].label))
       ).toBeInTheDocument();
     });
@@ -139,6 +141,7 @@ describe('NotificationSettings', function () {
         return;
       }
       expect(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         screen.getByText(String(NOTIFICATION_SETTING_FIELDS[field].label))
       ).toBeInTheDocument();
     });

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -143,6 +143,7 @@ class NotificationSettings extends AsyncComponent<Props, State> {
         help: (
           <Fragment>
             <p>
+              {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
               {NOTIFICATION_SETTING_FIELDS[notificationType].help}
               &nbsp;
               <Link

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -310,6 +310,7 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
 
     return organizations.filter(organization => {
       const externalID = integrationExternalIDsByOrganizationID[organization.id];
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       const identity = identitiesByExternalId[externalID];
       return identity === undefined || identity === null;
     });
@@ -322,6 +323,7 @@ class NotificationSettingsByType extends AsyncComponent<Props, State> {
       'slack'
     );
     const unlinkedOrgs = this.getUnlinkedOrgs();
+    // @ts-expect-error TS(2339) FIXME: Property 'title' does not exist on type 'FineTuneF... Remove this comment to see the full error message
     const {title, description} = ACCOUNT_NOTIFICATION_FIELDS[notificationType];
     return (
       <Fragment>

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -31,6 +31,7 @@ export const groupByOrganization = (
   >((acc, project) => {
     const orgSlug = project.organization.slug;
     if (acc.hasOwnProperty(orgSlug)) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       acc[orgSlug].projects.push(project);
     } else {
       acc[orgSlug] = {
@@ -68,6 +69,7 @@ export const getChoiceString = (choices: string[][], key: string): string => {
     throw new Error(`Could not find ${key}`);
   }
 
+  // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
   return found[1];
 };
 
@@ -177,7 +179,8 @@ export const getCurrentDefault = (
 ): string => {
   const providersList = getCurrentProviders(notificationType, notificationSettings);
   return providersList.length
-    ? getUserDefaultValues(notificationType, notificationSettings)[providersList[0]]
+    ? // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
+      getUserDefaultValues(notificationType, notificationSettings)[providersList[0]]
     : 'never';
 };
 
@@ -261,6 +264,7 @@ export const getParentData = (
   return Object.fromEntries(
     parents.map(parent => [
       parent.id,
+      // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
       getParentValues(notificationType, notificationSettings, parent.id)[provider],
     ])
   );
@@ -304,6 +308,7 @@ export const getStateToPutForProvider = (
 
   return {
     [notificationType]: Object.fromEntries(
+      // @ts-expect-error TS(2769) FIXME: No overload matches this call.
       Object.entries(notificationSettings[notificationType]).map(
         ([scopeType, scopeTypeData]) => [
           scopeType,
@@ -351,6 +356,7 @@ export const getStateToPutForDefault = (
   };
 
   if (newValue === 'never') {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     updatedNotificationSettings[notificationType][getParentKey(notificationType)] =
       Object.fromEntries(
         parentIds.map(parentId => [
@@ -360,6 +366,7 @@ export const getStateToPutForDefault = (
       );
   }
 
+  // @ts-expect-error TS(2322) FIXME: Type '{ [x: string]: { user: { me: { [k: string]: ... Remove this comment to see the full error message
   return updatedNotificationSettings;
 };
 
@@ -375,6 +382,7 @@ export const getStateToPutForParent = (
   const providerList = getCurrentProviders(notificationType, notificationSettings);
   const newValue = Object.values(changedData)[0];
 
+  // @ts-expect-error TS(2322) FIXME: Type '{ [x: string]: { [x: string]: { [x: string]:... Remove this comment to see the full error message
   return {
     [notificationType]: {
       [getParentKey(notificationType)]: {
@@ -400,6 +408,7 @@ export const getParentField = (
 ): FieldObject => {
   const defaultFields = NOTIFICATION_SETTING_FIELDS[notificationType];
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   let choices = defaultFields.choices;
   if (Array.isArray(choices)) {
     choices = choices.concat([

--- a/static/app/views/settings/components/dataScrubbing/convertRelayPiiConfig.tsx
+++ b/static/app/views/settings/components/dataScrubbing/convertRelayPiiConfig.tsx
@@ -14,6 +14,7 @@ export function convertRelayPiiConfig(relayPiiConfig?: string): Rule[] {
   const convertedRules: Array<Rule> = [];
 
   for (const application in applications) {
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     for (const rule of applications[application]) {
       const resolvedRule = rules[rule];
       const id = convertedRules.length;

--- a/static/app/views/settings/components/dataScrubbing/index.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.spec.tsx
@@ -156,6 +156,7 @@ describe('Data Scrubbing', function () {
         </Fragment>
       );
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByLabelText('Delete Rule')[0]);
 
       expect(
@@ -205,6 +206,7 @@ describe('Data Scrubbing', function () {
         {router}
       );
 
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       userEvent.click(screen.getAllByRole('button', {name: 'Edit Rule'})[0]);
 
       // Verify the router to open the modal was called

--- a/static/app/views/settings/components/dataScrubbing/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.tsx
@@ -80,6 +80,7 @@ export function DataScrubbing({
       modalProps => (
         <Edit
           {...modalProps}
+          // @ts-expect-error TS(2322) FIXME: Type 'Rule | undefined' is not assignable to type ... Remove this comment to see the full error message
           rule={rules[routeContext.params.scrubbingId]}
           projectId={project?.id}
           savedRules={rules}

--- a/static/app/views/settings/components/dataScrubbing/modals/add.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/add.spec.tsx
@@ -51,6 +51,7 @@ describe('Add Modal', function () {
     // Method Field
     expect(screen.getByText('Method')).toBeInTheDocument();
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByTestId('more-information')[0]);
     expect(await screen.findByText('What to do')).toBeInTheDocument();
 
@@ -66,6 +67,7 @@ describe('Add Modal', function () {
     // Type Field
     expect(screen.getByText('Data Type')).toBeInTheDocument();
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByTestId('more-information')[1]);
     expect(
       await screen.findByText(
@@ -90,6 +92,7 @@ describe('Add Modal', function () {
     // Source Field
     screen.getByRole('textbox', {name: 'Source'});
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByTestId('more-information')[2]);
 
     expect(
@@ -131,6 +134,7 @@ describe('Add Modal', function () {
 
     expect(screen.getByPlaceholderText('[Filtered]')).toBeInTheDocument();
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByTestId('more-information')[1]);
 
     expect(
@@ -167,6 +171,7 @@ describe('Add Modal', function () {
 
     expect(screen.getByPlaceholderText('[a-zA-Z0-9]+')).toBeInTheDocument();
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(screen.getAllByTestId('more-information')[2]);
 
     expect(

--- a/static/app/views/settings/components/dataScrubbing/modals/edit.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/edit.spec.tsx
@@ -38,6 +38,7 @@ async function renderComponent() {
       endpoint={endpoint}
       orgSlug={organizationSlug}
       onSubmitSuccess={successfullySaved}
+      // @ts-expect-error TS(2322) FIXME: Type 'Rule | undefined' is not assignable to type ... Remove this comment to see the full error message
       rule={rule}
     />
   ));
@@ -85,6 +86,7 @@ describe('Edit Modal', () => {
     );
     expect(placeholderField.find('Tooltip').prop('title')).toEqual(placeholderFieldHelp);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (rule.method === MethodType.REPLACE) {
       const placeholderInput = placeholderField.find('input');
       expect(placeholderInput.prop('value')).toEqual(rule.placeholder);
@@ -116,6 +118,7 @@ describe('Edit Modal', () => {
     expect(regexField.find('QuestionTooltip').prop('title')).toEqual(regexFieldHelp);
     expect(regexField.find('Tooltip').prop('title')).toEqual(regexFieldHelp);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (rule.type === RuleType.PATTERN) {
       const regexFieldInput = regexField.find('input');
       expect(regexFieldInput.prop('value')).toEqual(rule.pattern);
@@ -182,6 +185,7 @@ describe('Edit Modal', () => {
     // Source Field
     const sourceField = wrapper.find('[data-test-id="source-field"]');
     const sourceFieldInput = sourceField.find('input');
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     sourceFieldInput.simulate('change', {target: {value: valueSuggestions[2].value}});
 
     // Save rule

--- a/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.spec.tsx
@@ -162,7 +162,10 @@ describe('Source', function () {
 
     // everywhere
     expect(suggestions[0]).toHaveTextContent(
-      `${valueSuggestions[0].value}(${valueSuggestions[0].description})`
+      `${
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+        valueSuggestions[0].value
+      }(${valueSuggestions[0].description})`
     );
   });
 
@@ -182,6 +185,7 @@ describe('Source', function () {
 
     const suggestions = screen.getAllByRole('listitem');
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(suggestions[1]);
 
     expect(handleOnChange).toHaveBeenCalledWith('foo && password');

--- a/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
@@ -157,11 +157,13 @@ class SourceField extends Component<Props, State> {
     ) {
       // returns filtered binaries
       return this.getFilteredSuggestions(
+        // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
         lastFieldValue?.value,
         SourceSuggestionType.BINARY
       );
     }
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
     return this.getFilteredSuggestions(lastFieldValue?.value, lastFieldValue?.type);
   }
 
@@ -183,18 +185,23 @@ class SourceField extends Component<Props, State> {
         continue;
       }
 
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       if (value.includes('!') && !!value.split('!')[1]) {
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         const valueAfterUnaryOperator = value.split('!')[1];
         const selector = this.getAllSuggestions().find(
           s => s.value === valueAfterUnaryOperator
         );
         if (!selector) {
           fieldValues.push([
+            // @ts-expect-error TS(2322) FIXME: Type 'SourceSuggestion | undefined' is not assigna... Remove this comment to see the full error message
             unarySuggestions[0],
+            // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
             {type: SourceSuggestionType.STRING, value: valueAfterUnaryOperator},
           ]);
           continue;
         }
+        // @ts-expect-error TS(2322) FIXME: Type 'SourceSuggestion | undefined' is not assigna... Remove this comment to see the full error message
         fieldValues.push([unarySuggestions[0], selector]);
         continue;
       }
@@ -205,6 +212,7 @@ class SourceField extends Component<Props, State> {
         continue;
       }
 
+      // @ts-expect-error TS(2322) FIXME: Type 'string | undefined' is not assignable to typ... Remove this comment to see the full error message
       fieldValues.push({type: SourceSuggestionType.STRING, value});
     }
 
@@ -220,6 +228,7 @@ class SourceField extends Component<Props, State> {
   scrollToSuggestion() {
     const {activeSuggestion, hideCaret} = this.state;
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     this.suggestionList?.current?.children[activeSuggestion].scrollIntoView({
       behavior: 'smooth',
       block: 'nearest',
@@ -246,6 +255,7 @@ class SourceField extends Component<Props, State> {
         }
         continue;
       }
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       newValue.push(fieldValue.value);
     }
 
@@ -263,6 +273,7 @@ class SourceField extends Component<Props, State> {
     }
 
     if (Array.isArray(lastFieldValue)) {
+      // @ts-expect-error TS(2322) FIXME: Type 'SourceSuggestion | undefined' is not assigna... Remove this comment to see the full error message
       fieldValues[fieldValues.length - 1] = [lastFieldValue[0], suggestion];
       return fieldValues;
     }
@@ -353,6 +364,7 @@ class SourceField extends Component<Props, State> {
     }
 
     if (keyCode === 13) {
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'SourceSuggestion | undefined' is... Remove this comment to see the full error message
       this.handleClickSuggestionItem(suggestions[activeSuggestion]);
       return;
     }

--- a/static/app/views/settings/components/dataScrubbing/modals/handleError.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/handleError.tsx
@@ -16,6 +16,7 @@ type ResponseError = {
 };
 
 function handleError(error: ResponseError): Error {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const errorMessage = error.responseJSON?.relayPiiConfig[0];
 
   if (!errorMessage) {

--- a/static/app/views/settings/components/dataScrubbing/submitRules.tsx
+++ b/static/app/views/settings/components/dataScrubbing/submitRules.tsx
@@ -49,13 +49,18 @@ function submitRules(api: Client, endpoint: string, rules: Array<Rule>) {
   for (let i = 0; i < rules.length; i++) {
     const rule = rules[i];
     const ruleId = String(i);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'Rule | undefined' is not assigna... Remove this comment to see the full error message
     submitFormatRules[ruleId] = getSubmitFormatRule(rule);
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!applications[rule.source]) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       applications[rule.source] = [];
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!applications[rule.source].includes(ruleId)) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       applications[rule.source].push(ruleId);
     }
   }

--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -35,6 +35,7 @@ function SettingsLayout(props: Props) {
     const bodyElement = document.getElementsByTagName('body')[0];
 
     window.scrollTo?.(0, 0);
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     bodyElement.classList[visible ? 'add' : 'remove']('scroll-lock');
 
     setMobileNavVisible(visible);

--- a/static/app/views/settings/organizationAuth/organizationAuthList.tsx
+++ b/static/app/views/settings/organizationAuth/organizationAuthList.tsx
@@ -44,6 +44,7 @@ const OrganizationAuthList = ({organization, providerList, activeProvider}: Prop
     if (PROVIDER_POPULARITY[a.key] === PROVIDER_POPULARITY[b.key]) {
       return 0;
     }
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     return PROVIDER_POPULARITY[a.key] > PROVIDER_POPULARITY[b.key] ? 1 : -1;
   });
 

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.tsx
@@ -213,6 +213,7 @@ type InteractionsChartProps = {
 const InteractionsChart = ({data}: InteractionsChartProps) => {
   const elementInteractionsSeries: LineChartSeries[] = Object.keys(data).map(
     (key: string) => {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       const seriesData = data[key].map(point => ({
         value: point[1],
         name: point[0] * 1000,

--- a/static/app/views/settings/organizationDeveloperSettings/sentryFunctionsEnvironmentVariables.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryFunctionsEnvironmentVariables.tsx
@@ -27,6 +27,7 @@ function SentryFunctionEnvironmentVariables(props: Props) {
     while (newEnvVariables.length <= pos) {
       newEnvVariables.push({name: '', value: ''});
     }
+    // @ts-expect-error TS(2322) FIXME: Type '{ name: string; value?: string | undefined; ... Remove this comment to see the full error message
     newEnvVariables[pos] = {...newEnvVariables[pos], name: value};
     setEnvVariables(newEnvVariables);
   };
@@ -36,6 +37,7 @@ function SentryFunctionEnvironmentVariables(props: Props) {
     while (newEnvVariables.length <= pos) {
       newEnvVariables.push({name: '', value: ''});
     }
+    // @ts-expect-error TS(2322) FIXME: Type '{ value: string; name?: string | undefined; ... Remove this comment to see the full error message
     newEnvVariables[pos] = {...newEnvVariables[pos], value};
     setEnvVariables(newEnvVariables);
   };

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -263,6 +263,7 @@ class ConfigureIntegration extends AsyncView<Props, State> {
           <Alert type="info">
             {instructions?.length === 1 ? (
               <span
+                // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
                 dangerouslySetInnerHTML={{__html: singleLineRenderer(instructions[0])}}
               />
             ) : (

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -161,6 +161,7 @@ class OrganizationMembersList extends AsyncView<Props, State> {
       const inviteRequests = [...state.inviteRequests];
       const inviteIndex = inviteRequests.findIndex(request => request.id === id);
 
+      // @ts-expect-error TS(2322) FIXME: Type '{ dateCreated?: string | undefined; email?: ... Remove this comment to see the full error message
       inviteRequests[inviteIndex] = {...inviteRequests[inviteIndex], ...data};
 
       return {inviteRequests};
@@ -329,6 +330,7 @@ class OrganizationMembersList extends AsyncView<Props, State> {
                 params={params}
                 key={member.id}
                 member={member}
+                // @ts-expect-error TS(2769) FIXME: No overload matches this call.
                 status={this.state.invited[member.id]}
                 orgName={orgName}
                 memberCanLeave={!isOnlyOwner}

--- a/static/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersWrapper.tsx
@@ -98,6 +98,7 @@ class OrganizationMembersWrapper extends AsyncView<Props, State> {
       const inviteRequests = [...state.inviteRequests];
       const inviteIndex = inviteRequests.findIndex(request => request.id === id);
 
+      // @ts-expect-error TS(2322) FIXME: Type '{ dateCreated?: string | undefined; email?: ... Remove this comment to see the full error message
       inviteRequests[inviteIndex] = {...inviteRequests[inviteIndex], ...data};
 
       return {inviteRequests};

--- a/static/app/views/settings/organizationRelay/list/index.tsx
+++ b/static/app/views/settings/organizationRelay/list/index.tsx
@@ -40,6 +40,7 @@ const List = ({
   return (
     <div>
       {Object.keys(relaysByPublicKey).map(relayByPublicKey => {
+        // @ts-expect-error TS(2339) FIXME: Property 'name' does not exist on type '{ activiti... Remove this comment to see the full error message
         const {name, description, created, activities} =
           relaysByPublicKey[relayByPublicKey];
         return (

--- a/static/app/views/settings/organizationRelay/list/utils.tsx
+++ b/static/app/views/settings/organizationRelay/list/utils.tsx
@@ -14,7 +14,9 @@ export function getRelaysByPublicKey(
       relaysByPublicKey[publicKey] = {name, description, created, activities: []};
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     if (!relaysByPublicKey[publicKey].activities.length) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       relaysByPublicKey[publicKey].activities = relayActivities.filter(
         activity => activity.publicKey === publicKey
       );

--- a/static/app/views/settings/organizationTeams/roleOverwriteWarning.tsx
+++ b/static/app/views/settings/organizationTeams/roleOverwriteWarning.tsx
@@ -60,6 +60,7 @@ export function getOverwriteString(props: Props) {
     {
       selfNoun: isSelf ? 'Your' : "This user's",
       selfPronoun: isSelf ? 'you' : 'them',
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'string | undefined' is not assig... Remove this comment to see the full error message
       article: 'AEIOU'.includes(orgRoleObj.name[0]) ? 'an' : 'a',
       orgRole: <strong>{orgRoleObj.name}</strong>,
       teamRole: <strong>{teamRoleObj.name}</strong>,

--- a/static/app/views/settings/organizationTeams/teamMembersRow.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembersRow.tsx
@@ -73,6 +73,7 @@ const TeamRoleSelect = (props: {
   ) {
     return (
       <RoleName>
+        {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
         {teamRole.name}
         <IconWrapper>
           <RoleOverwriteIcon
@@ -89,6 +90,7 @@ const TeamRoleSelect = (props: {
     <RoleSelectWrapper>
       <RoleSelectControl
         roles={teamRoleList}
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         value={teamRole.id}
         onChange={option => updateMemberRole(member, option.value)}
         disableUnallowed

--- a/static/app/views/settings/organizationTeams/teamNotifications.tsx
+++ b/static/app/views/settings/organizationTeams/teamNotifications.tsx
@@ -124,6 +124,7 @@ class TeamNotificationSettings extends AsyncView<Props, State> {
             <div>
               <NotDisabledText>
                 {toTitleCase(externalTeam.provider)}:
+                {/* @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'. */}
                 {integrationsById[externalTeam.integrationId].name}
               </NotDisabledText>
               <NotDisabledSubText>

--- a/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/static/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -63,6 +63,7 @@ class ProjectFiltersChart extends Component<Props, State> {
   formatData(rawData: RawStats) {
     const seriesWithData: Set<string> = new Set();
     const transformed = Object.keys(STAT_OPS).map(stat => ({
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       data: rawData[stat].map(([timestamp, value]) => {
         if (value > 0) {
           seriesWithData.add(STAT_OPS[stat].title);
@@ -100,6 +101,7 @@ class ProjectFiltersChart extends Component<Props, State> {
       .then(results => {
         const rawStatsData: RawStats = {};
         for (let i = 0; i < statOptions.length; i++) {
+          // @ts-expect-error TS(2538) FIXME: Type 'undefined' cannot be used as an index type.
           rawStatsData[statOptions[i]] = results[i];
         }
 

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -152,6 +152,7 @@ class AddCodeOwnerModal extends AsyncComponent<Props, State> {
     const {errorJSON, codeMappingId, codeMappings} = this.state;
     const codeMapping = codeMappings.find(mapping => mapping.id === codeMappingId);
     const {integrationId, provider} = codeMapping as RepositoryProjectPathConfig;
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     const errActors = errorJSON?.raw?.[0].split('\n').map((el, i) => <p key={i}>{el}</p>);
     return (
       <Alert type="error" showIcon>

--- a/static/app/views/settings/project/projectSettingsNavigation.tsx
+++ b/static/app/views/settings/project/projectSettingsNavigation.tsx
@@ -16,6 +16,7 @@ const ProjectSettingsNavigation = ({organization, project}: Props) => {
 
   const debugFilesNeedsReview = appStoreConnectContext
     ? Object.keys(appStoreConnectContext).some(
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         key => appStoreConnectContext[key].credentials.status === 'invalid'
       )
     : false;

--- a/static/app/views/settings/project/server-side-sampling/draggableRuleList.tsx
+++ b/static/app/views/settings/project/server-side-sampling/draggableRuleList.tsx
@@ -79,6 +79,7 @@ export function DraggableRuleList({
             index={index}
             renderItem={renderItem}
             disabled={
+              // @ts-expect-error TS(2345) FIXME: Argument of type '{ id: number; active?: boolean |... Remove this comment to see the full error message
               disabled || isUniformRule({...items[index], id: Number(items[index].id)})
             }
             wrapperStyle={wrapperStyle}

--- a/static/app/views/settings/project/server-side-sampling/modals/affectOtherProjectsTransactionsAlert.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/affectOtherProjectsTransactionsAlert.tsx
@@ -25,6 +25,7 @@ export function AffectOtherProjectsTransactionsAlert({
   if (
     affectedProjects.length === 0 ||
     isProjectIncompatible ||
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     (affectedProjects.length === 1 && affectedProjects[0].slug === projectSlug)
   ) {
     return null;

--- a/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
@@ -64,7 +64,10 @@ describe('Server-Side Sampling - Recommended Steps Modal', function () {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          `This project is on ${mockedSamplingSdkVersions[1].latestSDKName}@v${mockedSamplingSdkVersions[1].latestSDKVersion}`
+          `This project is on ${
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
+            mockedSamplingSdkVersions[1].latestSDKName
+          }@v${mockedSamplingSdkVersions[1].latestSDKVersion}`
         )
       )
     ).toBeInTheDocument();

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.spec.tsx
@@ -402,6 +402,7 @@ describe('Server-Side Sampling - Specific Conditions Modal', function () {
       expect(screen.queryByTestId('multivalue')).not.toBeInTheDocument();
     });
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(screen.getAllByLabelText('Delete Condition')[0]);
 
     // Click on the release condition option

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/index.tsx
@@ -125,11 +125,14 @@ export function SpecificConditionsModal({
       return;
     }
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     switch (error.type) {
       case 'sampleRate':
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         setData({...data, errors: {...errors, sampleRate: error.message}});
         break;
       default:
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         addErrorMessage(error.message);
     }
   }
@@ -254,10 +257,12 @@ export function SpecificConditionsModal({
     value: Condition[T]
   ) {
     const newConditions = [...conditions];
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     newConditions[index][field] = value;
 
     // If custom tag key changes, reset the value
     if (field === 'category') {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       newConditions[index].match = '';
 
       trackAdvancedAnalyticsEvent('sampling.settings.modal.specific.rule.condition_add', {

--- a/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/utils.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/specificConditionsModal/utils.tsx
@@ -93,6 +93,7 @@ export function getErrorMessage(
 
   const responseErrors = errorResponse.dynamicSampling?.rules[currentRuleIndex] ?? {};
 
+  // @ts-expect-error TS(2488) FIXME: Type '[string, number | boolean | SamplingConditio... Remove this comment to see the full error message
   const [type, _value] = Object.entries(responseErrors)[0];
 
   if (type === 'sampleRate') {

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.spec.tsx
@@ -95,6 +95,7 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     expect(screen.queryByTestId('invalid-server-rate')).not.toBeInTheDocument(); // Server input warning is not visible
 
     // Enter invalid client-side sample rate
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.clear(screen.getAllByRole('spinbutton')[0]);
     userEvent.hover(screen.getByTestId('invalid-client-rate')); // Client input warning is visible
     expect(await screen.findByText('Set a value between 0 and 100')).toBeInTheDocument();
@@ -105,6 +106,7 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     expect(await screen.findByText('Sample rate is not valid')).toBeInTheDocument();
 
     // Enter valid custom client-sample rate
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.type(screen.getAllByRole('spinbutton')[0], '20{enter}');
     expect(screen.queryByText('Suggested')).not.toBeInTheDocument();
     expect(screen.getAllByRole('spinbutton')[0]).toHaveValue(20); // Custom client-side sample rate
@@ -112,11 +114,13 @@ describe('Server-Side Sampling - Uniform Rate Modal', function () {
     expect(screen.getByLabelText('Reset to suggested values')).toBeInTheDocument();
 
     // Enter invalid server-side sample rate
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.clear(screen.getAllByRole('spinbutton')[1]);
     userEvent.hover(screen.getByTestId('invalid-server-rate')); // Server input warning is visible
     expect(await screen.findByText('Set a value between 0 and 100')).toBeInTheDocument();
 
     // Enter a server-side sample rate higher than the client-side rate
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.type(screen.getAllByRole('spinbutton')[1], '30{enter}');
     userEvent.hover(screen.getByTestId('invalid-server-rate')); // Server input warning is visible
     expect(

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -138,6 +138,7 @@ export function UniformRateModal({
 
   const isWithoutTransactions =
     projectStats30d.data?.groups.reduce(
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       (acc, group) => acc + group.totals['sum(quantity)'],
       0
     ) === 0;

--- a/static/app/views/settings/project/server-side-sampling/samplingBreakdown.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingBreakdown.tsx
@@ -85,6 +85,7 @@ export function SamplingBreakdown({orgSlug}: Props) {
         ) : (
           <Fragment>
             <ColorBar
+              // @ts-expect-error TS(2322) FIXME: Type '{ color: string | undefined; percent: number... Remove this comment to see the full error message
               colorStops={projectsWithPercentages.map(({project, percentage}, index) => ({
                 color: theme.charts.getColorPalette(projectsWithPercentages.length)[
                   index

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
@@ -252,13 +252,16 @@ describe('Server-Side Sampling', function () {
     // Assert that project breakdown is there (avoids 'act' warnings)
     expect(await screen.findByText(samplingBreakdownTitle)).toBeInTheDocument();
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(screen.getAllByLabelText('Actions')[0]);
     expect(screen.getByRole('menuitemradio', {name: 'Delete'})).toHaveAttribute(
       'aria-disabled',
       'false'
     );
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(screen.getAllByLabelText('Actions')[0]);
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.click(screen.getAllByLabelText('Actions')[1]);
     expect(screen.getByRole('menuitemradio', {name: 'Delete'})).toHaveAttribute(
       'aria-disabled',
@@ -602,9 +605,11 @@ describe('Server-Side Sampling', function () {
     const samplingUniformRule = screen.getAllByTestId('sampling-rule')[1];
 
     expect(
+      // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
       within(samplingUniformRule).getByRole('button', {name: 'Drag Rule'})
     ).toHaveAttribute('aria-disabled', 'true');
 
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'HTMLElement | undefined' is not ... Remove this comment to see the full error message
     userEvent.hover(within(samplingUniformRule).getByLabelText('Drag Rule'));
 
     expect(

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -603,10 +603,15 @@ export function ServerSideSampling({project}: Props) {
                 const itemsRule = items[itemsRuleIndex];
 
                 const currentRule = {
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   active: itemsRule.active,
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   condition: itemsRule.condition,
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   sampleRate: itemsRule.sampleRate,
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   type: itemsRule.type,
+                  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                   id: Number(itemsRule.id),
                 };
 
@@ -614,6 +619,7 @@ export function ServerSideSampling({project}: Props) {
                   <RulesPanelLayout isContent>
                     <Rule
                       operator={
+                        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
                         itemsRule.id === items[0].id
                           ? SamplingRuleOperator.IF
                           : isUniformRule(currentRule)

--- a/static/app/views/settings/project/server-side-sampling/testUtils.tsx
+++ b/static/app/views/settings/project/server-side-sampling/testUtils.tsx
@@ -123,7 +123,9 @@ export const mockedSamplingSdkVersions: SamplingSdkVersion[] = [
 export const recommendedSdkUpgrades: RecommendedSdkUpgrade[] = [
   {
     project: mockedProjects[1],
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     latestSDKName: mockedSamplingSdkVersions[1].latestSDKName,
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     latestSDKVersion: mockedSamplingSdkVersions[1].latestSDKVersion,
   },
 ];

--- a/static/app/views/settings/project/server-side-sampling/utils/hasFirstBucketsEmpty.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/hasFirstBucketsEmpty.tsx
@@ -17,6 +17,7 @@ export function hasFirstBucketsEmpty(
     const series = group.series[quantityField];
 
     for (let i = 0; i < numberOfLeadingEmptyBuckets; i++) {
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       groupAcc += series[i];
     }
 

--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToPredictedSeries.tsx
@@ -46,13 +46,16 @@ export function projectStatsToPredictedSeries(
       projectStats.groups.forEach(group => {
         switch (group.by.outcome) {
           case Outcome.ACCEPTED:
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             result.indexedAndProcessed += group.series[quantityField][index];
             break;
           case Outcome.CLIENT_DISCARD:
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             result.discarded += group.series[quantityField][index];
             break;
           case Outcome.FILTERED:
             if (String(group.by.reason).startsWith('Sampled')) {
+              // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
               result.processed += group.series[quantityField][index];
             }
             break;

--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSampleRates.tsx
@@ -66,17 +66,23 @@ export function projectStatsToSampleRates(stats: SeriesApi | undefined): {
   safeSampleRates.sort((a, z) => a - z);
 
   let trueSampleRate = trueSampleRates[Math.floor(trueSampleRates.length / 2)];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   if (trueSampleRate > COMMON_SAMPLE_RATES[0]) {
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
     trueSampleRate = findClosestNumber(trueSampleRate, COMMON_SAMPLE_RATES);
   }
 
   let maxSafeSampleRate = safeSampleRates[0];
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   if (maxSafeSampleRate > COMMON_SAMPLE_RATES[0]) {
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
     maxSafeSampleRate = findClosestNumber(maxSafeSampleRate, COMMON_SAMPLE_RATES);
   }
 
   return {
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
     trueSampleRate: round(trueSampleRate, 4),
+    // @ts-expect-error TS(2345) FIXME: Argument of type 'number | undefined' is not assig... Remove this comment to see the full error message
     maxSafeSampleRate: round(maxSafeSampleRate, 4),
     hoursOverLimit,
   };

--- a/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSeries.tsx
+++ b/static/app/views/settings/project/server-side-sampling/utils/projectStatsToSeries.tsx
@@ -41,14 +41,18 @@ export function projectStatsToSeries(
     projectStats.groups.forEach(group => {
       switch (group.by.outcome) {
         case Outcome.ACCEPTED:
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           seriesData.indexedAndProcessed[index].value +=
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             group.series[quantityField][index];
           break;
         case Outcome.CLIENT_DISCARD:
+          // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
           seriesData.discarded[index].value += group.series[quantityField][index];
           break;
         case Outcome.FILTERED:
           if (String(group.by.reason).startsWith('Sampled')) {
+            // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
             seriesData.processed[index].value += group.series[quantityField][index];
           }
           break;
@@ -63,6 +67,7 @@ export function projectStatsToSeries(
     // calculate the discard client (SDK) bucket according to the specified client rate
     seriesData.discarded = seriesData.discarded.map((bucket, index) => {
       const totalHitServer =
+        // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
         seriesData.indexedAndProcessed[index].value + seriesData.processed[index].value;
 
       return {

--- a/static/app/views/settings/projectAlerts/settings.tsx
+++ b/static/app/views/settings/projectAlerts/settings.tsx
@@ -132,12 +132,14 @@ class Settings extends AsyncView<Props, State> {
           <JsonForm
             disabled={!canEditRule}
             title={t('Email Settings')}
+            // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
             fields={[fields.subjectTemplate]}
           />
 
           <JsonForm
             title={t('Digests')}
             disabled={!canEditRule}
+            // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
             fields={[fields.digestsMinDelay, fields.digestsMaxDelay]}
             renderHeader={() => (
               <PanelAlert type="info">

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
@@ -162,6 +162,7 @@ function CustomRepositories({
     newRepositories.splice(index, 1);
     persistData({
       updatedItems: newRepositories as CustomRepo[],
+      // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
       refresh: repositories[index].type === CustomRepoType.APP_STORE_CONNECT,
     });
   }

--- a/static/app/views/settings/projectGeneralSettings.tsx
+++ b/static/app/views/settings/projectGeneralSettings.tsx
@@ -267,18 +267,21 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
           <JsonForm
             {...jsonFormProps}
             title={t('Project Details')}
+            // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
             fields={[fields.name, fields.platform]}
           />
 
           <JsonForm
             {...jsonFormProps}
             title={t('Email')}
+            // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
             fields={[fields.subjectPrefix]}
           />
 
           <JsonForm
             {...jsonFormProps}
             title={t('Event Settings')}
+            // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
             fields={[fields.resolveAge]}
           />
 
@@ -286,10 +289,15 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
             {...jsonFormProps}
             title={t('Client Security')}
             fields={[
+              // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
               fields.allowedDomains,
+              // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
               fields.scrapeJavaScript,
+              // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
               fields.securityToken,
+              // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
               fields.securityTokenHeader,
+              // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
               fields.verifySSL,
             ]}
             renderHeader={() => (

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -91,12 +91,14 @@ class ProjectIssueGrouping extends AsyncView<Props, State> {
           <JsonForm
             {...jsonFormProps}
             title={t('Fingerprint Rules')}
+            // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
             fields={[fields.fingerprintingRules]}
           />
 
           <JsonForm
             {...jsonFormProps}
             title={t('Stack Trace Rules')}
+            // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
             fields={[fields.groupingEnhancements]}
           />
 
@@ -105,8 +107,11 @@ class ProjectIssueGrouping extends AsyncView<Props, State> {
               {...jsonFormProps}
               title={t('Change defaults')}
               fields={[
+                // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
                 fields.groupingConfig,
+                // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
                 fields.secondaryGroupingConfig,
+                // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
                 fields.secondaryGroupingExpiry,
               ]}
             />
@@ -115,6 +120,7 @@ class ProjectIssueGrouping extends AsyncView<Props, State> {
           <JsonForm
             {...jsonFormProps}
             title={t('Automatic Grouping Updates')}
+            // @ts-expect-error TS(2322) FIXME: Type 'Field | undefined' is not assignable to type... Remove this comment to see the full error message
             fields={[fields.groupingAutoUpdate]}
           />
 

--- a/static/app/views/settings/projectSecurityHeaders/reportUri.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/reportUri.tsx
@@ -9,6 +9,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 const DEFAULT_ENDPOINT = 'https://sentry.example.com/api/security-report/';
 
 export function getSecurityDsn(keyList: ProjectKey[]) {
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   const endpoint = keyList.length ? keyList[0].dsn.security : DEFAULT_ENDPOINT;
   return getDynamicText({
     value: endpoint,

--- a/tests/js/sentry-test/performance/initializePerformanceData.ts
+++ b/tests/js/sentry-test/performance/initializePerformanceData.ts
@@ -226,6 +226,7 @@ export function generateSampleSpan(
     data: {},
   };
 
+  // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
   event.entries[0].data.push(span);
   return span;
 }

--- a/tests/js/sentry-test/performance/utils.ts
+++ b/tests/js/sentry-test/performance/utils.ts
@@ -94,6 +94,7 @@ export class TransactionEventBuilder {
     span.trace_id = this.TRACE_ID;
     span.parent_span_id = parentSpanId ?? this.ROOT_SPAN_ID;
 
+    // @ts-expect-error TS(2532) FIXME: Object is possibly 'undefined'.
     this.#event.entries[0].data.push(span);
 
     switch (mSpan.problemSpan) {


### PR DESCRIPTION
I'm interested in turning this on, but first want to see how much effort will it be to bring the app into compliance.

CI says that there are 1,910 instances in static/app we'd need to deal with to turn this new rule on.

One strategy we could use is to first run https://github.com/airbnb/ts-migrate/tree/master/packages/ts-migrate so the app is happy and no new problems get added, then work through all the `@ts-expect-error` that were added (they have a pattern).