### PR TITLE
feat(issue-alert): show banner for existing incompatible rules

### DIFF
--- a/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
+++ b/static/app/views/alerts/rules/issue/details/ruleDetails.spec.jsx
@@ -190,6 +190,7 @@ describe('AlertRuleDetails', () => {
 
   it('incompatible rule banner hidden for good rule', async () => {
     createWrapper();
+    expect(await screen.getAllByText('My alert rule')).toHaveLength(2);
     expect(
       await screen.queryByText(
         'The conditions in this alert rule conflict and might not be working properly.'

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1421,7 +1421,9 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
 export default withOrganization(withProjects(IssueRuleEditor));
 
-export const findIncompatibleRules = (rule): IncompatibleRule => {
+export const findIncompatibleRules = (
+  rule: IssueAlertRule | UnsavedIssueAlertRule | null | undefined
+): IncompatibleRule => {
   if (!rule) {
     return {type: 'none', index: null};
   }


### PR DESCRIPTION
Shows an alert banner for existing rules that have incompatible conditions.
![Screen Shot 2022-11-09 at 10 03 58 AM](https://user-images.githubusercontent.com/39287272/200922548-018074af-e88f-4794-95b8-0bb61521ed21.png)

Runs the detector that is originally used in the create/edit alert rule page.