### PR TITLE
ref(serializer): Use select organization options as frontend feature flags

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
@@ -244,7 +244,11 @@ class OrganizationSerializer(Serializer):  # type: ignore
             organization=obj, key__in=ORGANIZATION_OPTIONS_AS_FEATURES.keys()
         )
         for option in options_as_features:
-            feature, func = ORGANIZATION_OPTIONS_AS_FEATURES.get(option.key)
+            option_feature = ORGANIZATION_OPTIONS_AS_FEATURES.get(option.key)
+            if not option_feature:
+                continue
+            feature: str = option_feature[0]  # feature flag string
+            func: Callable[[OrganizationOption], bool] | None = option_feature[1]  # flag validator
             if not callable(func) or func(option):
                 feature_list.add(feature)
 

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -245,7 +245,7 @@ class OrganizationSerializer(Serializer):  # type: ignore
         )
         for option in options_as_features:
             feature, func = ORGANIZATION_OPTIONS_AS_FEATURES.get(option.key)
-            if func is None or func(option):
+            if not callable(func) or func(option):
                 feature_list.add(feature)
 
         if getattr(obj.flags, "allow_joinleave"):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -29,7 +29,7 @@ from sentry.constants import (
     DEBUG_FILES_ROLE_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
     JOIN_REQUESTS_DEFAULT,
-    LEGACY_RATE_LIMIT_OPTIONS,
+    ORGANIZATION_OPTIONS_AS_FEATURES,
     PROJECT_RATE_LIMIT_DEFAULT,
     REQUIRE_SCRUB_DATA_DEFAULT,
     REQUIRE_SCRUB_DEFAULTS_DEFAULT,
@@ -240,10 +240,11 @@ class OrganizationSerializer(Serializer):  # type: ignore
             feature_list.add("api-keys")
 
         # Organization flag features (not provided through the features module)
-        if OrganizationOption.objects.filter(
-            organization=obj, key__in=LEGACY_RATE_LIMIT_OPTIONS
-        ).exists():
-            feature_list.add("legacy-rate-limits")
+        options_as_features = OrganizationOption.objects.filter(
+            organization=obj, key__in=ORGANIZATION_OPTIONS_AS_FEATURES.keys()
+        )
+        for option in options_as_features:
+            feature_list.add(ORGANIZATION_OPTIONS_AS_FEATURES.get(option.key))
         if getattr(obj.flags, "allow_joinleave"):
             feature_list.add("open-membership")
         if not getattr(obj.flags, "disable_shared_issues"):

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -244,7 +244,10 @@ class OrganizationSerializer(Serializer):  # type: ignore
             organization=obj, key__in=ORGANIZATION_OPTIONS_AS_FEATURES.keys()
         )
         for option in options_as_features:
-            feature_list.add(ORGANIZATION_OPTIONS_AS_FEATURES.get(option.key))
+            feature, func = ORGANIZATION_OPTIONS_AS_FEATURES.get(option.key)
+            if func is None or func(option):
+                feature_list.add(feature)
+
         if getattr(obj.flags, "allow_joinleave"):
             feature_list.add("open-membership")
         if not getattr(obj.flags, "disable_shared_issues"):

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -551,13 +551,14 @@ StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 
 LEGACY_RATE_LIMIT_OPTIONS = frozenset(("sentry:project-rate-limit", "sentry:account-rate-limit"))
 
-# A mapping of OrganizationOption keys to frontend features.
+# A mapping of OrganizationOption keys to frontend features, and functions to apply the feature.
 # Enabling feature-flagging frontend components without an extra API call/endpoint to verify
-# the OrganizationOption
+# the OrganizationOption.
+# If the function is None, the feature will be added regardless of the option value (if present)
 ORGANIZATION_OPTIONS_AS_FEATURES = {
-    "sentry:project-rate-limit": "legacy-rate-limits",
-    "sentry:account-rate-limit": "legacy-rate-limits",
-    "quotas:new-spike-protection": "spike-projections",
+    "sentry:project-rate-limit": ("legacy-rate-limits", None),
+    "sentry:account-rate-limit": ("legacy-rate-limits", None),
+    "quotas:new-spike-protection": ("spike-projections", lambda opt: bool(opt.value)),
 }
 
 

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -551,6 +551,15 @@ StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 
 LEGACY_RATE_LIMIT_OPTIONS = frozenset(("sentry:project-rate-limit", "sentry:account-rate-limit"))
 
+# A mapping of OrganizationOption keys to frontend features.
+# Enabling feature-flagging frontend components without an extra API call/endpoint to verify
+# the OrganizationOption
+ORGANIZATION_OPTIONS_AS_FEATURES = {
+    "sentry:project-rate-limit": "legacy-rate-limits",
+    "sentry:account-rate-limit": "legacy-rate-limits",
+    "quotas:new-spike-protection": "spike-projections",
+}
+
 
 # We need to limit the range of valid timestamps of an event because that
 # timestamp is used to control data retention.

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -81,6 +81,10 @@ class OrganizationSerializerTest(TestCase):
         assert "test-feature" in result["features"]
         assert "disabled-feature" not in result["features"]
 
+    @mock.patch("sentry.constants.ORGANIZATION_OPTIONS_AS_FEATURES")
+    def test_organization_options_as_flasg(self, mock_options_as_features):
+        mock_options_as_features = {"sentry:some_organization_option": "my-frontend-option-flag"}
+
 
 @region_silo_test
 class DetailedOrganizationSerializerTest(TestCase):

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -11,11 +11,20 @@ from sentry.api.serializers import (
     serialize,
 )
 from sentry.auth import access
+from sentry.constants import ORGANIZATION_OPTIONS_AS_FEATURES
 from sentry.features.base import OrganizationFeature
 from sentry.models import OrganizationOnboardingTask
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organizationonboardingtask import OnboardingTask, OnboardingTaskStatus
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
+
+mock_options_as_features = {
+    "sentry:set_no_func": ("frontend-flag-one", None),
+    "sentry:unset_no_func": ("frontend-flag-two", None),
+    "sentry:set_with_func_pass": ("frontend-flag-three", lambda opt: bool(opt.value)),
+    "sentry:set_with_func_fail": ("frontend-flag-four", lambda opt: bool(opt.value)),
+}
 
 
 @region_silo_test
@@ -81,9 +90,25 @@ class OrganizationSerializerTest(TestCase):
         assert "test-feature" in result["features"]
         assert "disabled-feature" not in result["features"]
 
-    @mock.patch("sentry.constants.ORGANIZATION_OPTIONS_AS_FEATURES")
-    def test_organization_options_as_flasg(self, mock_options_as_features):
-        mock_options_as_features = {"sentry:some_organization_option": "my-frontend-option-flag"}
+    @mock.patch.dict(ORGANIZATION_OPTIONS_AS_FEATURES, mock_options_as_features)
+    def test_organization_options_as_features(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+
+        OrganizationOption.objects.set_value(organization, "sentry:set_no_func", {})
+        OrganizationOption.objects.set_value(organization, "sentry:set_with_func_pass", 1)
+        OrganizationOption.objects.set_value(organization, "sentry:set_with_func_fail", 0)
+
+        features = serialize(organization, user)["features"]
+
+        # Setting a flag with no function checks for option, regardless of value
+        assert mock_options_as_features["sentry:set_no_func"][0] in features
+        # If the option isn't set, it doesn't appear in features
+        assert mock_options_as_features["sentry:unset_no_func"][0] not in features
+        # With a function, run it against the value
+        assert mock_options_as_features["sentry:set_with_func_pass"][0] in features
+        # If it returns False, it doesn't appear in features
+        assert mock_options_as_features["sentry:set_with_func_fail"][0] not in features
 
 
 @region_silo_test


### PR DESCRIPTION
This PR adopts a pattern I noticed for legacy ratelimiting of turning select feature flags into flags passed through to the frontend. The features list is great for selectively rendering UI, but doesn't work with organization options out of the box. This makes there a single source of truth so we don't have to manage a flagr flag alongside an org option for rolling out orgoptions features.