### PR TITLE
ref: Refactor eventWaiter firstIssue field to allow for booleans

### DIFF
--- a/static/app/utils/eventWaiter.tsx
+++ b/static/app/utils/eventWaiter.tsx
@@ -23,9 +23,10 @@ const recordAnalyticsFirstEvent = ({
   });
 
 /**
- * Should no issue object be available (the first issue has expired) then it
- * will simply be boolean true. When no event has been received this will be
- * null. Otherwise it will be the group
+ * When no event has been received this will be set to null or false.
+ * Otherwise it will be the Group of the issue that was received.
+ * Or in the case of transactions & replay the value will be set to true.
+ * The `group.id` value is used to generate links directly into the event.
  */
 type FirstIssue = null | boolean | Group;
 

--- a/static/app/utils/eventWaiter.tsx
+++ b/static/app/utils/eventWaiter.tsx
@@ -27,7 +27,7 @@ const recordAnalyticsFirstEvent = ({
  * will simply be boolean true. When no event has been received this will be
  * null. Otherwise it will be the group
  */
-type FirstIssue = null | true | Group;
+type FirstIssue = null | boolean | Group;
 
 export interface EventWaiterProps {
   api: Client;

--- a/static/app/views/onboarding/components/firstEventFooter.tsx
+++ b/static/app/views/onboarding/components/firstEventFooter.tsx
@@ -48,7 +48,7 @@ export default function FirstEventFooter({
     return null;
   };
 
-  const getPrimaryCta = ({firstIssue}: {firstIssue: null | true | Group}) => {
+  const getPrimaryCta = ({firstIssue}: {firstIssue: null | boolean | Group}) => {
     // if hasn't sent first event, allow creation of sample error
     if (!hasFirstEvent) {
       return (
@@ -65,7 +65,9 @@ export default function FirstEventFooter({
     return (
       <Button
         to={`/organizations/${organization.slug}/issues/${
-          firstIssue !== true && firstIssue !== null ? `${firstIssue.id}/` : ''
+          firstIssue && firstIssue !== true && 'id' in firstIssue
+            ? `${firstIssue.id}/`
+            : ''
         }?referrer=onboarding-first-event-footer`}
         priority="primary"
       >

--- a/static/app/views/onboarding/components/firstEventIndicator.tsx
+++ b/static/app/views/onboarding/components/firstEventIndicator.tsx
@@ -37,7 +37,9 @@ const FirstEventIndicator = ({children, ...props}: FirstEventIndicatorProps) => 
               })
             }
             to={`/organizations/${props.organization.slug}/issues/${
-              firstIssue !== true && firstIssue !== null ? `${firstIssue.id}/` : ''
+              firstIssue && firstIssue !== true && 'id' in firstIssue
+                ? `${firstIssue.id}/`
+                : ''
             }?referrer=onboarding-first-event-indicator`}
           >
             {t('Take me to my error')}
@@ -49,7 +51,7 @@ const FirstEventIndicator = ({children, ...props}: FirstEventIndicatorProps) => 
 );
 
 interface IndicatorProps extends Omit<EventWaiterProps, 'children' | 'api'> {
-  firstIssue: Group | null | true;
+  firstIssue: null | boolean | Group;
 }
 
 const Indicator = ({firstIssue}: IndicatorProps) => (


### PR DESCRIPTION
I'm preparing a larger change to add a `first_replay_recieved` event into this component, and this type change seemed like an easy thing to pull out early so it's easier to review outside of the big change.

Related to #40787