### PR TITLE
ref(dropdownMenu): Remove `showDividers` prop & modify default divider rules

### DIFF
--- a/static/app/components/actions/resolve.tsx
+++ b/static/app/components/actions/resolve.tsx
@@ -165,7 +165,6 @@ class ResolveActions extends Component<Props> {
         label: t('The next release'),
         details: actionTitle,
         onAction: () => onActionOrConfirm(this.handleNextReleaseResolution),
-        showDividers: !actionTitle,
       },
       {
         key: 'current-release',
@@ -174,19 +173,16 @@ class ResolveActions extends Component<Props> {
           : t('The current release'),
         details: actionTitle,
         onAction: () => onActionOrConfirm(this.handleCurrentReleaseResolution),
-        showDividers: !actionTitle,
       },
       {
         key: 'another-release',
         label: t('Another existing release\u2026'),
         onAction: () => this.openCustomReleaseModal(),
-        showDividers: !actionTitle,
       },
       {
         key: 'a-commit',
         label: t('A commit\u2026'),
         onAction: () => this.openCustomCommitModal(),
-        showDividers: !actionTitle,
       },
     ];
 

--- a/static/app/components/dropdownMenu.tsx
+++ b/static/app/components/dropdownMenu.tsx
@@ -118,15 +118,20 @@ function DropdownMenu({
     [menuProps, hasFocus]
   );
 
+  const showDividers = useMemo(
+    () => stateCollection.some(item => !!item.props.details),
+    [stateCollection]
+  );
+
   // Render a single menu item
   const renderItem = (node: Node<MenuItemProps>, isLastNode: boolean) => {
     return (
       <MenuItem
         node={node}
-        isLastNode={isLastNode}
         state={state}
         onClose={closeRootMenu}
         closeOnSelect={closeOnSelect}
+        showDivider={showDividers && !isLastNode}
       />
     );
   };
@@ -137,9 +142,9 @@ function DropdownMenu({
       <MenuItem
         renderAs="div"
         node={node}
-        isLastNode={isLastNode}
         state={state}
         isSubmenuTrigger
+        showDivider={showDividers && !isLastNode}
         {...submenuTriggerProps}
       />
     );

--- a/static/app/components/dropdownMenu.tsx
+++ b/static/app/components/dropdownMenu.tsx
@@ -118,10 +118,7 @@ function DropdownMenu({
     [menuProps, hasFocus]
   );
 
-  const showDividers = useMemo(
-    () => stateCollection.some(item => !!item.props.details),
-    [stateCollection]
-  );
+  const showDividers = stateCollection.some(item => !!item.props.details);
 
   // Render a single menu item
   const renderItem = (node: Node<MenuItemProps>, isLastNode: boolean) => {

--- a/static/app/components/dropdownMenuItem.tsx
+++ b/static/app/components/dropdownMenuItem.tsx
@@ -46,10 +46,6 @@ export type MenuItemProps = MenuListItemProps & {
    */
   onAction?: (key: MenuItemProps['key']) => void;
   /**
-   * Whether to show a line divider below this menu item
-   */
-  showDividers?: boolean;
-  /**
    * Passed as the `menuTitle` prop onto the associated sub-menu (applicable
    * if `children` is defined and `isSubmenu` is true)
    */
@@ -65,10 +61,6 @@ type Props = {
    * Whether to close the menu when an item has been clicked/selected
    */
   closeOnSelect: boolean;
-  /**
-   * Whether this is the last node in the collection
-   */
-  isLastNode: boolean;
   /**
    * Node representation (from @react-aria) of the item
    */
@@ -91,6 +83,10 @@ type Props = {
    * Tag name for item wrapper
    */
   renderAs?: React.ElementType;
+  /**
+   * Whether to show a divider below this item
+   */
+  showDivider?: boolean;
 };
 
 /**
@@ -101,10 +97,10 @@ type Props = {
 const BaseDropdownMenuItem: React.ForwardRefRenderFunction<HTMLLIElement, Props> = (
   {
     node,
-    isLastNode,
     state,
     onClose,
     closeOnSelect,
+    showDivider,
     isSubmenuTrigger = false,
     renderAs = 'li' as React.ElementType,
     ...submenuTriggerProps
@@ -114,7 +110,7 @@ const BaseDropdownMenuItem: React.ForwardRefRenderFunction<HTMLLIElement, Props>
   const ref = useRef<HTMLLIElement | null>(null);
   const isDisabled = state.disabledKeys.has(node.key);
   const isFocused = state.selectionManager.focusedKey === node.key;
-  const {key, onAction, to, label, showDividers, ...itemProps} = node.value;
+  const {key, onAction, to, label, ...itemProps} = node.value;
   const {size} = node.props;
 
   const actionHandler = () => {
@@ -194,7 +190,6 @@ const BaseDropdownMenuItem: React.ForwardRefRenderFunction<HTMLLIElement, Props>
   // etc. See: https://react-spectrum.adobe.com/react-aria/mergeProps.html
   const props = mergeProps(submenuTriggerProps, menuItemProps, hoverProps, keyboardProps);
   const itemLabel = node.rendered ?? label;
-  const showDivider = showDividers && !isLastNode;
   const innerWrapProps = {as: to ? Link : 'div', to};
 
   return (

--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 
 import Tooltip, {InternalTooltipProps} from 'sentry/components/tooltip';
 import space from 'sentry/styles/space';
-import {defined} from 'sentry/utils';
 import domId from 'sentry/utils/domId';
 import {FormSize, Theme} from 'sentry/utils/theme';
 
@@ -44,10 +43,6 @@ export type MenuListItemProps = {
    */
   priority?: Priority;
   /**
-   * Whether to show a line divider below this item
-   */
-  showDivider?: boolean;
-  /**
    * Determines the item's font sizes and internal paddings.
    */
   size?: FormSize;
@@ -79,6 +74,7 @@ interface OtherProps {
   innerWrapProps?: object;
   isFocused?: boolean;
   labelProps?: object;
+  showDivider?: boolean;
 }
 
 interface Props extends MenuListItemProps, OtherProps {
@@ -136,11 +132,7 @@ function BaseMenuListItem({
               {leadingItems}
             </LeadingItems>
           )}
-          <ContentWrap
-            isFocused={isFocused}
-            showDivider={defined(details) || showDivider}
-            size={size}
-          >
+          <ContentWrap isFocused={isFocused} showDivider={showDivider} size={size}>
             <LabelWrap>
               <Label id={labelId} aria-hidden="true" {...labelProps}>
                 {label}


### PR DESCRIPTION
So far the `showDividers` prop in dropdown menus hasn't been very useful (it's only used in one component). Also, we want to enforce certain rules for when to show dividers in a menu and don't want too much deviation from those rules. I think we can remove the prop in favor of some slightly modified default rules. Those rules include:
* In any single menu, dividers should appear on either all or none of the items, cause otherwise the menu would look a bit strange (see the before screenshot).
* If a menu item has `details` text (small gray text in a second line), it should have dividers around it

**Before:**
<img width="286" alt="Screen Shot 2022-11-03 at 12 25 03 PM" src="https://user-images.githubusercontent.com/44172267/199815603-56c8ffba-38c0-41d9-bb3a-5dea65e24293.png">


**After:**
<img width="267" alt="Screen Shot 2022-11-03 at 12 24 04 PM" src="https://user-images.githubusercontent.com/44172267/199815424-c77ebd45-e5de-4520-b865-3659af2de861.png">
<img width="286" alt="Screen Shot 2022-11-03 at 12 23 41 PM" src="https://user-images.githubusercontent.com/44172267/199815354-b9e4b62a-e7c1-4b61-8255-f6e493b18ac5.png">

