### PR TITLE
feat(code-mappings): Add option for code mappings

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -540,3 +540,6 @@ register("dynamic-sampling:enabled-biases", default=True)
 # System-wide options that observes latest releases on transactions and caches these values to be used later in
 # project config computation. This is temporary option to monitor the performance of this feature.
 register("dynamic-sampling:boost-latest-release", default=False)
+
+# Controls whether we should attempt to derive code mappings for projects during post processing.
+register("post_process.derive-code-mappings", default=True)


### PR DESCRIPTION
Add option for code mappings. This is currently set to `True` since the feature flag will restrict the feature by organization. In the event of an incident, we can set this to `False` and disable the feature entirely. 

WOR-2359