### PR TITLE
ref(codeowners): Remove project details endpoint and test for telemetry team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -351,7 +351,6 @@ yarn.lock           @getsentry/owners-js-deps
 /src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py                  @getsentry/telemetry-experience
 /src/sentry/snuba/metrics/query.py                                                       @getsentry/telemetry-experience
 /src/sentry/release_health/metrics_sessions_v2.py                                        @getsentry/telemetry-experience
-/src/sentry/api/endpoints/project_details.py                                             @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_data.py                             @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_details.py                          @getsentry/telemetry-experience
 /tests/sentry/api/endpoints/test_organization_metric_tag_details.py                      @getsentry/telemetry-experience
@@ -362,9 +361,7 @@ yarn.lock           @getsentry/owners-js-deps
 /tests/sentry/snuba/metrics/                                                             @getsentry/telemetry-experience
 /tests/snuba/api/endpoints/test_organization_sessions.py                                 @getsentry/telemetry-experience
 /tests/acceptance/test_project_settings_sampling.py                                      @getsentry/telemetry-experience
-/tests/sentry/api/endpoints/test_project_details.py                                      @getsentry/telemetry-experience
 
-/static/app/views/settings/project/sampling/                                             @getsentry/telemetry-experience
 /static/app/views/settings/project/server-side-sampling/                                 @getsentry/telemetry-experience
 /static/app/views/settings/project/dynamicSampling/                                      @getsentry/telemetry-experience
 /static/app/stores/serverSideSamplingStore.tsx                                           @getsentry/telemetry-experience


### PR DESCRIPTION
Remove Telemetry team as a codeowner of the project details endpoint and its test