### PR TITLE
fix(alert-preview): check if event is not found

### DIFF
--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -119,7 +119,9 @@ def get_events(
         group_map = {event["group_id"]: event["event_id"] for event in events}
         for activity in condition_activity:
             if activity.type == ConditionActivityType.CREATE_ISSUE:
-                activity.data = {"event_id": group_map.get(activity.group_id, None)}
+                event_id = group_map.get(activity.group_id, None)
+                if event_id is not None:
+                    activity.data = {"event_id": event_id}
 
     if event_ids:
         events.extend(

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -119,7 +119,7 @@ def get_events(
         group_map = {event["group_id"]: event["event_id"] for event in events}
         for activity in condition_activity:
             if activity.type == ConditionActivityType.CREATE_ISSUE:
-                activity.data = {"event_id": group_map[activity.group_id]}
+                activity.data = {"event_id": group_map.get(activity.group_id, None)}
 
     if event_ids:
         events.extend(


### PR DESCRIPTION
Event filters will only work for plain issues right now since we only query the events table. Check if the event for a group isn't found, probably means its a performance issue.