### PR TITLE
fix(menuListItem): Use gray hover background if option is selected but disabled

### DIFF
--- a/static/app/components/menuListItem.tsx
+++ b/static/app/components/menuListItem.tsx
@@ -207,7 +207,18 @@ function getTextColor({
   }
 }
 
-function getFocusBackground({theme, priority}: {priority: Priority; theme: Theme}) {
+function getFocusBackground({
+  theme,
+  priority,
+  disabled,
+}: {
+  disabled: boolean;
+  priority: Priority;
+  theme: Theme;
+}) {
+  if (disabled) {
+    return theme.hover;
+  }
   switch (priority) {
     case 'primary':
       return theme.purple100;


### PR DESCRIPTION
**Before:**
<img width="395" alt="Screen Shot 2022-11-04 at 1 01 12 PM" src="https://user-images.githubusercontent.com/44172267/200064630-82ab31c8-cb34-4ae7-a696-2a2708f9095f.png">

**After:**
<img width="395" alt="Screen Shot 2022-11-04 at 1 00 41 PM" src="https://user-images.githubusercontent.com/44172267/200064633-69a7cb54-5cb9-4696-bc85-5539cad3edde.png">
