### PR TITLE
fix(alerts): temporarily disable spike protection notif settings

### DIFF
--- a/static/app/views/settings/account/notifications/constants.tsx
+++ b/static/app/views/settings/account/notifications/constants.tsx
@@ -71,3 +71,10 @@ export const CONFIRMATION_MESSAGE = (
     </p>
   </div>
 );
+
+export const NOTIFICATION_FEATURE_MAP: Partial<Record<NotificationSettingsType, string>> =
+  {
+    quota: 'slack-overage-notifications',
+    activeRelease: 'active-release-monitor-alpha',
+    spikeProtection: 'spike-projections',
+  };

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -113,7 +113,6 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, Field> = {
       ['never', t('Off')],
     ],
     help: t('Notifications about spikes on a per project basis.'),
-    disabled: true,
   },
   personalActivityNotifications: {
     name: 'personalActivityNotifications',

--- a/static/app/views/settings/account/notifications/fields2.tsx
+++ b/static/app/views/settings/account/notifications/fields2.tsx
@@ -113,6 +113,7 @@ export const NOTIFICATION_SETTING_FIELDS: Record<string, Field> = {
       ['never', t('Off')],
     ],
     help: t('Notifications about spikes on a per project basis.'),
+    disabled: true,
   },
   personalActivityNotifications: {
     name: 'personalActivityNotifications',

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -7,7 +7,6 @@ import JsonForm from 'sentry/components/forms/jsonForm';
 import FormModel from 'sentry/components/forms/model';
 import {FieldObject} from 'sentry/components/forms/types';
 import Link from 'sentry/components/links/link';
-import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconMail} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
@@ -15,6 +14,7 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import withOrganizations from 'sentry/utils/withOrganizations';
 import {
   CONFIRMATION_MESSAGE,
+  NOTIFICATION_FEATURE_MAP,
   NOTIFICATION_SETTINGS_PATHNAMES,
   NOTIFICATION_SETTINGS_TYPES,
   NotificationSettingsObject,
@@ -96,22 +96,14 @@ class NotificationSettings extends AsyncComponent<Props, State> {
   };
 
   get notificationSettingsType() {
-    // filter out quotas if the feature flag isn't set
-    const hasSlackOverage = this.props.organizations.some(org =>
-      org.features?.includes('slack-overage-notifications')
-    );
-    const hasActiveRelease = this.props.organizations.some(org =>
-      org.features?.includes('active-release-monitor-alpha')
-    );
-
+    // filter out notification settings if the feature flag isn't set
     return NOTIFICATION_SETTINGS_TYPES.filter(type => {
-      if (type === 'quota' && !hasSlackOverage) {
-        return false;
+      const notificationFlag = NOTIFICATION_FEATURE_MAP[type];
+      if (notificationFlag) {
+        return this.props.organizations.some(org =>
+          org.features?.includes(notificationFlag)
+        );
       }
-      if (type === 'activeRelease' && !hasActiveRelease) {
-        return false;
-      }
-
       return true;
     });
   }
@@ -153,12 +145,6 @@ class NotificationSettings extends AsyncComponent<Props, State> {
               >
                 Fine tune
               </Link>
-              {notificationType === 'spikeProtection' && (
-                <Fragment>
-                  &nbsp;
-                  <QuestionTooltip position="top" title="Feature coming soon" size="xs" />
-                </Fragment>
-              )}
             </p>
           </Fragment>
         ),

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -7,6 +7,7 @@ import JsonForm from 'sentry/components/forms/jsonForm';
 import FormModel from 'sentry/components/forms/model';
 import {FieldObject} from 'sentry/components/forms/types';
 import Link from 'sentry/components/links/link';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import {IconMail} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
@@ -152,6 +153,12 @@ class NotificationSettings extends AsyncComponent<Props, State> {
               >
                 Fine tune
               </Link>
+              {notificationType === 'spikeProtection' && (
+                <Fragment>
+                  &nbsp;
+                  <QuestionTooltip position="top" title="Feature coming soon" size="xs" />
+                </Fragment>
+              )}
             </p>
           </Fragment>
         ),


### PR DESCRIPTION
Since spike protection isn't available yet, don't show the notification setting unless the feature flag is set

Without
![Screen Shot 2022-11-01 at 1 35 31 PM](https://user-images.githubusercontent.com/70817427/199335763-5193f377-9c42-4530-8313-8c860e55fa0b.png)


With
![Screen Shot 2022-11-01 at 1 34 35 PM](https://user-images.githubusercontent.com/70817427/199335571-c1b8daf2-1f48-4b55-9309-324a53c5f423.png)
