### PR TITLE
feat(issue-alerts): add event level filter to preview

### DIFF
--- a/src/sentry/db/models/fields/gzippeddict.py
+++ b/src/sentry/db/models/fields/gzippeddict.py
@@ -36,6 +36,9 @@ class GzippedDictField(TextField):
             return {}
         return value
 
+    def from_db_value(self, value, expression, connection):
+        return self.to_python(value)
+
     def get_prep_value(self, value):
         if not value and self.null:
             # save ourselves some storage

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import abc
 import logging
 from collections import namedtuple
-from typing import Any, Callable, MutableMapping, Sequence, Type
+from typing import Any, Callable, Dict, MutableMapping, Sequence, Type
 
 from django import forms
 
 from sentry.eventstore.models import GroupEvent
 from sentry.models import Project, Rule
+from sentry.types.condition_activity import ConditionActivity
 from sentry.types.rules import RuleFuture
 
 """
@@ -105,6 +106,11 @@ class RuleBase(abc.ABC):
 
     def get_event_columns(self) -> Sequence[str]:
         return []
+
+    def passes_activity(
+        self, condition_activity: ConditionActivity, event_map: Dict[str, Any]
+    ) -> bool:
+        raise NotImplementedError
 
 
 class EventState:

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -103,6 +103,9 @@ class RuleBase(abc.ABC):
     ) -> CallbackFuture:
         return CallbackFuture(callback=callback, key=key, kwargs=kwargs)
 
+    def get_event_columns(self) -> Sequence[str]:
+        return []
+
 
 class EventState:
     def __init__(

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -69,7 +69,7 @@ class LevelCondition(EventCondition):
         self, condition_activity: ConditionActivity, event_map: Dict[str, Any]
     ) -> bool:
         try:
-            level = event_map[condition_activity.data["event_id"]]["level"]
+            level = event_map[condition_activity.data["event_id"]]["tags"]["level"]
             return self._passes(level)
         except (TypeError, KeyError):
             return False

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -45,11 +45,11 @@ class LevelCondition(EventCondition):
             return False
 
         if desired_match == MatchType.EQUAL:
-            return bool(level == desired_level)
+            return level == desired_level
         elif desired_match == MatchType.GREATER_OR_EQUAL:
-            return bool(level >= desired_level)
+            return level >= desired_level
         elif desired_match == MatchType.LESS_OR_EQUAL:
-            return bool(level <= desired_level)
+            return level <= desired_level
         return False
 
     def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Tuple
+from typing import Any, Callable, Dict, Sequence, Tuple
 
 from django import forms
 
@@ -9,6 +9,7 @@ from sentry.eventstore.models import GroupEvent
 from sentry.rules import LEVEL_MATCH_CHOICES as MATCH_CHOICES
 from sentry.rules import EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
+from sentry.types.condition_activity import ConditionActivity
 
 key: Callable[[Tuple[int, str]], int] = lambda x: x[0]
 LEVEL_CHOICES = {f"{k}": v for k, v in sorted(LOG_LEVELS.items(), key=key, reverse=True)}
@@ -28,7 +29,7 @@ class LevelCondition(EventCondition):
         "match": {"type": "choice", "choices": list(MATCH_CHOICES.items())},
     }
 
-    def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
+    def _passes(self, level_name: str) -> bool:
         desired_level_raw = self.get_option("level")
         desired_match = self.get_option("match")
 
@@ -39,17 +40,20 @@ class LevelCondition(EventCondition):
         # Fetch the event level from the tags since event.level is
         # event.group.level which may have changed
         try:
-            level: int = LOG_LEVELS_MAP[event.get_tag("level")]
+            level: int = LOG_LEVELS_MAP[level_name]
         except KeyError:
             return False
 
         if desired_match == MatchType.EQUAL:
-            return level == desired_level
+            return bool(level == desired_level)
         elif desired_match == MatchType.GREATER_OR_EQUAL:
-            return level >= desired_level
+            return bool(level >= desired_level)
         elif desired_match == MatchType.LESS_OR_EQUAL:
-            return level <= desired_level
+            return bool(level <= desired_level)
         return False
+
+    def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
+        return self._passes(event.get_tag("level"))
 
     def render_label(self) -> str:
         data = {
@@ -57,3 +61,15 @@ class LevelCondition(EventCondition):
             "match": MATCH_CHOICES[self.data["match"]],
         }
         return self.label.format(**data)
+
+    def get_event_columns(self) -> Sequence[str]:
+        return ["tags.key", "tags.value"]
+
+    def passes_activity(
+        self, condition_activity: ConditionActivity, event_map: Dict[str, Any]
+    ) -> bool:
+        try:
+            level = event_map[condition_activity.data["event_id"]]["level"]
+            return self._passes(level)
+        except (TypeError, KeyError):
+            return False

--- a/src/sentry/rules/filters/age_comparison.py
+++ b/src/sentry/rules/filters/age_comparison.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import operator
 from datetime import datetime, timedelta
-from typing import Sequence, Tuple
+from typing import Any, Dict, Sequence, Tuple
 
 from django import forms
 from django.utils import timezone
@@ -89,7 +89,9 @@ class AgeComparisonFilter(EventFilter):
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         return self._passes(event.group.first_seen, timezone.now())
 
-    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+    def passes_activity(
+        self, condition_activity: ConditionActivity, event_map: Dict[str, Any]
+    ) -> bool:
         try:
             group = Group.objects.get_from_cache(id=condition_activity.group_id)
         except Group.DoesNotExist:

--- a/src/sentry/rules/filters/base.py
+++ b/src/sentry/rules/filters/base.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Any, Dict
 
 from sentry.eventstore.models import GroupEvent
 from sentry.rules.base import EventState, RuleBase
@@ -12,5 +13,7 @@ class EventFilter(RuleBase, abc.ABC):
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         pass
 
-    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+    def passes_activity(
+        self, condition_activity: ConditionActivity, event_map: Dict[str, Any]
+    ) -> bool:
         raise NotImplementedError

--- a/src/sentry/rules/filters/base.py
+++ b/src/sentry/rules/filters/base.py
@@ -1,9 +1,7 @@
 import abc
-from typing import Any, Dict
 
 from sentry.eventstore.models import GroupEvent
 from sentry.rules.base import EventState, RuleBase
-from sentry.types.condition_activity import ConditionActivity
 
 
 class EventFilter(RuleBase, abc.ABC):
@@ -12,8 +10,3 @@ class EventFilter(RuleBase, abc.ABC):
     @abc.abstractmethod
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         pass
-
-    def passes_activity(
-        self, condition_activity: ConditionActivity, event_map: Dict[str, Any]
-    ) -> bool:
-        raise NotImplementedError

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any
+from typing import Any, Dict
 
 from django import forms
 
@@ -39,7 +39,9 @@ class IssueCategoryFilter(EventFilter):
     def passes(self, event: GroupEvent, state: EventState, **kwargs: Any) -> bool:
         return self._passes(event.group)
 
-    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+    def passes_activity(
+        self, condition_activity: ConditionActivity, event_map: Dict[str, Any]
+    ) -> bool:
         try:
             group = Group.objects.get_from_cache(id=condition_activity.group_id)
         except Group.DoesNotExist:

--- a/src/sentry/rules/filters/issue_occurrences.py
+++ b/src/sentry/rules/filters/issue_occurrences.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 from django import forms
 from django.utils import timezone
 
@@ -30,7 +32,9 @@ class IssueOccurrencesFilter(EventFilter):
         issue_occurrences: int = event.group.times_seen_with_pending
         return bool(issue_occurrences >= value)
 
-    def passes_activity(self, condition_activity: ConditionActivity) -> bool:
+    def passes_activity(
+        self, condition_activity: ConditionActivity, event_map: Dict[str, Any]
+    ) -> bool:
         try:
             value = int(self.get_option("value"))
         except (TypeError, ValueError):

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -103,7 +103,6 @@ def get_events(
             if event_id is not None:
                 event_ids.append(event_id)
 
-    # TODO: Add more columns as more event filters are supported
     columns.append("event_id")
     events = []
     if group_ids:
@@ -138,8 +137,6 @@ def get_events(
             values = event["tags.value"]
             del event["tags.key"]
             del event["tags.value"]
-            event["tags"] = {}
-            for k, v in zip(keys, values):
-                event["tags"][k] = v
+            event["tags"] = {k: v for k, v in zip(keys, values)}
 
     return {event["event_id"]: event for event in events}

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -138,7 +138,8 @@ def get_events(
             values = event["tags.value"]
             del event["tags.key"]
             del event["tags.value"]
+            event["tags"] = {}
             for k, v in zip(keys, values):
-                event[k] = v
+                event["tags"][k] = v
 
     return {event["event_id"]: event for event in events}

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -133,10 +133,8 @@ def get_events(
     # the keys and values of tags come in 2 separate lists, pair them up together
     if "tags.key" in columns and "tags.value" in columns:
         for event in events:
-            keys = event["tags.key"]
-            values = event["tags.value"]
-            del event["tags.key"]
-            del event["tags.value"]
+            keys = event.pop("tags.key")
+            values = event.pop("tags.value")
             event["tags"] = {k: v for k, v in zip(keys, values)}
 
     return {event["event_id"]: event for event in events}

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -300,7 +300,7 @@ class GetEventsTest(TestCase):
                 timestamp=prev_hour,
             )
         ]
-        events = get_events(self.project, activity)
+        events = get_events(self.project, activity, [])
 
         assert len(events) == 1
         assert event.event_id in events
@@ -330,7 +330,7 @@ class GetEventsTest(TestCase):
                 data={"event_id": reappeared_event.event_id},
             ),
         ]
-        events = get_events(self.project, activity)
+        events = get_events(self.project, activity, [])
 
         assert len(events) == 2
         assert all([event.event_id in events for event in (regression_event, reappeared_event)])


### PR DESCRIPTION
Adds support for `LevelFilter` to the preview. Passes along an `event_map`, which should contain all the data needed to answer event filters, along to `passes_activity`.