### PR TITLE
feat(issues): Hide events environment picker w/ header picker

### DIFF
--- a/static/app/views/organizationGroupDetails/groupEvents.tsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.tsx
@@ -224,14 +224,21 @@ class GroupEvents extends Component<Props, State> {
   }
 
   render() {
+    // New issue actions moves the environment picker to the header
+    const hasIssueActionsV2 =
+      this.props.organization.features.includes('issue-actions-v2');
     return (
       <Layout.Body>
         <Layout.Main fullWidth>
           <Wrapper>
-            <FilterSection>
-              <EnvironmentPageFilter />
-              {this.renderSearchBar()}
-            </FilterSection>
+            {hasIssueActionsV2 ? (
+              this.renderSearchBar()
+            ) : (
+              <FilterSection>
+                <EnvironmentPageFilter />
+                {this.renderSearchBar()}
+              </FilterSection>
+            )}
             {this.renderBody()}
           </Wrapper>
         </Layout.Main>


### PR DESCRIPTION
Issue actions v2 makes the environment picker available in the issue header, we don't need the event's tab environment picker at the same time.


<img width="1094" alt="image" src="https://user-images.githubusercontent.com/1400464/199838822-c45da7d4-a3ef-4ff3-b9f3-9db9ea4c5175.png">
