### PR TITLE
feat(discover): allow querying device screen dpi, density, height, and width

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -166,6 +166,19 @@ class EventAttributeCondition(EventCondition):
                         if frame.post_context:
                             result.extend(frame.post_context)
             return result
+
+        elif path[0] == "device":
+            if path[1] in (
+                "screen_density",
+                "screen_dpi",
+                "screen_height_pixels",
+                "screen_width_pixels",
+            ):
+                contexts = event.data["contexts"]
+                device = contexts.get("device")
+                if device is None:
+                    device = []
+                return [device.get(path[1])]
         return []
 
     def render_label(self) -> str:

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -317,6 +317,34 @@ class Columns(Enum):
         discover_name="contexts[device.orientation]",
         alias="device.orientation",
     )
+    DEVICE_SCREEN_DENSITY = Column(
+        group_name="events.contexts[device.screen_density]",
+        event_name="contexts[device.screen_density]",
+        transaction_name="contexts[device.screen_density]",
+        discover_name="contexts[device.screen_density]",
+        alias="device.screen_density",
+    )
+    DEVICE_SCREEN_DPI = Column(
+        group_name="events.contexts[device.screen_dpi]",
+        event_name="contexts[device.screen_dpi]",
+        transaction_name="contexts[device.screen_dpi]",
+        discover_name="contexts[device.screen_dpi]",
+        alias="device.screen_dpi",
+    )
+    DEVICE_SCREEN_HEIGHT_PIXELS = Column(
+        group_name="events.contexts[device.screen_height_pixels]",
+        event_name="contexts[device.screen_height_pixels]",
+        transaction_name="contexts[device.screen_height_pixels]",
+        discover_name="contexts[device.screen_height_pixels]",
+        alias="device.screen_height_pixels",
+    )
+    DEVICE_SCREEN_WIDTH_PIXELS = Column(
+        group_name="events.contexts[device.screen_width_pixels]",
+        event_name="contexts[device.screen_width_pixels]",
+        transaction_name="contexts[device.screen_width_pixels]",
+        discover_name="contexts[device.screen_width_pixels]",
+        alias="device.screen_width_pixels",
+    )
     DEVICE_SIMULATOR = Column(
         group_name="events.contexts[device.simulator]",
         event_name="contexts[device.simulator]",

--- a/tests/sentry/rules/conditions/test_event_attribute.py
+++ b/tests/sentry/rules/conditions/test_event_attribute.py
@@ -44,6 +44,12 @@ class EventAttributeConditionTest(RuleTestCase):
                     "type": "response",
                     "status_code": 500,
                 },
+                "device": {
+                    "screen_width_pixels": 1920,
+                    "screen_height_pixels": 1080,
+                    "screen_dpi": 123,
+                    "screen_density": 2.5,
+                },
             },
         }
         data.update(kwargs)
@@ -638,6 +644,86 @@ class EventAttributeConditionTest(RuleTestCase):
                 "match": MatchType.EQUAL,
                 "attribute": "stacktrace.package",
                 "value": "package/otherotherpackage.lib",
+            }
+        )
+        self.assertDoesNotPass(rule, event)
+
+    def test_device_screen_width_pixels(self):
+        event = self.get_event()
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "device.screen_width_pixels",
+                "value": "1920",
+            }
+        )
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "device.screen_width_pixels",
+                "value": "400",
+            }
+        )
+        self.assertDoesNotPass(rule, event)
+
+    def test_device_screen_height_pixels(self):
+        event = self.get_event()
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "device.screen_height_pixels",
+                "value": "1080",
+            }
+        )
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "device.screen_height_pixels",
+                "value": "400",
+            }
+        )
+        self.assertDoesNotPass(rule, event)
+
+    def test_device_screen_dpi(self):
+        event = self.get_event()
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "device.screen_dpi",
+                "value": "123",
+            }
+        )
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "device.screen_dpi",
+                "value": "400",
+            }
+        )
+        self.assertDoesNotPass(rule, event)
+
+    def test_device_screen_density(self):
+        event = self.get_event()
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "device.screen_density",
+                "value": "2.5",
+            }
+        )
+        self.assertPasses(rule, event)
+
+        rule = self.get_rule(
+            data={
+                "match": MatchType.EQUAL,
+                "attribute": "device.screen_density",
+                "value": "400",
             }
         )
         self.assertDoesNotPass(rule, event)


### PR DESCRIPTION
Makes device screen dpi, density, height, and width queryable.
Also added to rules for testing.