### PR TITLE
feat(derived_code_mappings): Cache repository trees for orgs

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -166,7 +166,6 @@ class IntegrationProvider(PipelineProvider, abc.ABC):
         if cls.integration_cls is None:
             raise NotImplementedError
 
-        assert type(organization_id) == int
         return cls.integration_cls(model, organization_id, **kwargs)
 
     @property

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -166,6 +166,7 @@ class IntegrationProvider(PipelineProvider, abc.ABC):
         if cls.integration_cls is None:
             raise NotImplementedError
 
+        assert type(organization_id) == int
         return cls.integration_cls(model, organization_id, **kwargs)
 
     @property

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -103,19 +103,13 @@ class GitHubClientMixin(ApiClient):  # type: ignore
 
         return tree
 
-    def get_trees_for_org(
-        self, gh_org: str, org_slug: str, cache_seconds: int = 3600 * 24
-    ) -> JSONData:
+    def get_trees_for_org(self, gh_org: str, cache_seconds: int = 3600 * 24) -> JSONData:
         """
         This fetches tree representations of all repos for an org.
         """
-        # print("FOO")
-        logger.info("INFO")
-        logger.warning("WARNING")
         trees: JSONData = {}
-        cache_key = f"githubtrees:repositories:{org_slug}"
+        cache_key = f"githubtrees:repositories:{gh_org}"
         repo_key = "githubtrees:repo"
-        # XXX: Can the same GH org be installed in different Sentry orgs?
         # XXX: We do not support more than one org atm
         cached_repositories = cache.get(cache_key, [])
         if not cached_repositories:
@@ -134,8 +128,8 @@ class GitHubClientMixin(ApiClient):  # type: ignore
             cache.set(cache_key, repositories, cache_seconds)
             logger.info(f"Caching trees for {gh_org} org until TBD.")
         else:
-            for repo_info in repositories:
-                trees[full_name] = cache.get(f"{repo_key}:{repo_info['full_name']}")
+            for repo_info in cached_repositories:
+                trees[repo_info["full_name"]] = cache.get(f"{repo_key}:{repo_info['full_name']}")
             logger.info("Using cached trees until TBD.")
 
         return trees

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -103,12 +103,14 @@ class GitHubClientMixin(ApiClient):  # type: ignore
 
         return tree
 
-    def get_trees_for_org(self, gh_org: str, cache_seconds: int = 3600 * 24) -> JSONData:
+    def get_trees_for_org(
+        self, org_slug: str, gh_org: str, cache_seconds: int = 3600 * 24
+    ) -> JSONData:
         """
         This fetches tree representations of all repos for an org.
         """
         trees: JSONData = {}
-        cache_key = f"githubtrees:repositories:{gh_org}"
+        cache_key = f"githubtrees:repositories:{org_slug}:{gh_org}"
         repo_key = "githubtrees:repo"
         cached_repositories = cache.get(cache_key, [])
         if not cached_repositories:

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -108,8 +108,7 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
 
     def get_trees_for_org(self, cache_seconds: int = 3600 * 24) -> JSONData:
         return self.get_client().get_trees_for_org(
-            gh_org=self.model.name,
-            org_slug=self.organization_id.slug,
+            gh_org=self.model.metadata["domain_name"].split("github.com/")[1],
             cache_seconds=cache_seconds,
         )
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -106,8 +106,12 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
     def get_client(self) -> GitHubClientMixin:
         return GitHubAppsClient(integration=self.model)
 
-    def get_trees_for_org(self) -> JSONData:
-        return self.get_client().get_trees_for_org(self.model.name)
+    def get_trees_for_org(self, cache_seconds: int = 3600 * 24) -> JSONData:
+        return self.get_client().get_trees_for_org(
+            gh_org=self.model.name,
+            org_slug=self.organization_id.slug,
+            cache_seconds=cache_seconds,
+        )
 
     def get_repositories(
         self, query: str | None = None, fetch_max_pages: bool = False

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -107,10 +107,8 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
         return GitHubAppsClient(integration=self.model)
 
     def get_trees_for_org(self, cache_seconds: int = 3600 * 24) -> JSONData:
-        return self.get_client().get_trees_for_org(
-            gh_org=self.model.metadata["domain_name"].split("github.com/")[1],
-            cache_seconds=cache_seconds,
-        )
+        gh_org = self.model.metadata["domain_name"].split("github.com/")[1]
+        return self.get_client().get_trees_for_org(gh_org=gh_org, cache_seconds=cache_seconds)
 
     def get_repositories(
         self, query: str | None = None, fetch_max_pages: bool = False

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -108,7 +108,11 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
 
     def get_trees_for_org(self, cache_seconds: int = 3600 * 24) -> JSONData:
         gh_org = self.model.metadata["domain_name"].split("github.com/")[1]
-        return self.get_client().get_trees_for_org(gh_org=gh_org, cache_seconds=cache_seconds)
+        return self.get_client().get_trees_for_org(
+            org_slug=self.org_integration.organization.slug,
+            gh_org=gh_org,
+            cache_seconds=cache_seconds,
+        )
 
     def get_repositories(
         self, query: str | None = None, fetch_max_pages: bool = False

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -388,7 +388,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             },
         )
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization.id)
+        installation = integration.get_installation(self.organization)
         # This searches for any repositories matching the term 'ex'
         result = installation.get_repositories("ex")
         assert result == [
@@ -403,7 +403,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization.id)
+        installation = integration.get_installation(self.organization)
 
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
             result = installation.get_repositories(fetch_max_pages=True)
@@ -420,7 +420,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization.id)
+        installation = integration.get_installation(self.organization)
 
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
             result = installation.get_repositories()
@@ -449,7 +449,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             responses.HEAD,
             self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
         )
-        installation = integration.get_installation(self.organization.id)
+        installation = integration.get_installation(self.organization)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert result == "https://github.com/Test-Organization/foo/blob/1234567/README.md"
@@ -476,7 +476,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
             status=404,
         )
-        installation = integration.get_installation(self.organization.id)
+        installation = integration.get_installation(self.organization)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert not result
@@ -507,7 +507,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             responses.HEAD,
             self.base_url + f"/repos/{repo.name}/contents/{path}?ref={default}",
         )
-        installation = integration.get_installation(self.organization.id)
+        installation = integration.get_installation(self.organization)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert result == "https://github.com/Test-Organization/foo/blob/master/README.md"
@@ -516,7 +516,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def test_get_message_from_error(self):
         self.assert_setup_flow()
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization.id)
+        installation = integration.get_installation(self.organization)
         base_error = f"Error Communicating with GitHub (HTTP 404): {API_ERRORS[404]}"
         assert (
             installation.message_from_error(

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -114,6 +114,9 @@ class GitHubIntegrationTest(IntegrationTestCase):
                 "full_name": "Test-Organization/baz",
                 "default_branch": "master",
             },
+            "archived": {
+                "archived": True,
+            },
         }
         api_url = f"{self.base_url}/installation/repositories"
         first = f'<{api_url}?per_page={pp}&page=1>; rel="first"'
@@ -584,15 +587,15 @@ class GitHubIntegrationTest(IntegrationTestCase):
             # trees = installation.get_client().get_trees_for_org(self.organization.slug)
             trees = installation.get_trees_for_org()
             # This check is useful since it will be available in the GCP logs
-            # assert (
-            #     self._caplog.records[0].message
-            #     == "The Github App does not have access to Test-Organization/baz."
-            # )
-            # assert self._caplog.records[0].levelname == "ERROR"
+            assert (
+                self._caplog.records[0].message
+                == "The Github App does not have access to Test-Organization/baz."
+            )
+            assert self._caplog.records[0].levelname == "ERROR"
 
         assert trees == {
             "Test-Organization/bar": {"default_branch": "main", "files": []},
-            # "Test-Organization/baz": {"default_branch": "master", "files": []},
+            "Test-Organization/baz": {"default_branch": "master", "files": []},
             "Test-Organization/foo": {
                 "default_branch": "master",
                 "files": ["src/sentry/api/endpoints/auth_login.py"],

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -581,17 +581,18 @@ class GitHubIntegrationTest(IntegrationTestCase):
         integration = Integration.objects.get(provider=self.provider.key)
         installation = integration.get_installation(self.organization)
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
-            trees = installation.get_client().get_trees_for_org(self.organization.slug)
+            # trees = installation.get_client().get_trees_for_org(self.organization.slug)
+            trees = installation.get_trees_for_org()
             # This check is useful since it will be available in the GCP logs
-            assert (
-                self._caplog.records[0].message
-                == "The Github App does not have access to Test-Organization/baz."
-            )
-            assert self._caplog.records[0].levelname == "ERROR"
+            # assert (
+            #     self._caplog.records[0].message
+            #     == "The Github App does not have access to Test-Organization/baz."
+            # )
+            # assert self._caplog.records[0].levelname == "ERROR"
 
         assert trees == {
             "Test-Organization/bar": {"default_branch": "main", "files": []},
-            "Test-Organization/baz": {"default_branch": "master", "files": []},
+            # "Test-Organization/baz": {"default_branch": "master", "files": []},
             "Test-Organization/foo": {
                 "default_branch": "master",
                 "files": ["src/sentry/api/endpoints/auth_login.py"],

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -388,7 +388,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             },
         )
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         # This searches for any repositories matching the term 'ex'
         result = installation.get_repositories("ex")
         assert result == [
@@ -403,7 +403,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
 
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
             result = installation.get_repositories(fetch_max_pages=True)
@@ -420,7 +420,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
 
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
             result = installation.get_repositories()
@@ -449,7 +449,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             responses.HEAD,
             self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
         )
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert result == "https://github.com/Test-Organization/foo/blob/1234567/README.md"
@@ -476,7 +476,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
             status=404,
         )
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert not result
@@ -507,7 +507,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             responses.HEAD,
             self.base_url + f"/repos/{repo.name}/contents/{path}?ref={default}",
         )
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert result == "https://github.com/Test-Organization/foo/blob/master/README.md"
@@ -516,7 +516,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def test_get_message_from_error(self):
         self.assert_setup_flow()
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         base_error = f"Error Communicating with GitHub (HTTP 404): {API_ERRORS[404]}"
         assert (
             installation.message_from_error(
@@ -592,7 +592,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
 
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
             assert not cache.get("githubtrees:repositories:Test-Organization")
@@ -608,7 +608,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             assert self._caplog.records[9].message.startswith("Caching trees for Test-Organization")
             assert self._caplog.records[9].levelname == "INFO"
 
-            assert cache.get("githubtrees:repositories:Test-Organization") == [
+            assert cache.get("githubtrees:repositories:foo:Test-Organization") == [
                 {"full_name": "Test-Organization/foo", "default_branch": "master"},
                 {"full_name": "Test-Organization/bar", "default_branch": "main"},
                 {"full_name": "Test-Organization/baz", "default_branch": "master"},


### PR DESCRIPTION
Github API requests have rate limiting. In order to prevent blowing through the rate limit we will be caching the trees for an org for 24 hours.

With the new post processing logic, we will be processing an event per hour per project. We can't recreate the repo trees per org on every request, otherwise, every event processed would use N + 1 requests (N is the number of repos for an org).