### PR TITLE
Move invite code functionality from cookie to session

### DIFF
--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -62,4 +62,11 @@ class ApiTokensEndpoint(Endpoint):
 
         ApiToken.objects.filter(user=request.user, token=token, application__isnull=True).delete()
 
+        capture_security_activity(
+            account=request.user,
+            type="api-token-deleted",
+            actor=request.user,
+            ip_address=request.META["REMOTE_ADDR"],
+        )
+
         return Response(status=204)

--- a/src/sentry/api/endpoints/api_tokens.py
+++ b/src/sentry/api/endpoints/api_tokens.py
@@ -62,11 +62,4 @@ class ApiTokensEndpoint(Endpoint):
 
         ApiToken.objects.filter(user=request.user, token=token, application__isnull=True).delete()
 
-        capture_security_activity(
-            account=request.user,
-            type="api-token-deleted",
-            actor=request.user,
-            ip_address=request.META["REMOTE_ADDR"],
-        )
-
         return Response(status=204)

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -12,7 +12,7 @@ from sentry import ratelimits as ratelimiter
 from sentry.api.base import control_silo_endpoint
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.decorators import email_verification_required, sudo_required
-from sentry.api.invite_helper import ApiInviteHelper, remove_invite_cookie
+from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
 from sentry.api.serializers import serialize
 from sentry.auth.authenticators.base import EnrollmentStatus, NewEnrollmentDisallowed
 from sentry.auth.authenticators.sms import SMSRateLimitExceeded
@@ -285,6 +285,6 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
 
         if invite_helper and invite_helper.valid_request:
             invite_helper.accept_invite()
-            remove_invite_cookie(request, response)
+            remove_invite_details_from_session(request)
 
         return response

--- a/src/sentry/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/api/endpoints/user_authenticator_enroll.py
@@ -281,7 +281,7 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
 
         # If there is a pending organization invite accept after the
         # authenticator has been configured.
-        invite_helper = ApiInviteHelper.from_cookie(request=request, instance=self, logger=logger)
+        invite_helper = ApiInviteHelper.from_session(request=request, instance=self, logger=logger)
 
         if invite_helper and invite_helper.valid_request:
             invite_helper.accept_invite()

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -18,29 +18,15 @@ from sentry.utils.audit import create_audit_entry
 
 
 def add_invite_details_to_session(request: Request, member_id: int, token: str):
-    """Add member ID and token to the request session
-
-    Args:
-        request: rest_framework.request.Request
-        member_id: int
-        token: str
-    """
+    """Add member ID and token to the request session"""
     request.session["invite_token"] = token
     request.session["invite_member_id"] = member_id
 
 
 def remove_invite_details_from_session(request):
     """Deletes invite details from the request session"""
-    try:
-        del request.session["invite_member_id"]
-        del request.session["invite_token"]
-    except KeyError:
-        # we sometimes attempt to delete the invite values twice depending
-        # on the current state of the user:
-        #   1) when they have 2FA
-        #   2) when they are already authenticated
-        #   3) when they already have an account
-        pass
+    request.session.pop("invite_member_id", None)
+    request.session.pop("invite_token", None)
 
 
 def get_invite_details(request) -> Tuple[str, int]:

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -59,7 +59,7 @@ class ApiInviteHelper:
         invite_token, invite_member_id = get_invite_details(request)
 
         try:
-            if invite_token is not None:
+            if invite_token is not None and invite_member_id is not None:
                 om = OrganizationMember.objects.get(token=invite_token, id=invite_member_id)
             else:
                 om = OrganizationMember.objects.get(
@@ -78,7 +78,7 @@ class ApiInviteHelper:
     def from_session(cls, request, instance=None, logger=None):
         invite_token, invite_member_id = get_invite_details(request)
 
-        if not invite_token:
+        if not invite_token and not invite_member_id:
             return None
 
         try:

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -45,7 +45,7 @@ class ApiInviteHelper:
         invite_token, invite_member_id = get_invite_details(request)
 
         try:
-            if invite_token is not None and invite_member_id is not None:
+            if invite_token and invite_member_id:
                 om = OrganizationMember.objects.get(token=invite_token, id=invite_member_id)
             else:
                 om = OrganizationMember.objects.get(
@@ -64,7 +64,7 @@ class ApiInviteHelper:
     def from_session(cls, request, instance=None, logger=None):
         invite_token, invite_member_id = get_invite_details(request)
 
-        if not invite_token and not invite_member_id:
+        if not invite_token or not invite_member_id:
             return None
 
         try:

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -19,7 +19,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views import View
 
 from sentry import audit_log, features
-from sentry.api.invite_helper import ApiInviteHelper, remove_invite_cookie
+from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
 from sentry.api.utils import generate_organization_url
 from sentry.auth.email import AmbiguousUserFromEmail, resolve_email_to_user
 from sentry.auth.exceptions import IdentityNotValid
@@ -406,7 +406,7 @@ class AuthIdentityHandler:
 
         # Always remove any pending invite cookies, pending invites will have been
         # accepted during the SSO flow.
-        remove_invite_cookie(self.request, response)
+        remove_invite_details_from_session(self.request)
 
         return response
 

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -219,9 +219,9 @@ class AuthIdentityHandler:
         user = auth_identity.user
 
         # If the user is either currently *pending* invite acceptance (as indicated
-        # from the pending-invite cookie) OR an existing invite exists on this
+        # from the invite token and member id in the session) OR an existing invite exists on this
         # organization for the email provided by the identity provider.
-        invite_helper = ApiInviteHelper.from_cookie_or_email(
+        invite_helper = ApiInviteHelper.from_session_or_email(
             request=self.request, organization=self.organization, email=user.email
         )
 

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -11,7 +11,7 @@ from django.views.decorators.cache import never_cache
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.invite_helper import ApiInviteHelper, remove_invite_cookie
+from sentry.api.invite_helper import ApiInviteHelper, remove_invite_details_from_session
 from sentry.auth.superuser import is_active_superuser
 from sentry.constants import WARN_SESSION_EXPIRED
 from sentry.http import get_server_hostname
@@ -182,7 +182,7 @@ class AuthLoginView(BaseView):
             if invite_helper and invite_helper.valid_request:
                 invite_helper.accept_invite()
                 response = self.redirect_to_org(request)
-                remove_invite_cookie(request, response)
+                remove_invite_details_from_session(request)
 
                 return response
 

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -166,7 +166,7 @@ class AuthLoginView(BaseView):
             request.session.pop("invite_email", None)
 
             # Attempt to directly accept any pending invites
-            invite_helper = ApiInviteHelper.from_cookie(request=request, instance=self)
+            invite_helper = ApiInviteHelper.from_session(request=request, instance=self)
 
             # In single org mode, associate the user to the only organization.
             #

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -27,14 +27,12 @@ class AcceptInviteTest(TestCase):
         assert self.organization.flags.require_2fa.is_set
 
     def _assert_pending_invite_details_in_session(self, response, om):
-        session_invite_token = response.client.session["invite_token"]
-        session_invite_member_id = response.client.session["invite_member_id"]
-        assert om.token == session_invite_token
-        assert om.id == session_invite_member_id
+        assert self.client.session["invite_token"] == om.token
+        assert self.client.session["invite_member_id"] == om.id
 
     def _assert_pending_invite_details_not_in_session(self, response):
-        session_invite_token = response.client.session.get("invite_token", None)
-        session_invite_member_id = response.client.session.get("invite_member_id", None)
+        session_invite_token = self.client.session.get("invite_token", None)
+        session_invite_member_id = self.client.session.get("invite_member_id", None)
         assert session_invite_token is None
         assert session_invite_member_id is None
 

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -26,7 +26,7 @@ class AcceptInviteTest(TestCase):
         self.organization.update(flags=F("flags").bitor(Organization.flags.require_2fa))
         assert self.organization.flags.require_2fa.is_set
 
-    def _assert_pending_invite_details_in_session(self, response, om):
+    def _assert_pending_invite_details_in_session(self, om):
         assert self.client.session["invite_token"] == om.token
         assert self.client.session["invite_member_id"] == om.id
 
@@ -111,7 +111,7 @@ class AcceptInviteTest(TestCase):
         assert resp.status_code == 200
         assert resp.data["needs2fa"]
 
-        self._assert_pending_invite_details_in_session(resp, om)
+        self._assert_pending_invite_details_in_session(om)
 
     def test_user_has_2fa(self):
         self._require_2fa_for_organization()
@@ -291,7 +291,7 @@ class AcceptInviteTest(TestCase):
             reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
         )
         assert resp.status_code == 200
-        self._assert_pending_invite_details_in_session(resp, om)
+        self._assert_pending_invite_details_in_session(om)
 
         self._enroll_user_in_2fa()
         resp = self.client.post(
@@ -299,5 +299,4 @@ class AcceptInviteTest(TestCase):
         )
         assert resp.status_code == 204
 
-        # value set to empty string on deletion
         self._assert_pending_invite_details_not_in_session(resp)

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -318,8 +318,10 @@ class AcceptOrganizationInviteTest(APITestCase):
         new_options = settings.SENTRY_OPTIONS.copy()
         new_options["system.url-prefix"] = "https://testserver"
         with self.settings(SENTRY_OPTIONS=new_options):
-            # these session helper functions appear to modify the
-            # self.client.session?
+            # We have to add the invite details back in to the session
+            # prior to .save_session() since this re-creates the session property
+            # when under test. See here for more details:
+            # https://docs.djangoproject.com/en/2.2/topics/testing/tools/#django.test.Client.session
             self.session["webauthn_register_state"] = "state"
             self.session["invite_token"] = self.client.session["invite_token"]
             self.session["invite_member_id"] = self.client.session["invite_member_id"]

--- a/tests/sentry/auth/test_helper.py
+++ b/tests/sentry/auth/test_helper.py
@@ -1,5 +1,4 @@
 from unittest import mock
-from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.auth.models import AnonymousUser
@@ -138,14 +137,14 @@ class HandleNewUserTest(AuthIdentityHandlerTest):
 
     def test_associate_pending_invite(self):
         # The org member invite should have a non matching email, but the
-        # member id and token will match from the cookie, allowing association
+        # member id and token will match from the session, allowing association
         member = OrganizationMember.objects.create(
             organization=self.organization, email="different.email@example.com", token="abc"
         )
 
-        self.request.COOKIES["pending-invite"] = urlencode(
-            {"memberId": member.id, "token": member.token, "url": ""}
-        )
+        self.request.session["invite_member_id"] = member.id
+        self.request.session["invite_token"] = member.token
+        self.save_session()
 
         auth_identity = self.handler.handle_new_user()
 

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -176,15 +176,15 @@ class AuthLoginTest(TestCase):
         assert OrganizationMember.objects.filter(user=user).exists()
 
     @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
-    @mock.patch("sentry.web.frontend.auth_login.ApiInviteHelper.from_cookie")
-    def test_registration_single_org_with_invite(self, from_cookie):
+    @mock.patch("sentry.web.frontend.auth_login.ApiInviteHelper.from_session")
+    def test_registration_single_org_with_invite(self, from_session):
         self.session["can_register"] = True
         self.save_session()
 
         self.client.get(self.path)
 
         invite_helper = mock.Mock(valid_request=True)
-        from_cookie.return_value = invite_helper
+        from_session.return_value = invite_helper
 
         resp = self.client.post(
             self.path,
@@ -229,15 +229,15 @@ class AuthLoginTest(TestCase):
         assert resp.context["register_form"].initial["username"] == "foo@example.com"
         self.assertTemplateUsed("sentry/login.html")
 
-    @mock.patch("sentry.web.frontend.auth_login.ApiInviteHelper.from_cookie")
-    def test_register_accepts_invite(self, from_cookie):
+    @mock.patch("sentry.web.frontend.auth_login.ApiInviteHelper.from_session")
+    def test_register_accepts_invite(self, from_session):
         self.session["can_register"] = True
         self.save_session()
 
         self.client.get(self.path)
 
         invite_helper = mock.Mock(valid_request=True)
-        from_cookie.return_value = invite_helper
+        from_session.return_value = invite_helper
 
         resp = self.client.post(
             self.path,


### PR DESCRIPTION
Moves the invite functionality from cookies to the session. This is to harden the security of the platform.

With the cookie approach, a client can manipulate the cookie value for `pending-invite` resulting in situations where an invite code can be reused.