### PR TITLE
ref: remove installation of pip-tools in getsentry bump

### DIFF
--- a/.github/workflows/bump-sentry-in-getsentry.yml
+++ b/.github/workflows/bump-sentry-in-getsentry.yml
@@ -28,12 +28,6 @@ jobs:
           # who can write to getsentry and is SAML+SSO ready.
           token: ${{ secrets.BUMP_SENTRY_TOKEN }}
 
-      - name: install dependencies
-        shell: bash
-        run: |
-          cd getsentry
-          python -m pip install -q --constraint requirements-dev-frozen.txt pip-tools
-
       - name: bump-sentry ${{ github.sha }}
         shell: bash
         run: |


### PR DESCRIPTION
no longer needed since we just copy dependencies over


needs https://github.com/getsentry/getsentry/pull/8826 to land first!