### PR TITLE
fix(replays): Remove `undefined` from segment output

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
+++ b/src/sentry/replays/endpoints/project_replay_recording_segment_index.py
@@ -97,7 +97,10 @@ class ProjectReplayRecordingSegmentIndexEndpoint(ProjectEndpoint):
         for i, file in enumerate(recording_segments):
             if self.is_compressed(file):
                 buffer = file.read()
-                yield zlib.decompress(buffer, zlib.MAX_WBITS | 32)
+                decompressed = zlib.decompress(buffer, zlib.MAX_WBITS | 32)
+                if decompressed == "undefined":
+                    yield ""
+                yield decompressed
             else:
                 yield file.read().decode("utf-8")
 


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry-replay/pull/284, guard against `undefined` on the server side, before we send out the segment data.

