### PR TITLE
feat(hybrid-cloud): Set frontend tags on Sentry events emitted whenever a customer domain is used

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -111,6 +111,15 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
     Sentry.setTag('sentry_version', window.__SENTRY__VERSION);
   }
 
+  const {customerDomain} = window.__initialData;
+
+  if (customerDomain) {
+    Sentry.setTag('isCustomerDomain', 'yes');
+    Sentry.setTag('customerDomain.organizationUrl', customerDomain.organizationUrl);
+    Sentry.setTag('customerDomain.sentryUrl', customerDomain.sentryUrl);
+    Sentry.setTag('customerDomain.subdomain', customerDomain.subdomain);
+  }
+
   LongTaskObserver.startPerformanceObserver();
   initializeMeasureAssetsTimeout();
 }


### PR DESCRIPTION
Set frontend tags on Sentry events emitted whenever a customer domain is used.

This makes Sentry transactions, errors, replays, and other emitted payloads that occur on a customer domain be easier to search/query.