### PR TITLE
feat(ecosystem): Support multiple sentry app actions

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -728,14 +728,18 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     });
   };
 
-  handleAddRow = (type: ConditionOrActionProperty, id: string) => {
+  handleAddRow = (
+    type: ConditionOrActionProperty,
+    item: IssueAlertRuleActionTemplate
+  ) => {
     this.setState(prevState => {
       const clonedState = cloneDeep(prevState);
 
       // Set initial configuration
       const newRule = {
-        ...this.getInitialValue(type, id),
-        id,
+        ...this.getInitialValue(type, item.id),
+        id: item.id,
+        sentryAppInstallationUuid: item.sentryAppInstallationUuid,
       };
       const newTypeList = prevState.rule ? prevState.rule[type] : [];
 
@@ -749,7 +753,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       organization,
       project_id: project.id,
       type,
-      name: id,
+      name: item.id,
     });
   };
 
@@ -766,7 +770,8 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   };
 
   handleAddCondition = (id: string) => this.handleAddRow('conditions', id);
-  handleAddAction = (id: string) => this.handleAddRow('actions', id);
+  handleAddAction = (template: IssueAlertRuleActionTemplate) =>
+    this.handleAddRow('actions', template);
   handleAddFilter = (id: string) => this.handleAddRow('filters', id);
   handleDeleteCondition = (ruleIndex: number) =>
     this.handleDeleteRow('conditions', ruleIndex);

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -769,10 +769,12 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     });
   };
 
-  handleAddCondition = (id: string) => this.handleAddRow('conditions', id);
+  handleAddCondition = (template: IssueAlertRuleActionTemplate) =>
+    this.handleAddRow('conditions', template);
   handleAddAction = (template: IssueAlertRuleActionTemplate) =>
     this.handleAddRow('actions', template);
-  handleAddFilter = (id: string) => this.handleAddRow('filters', id);
+  handleAddFilter = (template: IssueAlertRuleActionTemplate) =>
+    this.handleAddRow('filters', template);
   handleDeleteCondition = (ruleIndex: number) =>
     this.handleDeleteRow('conditions', ruleIndex);
   handleDeleteAction = (ruleIndex: number) => this.handleDeleteRow('actions', ruleIndex);

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -125,9 +125,6 @@ function MailActionFields({
         {value: MailActionTargetType.IssueOwners, label: t('Issue Owners')},
         {value: MailActionTargetType.Team, label: t('Team')},
         {value: MailActionTargetType.Member, label: t('Member')},
-        ...(organization.features?.includes('alert-release-notification-workflow')
-          ? [{value: MailActionTargetType.ReleaseMembers, label: t('Release Members')}]
-          : []),
       ]}
       memberValue={MailActionTargetType.Member}
       teamValue={MailActionTargetType.Team}

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -35,7 +35,9 @@ type Props = {
    * All available actions or conditions
    */
   nodes: IssueAlertRuleActionTemplate[] | IssueAlertRuleConditionTemplate[] | null;
-  onAddRow: (value: string) => void;
+  onAddRow: (
+    value: IssueAlertRuleActionTemplate | IssueAlertRuleConditionTemplate
+  ) => void;
   onDeleteRow: (ruleIndex: number) => void;
   onPropertyChange: (ruleIndex: number, prop: string, val: string) => void;
   onResetRow: (ruleIndex: number, name: string, value: string) => void;
@@ -136,7 +138,7 @@ class RuleNodeList extends Component<Props> {
   propertyChangeTimeout: number | undefined = undefined;
 
   getNode = (
-    template: IssueAlertRuleConditionTemplate | IssueAlertRuleActionTemplate,
+    template: IssueAlertRuleAction | IssueAlertRuleCondition,
     itemIdx: number
   ): IssueAlertRuleActionTemplate | IssueAlertRuleConditionTemplate | null => {
     const {nodes, items, organization, onPropertyChange} = this.props;
@@ -247,22 +249,24 @@ class RuleNodeList extends Component<Props> {
       <Fragment>
         <RuleNodes>
           {error}
-          {items.map((item, idx) => (
-            <RuleNode
-              key={idx}
-              index={idx}
-              node={this.getNode(item, idx)}
-              onDelete={onDeleteRow}
-              onPropertyChange={onPropertyChange}
-              onReset={onResetRow}
-              data={item}
-              organization={organization}
-              project={project}
-              disabled={disabled}
-              ownership={ownership}
-              incompatibleRule={incompatibleRule === idx}
-            />
-          ))}
+          {items.map(
+            (item: IssueAlertRuleAction | IssueAlertRuleCondition, idx: number) => (
+              <RuleNode
+                key={idx}
+                index={idx}
+                node={this.getNode(item, idx)}
+                onDelete={onDeleteRow}
+                onPropertyChange={onPropertyChange}
+                onReset={onResetRow}
+                data={item}
+                organization={organization}
+                project={project}
+                disabled={disabled}
+                ownership={ownership}
+                incompatibleRule={incompatibleRule === idx}
+              />
+            )
+          )}
         </RuleNodes>
         <StyledSelectControl
           placeholder={placeholder}

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -50,6 +50,84 @@ type Props = {
   selectType?: 'grouped';
 };
 
+const createSelectOptions = (
+  actions: IssueAlertRuleActionTemplate[]
+): Array<{label: React.ReactNode; value: IssueAlertRuleActionTemplate}> => {
+  return actions.map(node => {
+    const isNew = node.id === EVENT_FREQUENCY_PERCENT_CONDITION;
+
+    if (node.id.includes('NotifyEmailAction')) {
+      return {
+        value: node,
+        label: t('Issue Owners, Team, or Member'),
+      };
+    }
+
+    return {
+      value: node,
+      label: (
+        <Fragment>
+          {isNew && <StyledFeatureBadge type="new" noTooltip />}
+          {node.prompt?.length ? node.prompt : node.label}
+        </Fragment>
+      ),
+    };
+  });
+};
+
+const groupLabels = {
+  notify: t('Send notification to\u{2026}'),
+  notifyIntegration: t('Notify integration\u{2026}'),
+  ticket: t('Create new\u{2026}'),
+  change: t('Issue state change'),
+  frequency: t('Issue frequency'),
+};
+
+/**
+ * Group options by category
+ */
+const groupSelectOptions = (actions: IssueAlertRuleActionTemplate[]) => {
+  const grouped = actions.reduce<
+    Record<
+      keyof typeof groupLabels,
+      IssueAlertRuleActionTemplate[] | IssueAlertRuleConditionTemplate[]
+    >
+  >(
+    (acc, curr) => {
+      if (curr.actionType === 'ticket') {
+        acc.ticket.push(curr);
+      } else if (curr.id.includes('event_frequency')) {
+        acc.frequency.push(curr);
+      } else if (
+        curr.id.includes('sentry.rules.conditions') &&
+        !curr.id.includes('event_frequency')
+      ) {
+        acc.change.push(curr);
+      } else if (curr.id.includes('sentry.integrations')) {
+        acc.notifyIntegration.push(curr);
+      } else if (curr.id.includes('notify_event')) {
+        acc.notifyIntegration.push(curr);
+      } else {
+        acc.notify.push(curr);
+      }
+      return acc;
+    },
+    {
+      notify: [],
+      notifyIntegration: [],
+      ticket: [],
+      change: [],
+      frequency: [],
+    }
+  );
+
+  return Object.entries(grouped)
+    .filter(([_, values]) => values.length)
+    .map(([key, values]) => {
+      return {label: groupLabels[key], options: createSelectOptions(values)};
+    });
+};
+
 class RuleNodeList extends Component<Props> {
   componentWillUnmount() {
     window.clearTimeout(this.propertyChangeTimeout);
@@ -58,15 +136,17 @@ class RuleNodeList extends Component<Props> {
   propertyChangeTimeout: number | undefined = undefined;
 
   getNode = (
-    id: string,
+    template: IssueAlertRuleConditionTemplate | IssueAlertRuleActionTemplate,
     itemIdx: number
-  ):
-    | IssueAlertRuleActionTemplate
-    | IssueAlertRuleConditionTemplate
-    | null
-    | undefined => {
+  ): IssueAlertRuleActionTemplate | IssueAlertRuleConditionTemplate | null => {
     const {nodes, items, organization, onPropertyChange} = this.props;
-    const node = nodes ? nodes.find(n => n.id === id) : null;
+    const node = nodes?.find(n => {
+      return (
+        n.id === template.id &&
+        // Match more than just the id for sentryApp actions, they share the same id
+        n.sentryAppInstallationUuid === template.sentryAppInstallationUuid
+      );
+    });
 
     if (!node) {
       return null;
@@ -158,76 +238,10 @@ class RuleNodeList extends Component<Props> {
 
     const enabledNodes = nodes ? nodes.filter(({enabled}) => enabled) : [];
 
-    const createSelectOptions = (actions: IssueAlertRuleActionTemplate[]) =>
-      actions.map(node => {
-        const isNew = node.id === EVENT_FREQUENCY_PERCENT_CONDITION;
-
-        if (node.id.includes('NotifyEmailAction')) {
-          return {
-            value: node.id,
-            label: organization.features?.includes('alert-release-notification-workflow')
-              ? t('Issue Owners, Team, Member, or Release Members')
-              : t('Issue Owners, Team, or Member'),
-          };
-        }
-
-        return {
-          value: node.id,
-          label: (
-            <Fragment>
-              {isNew && <StyledFeatureBadge type="new" noTooltip />}
-              {node.prompt?.length ? node.prompt : node.label}
-            </Fragment>
-          ),
-        };
-      });
-
-    let options: any = !selectType ? createSelectOptions(enabledNodes) : [];
-
-    if (selectType === 'grouped') {
-      const grouped = enabledNodes.reduce(
-        (acc, curr) => {
-          if (curr.actionType === 'ticket') {
-            acc.ticket.push(curr);
-          } else if (curr.id.includes('event_frequency')) {
-            acc.frequency.push(curr);
-          } else if (
-            curr.id.includes('sentry.rules.conditions') &&
-            !curr.id.includes('event_frequency')
-          ) {
-            acc.change.push(curr);
-          } else if (curr.id.includes('sentry.integrations')) {
-            acc.notifyIntegration.push(curr);
-          } else if (curr.id.includes('notify_event')) {
-            acc.notifyIntegration.push(curr);
-          } else {
-            acc.notify.push(curr);
-          }
-          return acc;
-        },
-        {
-          notify: [] as IssueAlertRuleActionTemplate[],
-          notifyIntegration: [] as IssueAlertRuleActionTemplate[],
-          ticket: [] as IssueAlertRuleActionTemplate[],
-          change: [] as IssueAlertRuleConditionTemplate[],
-          frequency: [] as IssueAlertRuleConditionTemplate[],
-        }
-      );
-
-      options = Object.entries(grouped)
-        .filter(([_, values]) => values.length)
-        .map(([key, values]) => {
-          const label = {
-            notify: t('Send notification to\u{2026}'),
-            notifyIntegration: t('Notify integration\u{2026}'),
-            ticket: t('Create new\u{2026}'),
-            change: t('Issue state change'),
-            frequency: t('Issue frequency'),
-          };
-
-          return {label: label[key], options: createSelectOptions(values)};
-        });
-    }
+    const options =
+      selectType === 'grouped'
+        ? groupSelectOptions(enabledNodes)
+        : createSelectOptions(enabledNodes);
 
     return (
       <Fragment>
@@ -237,7 +251,7 @@ class RuleNodeList extends Component<Props> {
             <RuleNode
               key={idx}
               index={idx}
-              node={this.getNode(item.id, idx)}
+              node={this.getNode(item, idx)}
               onDelete={onDeleteRow}
               onPropertyChange={onPropertyChange}
               onReset={onResetRow}
@@ -253,7 +267,9 @@ class RuleNodeList extends Component<Props> {
         <StyledSelectControl
           placeholder={placeholder}
           value={null}
-          onChange={obj => onAddRow(obj ? obj.value : obj)}
+          onChange={obj => {
+            onAddRow(obj.value);
+          }}
           options={options}
           disabled={disabled}
         />


### PR DESCRIPTION
Allows users to select more than the first sentry app action on issue alerts.

before this would show Linear for both, even though the user picked threads
![image](https://user-images.githubusercontent.com/1400464/200437657-26c38580-caa5-4680-9d33-c7c995771b92.png)

fixes https://getsentry.atlassian.net/browse/ISSUE-1618