### PR TITLE
fix(commit-context): Skip invalidating cache w/o autoassigment

### DIFF
--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -304,7 +304,8 @@ def process_resource_change(instance, change, **kwargs):
         READ_CACHE_DURATION,
     )
     autoassignment_types = ProjectOwnership._get_autoassignment_types(instance)
-    GroupOwner.invalidate_autoassigned_owner_cache(instance.project_id, autoassignment_types)
+    if len(autoassignment_types) > 0:
+        GroupOwner.invalidate_autoassigned_owner_cache(instance.project_id, autoassignment_types)
 
 
 # Signals update the cached reads used in post_processing

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -541,6 +541,17 @@ class ProjectOwnershipTestCase(TestCase):
             self.project.id, {"stacktrace": {"frames": [frame]}}
         ) == ([ActorTuple(self.team.id, Team)], [rule])
 
+    def test_saves_without_either_auto_assignment_option(self):
+        # Project has group for autoassigned_owner_cache
+        self.group = self.create_group(project=self.project)
+        # Turn off all autoassignment
+        ProjectOwnership.objects.create(
+            project_id=self.project.id,
+            suspect_committer_auto_assignment=False,
+            auto_assignment=False,
+        )
+        assert ProjectOwnership.get_owners(self.project.id, {}) == (ProjectOwnership.Everyone, None)
+
 
 class ResolveActorsTestCase(TestCase):
     def test_no_actors(self):


### PR DESCRIPTION
in #40534 we started invaliding auto assignment caches when updating project ownership. But if autoassignment is off this causes an error when invaliding the cache.

fixes SENTRY-WBV