### PR TITLE
fix(profiling): Add back device columns to profile summary

### DIFF
--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -137,7 +137,14 @@ function ProfileSummaryContent(props: ProfileSummaryContentProps) {
   );
 }
 
-const FIELDS = ['id', 'timestamp', 'release', 'profile.duration'] as const;
+const FIELDS = [
+  'id',
+  'timestamp',
+  'release',
+  'device.model',
+  'device.classification',
+  'profile.duration',
+] as const;
 
 type FieldType = typeof FIELDS[number];
 


### PR DESCRIPTION
These were accidentally removed in #41045, just adding them back.