### PR TITLE
feat(issue-alert): metrics for condition edits

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -145,7 +145,7 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
             trigger_sentry_app_action_creators_for_issues(kwargs.get("actions"))
 
             if rule.data["conditions"] != kwargs["conditions"]:
-                metrics.incr("sentry.issue_alert.conditions.edited")
+                metrics.incr("sentry.issue_alert.conditions.edited", sample_rate=1.0)
             updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
 
             RuleActivity.objects.create(

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -22,6 +22,7 @@ from sentry.models import (
 from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.signals import alert_rule_edited
 from sentry.tasks.integrations.slack import find_channel_id_for_rule
+from sentry.utils import metrics
 from sentry.web.decorators import transaction_start
 
 
@@ -143,6 +144,8 @@ class ProjectRuleDetailsEndpoint(RuleEndpoint):
 
             trigger_sentry_app_action_creators_for_issues(kwargs.get("actions"))
 
+            if rule.data["conditions"] != kwargs["conditions"]:
+                metrics.incr("sentry.issue_alert.conditions.edited")
             updated_rule = project_rules.Updater.run(rule=rule, request=request, **kwargs)
 
             RuleActivity.objects.create(

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -677,7 +677,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
         )
-        metrics.incr.assert_has_calls([call("sentry.issue_alert.conditions.edited")])
+        metrics.incr.assert_has_calls(
+            [call("sentry.issue_alert.conditions.edited", sample_rate=1.0)]
+        )
 
     @patch("sentry.utils.metrics")
     def test_edit_non_condition_metric(self, metrics):
@@ -692,7 +694,10 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
         )
-        assert call("sentry.issue_alert.conditions.edited") not in metrics.incr.call_args_list
+        assert (
+            call("sentry.issue_alert.conditions.edited", sample_rate=1.0)
+            not in metrics.incr.call_args_list
+        )
 
 
 @region_silo_test

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -677,8 +677,9 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
         )
-        metrics.incr.assert_has_calls(
-            [call("sentry.issue_alert.conditions.edited", sample_rate=1.0)]
+        assert (
+            call("sentry.issue_alert.conditions.edited", sample_rate=1.0)
+            in metrics.incr.call_args_list
         )
 
     @patch("sentry.utils.metrics")


### PR DESCRIPTION
Adds a metric to record number of edits to issue alert conditions. Hopefully can be used to gauge the effect of incompatible rules and previews.