### PR TITLE
feat(hybrid-cloud): Inject customer domain feature whenever a customer domain is used in the request.

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -20,6 +20,7 @@ from sentry.api.serializers.models.role import (
 )
 from sentry.api.serializers.models.team import TeamSerializerResponse
 from sentry.api.utils import generate_organization_url, generate_region_url
+from sentry.app import env
 from sentry.auth.access import Access
 from sentry.constants import (
     ACCOUNT_RATE_LIMIT_DEFAULT,
@@ -54,6 +55,7 @@ from sentry.models import (
     TeamStatus,
 )
 from sentry.models.user import User
+from sentry.utils.http import is_using_customer_domain
 
 _ORGANIZATION_SCOPE_PREFIX = "organizations:"
 
@@ -246,6 +248,10 @@ class OrganizationSerializer(Serializer):  # type: ignore
             feature_list.add("open-membership")
         if not getattr(obj.flags, "disable_shared_issues"):
             feature_list.add("shared-issues")
+        request = env.request
+        if request and is_using_customer_domain(request):
+            # If the current request is using a customer domain, then we activate the feature for this organization.
+            feature_list.add("customer-domains")
 
         if "server-side-sampling" not in feature_list and "mep-rollout-flag" in feature_list:
             feature_list.remove("mep-rollout-flag")

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -211,3 +211,7 @@ def origin_from_request(request: HttpRequest) -> str | None:
 def percent_encode(val: str) -> str:
     # see https://en.wikipedia.org/wiki/Percent-encoding
     return quote(val).replace("%7E", "~").replace("/", "%2F")
+
+
+def is_using_customer_domain(request: HttpRequest) -> bool:
+    return bool(hasattr(request, "subdomain") and request.subdomain)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -70,6 +70,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         assert response.data["orgRole"] == "owner"
         assert len(response.data["teams"]) == 0
         assert len(response.data["projects"]) == 0
+        assert "customer-domains" not in response.data["features"]
 
     def test_simple_customer_domain(self):
         HTTP_HOST = f"{self.organization.slug}.testserver"
@@ -88,6 +89,14 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         assert response.data["orgRole"] == "owner"
         assert len(response.data["teams"]) == 0
         assert len(response.data["projects"]) == 0
+        assert "customer-domains" in response.data["features"]
+
+        with self.feature({"organizations:customer-domains": False}):
+            HTTP_HOST = f"{self.organization.slug}.testserver"
+            response = self.get_success_response(
+                self.organization.slug, extra_headers={"HTTP_HOST": HTTP_HOST}
+            )
+            assert "customer-domains" in response.data["features"]
 
     def test_org_mismatch_customer_domain(self):
         HTTP_HOST = f"{self.organization.slug}-apples.testserver"


### PR DESCRIPTION
If the current request is using a customer domain, then we activate the feature for this organization.

We do this so that any and all UI features flagged behind the customer domain feature flag can be activated. This allows for a better user experience when navigating the product in a customer domain world (e.g. `orgslug.sentry.io`). 

For example, switching to `otherslug.sentry.io` while being on `orgslug.sentry.io` using the org switch menu bar.

The user experience outside of the customer domain world remains the same (e.g. `sentry.io/orgslug`).