### PR TITLE
fix(replays): Filter wizard docs from the list of platforms on the new project screen

### DIFF
--- a/static/app/data/platforms.tsx
+++ b/static/app/data/platforms.tsx
@@ -30,7 +30,9 @@ const platformIntegrations: PlatformIntegration[] = [
       // the project creation flow
       .filter(integration => !(tracing as readonly string[]).includes(integration.id))
       // filter out any performance onboarding documentation
-      .filter(integration => !integration.id.includes('performance-onboarding'));
+      .filter(integration => !integration.id.includes('performance-onboarding'))
+      // filter out any replay onboarding documentation
+      .filter(integration => !integration.id.includes('replay-onboarding'));
 
     return integrations;
   })


### PR DESCRIPTION
Without filtering extra "javascript" platforms appear in the New Project list:
<img width="1028" alt="Screen Shot 2022-11-07 at 4 21 59 PM" src="https://user-images.githubusercontent.com/187460/200443689-5f5b311c-e84f-4535-a88d-52a365d695d0.png">

After:
<img width="1023" alt="Screen Shot 2022-11-07 at 4 22 07 PM" src="https://user-images.githubusercontent.com/187460/200443719-cc88f1b9-5fc7-4e2e-b417-4fbb60528f9a.png">

