### PR TITLE
feat(issue-alerts): incompatible AgeComparisonFilter and 'any' filterMatches

### DIFF
--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -529,27 +529,56 @@ describe('ProjectAlertsCreate', function () {
     });
   });
 
-  it('shows error for incompatible conditions', async () => {
+  describe('test incompatible conditions', () => {
     const organization = TestStubs.Organization({
       features: ['issue-alert-incompatible-rules'],
     });
-    createWrapper({organization});
-    await selectEvent.select(screen.getByText('Add optional trigger...'), [
-      'A new issue is created',
-    ]);
-    await selectEvent.select(screen.getByText('Add optional trigger...'), [
-      'The issue changes state from resolved to unresolved',
-    ]);
     const errorText =
       'This condition conflicts with other condition(s) above. Please select a different condition.';
-    expect(screen.getByText(errorText)).toBeInTheDocument();
 
-    expect(screen.getByRole('button', {name: 'Save Rule'})).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    it('shows error for incompatible conditions', async () => {
+      createWrapper({organization});
+      await selectEvent.select(screen.getByText('Add optional trigger...'), [
+        'A new issue is created',
+      ]);
+      await selectEvent.select(screen.getByText('Add optional trigger...'), [
+        'The issue changes state from resolved to unresolved',
+      ]);
+      expect(screen.getByText(errorText)).toBeInTheDocument();
 
-    userEvent.click(screen.getAllByLabelText('Delete Node')[0]);
-    expect(screen.queryByText(errorText)).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Save Rule'})).toHaveAttribute(
+        'aria-disabled',
+        'true'
+      );
+
+      userEvent.click(screen.getAllByLabelText('Delete Node')[0]);
+      expect(screen.queryByText(errorText)).not.toBeInTheDocument();
+    });
+
+    it('test any filterMatch', async () => {
+      createWrapper({organization});
+      const allDropdowns = screen.getAllByText('all');
+      await selectEvent.select(screen.getByText('Add optional trigger...'), [
+        'A new issue is created',
+      ]);
+
+      await selectEvent.select(allDropdowns[1], ['any']);
+      await selectEvent.select(screen.getByText('Add optional filter...'), [
+        'The issue is older or newer than...',
+      ]);
+
+      userEvent.paste(screen.getByPlaceholderText('10'), '10');
+
+      await selectEvent.select(screen.getByText('Add optional filter...'), [
+        'The issue has happened at least {x} times (Note: this is approximate)',
+      ]);
+
+      expect(screen.getByText(errorText)).toBeInTheDocument();
+
+      userEvent.click(screen.getAllByLabelText('Delete Node')[1]);
+      userEvent.paste(screen.getByDisplayValue('10'), '-');
+
+      expect(screen.queryByText(errorText)).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -449,21 +449,51 @@ class IssueRuleEditor extends AsyncView<Props, State> {
         }
       }
     }
-    // Check for 'FirstSeenEventCondition' and 'IssueOccurrencesFilter'
+    // Check for 'FirstSeenEventCondition' and ('IssueOccurrencesFilter' or 'AgeComparisonFilter')
+    // Considers the case where filterMatch is 'any' and all filters are incompatible
     const firstSeen = conditions.some(condition =>
       condition.id.endsWith('FirstSeenEventCondition')
     );
-    if (
-      firstSeen &&
-      (rule.actionMatch === 'all' || conditions.length === 1) &&
-      (rule.filterMatch === 'all' || (rule.filterMatch === 'any' && filters.length === 1))
-    ) {
+    if (firstSeen && (rule.actionMatch === 'all' || conditions.length === 1)) {
+      let incompatibleFilters = 0;
       for (let i = 0; i < filters.length; i++) {
-        const id = filters[i].id;
-        if (id.endsWith('IssueOccurrencesFilter') && filters[i].value > 1) {
-          this.setState({incompatibleFilter: i});
-          return;
+        const filter = filters[i];
+        const id = filter.id;
+        if (id.endsWith('IssueOccurrencesFilter')) {
+          if (
+            (rule.filterMatch === 'all' && filter.value > 1) ||
+            (rule.filterMatch === 'none' && filter.value <= 1)
+          ) {
+            this.setState({incompatibleFilter: i});
+            return;
+          }
+          if (rule.filterMatch === 'any' && filter.value > 1) {
+            incompatibleFilters += 1;
+          }
+        } else if (id.endsWith('AgeComparisonFilter')) {
+          if (rule.filterMatch !== 'none') {
+            if (
+              (filter.comparison_type === 'older' && filter.value >= 0) ||
+              (filter.comparison_type === 'newer' && filter.value <= 0)
+            ) {
+              if (rule.filterMatch === 'all') {
+                this.setState({incompatibleFilter: i});
+                return;
+              }
+              incompatibleFilters += 1;
+            }
+          } else if (
+            (filter.comparison_type === 'older' && filter.value < 0) ||
+            (filter.comparison_type === 'newer' && filter.value > 0)
+          ) {
+            this.setState({incompatibleFilter: i});
+            return;
+          }
         }
+      }
+      if (incompatibleFilters === filters.length) {
+        this.setState({incompatibleFilter: incompatibleFilters - 1});
+        return;
       }
     }
   }, 500);


### PR DESCRIPTION
Checks for incompatible `AgeComparisonFilter`s with `FirstSeenEventCondition`. This is probably the last case that we're missing. 

This also adds checks for incompatible filters when the filter match is `any` and all the filters are incompatible, and when the filter match is `none`. 

This also adds a lot more logic, but it could be cut down if we disallow negative numbers in the form, since there's usually an alternative to them.