### PR TITLE
test(relay): Instrument SDK initialization to catch race [INGEST-1690]

### DIFF
--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -20,10 +20,13 @@ def post_event_with_sdk(settings, relay_server, wait_for_ingest_consumer):
     settings.SENTRY_PROJECT = 1
 
     configure_sdk()
+    assert Hub.current.client is not None
 
     wait_for_ingest_consumer = wait_for_ingest_consumer(settings)
+    assert Hub.current.client is not None
 
     def inner(*args, **kwargs):
+        assert Hub.current.client is not None
         event_id = sentry_sdk.capture_event(*args, **kwargs)
         Hub.current.client.flush()
 


### PR DESCRIPTION
We observe infrequent test failures in the relay integration test suite. The
trigger is failed SDK initialization. After initializing the SDK, there is no
client bound to the hub. This should not happen, but we do not know whether the
client is reset or not bound in the first place.

To debug this, we plan to put assertions and a monitor in place that should give
us more information on where this problem originates.

See https://sentry.io/organizations/sentry/issues/1926639047
cc @asottile-sentry 
