### PR TITLE
fix(settings): Fix platform documentation link

### DIFF
--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -24,7 +24,7 @@ import SettingsLayout from 'sentry/views/settings/components/settingsLayout';
 
 const LINKS = {
   DOCUMENTATION: 'https://docs.sentry.io/',
-  DOCUMENTATION_PLATFORMS: 'https://docs.sentry.io/clients/',
+  DOCUMENTATION_PLATFORMS: 'https://docs.sentry.io/platforms/',
   DOCUMENTATION_QUICKSTART: 'https://docs.sentry.io/platform-redirect/?next=/',
   DOCUMENTATION_CLI: 'https://docs.sentry.io/product/cli/',
   DOCUMENTATION_API: 'https://docs.sentry.io/api/',


### PR DESCRIPTION
I found this while auditing the settings page routes for customer domains.

https://docs.sentry.io/clients/ points to legacy clients. https://docs.sentry.io/platforms/ is the right link.