### PR TITLE
feat(savedsearch): Widen permissions to allow members PUT/POST/DELETE

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -144,9 +144,9 @@ class OrganizationPinnedSearchPermission(OrganizationPermission):
 class OrganizationSearchPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
-        "POST": ["org:write", "org:admin"],
-        "PUT": ["org:write", "org:admin"],
-        "DELETE": ["org:write", "org:admin"],
+        "POST": ["org:read", "org:write", "org:admin"],
+        "PUT": ["org:read", "org:write", "org:admin"],
+        "DELETE": ["org:read", "org:write", "org:admin"],
     }
 
 

--- a/src/sentry/api/serializers/rest_framework/savedsearch.py
+++ b/src/sentry/api/serializers/rest_framework/savedsearch.py
@@ -1,20 +1,45 @@
+from typing import List
+
 from rest_framework import serializers
 
 from sentry.models.savedsearch import SortOptions, Visibility
 
 
-class OrganizationSearchSerializer(serializers.Serializer):
+def select_visibility_choices(allowed_visibility: List[str]):
+    return list(filter(lambda item: item[0] in allowed_visibility, Visibility.as_choices()))
+
+
+class BaseOrganizationSearchSerializer(serializers.Serializer):
     type = serializers.IntegerField(required=True)
     name = serializers.CharField(required=True)
     query = serializers.CharField(required=True, min_length=1)
     sort = serializers.ChoiceField(
         choices=SortOptions.as_choices(), default=SortOptions.DATE, required=False
     )
+
+
+class OrganizationSearchAdminSerializer(BaseOrganizationSearchSerializer):
+    """
+    Organization admins/owners may create organization wide saved searches
+    """
+
     # TODO(epurkhiser): Once the frontend is deployed we should change this to
     # default to OWNER since that is a more sane default than organization
     # visibile.
     visibility = serializers.ChoiceField(
-        choices=Visibility.as_choices(include_pinned=False),
+        choices=select_visibility_choices([Visibility.OWNER, Visibility.ORGANIZATION]),
         default=Visibility.ORGANIZATION,
+        required=False,
+    )
+
+
+class OrganizationSearchMemberSerializer(BaseOrganizationSearchSerializer):
+    """
+    Organization members may only set visibility to Visibility.OWNER
+    """
+
+    visibility = serializers.ChoiceField(
+        choices=select_visibility_choices([Visibility.OWNER]),
+        default=Visibility.OWNER,
         required=False,
     )

--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -1,3 +1,5 @@
+from typing import Any, List, Tuple
+
 from django.db import models
 from django.db.models import Q, UniqueConstraint
 from django.utils import timezone
@@ -36,18 +38,15 @@ class Visibility:
     OWNER_PINNED = "owner_pinned"
 
     @classmethod
-    def as_choices(cls, include_pinned):
+    def as_choices(cls) -> List[Tuple[str, Any]]:
         # Note that the pinned value may not always be a visibility we want to
         # expose. The pinned search API explicitly will set this visibility,
         # but the saved search API should not allow it to be set
-        choices = [
+        return [
             (cls.ORGANIZATION, _("Organization")),
             (cls.OWNER, _("Only for me")),
+            (cls.OWNER_PINNED, _("My Pinned Search")),
         ]
-        if include_pinned:
-            choices.append((cls.OWNER_PINNED, _("My Pinned Search")))
-
-        return choices
 
 
 @region_silo_only_model
@@ -77,7 +76,7 @@ class SavedSearch(Model):
 
     # Defines who can see the saved search
     visibility = models.CharField(
-        max_length=16, default=Visibility.OWNER, choices=Visibility.as_choices(include_pinned=True)
+        max_length=16, default=Visibility.OWNER, choices=Visibility.as_choices()
     )
 
     class Meta:

--- a/tests/sentry/api/endpoints/test_organization_search_details.py
+++ b/tests/sentry/api/endpoints/test_organization_search_details.py
@@ -48,6 +48,20 @@ class DeleteOrganizationSearchTest(APITestCase):
         assert response.status_code == 204, response.content
         assert not SavedSearch.objects.filter(id=search.id).exists()
 
+    def test_member_can_delete_their_searches(self):
+        search = SavedSearch.objects.create(
+            organization=self.organization,
+            owner=self.member,
+            name="foo",
+            query="",
+            visibility=Visibility.OWNER,
+        )
+
+        self.login_as(user=self.member)
+        response = self.get_response(search.id)
+        assert response.status_code == 204, response.content
+        assert not SavedSearch.objects.filter(id=search.id).exists()
+
     def test_owners_cannot_delete_searches_they_do_not_own(self):
         search = SavedSearch.objects.create(
             organization=self.organization,
@@ -125,7 +139,6 @@ class PutOrganizationSearchTest(APITestCase):
         assert updated_obj.query == "test"
 
     def test_member_cannot_edit_org_search(self):
-        self.login_as(user=self.member)
         search = SavedSearch.objects.create(
             organization=self.organization,
             owner=self.user,
@@ -133,6 +146,7 @@ class PutOrganizationSearchTest(APITestCase):
             query="",
             visibility=Visibility.ORGANIZATION,
         )
+        self.login_as(user=self.member)
         response = self.get_response(
             self.organization.slug,
             search.id,
@@ -142,6 +156,48 @@ class PutOrganizationSearchTest(APITestCase):
             visibility=Visibility.ORGANIZATION,
         )
         assert response.status_code == 403, response.content
+
+    def test_member_can_edit_personal_search(self):
+        search = SavedSearch.objects.create(
+            organization=self.organization,
+            owner=self.member,
+            name="foo",
+            query="",
+            visibility=Visibility.OWNER,
+        )
+        self.login_as(user=self.member)
+        response = self.get_response(
+            self.organization.slug,
+            search.id,
+            type=SearchType.ISSUE.value,
+            name="foo",
+            query="test",
+            visibility=Visibility.OWNER,
+        )
+        assert response.status_code == 200, response.content
+
+        updated_obj = SavedSearch.objects.get(id=search.id)
+        assert updated_obj.name == "foo"
+        assert updated_obj.query == "test"
+
+    def test_member_cannot_switch_personal_search_to_org(self):
+        search = SavedSearch.objects.create(
+            organization=self.organization,
+            owner=self.member,
+            name="foo",
+            query="",
+            visibility=Visibility.OWNER,
+        )
+        self.login_as(user=self.member)
+        response = self.get_response(
+            self.organization.slug,
+            search.id,
+            type=SearchType.ISSUE.value,
+            name="foo",
+            query="test",
+            visibility=Visibility.ORGANIZATION,
+        )
+        assert response.status_code == 400, response.content
 
     def test_exists(self):
         SavedSearch.objects.create(

--- a/tests/sentry/api/endpoints/test_organization_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_searches.py
@@ -166,9 +166,21 @@ class CreateOrganizationSearchesTest(APITestCase):
             type=SearchType.ISSUE.value,
             name="hello",
             query="test",
-            Visibility=Visibility.ORGANIZATION,
+            visibility=Visibility.ORGANIZATION,
         )
-        assert resp.status_code == 403
+        assert resp.status_code == 400
+
+    def test_member_can_create_owner_search(self):
+        self.login_as(user=self.member)
+        resp = self.get_response(
+            self.organization.slug,
+            type=SearchType.ISSUE.value,
+            name="hello",
+            query="test",
+            visibility=Visibility.OWNER,
+        )
+        assert resp.status_code == 200
+        assert SavedSearch.objects.filter(id=resp.data["id"]).exists()
 
     def test_exists(self):
         global_search = SavedSearch.objects.create(


### PR DESCRIPTION
This adds additional permission checks that only allows uers with org:write to deal with Visibility.ORGANIZATION SavedSearch objects.