### PR TITLE
ref(forms): Simplify layouts & fix paddings

### DIFF
--- a/static/app/components/forms/field/controlState.tsx
+++ b/static/app/components/forms/field/controlState.tsx
@@ -67,7 +67,6 @@ const ControlStateWrapper = styled('div')`
   grid-auto-flow: column;
   align-items: center;
   gap: ${space(0.5)};
-  padding: 0 ${space(0.5)};
 `;
 
 const StyledIconCheckmark = styled(IconCheckmark)`

--- a/static/app/components/forms/field/fieldControl.tsx
+++ b/static/app/components/forms/field/fieldControl.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import space from 'sentry/styles/space';
+
 import FieldControlState from './fieldControlState';
 import {FieldGroupProps} from './types';
 
@@ -22,27 +24,23 @@ const FieldControl = ({
   hideControlState,
   flexibleControlStateSize,
 }: FieldControlProps) => (
-  <FieldControlErrorWrapper inline={inline}>
-    <FieldControlWrapper>
-      <FieldControlStyled alignRight={alignRight}>{children}</FieldControlStyled>
+  <FieldControlWrapper inline={inline}>
+    <FieldControlStyled alignRight={alignRight}>{children}</FieldControlStyled>
 
-      {!hideControlState && (
-        <FieldControlState flexibleControlStateSize={!!flexibleControlStateSize}>
-          {controlState}
-        </FieldControlState>
-      )}
-    </FieldControlWrapper>
-  </FieldControlErrorWrapper>
+    {!hideControlState && (
+      <FieldControlState flexibleControlStateSize={!!flexibleControlStateSize}>
+        {controlState}
+      </FieldControlState>
+    )}
+  </FieldControlWrapper>
 );
 
 export default FieldControl;
 
-// This wraps Control + ControlError message
-// * can NOT be a flex box here because of `position: absolute` on "control error message"
-// * can NOT have overflow hidden because "control error message" overflows
-const FieldControlErrorWrapper = styled('div')<{inline?: boolean}>`
-  ${p => (p.inline ? 'width: 50%; padding-left: 10px;' : '')};
-  position: relative;
+const FieldControlWrapper = styled('div')<{inline?: boolean}>`
+  display: flex;
+  flex: 1;
+  ${p => p.inline && `padding-left: ${space(2)}`};
 `;
 
 const FieldControlStyled = styled('div')<{alignRight?: boolean}>`
@@ -52,9 +50,4 @@ const FieldControlStyled = styled('div')<{alignRight?: boolean}>`
   position: relative;
   max-width: 100%;
   ${p => (p.alignRight ? 'align-items: flex-end;' : '')};
-`;
-
-const FieldControlWrapper = styled('div')`
-  display: flex;
-  flex-shrink: 0;
 `;

--- a/static/app/components/forms/field/fieldControlState.tsx
+++ b/static/app/components/forms/field/fieldControlState.tsx
@@ -9,11 +9,12 @@ type FieldControlStateProps = Pick<FieldGroupProps, 'flexibleControlStateSize'>;
 const FieldControlState = styled('div')<FieldControlStateProps>`
   display: flex;
   position: relative;
-  ${p => !p.flexibleControlStateSize && `width: 24px`};
   flex-shrink: 0;
   justify-content: end;
   align-items: center;
-  margin-left: ${space(0.5)};
+
+  margin-left: ${p => (p.flexibleControlStateSize ? space(1.5) : space(0.5))};
+  ${p => !p.flexibleControlStateSize && `width: 24px`};
 `;
 
 export default FieldControlState;

--- a/static/app/components/forms/field/fieldControlState.tsx
+++ b/static/app/components/forms/field/fieldControlState.tsx
@@ -13,8 +13,10 @@ const FieldControlState = styled('div')<FieldControlStateProps>`
   justify-content: end;
   align-items: center;
 
-  margin-left: ${p => (p.flexibleControlStateSize ? space(1.5) : space(0.5))};
-  ${p => !p.flexibleControlStateSize && `width: 24px`};
+  ${p =>
+    p.flexibleControlStateSize
+      ? `&:not(:empty) { margin-left: ${space(1.5)} }`
+      : `width: 24px; margin-left: ${space(0.5)};`};
 `;
 
 export default FieldControlState;

--- a/static/app/components/forms/field/fieldWrapper.tsx
+++ b/static/app/components/forms/field/fieldWrapper.tsx
@@ -23,10 +23,10 @@ const inlineStyle = (p: FieldWrapperProps) =>
 const getPadding = (p: FieldWrapperProps) =>
   p.stacked && !p.inline
     ? css`
-        padding: 0 ${space(1)} ${space(2)} 0;
+        padding: 0 ${space(2)} ${space(2)} 0;
       `
     : css`
-        padding: ${space(2)} ${space(1)} ${space(2)} ${space(2)};
+        padding: ${space(2)};
       `;
 
 const FieldWrapper = styled('div')<FieldWrapperProps>`


### PR DESCRIPTION
* Remove `FieldControlErrorWrapper`. It's no longer necessary since we recently removed `FieldErrorReason` in https://github.com/getsentry/sentry/pull/40738
* Fix padding issues related to `flexibleControlStateSize`

**Before:** there is not enough padding on the right
<img width="680" alt="Screen Shot 2022-11-04 at 12 03 29 PM" src="https://user-images.githubusercontent.com/44172267/200055086-6e1f2ae0-60a2-44f9-9544-ea7c7a8339d8.png">

**After:**
<img width="680" alt="Screen Shot 2022-11-04 at 12 03 51 PM" src="https://user-images.githubusercontent.com/44172267/200055152-b63a5787-b7ae-465b-a2da-487e14796f13.png">