### PR TITLE
fix(hybrid-cloud): Propagate organizations:customer-domains feature if a customer domain is used

### DIFF
--- a/tests/sentry/web/test_api.py
+++ b/tests/sentry/web/test_api.py
@@ -146,6 +146,13 @@ class ClientConfigViewTest(TestCase):
             data = json.loads(resp.content)
             assert data["features"] == ["organizations:create"]
 
+            # Customer domain feature is injected if a customer domain is used.
+            resp = self.client.get(self.path, HTTP_HOST="albertos-apples.testserver")
+            assert resp.status_code == 200
+            assert resp["Content-Type"] == "application/json"
+            data = json.loads(resp.content)
+            assert data["features"] == ["organizations:create", "organizations:customer-domains"]
+
     def test_unauthenticated(self):
         resp = self.client.get(self.path)
         assert resp.status_code == 200


### PR DESCRIPTION
A continuation of https://github.com/getsentry/sentry/pull/40877, whenever orgslug.sentry.io is accessed, we implicitly add the customer domain feature flag.