### PR TITLE
feat(mep): Remove transaction transform

### DIFF
--- a/src/sentry/search/events/datasets/metrics_layer.py
+++ b/src/sentry/search/events/datasets/metrics_layer.py
@@ -41,8 +41,6 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
             constants.PROJECT_NAME_ALIAS: self._resolve_project_slug_alias,
             constants.TEAM_KEY_TRANSACTION_ALIAS: self._resolve_team_key_transaction_alias,
             constants.TITLE_ALIAS: self._resolve_title_alias,
-            "transaction": self._resolve_transaction_alias,
-            "tags[transaction]": self._resolve_transaction_alias,
         }
 
     def resolve_metric(self, value: str) -> str:
@@ -397,16 +395,9 @@ class MetricsLayerDatasetConfig(MetricsDatasetConfig):
         return function_converter
 
     # Field Aliases
-    def _resolve_transaction_alias(self, alias: str) -> SelectType:
-        return Function(
-            "transform_null_to_unparameterized",
-            [Column("d:transactions/duration@millisecond"), "transaction"],
-            alias,
-        )
-
     def _resolve_title_alias(self, alias: str) -> SelectType:
         """title == transaction in discover"""
-        return self._resolve_transaction_alias(alias)
+        return AliasedExpression(self.builder.resolve_column("transaction"), alias)
 
     def _resolve_team_key_transaction_alias(self, _: str) -> SelectType:
         if self.builder.dry_run:

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -1949,3 +1949,15 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithMetricLayer(
     @pytest.mark.xfail(reason="Having not supported")
     def test_having_condition(self):
         super().test_having_condition()
+
+    @pytest.mark.xfail(reason="Transform function no longer required")
+    def test_unparam_filter(self):
+        super().test_unparam_filter()
+
+    @pytest.mark.xfail(reason="Transform function no longer required")
+    def test_merge_null_unparam(self):
+        super().test_merge_null_unparam()
+
+    @pytest.mark.xfail(reason="Transform function no longer required")
+    def test_has_transaction(self):
+        super().test_has_transaction()


### PR DESCRIPTION
- This removes the transaction transform from the metric layer, since it'll be automatically done by the metric layer instead now