### PR TITLE
feat(spike-protection): Add hook for new settings field component

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -217,7 +217,7 @@ export interface FeatureSpecificHooks extends SpendVisibilityHooks {}
  * (i.e. Per-Project Spike Protection + Spend Allocations)
  */
 export type SpendVisibilityHooks = {
-  'spend-visibility:project-settings-field': GenericProjectComponentHook;
+  'spend-visibility:spike-protection-project-settings': GenericProjectComponentHook;
 };
 
 /**
@@ -255,6 +255,9 @@ type GenericOrganizationComponentHook = (opts: {
   organization: Organization;
 }) => React.ReactNode;
 
+/**
+ * Receives a project object and should return a React node.
+ */
 type GenericProjectComponentHook = (opts: {project: Project}) => React.ReactNode;
 
 // TODO(ts): We should correct the organization header hook to conform to the

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -36,6 +36,7 @@ export interface Hooks
     InterfaceChromeHooks,
     OnboardingHooks,
     SettingsHooks,
+    FeatureSpecificHooks,
     ReactHooks,
     CallbackHooks {
   _: any;
@@ -207,6 +208,19 @@ export type SettingsHooks = {
 };
 
 /**
+ * Feature Specific Hooks
+ */
+export interface FeatureSpecificHooks extends SpendVisibilityHooks {}
+
+/**
+ * Hooks related to Spend Visibitlity
+ * (i.e. Per-Project Spike Protection + Spend Allocations)
+ */
+export type SpendVisibilityHooks = {
+  'spend-visibility:project-settings-field': GenericProjectComponentHook;
+};
+
+/**
  * Hooks that are actually React Hooks as well
  */
 export type ReactHooks = {
@@ -240,6 +254,8 @@ type RoutesHook = () => Route[];
 type GenericOrganizationComponentHook = (opts: {
   organization: Organization;
 }) => React.ReactNode;
+
+type GenericProjectComponentHook = (opts: {project: Project}) => React.ReactNode;
 
 // TODO(ts): We should correct the organization header hook to conform to the
 // GenericOrganizationComponentHook, passing org as a prop object, not direct

--- a/static/app/views/settings/projectGeneralSettings.tsx
+++ b/static/app/views/settings/projectGeneralSettings.tsx
@@ -13,6 +13,7 @@ import TextField from 'sentry/components/forms/fields/textField';
 import Form from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import {FieldValue} from 'sentry/components/forms/model';
+import Hook from 'sentry/components/hook';
 import {removePageFiltersStorage} from 'sentry/components/organizations/pageFilters/persistence';
 import {Panel, PanelAlert, PanelHeader} from 'sentry/components/panels';
 import {fields} from 'sentry/data/forms/projectGeneralSettings';
@@ -239,31 +240,40 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
     };
     const team = project.teams.length ? project.teams?.[0] : undefined;
 
+    /*
+    HACK: The <Form /> component applies its props to its children meaning the hooked component
+          would need to conform to the form settings applied in a separate repository. This is
+          not feasible to maintain and may introduce compatability errors if something changes
+          in either repository. For that reason, the Form component is split in two, since the
+          fields do not depend on one another, allowing for the Hook to manage it's own state.
+    */
+    const formProps = {
+      saveOnBlur: true,
+      allowUndo: true,
+      initialData: {
+        ...project,
+        team,
+      },
+      apiMethod: 'PUT' as const,
+      apiEndpoint: endpoint,
+      onSubmitSuccess: resp => {
+        this.setState({data: resp});
+        if (projectId !== resp.slug) {
+          changeProjectSlug(projectId, resp.slug);
+          // Container will redirect after stores get updated with new slug
+          this.props.onChangeSlug(resp.slug);
+        }
+        // This will update our project context
+        ProjectsStore.onUpdateSuccess(resp);
+      },
+    };
+
     return (
       <div>
         <SettingsPageHeader title={t('Project Settings')} />
         <PermissionAlert />
 
-        <Form
-          saveOnBlur
-          allowUndo
-          initialData={{
-            ...project,
-            team,
-          }}
-          apiMethod="PUT"
-          apiEndpoint={endpoint}
-          onSubmitSuccess={resp => {
-            this.setState({data: resp});
-            if (projectId !== resp.slug) {
-              changeProjectSlug(projectId, resp.slug);
-              // Container will redirect after stores get updated with new slug
-              this.props.onChangeSlug(resp.slug);
-            }
-            // This will update our project context
-            ProjectsStore.onUpdateSuccess(resp);
-          }}
-        >
+        <Form {...formProps}>
           <JsonForm
             {...jsonFormProps}
             title={t('Project Details')}
@@ -275,7 +285,9 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
             title={t('Email')}
             fields={[fields.subjectPrefix]}
           />
-
+        </Form>
+        <Hook name="spend-visibility:project-settings-field" project={project} />
+        <Form {...formProps}>
           <JsonForm
             {...jsonFormProps}
             title={t('Event Settings')}

--- a/static/app/views/settings/projectGeneralSettings.tsx
+++ b/static/app/views/settings/projectGeneralSettings.tsx
@@ -286,7 +286,10 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
             fields={[fields.subjectPrefix]}
           />
         </Form>
-        <Hook name="spend-visibility:project-settings-field" project={project} />
+        <Hook
+          name="spend-visibility:spike-protection-project-settings"
+          project={project}
+        />
         <Form {...formProps}>
           <JsonForm
             {...jsonFormProps}

--- a/static/app/views/settings/projectGeneralSettings.tsx
+++ b/static/app/views/settings/projectGeneralSettings.tsx
@@ -10,7 +10,7 @@ import Button from 'sentry/components/button';
 import Confirm from 'sentry/components/confirm';
 import Field from 'sentry/components/forms/field';
 import TextField from 'sentry/components/forms/fields/textField';
-import Form from 'sentry/components/forms/form';
+import Form, {FormProps} from 'sentry/components/forms/form';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import {FieldValue} from 'sentry/components/forms/model';
 import Hook from 'sentry/components/hook';
@@ -247,7 +247,7 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
           in either repository. For that reason, the Form component is split in two, since the
           fields do not depend on one another, allowing for the Hook to manage it's own state.
     */
-    const formProps = {
+    const formProps: FormProps = {
       saveOnBlur: true,
       allowUndo: true,
       initialData: {


### PR DESCRIPTION
 See [ER-1231](https://getsentry.atlassian.net/browse/ER-1231)

This PR adds a hook for the new project settings field from getsentry. It does a hack which I wasn't able to find a way around becuase of the way the Form component overrides it's children's state without any ability to opt out. That made it so that the toggle I was adding would submit to the wrong endpoint. To get around this, I had to split the form in two so that it wouldn't find the hooked component as a child, and override it's submission params/endpoint.

This is also the best course of action since hooks should be independent of where they are implemented in getsentry/sentry since they're in a separate repository.

<img width="908" alt="image" src="https://user-images.githubusercontent.com/35509934/199576811-05a45519-b0a2-470a-b148-99af36656d9d.png">
