### PR TITLE
feat(replays): Change replays badge from alpha to beta

### DIFF
--- a/static/app/components/replays/replaysFeatureBadge.tsx
+++ b/static/app/components/replays/replaysFeatureBadge.tsx
@@ -3,7 +3,7 @@ import FeatureBadge from 'sentry/components/featureBadge';
 function ReplaysFeatureBadge(
   props: Omit<React.ComponentProps<typeof FeatureBadge>, 'type'>
 ) {
-  return <FeatureBadge {...props} type="alpha" />;
+  return <FeatureBadge {...props} type="beta" />;
 }
 
 export default ReplaysFeatureBadge;

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -246,7 +246,7 @@ function Sidebar({location, organization}: Props) {
         label={t('Replays')}
         to={`/organizations/${organization.slug}/replays/`}
         id="replays"
-        isAlpha
+        isBeta
       />
     </Feature>
   );


### PR DESCRIPTION


<!-- Describe your PR here. -->
### Changes
- Changed the replays badge from alpha to beta in the sidebar and in `ReplaysFeatureBadge` component. Closes #41094

### Loom images: 

![image](https://user-images.githubusercontent.com/39612839/200432470-9b507b1e-5dcd-4ea4-aa9c-d0633a48f4e8.png)

![image](https://user-images.githubusercontent.com/39612839/200432488-e3ade6a8-dbf3-4484-85f2-4d9e709dfd48.png)

![image](https://user-images.githubusercontent.com/39612839/200432514-21aa8295-3f84-4d53-a8c7-aacd0892e298.png)

![image](https://user-images.githubusercontent.com/39612839/200432603-34a49f35-7943-442f-898b-419b335a25f8.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
