### PR TITLE
feat(issue-stream): Use new tab component

### DIFF
--- a/static/app/components/tabs/tabList.tsx
+++ b/static/app/components/tabs/tabList.tsx
@@ -121,14 +121,16 @@ function BaseTabList({hideBorder = false, className, ...props}: TabListProps) {
       (a, b) => sortedKeys.indexOf(a) - sortedKeys.indexOf(b)
     );
 
-    return sortedOverflowTabs.map(key => {
-      const item = state.collection.getItem(key);
-      return {
-        value: key,
-        label: item.props.children,
-        disabled: item.props.disabled,
-      };
-    });
+    return sortedOverflowTabs
+      .filter(key => state.collection.getItem(key))
+      .map(key => {
+        const item = state.collection.getItem(key);
+        return {
+          value: key,
+          label: item.props.children,
+          disabled: item.props.disabled,
+        };
+      });
   }, [state.collection, overflowTabs]);
 
   return (

--- a/static/app/views/issueList/header.tsx
+++ b/static/app/views/issueList/header.tsx
@@ -1,4 +1,5 @@
-import {InjectedRouter} from 'react-router';
+import {ReactNode} from 'react';
+import {InjectedRouter, Link} from 'react-router';
 import styled from '@emotion/styled';
 
 import Badge from 'sentry/components/badge';
@@ -6,8 +7,8 @@ import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import GlobalEventProcessingAlert from 'sentry/components/globalEventProcessingAlert';
 import * as Layout from 'sentry/components/layouts/thirds';
-import Link from 'sentry/components/links/link';
 import QueryCount from 'sentry/components/queryCount';
+import {Item, TabList} from 'sentry/components/tabs';
 import Tooltip from 'sentry/components/tooltip';
 import {SLOW_TOOLTIP_DELAY} from 'sentry/constants';
 import {IconPause, IconPlay, IconStar} from 'sentry/icons';
@@ -21,7 +22,7 @@ import IssueListSetAsDefault from 'sentry/views/issueList/issueListSetAsDefault'
 import SavedSearchTab from './savedSearchTab';
 import {getTabs, IssueSortOptions, Query, QueryCounts, TAB_MAX_COUNT} from './utils';
 
-type Props = {
+type IssueListHeaderProps = {
   displayReprocessingTab: boolean;
   isSavedSearchesOpen: boolean;
   onRealtimeChange: (realtime: boolean) => void;
@@ -36,6 +37,40 @@ type Props = {
   sort: string;
   queryCount?: number;
 } & React.ComponentProps<typeof SavedSearchTab>;
+
+type IssueListHeaderTabProps = {
+  name: string;
+  query: string;
+  count?: number;
+  hasMore?: boolean;
+  tooltipHoverable?: boolean;
+  tooltipTitle?: ReactNode;
+};
+
+function IssueListHeaderTabContent({
+  count = 0,
+  hasMore = false,
+  name,
+  query,
+  tooltipHoverable,
+  tooltipTitle,
+}: IssueListHeaderTabProps) {
+  return (
+    <Tooltip
+      title={tooltipTitle}
+      position="bottom"
+      isHoverable={tooltipHoverable}
+      delay={SLOW_TOOLTIP_DELAY}
+    >
+      {name}{' '}
+      {count > 0 && (
+        <Badge type={query === Query.FOR_REVIEW && count > 0 ? 'review' : 'default'}>
+          <QueryCount hideParens count={count} max={hasMore ? TAB_MAX_COUNT : 1000} />
+        </Badge>
+      )}
+    </Tooltip>
+  );
+}
 
 function IssueListHeader({
   organization,
@@ -54,7 +89,7 @@ function IssueListHeader({
   router,
   displayReprocessingTab,
   selectedProjectIds,
-}: Props) {
+}: IssueListHeaderProps) {
   const {projects} = useProjects();
   const tabs = getTabs(organization);
   const visibleTabs = displayReprocessingTab
@@ -115,61 +150,110 @@ function IssueListHeader({
         </ButtonBar>
       </Layout.HeaderActions>
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
-      <Layout.HeaderNavTabs underlined>
-        {visibleTabs.map(
-          ([tabQuery, {name: queryName, tooltipTitle, tooltipHoverable}]) => {
-            const to = {
-              query: {
-                ...queryParms,
-                query: tabQuery,
-                sort: tabQuery === Query.FOR_REVIEW ? IssueSortOptions.INBOX : sortParam,
-              },
-              pathname: `/organizations/${organization.slug}/issues/`,
-            };
+      {organization.features.includes('issue-list-saved-searches-v2') ? (
+        <TabList
+          onSelectionChange={key => trackTabClick(key.toString())}
+          selectedKey={query}
+          hideBorder
+        >
+          {[
+            ...visibleTabs.map(
+              ([tabQuery, {name: queryName, tooltipTitle, tooltipHoverable}]) => {
+                const to = {
+                  query: {
+                    ...queryParms,
+                    query: tabQuery,
+                    sort:
+                      tabQuery === Query.FOR_REVIEW ? IssueSortOptions.INBOX : sortParam,
+                  },
+                  pathname: `/organizations/${organization.slug}/issues/`,
+                };
 
-            return (
-              <li key={tabQuery} className={query === tabQuery ? 'active' : ''}>
-                <Link to={to} onClick={() => trackTabClick(tabQuery)}>
-                  <Tooltip
-                    title={tooltipTitle}
-                    position="bottom"
-                    isHoverable={tooltipHoverable}
-                    delay={SLOW_TOOLTIP_DELAY}
-                  >
-                    {queryName}{' '}
-                    {queryCounts[tabQuery]?.count > 0 && (
-                      <Badge
-                        type={
-                          tabQuery === Query.FOR_REVIEW &&
-                          queryCounts[tabQuery]!.count > 0
-                            ? 'review'
-                            : 'default'
-                        }
-                      >
-                        <QueryCount
-                          hideParens
-                          count={queryCounts[tabQuery].count}
-                          max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
-                        />
-                      </Badge>
-                    )}
-                  </Tooltip>
-                </Link>
-              </li>
-            );
-          }
-        )}
-        <SavedSearchTab
-          organization={organization}
-          query={query}
-          sort={sort}
-          savedSearchList={savedSearchList}
-          onSavedSearchSelect={onSavedSearchSelect}
-          onSavedSearchDelete={onSavedSearchDelete}
-          isActive={savedSearchTabActive}
-          queryCount={queryCount}
-        />
-      </Layout.HeaderNavTabs>
+                return (
+                  <Item key={tabQuery} to={to}>
+                    <IssueListHeaderTabContent
+                      tooltipTitle={tooltipTitle}
+                      tooltipHoverable={tooltipHoverable}
+                      name={queryName}
+                      count={queryCounts[tabQuery]?.count}
+                      hasMore={queryCounts[tabQuery]?.hasMore}
+                      query={tabQuery}
+                    />
+                  </Item>
+                );
+              }
+            ),
+            <Item
+              hidden={!savedSearchTabActive}
+              key={query}
+              to={{query: queryParms, pathname: location.pathname}}
+            >
+              <IssueListHeaderTabContent
+                name={savedSearch?.name ?? t('Custom Search')}
+                count={queryCount}
+                query={query}
+              />
+            </Item>,
+          ]}
+        </TabList>
+      ) : (
+        <Layout.HeaderNavTabs underlined>
+          {visibleTabs.map(
+            ([tabQuery, {name: queryName, tooltipTitle, tooltipHoverable}]) => {
+              const to = {
+                query: {
+                  ...queryParms,
+                  query: tabQuery,
+                  sort:
+                    tabQuery === Query.FOR_REVIEW ? IssueSortOptions.INBOX : sortParam,
+                },
+                pathname: `/organizations/${organization.slug}/issues/`,
+              };
+
+              return (
+                <li key={tabQuery} className={query === tabQuery ? 'active' : ''}>
+                  <Link to={to} onClick={() => trackTabClick(tabQuery)}>
+                    <Tooltip
+                      title={tooltipTitle}
+                      position="bottom"
+                      isHoverable={tooltipHoverable}
+                      delay={SLOW_TOOLTIP_DELAY}
+                    >
+                      {queryName}{' '}
+                      {queryCounts[tabQuery]?.count > 0 && (
+                        <Badge
+                          type={
+                            tabQuery === Query.FOR_REVIEW &&
+                            queryCounts[tabQuery]!.count > 0
+                              ? 'review'
+                              : 'default'
+                          }
+                        >
+                          <QueryCount
+                            hideParens
+                            count={queryCounts[tabQuery].count}
+                            max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
+                          />
+                        </Badge>
+                      )}
+                    </Tooltip>
+                  </Link>
+                </li>
+              );
+            }
+          )}
+          <SavedSearchTab
+            organization={organization}
+            query={query}
+            sort={sort}
+            savedSearchList={savedSearchList}
+            onSavedSearchSelect={onSavedSearchSelect}
+            onSavedSearchDelete={onSavedSearchDelete}
+            isActive={savedSearchTabActive}
+            queryCount={queryCount}
+          />
+        </Layout.HeaderNavTabs>
+      )}
     </Layout.Header>
   );
 }

--- a/static/app/views/issueList/header.tsx
+++ b/static/app/views/issueList/header.tsx
@@ -47,6 +47,8 @@ type IssueListHeaderTabProps = {
   tooltipTitle?: ReactNode;
 };
 
+const EXTRA_TAB_KEY = 'extra-tab-key';
+
 function IssueListHeaderTabContent({
   count = 0,
   hasMore = false,
@@ -152,8 +154,10 @@ function IssueListHeader({
       <StyledGlobalEventProcessingAlert projects={selectedProjects} />
       {organization.features.includes('issue-list-saved-searches-v2') ? (
         <TabList
-          onSelectionChange={key => trackTabClick(key.toString())}
-          selectedKey={query}
+          onSelectionChange={key =>
+            trackTabClick(key === EXTRA_TAB_KEY ? query : key.toString())
+          }
+          selectedKey={savedSearchTabActive ? EXTRA_TAB_KEY : query}
           hideBorder
         >
           {[
@@ -185,7 +189,7 @@ function IssueListHeader({
             ),
             <Item
               hidden={!savedSearchTabActive}
-              key={query}
+              key={EXTRA_TAB_KEY}
               to={{query: queryParms, pathname: location.pathname}}
               textValue={savedSearch?.name ?? t('Custom Search')}
             >

--- a/static/app/views/issueList/header.tsx
+++ b/static/app/views/issueList/header.tsx
@@ -170,7 +170,7 @@ function IssueListHeader({
                 };
 
                 return (
-                  <Item key={tabQuery} to={to}>
+                  <Item key={tabQuery} to={to} textValue={queryName}>
                     <IssueListHeaderTabContent
                       tooltipTitle={tooltipTitle}
                       tooltipHoverable={tooltipHoverable}
@@ -187,6 +187,7 @@ function IssueListHeader({
               hidden={!savedSearchTabActive}
               key={query}
               to={{query: queryParms, pathname: location.pathname}}
+              textValue={savedSearch?.name ?? t('Custom Search')}
             >
               <IssueListHeaderTabContent
                 name={savedSearch?.name ?? t('Custom Search')}

--- a/static/app/views/issueList/savedSearchTab.tsx
+++ b/static/app/views/issueList/savedSearchTab.tsx
@@ -28,7 +28,7 @@ type Props = {
   queryCount?: number;
 };
 
-function SavedSearchTabDropdown({
+function SavedSearchTab({
   isActive,
   organization,
   savedSearchList,
@@ -170,46 +170,7 @@ function SavedSearchTabDropdown({
   );
 }
 
-function SavedSearchTab(props: Props) {
-  if (!props.organization.features.includes('issue-list-saved-searches-v2')) {
-    return <SavedSearchTabDropdown {...props} />;
-  }
-
-  if (!props.isActive) {
-    return null;
-  }
-
-  const savedSearch = props.savedSearchList.find(
-    search => search.query === props.query && search.sort === props.sort
-  );
-
-  return (
-    <li data-test-id="saved-search-tab">
-      <StyledTab>
-        <span>{savedSearch ? savedSearch.name : t('Custom Search')}&nbsp;</span>
-        {props.queryCount && props.queryCount > 0 ? (
-          <Badge>
-            <QueryCount hideParens count={props.queryCount} max={1000} />
-          </Badge>
-        ) : null}
-      </StyledTab>
-    </li>
-  );
-}
-
 export default SavedSearchTab;
-
-const StyledTab = styled('div')`
-  display: flex;
-  height: 1.25rem;
-  align-items: center;
-  box-sizing: content-box;
-  padding: ${space(1)} 0;
-  color: ${p => p.theme.textColor};
-  border-bottom-width: 4px;
-  border-bottom-style: solid;
-  border-bottom-color: ${p => p.theme.active};
-`;
 
 const StyledCompactSelect = styled(CompactSelect)<{isActive?: boolean}>`
   && {


### PR DESCRIPTION
Uses the new tab component when `issue-list-saved-searches-v2` is enabled, since that gets rid of the dropdown. A bit messy right now, but we can delete all the excess code when we retire the feature flag.