### PR TITLE
feat(hybrid-cloud): Add superuser cookie domain to client config

### DIFF
--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -202,6 +202,7 @@ def get_client_config(request=None):
         "userIdentity": user_identity,
         "csrfCookieName": settings.CSRF_COOKIE_NAME,
         "superUserCookieName": superuser.COOKIE_NAME,
+        "superUserCookieDomain": superuser.COOKIE_DOMAIN,
         "sentryConfig": {
             "dsn": public_dsn,
             # XXX: In the world of frontend / backend deploys being separated,

--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -205,6 +205,29 @@ class ClientConfigViewTest(TestCase):
         assert data["lastOrganization"] is None
         assert "activeorg" not in self.client.session
 
+    def test_superuser_cookie_domain(self):
+        # Cannot set the superuser cookie domain using override_settings().
+        # So we set them and restore them manually.
+        old_super_cookie_domain = superuser.COOKIE_DOMAIN
+        superuser.COOKIE_DOMAIN = ".testserver"
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+        data = json.loads(resp.content)
+        assert data["superUserCookieDomain"] == ".testserver"
+
+        superuser.COOKIE_DOMAIN = None
+
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp["Content-Type"] == "application/json"
+        data = json.loads(resp.content)
+        assert data["superUserCookieDomain"] is None
+
+        # Restore values
+        superuser.COOKIE_DOMAIN = old_super_cookie_domain
+
     def test_links_unauthenticated(self):
         resp = self.client.get(self.path)
         assert resp.status_code == 200


### PR DESCRIPTION
In https://github.com/getsentry/sentry/blob/master/static/app/utils/isActiveSuperuser.tsx, we need to set the specific domain of the superuser cookie. 

Here, I'm propagating the superuser cookie domain. The frontend changes that will consume this value will be in https://github.com/getsentry/sentry/pull/40927.