### PR TITLE
feat(sampling): Change badges from beta to new

### DIFF
--- a/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
+++ b/static/app/views/settings/project/dynamicSampling/dynamicSampling.tsx
@@ -116,7 +116,7 @@ export function DynamicSampling({project}: Props) {
         <SettingsPageHeader
           title={
             <Fragment>
-              {t('Dynamic Sampling')} <FeatureBadge type="beta" />
+              {t('Dynamic Sampling')} <FeatureBadge type="new" />
             </Fragment>
           }
           action={<SamplingFeedback />}

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -85,7 +85,8 @@ export default function getConfiguration({
           description: t(
             "Per-Project basis solution to configure sampling rules within Sentry's UI"
           ),
-          badge: () => 'beta',
+          badge: () =>
+            organization?.features.includes('dynamic-sampling') ? 'new' : 'beta',
         },
         {
           path: `${pathPrefix}/security-and-privacy/`,


### PR DESCRIPTION
Changing the feature badge from `beta` to `new` for GA customers.
Existing LA customers with old experience will still see the `beta` badge.