### PR TITLE
ref(perf): Remove suspect spans feature flag BE

### DIFF
--- a/src/sentry/api/endpoints/organization_events_span_ops.py
+++ b/src/sentry/api/endpoints/organization_events_span_ops.py
@@ -3,7 +3,6 @@ from typing import Any, TypedDict
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -19,18 +18,7 @@ class SpanOp(TypedDict):
 
 @region_silo_endpoint
 class OrganizationEventsSpanOpsEndpoint(OrganizationEventsEndpointBase):  # type: ignore
-    def has_feature(self, request: Request, organization: Organization) -> bool:
-        return bool(
-            features.has(
-                "organizations:performance-suspect-spans-view",
-                organization,
-                actor=request.user,
-            )
-        )
-
     def get(self, request: Request, organization: Organization) -> Response:
-        if not self.has_feature(request, organization):
-            return Response(status=404)
 
         try:
             params = self.get_snuba_params(request, organization)

--- a/src/sentry/api/endpoints/organization_events_spans_performance.py
+++ b/src/sentry/api/endpoints/organization_events_spans_performance.py
@@ -14,7 +14,7 @@ from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.function import Function, Identifier, Lambda
 from snuba_sdk.orderby import Direction, OrderBy
 
-from sentry import eventstore, features
+from sentry import eventstore
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
@@ -82,15 +82,6 @@ SPAN_PERFORMANCE_COLUMNS: Dict[str, SpanPerformanceColumn] = {
 
 
 class OrganizationEventsSpansEndpointBase(OrganizationEventsV2EndpointBase):  # type: ignore
-    def has_feature(self, request: Request, organization: Organization) -> bool:
-        return bool(
-            features.has(
-                "organizations:performance-suspect-spans-view",
-                organization,
-                actor=request.user,
-            )
-        )
-
     def get_snuba_params(
         self, request: Request, organization: Organization, check_global_views: bool = True
     ) -> Dict[str, Any]:
@@ -151,8 +142,6 @@ class SpansPerformanceSerializer(serializers.Serializer):  # type: ignore
 @region_silo_endpoint
 class OrganizationEventsSpansPerformanceEndpoint(OrganizationEventsSpansEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
-        if not self.has_feature(request, organization):
-            return Response(status=404)
 
         try:
             params = self.get_snuba_params(request, organization)
@@ -226,8 +215,6 @@ class SpanSerializer(serializers.Serializer):  # type: ignore
 @region_silo_endpoint
 class OrganizationEventsSpansExamplesEndpoint(OrganizationEventsSpansEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
-        if not self.has_feature(request, organization):
-            return Response(status=404)
 
         try:
             params = self.get_snuba_params(request, organization)
@@ -309,8 +296,6 @@ class SpanExamplesPaginator:
 @region_silo_endpoint
 class OrganizationEventsSpansStatsEndpoint(OrganizationEventsSpansEndpointBase):
     def get(self, request: Request, organization: Organization) -> Response:
-        if not self.has_feature(request, organization):
-            return Response(status=404)
 
         serializer = SpanSerializer(data=request.GET)
         if not serializer.is_valid():

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1140,8 +1140,6 @@ SENTRY_FEATURES = {
     "organizations:performance-ops-breakdown": False,
     # Enable interpolation of null data points in charts instead of zerofilling in performance
     "organizations:performance-chart-interpolation": False,
-    # Enable views for suspect tags
-    "organizations:performance-suspect-spans-view": False,
     # Enable views for anomaly detection
     "organizations:performance-anomaly-detection-ui": False,
     # Enable histogram view in span details

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -132,7 +132,6 @@ default_manager.add("organizations:performance-issues-dev", OrganizationFeature,
 default_manager.add("organizations:performance-issues-all-events-tab", OrganizationFeature, True)
 default_manager.add("organizations:performance-onboarding-checklist", OrganizationFeature, True)
 default_manager.add("organizations:performance-span-histogram-view", OrganizationFeature, True)
-default_manager.add("organizations:performance-suspect-spans-view", OrganizationFeature, True)
 default_manager.add("organizations:performance-transaction-name-only-search", OrganizationFeature, True)
 default_manager.add("organizations:performance-transaction-name-only-search-indexed", OrganizationFeature, True)
 default_manager.add("organizations:performance-use-metrics", OrganizationFeature, True)

--- a/tests/acceptance/test_performance_span_summary.py
+++ b/tests/acceptance/test_performance_span_summary.py
@@ -13,7 +13,6 @@ from sentry.utils.samples import load_data
 FEATURES = {
     "organizations:performance-span-histogram-view": True,
     "organizations:performance-view": True,
-    "organizations:performance-suspect-spans-view": True,
 }
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_span_ops.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_ops.py
@@ -11,8 +11,6 @@ from sentry.utils.samples import load_data
 
 @region_silo_test
 class OrganizationEventsSpanOpsEndpointBase(APITestCase, SnubaTestCase):
-    FEATURES = ["organizations:performance-suspect-spans-view"]
-
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
@@ -82,14 +80,13 @@ class OrganizationEventsSpanOpsEndpointBase(APITestCase, SnubaTestCase):
     def test_basic(self):
         self.create_event()
 
-        with self.feature(self.FEATURES):
-            response = self.client.get(
-                self.url,
-                data={
-                    "project": self.project.id,
-                },
-                format="json",
-            )
+        response = self.client.get(
+            self.url,
+            data={
+                "project": self.project.id,
+            },
+            format="json",
+        )
 
         assert response.status_code == 200, response.content
         assert response.data == [

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -20,7 +20,6 @@ from sentry.utils.samples import load_data
 class OrganizationEventsSpansEndpointTestBase(APITestCase, SnubaTestCase):
     FEATURES = [
         "organizations:global-views",
-        "organizations:performance-suspect-spans-view",
     ]
 
     def setUp(self):

--- a/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_spans_performance.py
@@ -409,10 +409,6 @@ class OrganizationEventsSpansEndpointTestBase(APITestCase, SnubaTestCase):
 class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndpointTestBase):
     URL = "sentry-api-0-organization-events-spans-performance"
 
-    def test_no_feature(self):
-        response = self.client.get(self.url, format="json")
-        assert response.status_code == 404, response.content
-
     def test_no_projects(self):
         user = self.create_user()
         org = self.create_organization(owner=user)
@@ -1107,10 +1103,6 @@ class OrganizationEventsSpansPerformanceEndpointTest(OrganizationEventsSpansEndp
 class OrganizationEventsSpansExamplesEndpointTest(OrganizationEventsSpansEndpointTestBase):
     URL = "sentry-api-0-organization-events-spans"
 
-    def test_no_feature(self):
-        response = self.client.get(self.url, format="json")
-        assert response.status_code == 404, response.content
-
     def test_no_projects(self):
         user = self.create_user()
         org = self.create_organization(owner=user)
@@ -1755,10 +1747,6 @@ class OrganizationEventsSpansExamplesEndpointTest(OrganizationEventsSpansEndpoin
 @region_silo_test
 class OrganizationEventsSpansStatsEndpointTest(OrganizationEventsSpansEndpointTestBase):
     URL = "sentry-api-0-organization-events-spans-stats"
-
-    def test_no_feature(self):
-        response = self.client.get(self.url, format="json")
-        assert response.status_code == 404, response.content
 
     def test_require_span_param(self):
         with self.feature(self.FEATURES):


### PR DESCRIPTION
Suspect spans are fully rolled out and so the flag logic is no longer necessary.

Frontend PR: https://github.com/getsentry/sentry/pull/40903