### PR TITLE
fix(ecosystem): Track if commit clicks have a pull request link

### DIFF
--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -29,7 +29,7 @@ export function formatCommitMessage(message: string | null) {
 export interface CommitRowProps {
   commit: Commit;
   customAvatar?: React.ReactNode;
-  onCommitClick?: () => void;
+  onCommitClick?: (commit: Commit) => void;
   onPullRequestClick?: () => void;
 }
 
@@ -103,7 +103,7 @@ function CommitRow({
                 showIcon={false}
                 commitId={commit.id}
                 repository={commit.repository}
-                onClick={onCommitClick}
+                onClick={onCommitClick ? () => onCommitClick(commit) : undefined}
               />
             ),
           })}

--- a/static/app/components/events/eventCause.tsx
+++ b/static/app/components/events/eventCause.tsx
@@ -9,7 +9,7 @@ import {Panel} from 'sentry/components/panels';
 import {IconAdd, IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {AvatarProject, Group, IssueCategory} from 'sentry/types';
+import {AvatarProject, Commit, Group, IssueCategory} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import useCommitters from 'sentry/utils/useCommitters';
 import {useEffectAfterFirstRender} from 'sentry/utils/useEffectAfterFirstRender';
@@ -77,12 +77,13 @@ function EventCause({group, eventId, project, commitRow: CommitRow}: Props) {
     });
   };
 
-  const handleCommitClick = () => {
+  const handleCommitClick = (commit: Commit) => {
     trackAdvancedAnalyticsEvent('issue_details.suspect_commits.commit_clicked', {
       organization,
       project_id: parseInt(project.id as string, 10),
       group_id: parseInt(group?.id as string, 10),
       issue_category: group?.issueCategory ?? IssueCategory.ERROR,
+      has_pull_request: commit.pullRequest?.id !== undefined,
     });
   };
 

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -75,7 +75,9 @@ export type TeamInsightsEventParameters = {
   'issue_details.issue_tab.screenshot_modal_download': {};
   'issue_details.issue_tab.screenshot_modal_opened': {};
   'issue_details.suspect_commits': IssueDetailsWithAlert & {count: number};
-  'issue_details.suspect_commits.commit_clicked': IssueDetailsWithAlert;
+  'issue_details.suspect_commits.commit_clicked': IssueDetailsWithAlert & {
+    has_pull_request: boolean;
+  };
   'issue_details.suspect_commits.pull_request_clicked': IssueDetailsWithAlert;
   'issue_details.tab_changed': IssueDetailsWithAlert & {
     tab: Tab;


### PR DESCRIPTION
When someone clicks on a commit we track the click, however we don't know if they were shown a pull request link
