### PR TITLE
feat(github): Add span evidence to performance issues

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -38,14 +38,7 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
         return body
 
     def get_group_description(self, group: Group, event: Event, **kwargs: Any) -> str:
-        params = {}
-        if kwargs.get("link_referrer"):
-            params["referrer"] = kwargs.get("link_referrer")
-        output = [
-            "Sentry Issue: [{}]({})".format(
-                group.qualified_short_id, absolute_uri(group.get_absolute_url(params=params))
-            )
-        ]
+        output = self.get_group_link(group, **kwargs)
 
         if group.issue_category == GroupCategory.PERFORMANCE:
             body = self.build_performance_issue_description(event)

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -4,6 +4,7 @@ from typing import Any, Mapping, Sequence
 
 from django.urls import reverse
 
+from sentry.eventstore.models import Event
 from sentry.integrations.mixins import IssueBasicMixin
 from sentry.models import ExternalIssue, Group, User
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
@@ -21,7 +22,7 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
         repo, issue_id = key.split("#")
         return f"https://{domain_name}/{repo}/issues/{issue_id}"
 
-    def build_performance_issue_description(self, event):
+    def build_performance_issue_description(self, event: Event) -> str:
         (
             transaction_name,
             parent_span,
@@ -36,7 +37,7 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
         body += f"| **Repeating Spans ({num_repeating_spans})** | {truncatechars(repeating_spans, 50)} |"
         return body
 
-    def get_group_description(self, group, event, **kwargs):
+    def get_group_description(self, group: Group, event: Event, **kwargs: Any) -> str:
         params = {}
         if kwargs.get("link_referrer"):
             params["referrer"] = kwargs.get("link_referrer")

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -5,7 +5,7 @@ from typing import Any, Mapping, Sequence
 from django.urls import reverse
 
 from sentry.eventstore.models import Event
-from sentry.integrations.mixins import IssueBasicMixin
+from sentry.integrations.mixins.issues import MAX_CHAR, IssueBasicMixin
 from sentry.models import ExternalIssue, Group, User
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.types.issues import GroupCategory
@@ -22,7 +22,7 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
         repo, issue_id = key.split("#")
         return f"https://{domain_name}/{repo}/issues/{issue_id}"
 
-    def build_performance_issue_description(self, event: Event) -> str:
+    def get_performance_issue_body(self, event: Event) -> str:
         (
             transaction_name,
             parent_span,
@@ -32,16 +32,16 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
 
         body = "|  |  |\n"
         body += "| ------------- | --------------- |\n"
-        body += f"| **Transaction Name** | {truncatechars(transaction_name, 50)} |\n"
-        body += f"| **Parent Span** | {truncatechars(parent_span, 50)} |\n"
-        body += f"| **Repeating Spans ({num_repeating_spans})** | {truncatechars(repeating_spans, 50)} |"
+        body += f"| **Transaction Name** | {truncatechars(transaction_name, MAX_CHAR)} |\n"
+        body += f"| **Parent Span** | {truncatechars(parent_span, MAX_CHAR)} |\n"
+        body += f"| **Repeating Spans ({num_repeating_spans})** | {truncatechars(repeating_spans, MAX_CHAR)} |"
         return body
 
     def get_group_description(self, group: Group, event: Event, **kwargs: Any) -> str:
         output = self.get_group_link(group, **kwargs)
 
         if group.issue_category == GroupCategory.PERFORMANCE:
-            body = self.build_performance_issue_description(event)
+            body = self.get_performance_issue_body(event)
             output.extend([body])
 
         else:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -17,7 +17,7 @@ from sentry.integrations import (
     IntegrationMetadata,
     IntegrationProvider,
 )
-from sentry.integrations.mixins import IssueSyncMixin, ResolveSyncAction
+from sentry.integrations.mixins.issues import MAX_CHAR, IssueSyncMixin, ResolveSyncAction
 from sentry.models import (
     ExternalIssue,
     IntegrationExternalProject,
@@ -326,7 +326,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
     def get_persisted_ignored_fields(self):
         return self.org_integration.config.get(self.issues_ignored_fields_key, [])
 
-    def build_performance_issue_description(self, event):
+    def get_performance_issue_body(self, event):
         (
             transaction_name,
             parent_span,
@@ -334,11 +334,9 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             repeating_spans,
         ) = self.get_performance_issue_description_data(event)
 
-        body = f"| *Transaction Name* | {truncatechars(transaction_name, 50)} |\n"
-        body += f"| *Parent Span* | {truncatechars(parent_span, 50)} |\n"
-        body += (
-            f"| *Repeating Spans ({num_repeating_spans})* | {truncatechars(repeating_spans, 50)} |"
-        )
+        body = f"| *Transaction Name* | {truncatechars(transaction_name, MAX_CHAR)} |\n"
+        body += f"| *Parent Span* | {truncatechars(parent_span, MAX_CHAR)} |\n"
+        body += f"| *Repeating Spans ({num_repeating_spans})* | {truncatechars(repeating_spans, MAX_CHAR)} |"
         return body
 
     def get_group_description(self, group, event, **kwargs):
@@ -350,7 +348,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         ]
 
         if group.issue_category == GroupCategory.PERFORMANCE:
-            body = self.build_performance_issue_description(event)
+            body = self.get_performance_issue_body(event)
             output.extend([body])
 
         else:

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -79,15 +79,18 @@ class IssueBasicMixin:
                 result.append(output)
         return "\n\n".join(result)
 
-    def get_group_description(self, group, event, **kwargs):
+    def get_group_link(self, group, **kwargs):
         params = {}
         if kwargs.get("link_referrer"):
             params["referrer"] = kwargs.get("link_referrer")
-        output = [
+        return [
             "Sentry Issue: [{}]({})".format(
                 group.qualified_short_id, absolute_uri(group.get_absolute_url(params=params))
             )
         ]
+
+    def get_group_description(self, group, event, **kwargs):
+        output = self.get_group_link(group, **kwargs)
         body = self.get_group_body(group, event)
         if body:
             output.extend(["", "```", body, "```"])

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -21,6 +21,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
 
 logger = logging.getLogger("sentry.integrations.issues")
+MAX_CHAR = 50
 
 
 class ResolveSyncAction(enum.Enum):

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -127,6 +127,11 @@ class GitHubIssueBasicTest(TestCase):
 
         description = GitHubIssueBasic().get_group_description(event.group, event)
         assert "db - SELECT `books_author`.`id`, `books_author" in description
+        title = GitHubIssueBasic().get_group_title(event.group, event)
+        assert (
+            title
+            == 'N+1 Query: SELECT "books_author"."id", "books_author"."name" FROM "books_author" WHERE "books_author"."id" = %s LIMIT 21'
+        )
 
     def test_error_issues_description(self):
         """Test that a GitHub issue created from an error issue has message  data in it's description"""

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -102,7 +102,7 @@ class GitHubIssueBasicTest(TestCase):
         assert payload == {"body": "This is the description", "assignee": None, "title": "hello"}
 
     def test_performance_issues_description(self):
-        """Test that a GitHub issue created from a performance issue has span evidence data in it's description"""
+        """Test that a GitHub issue created from a performance issue has span evidence data in its description"""
         event_data = load_data(
             "transaction-n-plus-one",
             timestamp=before_now(minutes=10),
@@ -134,7 +134,7 @@ class GitHubIssueBasicTest(TestCase):
         )
 
     def test_error_issues_description(self):
-        """Test that a GitHub issue created from an error issue has message  data in it's description"""
+        """Test that a GitHub issue created from an error issue has message  data in its description"""
         event = self.store_event(
             data={
                 "event_id": "a" * 32,


### PR DESCRIPTION
Add span evidence to the description of a GitHub issue created from a performance issue. Currently the GitHub issue is fairly empty as for an error issue it shows the stacktrace, but for a performance issue it's just a link back to the Sentry issue.

<img width="1019" alt="Screen Shot 2022-11-04 at 2 03 29 PM" src="https://user-images.githubusercontent.com/29959063/200081055-f5119f8a-3467-490f-b5a4-f30f179a9620.png">