### PR TITLE
fix(releases): Use Release.is_valid_version on adding releases

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -188,7 +188,7 @@ def debounce_update_release_health_data(organization, project_ids):
                 continue
 
             # Ignore versions that were saved with an empty string before validation was added
-            if version == "":
+            if not Release.is_valid_version(version):
                 continue
 
             # We might have never observed the release.  This for instance can


### PR DESCRIPTION
Instead of checking for empty string, use the existing valid release version function
fixes SENTRY-VNS

fixes https://getsentry.atlassian.net/browse/WOR-2144