### PR TITLE
fix(replays): correctly process uncompressed replays

### DIFF
--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -235,6 +235,11 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
                 message_dict = msgpack.unpackb(message.payload.value)
 
                 if message_dict["type"] == "replay_recording_chunk":
+                    if type(message_dict["payload"]) is str:
+                        # if the payload is uncompressed, we need to encode it as bytes
+                        # as msgpack will decode it as a utf-8 python string
+                        message_dict["payload"] = message_dict["payload"].encode("utf-8")
+
                     with sentry_sdk.start_span(op="replay_recording_chunk"):
                         self._process_chunk(
                             cast(RecordingSegmentChunkMessage, message_dict), message

--- a/tests/sentry/replays/consumers/recording_consumer/test_consumer.py
+++ b/tests/sentry/replays/consumers/recording_consumer/test_consumer.py
@@ -1,6 +1,7 @@
 # type:ignore
 import time
 import uuid
+import zlib
 from datetime import datetime
 from hashlib import sha1
 from unittest.mock import patch
@@ -25,12 +26,12 @@ class TestRecordingsConsumerEndToEnd(TransactionTestCase):
         self.replay_recording_id = uuid.uuid4().hex
 
     @patch("sentry.analytics.record")
-    def test_basic_flow(self, mock_record):
+    def test_basic_flow_compressed(self, mock_record):
         processing_strategy = self.processing_factory().create_with_partitions(lambda x: None, None)
         segment_id = 0
         consumer_messages = [
             {
-                "payload": f'{{"segment_id":{segment_id}}}\ntest'.encode(),
+                "payload": f'{{"segment_id":{segment_id}}}\n'.encode() + zlib.compress(b"test"),
                 "replay_id": self.replay_id,
                 "project_id": self.project.id,
                 "id": self.replay_recording_id,
@@ -41,7 +42,77 @@ class TestRecordingsConsumerEndToEnd(TransactionTestCase):
                 "key_id": 123,
             },
             {
-                "payload": b"foobar",
+                "payload": zlib.compress(b"foobar"),
+                "replay_id": self.replay_id,
+                "project_id": self.project.id,
+                "id": self.replay_recording_id,
+                "chunk_index": 1,
+                "type": "replay_recording_chunk",
+                "org_id": self.organization.id,
+                "received": time.time(),
+            },
+            {
+                "type": "replay_recording",
+                "replay_id": self.replay_id,
+                "replay_recording": {
+                    "chunks": 2,
+                    "id": self.replay_recording_id,
+                },
+                "project_id": self.project.id,
+                "org_id": self.organization.id,
+                "received": time.time(),
+            },
+        ]
+        for message in consumer_messages:
+            processing_strategy.submit(
+                Message(
+                    Partition(Topic("ingest-replay-recordings"), 1),
+                    1,
+                    KafkaPayload(b"key", msgpack.packb(message), [("should_drop", b"1")]),
+                    datetime.now(),
+                )
+            )
+        processing_strategy.poll()
+        processing_strategy.join(1)
+        processing_strategy.terminate()
+        recording_file_name = f"rr:{self.replay_id}:{segment_id}"
+        recording = File.objects.get(name=recording_file_name)
+
+        assert recording
+        assert (
+            recording.checksum
+            == sha1(zlib.compress(b"test") + zlib.compress(b"foobar")).hexdigest()
+        )
+        assert ReplayRecordingSegment.objects.get(replay_id=self.replay_id)
+
+        self.project.refresh_from_db()
+        assert self.project.flags.has_replays
+
+        mock_record.assert_called_with(
+            "first_replay.sent",
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            platform=self.project.platform,
+            user_id=self.organization.default_owner_id,
+        )
+
+    def test_basic_flow_uncompressed(self):
+        processing_strategy = self.processing_factory().create_with_partitions(lambda x: None, None)
+        segment_id = 0
+        consumer_messages = [
+            {
+                "payload": f'{{"segment_id":{segment_id}}}\ntest',
+                "replay_id": self.replay_id,
+                "project_id": self.project.id,
+                "id": self.replay_recording_id,
+                "chunk_index": 0,
+                "type": "replay_recording_chunk",
+                "org_id": self.organization.id,
+                "received": time.time(),
+                "key_id": 123,
+            },
+            {
+                "payload": "foobar",
                 "replay_id": self.replay_id,
                 "project_id": self.project.id,
                 "id": self.replay_recording_id,
@@ -83,14 +154,6 @@ class TestRecordingsConsumerEndToEnd(TransactionTestCase):
 
         self.project.refresh_from_db()
         assert self.project.flags.has_replays
-
-        mock_record.assert_called_with(
-            "first_replay.sent",
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            platform=self.project.platform,
-            user_id=self.organization.default_owner_id,
-        )
 
     def test_duplicate_segment_flow(self):
         processing_strategy = self.processing_factory().create_with_partitions(lambda x: None, None)


### PR DESCRIPTION
- uncompressed replays get parsed in `messagepack.unpackb` as a string. this caused us to raise an error as when we split, we expect it to be bytes.
- fixes this by encoding as bytes if its a string.
- also fixes the tests to be more production-like in regards to the data of the payloads

Fixes SENTRY-WDT