### PR TITLE
fix(forms): clean optional value

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -256,7 +256,7 @@ class EventFrequencyPercentForm(EventFrequencyForm):
         if (
             cleaned_data
             and cleaned_data["comparisonType"] == COMPARISON_TYPE_COUNT
-            and cleaned_data["value"] > 100
+            and cleaned_data.get("value", 0) > 100
         ):
             self.add_error(
                 "value", forms.ValidationError("Ensure this value is less than or equal to 100")


### PR DESCRIPTION
The `value` field is optional, so check it is there before comparing. If it's not, the error is already recorded in another function.

fixes SENTRY-TK4