### PR TITLE
feat(alert-preview): record event_id in activity

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1752,7 +1752,9 @@ def _handle_regression(group: Group, event: Event, release: Release) -> Optional
 
     if is_regression:
         Activity.objects.create_group_activity(
-            group, ActivityType.SET_REGRESSION, data={"version": release.version if release else ""}
+            group,
+            ActivityType.SET_REGRESSION,
+            data={"version": release.version if release else "", "event_id": event.event_id},
         )
         record_group_history(group, GroupHistoryStatus.REGRESSED, actor=None, release=release)
 

--- a/src/sentry/rules/conditions/reappeared_event.py
+++ b/src/sentry/rules/conditions/reappeared_event.py
@@ -29,10 +29,12 @@ class ReappearedEventCondition(EventCondition):
                 user=None,
             )
             .order_by("-datetime")[:limit]
-            .values_list("group", "datetime")
+            .values_list("group", "datetime", "data")
         )
 
         return [
-            ConditionActivity(group_id=a[0], type=ConditionActivityType.REAPPEARED, timestamp=a[1])
+            ConditionActivity(
+                group_id=a[0], type=ConditionActivityType.REAPPEARED, timestamp=a[1], data=a[2]
+            )
             for a in activities
         ]

--- a/src/sentry/rules/conditions/regression_event.py
+++ b/src/sentry/rules/conditions/regression_event.py
@@ -27,10 +27,12 @@ class RegressionEventCondition(EventCondition):
                 type=ActivityType.SET_REGRESSION.value,
             )
             .order_by("-datetime")[:limit]
-            .values_list("group", "datetime")
+            .values_list("group", "datetime", "data")
         )
 
         return [
-            ConditionActivity(group_id=a[0], type=ConditionActivityType.REGRESSION, timestamp=a[1])
+            ConditionActivity(
+                group_id=a[0], type=ConditionActivityType.REGRESSION, timestamp=a[1], data=a[2]
+            )
             for a in activities
         ]

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -97,18 +97,22 @@ def get_events(
 
     # TODO: Add more columns as more event filters are supported
     columns = ["event_id"]
-    events_from_group_ids = raw_query(  # retrieves the first event for each group
-        dataset=Dataset.Events,
-        filter_keys={"project_id": [project.id], "group_id": group_ids},
-        orderby=["group_id", "timestamp"],
-        limitby=(1, "group_id"),
-        selected_columns=columns,
-    )
-    events_from_event_ids = raw_query(
-        dataset=Dataset.Events,
-        filter_keys={"project_id": [project.id], "event_id": event_ids},
-        selected_columns=columns,
-    )
+    events_from_group_ids = {"data": []}
+    events_from_event_ids = {"data": []}
+    if len(group_ids) > 0:
+        events_from_group_ids = raw_query(  # retrieves the first event for each group
+            dataset=Dataset.Events,
+            filter_keys={"project_id": [project.id], "group_id": group_ids},
+            orderby=["group_id", "timestamp"],
+            limitby=(1, "group_id"),
+            selected_columns=columns,
+        )
+    if len(event_ids) > 0:
+        events_from_event_ids = raw_query(
+            dataset=Dataset.Events,
+            filter_keys={"project_id": [project.id], "event_id": event_ids},
+            selected_columns=columns,
+        )
 
     return {
         event["event_id"]: event

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -79,9 +79,7 @@ def preview(
     return Group.objects.filter(id__in=group_ids)
 
 
-def get_events(
-    project: Project, condition_activity: Sequence[ConditionActivity]
-) -> Dict[str, Dict[str, str]]:
+def get_events(project: Project, condition_activity: Sequence[ConditionActivity]) -> Dict[str, Any]:
     """
     Returns events that have caused issue state changes.
     """
@@ -97,8 +95,8 @@ def get_events(
 
     # TODO: Add more columns as more event filters are supported
     columns = ["event_id"]
-    events_from_group_ids = {"data": []}
-    events_from_event_ids = {"data": []}
+    events_from_group_ids: Dict[str, Any] = {"data": []}
+    events_from_event_ids: Dict[str, Any] = {"data": []}
     if len(group_ids) > 0:
         events_from_group_ids = raw_query(  # retrieves the first event for each group
             dataset=Dataset.Events,

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -95,24 +95,24 @@ def get_events(project: Project, condition_activity: Sequence[ConditionActivity]
 
     # TODO: Add more columns as more event filters are supported
     columns = ["event_id"]
-    events_from_group_ids: Dict[str, Any] = {"data": []}
-    events_from_event_ids: Dict[str, Any] = {"data": []}
-    if len(group_ids) > 0:
-        events_from_group_ids = raw_query(  # retrieves the first event for each group
-            dataset=Dataset.Events,
-            filter_keys={"project_id": [project.id], "group_id": group_ids},
-            orderby=["group_id", "timestamp"],
-            limitby=(1, "group_id"),
-            selected_columns=columns,
+    events = []
+    if group_ids:
+        events.extend(
+            raw_query(  # retrieves the first event for each group
+                dataset=Dataset.Events,
+                filter_keys={"project_id": [project.id], "group_id": group_ids},
+                orderby=["group_id", "timestamp"],
+                limitby=(1, "group_id"),
+                selected_columns=columns,
+            ).get("data", [])
         )
-    if len(event_ids) > 0:
-        events_from_event_ids = raw_query(
-            dataset=Dataset.Events,
-            filter_keys={"project_id": [project.id], "event_id": event_ids},
-            selected_columns=columns,
+    if event_ids:
+        events.extend(
+            raw_query(
+                dataset=Dataset.Events,
+                filter_keys={"project_id": [project.id], "event_id": event_ids},
+                selected_columns=columns,
+            ).get("data", [])
         )
 
-    return {
-        event["event_id"]: event
-        for event in events_from_group_ids["data"] + events_from_event_ids["data"]
-    }
+    return {event["event_id"]: event for event in events}

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -103,9 +103,15 @@ def get_events(project: Project, condition_activity: Sequence[ConditionActivity]
                 filter_keys={"project_id": [project.id], "group_id": group_ids},
                 orderby=["group_id", "timestamp"],
                 limitby=(1, "group_id"),
-                selected_columns=columns,
+                selected_columns=columns + ["group_id"],
             ).get("data", [])
         )
+        # store event_ids for CREATE_ISSUE condition activities
+        group_map = {event["group_id"]: event["event_id"] for event in events}
+        for act in condition_activity:
+            if act.type == ConditionActivityType.CREATE_ISSUE:
+                act.data = {"event_id": group_map[act.group_id]}
+
     if event_ids:
         events.extend(
             raw_query(

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -85,11 +85,11 @@ def get_events(project: Project, condition_activity: Sequence[ConditionActivity]
     """
     group_ids = []
     event_ids = []
-    for act in condition_activity:
-        if act.type == ConditionActivityType.CREATE_ISSUE:
-            group_ids.append(act.group_id)
-        elif act.type in (ConditionActivityType.REGRESSION, ConditionActivityType.REAPPEARED):
-            event_id = act.data.get("event_id", None)
+    for activity in condition_activity:
+        if activity.type == ConditionActivityType.CREATE_ISSUE:
+            group_ids.append(activity.group_id)
+        elif activity.type in (ConditionActivityType.REGRESSION, ConditionActivityType.REAPPEARED):
+            event_id = activity.data.get("event_id", None)
             if event_id is not None:
                 event_ids.append(event_id)
 
@@ -108,9 +108,9 @@ def get_events(project: Project, condition_activity: Sequence[ConditionActivity]
         )
         # store event_ids for CREATE_ISSUE condition activities
         group_map = {event["group_id"]: event["event_id"] for event in events}
-        for act in condition_activity:
-            if act.type == ConditionActivityType.CREATE_ISSUE:
-                act.data = {"event_id": group_map[act.group_id]}
+        for activity in condition_activity:
+            if activity.type == ConditionActivityType.CREATE_ISSUE:
+                activity.data = {"event_id": group_map[activity.group_id]}
 
     if event_ids:
         events.extend(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -552,6 +552,7 @@ def process_snoozes(job: PostProcessJob) -> None:
             group=group,
             type=ActivityType.SET_UNRESOLVED.value,
             user=None,
+            data={"event_id": job["event"].event_id},
         )
 
         snooze.delete()

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -12,7 +12,7 @@ class ConditionActivityType(Enum):
     REAPPEARED = 2
 
 
-@dataclass(frozen=True)
+@dataclass
 class ConditionActivity:
     group_id: str
     # potentially can have multiple types if even more conditions are supported

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -274,6 +274,7 @@ class GetEventsTest(TestCase):
 
         assert len(events) == 1
         assert event.event_id in events
+        assert activity[0].data["event_id"] == event.event_id
 
     def test_get_activity(self):
         prev_hour = timezone.now() - timedelta(hours=1)

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -256,10 +256,12 @@ class ProjectRulePreviewTest(TestCase):
 class GetEventsTest(TestCase):
     def test_get_first_seen(self):
         prev_hour = timezone.now() - timedelta(hours=1)
+        two_hours = timezone.now() - timedelta(hours=2)
+        self.store_event(project_id=self.project.id, data={"timestamp": iso_format(prev_hour)})
         event = self.store_event(
-            project_id=self.project.id, data={"timestamp": iso_format(prev_hour)}
+            project_id=self.project.id, data={"timestamp": iso_format(two_hours)}
         )
-        event.group.update(first_seen=prev_hour)
+        event.group.update(first_seen=two_hours)
 
         activity = [
             ConditionActivity(

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -4,10 +4,12 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from sentry.models import Activity, Group, Project
-from sentry.rules.history.preview import PREVIEW_TIME_RANGE, preview
+from sentry.rules.history.preview import PREVIEW_TIME_RANGE, get_events, preview
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.datetime import iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
+from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.types.issues import GroupType
 
 
@@ -247,3 +249,55 @@ class ProjectRulePreviewTest(TestCase):
         ]
         result = preview(self.project, conditions, [], "all", "all", 0)
         assert result.count() == 0
+
+
+@freeze_time()
+@region_silo_test
+class GetEventsTest(TestCase):
+    def test_get_first_seen(self):
+        prev_hour = timezone.now() - timedelta(hours=1)
+        event = self.store_event(
+            project_id=self.project.id, data={"timestamp": iso_format(prev_hour)}
+        )
+        event.group.update(first_seen=prev_hour)
+
+        activity = [
+            ConditionActivity(
+                group_id=event.group.id,
+                type=ConditionActivityType.CREATE_ISSUE,
+                timestamp=prev_hour,
+            )
+        ]
+        events = get_events(self.project, activity)
+
+        assert len(events) == 1
+        assert event.event_id in events
+
+    def test_get_activity(self):
+        prev_hour = timezone.now() - timedelta(hours=1)
+        group = Group.objects.create(project=self.project)
+        regression_event = self.store_event(
+            project_id=self.project.id, data={"timestamp": iso_format(prev_hour)}
+        )
+        reappeared_event = self.store_event(
+            project_id=self.project.id, data={"timestamp": iso_format(prev_hour)}
+        )
+
+        activity = [
+            ConditionActivity(
+                group_id=group.id,
+                type=ConditionActivityType.REGRESSION,
+                timestamp=prev_hour,
+                data={"event_id": regression_event.event_id},
+            ),
+            ConditionActivity(
+                group_id=group.id,
+                type=ConditionActivityType.REAPPEARED,
+                timestamp=prev_hour,
+                data={"event_id": reappeared_event.event_id},
+            ),
+        ]
+        events = get_events(self.project, activity)
+
+        assert len(events) == 2
+        assert all([event.event_id in events for event in (regression_event, reappeared_event)])


### PR DESCRIPTION
Records `event_id` in `Activity.data` for regression and reappeared activity. Also adds a function to query events that have caused issue state changes. Not used yet, but will be passed into `EventFilter.passes_activity` so that filters that look at event data can be supported (release, attributes, and level).