### PR TITLE
meta(launch-configs): Add Python debug server launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,11 +25,9 @@
       "name": "sentry backend debug",
       "type": "python",
       "request": "launch",
-      "stopOnEntry": true,
       "program": "${workspaceRoot}/.venv/bin/sentry",
       "args": ["devserver", "--debug-server", "--no-pretty"],
-      "cwd": "${workspaceRoot}",
-      "debugOptions": ["WaitOnAbnormalExit", "WaitOnNormalExit", "RedirectOutput"]
+      "cwd": "${workspaceRoot}"
     },
     {
       "name": "jest",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,36 +1,34 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-          "name": "sentry frontend",
-          "type": "chrome",
-          "request": "launch",
-          "url": "http://dev.getsentry.net:8000",
-          "webRoot": "${workspaceRoot}/src/sentry/static/sentry/app"
-        },
-        {
-          "name": "sentry backend",
-          "type": "python",
-          "request": "launch",
-          "stopOnEntry": true,
-          "program": "${workspaceRoot}/.venv/bin/sentry",
-          "args": ["devserver"],
-          "cwd": "${workspaceRoot}",
-          "debugOptions": ["WaitOnAbnormalExit", "WaitOnNormalExit", "RedirectOutput"]
-        },
-        {
-            "name": "jest",
-            "type": "node",
-            "request": "launch",
-            "protocol": "inspector",
-            "program": "${workspaceFolder}/node_modules/.bin/jest",
-            "internalConsoleOptions": "openOnSessionStart",
-            "args": [
-                "--runInBand"
-            ]
-        }
-    ]
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "sentry frontend",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://dev.getsentry.net:8000",
+      "webRoot": "${workspaceRoot}/src/sentry/static/sentry/app"
+    },
+    {
+      "name": "sentry backend",
+      "type": "python",
+      "request": "launch",
+      "stopOnEntry": true,
+      "program": "${workspaceRoot}/.venv/bin/sentry",
+      "args": ["devserver"],
+      "cwd": "${workspaceRoot}",
+      "debugOptions": ["WaitOnAbnormalExit", "WaitOnNormalExit", "RedirectOutput"]
+    },
+    {
+      "name": "jest",
+      "type": "node",
+      "request": "launch",
+      "protocol": "inspector",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "internalConsoleOptions": "openOnSessionStart",
+      "args": ["--runInBand"]
+    }
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,16 @@
       "debugOptions": ["WaitOnAbnormalExit", "WaitOnNormalExit", "RedirectOutput"]
     },
     {
+      "name": "sentry backend debug",
+      "type": "python",
+      "request": "launch",
+      "stopOnEntry": true,
+      "program": "${workspaceRoot}/.venv/bin/sentry",
+      "args": ["devserver", "--debug-server", "--no-pretty"],
+      "cwd": "${workspaceRoot}",
+      "debugOptions": ["WaitOnAbnormalExit", "WaitOnNormalExit", "RedirectOutput"]
+    },
+    {
       "name": "jest",
       "type": "node",
       "request": "launch",


### PR DESCRIPTION
When launched, starts up the devserver in debug mode, which makes it possible to use VS Code's interactive debugger.

**e.g.,**
![Screen Shot 2022-11-03 at 1 43 27 PM](https://user-images.githubusercontent.com/989898/199796250-594db57a-c63c-4ea6-b474-de05c02b4424.png)