### PR TITLE
test(modal): use paste instead of type

### DIFF
--- a/static/app/components/modals/inviteMembersModal/index.spec.jsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.jsx
@@ -77,10 +77,10 @@ describe('InviteMembersModal', function () {
 
     const emailInputs = screen.getAllByRole('textbox', {name: 'Email Addresses'});
 
-    userEvent.type(emailInputs[0], 'test@test.com');
+    userEvent.paste(emailInputs[0], 'test@test.com');
     userEvent.tab();
 
-    userEvent.type(emailInputs[1], 'test@test.com');
+    userEvent.paste(emailInputs[1], 'test@test.com');
     userEvent.tab();
 
     expect(screen.getByText('Duplicate emails between invite rows.')).toBeInTheDocument();
@@ -91,10 +91,10 @@ describe('InviteMembersModal', function () {
 
     const emailInput = screen.getByRole('textbox', {name: 'Email Addresses'});
 
-    userEvent.type(emailInput, 'test@test.com');
+    userEvent.paste(emailInput, 'test@test.com');
     userEvent.tab();
 
-    userEvent.type(emailInput, 'test2@test.com');
+    userEvent.paste(emailInput, 'test2@test.com');
     userEvent.tab();
 
     expect(screen.getByRole('button', {name: 'Send invites (2)'})).toBeInTheDocument();
@@ -124,12 +124,12 @@ describe('InviteMembersModal', function () {
     const roleInputs = screen.getAllByRole('textbox', {name: 'Role'});
     const teamInputs = screen.getAllByRole('textbox', {name: 'Add to Team'});
 
-    userEvent.type(emailInputs[0], 'test1@test.com');
+    userEvent.paste(emailInputs[0], 'test1@test.com');
     userEvent.tab();
     await selectEvent.select(roleInputs[0], 'Admin');
     await selectEvent.select(teamInputs[0], '#team-slug');
 
-    userEvent.type(emailInputs[1], 'test2@test.com');
+    userEvent.paste(emailInputs[1], 'test2@test.com');
     userEvent.tab();
 
     userEvent.click(screen.getByRole('button', {name: 'Send invites (2)'}));
@@ -187,7 +187,7 @@ describe('InviteMembersModal', function () {
 
     render(<InviteMembersModal {...modalProps} organization={org} />);
 
-    userEvent.type(screen.getByRole('textbox', {name: 'Email Addresses'}), 'bademail');
+    userEvent.paste(screen.getByRole('textbox', {name: 'Email Addresses'}), 'bademail');
     userEvent.tab();
     userEvent.click(screen.getByRole('button', {name: 'Send invite'}));
 


### PR DESCRIPTION
These tests are very slow as the component being re-rendered is slow + we are typing in a lot of characters via userEvent.type. We can mitigate the number of rerenders by using keyboardEvent.paste

https://sentry.io/organizations/sentry/profiling/profile/jest/adcdbeab6a8c45a3b30f144658348cf6/flamechart/?colorCoding=by+symbol+name&query=&sorting=call+order&tid=0&view=top+down&xAxis=standalone

![image](https://user-images.githubusercontent.com/9317857/200666653-77e2b0ce-191a-4c68-a3e4-f87c46d49399.png)

