### PR TITLE
fix(profiling): Fix stack (frame indices) regression

### DIFF
--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -304,8 +304,6 @@ def _process_symbolicator_results_for_sample(profile: Profile, stacktraces: List
         ) -> List[Any]:
             return stack
 
-    idx_map = {}
-
     if profile["platform"] in SHOULD_SYMBOLICATE:
         idx_map = get_frame_index_map(profile["profile"]["frames"])
 

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -313,7 +313,7 @@ def _process_symbolicator_results_for_sample(profile: Profile, stacktraces: List
     for sample in profile["profile"]["samples"]:
         stack_id = sample["stack_id"]
         if profile["platform"] in native_platforms:
-            stack = []
+            stack: List[int] = []
             for index in profile["profile"]["stacks"][stack_id]:
                 # the new stack extends the older by replacing
                 # a specific frame index with the indeces of
@@ -392,7 +392,7 @@ The sorting order is callee to caller (child to parent)
 """
 
 
-def get_frame_index_map(frames):
+def get_frame_index_map(frames: List[dict[str, Any]]) -> dict[int, List[int]]:
     counter = 0
     index_map = {}
     for i, frame in enumerate(frames):

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -393,7 +393,7 @@ The sorting order is callee to caller (child to parent)
 
 
 def get_frame_index_map(frames: List[dict[str, Any]]) -> dict[int, List[int]]:
-    index_map = {}
+    index_map: dict[int, List[int]] = {}
     for i, frame in enumerate(frames):
         original_idx = frame["original_index"]
         idx_list = index_map.get(original_idx, [])

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -393,18 +393,12 @@ The sorting order is callee to caller (child to parent)
 
 
 def get_frame_index_map(frames: List[dict[str, Any]]) -> dict[int, List[int]]:
-    counter = 0
     index_map = {}
     for i, frame in enumerate(frames):
-        if frame["status"] != "symbolicated":
-            index_map[counter] = [i]
-            counter += 1
-        else:
-            idx = index_map.get(counter, [])
-            idx.append(i)
-            index_map[counter] = idx
-            if "sym_addr" in frame:
-                counter += 1
+        original_idx = frame["original_index"]
+        idx_list = index_map.get(original_idx, [])
+        idx_list.append(i)
+        index_map[original_idx] = idx_list
     return index_map
 
 

--- a/src/sentry/profiles/task.py
+++ b/src/sentry/profiles/task.py
@@ -311,10 +311,10 @@ def _process_symbolicator_results_for_sample(profile: Profile, stacktraces: List
             new_stack: List[int] = []
             for index in stack:
                 # the new stack extends the older by replacing
-                # a specific frame index with the indeces of
+                # a specific frame index with the indices of
                 # the frames originated from the original frame
                 # should inlines be present
-                new_stack = new_stack + idx_map[index]
+                new_stack.extend(idx_map[index])
             return new_stack
 
     else:


### PR DESCRIPTION
This PR fixes a regression that was introduced when we moved to the new sample format that causes flamechart to show wrong frames whenever inlines are present in some of the samples collected.

This affects both `iOS` and `Rust` profiles.

Since we're not directly storing frames anymore for a sample but instead we have a list of frame indices, as we get a bigger "pool" of frames from `Symbolicator` due to `inlines`, the list of frame indices inside the `stack` field should be extended accordingly.