### PR TITLE
feat(mobile-exp): Use readable device value when available in Tag Summary

### DIFF
--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -225,4 +225,40 @@ describe('Tag Facets', function () {
     expect(screen.getByText('100%')).toBeInTheDocument();
     expect(screen.queryByText('Other')).not.toBeInTheDocument();
   });
+
+  it('renders readable device name when available', async () => {
+    tagsMock = MockApiClient.addMockResponse({
+      url: '/issues/1/tags/',
+      body: {
+        device: {
+          key: 'device',
+          topValues: [
+            {
+              name: 'abcdef123456',
+              readable: 'Galaxy S22',
+              count: 2,
+            },
+          ],
+        },
+      },
+    });
+    render(
+      <TagFacets
+        environments={[]}
+        groupId="1"
+        tagKeys={MOBILE_TAGS}
+        tagFormatter={MOBILE_TAGS_FORMATTER}
+      />,
+      {
+        organization,
+      }
+    );
+    await waitFor(() => {
+      expect(tagsMock).toHaveBeenCalled();
+    });
+
+    userEvent.click(screen.getByText('device'));
+    expect(screen.getByText('Galaxy S22')).toBeInTheDocument();
+    expect(screen.getByText('100%')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -20,6 +20,7 @@ import ButtonBar from '../../buttonBar';
 import TagBreakdown from './tagBreakdown';
 
 export const MOBILE_TAGS = ['os', 'device', 'release'];
+
 export function MOBILE_TAGS_FORMATTER(tagsData: Record<string, TagWithTopValues>) {
   // For "release" tag keys, format the release tag value to be more readable (ie removing version prefix)
   const transformedTagsData = {};
@@ -31,6 +32,16 @@ export function MOBILE_TAGS_FORMATTER(tagsData: Record<string, TagWithTopValues>
           return {
             ...topValue,
             name: formatVersion(topValue.name),
+          };
+        }),
+      };
+    } else if (tagKey === 'device') {
+      transformedTagsData[tagKey] = {
+        ...tagsData[tagKey],
+        topValues: tagsData[tagKey].topValues.map(topValue => {
+          return {
+            ...topValue,
+            name: topValue.readable ?? topValue.name,
           };
         }),
       };
@@ -86,6 +97,7 @@ export function TagFacets({
         query: {
           key: tagKeys,
           environment: environments.map(env => env.name),
+          readable: true,
         },
       });
       setState({...state, tagsData: keyBy(data, 'key'), loading: false});

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -149,6 +149,7 @@ type Topvalue = {
   value: string;
   // Might not actually exist.
   query?: string;
+  readable?: string;
 };
 
 export type TagWithTopValues = {


### PR DESCRIPTION
Uses readable device value from `/tags` endpoint when available.
![image](https://user-images.githubusercontent.com/83961295/199525914-19fe4a4e-2dab-497e-bcbc-1ef3155bb81b.png)