### PR TITLE
feat(replays): Create a basic onboarding page when people visit the replay index

### DIFF
--- a/docs-ui/stories/views/onboardingPanel.stories.js
+++ b/docs-ui/stories/views/onboardingPanel.stories.js
@@ -15,4 +15,13 @@ export const Default = () => {
   );
 };
 
+export const NoImage = () => {
+  return (
+    <OnboardingPanel>
+      <h3>A title</h3>
+      <p>Some content to show in the onboarding state.</p>
+    </OnboardingPanel>
+  );
+};
+
 Default.storyName = 'Onboarding Panel';

--- a/static/app/components/onboardingPanel.tsx
+++ b/static/app/components/onboardingPanel.tsx
@@ -5,15 +5,15 @@ import space from 'sentry/styles/space';
 
 interface Props extends React.ComponentProps<typeof Panel> {
   children: React.ReactNode;
-  image: React.ReactNode;
+  image?: React.ReactNode;
 }
 
 function OnboardingPanel({image, children, ...props}: Props) {
   return (
     <Panel {...props}>
       <Container>
-        <IlloBox>{image}</IlloBox>
-        <StyledBox>{children}</StyledBox>
+        {image ? <IlloBox>{image}</IlloBox> : null}
+        <StyledBox centered={!image}>{children}</StyledBox>
       </Container>
     </Panel>
   );
@@ -39,8 +39,11 @@ const Container = styled('div')`
   }
 `;
 
-const StyledBox = styled('div')`
+const StyledBox = styled('div')<{centered?: boolean}>`
   z-index: 1;
+
+  ${p => (p.centered ? 'text-align: center;' : '')}
+  ${p => (p.centered ? 'max-width: 600px;' : '')}
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
     flex: 2;

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -36,6 +36,7 @@ export type Project = {
   groupingConfig: string;
   hasAccess: boolean;
   hasProfiles: boolean;
+  hasReplays: boolean;
   hasSessions: boolean;
   id: string;
   isBookmarked: boolean;

--- a/static/app/views/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/replays/list/replayOnboardingPanel.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+
+import ButtonBar from 'sentry/components/buttonBar';
+import OnboardingPanel from 'sentry/components/onboardingPanel';
+import {t} from 'sentry/locale';
+
+interface Props {
+  children?: React.ReactNode;
+}
+
+export default function ReplayOnboardingPanel(props: Props) {
+  return (
+    <OnboardingPanel image={null}>
+      <h3>{t('Playback of Your App')}</h3>
+      <p>
+        {t(
+          'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay of your web application.'
+        )}
+      </p>
+      <ButtonList gap={1}>{props.children}</ButtonList>
+    </OnboardingPanel>
+  );
+}
+
+const ButtonList = styled(ButtonBar)`
+  grid-template-columns: repeat(auto-fit, minmax(130px, max-content));
+  justify-content: center;
+`;

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -1,15 +1,16 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useCallback, useMemo} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import Button from 'sentry/components/button';
+import * as Layout from 'sentry/components/layouts/thirds';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
 import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import {t} from 'sentry/locale';
-import {PageContent, PageHeader} from 'sentry/styles/organization';
-import space from 'sentry/styles/space';
+import {PageContent} from 'sentry/styles/organization';
 import EventView from 'sentry/utils/discover/eventView';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {DEFAULT_SORT, REPLAY_LIST_FIELDS} from 'sentry/utils/replays/fetchReplayList';
@@ -18,6 +19,7 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import ReplaysFilters from 'sentry/views/replays/filters';
+import ReplayOnboardingPanel from 'sentry/views/replays/list/replayOnboardingPanel';
 import ReplayTable from 'sentry/views/replays/replayTable';
 import type {ReplayListLocationQuery} from 'sentry/views/replays/types';
 
@@ -51,52 +53,78 @@ function Replays({location}: Props) {
     eventView,
   });
 
+  const shouldShowOnboardingPanel = useMemo(() => {
+    return true;
+  }, []);
+
+  const onSetupReplaysClick = useCallback(() => {
+    return true;
+  }, []);
+
   return (
     <Fragment>
-      <StyledPageHeader>
-        <HeaderTitle>
-          {t('Replays')} <ReplaysFeatureBadge space={1} />
-        </HeaderTitle>
-      </StyledPageHeader>
+      <Layout.Header>
+        <StyledLayoutHeaderContent>
+          <StyledHeading>
+            {t('Replays')} <ReplaysFeatureBadge space={1} />
+          </StyledHeading>
+        </StyledLayoutHeaderContent>
+      </Layout.Header>
       <PageFiltersContainer>
         <StyledPageContent>
           <ReplaysFilters />
-          <ReplayTable
-            isFetching={isFetching}
-            fetchError={fetchError}
-            replays={replays}
-            showProjectColumn={minWidthIsSmall}
-            sort={eventView.sorts[0]}
-          />
-          <Pagination
-            pageLinks={pageLinks}
-            onCursor={(cursor, path, searchQuery) => {
-              browserHistory.push({
-                pathname: path,
-                query: {...searchQuery, cursor},
-              });
-            }}
-          />
+          {shouldShowOnboardingPanel ? (
+            <ReplayOnboardingPanel>
+              <Button
+                href="https://github.com/getsentry/sentry-replay/blob/main/README.md"
+                external
+              >
+                {t('Read Docs')}
+              </Button>
+              <Button onClick={onSetupReplaysClick} priority="primary">
+                {t('Get Started')}
+              </Button>
+            </ReplayOnboardingPanel>
+          ) : (
+            <Fragment>
+              <ReplayTable
+                isFetching={isFetching}
+                fetchError={fetchError}
+                replays={replays}
+                showProjectColumn={minWidthIsSmall}
+                sort={eventView.sorts[0]}
+              />
+              <Pagination
+                pageLinks={pageLinks}
+                onCursor={(cursor, path, searchQuery) => {
+                  browserHistory.push({
+                    pathname: path,
+                    query: {...searchQuery, cursor},
+                  });
+                }}
+              />
+            </Fragment>
+          )}
         </StyledPageContent>
       </PageFiltersContainer>
     </Fragment>
   );
 }
 
-const StyledPageHeader = styled(PageHeader)`
-  background-color: ${p => p.theme.surface100};
-  min-width: max-content;
-  margin: ${space(3)} ${space(0)} ${space(4)} ${space(4)};
+const StyledLayoutHeaderContent = styled(Layout.HeaderContent)`
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row;
+`;
+
+const StyledHeading = styled(PageHeading)`
+  line-height: 40px;
+  display: flex;
 `;
 
 const StyledPageContent = styled(PageContent)`
   box-shadow: 0px 0px 1px ${p => p.theme.gray200};
   background-color: ${p => p.theme.background};
-`;
-
-const HeaderTitle = styled(PageHeading)`
-  display: flex;
-  flex: 1;
 `;
 
 export default Replays;

--- a/tests/acceptance/test_replay_list.py
+++ b/tests/acceptance/test_replay_list.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from uuid import uuid4
 
+from sentry.models import Project
 from sentry.replays.testutils import mock_replay
 from sentry.testutils import ReplaysAcceptanceTestCase
 
@@ -18,6 +19,7 @@ class ReplayListTest(ReplaysAcceptanceTestCase):
             organization=self.org,
             teams=[self.team],
             name="Bengal",
+            flags=Project.flags.has_replays,
         )
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
 


### PR DESCRIPTION
We've got a basic onboarding page setup for the Replay Index

There's a few cases:

1. If you select only non-js projects
    THEN you're going to see the setup instructions (which will say that it's only a JS feature)
<img width="1366" alt="Screen Shot 2022-11-02 at 1 58 52 PM" src="https://user-images.githubusercontent.com/187460/199601360-8e0f23d5-8966-4449-a16d-54181372c39b.png">

2. If you select one or more JS projects
    AND none have sent a replay yet
    THEN you will see the setup instructions:
<img width="1366" alt="Screen Shot 2022-11-02 at 1 58 48 PM" src="https://user-images.githubusercontent.com/187460/199601367-9d5168b5-1b5f-45cf-b8a2-76e21087154a.png">

3. If you select one or more JS projects
    AND one of them has sent a replay in the past
    AND the current filters don't have any results
    THEN you see the empty results page:
<img width="1366" alt="Screen Shot 2022-11-02 at 1 58 45 PM" src="https://user-images.githubusercontent.com/187460/199601357-465540a0-51c1-4eb6-9eb4-24c5125544f8.png">

4. If you select one or more JS projects
    AND one of them has sent a replay in the past
    AND there are results
    THEN you will see the results
_no image needed for this_

Related to #40787