### PR TITLE
ref(searchbox): quick pass on performance

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -48,17 +48,6 @@ const getFunctionTags = (fields: Readonly<Field[]>) =>
       ])
   );
 
-const getFieldTags = () =>
-  Object.fromEntries(
-    Object.keys(FIELD_TAGS).map(key => [
-      key,
-      {
-        ...FIELD_TAGS[key],
-        kind: FieldKind.FIELD,
-      },
-    ])
-  );
-
 const getMeasurementTags = (
   measurements: Parameters<
     React.ComponentProps<typeof Measurements>['children']
@@ -74,22 +63,29 @@ const getMeasurementTags = (
     ])
   );
 
-const getSpanTags = () => {
-  return Object.fromEntries(
-    SPAN_OP_BREAKDOWN_FIELDS.map(key => [key, {key, name: key, kind: FieldKind.METRICS}])
-  );
-};
+const COMPUTED_FIELD_TAGS = Object.fromEntries(
+  Object.keys(FIELD_TAGS).map(key => [
+    key,
+    {
+      ...FIELD_TAGS[key],
+      kind: FieldKind.FIELD,
+    },
+  ])
+);
 
-const getSemverTags = () =>
-  Object.fromEntries(
-    Object.keys(SEMVER_TAGS).map(key => [
-      key,
-      {
-        ...SEMVER_TAGS[key],
-        kind: FieldKind.FIELD,
-      },
-    ])
-  );
+const COMPUTER_SPAN_TAGS = Object.fromEntries(
+  SPAN_OP_BREAKDOWN_FIELDS.map(key => [key, {key, name: key, kind: FieldKind.METRICS}])
+);
+
+const COMPUTER_SEMVER_TAGS = Object.fromEntries(
+  Object.keys(SEMVER_TAGS).map(key => [
+    key,
+    {
+      ...SEMVER_TAGS[key],
+      kind: FieldKind.FIELD,
+    },
+  ])
+);
 
 export type SearchBarProps = Omit<React.ComponentProps<typeof SmartSearchBar>, 'tags'> & {
   organization: Organization;
@@ -181,10 +177,10 @@ function SearchBar(props: SearchBarProps) {
     }
 
     const functionTags = getFunctionTags(fields ?? []);
-    const fieldTags = getFieldTags();
     const measurementsWithKind = getMeasurementTags(measurements);
-    const spanTags = getSpanTags();
-    const semverTags = getSemverTags();
+    const fieldTags = COMPUTED_FIELD_TAGS;
+    const spanTags = COMPUTER_SPAN_TAGS;
+    const semverTags = COMPUTER_SEMVER_TAGS;
 
     const orgHasPerformanceView = organization.features.includes('performance-view');
 

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -633,8 +633,7 @@ export const MEASUREMENT_PATTERN = /^measurements\.([a-zA-Z0-9-_.]+)$/;
 export const SPAN_OP_BREAKDOWN_PATTERN = /^spans\.([a-zA-Z0-9-_.]+)$/;
 
 export function isMeasurement(field: string): boolean {
-  const results = field.match(MEASUREMENT_PATTERN);
-  return !!results;
+  return MEASUREMENT_PATTERN.test(field);
 }
 
 export function measurementType(field: string): MeasurementType {

--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -363,9 +363,9 @@ export function getNumEquations(possibleEquations: string[]) {
   return possibleEquations.filter(isEquation).length;
 }
 
+const DEFINED_MEASUREMENTS = new Set(Object.keys(getMeasurements()));
 export function isCustomMeasurement(field: string) {
-  const definedMeasurements = Object.keys(getMeasurements());
-  return isMeasurement(field) && !definedMeasurements.includes(field);
+  return !DEFINED_MEASUREMENTS.has(field) && isMeasurement(field);
 }
 
 export function isCustomMeasurementWidget(widget: Widget) {


### PR DESCRIPTION
We have been tracking this fn for a while through a [transaction in Sentry](https://sentry.io/organizations/sentry/discover/results/?field=p75%28transaction.duration%29&field=p99%28transaction.duration%29&field=p100%28transaction.duration%29&name=SearchBox.getTagList&project=-1&query=title%3ASearchBar.getTagList&statsPeriod=14d&yAxis=p75%28transaction.duration%29&yAxis=p99%28transaction.duration%29&yAxis=p100%28transaction.duration%29) and it seems that for some users the execution time could be well above the 16ms budget which would result in dropped frames. 

This is just a quick initial pass that avoids a few unnecessary fn calls and tries to reuse some values, there is probably more to do here, but we can re-evaluate this after.

<img width="1255" alt="CleanShot 2022-11-01 at 13 55 48@2x" src="https://user-images.githubusercontent.com/9317857/199304207-ae264f2d-35a6-4585-b2ab-9fb63db5af38.png">
