### PR TITLE
fix(all-events) ensure error state is set correctly

### DIFF
--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -87,7 +87,7 @@ const AllEventsTable = (props: Props) => {
       projectId={projectId}
       totalEventCount={totalEventCount}
       customColumns={['minidump']}
-      setError={(msg: string | undefined) => setError(msg || '')}
+      setError={(msg: string | undefined) => setError(msg ?? '')}
       transactionName=""
       columnTitles={columnTitles.slice()}
       referrer="api.issues.issue_events"

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -87,9 +87,7 @@ const AllEventsTable = (props: Props) => {
       projectId={projectId}
       totalEventCount={totalEventCount}
       customColumns={['minidump']}
-      setError={() => {
-        (msg: string) => setError(msg);
-      }}
+      setError={(msg: string | undefined) => setError(msg || '')}
       transactionName=""
       columnTitles={columnTitles.slice()}
       referrer="api.issues.issue_events"

--- a/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
@@ -389,6 +389,32 @@ describe('groupEvents', function () {
         expect.objectContaining({query: expect.not.objectContaining({sort: 'user'})})
       );
     });
+
+    it('shows discover query error message', async () => {
+      discoverRequest = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events/',
+        statusCode: 500,
+        body: {
+          detail: 'Internal Error',
+          errorId: '69ab396e73704cdba9342ff8dcd59795',
+        },
+      });
+
+      render(
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging']}}}
+        />,
+        {context: routerContext, organization}
+      );
+
+      await waitForElementToBeRemoved(document.querySelector('div.loading-indicator'));
+
+      expect(screen.getByTestId('loading-error')).toHaveTextContent('Internal Error');
+    });
   });
 
   it('does not renders new events table if error', function () {


### PR DESCRIPTION
Fixes PERF-1794

Perviously when the discover query would timeout, or have some error, the error state would not be set correctly, and instead the table would just show there are no events for the query.

This PR ensures error state is set correctly
<img width="599" alt="image" src="https://user-images.githubusercontent.com/44422760/199325911-203c2754-bfdc-4bbf-b30f-f9161ddca82e.png">
