### PR TITLE
feat(saved-searches): Add is_global, visibility, and query to select saved search analytics event

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -33,7 +33,14 @@ export type SavedSearch = {
   query: string;
   sort: string;
   type: SavedSearchType;
+  visibility: SavedSearchVisibility;
 };
+
+export enum SavedSearchVisibility {
+  Organization = 'organization',
+  Owner = 'owner',
+  OwnerPinned = 'owner_pinned',
+}
 
 export enum SavedSearchType {
   ISSUE = 0,

--- a/static/app/utils/analytics/searchAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/searchAnalyticsEvents.tsx
@@ -17,7 +17,10 @@ export type SearchEventParameters = {
   'command_palette.select': SelectEvent;
   'organization_saved_search.selected': {
     id: number;
+    is_global: boolean;
+    query: string;
     search_type: string;
+    visibility: string;
   };
   'projectselector.clear': ProjectSelectorEvent;
   'projectselector.direct_selection': ProjectSelectorEvent;

--- a/static/app/views/issueList/filters.spec.tsx
+++ b/static/app/views/issueList/filters.spec.tsx
@@ -2,6 +2,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import TagStore from 'sentry/stores/tagStore';
+import {SavedSearchVisibility} from 'sentry/types';
 
 import IssueListFilters from './filters';
 
@@ -94,6 +95,7 @@ describe('IssueListFilters', function () {
             dateCreated: '',
             isGlobal: false,
             type: 0,
+            visibility: SavedSearchVisibility.OwnerPinned,
           }}
         />,
         {context: routerContext}

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -955,7 +955,7 @@ class IssueListOverview extends Component<Props, State> {
       id: savedSearch.id ? parseInt(savedSearch.id, 10) : -1,
       is_global: savedSearch.isGlobal,
       query: savedSearch.query,
-      visibility: 'organization',
+      visibility: savedSearch.visibility,
     });
     this.setState({issuesLoading: true}, () => this.transitionTo(undefined, savedSearch));
   };

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -953,6 +953,9 @@ class IssueListOverview extends Component<Props, State> {
       organization: this.props.organization,
       search_type: 'issues',
       id: savedSearch.id ? parseInt(savedSearch.id, 10) : -1,
+      is_global: savedSearch.isGlobal,
+      query: savedSearch.query,
+      visibility: 'organization',
     });
     this.setState({issuesLoading: true}, () => this.transitionTo(undefined, savedSearch));
   };


### PR DESCRIPTION
https://github.com/getsentry/reload/pull/295