### PR TITLE
ref(monitors): Remove logging statements

### DIFF
--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.db import transaction
 from rest_framework import serializers
 from rest_framework.request import Request
@@ -12,8 +10,6 @@ from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, ProjectKey
-
-logger = logging.getLogger("sentry.monitors")
 
 
 class CheckInSerializer(serializers.Serializer):
@@ -80,13 +76,6 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
                 status=getattr(CheckInStatus, result["status"].upper()),
             )
             if checkin.status == CheckInStatus.ERROR and monitor.status != MonitorStatus.DISABLED:
-                logger.info(
-                    "monitor.error-checkin",
-                    extra={
-                        "monitor_id": monitor.id,
-                        "project_id": project.id,
-                    },
-                )
                 if not monitor.mark_failed(last_checkin=checkin.date_added):
                     if isinstance(request.auth, ProjectKey):
                         return self.respond(status=200)

--- a/src/sentry/models/monitor.py
+++ b/src/sentry/models/monitor.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime, timedelta
 from uuid import uuid4
 
@@ -28,8 +27,6 @@ SCHEDULE_INTERVAL_MAP = {
     "hour": rrule.HOURLY,
     "minute": rrule.MINUTELY,
 }
-
-logger = logging.getLogger("sentry.monitors")
 
 
 def generate_secret():
@@ -181,15 +178,6 @@ class Monitor(Model):
         else:
             next_checkin_base = last_checkin
 
-        logger.info(
-            "monitor.failed.last-checkin",
-            extra={
-                "monitor_id": self.id,
-                "current_last_checkin": last_checkin,
-                "monitor_last_checkin": self.last_checkin,
-            },
-        )
-
         affected = (
             type(self)
             .objects.filter(
@@ -202,14 +190,6 @@ class Monitor(Model):
             )
         )
         if not affected:
-            logger.info(
-                "monitor.failed.not-affected",
-                extra={
-                    "monitor_id": self.id,
-                    "next_checkin_base": next_checkin_base,
-                    "monitor_next_checkin": self.next_checkin,
-                },
-            )
             return False
 
         event_manager = EventManager(
@@ -223,13 +203,5 @@ class Monitor(Model):
         event_manager.normalize()
         data = event_manager.get_data()
         insert_data_to_database_legacy(data)
-        logger.info(
-            "monitor.failed.event-created",
-            extra={
-                "monitor_id": self.id,
-                "project_id": self.project_id,
-                "event_id": data["event_id"],
-            },
-        )
         monitor_failed.send(monitor=self, sender=type(self))
         return True


### PR DESCRIPTION
After investigating and fixing https://github.com/getsentry/sentry/pull/40980 why monitor error events weren't being created we can revert the logger statements we added https://github.com/getsentry/sentry/pull/40932 for debugging purposes.