### PR TITLE
chore(migrations): Remove `atomic` from migration template

### DIFF
--- a/src/sentry/new_migrations/migrations.py
+++ b/src/sentry/new_migrations/migrations.py
@@ -7,6 +7,13 @@ class CheckedMigration(Migration):
     won't cause production issues during deploy.
     """
 
+    # This flag is used to decide whether to run this migration in a transaction or not. Generally
+    # we don't want to run in a transaction here, since for long running operations like data
+    # back-fills this results in us locking an increasing number of rows until we finally commit.
+    atomic = False
+
+    # This can be set to `False` to disable safety checks. Don't do this without approval from
+    # the `owners-migrations` team.
     checked = True
 
     def apply(self, project_state, schema_editor, collect_sql=False):

--- a/src/sentry/new_migrations/monkey/__init__.py
+++ b/src/sentry/new_migrations/monkey/__init__.py
@@ -48,11 +48,6 @@ class Migration(CheckedMigration):
     #   change, it's completely safe to run the operation after the code has deployed.
     is_dangerous = False
 
-    # This flag is used to decide whether to run this migration in a transaction or not. Generally
-    # we don't want to run in a transaction here, since for long running operations like data
-    # back-fills this results in us locking an increasing number of rows until we finally commit.
-    atomic = False
-
 %(replaces_str)s%(initial_str)s
     dependencies = [
 %(dependencies)s\


### PR DESCRIPTION
Generally there isn't any reason we really want to set `atomic = True` in our migrations. Removing this from the template and defaulting it to `False` in `CheckedMigration` to reduce any confusion
