### PR TITLE
fix(api-gateway): Fixes from integration testing

### DIFF
--- a/src/sentry/api_gateway/api_gateway.py
+++ b/src/sentry/api_gateway/api_gateway.py
@@ -10,7 +10,7 @@ from sentry.silo import SiloMode
 def _request_should_be_proxied(request: Request, view_func, view_kwargs) -> bool:
     view_class = getattr(view_func, "view_class", None)
     current_silo_mode = SiloMode.get_current_mode()
-    if view_class is not None:
+    if current_silo_mode != SiloMode.MONOLITH and view_class is not None:
         endpoint_silo_limit = getattr(view_class, "silo_limit", None)
         if endpoint_silo_limit is not None:
             endpoint_silo_set = endpoint_silo_limit.modes

--- a/src/sentry/api_gateway/proxy.py
+++ b/src/sentry/api_gateway/proxy.py
@@ -16,7 +16,7 @@ from sentry.api.exceptions import RequestTimeout
 PROXY_CHUNK_SIZE = 512 * 1024
 
 # List of headers to strip from a proxied request
-HEADER_STRIKE_LIST = {"Content-Length"}
+HEADER_STRIKE_LIST = {"Content-Length", "Content-Encoding"}
 
 
 def _parse_response(response: ExternalResponse, remote_url: str) -> StreamingHttpResponse:
@@ -46,6 +46,7 @@ def _strip_request_headers(headers) -> dict:
     for header, value in headers.items():
         if header not in HEADER_STRIKE_LIST:
             header_dict[header] = value
+    return header_dict
 
 
 def proxy_request(request: Request, org_slug: str) -> StreamingHttpResponse:


### PR DESCRIPTION
Running a simple end-to-end test on a dev setup. Encountered the following bugs in the api-gateway
- Drop proxy headers before returning
- Drop Content length before proxying