### PR TITLE
fix(migrations): Mark reconstrain_savedsearch_pinning_fields is_dangerous

### DIFF
--- a/src/sentry/migrations/0341_reconstrain_savedsearch_pinning_fields.py
+++ b/src/sentry/migrations/0341_reconstrain_savedsearch_pinning_fields.py
@@ -16,7 +16,16 @@ class Migration(CheckedMigration):
     # - Adding indexes to large tables. Since this can take a long time, we'd generally prefer to
     #   have ops run this and not block the deploy. Note that while adding an index is a schema
     #   change, it's completely safe to run the operation after the code has deployed.
-    is_dangerous = False
+    #
+    # XXX(epurkhiser): For some reason in producton this migration is failing
+    #                  to run. We're mmarking as dangersous so we can run some
+    #                  custom SQL instead.
+    #
+    #                  psycopg2.errors.UndefinedObject:
+    #                  UndefinedObject('constraint
+    #                  "sentry_savedsearch_organization_id_48379b0f7f6794f" of
+    #                  relation "sentry_savedsearch" does not exist\n')
+    is_dangerous = True
 
     # This flag is used to decide whether to run this migration in a transaction or not. Generally
     # we don't want to run in a transaction here, since for long running operations like data


### PR DESCRIPTION
We are marking this migration as dangerous because it is not applying in production

The original migration PR: #40876

## Why is it not applying

django migrations expect unique_together to be handled by a postgres constraint, in production it is trying to run

```sql
ALTER TABLE "sentry_savedsearch" DROP CONSTRAINT "sentry_savedsearch_organization_id_48379b0f7f6794f"
```

However, that constraint does not exist, instead it exists as a index on the table. This is likely from when we moved from south to django migrations

<img width="1023" alt="image" src="https://user-images.githubusercontent.com/1421724/199633534-b834120e-9557-4da4-8822-12e6e3a9510b.png">

