### PR TITLE
feat(discover): updates time since tooltip of event detail page to show occurred and received timestamps

### DIFF
--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -43,6 +43,7 @@ interface Props extends React.TimeHTMLAttributes<HTMLTimeElement> {
    */
   suffix?: string;
 
+  tooltipBody?: React.ReactNode;
   tooltipShowSeconds?: boolean;
   tooltipTitle?: React.ReactNode;
   tooltipUnderlineColor?: ColorOrAlias;
@@ -54,6 +55,7 @@ function TimeSince({
   disabledAbsoluteTooltip,
   tooltipShowSeconds,
   tooltipTitle,
+  tooltipBody,
   tooltipUnderlineColor,
   shorten,
   extraShort,
@@ -105,7 +107,7 @@ function TimeSince({
       title={
         <Fragment>
           {tooltipTitle && <div>{tooltipTitle}</div>}
-          {tooltip}
+          {tooltipBody ?? tooltip}
         </Fragment>
       }
     >

--- a/static/app/views/organizationGroupDetails/eventCreatedTooltip.tsx
+++ b/static/app/views/organizationGroupDetails/eventCreatedTooltip.tsx
@@ -1,0 +1,72 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+import moment from 'moment-timezone';
+
+import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
+import space from 'sentry/styles/space';
+import {Event} from 'sentry/types/event';
+
+const formatDateDelta = (reference: moment.Moment, observed: moment.Moment) => {
+  const duration = moment.duration(Math.abs(+observed - +reference));
+  const hours = Math.floor(+duration / (60 * 60 * 1000));
+  const minutes = duration.minutes();
+  const results: string[] = [];
+
+  if (hours) {
+    results.push(`${hours} hour${hours !== 1 ? 's' : ''}`);
+  }
+
+  if (minutes) {
+    results.push(`${minutes} minute${minutes !== 1 ? 's' : ''}`);
+  }
+
+  if (results.length === 0) {
+    results.push('a few seconds');
+  }
+
+  return results.join(', ');
+};
+
+type Props = {
+  event: Event;
+};
+
+export default function EventCreatedTooltip({event}: Props) {
+  const user = ConfigStore.get('user');
+  const options = user?.options ?? {};
+  const format = options.clock24Hours ? 'HH:mm:ss z' : 'LTS z';
+  const dateCreated = moment(event.dateCreated);
+  const dateReceived = event.dateReceived ? moment(event.dateReceived) : null;
+
+  return (
+    <DescriptionList>
+      <dt>{t('Occurred')}</dt>
+      <dd>
+        {dateCreated.format('ll')}
+        <br />
+        {dateCreated.format(format)}
+      </dd>
+      {dateReceived && (
+        <Fragment>
+          <dt>{t('Received')}</dt>
+          <dd>
+            {dateReceived.format('ll')}
+            <br />
+            {dateReceived.format(format)}
+          </dd>
+          <dt>{t('Latency')}</dt>
+          <dd>{formatDateDelta(dateCreated, dateReceived)}</dd>
+        </Fragment>
+      )}
+    </DescriptionList>
+  );
+}
+
+const DescriptionList = styled('dl')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: ${space(0.75)} ${space(1)};
+  text-align: left;
+  margin: 0;
+`;

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment} from 'react';
+import {Component} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 import moment from 'moment-timezone';
@@ -14,7 +14,6 @@ import NavigationButtonGroup from 'sentry/components/navigationButtonGroup';
 import Tooltip from 'sentry/components/tooltip';
 import {IconPlay, IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import ConfigStore from 'sentry/stores/configStore';
 import space from 'sentry/styles/space';
 import {Group, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
@@ -22,28 +21,8 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import {shouldUse24Hours} from 'sentry/utils/dates';
 import getDynamicText from 'sentry/utils/getDynamicText';
 
+import EventCreatedTooltip from './eventCreatedTooltip';
 import QuickTrace from './quickTrace';
-
-const formatDateDelta = (reference: moment.Moment, observed: moment.Moment) => {
-  const duration = moment.duration(Math.abs(+observed - +reference));
-  const hours = Math.floor(+duration / (60 * 60 * 1000));
-  const minutes = duration.minutes();
-  const results: string[] = [];
-
-  if (hours) {
-    results.push(`${hours} hour${hours !== 1 ? 's' : ''}`);
-  }
-
-  if (minutes) {
-    results.push(`${minutes} minute${minutes !== 1 ? 's' : ''}`);
-  }
-
-  if (results.length === 0) {
-    results.push('a few seconds');
-  }
-
-  return results.join(', ');
-};
 
 type Props = {
   event: Event;
@@ -65,38 +44,6 @@ class GroupEventToolbar extends Component<Props> {
       project_id: parseInt(this.props.project.id, 10),
       button,
     });
-  }
-
-  getDateTooltip() {
-    const evt = this.props.event;
-    const user = ConfigStore.get('user');
-    const options = user?.options ?? {};
-    const format = options.clock24Hours ? 'HH:mm:ss z' : 'LTS z';
-    const dateCreated = moment(evt.dateCreated);
-    const dateReceived = evt.dateReceived ? moment(evt.dateReceived) : null;
-
-    return (
-      <DescriptionList>
-        <dt>Occurred</dt>
-        <dd>
-          {dateCreated.format('ll')}
-          <br />
-          {dateCreated.format(format)}
-        </dd>
-        {dateReceived && (
-          <Fragment>
-            <dt>Received</dt>
-            <dd>
-              {dateReceived.format('ll')}
-              <br />
-              {dateReceived.format(format)}
-            </dd>
-            <dt>Latency</dt>
-            <dd>{formatDateDelta(dateCreated, dateReceived)}</dd>
-          </Fragment>
-        )}
-      </DescriptionList>
-    );
   }
 
   render() {
@@ -138,7 +85,11 @@ class GroupEventToolbar extends Component<Props> {
               </ExternalLink>
             </LinkContainer>
           </Heading>
-          <Tooltip title={this.getDateTooltip()} showUnderline disableForVisualTest>
+          <Tooltip
+            title={<EventCreatedTooltip event={evt} />}
+            showUnderline
+            disableForVisualTest
+          >
             <StyledDateTime
               format={is24Hours ? 'MMM D, YYYY HH:mm:ss zz' : 'll LTS z'}
               date={getDynamicText({
@@ -250,14 +201,6 @@ const LinkContainer = styled('span')`
     height: 14px;
     border-left: 1px solid ${p => p.theme.border};
   }
-`;
-
-const DescriptionList = styled('dl')`
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: ${space(0.75)} ${space(1)};
-  text-align: left;
-  margin: 0;
 `;
 
 const NavigationContainer = styled('div')`

--- a/static/app/views/performance/transactionDetails/eventMetas.spec.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.spec.tsx
@@ -1,0 +1,36 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import EventMetas from './eventMetas';
+
+describe('EventMetas', () => {
+  it('Displays event created and received dates when hovering', async () => {
+    const event = {
+      ...TestStubs.Event(),
+      dateReceived: '2017-05-21T18:01:48.762Z',
+      dateCreated: '2017-05-21T18:02:48.762Z',
+    };
+    const routerContext = TestStubs.routerContext([]);
+    const organization = TestStubs.Organization({});
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    render(
+      <EventMetas
+        event={event}
+        location={routerContext.context.location}
+        organization={organization}
+        errorDest="discover"
+        transactionDest="discover"
+        meta={null}
+        projectId="1"
+        quickTrace={null}
+      />
+    );
+    userEvent.hover(screen.getByText('5 months ago'));
+    expect(await screen.findByText('Occurred')).toBeInTheDocument();
+    expect(screen.getByText(/6:01:48 PM UTC/)).toBeInTheDocument();
+    expect(screen.getByText('Received')).toBeInTheDocument();
+    expect(screen.getByText(/6:02:48 PM UTC/)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -24,6 +24,7 @@ import {
 import {isTransaction} from 'sentry/utils/performance/quickTrace/utils';
 import Projects from 'sentry/utils/projects';
 import theme from 'sentry/utils/theme';
+import EventCreatedTooltip from 'sentry/views/organizationGroupDetails/eventCreatedTooltip';
 
 import QuickTraceMeta from './quickTraceMeta';
 import {MetaData} from './styles';
@@ -97,7 +98,10 @@ class EventMetas extends Component<Props, State> {
     const type = isTransaction(event) ? 'transaction' : 'event';
 
     const timestamp = (
-      <TimeSince date={event.dateCreated || (event.endTimestamp || 0) * 1000} />
+      <TimeSince
+        tooltipBody={<EventCreatedTooltip event={event} />}
+        date={event.dateCreated || (event.endTimestamp || 0) * 1000}
+      />
     );
 
     const httpStatus = <HttpStatus event={event} />;


### PR DESCRIPTION
Updates the time since component in the event detail page to display occurred and received details of the event(matches issue details page) 
![image](https://user-images.githubusercontent.com/83961295/200048281-150c3c3a-9cdf-46cb-96f8-b3097aeb133b.png)