### PR TITLE
ref(savedsearch): Remove pinned search dedupe logic

### DIFF
--- a/src/sentry/api/endpoints/organization_searches.py
+++ b/src/sentry/api/endpoints/organization_searches.py
@@ -48,28 +48,8 @@ class OrganizationSearchesEndpoint(OrganizationEndpoint):
                 order_by=["-has_owner", "name__upper"],
             )
         )
-        results = []
-        if saved_searches:
-            pinned_search = None
-            # If the saved search has an owner then it's the user's pinned
-            # search. The user can only have one pinned search.
-            results.append(saved_searches[0])
-            if saved_searches[0].is_pinned:
-                pinned_search = saved_searches[0]
-            for saved_search in saved_searches[1:]:
-                # If a search has the same query and sort as the pinned search we
-                # want to use that search as the pinned search
-                if (
-                    pinned_search
-                    and saved_search.query == pinned_search.query
-                    and saved_search.sort == pinned_search.sort
-                ):
-                    saved_search.is_pinned = True
-                    results[0] = saved_search
-                else:
-                    results.append(saved_search)
 
-        return Response(serialize(results, request.user))
+        return Response(serialize(saved_searches, request.user))
 
     def post(self, request: Request, organization) -> Response:
         serializer = OrganizationSearchSerializer(data=request.data)

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -77,13 +77,7 @@ class SavedSearch(Model):
 
     @property
     def is_pinned(self):
-        if hasattr(self, "_is_pinned"):
-            return self._is_pinned
         return self.owner is not None and self.organization is not None
-
-    @is_pinned.setter
-    def is_pinned(self, value):
-        self._is_pinned = value
 
     __repr__ = sane_repr("project_id", "name")
 

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -1,4 +1,3 @@
-from django.utils import timezone
 from exam import fixture
 
 from sentry.api.endpoints.organization_pinned_searches import PINNED_SEARCH_NAME
@@ -80,28 +79,6 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
             type=search_type,
             query=query,
         ).exists()
-
-    def test_pin_org_search(self):
-        org_search = SavedSearch.objects.create(
-            organization=self.organization, name="foo", query="some test", date_added=timezone.now()
-        )
-        self.login_as(self.user)
-        resp = self.get_success_response(
-            type=org_search.type, query=org_search.query, status_code=201
-        )
-        assert resp.data["isPinned"]
-        assert resp.data["id"] == str(org_search.id)
-
-    def test_pin_global_search(self):
-        global_search = SavedSearch.objects.create(
-            name="Global Query", query="global query", is_global=True, date_added=timezone.now()
-        )
-        self.login_as(self.user)
-        resp = self.get_success_response(
-            type=global_search.type, query=global_search.query, status_code=201
-        )
-        assert resp.data["isPinned"]
-        assert resp.data["id"] == str(global_search.id)
 
     def test_pin_sort_mismatch(self):
         saved_search = SavedSearch.objects.create(

--- a/tests/sentry/api/endpoints/test_organization_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_searches.py
@@ -85,14 +85,6 @@ class OrgLevelOrganizationSearchesListTest(APITestCase):
         )
         included.append(pinned_query)
         self.check_results(included)
-        # Check a pinned query that uses an existing query correctly filters
-        # the existing query
-        to_be_pinned = included.pop()
-        to_be_pinned.is_pinned = True
-        pinned_query.query = to_be_pinned.query
-        pinned_query.save()
-        included[0] = to_be_pinned
-        self.check_results(included)
 
 
 @region_silo_test


### PR DESCRIPTION
This logic is likely from an err where the saved search frontend UI caused this to be more problematic.

The result of this is simply that pinned searches that matched existing saved searches now show up in the list next to your pinned search.

In the upcoming saved searches UI revamp we can simply reduplicate them on the frontend. This really shouldn't be the responsibility of the backend.