### PR TITLE
feat(profiling): Introduce generic profile events table

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -395,7 +395,7 @@ class GridEditable<
     return (
       <GridRow>
         <GridBodyCellStatus>
-          <IconWarning color="gray300" size="lg" />
+          <IconWarning data-test-id="error-indicator" color="gray300" size="lg" />
         </GridBodyCellStatus>
       </GridRow>
     );

--- a/static/app/components/profiling/profileEventsTable.spec.tsx
+++ b/static/app/components/profiling/profileEventsTable.spec.tsx
@@ -1,0 +1,217 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {ProfileEventsTable} from 'sentry/components/profiling/profileEventsTable';
+import ProjectsStore from 'sentry/stores/projectsStore';
+import {FieldValueType} from 'sentry/utils/fields';
+import {EventsResults} from 'sentry/utils/profiling/hooks/useProfileEvents';
+
+function customEncodeURIComponent(str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
+    return '%' + c.charCodeAt(0).toString(16);
+  });
+}
+
+const project = TestStubs.Project({
+  id: '1',
+  slug: 'foo',
+});
+
+describe('ProfileEventsTable', function () {
+  beforeEach(function () {
+    act(() => ProjectsStore.loadInitialData([project]));
+  });
+
+  it('renders loading', function () {
+    const {organization, routerContext} = initializeOrg();
+
+    const columns = ['count()' as const];
+    const sort = {
+      key: 'count()' as const,
+      order: 'desc' as const,
+    };
+
+    render(
+      <ProfileEventsTable
+        columns={columns}
+        data={null}
+        error={null}
+        isLoading
+        sort={sort}
+      />,
+      {context: routerContext, organization}
+    );
+
+    expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
+  });
+
+  it('renders error', function () {
+    const {organization, routerContext} = initializeOrg();
+
+    const columns = ['count()' as const];
+    const sort = {
+      key: 'count()' as const,
+      order: 'desc' as const,
+    };
+
+    render(
+      <ProfileEventsTable
+        columns={columns}
+        data={null}
+        error="error"
+        isLoading={false}
+        sort={sort}
+      />,
+      {context: routerContext, organization}
+    );
+
+    expect(screen.getByTestId('error-indicator')).toBeInTheDocument();
+  });
+
+  it('renders asc sort links on the header', function () {
+    const {organization, routerContext} = initializeOrg();
+
+    const columns = ['count()' as const];
+    const sort = {
+      key: 'count()' as const,
+      order: 'desc' as const,
+    };
+
+    render(
+      <ProfileEventsTable
+        columns={columns}
+        data={null}
+        error={null}
+        isLoading
+        sort={sort}
+        sortableColumns={new Set(columns)}
+      />,
+      {context: routerContext, organization}
+    );
+
+    const link = screen.getByRole('link', {name: 'Count()'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      `/mock-pathname/?sort=${customEncodeURIComponent('count()')}`
+    );
+  });
+
+  it('renders desc sort links on the header', function () {
+    const {organization, routerContext} = initializeOrg();
+
+    const columns = ['count()' as const];
+    const sort = {
+      key: 'count()' as const,
+      order: 'asc' as const,
+    };
+
+    render(
+      <ProfileEventsTable
+        columns={columns}
+        data={null}
+        error={null}
+        isLoading
+        sort={sort}
+        sortableColumns={new Set(columns)}
+      />,
+      {context: routerContext, organization}
+    );
+
+    const link = screen.getByRole('link', {name: 'Count()'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      `/mock-pathname/?sort=${customEncodeURIComponent('-count()')}`
+    );
+  });
+
+  it('renders formatted values', function () {
+    const {organization, routerContext} = initializeOrg();
+
+    const columns = [
+      'id',
+      'project',
+      'transaction',
+      'release',
+      'timestamp',
+      'profile.duration',
+      'count()',
+    ] as const;
+
+    const data: EventsResults<typeof columns[number]> = {
+      data: [
+        {
+          id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          project: 'foo',
+          transaction: 'bar',
+          release: 'baz@1.0.0+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          timestamp: '2022-11-01T00:00:00+00:00',
+          'profile.duration': 100000000,
+          'count()': 123,
+        },
+      ],
+      meta: {
+        fields: {
+          id: FieldValueType.STRING,
+          project: FieldValueType.STRING,
+          transaction: FieldValueType.STRING,
+          release: FieldValueType.STRING,
+          timestamp: FieldValueType.DATE,
+          'profile.duration': FieldValueType.DURATION,
+          'count()': FieldValueType.INTEGER,
+        },
+        units: {
+          id: null,
+          project: null,
+          transaction: null,
+          release: null,
+          timestamp: null,
+          'profile.duration': 'nanosecond',
+          'count()': null,
+        },
+      },
+    };
+
+    const sort = {
+      key: 'transaction' as const,
+      order: 'asc' as const,
+    };
+
+    render(
+      <ProfileEventsTable
+        columns={columns.slice()}
+        data={data}
+        error={null}
+        isLoading={false}
+        sort={sort}
+        sortableColumns={new Set(columns)}
+      />,
+      {context: routerContext, organization}
+    );
+
+    // id
+    expect(screen.getByRole('cell', {name: 'aaaaaaaa'})).toBeInTheDocument();
+
+    // project
+    expect(screen.getByRole('cell', {name: 'foo'})).toBeInTheDocument();
+
+    // the transaction is both a cell and a link
+    expect(screen.getByRole('link', {name: 'bar'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'bar'})).toBeInTheDocument();
+
+    // release
+    expect(screen.getByRole('cell', {name: '1.0.0 (aaaaaaaaaaaa)'})).toBeInTheDocument();
+
+    // timestamp
+    expect(
+      screen.getByRole('cell', {name: 'Nov 1, 2022 12:00:00 AM UTC'})
+    ).toBeInTheDocument();
+
+    // profile.duration
+    expect(screen.getByRole('cell', {name: '100.00ms'})).toBeInTheDocument();
+
+    // count()
+    expect(screen.getByRole('cell', {name: '123'})).toBeInTheDocument();
+  });
+});

--- a/static/app/components/profiling/profileEventsTable.tsx
+++ b/static/app/components/profiling/profileEventsTable.tsx
@@ -1,0 +1,430 @@
+import {useCallback} from 'react';
+import {Location} from 'history';
+
+import Count from 'sentry/components/count';
+import DateTime from 'sentry/components/dateTime';
+import GridEditable, {
+  COL_WIDTH_UNDEFINED,
+  GridColumnOrder,
+  GridColumnSortBy,
+} from 'sentry/components/gridEditable';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
+import Link from 'sentry/components/links/link';
+import PerformanceDuration from 'sentry/components/performanceDuration';
+import Version from 'sentry/components/version';
+import {t} from 'sentry/locale';
+import {Organization, Project} from 'sentry/types';
+import {defined} from 'sentry/utils';
+import {DURATION_UNITS} from 'sentry/utils/discover/fieldRenderers';
+import {Container, NumberContainer, VersionContainer} from 'sentry/utils/discover/styles';
+import {getShortEventId} from 'sentry/utils/events';
+import {EventsResults} from 'sentry/utils/profiling/hooks/useProfileEvents';
+import {
+  generateProfileFlamechartRoute,
+  generateProfileSummaryRouteWithQuery,
+} from 'sentry/utils/profiling/routes';
+import {renderTableHead} from 'sentry/utils/profiling/tableRenderer';
+import {useLocation} from 'sentry/utils/useLocation';
+import useOrganization from 'sentry/utils/useOrganization';
+import useProjects from 'sentry/utils/useProjects';
+
+interface ProfileEventsTableProps<F extends FieldType> {
+  columns: F[];
+  data: EventsResults<F> | null;
+  error: string | null;
+  isLoading: boolean;
+  sort: GridColumnSortBy<F>;
+  sortableColumns?: Set<F>;
+}
+
+export function ProfileEventsTable<F extends FieldType>(
+  props: ProfileEventsTableProps<F>
+) {
+  const location = useLocation();
+  const organization = useOrganization();
+  const {projects} = useProjects();
+
+  const generateSortLink = useCallback(
+    (column: F) => () => {
+      let dir = 'desc';
+      if (column === props.sort.key && props.sort.order === dir) {
+        dir = 'asc';
+      }
+      return {
+        ...location,
+        query: {
+          ...location.query,
+          sort: dir === 'asc' ? column : `-${column}`,
+        },
+      };
+    },
+    [location, props.sort]
+  );
+
+  return (
+    <GridEditable
+      isLoading={props.isLoading}
+      error={props.error}
+      data={props.data?.data ?? []}
+      columnOrder={props.columns.map(field => getColumnOrder<F>(field))}
+      columnSortBy={[props.sort]}
+      grid={{
+        renderHeadCell: renderTableHead<F>({
+          currentSort: props.sort,
+          generateSortLink,
+          rightAlignedColumns: getRightAlignedColumns(props.columns),
+          sortableColumns: props.sortableColumns,
+        }),
+        renderBodyCell: renderTableBody(
+          props.data?.meta ?? ({fields: {}, units: {}} as EventsResults<F>['meta']),
+          {location, organization, projects}
+        ),
+      }}
+      location={location}
+    />
+  );
+}
+
+type RenderBagger = {
+  location: Location;
+  organization: Organization;
+  projects: Project[];
+};
+
+function renderTableBody<F extends FieldType>(
+  meta: EventsResults<F>['meta'],
+  baggage: RenderBagger
+) {
+  function _renderTableBody(
+    column: GridColumnOrder<F>,
+    dataRow: Record<F, any>,
+    rowIndex: number,
+    columnIndex: number
+  ) {
+    return (
+      <ProfileEventsCell
+        meta={meta}
+        baggage={baggage}
+        column={column}
+        dataRow={dataRow}
+        rowIndex={rowIndex}
+        columnIndex={columnIndex}
+      />
+    );
+  }
+
+  return _renderTableBody;
+}
+
+interface ProfileEventsCellProps<F extends FieldType> {
+  baggage: RenderBagger;
+  column: GridColumnOrder<F>;
+  columnIndex: number;
+  dataRow: Record<F, any>;
+  meta: EventsResults<F>['meta'];
+  rowIndex: number;
+}
+
+function ProfileEventsCell<F extends FieldType>(props: ProfileEventsCellProps<F>) {
+  const key = props.column.key;
+  const value = props.dataRow[key];
+  const columnType = props.meta.fields[key];
+  const columnUnit = props.meta.units[key];
+
+  if (key === 'id') {
+    const project = getProjectForRow(props.baggage, props.dataRow);
+
+    if (!defined(project)) {
+      // should never happen but just in case
+      return <Container>{getShortEventId(value)}</Container>;
+    }
+
+    const flamegraphTarget = generateProfileFlamechartRoute({
+      orgSlug: props.baggage.organization.slug,
+      projectSlug: project.slug,
+      profileId: value,
+    });
+
+    return (
+      <Container>
+        <Link to={flamegraphTarget}>{getShortEventId(value)}</Link>
+      </Container>
+    );
+  }
+
+  if (key === 'project.id' || key === 'project' || key === 'project.name') {
+    const project = getProjectForRow(props.baggage, props.dataRow);
+
+    if (!defined(project)) {
+      // should never happen but just in case
+      return <Container>{t('n/a')}</Container>;
+    }
+
+    return (
+      <Container>
+        <ProjectBadge project={project} avatarSize={16} />
+      </Container>
+    );
+  }
+
+  if (key === 'transaction') {
+    const project = getProjectForRow(props.baggage, props.dataRow);
+
+    if (defined(project)) {
+      return (
+        <Container>
+          <Link
+            to={generateProfileSummaryRouteWithQuery({
+              query: props.baggage.location.query,
+              orgSlug: props.baggage.organization.slug,
+              projectSlug: project.slug,
+              transaction: value,
+            })}
+          >
+            {value}
+          </Link>
+        </Container>
+      );
+    }
+
+    // let this fall through and use one of the other renderers
+  }
+
+  if (key === 'release') {
+    if (value) {
+      return (
+        <VersionContainer>
+          <Version version={value} anchor={false} tooltipRawVersion truncate />
+        </VersionContainer>
+      );
+    }
+  }
+
+  switch (columnType) {
+    case 'integer':
+    case 'number':
+      return (
+        <NumberContainer>
+          <Count value={value} />
+        </NumberContainer>
+      );
+    case 'duration':
+      const multiplier = columnUnit ? DURATION_UNITS[columnUnit as string] ?? 1 : 1;
+      return (
+        <NumberContainer>
+          <PerformanceDuration milliseconds={value * multiplier} abbreviation />
+        </NumberContainer>
+      );
+    case 'date':
+      return (
+        <Container>
+          <DateTime date={value} year seconds timeZone />
+        </Container>
+      );
+    default:
+      return <Container>{value}</Container>;
+  }
+}
+
+function getProjectForRow<F extends FieldType>(
+  baggage: ProfileEventsCellProps<F>['baggage'],
+  dataRow: ProfileEventsCellProps<F>['dataRow']
+) {
+  let project: Project | undefined = undefined;
+
+  if (defined(dataRow['project.id'])) {
+    const projectId = dataRow['project.id'].toString();
+    project = baggage.projects.find(proj => proj.id === projectId);
+  } else if (defined((dataRow as any).project)) {
+    const projectSlug = (dataRow as any).project;
+    project = baggage.projects.find(proj => proj.slug === projectSlug);
+  } else if (defined(dataRow['project.name'])) {
+    const projectSlug = dataRow['project.name'];
+    project = baggage.projects.find(proj => proj.slug === projectSlug);
+  }
+
+  return project ?? null;
+}
+
+const FIELDS = [
+  'id',
+  'trace.transaction',
+  'trace',
+  'transaction',
+  'profile.duration',
+  'project',
+  'project.id',
+  'project.name',
+  'environment',
+  'timestamp',
+  'release',
+  'platform.name',
+  'device.arch',
+  'device.classification',
+  'device.locale',
+  'device.manufacturer',
+  'device.model',
+  'os.build',
+  'os.name',
+  'os.version',
+  'last_seen()',
+  'p75()',
+  'p95()',
+  'p99()',
+  'count()',
+] as const;
+
+type FieldType = typeof FIELDS[number];
+
+const RIGHT_ALIGNED_FIELDS = new Set<FieldType>([
+  'profile.duration',
+  'p75()',
+  'p95()',
+  'p99()',
+  'count()',
+]);
+
+// TODO: add all the columns here
+const COLUMN_ORDERS: Record<FieldType, GridColumnOrder<FieldType>> = {
+  id: {
+    key: 'id',
+    name: t('Profile ID'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  trace: {
+    key: 'trace',
+    name: t('Trace ID'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'trace.transaction': {
+    key: 'trace.transaction',
+    name: t('Transaction ID'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  transaction: {
+    key: 'transaction',
+    name: t('Transaction'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'profile.duration': {
+    key: 'profile.duration',
+    name: t('Duration'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  project: {
+    key: 'project',
+    name: t('Project'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'project.id': {
+    key: 'project.id',
+    name: t('Project'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'project.name': {
+    key: 'project.name',
+    name: t('Project'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  environment: {
+    key: 'environment',
+    name: t('Environment'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  timestamp: {
+    key: 'timestamp',
+    name: t('Timestamp'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  release: {
+    key: 'release',
+    name: t('Release'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'platform.name': {
+    key: 'platform.name',
+    name: t('Platform'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'device.arch': {
+    key: 'device.arch',
+    name: t('Device Architecture'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'device.classification': {
+    key: 'device.classification',
+    name: t('Device Classification'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'device.locale': {
+    key: 'device.locale',
+    name: t('Device Locale'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'device.manufacturer': {
+    key: 'device.manufacturer',
+    name: t('Device Manufacturer'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'device.model': {
+    key: 'device.model',
+    name: t('Device Model'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'os.build': {
+    key: 'os.build',
+    name: t('OS Build'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'os.name': {
+    key: 'os.name',
+    name: t('OS Name'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'os.version': {
+    key: 'os.version',
+    name: t('OS Version'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'last_seen()': {
+    key: 'last_seen()',
+    name: t('Last Seen'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'p75()': {
+    key: 'p75()',
+    name: t('P75'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'p95()': {
+    key: 'p95()',
+    name: t('P95()'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'p99()': {
+    key: 'p99()',
+    name: t('P99()'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+  'count()': {
+    key: 'count()',
+    name: t('Count()'),
+    width: COL_WIDTH_UNDEFINED,
+  },
+};
+
+function getColumnOrder<F extends FieldType>(field: F): GridColumnOrder<F> {
+  if (COLUMN_ORDERS[field as string]) {
+    return COLUMN_ORDERS[field as string] as GridColumnOrder<F>;
+  }
+
+  return {
+    key: field,
+    name: field,
+    width: COL_WIDTH_UNDEFINED,
+  };
+}
+
+function getRightAlignedColumns<F extends FieldType>(columns: F[]): Set<F> {
+  return new Set(columns.filter(col => RIGHT_ALIGNED_FIELDS.has(col)));
+}


### PR DESCRIPTION
This works in conjunction with the useProfileEvents hook to render a table from any profiles dataset query.