### PR TITLE
fix (events-table) move referrer up

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.tsx
@@ -96,6 +96,7 @@ function EventsContent(props: Props) {
     <Layout.Main fullWidth>
       <Search {...props} />
       <EventsTable
+        referrer="api.performance.transaction-events"
         totalEventCount={totalEventCount}
         eventView={eventView}
         organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -168,6 +168,7 @@ describe('Performance GridEditable Table', function () {
 
     render(
       <EventsTable
+        referrer="referrer"
         totalEventCount={totalEventCount}
         eventView={eventView}
         organization={organization}
@@ -222,6 +223,7 @@ describe('Performance GridEditable Table', function () {
 
     render(
       <EventsTable
+        referrer="referrer"
         totalEventCount={totalEventCount}
         eventView={eventView}
         organization={organization}
@@ -257,6 +259,7 @@ describe('Performance GridEditable Table', function () {
 
     render(
       <EventsTable
+        referrer="referrer"
         totalEventCount={totalEventCount}
         eventView={eventView}
         organization={organization}

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -82,6 +82,7 @@ type Props = {
   eventView: EventView;
   location: Location;
   organization: Organization;
+  referrer: string;
   routes: RouteContextInterface['routes'];
   setError: (msg: string | undefined) => void;
   transactionName: string;
@@ -90,7 +91,6 @@ type Props = {
   excludedTags?: string[];
   issueId?: string;
   projectId?: string;
-  referrer?: string;
   showReplayCol?: boolean;
   totalEventCount?: string;
 };
@@ -446,7 +446,7 @@ class EventsTable extends Component<Props, State> {
           orgSlug={organization.slug}
           location={location}
           setError={error => setError(error?.message)}
-          referrer={referrer || 'api.performance.transaction-events'}
+          referrer={referrer}
           useEvents
         >
           {({pageLinks, isLoading: isDiscoverQueryLoading, tableData}) => {


### PR DESCRIPTION
As the events table is now being used in more places, the referrer should be moved up