### PR TITLE
fix(issue-stream): Fix route so issue list doesn't unmount when a saved search is selected [UP-198]

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1253,7 +1253,7 @@ function buildRoutes() {
 
   const issueListRoutes = (
     <Route
-      path="/organizations/:orgId/issues/(searches/)(:searchId/)"
+      path="/organizations/:orgId/issues/(searches/:searchId/)"
       component={errorHandler(IssueListContainer)}
     >
       <Redirect from="/organizations/:orgId/" to="/organizations/:orgId/issues/" />

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1253,12 +1253,11 @@ function buildRoutes() {
 
   const issueListRoutes = (
     <Route
-      path="/organizations/:orgId/issues/"
+      path="/organizations/:orgId/issues/(searches/)(:searchId/)"
       component={errorHandler(IssueListContainer)}
     >
       <Redirect from="/organizations/:orgId/" to="/organizations/:orgId/issues/" />
       <IndexRoute component={errorHandler(IssueListOverview)} />
-      <Route path="searches/:searchId/" component={errorHandler(IssueListOverview)} />
     </Route>
   );
 


### PR DESCRIPTION
The reason that the issue list was causing a full-page refresh was because the component was unmounting when the URL changed to `/searches/:searchId`. I added this as an optional path to the container to prevent this from occurring.

Before (see how the whole page flashes and the issue stream disappears temporarily):

https://user-images.githubusercontent.com/10888943/200410047-36d9d2ba-e4d9-4de3-b006-12f9699c90f3.mov

After (issue stream always visible):

https://user-images.githubusercontent.com/10888943/200410209-64a579bb-6b2b-4f14-9111-382c2744bd37.mov


