### PR TITLE
ref(proj-config): Add context info to build task

### DIFF
--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -7,7 +7,7 @@ from sentry.models.organization import Organization
 from sentry.relay import projectconfig_cache, projectconfig_debounce_cache
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
-from sentry.utils.sdk import set_current_event_project
+from sentry.utils.sdk import configure_scope, set_current_event_project
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +32,9 @@ def build_project_config(public_key=None, **kwargs):
 
     Do not invoke this task directly, instead use :func:`schedule_build_project_config`.
     """
+    with configure_scope() as scope:
+        scope.set_tag("project.public_key", public_key)
+
     try:
         from sentry.models import ProjectKey
 

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -7,7 +7,7 @@ from sentry.models.organization import Organization
 from sentry.relay import projectconfig_cache, projectconfig_debounce_cache
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
-from sentry.utils.sdk import configure_scope, set_current_event_project
+from sentry.utils.sdk import set_current_event_project
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +32,7 @@ def build_project_config(public_key=None, **kwargs):
 
     Do not invoke this task directly, instead use :func:`schedule_build_project_config`.
     """
-    with configure_scope() as scope:
-        scope.set_tag("project.public_key", public_key)
+    sentry_sdk.set_tag("project.public_key", public_key)
 
     try:
         from sentry.models import ProjectKey

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -32,7 +32,7 @@ def build_project_config(public_key=None, **kwargs):
 
     Do not invoke this task directly, instead use :func:`schedule_build_project_config`.
     """
-    sentry_sdk.set_tag("project.public_key", public_key)
+    sentry_sdk.set_tag("public_key", public_key)
 
     try:
         from sentry.models import ProjectKey


### PR DESCRIPTION
Looking at transactions in the performance product, it's impossible to know if tasks that take longer (including outliers) are all coming from the same project or from different projects. Adding the public key as a tag addresses that issue.

This function is called in a single place and all the additional parameters that go into `kwargs` is the time the task was scheduled, which is not useful information, so I've decided to not include it (as the context). We may want to revisit this in the future.