### PR TITLE
feat(saved-searches): Add visibility dropdown to create saved search modal

### DIFF
--- a/static/app/actionCreators/savedSearches.tsx
+++ b/static/app/actionCreators/savedSearches.tsx
@@ -3,7 +3,12 @@ import {Client} from 'sentry/api';
 import {MAX_AUTOCOMPLETE_RECENT_SEARCHES} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import SavedSearchesStore from 'sentry/stores/savedSearchesStore';
-import {RecentSearch, SavedSearch, SavedSearchType} from 'sentry/types';
+import {
+  RecentSearch,
+  SavedSearch,
+  SavedSearchType,
+  SavedSearchVisibility,
+} from 'sentry/types';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
 
 export function resetSavedSearches() {
@@ -74,7 +79,8 @@ export function createSavedSearch(
   orgSlug: string,
   name: string,
   query: string,
-  sort: string | null
+  sort: string | null,
+  visibility: SavedSearchVisibility
 ): Promise<SavedSearch> {
   const promise = api.requestPromise(`/organizations/${orgSlug}/searches/`, {
     method: 'POST',
@@ -83,6 +89,7 @@ export function createSavedSearch(
       query,
       name,
       sort,
+      visibility,
     },
   });
 

--- a/static/app/components/modals/createSavedSearchModal.tsx
+++ b/static/app/components/modals/createSavedSearchModal.tsx
@@ -58,7 +58,7 @@ function CreateSavedSearchModal({
 
   const selectFieldVisibilityOptions = [
     {value: SavedSearchVisibility.Owner, label: t('Only me')},
-    {value: SavedSearchVisibility.Organization, label: 'Users in my organization'},
+    {value: SavedSearchVisibility.Organization, label: t('Users in my organization')},
   ];
 
   const canChangeVisibility = organization.access.includes('org:write');
@@ -177,7 +177,9 @@ function CreateSavedSearchModal({
         {organization.features.includes('issue-list-saved-searches-v2') && (
           <SelectField
             disabled={!canChangeVisibility}
-            disabledReason="Only organization admins can create global saved searches."
+            disabledReason={t(
+              'Only organization admins can create global saved searches.'
+            )}
             name="visibility"
             label={t('Choose who can view this saved search')}
             options={selectFieldVisibilityOptions}

--- a/static/app/views/issueList/savedIssueSearches.spec.tsx
+++ b/static/app/views/issueList/savedIssueSearches.spec.tsx
@@ -141,7 +141,7 @@ describe('SavedIssueSearches', function () {
     const modal = screen.getByRole('dialog');
 
     userEvent.type(
-      within(modal).getByRole('textbox', {name: 'Name'}),
+      within(modal).getByRole('textbox', {name: /name/i}),
       'new saved search'
     );
 
@@ -159,22 +159,5 @@ describe('SavedIssueSearches', function () {
 
     // Modal should close
     await waitForElementToBeRemoved(() => screen.getByRole('dialog'));
-  });
-
-  it('disables saved search creation without org:write permission', function () {
-    render(
-      <SavedIssueSearches
-        {...defaultProps}
-        organization={{
-          ...organization,
-          access: organization.access.filter(access => access !== 'org:write'),
-        }}
-      />
-    );
-    renderGlobalModal();
-
-    expect(
-      screen.getByRole('button', {name: /create a new saved search/i})
-    ).toBeDisabled();
   });
 });

--- a/static/app/views/issueList/savedIssueSearches.tsx
+++ b/static/app/views/issueList/savedIssueSearches.tsx
@@ -115,12 +115,6 @@ function CreateNewSavedSearchButton({
   query,
   sort,
 }: CreateNewSavedSearchButtonProps) {
-  const disabled = !organization.access.includes('org:write');
-
-  const title = disabled
-    ? t('You do not have permission to create a saved search')
-    : t('Create a new saved search for your organization');
-
   const onClick = () => {
     trackAdvancedAnalyticsEvent('search.saved_search_open_create_modal', {
       organization,
@@ -132,11 +126,9 @@ function CreateNewSavedSearchButton({
 
   return (
     <Button
-      aria-label={t('Create a new saved search for your organization')}
-      disabled={disabled}
+      aria-label={t('Create a new saved search')}
       onClick={onClick}
       icon={<IconAdd size="sm" />}
-      title={title}
       borderless
       size="sm"
     />


### PR DESCRIPTION
With the feature flag enabled, adds a visibility dropdown. Without the feature flag, should function the same as it does today (with `organization` being the default visibility)

![image](https://user-images.githubusercontent.com/10888943/200371568-7612168a-2ec7-40bb-bf65-e59a5464b4fd.png)
