### PR TITLE
fix(events-table): remove referrer for events table

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -179,13 +179,12 @@ class EventsTable extends Component<Props, State> {
       const {issueId} = this.props;
       const isIssue: boolean = !!issueId;
       let target: LocationDescriptor = {};
+      // TODO: set referrer properly
       if (isIssue && field === 'id') {
         target.pathname = `/organizations/${organization.slug}/issues/${issueId}/events/${dataRow.id}/`;
-        target.search = '?referrer=events-table';
       } else {
         const generateLink = field === 'id' ? generateTransactionLink : generateTraceLink;
         target = generateLink(transactionName)(organization, dataRow, location.query);
-        // TODO: add referrer
       }
 
       return (


### PR DESCRIPTION
Seems like the logic for setting the referrer for `events-table` is corrupting the URL and referrer. Just reverting for now until we have a proper fix.

<img width="1077" alt="Screen Shot 2022-11-02 at 12 59 42 AM" src="https://user-images.githubusercontent.com/8533851/199363984-6c88f907-d7ed-4928-b682-243a3867099c.png">
