### PR TITLE
ref(monitors): Improve create monitors form with descriptions

### DIFF
--- a/static/app/views/monitors/create.tsx
+++ b/static/app/views/monitors/create.tsx
@@ -1,6 +1,8 @@
 import {Fragment} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
 
+import {t} from 'sentry/locale';
 import AsyncView from 'sentry/views/asyncView';
 
 import MonitorForm from './monitorForm';
@@ -21,12 +23,26 @@ export default class CreateMonitor extends AsyncView<Props, AsyncView['state']> 
     return (
       <Fragment>
         <h1>New Monitor</h1>
+        <HelpText>
+          {t(
+            `Creating a monitor will allow you to track the executions of a scheduled
+             job in your organization. For example, ensure a cron job that is
+             scheduled to run once a day executes and finishes within a specified
+             duration.`
+          )}
+        </HelpText>
         <MonitorForm
           apiMethod="POST"
           apiEndpoint={`/organizations/${this.props.params.orgId}/monitors/`}
           onSubmitSuccess={this.onSubmitSuccess}
+          submitLabel={t('Next Steps')}
         />
       </Fragment>
     );
   }
 }
+
+const HelpText = styled('p')`
+  color: ${p => p.theme.subText};
+  max-width: 760px;
+`;

--- a/static/app/views/monitors/monitorForm.tsx
+++ b/static/app/views/monitors/monitorForm.tsx
@@ -42,6 +42,7 @@ type Props = {
   projects: Project[];
   selection: PageFilters;
   monitor?: Monitor;
+  submitLabel?: string;
 };
 
 type TransformedData = {
@@ -103,7 +104,7 @@ class MonitorForm extends Component<Props> {
   }
 
   render() {
-    const {monitor} = this.props;
+    const {monitor, submitLabel} = this.props;
     const selectedProjectId = this.props.selection.projects[0];
     const selectedProject = selectedProjectId
       ? this.props.projects.find(p => p.id === selectedProjectId + '')
@@ -130,6 +131,7 @@ class MonitorForm extends Component<Props> {
                   }
             }
             onSubmitSuccess={this.props.onSubmitSuccess}
+            submitLabel={submitLabel}
           >
             <Panel>
               <PanelHeader>{t('Details')}</PanelHeader>
@@ -149,6 +151,7 @@ class MonitorForm extends Component<Props> {
                   options={this.props.projects
                     .filter(p => p.isMember)
                     .map(p => ({value: p.slug, label: p.slug}))}
+                  help={t('Associate your monitor with the appropriate project.')}
                   required
                 />
                 <TextField
@@ -238,6 +241,9 @@ class MonitorForm extends Component<Props> {
                               label={t('Frequency')}
                               disabled={!hasAccess}
                               placeholder="e.g. 1"
+                              help={t(
+                                'The amount of times you expect the cron job to run within the specified interval.'
+                              )}
                               required
                             />
                             <SelectField
@@ -245,6 +251,9 @@ class MonitorForm extends Component<Props> {
                               label={t('Interval')}
                               disabled={!hasAccess}
                               options={INTERVALS}
+                              help={t(
+                                'The interval on which the frequency will be applied. X times an (hour, day, week...)'
+                              )}
                               required
                             />
                             <NumberField


### PR DESCRIPTION
Adds description to top of page explaining what the user is creating and help text to some previously unlabeled fields.

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/9372512/199851159-42db4a7a-aeeb-4b39-934d-d61358c93044.png">