### PR TITLE
fix(perf-issue): update Group.message value to use the title instead of transaction search_message

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1768,7 +1768,11 @@ def _process_existing_aggregate(
 ) -> bool:
     date = max(event.datetime, group.last_seen)
     extra = {"last_seen": date, "data": data["data"]}
-    if event.search_message and event.search_message != group.message:
+    if (
+        event.search_message
+        and event.search_message != group.message
+        and event.get_event_type() != TransactionEvent.key
+    ):
         extra["message"] = event.search_message
     if group.level != data["level"]:
         extra["level"] = data["level"]
@@ -2321,6 +2325,8 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
                         group_kwargs["data"]["metadata"] = inject_performance_problem_metadata(
                             group_kwargs["data"]["metadata"], problem
                         )
+                        if group_kwargs["data"]["metadata"].get("title"):
+                            group_kwargs["message"] = group_kwargs["data"]["metadata"].get("title")
 
                         group, is_new = _save_grouphash_and_group(
                             project, event, new_grouphash, **group_kwargs
@@ -2364,6 +2370,8 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
                     group_kwargs["data"]["metadata"] = inject_performance_problem_metadata(
                         group_kwargs["data"]["metadata"], problem
                     )
+                    if group_kwargs["data"]["metadata"].get("title"):
+                        group_kwargs["message"] = group_kwargs["data"]["metadata"].get("title")
 
                     is_regression = _process_existing_aggregate(
                         group=group, event=job["event"], data=group_kwargs, release=job["release"]

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2170,7 +2170,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
             assert len(event.groups) == 1
             group = event.groups[0]
             assert group.title == "N+1 Query"
-            assert group.message == "/books/"
+            assert group.message == "N+1 Query"
             assert group.culprit == "/books/"
             assert group.get_event_type() == "transaction"
             description = "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
@@ -2179,6 +2179,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
                 "title": "N+1 Query",
                 "value": description,
             }
+            assert event.search_message == "/books/"
             assert group.location() == "/books/"
             assert group.level == 40
             assert group.issue_category == GroupCategory.PERFORMANCE
@@ -2247,7 +2248,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
                 "value": "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21",
             }
             assert group.location() == "/books/"
-            assert group.message == "/books/"
+            assert group.message == "nope"
             assert group.culprit == "/books/"
 
     @override_options({"performance.issues.all.problem-creation": 1.0})


### PR DESCRIPTION
When we create new Performance issues the `message` column gets populated with the [transaction.search_message](https://github.com/getsentry/sentry/blob/0e318053dc296b23e2dbc55a65d91121ff9abfea/src/sentry/eventstore/models.py#L537-L565) - which looks like an amalgamation of data at the event-level. For error-issues, this works ok since the contextual 'culprit'/'problem' would be available in the event data. But for transaction events, we run the event through detection before we find a problem so the 'problem' is decoupled from the transaction data. 

