### PR TITLE
fix(all-events) typo in performance.issue_id which exposes it in the search bar

### DIFF
--- a/static/app/views/organizationGroupDetails/groupEvents.tsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.tsx
@@ -39,7 +39,7 @@ type State = {
   renderNewAllEventsTab: boolean;
 };
 
-const excludedTags = ['environment', 'issue', 'issue.id', 'performance.issues_ids'];
+const excludedTags = ['environment', 'issue', 'issue.id', 'performance.issue_ids'];
 
 class GroupEvents extends Component<Props, State> {
   constructor(props: Props) {


### PR DESCRIPTION
Fixes PERF-1793

The discover field is `performance.issue_ids` and not `performance.issues_ids`, which resulted it to appear in the search bar.