### PR TITLE
feat: Arroyo 1.1.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -54,7 +54,7 @@ requests>=2.25.1
 rfc3339-validator>=0.1.2
 rfc3986-validator>=0.1.1
 # [end] jsonschema format validators
-sentry-arroyo>=1.0.7
+sentry-arroyo>=1.1.0
 sentry-relay>=0.8.15
 sentry-sdk>=1.10.1
 snuba-sdk>=1.0.1

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -146,7 +146,7 @@ rfc3986-validator==0.1.1
 rsa==4.8
 s3transfer==0.5.2
 selenium==4.3.0
-sentry-arroyo==1.0.7
+sentry-arroyo==1.1.0
 sentry-relay==0.8.15
 sentry-sdk==1.10.1
 simplejson==3.17.6

--- a/requirements-frozen.txt
+++ b/requirements-frozen.txt
@@ -98,7 +98,7 @@ rfc3986-validator==0.1.1
 rsa==4.8
 s3transfer==0.5.2
 selenium==4.3.0
-sentry-arroyo==1.0.7
+sentry-arroyo==1.1.0
 sentry-relay==0.8.15
 sentry-sdk==1.10.1
 simplejson==3.17.6

--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -15,6 +15,7 @@ from typing import (
 from arroyo import Topic
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.backends.kafka.configuration import build_kafka_consumer_configuration
+from arroyo.commit import IMMEDIATE
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy, ProcessingStrategyFactory
 from arroyo.types import Message, Partition, Position
@@ -51,6 +52,7 @@ def get_metrics_billing_consumer(
         ),
         topic=Topic(topic),
         processor_factory=BillingMetricsConsumerStrategyFactory(max_batch_size, max_batch_time),
+        commit_policy=IMMEDIATE,
     )
 
 

--- a/src/sentry/region_to_control/consumer.py
+++ b/src/sentry/region_to_control/consumer.py
@@ -5,6 +5,7 @@ import sentry_sdk
 from arroyo import Partition, Topic
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
 from arroyo.backends.kafka.configuration import build_kafka_consumer_configuration
+from arroyo.commit import IMMEDIATE
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy, ProcessingStrategyFactory
 from arroyo.processing.strategies.batching import AbstractBatchWorker, BatchProcessingStrategy
@@ -48,6 +49,7 @@ def get_region_to_control_consumer(
                 max_batch_time=max_batch_time,
             )
         ),
+        commit_policy=IMMEDIATE,
     )
 
     def handler(*args) -> None:

--- a/src/sentry/replays/consumers/__init__.py
+++ b/src/sentry/replays/consumers/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, MutableMapping
 
 from arroyo import Topic
 from arroyo.backends.kafka.consumer import KafkaConsumer, KafkaPayload
+from arroyo.commit import IMMEDIATE
 from arroyo.processing.processor import StreamProcessor
 from django.conf import settings
 
@@ -28,6 +29,7 @@ def get_replays_recordings_consumer(
         consumer=consumer,
         topic=Topic(topic),
         processor_factory=ProcessReplayRecordingStrategyFactory(),
+        commit_policy=IMMEDIATE,
     )
 
     def handler(signum: int, frame: Any) -> None:

--- a/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/multiprocess.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Mapping, MutableMapping, Optional, Union
 
 from arroyo.backends.abstract import Producer as AbstractProducer
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.commit import IMMEDIATE
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
@@ -259,4 +260,5 @@ def get_streaming_metrics_consumer(
         KafkaConsumer(get_config(indexer_profile.input_topic, group_id, auto_offset_reset)),
         Topic(indexer_profile.input_topic),
         processing_factory,
+        IMMEDIATE,
     )

--- a/src/sentry/sentry_metrics/consumers/indexer/parallel.py
+++ b/src/sentry/sentry_metrics/consumers/indexer/parallel.py
@@ -5,6 +5,7 @@ import logging
 from typing import Callable, Mapping, Optional, Union
 
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.commit import IMMEDIATE
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies import ProcessingStrategy as ProcessingStep
@@ -185,4 +186,5 @@ def get_parallel_metrics_consumer(
         KafkaConsumer(get_config(indexer_profile.input_topic, group_id, auto_offset_reset)),
         Topic(indexer_profile.input_topic),
         processing_factory,
+        IMMEDIATE,
     )

--- a/src/sentry/sentry_metrics/consumers/last_seen_updater.py
+++ b/src/sentry/sentry_metrics/consumers/last_seen_updater.py
@@ -6,6 +6,7 @@ from typing import Any, Mapping, Optional, Set, Union
 import rapidjson
 from arroyo import Message, Topic
 from arroyo.backends.kafka import KafkaConsumer, KafkaPayload
+from arroyo.commit import IMMEDIATE
 from arroyo.processing import StreamProcessor
 from arroyo.processing.strategies import ProcessingStrategy
 from arroyo.processing.strategies.factory import KafkaConsumerStrategyFactory, StreamMessageFilter
@@ -192,4 +193,5 @@ def get_last_seen_updater(
         KafkaConsumer(get_config(ingest_config.output_topic, group_id, auto_offset_reset)),
         Topic(ingest_config.output_topic),
         processing_factory,
+        IMMEDIATE,
     )


### PR DESCRIPTION
Bumps arroyo from 1.0.7 to 1.1.0. Specifying a commit policy is now mandatory. This PR passes IMMEDIATE everywhere where this was previously missing, since this was the default value applied by the library before.