### PR TITLE
feat(issue-details): Improve response header display

### DIFF
--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -164,7 +164,7 @@ class ClippedBox extends PureComponent<Props, State> {
 
 export default ClippedBox;
 
-const Wrapper = styled('div', {
+export const Wrapper = styled('div', {
   shouldForwardProp: prop =>
     prop !== 'clipHeight' && prop !== 'isClipped' && prop !== 'isRevealed',
 })<State & {clipHeight: number}>`

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {t} from 'sentry/locale';
 import {Group} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {objectIsEmpty} from 'sentry/utils';
@@ -16,24 +15,11 @@ type Props = {
 function Contexts({event, group}: Props) {
   const {user, contexts} = event;
 
-  console.log(contexts);
-  const {feedback, response, ...otherContexts} = contexts;
+  const {feedback, ...otherContexts} = contexts;
 
   return (
     <Fragment>
-      {response && !objectIsEmpty(response) && (
-        <ResponseChunk>
-          <Chunk
-            key="response"
-            type="response"
-            alias="response"
-            group={group}
-            event={event}
-            value={response}
-          />
-        </ResponseChunk>
-      )}
-      {/* {!objectIsEmpty(feedback) && (
+      {!objectIsEmpty(feedback) && (
         <Chunk
           key="feedback"
           type="feedback"
@@ -53,22 +39,43 @@ function Contexts({event, group}: Props) {
           value={user}
         />
       )}
-      {Object.entries(otherContexts).map(([key, value]) => (
-        <Chunk
-          key={key}
-          type={value?.type ?? ''}
-          alias={key}
-          group={group}
-          event={event}
-          value={value}
-        />
-      ))} */}
+      {Object.entries(otherContexts).map(([key, value]) => {
+        if (key === 'response') {
+          return (
+            <ResponseChunk key="response">
+              <Chunk
+                type="response"
+                alias="response"
+                group={group}
+                event={event}
+                value={value}
+              />
+            </ResponseChunk>
+          );
+        }
+
+        return (
+          <Chunk
+            key={key}
+            type={value?.type ?? ''}
+            alias={key}
+            group={group}
+            event={event}
+            value={value}
+          />
+        );
+      })}
     </Fragment>
   );
 }
 
 export default Contexts;
 
+// HACK: Styling overrides to render Response headers as key-value pairs
 const ResponseChunk = styled('div')`
-  border: 1px solid red;
+  #response-headers > pre {
+    padding: 0;
+    margin-left: 10px;
+    background: ${p => p.theme.background};
+  }
 `;

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -71,7 +71,7 @@ function Contexts({event, group}: Props) {
 
 export default Contexts;
 
-// HACK: Override styling from less files to render response headers
+// Override styling from less files to render response headers
 const ResponseChunkWrapper = styled('div')`
   #response-headers > pre {
     padding: 0;

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -1,5 +1,7 @@
 import {Fragment} from 'react';
+import styled from '@emotion/styled';
 
+import {t} from 'sentry/locale';
 import {Group} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {objectIsEmpty} from 'sentry/utils';
@@ -14,11 +16,24 @@ type Props = {
 function Contexts({event, group}: Props) {
   const {user, contexts} = event;
 
-  const {feedback, ...otherContexts} = contexts;
+  console.log(contexts);
+  const {feedback, response, ...otherContexts} = contexts;
 
   return (
     <Fragment>
-      {!objectIsEmpty(feedback) && (
+      {response && !objectIsEmpty(response) && (
+        <ResponseChunk>
+          <Chunk
+            key="response"
+            type="response"
+            alias="response"
+            group={group}
+            event={event}
+            value={response}
+          />
+        </ResponseChunk>
+      )}
+      {/* {!objectIsEmpty(feedback) && (
         <Chunk
           key="feedback"
           type="feedback"
@@ -47,9 +62,13 @@ function Contexts({event, group}: Props) {
           event={event}
           value={value}
         />
-      ))}
+      ))} */}
     </Fragment>
   );
 }
 
 export default Contexts;
+
+const ResponseChunk = styled('div')`
+  border: 1px solid red;
+`;

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -42,7 +42,7 @@ function Contexts({event, group}: Props) {
       {Object.entries(otherContexts).map(([key, value]) => {
         if (key === 'response') {
           return (
-            <ResponseChunk key="response">
+            <ResponseChunkWrapper key="response">
               <Chunk
                 type="response"
                 alias="response"
@@ -50,7 +50,7 @@ function Contexts({event, group}: Props) {
                 event={event}
                 value={value}
               />
-            </ResponseChunk>
+            </ResponseChunkWrapper>
           );
         }
 
@@ -71,11 +71,14 @@ function Contexts({event, group}: Props) {
 
 export default Contexts;
 
-// HACK: Styling overrides to render Response headers as key-value pairs
-const ResponseChunk = styled('div')`
+// HACK: Override styling from less files to render response headers
+const ResponseChunkWrapper = styled('div')`
   #response-headers > pre {
     padding: 0;
     margin-left: 10px;
+  }
+
+  #response-headers table {
     background: ${p => p.theme.background};
   }
 `;

--- a/static/app/components/events/contexts/response.spec.tsx
+++ b/static/app/components/events/contexts/response.spec.tsx
@@ -1,0 +1,27 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import ResponseContextComponent from './response';
+
+describe('ResponseContextComponent', () => {
+  it('renders body size, headers, and status code', () => {
+    render(
+      <ResponseContextComponent
+        alias="response"
+        event={TestStubs.Event()}
+        data={{
+          ['body_size']: '8610',
+          headers: [['test-key', 'test-value']],
+          ['status_code']: '200',
+        }}
+      />
+    );
+
+    expect(screen.getByText('Body Size')).toBeInTheDocument();
+    expect(screen.getByText('8610')).toBeInTheDocument();
+    expect(screen.getByText('Headers')).toBeInTheDocument();
+    expect(screen.getByText('test-key')).toBeInTheDocument();
+    expect(screen.getByText('test-value')).toBeInTheDocument();
+    expect(screen.getByText('Status Code')).toBeInTheDocument();
+    expect(screen.getByText('200')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/events/contexts/response.tsx
+++ b/static/app/components/events/contexts/response.tsx
@@ -5,7 +5,10 @@ import {Wrapper} from 'sentry/components/clippedBox';
 import ContextBlock from 'sentry/components/events/contexts/contextBlock';
 import {Event} from 'sentry/types/event';
 
-import {RichHttpContentClippedBoxKeyValueList} from '../interfaces/request/richHttpContentClippedBoxKeyValueList';
+import {
+  Props as RichHttpContentClippedBoxKeyValueListProps,
+  RichHttpContentClippedBoxKeyValueList,
+} from '../interfaces/request/richHttpContentClippedBoxKeyValueList';
 
 type Props = {
   alias: string;
@@ -19,11 +22,14 @@ function getKnownData(data: Props['data']) {
     .map(([key, value]) => {
       if (key === 'headers') {
         return {
-          key,
+          key: 'response-headers',
           subject: startCase(key),
           value: (
             <StyledWrapper>
-              <RichHttpContentClippedBoxKeyValueList data={value} />
+              <RichHttpContentClippedBoxKeyValueList
+                title=""
+                data={value as RichHttpContentClippedBoxKeyValueListProps['data']}
+              />
             </StyledWrapper>
           ),
         };
@@ -36,22 +42,15 @@ function getKnownData(data: Props['data']) {
     });
 }
 
-const DefaultContextType = ({data}: Props) => (
-  <StyledContextBlock data={getKnownData(data)} />
-);
+const DefaultContextType = ({data}: Props) => <ContextBlock data={getKnownData(data)} />;
 
 export default DefaultContextType;
 
-const StyledContextBlock = styled(ContextBlock)`
-  pre {
-    padding: 0;
-    margin-left: 10px;
-  }
-`;
-
 const StyledWrapper = styled('div')`
-  background-color: green;
-  border: 1px solid red;
+  .val-string {
+    padding-left: 10px !important;
+  }
+
   ${Wrapper} {
     padding: 0;
 

--- a/static/app/components/events/contexts/response.tsx
+++ b/static/app/components/events/contexts/response.tsx
@@ -42,9 +42,9 @@ function getKnownData(data: Props['data']) {
     });
 }
 
-const DefaultContextType = ({data}: Props) => <ContextBlock data={getKnownData(data)} />;
+const ResponseContextType = ({data}: Props) => <ContextBlock data={getKnownData(data)} />;
 
-export default DefaultContextType;
+export default ResponseContextType;
 
 const StyledWrapper = styled('div')`
   .val-string {

--- a/static/app/components/events/contexts/response.tsx
+++ b/static/app/components/events/contexts/response.tsx
@@ -1,0 +1,62 @@
+import styled from '@emotion/styled';
+import startCase from 'lodash/startCase';
+
+import {Wrapper} from 'sentry/components/clippedBox';
+import ContextBlock from 'sentry/components/events/contexts/contextBlock';
+import {Event} from 'sentry/types/event';
+
+import {RichHttpContentClippedBoxKeyValueList} from '../interfaces/request/richHttpContentClippedBoxKeyValueList';
+
+type Props = {
+  alias: string;
+  data: Record<string, React.ReactNode | undefined>;
+  event: Event;
+};
+
+function getKnownData(data: Props['data']) {
+  return Object.entries(data)
+    .filter(([k]) => k !== 'type' && k !== 'title')
+    .map(([key, value]) => {
+      if (key === 'headers') {
+        return {
+          key,
+          subject: startCase(key),
+          value: (
+            <StyledWrapper>
+              <RichHttpContentClippedBoxKeyValueList data={value} />
+            </StyledWrapper>
+          ),
+        };
+      }
+      return {
+        key,
+        subject: startCase(key),
+        value,
+      };
+    });
+}
+
+const DefaultContextType = ({data}: Props) => (
+  <StyledContextBlock data={getKnownData(data)} />
+);
+
+export default DefaultContextType;
+
+const StyledContextBlock = styled(ContextBlock)`
+  pre {
+    padding: 0;
+    margin-left: 10px;
+  }
+`;
+
+const StyledWrapper = styled('div')`
+  background-color: green;
+  border: 1px solid red;
+  ${Wrapper} {
+    padding: 0;
+
+    table {
+      margin-bottom: 0;
+    }
+  }
+`;

--- a/static/app/components/events/contexts/utils.tsx
+++ b/static/app/components/events/contexts/utils.tsx
@@ -25,6 +25,7 @@ const CONTEXT_TYPES = {
   // 'redux.state' will be replaced with more generic context called 'state'
   'redux.state': require('sentry/components/events/contexts/redux').default,
   state: require('sentry/components/events/contexts/state').StateEventContext,
+  response: require('sentry/components/events/contexts/response').default,
 };
 
 export function getContextComponent(type: string) {

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -507,7 +507,6 @@ function Entries({
             </EventDataSection>
           }
         >
-          {console.log(entry.type)}
           <EventEntry
             projectSlug={projectSlug}
             group={group}

--- a/static/app/components/events/eventEntries.tsx
+++ b/static/app/components/events/eventEntries.tsx
@@ -507,6 +507,7 @@ function Entries({
             </EventDataSection>
           }
         >
+          {console.log(entry.type)}
           <EventEntry
             projectSlug={projectSlug}
             group={group}

--- a/static/app/components/events/interfaces/keyValueList/index.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.tsx
@@ -58,7 +58,7 @@ function KeyValueList({
                   {subject}
                 </TableSubject>
                 <td className="val" data-test-id={subjectDataTestId}>
-                  <Tablevalue>
+                  <Tablevalue id={key}>
                     {actionButton ? (
                       <ValueWithButtonContainer>
                         <Value {...valueProps} />

--- a/static/app/components/events/interfaces/request/richHttpContentClippedBoxKeyValueList.tsx
+++ b/static/app/components/events/interfaces/request/richHttpContentClippedBoxKeyValueList.tsx
@@ -9,7 +9,7 @@ import getTransformedData from './getTransformedData';
 
 type Data = EntryRequest['data']['data'];
 
-type Props = {
+export type Props = {
   data: Data;
   title: string;
   defaultCollapsed?: boolean;


### PR DESCRIPTION
We currently display the response headers as an array of key-value pairs, this provides a custom renderer that displays the header values similar to our request headers. Due to some styling from `.less` files, I had to add some wrappers to help with overriding styles to nest this component.

Before:
![Screen Shot 2022-11-08 at 9 28 44 AM](https://user-images.githubusercontent.com/22846452/200592208-482847ea-a85f-40a1-bf7a-6a015777267b.png)

After:
![Screen Shot 2022-11-08 at 9 30 09 AM](https://user-images.githubusercontent.com/22846452/200592239-8f86460b-0cb1-4f46-a595-3f66cab41e2d.png)
