### PR TITLE
feat(saved-searches): Get saved searches from react-query instead of SavedSearchesStore

### DIFF
--- a/static/app/utils/withSavedSearches.tsx
+++ b/static/app/utils/withSavedSearches.tsx
@@ -20,7 +20,7 @@ type State = {
 };
 
 /**
- * HOC to provide saved search data class components.
+ * HOC to provide saved search data to class components.
  * When possible, use the hooks directly instead.
  */
 function withSavedSearchesV2<P extends InjectedSavedSearchesProps>(

--- a/static/app/utils/withSavedSearches.tsx
+++ b/static/app/utils/withSavedSearches.tsx
@@ -1,9 +1,12 @@
-import {Component} from 'react';
+import {Component, useMemo} from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import SavedSearchesStore from 'sentry/stores/savedSearchesStore';
 import {SavedSearch} from 'sentry/types';
 import getDisplayName from 'sentry/utils/getDisplayName';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
+import {useSelectedSavedSearch} from 'sentry/views/issueList/utils/useSelectedSavedSearch';
 
 type InjectedSavedSearchesProps = {
   savedSearch: SavedSearch | null;
@@ -17,9 +20,36 @@ type State = {
 };
 
 /**
+ * HOC to provide saved search data class components.
+ * When possible, use the hooks directly instead.
+ */
+function withSavedSearchesV2<P extends InjectedSavedSearchesProps>(
+  WrappedComponent: React.ComponentType<P>
+) {
+  return (
+    props: Omit<P, keyof InjectedSavedSearchesProps> & Partial<InjectedSavedSearchesProps>
+  ) => {
+    const organization = useOrganization();
+    const {data: savedSearches, isLoading} = useFetchSavedSearchesForOrg({
+      orgSlug: organization.slug,
+    });
+    const selectedSavedSearch = useSelectedSavedSearch();
+
+    return (
+      <WrappedComponent
+        {...(props as P)}
+        savedSearches={props.savedSearches ?? savedSearches}
+        savedSearchLoading={props.savedSearchLoading ?? isLoading}
+        savedSearch={props.savedSearch ?? selectedSavedSearch}
+      />
+    );
+  };
+}
+
+/**
  * Wrap a component with saved issue search data from the store.
  */
-function withSavedSearches<P extends InjectedSavedSearchesProps>(
+function withSavedSearchesV1<P extends InjectedSavedSearchesProps>(
   WrappedComponent: React.ComponentType<P>
 ) {
   class WithSavedSearches extends Component<
@@ -84,6 +114,28 @@ function withSavedSearches<P extends InjectedSavedSearchesProps>(
   }
 
   return WithSavedSearches;
+}
+
+/**
+ * Temporary wrapper that provides saved searches data from the store or react-query,
+ * depending on the issue-list-saved-searches-v2 feature flag.
+ */
+function withSavedSearches<P extends InjectedSavedSearchesProps>(
+  WrappedComponent: React.ComponentType<P>
+) {
+  return (
+    props: Omit<P, keyof InjectedSavedSearchesProps> & Partial<InjectedSavedSearchesProps>
+  ) => {
+    const organization = useOrganization();
+
+    const WithSavedSearchesComponent = useMemo(() => {
+      return organization.features.includes('issue-list-saved-searches-v2')
+        ? withSavedSearchesV2(WrappedComponent)
+        : withSavedSearchesV1(WrappedComponent);
+    }, [organization]);
+
+    return <WithSavedSearchesComponent {...props} />;
+  };
 }
 
 export default withSavedSearches;

--- a/static/app/views/issueList/mutations/useUnpinSearch.tsx
+++ b/static/app/views/issueList/mutations/useUnpinSearch.tsx
@@ -1,6 +1,6 @@
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
-import {SavedSearch, SavedSearchType, SavedSearchVisibility} from 'sentry/types';
+import {SavedSearch, SavedSearchType} from 'sentry/types';
 import {useMutation, UseMutationOptions, useQueryClient} from 'sentry/utils/queryClient';
 import RequestError from 'sentry/utils/requestError/requestError';
 import useApi from 'sentry/utils/useApi';
@@ -39,15 +39,14 @@ export const useUnpinSearch = (
             return oldData;
           }
 
-          return oldData.filter(
-            search => search.visibility === SavedSearchVisibility.OwnerPinned
-          );
+          return oldData.filter(search => !search.isPinned);
         }
       );
+      addSuccessMessage(t('Successfully removed Issues default'));
       options.onSuccess?.(savedSearch, variables, context);
     },
     onError: (error, variables, context) => {
-      addErrorMessage(t('Failed to unpin search.'));
+      addErrorMessage(t('Unable to remove Issues default'));
       options.onError?.(error, variables, context);
     },
   });

--- a/static/app/views/issueList/overview.spec.jsx
+++ b/static/app/views/issueList/overview.spec.jsx
@@ -1162,8 +1162,8 @@ describe('IssueList', function () {
   });
 
   describe('render states', function () {
-    it('displays the loading icon', function () {
-      render(<IssueListOverview {...routerProps} {...props} />, {
+    it('displays the loading icon when saved searches are loading', function () {
+      render(<IssueListOverview {...routerProps} {...props} savedSearchLoading />, {
         context: routerContext,
       });
       expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
@@ -1175,13 +1175,9 @@ describe('IssueList', function () {
         status: 500,
         statusCode: 500,
       });
-      const {rerender} = render(
-        <IssueListOverview {...routerProps} {...props} savedSearchLoading />,
-        {context: routerContext}
-      );
-      rerender(
-        <IssueListOverview {...routerProps} {...props} savedSearchLoading={false} />
-      );
+      render(<IssueListOverview {...routerProps} {...props} />, {
+        context: routerContext,
+      });
 
       expect(await screen.findByTestId('loading-error')).toBeInTheDocument();
     });
@@ -1194,14 +1190,7 @@ describe('IssueList', function () {
           Link: DEFAULT_LINKS_HEADER,
         },
       });
-      const {rerender} = render(
-        <IssueListOverview {...routerProps} {...props} savedSearchLoading />,
-        {context: routerContext}
-      );
-
-      rerender(
-        <IssueListOverview {...routerProps} {...props} savedSearchLoading={false} />
-      );
+      render(<IssueListOverview {...routerProps} {...props} />, {context: routerContext});
 
       expect(
         await screen.findByText(/We couldn't find any issues that matched your filters/i)
@@ -1217,16 +1206,8 @@ describe('IssueList', function () {
         },
       });
 
-      const {rerender} = render(
-        <IssueListOverview {...routerProps} {...props} savedSearchLoading />,
-        {context: routerContext}
-      );
+      render(<IssueListOverview {...routerProps} {...props} />, {context: routerContext});
 
-      rerender(
-        <IssueListOverview {...routerProps} {...props} savedSearchLoading={false} />
-      );
-
-      await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
       userEvent.type(screen.getByRole('textbox'), ' level:error{enter}');
 
       expect(
@@ -1247,7 +1228,6 @@ describe('IssueList', function () {
 
       const defaultProps = {
         ...props,
-        savedSearchLoading: true,
         useOrgSavedSearches: true,
         selection: {
           projects: [],
@@ -1263,16 +1243,11 @@ describe('IssueList', function () {
         }),
         ...moreProps,
       };
-      const {rerender} = render(
-        <IssueListOverview {...defaultProps} savedSearchLoading />,
-        {context: routerContext}
-      );
-
-      rerender(<IssueListOverview {...defaultProps} savedSearchLoading={false} />);
+      render(<IssueListOverview {...defaultProps} />, {
+        context: routerContext,
+      });
 
       await waitForElementToBeRemoved(() => screen.getByTestId('loading-indicator'));
-
-      return rerender;
     };
 
     it('displays when no projects selected and all projects user is member of, does not have first event', async function () {
@@ -1491,10 +1466,9 @@ describe('IssueList', function () {
     };
 
     const {routerContext: newRouterContext} = initializeOrg();
-    const {rerender} = render(<IssueListOverview {...props} savedSearchLoading />, {
+    render(<IssueListOverview {...props} />, {
       context: newRouterContext,
     });
-    rerender(<IssueListOverview {...props} savedSearchLoading={false} />);
 
     expect(
       screen.getByText(textWithMarkupMatcher('Showing 25 of 500 issues'))
@@ -1508,7 +1482,6 @@ describe('IssueList', function () {
         results: true,
       },
     });
-    rerender(<IssueListOverview {...props} />);
 
     expect(
       screen.getByText(textWithMarkupMatcher('Showing 25 of 500 issues'))

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -188,7 +188,12 @@ class IssueListOverview extends Component<Props, State> {
 
     // Start by getting searches first so if the user is on a saved search
     // or they have a pinned search we load the correct data the first time.
-    this.fetchSavedSearches();
+    // But if searches are already there, we can go right to fetching issues
+    if (this.props.savedSearchLoading) {
+      this.fetchSavedSearches();
+    } else {
+      this.fetchData();
+    }
     this.fetchTags();
     this.fetchMemberList();
     // let custom analytics take control
@@ -380,7 +385,9 @@ class IssueListOverview extends Component<Props, State> {
   fetchSavedSearches() {
     const {organization, api} = this.props;
 
-    fetchSavedSearches(api, organization.slug);
+    if (!organization.features.includes('issue-list-saved-searches-v2')) {
+      fetchSavedSearches(api, organization.slug);
+    }
   }
 
   fetchStats = (groups: string[]) => {

--- a/static/app/views/issueList/utils/useSelectedSavedSearch.tsx
+++ b/static/app/views/issueList/utils/useSelectedSavedSearch.tsx
@@ -1,0 +1,20 @@
+import {SavedSearch} from 'sentry/types';
+import useOrganization from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
+
+// Uses the saved search ID in the URL and the cached response to return
+// the selected saved search object
+export const useSelectedSavedSearch = (): SavedSearch | null => {
+  const organization = useOrganization();
+  const params = useParams();
+
+  const {data: savedSearches} = useFetchSavedSearchesForOrg(
+    {orgSlug: organization.slug},
+    {notifyOnChangeProps: ['data']}
+  );
+
+  const selectedSearchId: string | undefined = params.searchId;
+
+  return savedSearches?.find(({id}) => id === selectedSearchId) ?? null;
+};

--- a/static/app/views/issueList/utils/useSelectedSavedSearch.tsx
+++ b/static/app/views/issueList/utils/useSelectedSavedSearch.tsx
@@ -1,4 +1,7 @@
+import isNil from 'lodash/isNil';
+
 import {SavedSearch} from 'sentry/types';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFetchSavedSearchesForOrg';
@@ -7,6 +10,7 @@ import {useFetchSavedSearchesForOrg} from 'sentry/views/issueList/queries/useFet
 // the selected saved search object
 export const useSelectedSavedSearch = (): SavedSearch | null => {
   const organization = useOrganization();
+  const location = useLocation();
   const params = useParams();
 
   const {data: savedSearches} = useFetchSavedSearchesForOrg(
@@ -15,6 +19,14 @@ export const useSelectedSavedSearch = (): SavedSearch | null => {
   );
 
   const selectedSearchId: string | undefined = params.searchId;
+
+  // If there's no direct saved search being requested (via URL route)
+  // *AND* there's no query in URL, then check if there is pinned search
+  //
+  // Note: Don't use pinned searches when there is an empty query (query === empty string)
+  if (!selectedSearchId && isNil(location.query.query)) {
+    return savedSearches?.find(search => search.isPinned) ?? null;
+  }
 
   return savedSearches?.find(({id}) => id === selectedSearchId) ?? null;
 };


### PR DESCRIPTION
SavedSearchesStore is still used without the `issue-list-saved-searches-v2` flag, but with it on it uses react-query entirely!