### PR TITLE
fix(routes): Getting started routes are not legacy routes

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1514,9 +1514,7 @@ function buildRoutes() {
     </Route>
   );
 
-  // XXX(epurkhiser): These also exist in the legacyOrganizationRootRoutes. Not
-  // sure which one here is more correct.
-  const legacyGettingStartedRoutes = (
+  const gettingStartedRoutes = (
     <Route
       path="/:orgId/:projectId/getting-started/"
       component={make(() => import('sentry/views/projectInstall/gettingStarted'))}
@@ -1665,8 +1663,8 @@ function buildRoutes() {
       {performanceRoutes}
       {profilingRoutes}
       {adminManageRoutes}
+      {gettingStartedRoutes}
       {legacyOrganizationRootRoutes}
-      {legacyGettingStartedRoutes}
       {legacyOrgRedirects}
     </Route>
   );


### PR DESCRIPTION
The `/:orgId/:projectId/getting-started/*` are actually not legacy routes. They're still used as landing pages after creating a new project. 

This was cherry-picked from https://github.com/getsentry/sentry/pull/40215.