### PR TITLE
fix(code_mappings): Files that do not match the package name should not match

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -31,11 +31,12 @@ class FrameFilename:
         if stacktrace_frame_file_path.find("/") > -1:
             # XXX: This code assumes that all stack trace frames are part of a module
             self.root, self.file_and_dir_path = stacktrace_frame_file_path.split("/", 1)
-            # Does it have more than one level?
+
+            # Check that it does have at least a dir
             if self.file_and_dir_path.find("/") > -1:
                 self.dir_path, self.file_name = self.file_and_dir_path.rsplit("/", 1)
             else:
-                # A package name + a file (e.g. requests/models.py)
+                # A package name, a file but no dir (e.g. requests/models.py)
                 self.dir_path = ""
                 self.file_name = self.file_and_dir_path
         else:
@@ -124,6 +125,16 @@ class CodeMappingTreesHelper:
 
         return _code_mappings[0]
 
+    def _get_code_mapping_source_path(self, src_file: str, frame_filename: FrameFilename) -> str:
+        """Generate the source path of a code mapping
+        e.g. src/sentry/identity/oauth2.py -> src/sentry
+        e.g. ssl.py -> raise NotImplemented
+        """
+        if frame_filename.dir_path != "":
+            return src_file.rsplit(frame_filename.dir_path)[0].rstrip("/")
+        else:
+            raise NotImplementedError("We do not support top level files.")
+
     def _generate_code_mapping_from_tree(
         self,
         repo_full_name: str,
@@ -141,8 +152,9 @@ class CodeMappingTreesHelper:
                 CodeMapping(
                     repo=self.trees[repo_full_name].repo,
                     stacktrace_root=frame_filename.root,  # sentry
-                    # e.g. src/sentry/identity/oauth2.py -> src/sentry
-                    source_path=matched_files[0].rsplit(frame_filename.dir_path)[0].rstrip("/"),
+                    source_path=self._get_code_mapping_source_path(
+                        matched_files[0], frame_filename
+                    ),
                 )
             ]
             if len(matched_files) == 1
@@ -170,4 +182,15 @@ class CodeMappingTreesHelper:
         if self._matches_current_code_mappings(src_file, frame_filename):
             return False
 
-        return src_file.rfind(frame_filename.file_and_dir_path) > -1
+        match = False
+        # For instance:
+        #  src_file: "src/sentry/integrations/slack/client.py"
+        #  frame_filename.full_path: "sentry/integrations/slack/client.py"
+        split = src_file.split(frame_filename.file_and_dir_path)
+        if len(split) > 1:
+            # This is important because we only want stack frames to match when they
+            # include the exact package name
+            # e.g. raven/base.py stackframe should not match this source file: apostello/views/base.py
+            match = split[0].rfind(f"{frame_filename.root}/") > -1
+
+        return match

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -128,7 +128,7 @@ class CodeMappingTreesHelper:
     def _get_code_mapping_source_path(self, src_file: str, frame_filename: FrameFilename) -> str:
         """Generate the source path of a code mapping
         e.g. src/sentry/identity/oauth2.py -> src/sentry
-        e.g. ssl.py -> raise NotImplemented
+        e.g. ssl.py -> raise NotImplementedError
         """
         if frame_filename.dir_path != "":
             return src_file.rsplit(frame_filename.dir_path)[0].rstrip("/")

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -40,6 +40,7 @@ class FrameFilename:
                 self.file_name = self.file_and_dir_path
         else:
             self.root = ""
+            self.dir_path = ""
             self.file_and_dir_path = self.full_path
             self.file_name = self.full_path
 

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -147,9 +147,7 @@ class TestDerivedCodeMappings(TestCase):
             "sentry/identity/oauth2.py",
         ]
         code_mappings = self.code_mapping_helper.generate_code_mappings(stacktraces)
-        # Asserting lists with different order of elements would fail, thus, checking indexes
-        assert code_mappings[0] == self.expected_code_mappings[1]
-        assert code_mappings[1] == self.expected_code_mappings[0]
+        assert sorted(code_mappings) == sorted(self.expected_code_mappings)
 
     def test_more_than_one_repo_match(self):
         # XXX: There's a chance that we could infer package names but that is risky

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -94,9 +94,7 @@ class TestDerivedCodeMappings(TestCase):
 
         # We should not derive a code mapping since we do not yet
         # support stackframes for non-packaged files
-        assert (
-            cmh.generate_code_mappings(repo_full_name=self.foo_repo.name, frame_filename=ff) == []
-        )
+        assert cmh.generate_code_mappings([file_name]) == []
 
         # Make sure that we raise an error if we hit the code path
         assert not cmh._potential_match(file_name, ff)
@@ -128,6 +126,10 @@ class TestDerivedCodeMappings(TestCase):
                 source_path="src/sentry_plugins",
             )
         ]
+
+    def test_no_stacktraces_to_process(self):
+        code_mappings = self.code_mapping_helper.generate_code_mappings([])
+        assert code_mappings == []
 
     def test_more_than_one_match_works_when_code_mapping_excludes_other_match(self):
         stacktraces = [

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -29,8 +29,8 @@ class TestDerivedCodeMappings(TestCase):
         bar_repo = Repo("Test-Organization/bar", "main")
         self.code_mapping_helper = CodeMappingTreesHelper(
             {
-                "sentry": RepoTree(foo_repo, files=sentry_files),
-                "getsentry": RepoTree(bar_repo, files=["getsentry/web/urls.py"]),
+                foo_repo.name: RepoTree(foo_repo, files=sentry_files),
+                bar_repo.name: RepoTree(bar_repo, files=["getsentry/web/urls.py"]),
             }
         )
 
@@ -38,6 +38,23 @@ class TestDerivedCodeMappings(TestCase):
             CodeMapping(foo_repo, "sentry", "src/sentry"),
             CodeMapping(foo_repo, "sentry_plugins", "src/sentry_plugins"),
         ]
+
+    def test_frame_filename_package_and_more_than_one_level(self):
+        ff = FrameFilename("getsentry/billing/tax/manager.py")
+        assert f"{ff.root}/{ff.dir_path}/{ff.file_name}" == "getsentry/billing/tax/manager.py"
+        assert f"{ff.dir_path}/{ff.file_name}" == ff.file_and_dir_path
+
+    def test_frame_filename_package_and_no_levels(self):
+        ff = FrameFilename("root/bar.py")
+        assert f"{ff.root}/{ff.file_name}" == "root/bar.py"
+        assert f"{ff.root}/{ff.file_and_dir_path}" == "root/bar.py"
+        assert ff.dir_path == ""
+
+    def test_frame_filename_no_package(self):
+        ff = FrameFilename("foo.py")
+        assert ff.root == ""
+        assert ff.dir_path == ""
+        assert ff.file_name == "foo.py"
 
     def test_frame_filename_repr(self):
         path = "getsentry/billing/tax/manager.py"


### PR DESCRIPTION
For instance, `raven/base.py` should not think that the file `apostello/views/base.py` should be the related source file.

There's also some other minor tests added.