### PR TITLE
fix(discover): Wrap issue fields with link to issue detail

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -487,7 +487,9 @@ const SPECIAL_FIELDS: SpecialFields = {
               </StyledLink>
             </QuickContextHoverWrapper>
           ) : (
-            <OverflowFieldShortId shortId={`${data.issue}`} />
+            <StyledLink to={target} aria-label={issueID}>
+              <OverflowFieldShortId shortId={`${data.issue}`} />
+            </StyledLink>
           )}
         </Container>
       );


### PR DESCRIPTION
Issue field on field renderer wasn't being wrapped 
with the link to the issue detail if the quick-context 
flag wasn't enabled. Fixed so that it's clickable
again.

Will add a test in a follow up