### PR TITLE
feat(replays): Log `project_has_replays` during the Issue Details: Viewed event

### DIFF
--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -94,6 +94,7 @@ export type TeamInsightsEventParameters = {
       integration_assignment_source?: string;
       issue_level?: string;
       issue_status?: string;
+      project_has_replay?: boolean;
       project_platform?: string;
     };
   'new_alert_rule.viewed': RuleViewed & {

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -189,6 +189,7 @@ class GroupDetails extends Component<Props, State> {
       error_has_replay: Boolean(event?.tags?.find(({key}) => key === 'replayId')),
       group_has_replay: Boolean(group?.tags?.find(({key}) => key === 'replayId')),
       num_comments: group ? group.numComments : -1,
+      project_has_replay: group?.project.hasReplays,
       project_platform: group?.project.platform,
       has_external_issue: group?.annotations ? group?.annotations.length > 0 : false,
       has_owner: group?.owners ? group?.owners.length > 0 : false,


### PR DESCRIPTION
I want to add this field so we can narrow our metrics only to those JS projects which have setup replays. 
For example: a funnel of users viewing an Issue and clicking through to the replay, it'll be more specific if we know that the project has 1 or more replays saved.

Fixes #40987