### PR TITLE
fix(tabs): Prevent focus on <a /> tags inside tab links

### DIFF
--- a/static/app/components/tabs/tab.tsx
+++ b/static/app/components/tabs/tab.tsx
@@ -61,6 +61,7 @@ function BaseTab(
           onMouseDown={handleLinkClick}
           onPointerDown={handleLinkClick}
           orientation={orientation}
+          tabIndex={-1}
         >
           {children}
         </TabLink>


### PR DESCRIPTION
Prevent focus on `<a />` tags inside tab links. The tab elements themselves (`<li />`) are still focusable.

**Before:**
<img width="840" alt="Screen Shot 2022-11-08 at 10 18 54 AM" src="https://user-images.githubusercontent.com/44172267/200644122-d6140c98-07e7-45e6-ac57-644b2d72c056.png">


**After:**
<img width="840" alt="Screen Shot 2022-11-08 at 10 19 15 AM" src="https://user-images.githubusercontent.com/44172267/200644191-041bd3b2-92f6-4c3e-af44-e08dfb9deb74.png">
