### PR TITLE
fix(savedsearch): Allow editing without changing the query

### DIFF
--- a/src/sentry/api/endpoints/organization_search_details.py
+++ b/src/sentry/api/endpoints/organization_search_details.py
@@ -51,6 +51,7 @@ class OrganizationSearchDetailsEndpoint(OrganizationEndpoint):
             SavedSearch.objects
             # Query duplication for pinned searches is fine, exlcuded these
             .exclude(visibility=Visibility.OWNER_PINNED)
+            .exclude(id=search.id)
             .filter(Q(is_global=True) | Q(organization=organization), query=result["query"])
             .exists()
         ):

--- a/tests/sentry/api/endpoints/test_organization_search_details.py
+++ b/tests/sentry/api/endpoints/test_organization_search_details.py
@@ -188,3 +188,25 @@ class PutOrganizationSearchTest(APITestCase):
         )
         assert response.status_code == 400, response.content
         assert "already exists" in response.data["detail"]
+
+    def test_can_edit_without_changing_query(self):
+        search = SavedSearch.objects.create(
+            organization=self.organization,
+            owner=self.create_user(),
+            name="foo",
+            query="test123",
+            visibility=Visibility.ORGANIZATION,
+        )
+        response = self.get_response(
+            self.organization.slug,
+            search.id,
+            type=SearchType.ISSUE.value,
+            name="bar",
+            query="test123",
+            visibility=Visibility.ORGANIZATION,
+        )
+        assert response.status_code == 200, response.content
+
+        updated_obj = SavedSearch.objects.get(id=search.id)
+        assert updated_obj.name == "bar"
+        assert updated_obj.query == "test123"


### PR DESCRIPTION
Fixes a bug where you can't change a seaved search without changing the query