### PR TITLE
ref(relay): Remove deprecated legacy quotas from config [INGEST-1683]

### DIFF
--- a/src/sentry/quotas/base.py
+++ b/src/sentry/quotas/base.py
@@ -106,20 +106,6 @@ class QuotaConfig:
 
         return self.id is not None and self.window is not None
 
-    def to_json_legacy(self):
-        data = {
-            "prefix": str(self.id) if self.id is not None else None,
-            "subscope": str(self.scope_id) if self.scope_id is not None else None,
-            "limit": self.limit,
-            "window": self.window,
-            "reasonCode": self.reason_code,
-        }
-
-        if self.scope != QuotaScope.ORGANIZATION and self.scope_id is not None:
-            data["subscope"] = self.scope_id
-
-        return prune_empty_keys(data)
-
     def to_json(self):
         categories = None
         if self.categories:

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -90,11 +90,6 @@ def get_public_key_configs(project, full_config, project_keys=None):
             "isEnabled": True,
         }
 
-        if full_config:
-            key["quotas"] = [
-                q.to_json_legacy() for q in quotas.get_quotas(project, key=project_key)
-            ]
-
         public_keys.append(key)
 
     return public_keys

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -135,7 +135,6 @@ def test_internal_relays_should_receive_full_configs(
     (public_key,) = cfg["publicKeys"]
     assert public_key["publicKey"] == default_projectkey.public_key
     assert public_key["isEnabled"]
-    assert "quotas" in public_key
 
     assert safe.get_path(cfg, "slug") == default_project.slug
     last_change = safe.get_path(cfg, "lastChange")

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -136,7 +136,6 @@ def test_internal_relays_should_receive_full_configs(
     assert public_key["publicKey"] == default_projectkey.public_key
     assert public_key["numericId"] == default_projectkey.id
     assert public_key["isEnabled"]
-    assert "quotas" in public_key
 
     assert safe.get_path(cfg, "slug") == default_project.slug
     last_change = safe.get_path(cfg, "lastChange")

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -94,35 +94,6 @@ class QuotaTest(TestCase):
     [
         (
             QuotaConfig(id="o", limit=4711, window=42, reason_code="not_so_fast"),
-            {"prefix": "o", "limit": 4711, "window": 42, "reasonCode": "not_so_fast"},
-        ),
-        (
-            QuotaConfig(
-                id="p",
-                scope=QuotaScope.PROJECT,
-                scope_id=1,
-                limit=None,
-                window=1,
-                reason_code="go_away",
-            ),
-            {"prefix": "p", "subscope": "1", "window": 1, "reasonCode": "go_away"},
-        ),
-        (QuotaConfig(limit=0, reason_code="go_away"), {"limit": 0, "reasonCode": "go_away"}),
-        (
-            QuotaConfig(limit=0, categories=[DataCategory.TRANSACTION], reason_code="not_yet"),
-            {"limit": 0, "reasonCode": "not_yet"},
-        ),
-    ],
-)
-def test_quotas_to_json_legacy(obj, json):
-    assert obj.to_json_legacy() == json
-
-
-@pytest.mark.parametrize(
-    "obj,json",
-    [
-        (
-            QuotaConfig(id="o", limit=4711, window=42, reason_code="not_so_fast"),
             {
                 "id": "o",
                 "scope": "organization",

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -166,7 +166,6 @@ def test_generate(
             "isEnabled": True,
             "publicKey": default_projectkey.public_key,
             "numericId": default_projectkey.id,
-            "quotas": [],
         }
     ]
 


### PR DESCRIPTION
The schema for quotas was changed in getsentry/relay#503. Since then,
quota entries in the public key object have been unused. Sentry still
generated them to preserve compatibility with older Relay versions.

Since then, there have been two major revisions to the project config
format. This key has been unused for more than two years. Relay has
always treated this field as optional, so it can be safely removed now.

Aside, we've noticed that this branch is causing increasingly slow Snuba
queries, as `get_quotas` will query outcomes for spike protection
internally.