### PR TITLE
feat(profiling): default to bottom up

### DIFF
--- a/static/app/components/profiling/FrameStack/frameStack.tsx
+++ b/static/app/components/profiling/FrameStack/frameStack.tsx
@@ -36,7 +36,7 @@ const FrameStack = memo(function FrameStack(props: FrameStackProps) {
   const flamegraphPreferences = useFlamegraphPreferences();
   const dispatch = useDispatchFlamegraphState();
 
-  const [tab, setTab] = useState<'bottom up' | 'call order'>('call order');
+  const [tab, setTab] = useState<'bottom up' | 'call order'>('bottom up');
   const [treeType, setTreeType] = useState<'all' | 'application' | 'system'>('all');
   const [recursion, setRecursion] = useState<'collapsed' | null>(null);
 


### PR DESCRIPTION
Bottom up view highlights long running leaf nodes and makes it easier to identify perf bottlenecks as soon as the page loads and avoids forcing users from investigating the flamechart