### PR TITLE
fix(workflow): Skip ProjectTeams for external projects

### DIFF
--- a/src/sentry/models/projectteam.py
+++ b/src/sentry/models/projectteam.py
@@ -31,9 +31,10 @@ class ProjectTeamManager(BaseManager):
         orgs = {i.organization_id: i.organization for i in teams}
 
         for project_team in project_teams:
-            project_team.project.set_cached_field_value(
-                "organization", orgs[project_team.project.organization_id]
-            )
+            if project_team.project.organization_id in orgs:
+                project_team.project.set_cached_field_value(
+                    "organization", orgs[project_team.project.organization_id]
+                )
 
         return project_teams
 

--- a/tests/sentry/manager/test_projectteam_manager.py
+++ b/tests/sentry/manager/test_projectteam_manager.py
@@ -1,0 +1,16 @@
+from sentry.models import ProjectTeam, Team, User
+from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
+
+
+@region_silo_test
+class TeamManagerTest(TestCase):
+    def test_simple(self):
+        user = User.objects.create(username="foo")
+        org = self.create_organization()
+        team = self.create_team(organization=org, name="Test")
+        self.create_member(organization=org, user=user, teams=[team])
+        ProjectTeam.objects.create(team=team, project=self.project)
+
+        teams = Team.objects.get_for_user(organization=org, user=user)
+        ProjectTeam.objects.get_for_teams_with_org_cache(teams)


### PR DESCRIPTION
It looks like either a project was transferred or the org was imported or something.

fixes https://getsentry.atlassian.net/browse/WOR-2374
fixes [SENTRY-VVB](https://sentry.io/organizations/sentry/issues/3505564023/events/ad64fa3cd02b48fe964f414d6e518bf5/?project=1&referrer=issue-list&statsPeriod=14d)