### PR TITLE
ref(access): Remove models from Access fields

### DIFF
--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -72,10 +72,11 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
                     team__organization=organization, member__user__is_active=True
                 ).select_related("team", "member__user")
             )
-        elif request.access.has_scope("team:write") and request.access.enrolled_team_ids:
+        elif request.access.has_scope("team:write") and request.access.team_ids_with_membership:
             access_requests = list(
                 OrganizationAccessRequest.objects.filter(
-                    member__user__is_active=True, team__id__in=request.access.enrolled_team_ids
+                    member__user__is_active=True,
+                    team__id__in=request.access.team_ids_with_membership,
                 ).select_related("team", "member__user")
             )
         else:

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -72,10 +72,10 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
                     team__organization=organization, member__user__is_active=True
                 ).select_related("team", "member__user")
             )
-        elif request.access.has_scope("team:write") and request.access.teams:
+        elif request.access.has_scope("team:write") and request.access.visible_team_ids:
             access_requests = list(
                 OrganizationAccessRequest.objects.filter(
-                    member__user__is_active=True, team__in=request.access.teams
+                    member__user__is_active=True, team__id__in=request.access.visible_team_ids
                 ).select_related("team", "member__user")
             )
         else:

--- a/src/sentry/api/endpoints/organization_access_request_details.py
+++ b/src/sentry/api/endpoints/organization_access_request_details.py
@@ -72,10 +72,10 @@ class OrganizationAccessRequestDetailsEndpoint(OrganizationEndpoint):
                     team__organization=organization, member__user__is_active=True
                 ).select_related("team", "member__user")
             )
-        elif request.access.has_scope("team:write") and request.access.visible_team_ids:
+        elif request.access.has_scope("team:write") and request.access.enrolled_team_ids:
             access_requests = list(
                 OrganizationAccessRequest.objects.filter(
-                    member__user__is_active=True, team__id__in=request.access.visible_team_ids
+                    member__user__is_active=True, team__id__in=request.access.enrolled_team_ids
                 ).select_related("team", "member__user")
             )
         else:

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -272,9 +272,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 # projects that the user is a member of. This gives us a better
                 # chance of returning the correct result, even if the wrong
                 # project is selected.
-                direct_hit_projects = set(project_ids) | {
-                    project.id for project in request.access.projects
-                }
+                direct_hit_projects = set(project_ids) | request.access.visible_project_ids
                 groups = list(Group.objects.filter_by_event_id(direct_hit_projects, event_id))
                 if len(groups) == 1:
                     serialized_groups = serialize(groups, request.user, serializer())

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -272,7 +272,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 # projects that the user is a member of. This gives us a better
                 # chance of returning the correct result, even if the wrong
                 # project is selected.
-                direct_hit_projects = set(project_ids) | request.access.visible_project_ids
+                direct_hit_projects = set(project_ids) | request.access.enrolled_project_ids
                 groups = list(Group.objects.filter_by_event_id(direct_hit_projects, event_id))
                 if len(groups) == 1:
                     serialized_groups = serialize(groups, request.user, serializer())

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -272,7 +272,9 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 # projects that the user is a member of. This gives us a better
                 # chance of returning the correct result, even if the wrong
                 # project is selected.
-                direct_hit_projects = set(project_ids) | request.access.enrolled_project_ids
+                direct_hit_projects = (
+                    set(project_ids) | request.access.project_ids_with_team_membership
+                )
                 groups = list(Group.objects.filter_by_event_id(direct_hit_projects, event_id))
                 if len(groups) == 1:
                     serialized_groups = serialize(groups, request.user, serializer())

--- a/src/sentry/api/endpoints/organization_user_teams.py
+++ b/src/sentry/api/endpoints/organization_user_teams.py
@@ -29,6 +29,6 @@ class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
             queryset = Team.objects.filter(
                 organization=organization,
                 status=TeamStatus.VISIBLE,
-                id__in=request.access.visible_team_ids,
+                id__in=request.access.enrolled_team_ids,
             ).order_by("slug")
         return Response(serialize(list(queryset), request.user, TeamWithProjectsSerializer()))

--- a/src/sentry/api/endpoints/organization_user_teams.py
+++ b/src/sentry/api/endpoints/organization_user_teams.py
@@ -29,6 +29,6 @@ class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
             queryset = Team.objects.filter(
                 organization=organization,
                 status=TeamStatus.VISIBLE,
-                id__in=request.access.enrolled_team_ids,
+                id__in=request.access.team_ids_with_membership,
             ).order_by("slug")
         return Response(serialize(list(queryset), request.user, TeamWithProjectsSerializer()))

--- a/src/sentry/api/endpoints/organization_user_teams.py
+++ b/src/sentry/api/endpoints/organization_user_teams.py
@@ -25,8 +25,10 @@ class OrganizationUserTeamsEndpoint(OrganizationEndpoint):
             queryset = Team.objects.filter(
                 organization=organization, status=TeamStatus.VISIBLE
             ).order_by("slug")
-            return Response(serialize(list(queryset), request.user, TeamWithProjectsSerializer()))
         else:
-            return Response(
-                serialize(list(request.access.teams), request.user, TeamWithProjectsSerializer())
-            )
+            queryset = Team.objects.filter(
+                organization=organization,
+                status=TeamStatus.VISIBLE,
+                id__in=request.access.visible_team_ids,
+            ).order_by("slug")
+        return Response(serialize(list(queryset), request.user, TeamWithProjectsSerializer()))

--- a/src/sentry/api/helpers/teams.py
+++ b/src/sentry/api/helpers/teams.py
@@ -20,7 +20,7 @@ def get_teams(request, organization, teams=None):
             ).values_list("id", flat=True)
             verified_ids.update(myteams)
         else:
-            myteams = request.access.enrolled_team_ids
+            myteams = request.access.team_ids_with_membership
             verified_ids.update(myteams)
 
     for team_id in requested_teams:  # Verify each passed Team id is numeric

--- a/src/sentry/api/helpers/teams.py
+++ b/src/sentry/api/helpers/teams.py
@@ -20,7 +20,7 @@ def get_teams(request, organization, teams=None):
             ).values_list("id", flat=True)
             verified_ids.update(myteams)
         else:
-            myteams = [t.id for t in request.access.teams]
+            myteams = request.access.visible_team_ids
             verified_ids.update(myteams)
 
     for team_id in requested_teams:  # Verify each passed Team id is numeric

--- a/src/sentry/api/helpers/teams.py
+++ b/src/sentry/api/helpers/teams.py
@@ -20,7 +20,7 @@ def get_teams(request, organization, teams=None):
             ).values_list("id", flat=True)
             verified_ids.update(myteams)
         else:
-            myteams = request.access.visible_team_ids
+            myteams = request.access.enrolled_team_ids
             verified_ids.update(myteams)
 
     for team_id in requested_teams:  # Verify each passed Team id is numeric

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -486,14 +486,11 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
         return super().get_attrs(item_list, user)
 
     def _project_list(self, organization: Organization, access: Access) -> list[Project]:
-        member_projects = list(access.projects)
-        member_project_ids = [p.id for p in member_projects]
-        other_projects = list(
-            Project.objects.filter(organization=organization, status=ProjectStatus.VISIBLE).exclude(
-                id__in=member_project_ids
-            )
+        project_list = list(
+            Project.objects.filter(
+                organization=organization, status=ProjectStatus.VISIBLE
+            ).order_by("slug")
         )
-        project_list = sorted(other_projects + member_projects, key=lambda x: x.slug)  # type: ignore
 
         for project in project_list:
             project.set_cached_field_value("organization", organization)
@@ -501,14 +498,11 @@ class DetailedOrganizationSerializerWithProjectsAndTeams(DetailedOrganizationSer
         return project_list
 
     def _team_list(self, organization: Organization, access: Access) -> list[Team]:
-        member_teams = list(access.teams)
-        member_team_ids = [p.id for p in member_teams]
-        other_teams = list(
-            Team.objects.filter(organization=organization, status=TeamStatus.VISIBLE).exclude(
-                id__in=member_team_ids
+        team_list = list(
+            Team.objects.filter(organization=organization, status=TeamStatus.VISIBLE).order_by(
+                "slug"
             )
         )
-        team_list = sorted(other_teams + member_teams, key=lambda x: x.slug)  # type: ignore
 
         for team in team_list:
             team.set_cached_field_value("organization", organization)

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -416,6 +416,18 @@ class SystemAccess(Access):
     def has_project_access(self, project: Project) -> bool:
         return True
 
+    # The semantically correct behavior for accessible_(team|project)_ids would be to
+    # query for all teams or projects in the system, which we don't want to attempt.
+    # Code paths that may have SystemAccess must avoid looking at these properties.
+
+    @property
+    def accessible_team_ids(self) -> FrozenSet[int]:
+        raise Exception("Cannot list all accessible teams for SystemAccess")
+
+    @property
+    def accessible_project_ids(self) -> FrozenSet[int]:
+        raise Exception("Cannot list all accessible projects for SystemAccess")
+
 
 class NoAccess(OrganizationlessAccess):
     def __init__(self) -> None:

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 __all__ = ["from_user", "from_member", "DEFAULT"]
 
 import abc
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Collection, FrozenSet, Iterable, Mapping, Optional, Tuple
+from typing import Collection, FrozenSet, Iterable, Mapping, Tuple
 
 import sentry_sdk
 from django.conf import settings
@@ -100,10 +102,10 @@ class Access(abc.ABC):
     scopes: FrozenSet[str] = frozenset()
     permissions: FrozenSet[str] = frozenset()
 
-    member: Optional[OrganizationMember] = None
+    member: OrganizationMember | None = None
 
     @property
-    def role(self) -> Optional[str]:
+    def role(self) -> str | None:
         return self.member.role if self.member else None
 
     @cached_property
@@ -155,7 +157,7 @@ class Access(abc.ABC):
         """
         return scope in self.scopes
 
-    def get_organization_role(self) -> Optional[OrganizationRole]:
+    def get_organization_role(self) -> OrganizationRole | None:
         return self.role and organization_roles.get(self.role)
 
     @abc.abstractmethod
@@ -192,7 +194,7 @@ class Access(abc.ABC):
     def has_team_membership(self, team: Team) -> bool:
         return team in self.teams
 
-    def get_team_role(self, team: Team) -> Optional[TeamRole]:
+    def get_team_role(self, team: Team) -> TeamRole | None:
         team_member = self._team_memberships.get(team)
         return team_member and team_member.get_team_role()
 
@@ -371,7 +373,7 @@ class NoAccess(OrganizationlessAccess):
 
 
 def from_request(
-    request, organization: Organization = None, scopes: Optional[Iterable[str]] = None
+    request, organization: Organization = None, scopes: Iterable[str] | None = None
 ) -> Access:
     is_superuser = is_active_superuser(request)
 
@@ -410,7 +412,7 @@ def from_request(
 
 
 # only used internally
-def _from_sentry_app(user, organization: Optional[Organization] = None) -> Access:
+def _from_sentry_app(user, organization: Organization | None = None) -> Access:
     if not organization:
         return NoAccess()
 
@@ -429,8 +431,8 @@ def _from_sentry_app(user, organization: Optional[Organization] = None) -> Acces
 
 def from_user(
     user,
-    organization: Optional[Organization] = None,
-    scopes: Optional[Iterable[str]] = None,
+    organization: Organization | None = None,
+    scopes: Iterable[str] | None = None,
     is_superuser: bool = False,
 ) -> Access:
     if not user or user.is_anonymous or not user.is_active:
@@ -457,7 +459,7 @@ def from_user(
 
 def from_member(
     member: OrganizationMember,
-    scopes: Optional[Iterable[str]] = None,
+    scopes: Iterable[str] | None = None,
     is_superuser: bool = False,
 ) -> Access:
     if scopes is not None:

--- a/src/sentry/web/frontend/newest_performance_issue.py
+++ b/src/sentry/web/frontend/newest_performance_issue.py
@@ -3,29 +3,16 @@ from django.urls import reverse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.auth.superuser import is_active_superuser
 from sentry.models.group import Group, GroupStatus
-from sentry.models.project import Project, ProjectStatus
 
 from .react_page import ReactPageView
 
 
-def _get_project_ids(request, organization):
-    if is_active_superuser(request):
-        return Project.objects.filter(
-            status=ProjectStatus.VISIBLE, organization_id=organization.id
-        ).values_list("id", flat=True)
-    else:
-        return request.access.visible_project_ids
-
-
 class NewestPerformanceIssueView(ReactPageView):
     def handle(self, request: Request, organization, **kwargs) -> Response:
-        project_ids = _get_project_ids(request, organization)
-
         group = (
             Group.objects.filter(
-                project_id__in=project_ids,
+                project_id__in=request.access.accessible_project_ids,
                 status=GroupStatus.UNRESOLVED,
                 # performance issue range
                 type__gte=1000,

--- a/src/sentry/web/frontend/newest_performance_issue.py
+++ b/src/sentry/web/frontend/newest_performance_issue.py
@@ -10,19 +10,18 @@ from sentry.models.project import Project, ProjectStatus
 from .react_page import ReactPageView
 
 
-def get_projects(request, organization):
+def _get_project_ids(request, organization):
     if is_active_superuser(request):
-        return list(
-            Project.objects.filter(status=ProjectStatus.VISIBLE, organization_id=organization.id)
-        )
+        return Project.objects.filter(
+            status=ProjectStatus.VISIBLE, organization_id=organization.id
+        ).values_list("id", flat=True)
     else:
-        return request.access.projects
+        return request.access.visible_project_ids
 
 
 class NewestPerformanceIssueView(ReactPageView):
     def handle(self, request: Request, organization, **kwargs) -> Response:
-        projects = get_projects(request, organization)
-        project_ids = [project.id for project in projects]
+        project_ids = _get_project_ids(request, organization)
 
         group = (
             Group.objects.filter(

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -138,7 +138,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
         options.delete("store.symbolicate-event-lpq-always")
         options.delete("store.symbolicate-event-lpq-never")
 
-        expected_queries += 3
+        expected_queries += 1
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -58,7 +58,7 @@ class FromUserTest(TestCase):
         for result in results:
             assert result.has_project_access(deleted_project) is False
             assert result.has_project_membership(deleted_project) is False
-            assert len(result.visible_project_ids) == 0
+            assert len(result.enrolled_project_ids) == 0
 
     def test_no_deleted_teams(self):
         user = self.create_user()
@@ -78,7 +78,7 @@ class FromUserTest(TestCase):
         for result in results:
             assert result.has_team_access(team) is True
             assert result.has_team_access(deleted_team) is False
-            assert result.visible_team_ids == frozenset({team.id})
+            assert result.enrolled_team_ids == frozenset({team.id})
 
     def test_unique_projects(self):
         user = self.create_user()
@@ -96,7 +96,7 @@ class FromUserTest(TestCase):
 
         for result in results:
             assert result.has_project_access(project)
-            assert len(result.visible_project_ids) == 1
+            assert len(result.enrolled_project_ids) == 1
 
     def test_mixed_access(self):
         user = self.create_user()
@@ -324,9 +324,9 @@ class FromRequestTest(TestCase):
         def assert_memberships(result: Access) -> None:
             assert result.role == "admin"
 
-            assert result.visible_team_ids == frozenset({self.team1.id})
+            assert result.enrolled_team_ids == frozenset({self.team1.id})
             assert result.has_team_access(self.team1)
-            assert result.visible_project_ids == frozenset({self.project1.id})
+            assert result.enrolled_project_ids == frozenset({self.project1.id})
             assert result.has_project_access(self.project1)
             assert result.has_project_membership(self.project1)
             assert not result.has_project_membership(self.project2)
@@ -356,9 +356,9 @@ class FromRequestTest(TestCase):
         assert not result.requires_sso
         assert result.sso_is_valid
 
-        assert result.visible_team_ids == frozenset()
+        assert result.enrolled_team_ids == frozenset()
         assert result.has_team_access(self.team1)
-        assert result.visible_project_ids == frozenset()
+        assert result.enrolled_project_ids == frozenset()
         assert result.has_project_access(self.project1)
 
     def test_member_role_in_organization_closed_membership(self):
@@ -373,9 +373,9 @@ class FromRequestTest(TestCase):
         result = access.from_request(request, self.org)
 
         assert result.role == "member"
-        assert result.visible_team_ids == frozenset({self.team1.id})
+        assert result.enrolled_team_ids == frozenset({self.team1.id})
         assert result.has_team_access(self.team1)
-        assert result.visible_project_ids == frozenset({self.project1.id})
+        assert result.enrolled_project_ids == frozenset({self.project1.id})
         assert result.has_project_access(self.project1)
         assert result.has_project_membership(self.project1)
         assert not result.has_project_membership(self.project2)
@@ -397,9 +397,9 @@ class FromRequestTest(TestCase):
         result = access.from_request(request, self.org)
 
         assert result.role == "member"
-        assert result.visible_team_ids == frozenset({self.team1.id})
+        assert result.enrolled_team_ids == frozenset({self.team1.id})
         assert result.has_team_access(self.team1)
-        assert result.visible_project_ids == frozenset({self.project1.id})
+        assert result.enrolled_project_ids == frozenset({self.project1.id})
         assert result.has_project_access(self.project1)
         assert result.has_project_membership(self.project1)
         assert not result.has_project_membership(self.project2)
@@ -423,10 +423,10 @@ class FromRequestTest(TestCase):
         request.auth = ApiKey.objects.create(organization=organization, allowed_origins="*")
         result = access.from_request(request, organization)
 
-        assert result.visible_team_ids == frozenset({})
+        assert result.enrolled_team_ids == frozenset({})
         assert result.has_team_access(member_team)
         assert result.has_team_access(non_member_team)
-        assert result.visible_project_ids == frozenset({})
+        assert result.enrolled_project_ids == frozenset({})
         assert result.has_project_access(member_project)
         assert result.has_project_access(non_member_project)
         assert result.has_project_membership(member_project) is False
@@ -448,9 +448,9 @@ class FromRequestTest(TestCase):
 
         assert result == NoAccess()
 
-        assert result.visible_team_ids == frozenset({})
+        assert result.enrolled_team_ids == frozenset({})
         assert result.has_team_access(team) is False
-        assert result.visible_project_ids == frozenset({})
+        assert result.enrolled_project_ids == frozenset({})
         assert result.has_project_access(project) is False
         assert result.has_project_membership(project) is False
         assert result.has_global_access is False
@@ -496,7 +496,7 @@ class FromSentryAppTest(TestCase):
         result = access.from_request(request, self.org)
         assert result.has_global_access
         assert result.has_team_access(self.team)
-        assert result.visible_team_ids == frozenset({self.team.id})
+        assert result.enrolled_team_ids == frozenset({self.team.id})
         assert result.scopes == frozenset()
         assert result.has_project_access(self.project)
         assert result.has_project_membership(self.project)

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -58,7 +58,7 @@ class FromUserTest(TestCase):
         for result in results:
             assert result.has_project_access(deleted_project) is False
             assert result.has_project_membership(deleted_project) is False
-            assert len(result.projects) == 0
+            assert len(result.visible_project_ids) == 0
 
     def test_no_deleted_teams(self):
         user = self.create_user()
@@ -78,7 +78,7 @@ class FromUserTest(TestCase):
         for result in results:
             assert result.has_team_access(team) is True
             assert result.has_team_access(deleted_team) is False
-            assert result.teams == frozenset({team})
+            assert result.visible_team_ids == frozenset({team.id})
 
     def test_unique_projects(self):
         user = self.create_user()
@@ -96,7 +96,7 @@ class FromUserTest(TestCase):
 
         for result in results:
             assert result.has_project_access(project)
-            assert len(result.projects) == 1
+            assert len(result.visible_project_ids) == 1
 
     def test_mixed_access(self):
         user = self.create_user()
@@ -324,9 +324,9 @@ class FromRequestTest(TestCase):
         def assert_memberships(result: Access) -> None:
             assert result.role == "admin"
 
-            assert result.teams == frozenset({self.team1})
+            assert result.visible_team_ids == frozenset({self.team1.id})
             assert result.has_team_access(self.team1)
-            assert result.projects == frozenset({self.project1})
+            assert result.visible_project_ids == frozenset({self.project1.id})
             assert result.has_project_access(self.project1)
             assert result.has_project_membership(self.project1)
             assert not result.has_project_membership(self.project2)
@@ -356,9 +356,9 @@ class FromRequestTest(TestCase):
         assert not result.requires_sso
         assert result.sso_is_valid
 
-        assert result.teams == frozenset()
+        assert result.visible_team_ids == frozenset()
         assert result.has_team_access(self.team1)
-        assert result.projects == frozenset()
+        assert result.visible_project_ids == frozenset()
         assert result.has_project_access(self.project1)
 
     def test_member_role_in_organization_closed_membership(self):
@@ -373,9 +373,9 @@ class FromRequestTest(TestCase):
         result = access.from_request(request, self.org)
 
         assert result.role == "member"
-        assert result.teams == frozenset({self.team1})
+        assert result.visible_team_ids == frozenset({self.team1.id})
         assert result.has_team_access(self.team1)
-        assert result.projects == frozenset({self.project1})
+        assert result.visible_project_ids == frozenset({self.project1.id})
         assert result.has_project_access(self.project1)
         assert result.has_project_membership(self.project1)
         assert not result.has_project_membership(self.project2)
@@ -397,9 +397,9 @@ class FromRequestTest(TestCase):
         result = access.from_request(request, self.org)
 
         assert result.role == "member"
-        assert result.teams == frozenset({self.team1})
+        assert result.visible_team_ids == frozenset({self.team1.id})
         assert result.has_team_access(self.team1)
-        assert result.projects == frozenset({self.project1})
+        assert result.visible_project_ids == frozenset({self.project1.id})
         assert result.has_project_access(self.project1)
         assert result.has_project_membership(self.project1)
         assert not result.has_project_membership(self.project2)
@@ -423,10 +423,10 @@ class FromRequestTest(TestCase):
         request.auth = ApiKey.objects.create(organization=organization, allowed_origins="*")
         result = access.from_request(request, organization)
 
-        assert result.teams == frozenset({})
+        assert result.visible_team_ids == frozenset({})
         assert result.has_team_access(member_team)
         assert result.has_team_access(non_member_team)
-        assert result.projects == frozenset({})
+        assert result.visible_project_ids == frozenset({})
         assert result.has_project_access(member_project)
         assert result.has_project_access(non_member_project)
         assert result.has_project_membership(member_project) is False
@@ -448,9 +448,9 @@ class FromRequestTest(TestCase):
 
         assert result == NoAccess()
 
-        assert result.teams == frozenset({})
+        assert result.visible_team_ids == frozenset({})
         assert result.has_team_access(team) is False
-        assert result.projects == frozenset({})
+        assert result.visible_project_ids == frozenset({})
         assert result.has_project_access(project) is False
         assert result.has_project_membership(project) is False
         assert result.has_global_access is False
@@ -496,7 +496,7 @@ class FromSentryAppTest(TestCase):
         result = access.from_request(request, self.org)
         assert result.has_global_access
         assert result.has_team_access(self.team)
-        assert result.teams == frozenset({self.team})
+        assert result.visible_team_ids == frozenset({self.team.id})
         assert result.scopes == frozenset()
         assert result.has_project_access(self.project)
         assert result.has_project_membership(self.project)

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -58,7 +58,7 @@ class FromUserTest(TestCase):
         for result in results:
             assert result.has_project_access(deleted_project) is False
             assert result.has_project_membership(deleted_project) is False
-            assert len(result.enrolled_project_ids) == 0
+            assert len(result.project_ids_with_team_membership) == 0
 
     def test_no_deleted_teams(self):
         user = self.create_user()
@@ -78,7 +78,7 @@ class FromUserTest(TestCase):
         for result in results:
             assert result.has_team_access(team) is True
             assert result.has_team_access(deleted_team) is False
-            assert result.enrolled_team_ids == frozenset({team.id})
+            assert result.team_ids_with_membership == frozenset({team.id})
 
     def test_unique_projects(self):
         user = self.create_user()
@@ -96,7 +96,7 @@ class FromUserTest(TestCase):
 
         for result in results:
             assert result.has_project_access(project)
-            assert len(result.enrolled_project_ids) == 1
+            assert len(result.project_ids_with_team_membership) == 1
 
     def test_mixed_access(self):
         user = self.create_user()
@@ -324,9 +324,9 @@ class FromRequestTest(TestCase):
         def assert_memberships(result: Access) -> None:
             assert result.role == "admin"
 
-            assert result.enrolled_team_ids == frozenset({self.team1.id})
+            assert result.team_ids_with_membership == frozenset({self.team1.id})
             assert result.has_team_access(self.team1)
-            assert result.enrolled_project_ids == frozenset({self.project1.id})
+            assert result.project_ids_with_team_membership == frozenset({self.project1.id})
             assert result.has_project_access(self.project1)
             assert result.has_project_membership(self.project1)
             assert not result.has_project_membership(self.project2)
@@ -356,9 +356,9 @@ class FromRequestTest(TestCase):
         assert not result.requires_sso
         assert result.sso_is_valid
 
-        assert result.enrolled_team_ids == frozenset()
+        assert result.team_ids_with_membership == frozenset()
         assert result.has_team_access(self.team1)
-        assert result.enrolled_project_ids == frozenset()
+        assert result.project_ids_with_team_membership == frozenset()
         assert result.has_project_access(self.project1)
 
     def test_member_role_in_organization_closed_membership(self):
@@ -373,9 +373,9 @@ class FromRequestTest(TestCase):
         result = access.from_request(request, self.org)
 
         assert result.role == "member"
-        assert result.enrolled_team_ids == frozenset({self.team1.id})
+        assert result.team_ids_with_membership == frozenset({self.team1.id})
         assert result.has_team_access(self.team1)
-        assert result.enrolled_project_ids == frozenset({self.project1.id})
+        assert result.project_ids_with_team_membership == frozenset({self.project1.id})
         assert result.has_project_access(self.project1)
         assert result.has_project_membership(self.project1)
         assert not result.has_project_membership(self.project2)
@@ -397,9 +397,9 @@ class FromRequestTest(TestCase):
         result = access.from_request(request, self.org)
 
         assert result.role == "member"
-        assert result.enrolled_team_ids == frozenset({self.team1.id})
+        assert result.team_ids_with_membership == frozenset({self.team1.id})
         assert result.has_team_access(self.team1)
-        assert result.enrolled_project_ids == frozenset({self.project1.id})
+        assert result.project_ids_with_team_membership == frozenset({self.project1.id})
         assert result.has_project_access(self.project1)
         assert result.has_project_membership(self.project1)
         assert not result.has_project_membership(self.project2)
@@ -423,10 +423,10 @@ class FromRequestTest(TestCase):
         request.auth = ApiKey.objects.create(organization=organization, allowed_origins="*")
         result = access.from_request(request, organization)
 
-        assert result.enrolled_team_ids == frozenset({})
+        assert result.team_ids_with_membership == frozenset({})
         assert result.has_team_access(member_team)
         assert result.has_team_access(non_member_team)
-        assert result.enrolled_project_ids == frozenset({})
+        assert result.project_ids_with_team_membership == frozenset({})
         assert result.has_project_access(member_project)
         assert result.has_project_access(non_member_project)
         assert result.has_project_membership(member_project) is False
@@ -448,9 +448,9 @@ class FromRequestTest(TestCase):
 
         assert result == NoAccess()
 
-        assert result.enrolled_team_ids == frozenset({})
+        assert result.team_ids_with_membership == frozenset({})
         assert result.has_team_access(team) is False
-        assert result.enrolled_project_ids == frozenset({})
+        assert result.project_ids_with_team_membership == frozenset({})
         assert result.has_project_access(project) is False
         assert result.has_project_membership(project) is False
         assert result.has_global_access is False
@@ -496,7 +496,7 @@ class FromSentryAppTest(TestCase):
         result = access.from_request(request, self.org)
         assert result.has_global_access
         assert result.has_team_access(self.team)
-        assert result.enrolled_team_ids == frozenset({self.team.id})
+        assert result.team_ids_with_membership == frozenset({self.team.id})
         assert result.scopes == frozenset()
         assert result.has_project_access(self.project)
         assert result.has_project_membership(self.project)


### PR DESCRIPTION
Anticipating changes for Hybrid Cloud silo boundaries, change the public interface of the `Access` class to not expose any ORM models as dataclass fields. As a first step, replace all such objects with their raw IDs. (Credit to @corps for the underlying idea. Future steps: replace models as method parameters; replace raw IDs with API object representations.)