### PR TITLE
ref(discover): Make needing organization a param

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -44,6 +44,8 @@ from sentry.utils.snuba import DATASETS, Dataset, bulk_snql_query, raw_snql_quer
 
 
 class MetricsQueryBuilder(QueryBuilder):
+    requires_organization_condition = True
+
     def __init__(
         self,
         *args: Any,
@@ -244,11 +246,6 @@ class MetricsQueryBuilder(QueryBuilder):
         else:
             granularity = 60
         return Granularity(granularity)
-
-    def resolve_params(self) -> List[WhereType]:
-        conditions = super().resolve_params()
-        conditions.append(Condition(self.column("organization_id"), Op.EQ, self.organization_id))
-        return conditions
 
     def resolve_having(
         self, parsed_terms: ParsedTerms, use_aggregate_conditions: bool

--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -45,6 +45,7 @@ from sentry.utils.snuba import DATASETS, Dataset, bulk_snql_query, raw_snql_quer
 
 class MetricsQueryBuilder(QueryBuilder):
     requires_organization_condition = True
+    organization_column: str = "organization_id"
 
     def __init__(
         self,

--- a/src/sentry/search/events/builder/profiles.py
+++ b/src/sentry/search/events/builder/profiles.py
@@ -1,11 +1,10 @@
-from typing import List, Optional, Protocol
+from typing import Optional, Protocol
 
-from snuba_sdk import Column, Condition, Op
+from snuba_sdk import Column
 
-from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events.builder import QueryBuilder, TimeseriesQueryBuilder
 from sentry.search.events.datasets.profiles import ProfilesDatasetConfig
-from sentry.search.events.types import SnubaParams, WhereType
+from sentry.search.events.types import SnubaParams
 
 
 class ProfilesQueryBuilderProtocol(Protocol):
@@ -20,34 +19,14 @@ class ProfilesQueryBuilderProtocol(Protocol):
     def column(self, name: str) -> Column:
         ...
 
-    def resolve_params(self) -> List[WhereType]:
-        ...
-
 
 class ProfilesQueryBuilderMixin:
+    requires_organization_condition: bool = True
+
     def resolve_column_name(self: ProfilesQueryBuilderProtocol, col: str) -> str:
         # giving resolved a type here convinces mypy that the type is str
         resolved: str = self.config.resolve_column(col)
         return resolved
-
-    def resolve_params(self: ProfilesQueryBuilderProtocol) -> List[WhereType]:
-        if self.params.organization is None:
-            raise InvalidSearchQuery("Organization is a required parameter")
-        # not sure how to make mypy happy here as `super()`
-        # refers to the other parent query builder class
-        conditions: List[WhereType] = super().resolve_params()  # type: ignore
-
-        # the profiles dataset requires a condition
-        # on the organization_id in the query
-        conditions.append(
-            Condition(
-                self.column("organization.id"),
-                Op.EQ,
-                self.params.organization.id,
-            )
-        )
-
-        return conditions
 
     def get_field_type(self: ProfilesQueryBuilderProtocol, field: str) -> Optional[str]:
         # giving resolved a type here convinces mypy that the type is str

--- a/src/sentry/search/events/builder/profiles.py
+++ b/src/sentry/search/events/builder/profiles.py
@@ -22,6 +22,7 @@ class ProfilesQueryBuilderProtocol(Protocol):
 
 class ProfilesQueryBuilderMixin:
     requires_organization_condition: bool = True
+    organization_column: str = "organization.id"
 
     def resolve_column_name(self: ProfilesQueryBuilderProtocol, col: str) -> str:
         # giving resolved a type here convinces mypy that the type is str

--- a/src/sentry/search/events/builder/sessions.py
+++ b/src/sentry/search/events/builder/sessions.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional, Sequence
 
-from snuba_sdk import Column, Condition, Entity, Flags, Granularity, Op, Query, Request
+from snuba_sdk import Column, Entity, Flags, Granularity, Query, Request
 
 from sentry.api.event_search import SearchFilter
 from sentry.exceptions import InvalidSearchQuery
@@ -9,15 +9,14 @@ from sentry.search.events.types import SelectType, WhereType
 
 
 class SessionsQueryBuilder(QueryBuilder):
-    # ToDo(ahmed): Rename this to AlertsSessionsQueryBuilder as it is exclusively used for crash rate alerts
-    def resolve_params(self) -> List[WhereType]:
-        conditions = super().resolve_params()
-        conditions.append(Condition(self.column("org_id"), Op.EQ, self.organization_id))
-        return conditions
+    requires_organization_condition = True
+    organization_column: str = "org_id"
 
 
 class SessionsV2QueryBuilder(QueryBuilder):
     filter_allowlist_fields = {"project", "project_id", "environment", "release"}
+    requires_organization_condition = True
+    organization_column: str = "org_id"
 
     def __init__(
         self,
@@ -29,11 +28,6 @@ class SessionsV2QueryBuilder(QueryBuilder):
         self._extra_filter_allowlist_fields = extra_filter_allowlist_fields or []
         self.granularity = Granularity(granularity) if granularity is not None else None
         super().__init__(*args, **kwargs)
-
-    def resolve_params(self) -> List[WhereType]:
-        conditions = super().resolve_params()
-        conditions.append(Condition(self.column("org_id"), Op.EQ, self.organization_id))
-        return conditions
 
     def resolve_groupby(self, groupby_columns: Optional[List[str]] = None) -> List[SelectType]:
         """

--- a/tests/sentry/snuba/test_entity_subscriptions.py
+++ b/tests/sentry/snuba/test_entity_subscriptions.py
@@ -122,7 +122,7 @@ class EntitySubscriptionTestCase(TestCase):
         ]
         assert snql_query.query.where == [
             Condition(Column(name="project_id"), Op.IN, [self.project.id]),
-            Condition(Column(name="org_id"), Op.EQ, None),
+            Condition(Column(name="org_id"), Op.EQ, self.organization.id),
         ]
 
     def test_get_entity_subscription_for_metrics_dataset_non_supported_aggregate(self) -> None:


### PR DESCRIPTION
- This makes requiring an organization condition a class variable instead so it doesn't need to be written in every builder