### PR TITLE
feat(issue-alerts): preview for assign to filter

### DIFF
--- a/src/sentry/rules/filters/age_comparison.py
+++ b/src/sentry/rules/filters/age_comparison.py
@@ -89,7 +89,7 @@ class AgeComparisonFilter(EventFilter):
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         return self._passes(event.group.first_seen, timezone.now())
 
-    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+    def passes_activity(self, condition_activity: ConditionActivity, **kwargs) -> bool:
         try:
             group = Group.objects.get_from_cache(id=condition_activity.group_id)
         except Group.DoesNotExist:

--- a/src/sentry/rules/filters/age_comparison.py
+++ b/src/sentry/rules/filters/age_comparison.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 from datetime import datetime, timedelta
-from typing import Sequence, Tuple
+from typing import Any, Sequence, Tuple
 
 from django import forms
 from django.utils import timezone
@@ -89,7 +89,7 @@ class AgeComparisonFilter(EventFilter):
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         return self._passes(event.group.first_seen, timezone.now())
 
-    def passes_activity(self, condition_activity: ConditionActivity, **kwargs) -> bool:
+    def passes_activity(self, condition_activity: ConditionActivity, **kwargs: Any) -> bool:
         try:
             group = Group.objects.get_from_cache(id=condition_activity.group_id)
         except Group.DoesNotExist:

--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
 from django import forms
 
@@ -50,7 +50,7 @@ class AssignedToFilter(EventFilter):
                         return True
             return False
 
-    def passes_activity(self, condition_activity: ConditionActivity, **kwargs) -> bool:
+    def passes_activity(self, condition_activity: ConditionActivity, **kwargs: Any) -> bool:
         target_type = AssigneeTargetType(self.get_option("targetType"))
         assignee = kwargs["assignee_status"][condition_activity.group_id]
 
@@ -60,9 +60,9 @@ class AssignedToFilter(EventFilter):
         target_id = str(self.get_option("targetIdentifier", None))
 
         if target_type == AssigneeTargetType.TEAM:
-            return assignee["assigneeType"] == "team" and assignee["assignee"] == target_id
+            return bool(assignee["assigneeType"] == "team" and assignee["assignee"] == target_id)
         elif target_type == AssigneeTargetType.MEMBER:
-            return assignee["assigneeType"] == "user" and assignee["assignee"] == target_id
+            return bool(assignee["assigneeType"] == "user" and assignee["assignee"] == target_id)
 
         return False
 

--- a/src/sentry/rules/filters/assigned_to.py
+++ b/src/sentry/rules/filters/assigned_to.py
@@ -38,7 +38,7 @@ class AssignedToFilter(EventFilter):
         if target_type == AssigneeTargetType.UNASSIGNED:
             return len(self.get_assignees(event.group)) == 0
         else:
-            target_id = self.get_option("targetIdentifier", None)
+            target_id = self.get_option("targetIdentifier", "")
 
             if target_type == AssigneeTargetType.TEAM:
                 for assignee in self.get_assignees(event.group):
@@ -57,7 +57,7 @@ class AssignedToFilter(EventFilter):
         if assignee is None:
             return target_type == AssigneeTargetType.UNASSIGNED
 
-        target_id = str(self.get_option("targetIdentifier", None))
+        target_id = str(self.get_option("targetIdentifier", ""))
 
         if target_type == AssigneeTargetType.TEAM:
             return bool(assignee["assigneeType"] == "team" and assignee["assignee"] == target_id)

--- a/src/sentry/rules/filters/base.py
+++ b/src/sentry/rules/filters/base.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Any
 
 from sentry.eventstore.models import GroupEvent
 from sentry.rules.base import EventState, RuleBase
@@ -12,5 +13,5 @@ class EventFilter(RuleBase, abc.ABC):
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         pass
 
-    def passes_activity(self, condition_activity: ConditionActivity, **kwargs) -> bool:
+    def passes_activity(self, condition_activity: ConditionActivity, **kwargs: Any) -> bool:
         raise NotImplementedError

--- a/src/sentry/rules/filters/base.py
+++ b/src/sentry/rules/filters/base.py
@@ -12,5 +12,5 @@ class EventFilter(RuleBase, abc.ABC):
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         pass
 
-    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+    def passes_activity(self, condition_activity: ConditionActivity, **kwargs) -> bool:
         raise NotImplementedError

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -39,7 +39,7 @@ class IssueCategoryFilter(EventFilter):
     def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
         return self._passes(event.group)
 
-    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+    def passes_activity(self, condition_activity: ConditionActivity, **kwargs) -> bool:
         try:
             group = Group.objects.get_from_cache(id=condition_activity.group_id)
         except Group.DoesNotExist:

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -39,7 +39,7 @@ class IssueCategoryFilter(EventFilter):
     def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
         return self._passes(event.group)
 
-    def passes_activity(self, condition_activity: ConditionActivity, **kwargs) -> bool:
+    def passes_activity(self, condition_activity: ConditionActivity, **kwargs: Any) -> bool:
         try:
             group = Group.objects.get_from_cache(id=condition_activity.group_id)
         except Group.DoesNotExist:

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -30,7 +30,7 @@ class IssueOccurrencesFilter(EventFilter):
         issue_occurrences: int = event.group.times_seen_with_pending
         return bool(issue_occurrences >= value)
 
-    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+    def passes_activity(self, condition_activity: ConditionActivity, **kwargs) -> bool:
         try:
             value = int(self.get_option("value"))
         except (TypeError, ValueError):

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django import forms
 from django.utils import timezone
 
@@ -30,7 +32,7 @@ class IssueOccurrencesFilter(EventFilter):
         issue_occurrences: int = event.group.times_seen_with_pending
         return bool(issue_occurrences >= value)
 
-    def passes_activity(self, condition_activity: ConditionActivity, **kwargs) -> bool:
+    def passes_activity(self, condition_activity: ConditionActivity, **kwargs: Any) -> bool:
         try:
             value = int(self.get_option("value"))
         except (TypeError, ValueError):

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, List, Sequence
 
 from django.utils import timezone
 
@@ -100,7 +100,9 @@ def preview(
     return Group.objects.filter(id__in=fired_group_ids)
 
 
-def update_assignee(assignee_status, assignee_activity, timestamp):
+def update_assignee(
+    assignee_status: Dict[str, Any], assignee_activity: List[Activity], timestamp: datetime
+) -> None:
     while len(assignee_activity) > 0 and assignee_activity[-1].datetime < timestamp:
         activity = assignee_activity.pop()
         if activity.type == ActivityType.ASSIGNED.value:

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -6,9 +6,11 @@ from typing import Any, Dict, Sequence
 from django.utils import timezone
 
 from sentry.db.models import BaseQuerySet
-from sentry.models import Group, Project
+from sentry.models import Activity, Group, Project
 from sentry.rules import rules
+from sentry.rules.filters.assigned_to import AssignedToFilter
 from sentry.rules.processor import get_match_function
+from sentry.types.activity import ActivityType
 
 PREVIEW_TIME_RANGE = timedelta(weeks=2)
 # limit on number of ConditionActivity's a condition will return
@@ -35,6 +37,7 @@ def preview(
         return Group.objects.none()
 
     activity = []
+    group_ids = set()
     for condition in conditions:
         condition_cls = rules.get(condition["id"])
         if condition_cls is None:
@@ -42,35 +45,65 @@ def preview(
         # instantiates a EventCondition subclass and retrieves activities related to it
         condition_inst = condition_cls(project, data=condition)
         try:
-            activity.extend(condition_inst.get_activity(start, end, CONDITION_ACTIVITY_LIMIT))
+            condition_activity = condition_inst.get_activity(start, end, CONDITION_ACTIVITY_LIMIT)
+            activity.extend(condition_activity)
+            group_ids.update([activity.group_id for activity in condition_activity])
         except NotImplementedError:
             return None
 
     k = lambda a: a.timestamp
     activity.sort(key=k)
 
+    assigned_to_filter = False
     filter_objects = []
     for filter in filters:
         filter_cls = rules.get(filter["id"])
         if filter_cls is None:
             return None
         filter_objects.append(filter_cls(project, data=filter))
+        if filter_cls == AssignedToFilter:
+            assigned_to_filter = True
 
     filter_func = get_match_function(filter_match)
     if filter_func is None:
         return None
 
+    kwargs = {}
+    assignee_status = {id: None for id in group_ids}
+    assignee_activity = []
+    if assigned_to_filter:
+        assignee_activity = list(
+            Activity.objects.filter(
+                group__id__in=group_ids,
+                type__in=(ActivityType.ASSIGNED.value, ActivityType.UNASSIGNED.value),
+                datetime__gte=start,
+                datetime__lt=end,
+            ).order_by("datetime")[:CONDITION_ACTIVITY_LIMIT]
+        )
+        assignee_activity.reverse()
+        kwargs["assignee_status"] = assignee_status
+
     frequency = timedelta(minutes=frequency_minutes)
     group_last_fire: Dict[str, datetime] = {}
-    group_ids = set()
+    fired_group_ids = set()
     for event in activity:
+        update_assignee(assignee_status, assignee_activity, event.timestamp)
         try:
-            passes = [f.passes_activity(event) for f in filter_objects]
+            passes = [f.passes_activity(event, **kwargs) for f in filter_objects]
         except NotImplementedError:
             return None
         last_fire = group_last_fire.get(event.group_id, event.timestamp - frequency)
         if last_fire <= event.timestamp - frequency and filter_func(passes):
-            group_ids.add(event.group_id)
+            fired_group_ids.add(event.group_id)
             group_last_fire[event.group_id] = event.timestamp
 
-    return Group.objects.filter(id__in=group_ids)
+    return Group.objects.filter(id__in=fired_group_ids)
+
+
+def update_assignee(assignee_status, assignee_activity, timestamp):
+    while len(assignee_activity) > 0 and assignee_activity[-1].datetime < timestamp:
+        activity = assignee_activity.pop()
+        if activity.type == ActivityType.ASSIGNED.value:
+            assignee_status[activity.group_id] = activity.data
+        elif activity.type == ActivityType.UNASSIGNED.value:
+            assignee_status[activity.group_id] = None

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -72,6 +72,7 @@ def preview(
     assignee_status = {id: None for id in group_ids}
     assignee_activity = []
     if assigned_to_filter:
+        # retrieve assigned/unassigned activities that happened in the interval
         assignee_activity = list(
             Activity.objects.filter(
                 group__id__in=group_ids,
@@ -87,6 +88,7 @@ def preview(
     group_last_fire: Dict[str, datetime] = {}
     fired_group_ids = set()
     for event in activity:
+        # update assignee statuses for activities that happened between the previous event and current one
         update_assignee(assignee_status, assignee_activity, event.timestamp)
         try:
             passes = [f.passes_activity(event, **kwargs) for f in filter_objects]

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -105,9 +105,12 @@ def preview(
 def update_assignee(
     assignee_status: Dict[str, Any], assignee_activity: List[Activity], timestamp: datetime
 ) -> None:
+    last_activity = None
     while len(assignee_activity) > 0 and assignee_activity[-1].datetime < timestamp:
-        activity = assignee_activity.pop()
-        if activity.type == ActivityType.ASSIGNED.value:
-            assignee_status[activity.group_id] = activity.data
-        elif activity.type == ActivityType.UNASSIGNED.value:
-            assignee_status[activity.group_id] = None
+        last_activity = assignee_activity.pop()
+
+    if last_activity is not None:
+        if last_activity.type == ActivityType.ASSIGNED.value:
+            assignee_status[last_activity.group_id] = last_activity.data
+        elif last_activity.type == ActivityType.UNASSIGNED.value:
+            assignee_status[last_activity.group_id] = None


### PR DESCRIPTION
Adds support to previews for `assigned_to` filter. Queries for `ASSIGNED/UNASSIGNED` activity and maintains the current assignee of each relevant group while replaying through the `ConditionActivities`