### PR TITLE
ref(tests): Convert `TransactionThresholdModal` to RTL and TSX

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
@@ -18,10 +18,11 @@ function mountModal(
 ) {
   render(
     <TransactionThresholdModal
-      Header={stubEl as ModalRenderProps['Header']}
-      Footer={stubEl as ModalRenderProps['Footer']}
-      Body={stubEl as ModalRenderProps['Body']}
-      CloseButton={stubEl as ModalRenderProps['CloseButton']}
+     Body={ModalBody}
+      closeModal={jest.fn()}
+      CloseButton={makeCloseButton(jest.fn())}
+      Header={makeClosableHeader(jest.fn())}
+      Footer={ModalFooter}
       eventView={eventView}
       organization={organization}
       transactionName="transaction/threshold"

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
@@ -2,14 +2,18 @@ import selectEvent from 'react-select-event';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {
+  makeClosableHeader,
+  makeCloseButton,
+  ModalBody,
+  ModalFooter,
+} from 'sentry/components/globalModal/components';
 import ProjectsStore from 'sentry/stores/projectsStore';
+import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import TransactionThresholdModal, {
   TransactionThresholdMetric,
 } from 'sentry/views/performance/transactionSummary/transactionThresholdModal';
-
-const stubEl = props => <div>{props.children}</div>;
 
 function mountModal(
   eventView: EventView,
@@ -18,7 +22,7 @@ function mountModal(
 ) {
   render(
     <TransactionThresholdModal
-     Body={ModalBody}
+      Body={ModalBody}
       closeModal={jest.fn()}
       CloseButton={makeCloseButton(jest.fn())}
       Header={makeClosableHeader(jest.fn())}
@@ -29,7 +33,6 @@ function mountModal(
       transactionThreshold={400}
       transactionThresholdMetric={TransactionThresholdMetric.LARGEST_CONTENTFUL_PAINT}
       onApply={onApply}
-      closeModal={() => void 0}
     />
   );
 }

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
@@ -1,6 +1,6 @@
 import selectEvent from 'react-select-event';
 
-import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {
   makeClosableHeader,
@@ -58,7 +58,7 @@ describe('TransactionThresholdModal', function () {
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
-    act(() => ProjectsStore.loadInitialData([project]));
+    ProjectsStore.loadInitialData([project]);
     postTransactionThresholdMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/project-transaction-threshold-override/',
       method: 'POST',

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
@@ -2,23 +2,27 @@ import selectEvent from 'react-select-event';
 
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {ModalRenderProps} from 'sentry/actionCreators/modal';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
-import TransactionThresholdModal from 'sentry/views/performance/transactionSummary/transactionThresholdModal';
+import TransactionThresholdModal, {
+  TransactionThresholdMetric,
+} from 'sentry/views/performance/transactionSummary/transactionThresholdModal';
 
 const stubEl = props => <div>{props.children}</div>;
 
 function mountModal(eventView, organization, onApply) {
   render(
     <TransactionThresholdModal
-      Header={stubEl}
-      Footer={stubEl}
-      Body={stubEl}
+      Header={stubEl as ModalRenderProps['Header']}
+      Footer={stubEl as ModalRenderProps['Footer']}
+      Body={stubEl as ModalRenderProps['Body']}
+      CloseButton={stubEl as ModalRenderProps['CloseButton']}
       eventView={eventView}
       organization={organization}
       transactionName="transaction/threshold"
-      transactionThreshold="400"
-      transactionThresholdMetric="lcp"
+      transactionThreshold={400}
+      transactionThresholdMetric={TransactionThresholdMetric.LARGEST_CONTENTFUL_PAINT}
       onApply={onApply}
       closeModal={() => void 0}
     />
@@ -28,16 +32,16 @@ function mountModal(eventView, organization, onApply) {
 describe('TransactionThresholdModal', function () {
   const organization = TestStubs.Organization({features: ['performance-view']});
   const project = TestStubs.Project();
-  const eventView = new EventView({
+  const eventView = EventView.fromSavedQuery({
     id: '1',
+    version: 2,
     name: 'my query',
-    fields: [{field: 'count()'}],
-    sorts: [{field: 'count', kind: 'desc'}],
+    fields: ['count()'],
+    orderby: '-count',
     query: '',
-    project: [project.id],
+    projects: [project.id],
     start: '2019-10-01T00:00:00',
     end: '2019-10-02T00:00:00',
-    statsPeriod: '14d',
     environment: [],
   });
 
@@ -87,7 +91,7 @@ describe('TransactionThresholdModal', function () {
       expect.objectContaining({
         data: {
           metric: 'duration',
-          threshold: '400',
+          threshold: 400,
           transaction: 'transaction/threshold',
         },
       })

--- a/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionThresholdModal.spec.tsx
@@ -11,7 +11,11 @@ import TransactionThresholdModal, {
 
 const stubEl = props => <div>{props.children}</div>;
 
-function mountModal(eventView, organization, onApply) {
+function mountModal(
+  eventView: EventView,
+  organization: Organization,
+  onApply: React.ComponentProps<typeof TransactionThresholdModal>['onApply']
+) {
   render(
     <TransactionThresholdModal
       Header={stubEl as ModalRenderProps['Header']}


### PR DESCRIPTION
This one is a little weird in a few places:

- RTL refuses to find `spinbutton` with a name, so I guess I'm just lucky there's only one?
- there's no visible loading state, so I had to manually await the mock, which I don't like
- typing into a `spinbutton` apparently saves its `value` as a string, very mysterious
