### PR TITLE
feat(replays): Create an onboarding sidebar to show install/config steps

### DIFF
--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -43,27 +43,23 @@ function ReplaysOnboardingSidebar(props: CommonSidebarProps) {
     return null;
   }
 
-  const items: MenuItemProps[] = projects
-    .reduce((acc: MenuItemProps[], project) => {
-      const itemProps: MenuItemProps = {
-        key: project.id,
-        label: (
-          <StyledIdBadge project={project} avatarSize={16} hideOverflow disableLink />
-        ),
-        onAction: function switchProject() {
-          setCurrentProject(project);
-        },
-      };
+  const items: MenuItemProps[] = projects.reduce((acc: MenuItemProps[], project) => {
+    const itemProps: MenuItemProps = {
+      key: project.id,
+      label: <StyledIdBadge project={project} avatarSize={16} hideOverflow disableLink />,
+      onAction: function switchProject() {
+        setCurrentProject(project);
+      },
+    };
 
-      if (currentProject.id === project.id) {
-        acc.unshift(itemProps);
-      } else {
-        acc.push(itemProps);
-      }
+    if (currentProject.id === project.id) {
+      acc.unshift(itemProps);
+    } else {
+      acc.push(itemProps);
+    }
 
-      return acc;
-    }, [])
-    .sort((a, b) => a.key.localeCompare(b.key));
+    return acc;
+  }, []);
 
   return (
     <TaskSidebarPanel

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -9,14 +9,17 @@ import {MenuItemProps} from 'sentry/components/dropdownMenuItem';
 import IdBadge from 'sentry/components/idBadge';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import useOnboardingDocs from 'sentry/components/onboardingWizard/useOnboardingDocs';
+import useCurrentProjectState from 'sentry/components/replaysOnboarding/useCurrentProjectState';
+import {
+  generateDocKeys,
+  isPlatformSupported,
+} from 'sentry/components/replaysOnboarding/utils';
 import OnboardingStep from 'sentry/components/sidebar/onboardingStep';
 import SidebarPanel from 'sentry/components/sidebar/sidebarPanel';
 import {CommonSidebarProps, SidebarPanelKey} from 'sentry/components/sidebar/types';
-import {withoutPerformanceSupport} from 'sentry/data/platformCategories';
+import {replayPlatforms} from 'sentry/data/platformCategories';
 import platforms from 'sentry/data/platforms';
 import {t, tct} from 'sentry/locale';
-import PageFiltersStore from 'sentry/stores/pageFiltersStore';
-import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import pulsingIndicatorStyles from 'sentry/styles/pulsingIndicator';
 import space from 'sentry/styles/space';
 import {Project} from 'sentry/types';
@@ -24,100 +27,24 @@ import EventWaiter from 'sentry/utils/eventWaiter';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePrevious from 'sentry/utils/usePrevious';
-import useProjects from 'sentry/utils/useProjects';
 
-import {filterProjects, generateDocKeys, isPlatformSupported} from './utils';
-
-function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
+function ReplaysOnboardingSidebar(props: CommonSidebarProps) {
   const {currentPanel, collapsed, hidePanel, orientation} = props;
-  const isActive = currentPanel === SidebarPanelKey.PerformanceOnboarding;
   const organization = useOrganization();
+
+  const isActive = currentPanel === SidebarPanelKey.ReplaysOnboarding;
   const hasProjectAccess = organization.access.includes('project:read');
 
-  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+  const {projects, currentProject, setCurrentProject} = useCurrentProjectState({
+    currentPanel,
+  });
 
-  const [currentProject, setCurrentProject] = useState<Project | undefined>(undefined);
-
-  const {selection, isReady} = useLegacyStore(PageFiltersStore);
-
-  const {projectsWithoutFirstTransactionEvent, projectsForOnboarding} =
-    filterProjects(projects);
-
-  useEffect(() => {
-    if (
-      currentProject ||
-      projects.length === 0 ||
-      !isReady ||
-      !isActive ||
-      projectsWithoutFirstTransactionEvent.length <= 0
-    ) {
-      return;
-    }
-    // Establish current project
-
-    const projectMap: Record<string, Project> = projects.reduce((acc, project) => {
-      acc[project.id] = project;
-      return acc;
-    }, {});
-
-    if (selection.projects.length) {
-      const projectSelection = selection.projects.map(
-        projectId => projectMap[String(projectId)]
-      );
-
-      // Among the project selection, find a project that has performance onboarding docs support, and has not sent
-      // a first transaction event.
-      const maybeProject = projectSelection.find(project =>
-        projectsForOnboarding.includes(project)
-      );
-      if (maybeProject) {
-        setCurrentProject(maybeProject);
-        return;
-      }
-
-      // Among the project selection, find a project that has not sent a first transaction event
-      const maybeProjectFallback = projectSelection.find(project =>
-        projectsWithoutFirstTransactionEvent.includes(project)
-      );
-      if (maybeProjectFallback) {
-        setCurrentProject(maybeProjectFallback);
-        return;
-      }
-    }
-
-    // Among the projects, find a project that has performance onboarding docs support, and has not sent
-    // a first transaction event.
-    if (projectsForOnboarding.length) {
-      setCurrentProject(projectsForOnboarding[0]);
-      return;
-    }
-
-    // Otherwise, pick a first project that has not sent a first transaction event.
-    setCurrentProject(projectsWithoutFirstTransactionEvent[0]);
-  }, [
-    selection.projects,
-    projects,
-    isActive,
-    isReady,
-    projectsForOnboarding,
-    projectsWithoutFirstTransactionEvent,
-    currentProject,
-  ]);
-
-  if (
-    !isActive ||
-    !hasProjectAccess ||
-    currentProject === undefined ||
-    !projectsLoaded ||
-    !projects ||
-    projects.length <= 0 ||
-    projectsWithoutFirstTransactionEvent.length <= 0
-  ) {
+  if (!isActive || !hasProjectAccess || !currentProject) {
     return null;
   }
 
-  const items: MenuItemProps[] = projectsWithoutFirstTransactionEvent.reduce(
-    (acc: MenuItemProps[], project) => {
+  const items: MenuItemProps[] = projects
+    .reduce((acc: MenuItemProps[], project) => {
       const itemProps: MenuItemProps = {
         key: project.id,
         label: (
@@ -135,9 +62,8 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
       }
 
       return acc;
-    },
-    []
-  );
+    }, [])
+    .sort((a, b) => a.key.localeCompare(b.key));
 
   return (
     <TaskSidebarPanel
@@ -147,7 +73,7 @@ function PerformanceOnboardingSidebar(props: CommonSidebarProps) {
     >
       <TopRightBackgroundImage src={HighlightTopRightPattern} />
       <TaskList>
-        <Heading>{t('Boost Performance')}</Heading>
+        <Heading>{t('Replay Sessions')}</Heading>
         <DropdownMenuControl
           items={items}
           triggerLabel={
@@ -193,16 +119,16 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     ? platforms.find(p => p.id === currentProject.platform)
     : undefined;
 
-  const doesNotSupportPerformance = currentProject.platform
-    ? withoutPerformanceSupport.has(currentProject.platform)
-    : false;
+  const doesNotSupportReplay = currentProject.platform
+    ? !replayPlatforms.includes(currentProject.platform)
+    : true;
 
-  if (doesNotSupportPerformance) {
+  if (doesNotSupportReplay) {
     return (
       <Fragment>
         <div>
           {tct(
-            'Fiddlesticks. Performance isn’t available for your [platform] project yet but we’re definitely still working on it. Stay tuned.',
+            'Fiddlesticks. Session Replay isn’t available for your [platform] project yet but we’re definitely still working on it. Stay tuned.',
             {platform: currentPlatform?.name || currentProject.slug}
           )}
         </div>
@@ -227,10 +153,10 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
         <div>
           <Button
             size="sm"
-            href="https://docs.sentry.io/product/performance/getting-started/"
+            href="https://github.com/getsentry/sentry-replay/blob/main/README.md"
             external
           >
-            {t('Go to documentation')}
+            {t('See Readme')}
           </Button>
         </div>
       </Fragment>
@@ -243,7 +169,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
     <Fragment>
       <div>
         {tct(
-          `Adding Performance to your [platform] project is simple. Make sure you've got these basics down.`,
+          `Adding Session Replay to your [platform] project is simple. Make sure you've got these basics down.`,
           {platform: currentPlatform?.name || currentProject.slug}
         )}
       </div>
@@ -256,7 +182,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
               api={api}
               organization={organization}
               project={currentProject}
-              eventType="transaction"
+              eventType="replay"
               onIssueReceived={() => {
                 setReceived(true);
               }}
@@ -270,7 +196,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
             <OnboardingStep
               docContent={docContents[docKey]}
               docKey={docKey}
-              prefix="perf"
+              prefix="replay"
               project={currentProject}
             />
             {footer}
@@ -325,7 +251,7 @@ const PulsingIndicator = styled('div')`
 const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
   <div {...p}>
     <PulsingIndicator />
-    {t("Waiting for this project's first transaction event")}
+    {t("Waiting for this project's first replay event")}
   </div>
 ))`
   display: flex;
@@ -338,7 +264,7 @@ const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) =
 const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
   <div {...p}>
     {'🎉 '}
-    {t("We've received this project's first transaction event!")}
+    {t("We've received this project's first replay event!")}
   </div>
 ))`
   display: flex;
@@ -348,4 +274,4 @@ const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) 
   color: ${p => p.theme.green300};
 `;
 
-export default PerformanceOnboardingSidebar;
+export default ReplaysOnboardingSidebar;

--- a/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
+++ b/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
@@ -18,15 +18,17 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
   // Projects where we have the onboarding instructions ready:
   const projectsWithOnboarding = useMemo(
     () =>
-      projects.filter(p => p.platform && replayOnboardingPlatforms.includes(p.platform)),
+      projects.filter(
+        p => p.platform && replayOnboardingPlatforms.includes(p.platform) && !p.hasReplays
+      ),
     [projects]
   );
 
   // Projects that support replays, but we haven't created the onboarding instructions (yet):
-  const projectsWithoutFirstReplay = useMemo(
+  const projectWithReplaySupport = useMemo(
     () =>
       projects.filter(
-        p => p.platform && replayPlatforms.includes(p.platform) && p.hasReplays === false
+        p => p.platform && replayPlatforms.includes(p.platform) && !p.hasReplays
       ),
     [projects]
   );
@@ -42,7 +44,7 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
       return;
     }
 
-    if (!projectsWithoutFirstReplay) {
+    if (!projectWithReplaySupport) {
       return;
     }
 
@@ -57,7 +59,7 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
       }
 
       // If we selected something that supports replays pick that
-      const projectSupportsReplay = projectsWithoutFirstReplay.find(p =>
+      const projectSupportsReplay = projectWithReplaySupport.find(p =>
         selectedProjectIds.includes(p.id)
       );
       if (projectSupportsReplay) {
@@ -67,9 +69,7 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
       setCurrentProject(firstSelectedProject);
     } else {
       // We have no selection, so pick a project which we've found
-      setCurrentProject(
-        first(projectsWithOnboarding) || first(projectsWithoutFirstReplay)
-      );
+      setCurrentProject(first(projectsWithOnboarding) || first(projectWithReplaySupport));
     }
   }, [
     currentProject,
@@ -79,11 +79,11 @@ function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanel
     isActive,
     selection.projects,
     projectsWithOnboarding,
-    projectsWithoutFirstReplay,
+    projectWithReplaySupport,
   ]);
 
   return {
-    projects: projectsWithoutFirstReplay,
+    projects: projectWithReplaySupport,
     currentProject,
     setCurrentProject,
   };

--- a/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
+++ b/static/app/components/replaysOnboarding/useCurrentProjectState.tsx
@@ -1,0 +1,92 @@
+import {useEffect, useMemo, useState} from 'react';
+import first from 'lodash/first';
+
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
+import {replayOnboardingPlatforms, replayPlatforms} from 'sentry/data/platformCategories';
+import PageFiltersStore from 'sentry/stores/pageFiltersStore';
+import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {Project} from 'sentry/types';
+import useProjects from 'sentry/utils/useProjects';
+
+function useCurrentProjectState({currentPanel}: {currentPanel: '' | SidebarPanelKey}) {
+  const [currentProject, setCurrentProject] = useState<Project | undefined>(undefined);
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+  const {selection, isReady} = useLegacyStore(PageFiltersStore);
+
+  const isActive = currentPanel === SidebarPanelKey.ReplaysOnboarding;
+
+  // Projects where we have the onboarding instructions ready:
+  const projectsWithOnboarding = useMemo(
+    () =>
+      projects.filter(p => p.platform && replayOnboardingPlatforms.includes(p.platform)),
+    [projects]
+  );
+
+  // Projects that support replays, but we haven't created the onboarding instructions (yet):
+  const projectsWithoutFirstReplay = useMemo(
+    () =>
+      projects.filter(
+        p => p.platform && replayPlatforms.includes(p.platform) && p.hasReplays === false
+      ),
+    [projects]
+  );
+
+  useEffect(() => {
+    if (!isActive) {
+      setCurrentProject(undefined);
+    }
+  }, [isActive]);
+
+  useEffect(() => {
+    if (currentProject || !projectsLoaded || !projects.length || !isReady || !isActive) {
+      return;
+    }
+
+    if (!projectsWithoutFirstReplay) {
+      return;
+    }
+
+    if (selection.projects.length) {
+      const selectedProjectIds = selection.projects.map(String);
+      // If we selected something that has onboarding instructions, pick that first
+      const projectForOnboarding = projectsWithOnboarding.find(p =>
+        selectedProjectIds.includes(p.id)
+      );
+      if (projectForOnboarding) {
+        setCurrentProject(projectForOnboarding);
+      }
+
+      // If we selected something that supports replays pick that
+      const projectSupportsReplay = projectsWithoutFirstReplay.find(p =>
+        selectedProjectIds.includes(p.id)
+      );
+      if (projectSupportsReplay) {
+        setCurrentProject(projectSupportsReplay);
+      }
+      const firstSelectedProject = projects.find(p => selectedProjectIds.includes(p.id));
+      setCurrentProject(firstSelectedProject);
+    } else {
+      // We have no selection, so pick a project which we've found
+      setCurrentProject(
+        first(projectsWithOnboarding) || first(projectsWithoutFirstReplay)
+      );
+    }
+  }, [
+    currentProject,
+    projectsLoaded,
+    projects,
+    isReady,
+    isActive,
+    selection.projects,
+    projectsWithOnboarding,
+    projectsWithoutFirstReplay,
+  ]);
+
+  return {
+    projects: projectsWithoutFirstReplay,
+    currentProject,
+    setCurrentProject,
+  };
+}
+
+export default useCurrentProjectState;

--- a/static/app/components/replaysOnboarding/utils.tsx
+++ b/static/app/components/replaysOnboarding/utils.tsx
@@ -1,0 +1,10 @@
+import {PlatformKey, replayPlatforms} from 'sentry/data/platformCategories';
+import {PlatformIntegration} from 'sentry/types';
+
+export function generateDocKeys(platform: PlatformKey): string[] {
+  return ['1-install', '2-configure'].map(key => `${platform}-replay-onboarding-${key}`);
+}
+
+export function isPlatformSupported(platform: undefined | PlatformIntegration) {
+  return platform?.id ? replayPlatforms.includes(platform?.id) : false;
+}

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -8,6 +8,7 @@ import Feature from 'sentry/components/acl/feature';
 import GuideAnchor from 'sentry/components/assistant/guideAnchor';
 import HookOrDefault from 'sentry/components/hookOrDefault';
 import PerformanceOnboardingSidebar from 'sentry/components/performanceOnboarding/sidebar';
+import ReplaysOnboardingSidebar from 'sentry/components/replaysOnboarding/sidebar';
 import {
   IconChevron,
   IconDashboard,
@@ -367,6 +368,12 @@ function Sidebar({location, organization}: Props) {
           <PerformanceOnboardingSidebar
             currentPanel={activePanel}
             onShowPanel={() => togglePanel(SidebarPanelKey.PerformanceOnboarding)}
+            hidePanel={hidePanel}
+            {...sidebarItemProps}
+          />
+          <ReplaysOnboardingSidebar
+            currentPanel={activePanel}
+            onShowPanel={() => togglePanel(SidebarPanelKey.ReplaysOnboarding)}
             hidePanel={hidePanel}
             {...sidebarItemProps}
           />

--- a/static/app/components/sidebar/onboardingStep.tsx
+++ b/static/app/components/sidebar/onboardingStep.tsx
@@ -11,19 +11,18 @@ import localStorage from 'sentry/utils/localStorage';
 type Props = {
   docContent: string | undefined;
   docKey: string;
+  prefix: string;
   project: Project;
 };
 
-function OnBoardingStep(props: Props) {
-  const {docKey, project, docContent} = props;
-
+function OnBoardingStep({docContent, docKey, prefix, project}: Props) {
   const [increment, setIncrement] = useState<number>(0);
 
   if (!docContent) {
     return null;
   }
 
-  const localStorageKey = `perf-onboarding-${project.id}-${docKey}`;
+  const localStorageKey = `${prefix}-onboarding-${project.id}-${docKey}`;
 
   function isChecked() {
     return localStorage.getItem(localStorageKey) === 'check';

--- a/static/app/components/sidebar/types.tsx
+++ b/static/app/components/sidebar/types.tsx
@@ -5,6 +5,7 @@ export enum SidebarPanelKey {
   OnboardingWizard = 'todos',
   ServiceIncidents = 'statusupdate',
   PerformanceOnboarding = 'performance_onboarding',
+  ReplaysOnboarding = 'replays_onboarding',
 }
 
 export type CommonSidebarProps = {

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -259,7 +259,6 @@ export const replayPlatforms: PlatformKey[] = [
   'javascript',
   'javascript-react',
   'javascript-angular',
-  'javascript-angularjs',
   'javascript-backbone',
   'javascript-ember',
   'javascript-gatsby',
@@ -268,6 +267,13 @@ export const replayPlatforms: PlatformKey[] = [
   'javascript-remix',
   'javascript-svelte',
 ];
+
+/**
+ * The list of platforms for which we have created onboarding instructions.
+ * This should match sentry-docs: `/src/wizard/${platform}/replay-onboarding/${subPlatform}/`.
+ * See: https://github.com/getsentry/sentry-docs/tree/master/src/wizard/javascript/replay-onboarding
+ */
+export const replayOnboardingPlatforms: PlatformKey[] = ['javascript'];
 
 /**
  * Additional aliases used for filtering in the platform picker

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -255,7 +255,7 @@ export const releaseHealth: PlatformKey[] = [
   'native-qt',
 ];
 
-export const replayPlatforms: PlatformKey[] = [
+export const replayPlatforms: readonly PlatformKey[] = [
   'javascript',
   'javascript-react',
   'javascript-angular',
@@ -270,10 +270,11 @@ export const replayPlatforms: PlatformKey[] = [
 
 /**
  * The list of platforms for which we have created onboarding instructions.
+ * Should be a subset of the list of `replayPlatforms`.
  * This should match sentry-docs: `/src/wizard/${platform}/replay-onboarding/${subPlatform}/`.
  * See: https://github.com/getsentry/sentry-docs/tree/master/src/wizard/javascript/replay-onboarding
  */
-export const replayOnboardingPlatforms: PlatformKey[] = ['javascript'];
+export const replayOnboardingPlatforms: readonly PlatformKey[] = ['javascript'];
 
 /**
  * Additional aliases used for filtering in the platform picker

--- a/static/app/utils/eventWaiter.tsx
+++ b/static/app/utils/eventWaiter.tsx
@@ -130,7 +130,6 @@ class EventWaiter extends Component<EventWaiterProps, EventWaiterState> {
       // The event may have expired, default to true
       firstIssue = issues.find((issue: Group) => issue.firstSeen === firstEvent) || true;
 
-      // noinspection SpellCheckingInspection
       recordAnalyticsFirstEvent({
         key: 'first_event_recieved',
         organization,
@@ -138,7 +137,6 @@ class EventWaiter extends Component<EventWaiterProps, EventWaiterState> {
       });
     } else if (eventType === 'transaction') {
       firstIssue = Boolean(firstEvent);
-      // noinspection SpellCheckingInspection
       recordAnalyticsFirstEvent({
         key: 'first_transaction_recieved',
         organization,
@@ -146,7 +144,6 @@ class EventWaiter extends Component<EventWaiterProps, EventWaiterState> {
       });
     } else if (eventType === 'replay') {
       firstIssue = Boolean(firstEvent);
-      // noinspection SpellCheckingInspection
       recordAnalyticsFirstEvent({
         key: 'first_replay_recieved',
         organization,

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -9,8 +9,10 @@ import PageFiltersContainer from 'sentry/components/organizations/pageFilters/co
 import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
 import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
+import {SidebarPanelKey} from 'sentry/components/sidebar/types';
 import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t} from 'sentry/locale';
+import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {PageContent} from 'sentry/styles/organization';
 import {Project} from 'sentry/types';
 import {PageFilters} from 'sentry/types/core';
@@ -23,6 +25,7 @@ import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 import ReplaysFilters from 'sentry/views/replays/filters';
 import ReplayOnboardingPanel from 'sentry/views/replays/list/replayOnboardingPanel';
 import ReplayTable from 'sentry/views/replays/replayTable';
@@ -55,6 +58,25 @@ function useShouldShowOnboardingPanel() {
   return shouldShowOnboardingPanel;
 }
 
+function useReplayOnboardingSidebarPanel() {
+  const {location} = useRouteContext();
+  const enabled = useShouldShowOnboardingPanel();
+
+  useEffect(() => {
+    if (enabled && location.hash === '#replay-sidequest') {
+      SidebarPanelStore.activatePanel(SidebarPanelKey.ReplaysOnboarding);
+    }
+  }, [enabled, location.hash]);
+
+  const activate = useCallback(event => {
+    event.preventDefault();
+    window.location.hash = 'replay-sidequest';
+    SidebarPanelStore.activatePanel(SidebarPanelKey.ReplaysOnboarding);
+  }, []);
+
+  return {enabled, activate};
+}
+
 function Replays({location}: Props) {
   const organization = useOrganization();
   const theme = useTheme();
@@ -83,7 +105,8 @@ function Replays({location}: Props) {
     eventView,
   });
 
-  const shouldShowOnboardingPanel = useShouldShowOnboardingPanel();
+  const {enabled: shouldShowOnboardingPanel, activate: activateOnboardingSidebarPanel} =
+    useReplayOnboardingSidebarPanel();
 
   return (
     <Fragment>
@@ -99,6 +122,9 @@ function Replays({location}: Props) {
           <ReplaysFilters />
           {shouldShowOnboardingPanel ? (
             <ReplayOnboardingPanel>
+              <Button onClick={activateOnboardingSidebarPanel} priority="primary">
+                {t('Get Started')}
+              </Button>
               <Button
                 href="https://github.com/getsentry/sentry-replay/blob/main/README.md"
                 external


### PR DESCRIPTION
This PR creates an onboarding sidebar that opens to give users install & configure steps to follow. 

The figma is here "setup tray": https://www.figma.com/file/MnKsgpxDrfEphCKLKuOetG/Specs%3A-Onboarding-v1?node-id=330%3A3539

And it looks like this:
| Install Step | Config Step |
| --- | --- |
| <img width="1240" alt="js - open 1" src="https://user-images.githubusercontent.com/187460/200651141-afb4fa34-d7ec-49e7-b8f2-d5c6fe8d962b.png"> | <img width="1240" alt="js open 2" src="https://user-images.githubusercontent.com/187460/200651159-8b8e3eb7-4e1a-4560-b474-1d25a2285fce.png"> |

**Test Notes:**

| Case | Example |
| --- | --- |
| Replay is only supported in JavaScript, so when you are on the Replay Index page, your selection needs to include at least one javascript project | <img width="250" alt="js - empty" src="https://user-images.githubusercontent.com/187460/200651581-31364aca-19fd-4e7b-88ff-cdbee21dcabf.png"> |
| If you pick a framework where we haven't written the docs yet*, then you'll see a link to the readme instead | <img width="250" alt="nextjs - open" src="https://user-images.githubusercontent.com/187460/200651926-4fa8c176-41f9-424e-b619-c2c180412f0e.png"> |
| If you pick a only projects that use another language, you get a similar message and a link to https://docs.sentry.io/platforms/ | <img width="250" alt="elixir - open" src="https://user-images.githubusercontent.com/187460/200652274-f2f49f40-132c-4501-b1d9-d3eecb1f33e7.png"> |
| If you select multiple projects in the project picker, and one of them has replays already, then you'll just see the list of replays and won't get the onboarding empty-state | <img width="250" alt="Screen Shot 2022-11-08 at 11 07 21 AM" src="https://user-images.githubusercontent.com/187460/200653365-1b9901dc-489b-44df-951d-3653ba1b6ffc.png"> |


Notes:
- NextJS docs will be merged with: https://github.com/getsentry/sentry-docs/pull/5727
- In all cases, when the Sidebar is open there's a dropdown which will allow you to pick from all eligible projects and see the setup steps for that project.
  - This list is sorted, so it's stable if you want to click through.
- Clicking outside of the sidebar will cause it to close
- Checkboxes inside the list are saved to localstorage, the key includes the project id

 Related to https://github.com/getsentry/sentry/issues/40787