### PR TITLE
feat(saved-searches): Remove saved searches dropdown when feature flag is enabled

### DIFF
--- a/static/app/views/issueList/savedSearchTab.spec.jsx
+++ b/static/app/views/issueList/savedSearchTab.spec.jsx
@@ -100,4 +100,59 @@ describe('IssueListSavedSearchTab', () => {
     renderSavedSearch();
     expect(screen.queryByText('Unresolved')).not.toBeInTheDocument();
   });
+
+  describe('saved searches v2', () => {
+    const orgWithSavedSearchesV2 = TestStubs.Organization({
+      features: ['issue-list-saved-searches-v2'],
+    });
+
+    it('renders nothing when inactive', () => {
+      render(
+        <IssueListSavedSearchTab
+          organization={orgWithSavedSearchesV2}
+          savedSearchList={savedSearchList}
+          onSavedSearchSelect={onSelect}
+          onSavedSearchDelete={onDelete}
+          query="not a saved search"
+          isActive={false}
+        />,
+        {context: TestStubs.routerContext()}
+      );
+
+      expect(screen.queryByTestId('saved-search-tab')).not.toBeInTheDocument();
+    });
+
+    it('displays Custom Search when on a search that is not saved', () => {
+      render(
+        <IssueListSavedSearchTab
+          organization={orgWithSavedSearchesV2}
+          savedSearchList={savedSearchList}
+          onSavedSearchSelect={onSelect}
+          onSavedSearchDelete={onDelete}
+          query="not a saved search"
+          isActive
+        />,
+        {context: TestStubs.routerContext()}
+      );
+
+      expect(screen.getByText('Custom Search')).toBeInTheDocument();
+    });
+
+    it('displays the saved search name when on a saved search', () => {
+      render(
+        <IssueListSavedSearchTab
+          organization={orgWithSavedSearchesV2}
+          savedSearchList={savedSearchList}
+          onSavedSearchSelect={onSelect}
+          onSavedSearchDelete={onDelete}
+          query="is:unresolved assigned:me"
+          sort="date"
+          isActive
+        />,
+        {context: TestStubs.routerContext()}
+      );
+
+      expect(screen.getByText('Assigned to me')).toBeInTheDocument();
+    });
+  });
 });

--- a/static/app/views/issueList/savedSearchTab.tsx
+++ b/static/app/views/issueList/savedSearchTab.tsx
@@ -28,7 +28,7 @@ type Props = {
   queryCount?: number;
 };
 
-function SavedSearchTab({
+function SavedSearchTabDropdown({
   isActive,
   organization,
   savedSearchList,
@@ -170,7 +170,46 @@ function SavedSearchTab({
   );
 }
 
+function SavedSearchTab(props: Props) {
+  if (!props.organization.features.includes('issue-list-saved-searches-v2')) {
+    return <SavedSearchTabDropdown {...props} />;
+  }
+
+  if (!props.isActive) {
+    return null;
+  }
+
+  const savedSearch = props.savedSearchList.find(
+    search => search.query === props.query && search.sort === props.sort
+  );
+
+  return (
+    <li data-test-id="saved-search-tab">
+      <StyledTab>
+        <span>{savedSearch ? savedSearch.name : t('Custom Search')}&nbsp;</span>
+        {props.queryCount && props.queryCount > 0 ? (
+          <Badge>
+            <QueryCount hideParens count={props.queryCount} max={1000} />
+          </Badge>
+        ) : null}
+      </StyledTab>
+    </li>
+  );
+}
+
 export default SavedSearchTab;
+
+const StyledTab = styled('div')`
+  display: flex;
+  height: 1.25rem;
+  align-items: center;
+  box-sizing: content-box;
+  padding: ${space(1)} 0;
+  color: ${p => p.theme.textColor};
+  border-bottom-width: 4px;
+  border-bottom-style: solid;
+  border-bottom-color: ${p => p.theme.active};
+`;
 
 const StyledCompactSelect = styled(CompactSelect)<{isActive?: boolean}>`
   && {


### PR DESCRIPTION
- When one of the other tabs is selected, renders nothing
- When on a custom search, displays "Custom Search"
- When on a saved search, displays the search name (but no dropdown)

![image](https://user-images.githubusercontent.com/10888943/200029522-21087294-d5f6-40ac-b1f4-affece6cc659.png)

![image](https://user-images.githubusercontent.com/10888943/200029571-aea5b154-c003-4125-90c6-71407244cb87.png)

![image](https://user-images.githubusercontent.com/10888943/200029485-aad4666b-281a-408e-92b7-6308f9855698.png)


