### PR TITLE
fix(dropdownMenu): Fix submenu touchscreen issue

### DIFF
--- a/static/app/components/dropdownMenuControl.tsx
+++ b/static/app/components/dropdownMenuControl.tsx
@@ -153,7 +153,10 @@ function DropdownMenuControl({
     isDismissable: !isSubmenu && isDismissable,
     shouldCloseOnBlur: !isSubmenu && shouldCloseOnBlur,
     shouldCloseOnInteractOutside: target =>
-      target && triggerRef.current !== target && !triggerRef.current?.contains(target),
+      !isSubmenu &&
+      target &&
+      triggerRef.current !== target &&
+      !triggerRef.current?.contains(target),
   });
 
   const {menuTriggerProps, menuProps} = useMenuTrigger(


### PR DESCRIPTION
Fix a problem with dropdown submenus on touch devices where the submenus won't render when pressing on the parent item.

**Before:**
https://user-images.githubusercontent.com/44172267/199854068-910a7d05-d4c9-495c-a33e-e09d1b1b47ab.mov

**After:**
https://user-images.githubusercontent.com/44172267/199854110-21a6a20a-12ed-46e5-ba6b-400c8b322ad3.mov



