### PR TITLE
feat(metric-layer): Allow ordering by rate

### DIFF
--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -1547,7 +1547,7 @@ DERIVED_OPS: Mapping[MetricOperationType, DerivedOp] = {
         ),
         DerivedOp(
             op="rate",
-            can_orderby=False,
+            can_orderby=True,
             snql_func=rate_snql_factory,
             default_null_value=0,
         ),

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -404,6 +404,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
                         "user_misery()",
                         "failure_rate()",
                     ],
+                    "orderby": "tpm()",
                     "query": "event.type:transaction",
                     "dataset": dataset,
                     "per_page": 50,


### PR DESCRIPTION
- This enables the rate function to be used in the sort, I'm not aware of any reason it can't be ordered