### PR TITLE
feat(hybrid-cloud): Consume superUserCookieDomain from client config

### DIFF
--- a/fixtures/js-stubs/config.js
+++ b/fixtures/js-stubs/config.js
@@ -8,6 +8,7 @@ export function Config(params = {}) {
     languageCode: 'en',
     csrfCookieName: 'csrf-test-cookie',
     superUserCookieName: 'su-test-cookie',
+    superUserCookieDomain: '.sentry.io',
     features: new Set(),
     singleOrganization: false,
     urlPrefix: 'https://sentry-jest-tests.example.com/',

--- a/static/app/bootstrap/index.tsx
+++ b/static/app/bootstrap/index.tsx
@@ -5,6 +5,7 @@ const BOOTSTRAP_URL = '/api/client-config/';
 const bootApplication = (data: Config) => {
   window.csrfCookieName = data.csrfCookieName;
   window.superUserCookieName = data.superUserCookieName;
+  window.superUserCookieDomain = data.superUserCookieDomain;
 
   return data;
 };

--- a/static/app/bootstrap/index.tsx
+++ b/static/app/bootstrap/index.tsx
@@ -5,7 +5,7 @@ const BOOTSTRAP_URL = '/api/client-config/';
 const bootApplication = (data: Config) => {
   window.csrfCookieName = data.csrfCookieName;
   window.superUserCookieName = data.superUserCookieName;
-  window.superUserCookieDomain = data.superUserCookieDomain;
+  window.superUserCookieDomain = data.superUserCookieDomain ?? undefined;
 
   return data;
 };

--- a/static/app/components/acl/role.spec.tsx
+++ b/static/app/components/acl/role.spec.tsx
@@ -74,7 +74,11 @@ describe('Role', function () {
       expect(childrenMock).toHaveBeenCalledWith({
         hasRole: true,
       });
-      expect(Cookies.set).toHaveBeenCalledWith('su-test-cookie', 'test');
+      expect(Cookies.set).toHaveBeenCalledWith(
+        'su-test-cookie',
+        'set-in-isActiveSuperuser',
+        {domain: '.sentry.io'}
+      );
       ConfigStore.config.user = TestStubs.User({isSuperuser: false});
     });
 

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -106,6 +106,10 @@ declare global {
     csrfCookieName?: string;
     sentryEmbedCallback?: ((embed: any) => void) | null;
     /**
+     * The domain of which the superuser cookie is set onto.
+     */
+    superUserCookieDomain?: string;
+    /**
      * The superuser cookie used on the backend
      */
     superUserCookieName?: string;
@@ -148,6 +152,7 @@ export interface Config {
     whitelistUrls: string[];
   };
   singleOrganization: boolean;
+  superUserCookieDomain: string | null;
   superUserCookieName: string;
   supportEmail: string;
   termsUrl: string | null;

--- a/static/app/utils/isActiveSuperuser.tsx
+++ b/static/app/utils/isActiveSuperuser.tsx
@@ -3,6 +3,7 @@ import Cookies from 'js-cookie';
 import ConfigStore from 'sentry/stores/configStore';
 
 const SUPERUSER_COOKIE_NAME = window.superUserCookieName ?? 'su';
+const SUPERUSER_COOKIE_DOMAIN = window.superUserCookieDomain;
 
 /**
  * Checking for just isSuperuser on a config object may not be enough as backend often checks for *active* superuser.
@@ -14,12 +15,16 @@ export function isActiveSuperuser() {
   if (isSuperuser) {
     const superUserCookieName =
       ConfigStore.get('superUserCookieName') || SUPERUSER_COOKIE_NAME;
+    const superUserCookieDomain =
+      ConfigStore.get('superUserCookieDomain') || SUPERUSER_COOKIE_DOMAIN;
     /**
      * Superuser cookie cannot be checked for existence as it is HttpOnly.
      * As a workaround, we try to change it to something else and if that fails we can assume that it's being present.
      * There may be an edgecase where it's present and expired but for current usage it's not a big deal.
      */
-    Cookies.set(superUserCookieName, 'test');
+    Cookies.set(superUserCookieName, 'set-in-isActiveSuperuser', {
+      domain: superUserCookieDomain,
+    });
 
     if (Cookies.get(superUserCookieName) === undefined) {
       return true;


### PR DESCRIPTION
In https://github.com/getsentry/sentry/blob/master/static/app/utils/isActiveSuperuser.tsx, we need to set the specific domain of the superuser cookie. 

Here, I'm consuming the superuser cookie domain and setting it for the superuser cookie existence test. Otherwise, duplicate superuser cookies will occur.

The backend changes resides in https://github.com/getsentry/sentry/pull/40926.