### PR TITLE
fix(discover): Flaky backend tests - sort project ids

### DIFF
--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -75,7 +75,7 @@ class SnubaParams:
 
     @property
     def project_ids(self) -> Sequence[int]:
-        return [proj.id for proj in self.projects]
+        return sorted([proj.id for proj in self.projects])
 
     @property
     def project_slug_map(self) -> Mapping[str, int]:

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -39,6 +39,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
 
     def setUp(self):
         super().setUp()
+        self.nine_mins_ago = before_now(minutes=9)
         self.ten_mins_ago = before_now(minutes=10)
         self.ten_mins_ago_iso = iso_format(self.ten_mins_ago)
         self.eleven_mins_ago = before_now(minutes=11)
@@ -2533,8 +2534,8 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
             "field": ["transaction", "epm()"],
             "query": "event.type:transaction",
             "orderby": ["transaction"],
-            "start": iso_format(self.eleven_mins_ago),
-            "end": iso_format(before_now(minutes=9)),
+            "start": self.eleven_mins_ago_iso,
+            "end": iso_format(self.nine_mins_ago),
         }
         response = self.do_request(query)
 


### PR DESCRIPTION
Sort project ids and stabilize timestamps a bit.
Failing [tests](https://sentry.io/organizations/sentry/discover/results/?field=title&field=transaction&field=count%28%29&name=All+Events&project=2423079&query=%28transaction%3A%2Asearch%2Fevents%2F%2A+OR+transaction%3A%2Aendpoints%2Ftest_organization_tag%2A+OR+transaction%3A%2Aendpoints%2Ftest_organization_events%2A+OR+transaction%3A%2Asnuba%2Fsearch%2Ftest_backend.py%2A+OR+transaction%3A%2Asnuba%2Ftest_discover.py%2A+OR+transaction%3A%2Aapi%2Ftest_event_search.py%2A+OR+transaction%3A%2Adata_export%2F%2A%29+%21pytest.result%3Askipped+event.type%3Aerror&sort=-count&statsPeriod=24h&widths=577&widths=867&yAxis=count%28%29)

