### PR TITLE
feat(autodoc): Retrieve operation ID and description from docstring

### DIFF
--- a/src/sentry/apidocs/schema.py
+++ b/src/sentry/apidocs/schema.py
@@ -1,7 +1,28 @@
 from drf_spectacular.openapi import AutoSchema
+from drf_spectacular.plumbing import get_doc
 
 
 class SentrySchema(AutoSchema):
     """DRF Documentation Schema for sentry endpoints"""
 
-    pass
+    @property
+    def view_func(self):
+        return getattr(self.view, self.method.lower())
+
+    def get_operation_id(self):
+        """
+        First line of an endpoint's docstring is the operation ID
+        """
+        docstring = self.view_func.__doc__.strip().splitlines()
+        if len(docstring) > 1:
+            return docstring[0]
+        return super().get_operation_id()
+
+    def get_description(self):
+        """
+        Docstring is used as a description for the endpoint. The operation ID is included in this.
+        """
+        docstring = self.view_func.__doc__.strip().splitlines()
+        if len(docstring) > 1:
+            return get_doc(self.view_func)
+        return super().get_description()

--- a/src/sentry/apidocs/schema.py
+++ b/src/sentry/apidocs/schema.py
@@ -9,7 +9,7 @@ class SentrySchema(AutoSchema):
     def view_func(self):
         return getattr(self.view, self.method.lower())
 
-    def get_operation_id(self):
+    def get_operation_id(self) -> str:
         """
         First line of an endpoint's docstring is the operation ID
         """
@@ -18,7 +18,7 @@ class SentrySchema(AutoSchema):
             return docstring[0]
         return super().get_operation_id()
 
-    def get_description(self):
+    def get_description(self) -> str:
         """
         Docstring is used as a description for the endpoint. The operation ID is included in this.
         """

--- a/src/sentry/apidocs/schema.py
+++ b/src/sentry/apidocs/schema.py
@@ -13,7 +13,7 @@ class SentrySchema(AutoSchema):
         """
         First line of an endpoint's docstring is the operation ID
         """
-        docstring = self.view_func.__doc__.strip().splitlines()
+        docstring = get_doc(self.view_func).splitlines()
         if len(docstring) > 1:
             return docstring[0]
         return super().get_operation_id()
@@ -22,7 +22,7 @@ class SentrySchema(AutoSchema):
         """
         Docstring is used as a description for the endpoint. The operation ID is included in this.
         """
-        docstring = self.view_func.__doc__.strip().splitlines()
-        if len(docstring) > 1:
-            return get_doc(self.view_func)
+        docstring = get_doc(self.view_func)
+        if len(docstring.splitlines()) > 1:
+            return docstring
         return super().get_description()

--- a/src/sentry/apidocs/schema.py
+++ b/src/sentry/apidocs/schema.py
@@ -6,23 +6,23 @@ class SentrySchema(AutoSchema):
     """DRF Documentation Schema for sentry endpoints"""
 
     @property
-    def view_func(self):
+    def view_func(self):  # type: ignore
         return getattr(self.view, self.method.lower())
 
     def get_operation_id(self) -> str:
         """
-        First line of an endpoint's docstring is the operation ID
+        First line of an endpoint's docstring is the operation IDZ
         """
-        docstring = get_doc(self.view_func).splitlines()
+        docstring = get_doc(self.view_func).splitlines()  # type: ignore
         if len(docstring) > 1:
-            return docstring[0]
-        return super().get_operation_id()
+            return docstring[0]  # type: ignore
+        return super().get_operation_id()  # type: ignore
 
     def get_description(self) -> str:
         """
         Docstring is used as a description for the endpoint. The operation ID is included in this.
         """
-        docstring = get_doc(self.view_func)
+        docstring = get_doc(self.view_func)  # type: ignore
         if len(docstring.splitlines()) > 1:
-            return docstring
-        return super().get_description()
+            return docstring  # type: ignore
+        return super().get_description()  # type: ignore

--- a/tests/sentry/apidocs/test_schema.py
+++ b/tests/sentry/apidocs/test_schema.py
@@ -17,3 +17,48 @@ def test_simple():
 
     schema = generate_schema("foo", view=ExampleEndpoint)
     assert schema["paths"]["/foo"]["get"]["operationId"] == op_id
+
+
+def test_description():
+    class ExampleEndpoint(Endpoint):
+        def get(self, request, *args, **kwargs):
+            """
+            Operation ID
+
+            Description Line 1
+            Description Line 2
+
+            Description Line 3
+
+
+            """
+            pass
+
+        @extend_schema(operation_id="Ignore Docstring")
+        def post(self, request):
+            """
+            Autoschema Description
+            Extended Lines
+            """
+            pass
+
+        def put(self, request):
+            """
+            Autoschema Description
+            """
+            pass
+
+    schema = generate_schema("foo", view=ExampleEndpoint)
+    assert schema["paths"]["/foo"]["get"]["operationId"] == "Operation ID"
+    assert (
+        schema["paths"]["/foo"]["get"]["description"]
+        == "Operation ID\n\nDescription Line 1\nDescription Line 2\n\nDescription Line 3"
+    )
+
+    assert schema["paths"]["/foo"]["post"]["operationId"] == "Ignore Docstring"
+    assert (
+        schema["paths"]["/foo"]["post"]["description"] == "Autoschema Description\nExtended Lines"
+    )
+
+    assert schema["paths"]["/foo"]["put"]["operationId"] != "Autoschema Description"
+    assert schema["paths"]["/foo"]["put"]["description"] == "Autoschema Description"

--- a/tests/sentry/apidocs/test_schema.py
+++ b/tests/sentry/apidocs/test_schema.py
@@ -21,6 +21,8 @@ def test_simple():
 
 def test_description():
     class ExampleEndpoint(Endpoint):
+        permission_classes = ()
+
         def get(self, request, *args, **kwargs):
             """
 

--- a/tests/sentry/apidocs/test_schema.py
+++ b/tests/sentry/apidocs/test_schema.py
@@ -23,6 +23,7 @@ def test_description():
     class ExampleEndpoint(Endpoint):
         def get(self, request, *args, **kwargs):
             """
+
             Operation ID
 
             Description Line 1
@@ -46,6 +47,10 @@ def test_description():
             """
             Autoschema Description
             """
+            pass
+
+        # Should not result in an error when generating a schema
+        def delete(self, request):
             pass
 
     schema = generate_schema("foo", view=ExampleEndpoint)


### PR DESCRIPTION
This change makes it so that the operation ID and description can be extract from the docstring using the following format:

* Operation ID is the first line of the docstring
* Description is the entire docstring including the Operation ID

This does not override anything set in extend_schema. If there are fewer than 2 lines in the docstring then it falls back on default drf spectacular behavior
