### PR TITLE
doc: New sessions API features [INGEST-1287]

### DIFF
--- a/api-docs/paths/releases/sessions.json
+++ b/api-docs/paths/releases/sessions.json
@@ -74,7 +74,7 @@
       {
         "name": "orderBy",
         "in": "query",
-        "description": "An optional field to order by, which must be one of the fields provided in `field`\n\nThis alters the order of the `groups` returned, so it only makes sense in combination with `groupBy`. \n\nOrdering by more than one field is currently not supported.",
+        "description": "An optional field to order by, which must be one of the fields provided in `field`. Use `-` for descending order, for example `-sum(session)`. \n\nThis alters the order of the `groups` returned, so it only makes sense in combination with `groupBy`. \n\nOrdering by more than one field is currently not supported.",
         "required": false,
         "schema": {
           "type": "string"
@@ -94,42 +94,56 @@
         "in": "query",
         "description": "This defines the range of the time series, relative to now.\n\nThe range is given in a `\"<number><unit>\"` format.\n\nFor example `1d` for a one day range. Possible units are `m` for minutes, `h` for hours, `d` for days and `w` for weeks.\n\nIt defaults to `90d`.",
         "required": false,
-        "schema": {"type": "string"}
+        "schema": {
+          "type": "string"
+        }
       },
       {
         "name": "interval",
         "in": "query",
         "description": "This is the resolution of the time series, given in the same format as `statsPeriod`.\n\nThe default resolution is `1h` and the minimum resolution is currently restricted to `1h` as well.\n\nIntervals larger than `1d` are not supported, and the interval has to cleanly divide one day.",
         "required": false,
-        "schema": {"type": "string"}
+        "schema": {
+          "type": "string"
+        }
       },
       {
         "name": "statsPeriodStart",
         "in": "query",
         "description": "This defines the start of the time series range, in the same format as the `interval`, relative to now.",
         "required": false,
-        "schema": {"type": "string"}
+        "schema": {
+          "type": "string"
+        }
       },
       {
         "name": "statsPeriodEnd",
         "in": "query",
         "description": "This defines the end of the time series range, in the same format as the `interval`, relative to now.",
         "required": false,
-        "schema": {"type": "string"}
+        "schema": {
+          "type": "string"
+        }
       },
       {
         "name": "start",
         "in": "query",
         "description": "This defines the start of the time series range as an explicit datetime.",
         "required": false,
-        "schema": {"type": "string", "format": "date-time"}
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
       },
       {
         "name": "end",
         "in": "query",
         "description": "This defines the inclusive end of the time series range as an explicit datetime.",
         "required": false,
-        "schema": {"type": "string", "format": "date-time"}
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
       }
     ],
     "responses": {
@@ -150,24 +164,64 @@
               ],
               "groups": [
                 {
-                  "by": {"session.status": "healthy"},
-                  "totals": {"sum(session)": 1715553},
-                  "series": {"sum(session)": [683772, 677788, 353993]}
+                  "by": {
+                    "session.status": "healthy"
+                  },
+                  "totals": {
+                    "sum(session)": 1715553
+                  },
+                  "series": {
+                    "sum(session)": [
+                      683772,
+                      677788,
+                      353993
+                    ]
+                  }
                 },
                 {
-                  "by": {"session.status": "abnormal"},
-                  "totals": {"sum(session)": 0},
-                  "series": {"sum(session)": [0, 0, 0]}
+                  "by": {
+                    "session.status": "abnormal"
+                  },
+                  "totals": {
+                    "sum(session)": 0
+                  },
+                  "series": {
+                    "sum(session)": [
+                      0,
+                      0,
+                      0
+                    ]
+                  }
                 },
                 {
-                  "by": {"session.status": "crashed"},
-                  "totals": {"sum(session)": 383},
-                  "series": {"sum(session)": [33, 26, 324]}
+                  "by": {
+                    "session.status": "crashed"
+                  },
+                  "totals": {
+                    "sum(session)": 383
+                  },
+                  "series": {
+                    "sum(session)": [
+                      33,
+                      26,
+                      324
+                    ]
+                  }
                 },
                 {
-                  "by": {"session.status": "errored"},
-                  "totals": {"sum(session)": 1565},
-                  "series": {"sum(session)": [163, 201, 1201]}
+                  "by": {
+                    "session.status": "errored"
+                  },
+                  "totals": {
+                    "sum(session)": 1565
+                  },
+                  "series": {
+                    "sum(session)": [
+                      163,
+                      201,
+                      1201
+                    ]
+                  }
                 }
               ]
             }
@@ -193,7 +247,9 @@
     },
     "security": [
       {
-        "auth_token": ["org: read"]
+        "auth_token": [
+          "org: read"
+        ]
       }
     ]
   }

--- a/api-docs/paths/releases/sessions.json
+++ b/api-docs/paths/releases/sessions.json
@@ -1,7 +1,9 @@
 {
   "get": {
-    "tags": ["Releases"],
-    "description": "Returns a time series of release health session statistics for projects bound to an organization.\n\nThe interval and date range are subject to certain restrictions and rounding rules.\n\nThe date range is rounded to align with the interval, and is rounded to at least one hour. The interval can at most be one day and at least one hour currently. It has to cleanly divide one day, for rounding reasons.",
+    "tags": [
+      "Releases"
+    ],
+    "description": "Returns a time series of release health session statistics for projects bound to an organization.\n\nThe interval and date range are subject to certain restrictions and rounding rules.\n\nThe date range is rounded to align with the interval, and is rounded to at least one hour. The interval can at most be one day and at least one hour currently. It has to cleanly divide one day, for rounding reasons.\n\nApart from the query parameters listed below, this endpoint also supports the usual [pagination parameters](https://docs.sentry.io/api/pagination/).",
     "operationId": "Retrieve Release Health Session Statistics",
     "parameters": [
       {
@@ -30,7 +32,7 @@
       {
         "name": "field",
         "in": "query",
-        "description": "The list of fields to query.\n\nThe available fields are `sum(session)`, `count_unique(user)`, and the following functions applied to the `session.duration` metric: `avg`, `p50`, `p75`, `p90`, `p95`, `p99` and `max`.\n\nFor example, `p99(session.duration)`.",
+        "description": "The list of fields to query.\n\nThe available fields are\n  - `sum(session)`\n  - `count_unique(user)`\n  - `avg`, `p50`, `p75`, `p90`, `p95`, `p99`, `max` applied to `session.duration`. For example, `p99(session.duration)`\n  - `crash_rate`, `crash_free_rate` applied to `user` or `session`. For example, `crash_free_rate(user)`",
         "required": true,
         "schema": {
           "type": "array",
@@ -58,7 +60,7 @@
       {
         "name": "groupBy",
         "in": "query",
-        "description": "The list of properties to group by.\n\nThe available groupBy conditions are `project`, `release`, `environment` and `session.status`.",
+        "description": "The list of properties to group by.\n\nThe available groupBy conditions are `project`, `release`, `environment` and `session.status`.\n\nGrouping by `session.status` does not work when `crash_rate` or `crash_free_rate` are queried.",
         "required": false,
         "schema": {
           "type": "array",
@@ -68,6 +70,15 @@
         },
         "style": "form",
         "explode": true
+      },
+      {
+        "name": "orderBy",
+        "in": "query",
+        "description": "An optional field to order by, which must be one of the fields provided in `field`\n\nThis alters the order of the `groups` returned, so it only makes sense in combination with `groupBy`. \n\nOrdering by more than one field is currently not supported.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
       },
       {
         "name": "query",

--- a/api-docs/paths/releases/sessions.json
+++ b/api-docs/paths/releases/sessions.json
@@ -94,56 +94,42 @@
         "in": "query",
         "description": "This defines the range of the time series, relative to now.\n\nThe range is given in a `\"<number><unit>\"` format.\n\nFor example `1d` for a one day range. Possible units are `m` for minutes, `h` for hours, `d` for days and `w` for weeks.\n\nIt defaults to `90d`.",
         "required": false,
-        "schema": {
-          "type": "string"
-        }
+        "schema": {"type": "string"}
       },
       {
         "name": "interval",
         "in": "query",
         "description": "This is the resolution of the time series, given in the same format as `statsPeriod`.\n\nThe default resolution is `1h` and the minimum resolution is currently restricted to `1h` as well.\n\nIntervals larger than `1d` are not supported, and the interval has to cleanly divide one day.",
         "required": false,
-        "schema": {
-          "type": "string"
-        }
+        "schema": {"type": "string"}
       },
       {
         "name": "statsPeriodStart",
         "in": "query",
         "description": "This defines the start of the time series range, in the same format as the `interval`, relative to now.",
         "required": false,
-        "schema": {
-          "type": "string"
-        }
+        "schema": {"type": "string"}
       },
       {
         "name": "statsPeriodEnd",
         "in": "query",
         "description": "This defines the end of the time series range, in the same format as the `interval`, relative to now.",
         "required": false,
-        "schema": {
-          "type": "string"
-        }
+        "schema": {"type": "string"}
       },
       {
         "name": "start",
         "in": "query",
         "description": "This defines the start of the time series range as an explicit datetime.",
         "required": false,
-        "schema": {
-          "type": "string",
-          "format": "date-time"
-        }
+        "schema": {"type": "string", "format": "date-time"}
       },
       {
         "name": "end",
         "in": "query",
         "description": "This defines the inclusive end of the time series range as an explicit datetime.",
         "required": false,
-        "schema": {
-          "type": "string",
-          "format": "date-time"
-        }
+        "schema": {"type": "string", "format": "date-time"}
       }
     ],
     "responses": {
@@ -164,64 +150,24 @@
               ],
               "groups": [
                 {
-                  "by": {
-                    "session.status": "healthy"
-                  },
-                  "totals": {
-                    "sum(session)": 1715553
-                  },
-                  "series": {
-                    "sum(session)": [
-                      683772,
-                      677788,
-                      353993
-                    ]
-                  }
+                  "by": {"session.status": "healthy"},
+                  "totals": {"sum(session)": 1715553},
+                  "series": {"sum(session)": [683772, 677788, 353993]}
                 },
                 {
-                  "by": {
-                    "session.status": "abnormal"
-                  },
-                  "totals": {
-                    "sum(session)": 0
-                  },
-                  "series": {
-                    "sum(session)": [
-                      0,
-                      0,
-                      0
-                    ]
-                  }
+                  "by": {"session.status": "abnormal"},
+                  "totals": {"sum(session)": 0},
+                  "series": {"sum(session)": [0, 0, 0]}
                 },
                 {
-                  "by": {
-                    "session.status": "crashed"
-                  },
-                  "totals": {
-                    "sum(session)": 383
-                  },
-                  "series": {
-                    "sum(session)": [
-                      33,
-                      26,
-                      324
-                    ]
-                  }
+                  "by": {"session.status": "crashed"},
+                  "totals": {"sum(session)": 383},
+                  "series": {"sum(session)": [33, 26, 324]}
                 },
                 {
-                  "by": {
-                    "session.status": "errored"
-                  },
-                  "totals": {
-                    "sum(session)": 1565
-                  },
-                  "series": {
-                    "sum(session)": [
-                      163,
-                      201,
-                      1201
-                    ]
-                  }
+                  "by": {"session.status": "errored"},
+                  "totals": {"sum(session)": 1565},
+                  "series": {"sum(session)": [163, 201, 1201]}
                 }
               ]
             }
@@ -247,9 +193,7 @@
     },
     "security": [
       {
-        "auth_token": [
-          "org: read"
-        ]
+        "auth_token": ["org: read"]
       }
     ]
   }


### PR DESCRIPTION
We now serve 100% of sessions queries using the [metrics backend](https://github.com/getsentry/getsentry/pull/8804), so we can now publicly document the new features enabled by it for the sessions v2 API.