### PR TITLE
feat(replays): Add `session-replay-sdk-errors-only` feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1169,6 +1169,7 @@ SENTRY_FEATURES = {
     "organizations:session-replay": False,
     # Enable experimental session replay SDK for recording on Sentry
     "organizations:session-replay-sdk": False,
+    "organizations:session-replay-sdk-errors-only": False,
     # Enable experimental session replay UI
     "organizations:session-replay-ui": False,
     # Enable Session Stats down to a minute resolution

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -153,6 +153,7 @@ default_manager.add("organizations:sentry-functions", OrganizationFeature, False
 default_manager.add("organizations:server-side-sampling-allow-incompatible-platforms", OrganizationFeature, True)
 default_manager.add("organizations:session-replay", OrganizationFeature)
 default_manager.add("organizations:session-replay-sdk", OrganizationFeature, True)
+default_manager.add("organizations:session-replay-sdk-errors-only", OrganizationFeature, True)
 default_manager.add("organizations:session-replay-ui", OrganizationFeature, True)
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)
 default_manager.add("organizations:slack-overage-notifications", OrganizationFeature, True)


### PR DESCRIPTION
Used for Session Replays
