### PR TITLE
ref(mechnism-tag): Improve style when description available - [TET-466]

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import forOwn from 'lodash/forOwn';
@@ -9,6 +10,7 @@ import {Hovercard} from 'sentry/components/hovercard';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Pill from 'sentry/components/pill';
 import Pills from 'sentry/components/pills';
+import Tooltip from 'sentry/components/tooltip';
 import {IconInfo, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -23,6 +25,7 @@ type Props = {
 
 export function Mechanism({data: mechanism, meta: mechanismMeta}: Props) {
   const {type, description, help_link, handled, meta = {}, data = {}} = mechanism;
+
   const {errno, signal, mach_exception} = meta;
 
   const linkElement = help_link && isUrl(help_link) && (
@@ -31,23 +34,34 @@ export function Mechanism({data: mechanism, meta: mechanismMeta}: Props) {
     </StyledExternalLink>
   );
 
-  const descriptionElement = description && (
-    <Hovercard
-      header={
-        <span>
-          <Details>{t('Details')}</Details> {linkElement}
-        </span>
-      }
-      body={description}
-    >
-      <StyledIconInfo size="14px" />
-    </Hovercard>
-  );
-
   const pills = [
-    <Pill key="mechanism" name="mechanism" value={type || 'unknown'}>
-      {descriptionElement || linkElement}
-    </Pill>,
+    <Pill
+      key="mechanism"
+      name={
+        description ? (
+          <Hovercard
+            showUnderline
+            header={
+              <Details>
+                {t('Details')}
+                {linkElement}
+              </Details>
+            }
+            body={description}
+          >
+            {'mechanism'}
+          </Hovercard>
+        ) : linkElement ? (
+          <Name>
+            {'mechanism '}
+            {linkElement}
+          </Name>
+        ) : (
+          'mechanism'
+        )
+      }
+      value={type || 'unknown'}
+    />,
   ];
 
   if (!isNil(handled)) {
@@ -109,8 +123,15 @@ const StyledExternalLink = styled(ExternalLink)`
   ${iconStyle};
 `;
 
-const Details = styled('span')`
-  margin-right: ${space(1)};
+const Name = styled('span')`
+  display: grid;
+  grid-template-columns: max-content max-content;
+  gap: ${space(0.5)};
+  align-items: center;
+`;
+
+const Details = styled(Name)`
+  gap: ${space(1)};
 `;
 
 const StyledPills = styled(Pills)`
@@ -120,9 +141,4 @@ const StyledPills = styled(Pills)`
     overflow: hidden;
     text-overflow: ellipsis;
   }
-`;
-
-const StyledIconInfo = styled(IconInfo)`
-  display: flex;
-  ${iconStyle};
 `;

--- a/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/mechanism.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import forOwn from 'lodash/forOwn';
@@ -10,8 +9,7 @@ import {Hovercard} from 'sentry/components/hovercard';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Pill from 'sentry/components/pill';
 import Pills from 'sentry/components/pills';
-import Tooltip from 'sentry/components/tooltip';
-import {IconInfo, IconOpen} from 'sentry/icons';
+import {IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {StackTraceMechanism} from 'sentry/types/stacktrace';


### PR DESCRIPTION
The `mechanism` tag on the issue details page does not look good when it contains a description, hiding the `mechanism`'s type. This PR updates the code to always display the type regardless of whether the description is available or not. If the description is available, it will be displayed when the user hovers over the `mechanism` name that will be shown underlined


**Before:**

![image](https://user-images.githubusercontent.com/29228205/200603797-fd535690-21da-45b4-9f7b-c4eb17d9d1ae.png)


**After:**


https://user-images.githubusercontent.com/29228205/200603442-43551ec7-d4df-4ef1-988f-b9e2e670e280.mov

