### PR TITLE
fix(replays): Add validation if there's no data for the replay count

### DIFF
--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -128,7 +128,7 @@ function TransactionHeader({
           replayEventView.getEventsAPIPayload(location)
         );
 
-        setReplaysCount(Number(data.data[0]['count_unique(replayId)']));
+        setReplaysCount(Number(data.data?.[0]?.['count_unique(replayId)'] ?? 0));
       } catch (err) {
         Sentry.captureException(err);
         return null;


### PR DESCRIPTION


<!-- Describe your PR here. -->
### Changes
- Added a validation when setting the count number of replays inside transactions


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
