### PR TITLE
feat(mobile-exp): Optimize gallery for portrait mode screenshots

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
@@ -41,7 +41,7 @@ function renderModal({
       downloadUrl=""
       pageLinks={
         '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1",' +
-        '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:6:0>; rel="next"; results="true"; cursor="0:6:0"'
+        '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:12:0>; rel="next"; results="true"; cursor="0:12:0"'
       }
       attachments={attachments}
       attachmentIndex={attachmentIndex}
@@ -77,7 +77,7 @@ describe('Modals -> ScreenshotModal', function () {
       headers: {
         link:
           '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:0:1>; rel="previous"; results="false"; cursor="0:0:1",' +
-          '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:6:0>; rel="next"; results="true"; cursor="0:10:0"',
+          '<http://localhost/api/0/issues/group-id/attachments/?cursor=0:12:0>; rel="next"; results="true"; cursor="0:12:0"',
       },
     });
   });
@@ -116,13 +116,19 @@ describe('Modals -> ScreenshotModal', function () {
       eventAttachment,
       initialData,
       projectSlug: project.slug,
-      attachmentIndex: 5,
+      attachmentIndex: 11,
       attachments: [
         TestStubs.EventAttachment({id: '2'}),
         TestStubs.EventAttachment({id: '3'}),
         TestStubs.EventAttachment({id: '4'}),
         TestStubs.EventAttachment({id: '5'}),
         TestStubs.EventAttachment({id: '6'}),
+        TestStubs.EventAttachment({id: '7'}),
+        TestStubs.EventAttachment({id: '8'}),
+        TestStubs.EventAttachment({id: '9'}),
+        TestStubs.EventAttachment({id: '10'}),
+        TestStubs.EventAttachment({id: '11'}),
+        TestStubs.EventAttachment({id: '12'}),
         eventAttachment,
       ],
       enablePagination: true,
@@ -134,7 +140,7 @@ describe('Modals -> ScreenshotModal', function () {
       expect(getAttachmentsMock).toHaveBeenCalledWith(
         '/issues/group-id/attachments/',
         expect.objectContaining({
-          query: expect.objectContaining({cursor: '0:6:0'}),
+          query: expect.objectContaining({cursor: '0:12:0'}),
         })
       );
     });

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -107,7 +107,9 @@ function Modal({
   const links = pageLinks ? parseLinkHeader(pageLinks) : undefined;
   const previousDisabled =
     links?.previous?.results === false && currentAttachmentIndex === 0;
-  const nextDisabled = links?.next?.results === false && currentAttachmentIndex === 5;
+  const nextDisabled =
+    links?.next?.results === false &&
+    currentAttachmentIndex === MAX_SCREENSHOTS_PER_PAGE - 1;
 
   return (
     <Fragment>

--- a/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.spec.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.spec.tsx
@@ -5,7 +5,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import GroupStore from 'sentry/stores/groupStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 
-import GroupEventAttachments from './groupEventAttachments';
+import GroupEventAttachments, {MAX_SCREENSHOTS_PER_PAGE} from './groupEventAttachments';
 
 jest.mock('sentry/actionCreators/modal');
 
@@ -47,7 +47,7 @@ describe('GroupEventAttachments > Screenshots', function () {
     expect(getAttachmentsMock).toHaveBeenCalledWith(
       '/issues/group-id/attachments/',
       expect.objectContaining({
-        query: {per_page: 6, screenshot: 1, types: undefined},
+        query: {per_page: MAX_SCREENSHOTS_PER_PAGE, screenshot: 1, types: undefined},
       })
     );
   });

--- a/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -39,7 +39,7 @@ type State = {
   eventAttachments?: IssueAttachment[];
 } & AsyncComponent['state'];
 
-export const MAX_SCREENSHOTS_PER_PAGE = 6;
+export const MAX_SCREENSHOTS_PER_PAGE = 12;
 
 class GroupEventAttachments extends AsyncComponent<Props, State> {
   getDefaultState() {
@@ -244,10 +244,14 @@ const ScreenshotGrid = styled('div')`
   gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints.small}) {
-    grid-template-columns: repeat(2, minmax(100px, 1fr));
+    grid-template-columns: repeat(3, minmax(100px, 1fr));
   }
 
   @media (min-width: ${p => p.theme.breakpoints.large}) {
-    grid-template-columns: repeat(3, minmax(100px, 1fr));
+    grid-template-columns: repeat(4, minmax(100px, 1fr));
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints.xxlarge}) {
+    grid-template-columns: repeat(6, minmax(100px, 1fr));
   }
 `;


### PR DESCRIPTION
Fits 12 screenshots now instead of 6.
