### PR TITLE
fix(integration): Calls to get_installation() should check for int

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -166,6 +166,7 @@ class IntegrationProvider(PipelineProvider, abc.ABC):
         if cls.integration_cls is None:
             raise NotImplementedError
 
+        assert type(organization_id) == int
         return cls.integration_cls(model, organization_id, **kwargs)
 
     @property

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -38,7 +38,7 @@ class BitbucketIntegrationTest(APITestCase):
             url,
             json={"values": [{"full_name": "sentryuser/stuf"}]},
         )
-        installation = self.integration.get_installation(self.organization)
+        installation = self.integration.get_installation(self.organization.id)
         result = installation.get_repositories()
         assert result == [{"identifier": "sentryuser/stuf", "name": "sentryuser/stuf"}]
 
@@ -73,7 +73,7 @@ class BitbucketIntegrationTest(APITestCase):
             },
         )
 
-        installation = self.integration.get_installation(self.organization)
+        installation = self.integration.get_installation(self.organization.id)
         result = installation.get_repositories("stuf")
         assert result == [
             {"identifier": "sentryuser/stuf", "name": "sentryuser/stuf"},
@@ -121,7 +121,7 @@ class BitbucketIntegrationTest(APITestCase):
             json={"values": []},
         )
 
-        installation = self.integration.get_installation(self.organization)
+        installation = self.integration.get_installation(self.organization.id)
         result = installation.get_repositories("stu")
         assert result == [
             {"identifier": "sentryuser/stuff", "name": "sentryuser/stuff"},

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -59,7 +59,9 @@ class BitbucketIssueTest(APITestCase):
 
         data = {"repo": repo, "externalIssue": issue_id, "comment": "hello"}
 
-        assert self.integration.get_installation(None).get_issue(issue_id, data=data) == {
+        assert self.integration.get_installation(self.organization.id).get_issue(
+            issue_id, data=data
+        ) == {
             "key": issue_id,
             "description": "This is the description",
             "title": "hello",

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -34,7 +34,7 @@ class GitHubAppsClientTest(TestCase):
             integration_id=integration.id,
         )
 
-        self.install = integration.get_installation(organization_id="123")
+        self.install = integration.get_installation(organization_id=123)
         self.client = self.install.get_client()
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -388,7 +388,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             },
         )
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         # This searches for any repositories matching the term 'ex'
         result = installation.get_repositories("ex")
         assert result == [
@@ -403,7 +403,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
 
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
             result = installation.get_repositories(fetch_max_pages=True)
@@ -420,7 +420,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.assert_setup_flow()
 
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
 
         with patch.object(sentry.integrations.github.client.GitHubClientMixin, "page_size", 1):
             result = installation.get_repositories()
@@ -449,7 +449,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             responses.HEAD,
             self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
         )
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert result == "https://github.com/Test-Organization/foo/blob/1234567/README.md"
@@ -476,7 +476,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
             status=404,
         )
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert not result
@@ -507,7 +507,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             responses.HEAD,
             self.base_url + f"/repos/{repo.name}/contents/{path}?ref={default}",
         )
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert result == "https://github.com/Test-Organization/foo/blob/master/README.md"
@@ -516,7 +516,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
     def test_get_message_from_error(self):
         self.assert_setup_flow()
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         base_error = f"Error Communicating with GitHub (HTTP 404): {API_ERRORS[404]}"
         assert (
             installation.message_from_error(

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -179,7 +179,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
             },
         )
         integration = Integration.objects.get(provider=self.provider.key)
-        installation = integration.get_installation(self.organization)
+        installation = integration.get_installation(self.organization.id)
         result = installation.get_repositories("ex")
         assert result == [
             {"identifier": "test/example", "name": "example"},

--- a/tests/sentry/integrations/pagerduty/test_integration.py
+++ b/tests/sentry/integrations/pagerduty/test_integration.py
@@ -154,7 +154,7 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
                 {"service": "new_service", "integration_key": "new_key", "id": service_id},
             ]
         }
-        integration.get_installation(self.organization).update_organization_config(config_data)
+        integration.get_installation(self.organization.id).update_organization_config(config_data)
         assert len(PagerDutyService.objects.filter()) == 2
         service_row = PagerDutyService.objects.get(id=service_id)
         assert service_row.service_name == "new_service"
@@ -169,7 +169,7 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
         config_data = {
             "service_table": [{"service": "new_service", "integration_key": "new_key", "id": None}]
         }
-        integration.get_installation(self.organization).update_organization_config(config_data)
+        integration.get_installation(self.organization.id).update_organization_config(config_data)
         assert len(PagerDutyService.objects.all()) == 1
         assert not PagerDutyService.objects.filter(id=service_id).exists()
 
@@ -183,7 +183,9 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
             "service_table": [{"service": "new_service", "integration_key": "", "id": service_id}]
         }
         with pytest.raises(IntegrationError) as error:
-            integration.get_installation(self.organization).update_organization_config(config_data)
+            integration.get_installation(self.organization.id).update_organization_config(
+                config_data
+            )
         assert str(error.value) == "Name and key are required"
 
     @responses.activate
@@ -197,7 +199,7 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
                 integration=integration, organization=self.organization
             )
         )
-        config = integration.get_installation(self.organization).get_config_data()
+        config = integration.get_installation(self.organization.id).get_config_data()
         assert config == {
             "service_table": [
                 {


### PR DESCRIPTION
Some of our tests were passing an organization or a string instead of an int.