### PR TITLE
fix(menuListItem): Allow details text to wrap

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -353,7 +353,6 @@ const Details = styled('p')<{disabled: boolean; priority: Priority}>`
   color: ${p => p.theme.subText};
   line-height: 1.2;
   margin-bottom: 0;
-  ${p => p.theme.overflowEllipsis}
 
   ${p => p.priority !== 'default' && `color: ${getTextColor(p)};`}
 `;


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/UP-205

Fix a regression from https://github.com/getsentry/sentry/pull/35918

**Before:**
<img width="444" alt="Screen Shot 2022-11-04 at 12 38 19 PM" src="https://user-images.githubusercontent.com/44172267/200060901-802460c2-da54-420a-9fa2-2b025cb6fd42.png">


**After:**
<img width="444" alt="Screen Shot 2022-11-04 at 12 37 26 PM" src="https://user-images.githubusercontent.com/44172267/200060775-332a9e92-48bd-403d-b7c9-09c72ed4847b.png">
