### PR TITLE
feat(pagerduty): Update issue alerts for performance issues

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -431,7 +431,7 @@ class ExternalEventSerializer(EventSerializer):
     """
 
     def serialize(self, obj, attrs, user):
-        from sentry.notifications.utils import get_group_title
+        from sentry.notifications.utils import get_notification_group_title
 
         tags = [{"key": key.split("sentry:", 1)[-1], "value": value} for key, value in obj.tags]
         for tag in tags:
@@ -448,7 +448,7 @@ class ExternalEventSerializer(EventSerializer):
             # XXX for 'message' this doesn't do the proper resolution of logentry
             # etc. that _get_legacy_message_with_meta does.
             "message": obj.message,
-            "title": get_group_title(obj.group, obj, 1024),
+            "title": get_notification_group_title(obj.group, obj, 1024),
             "location": obj.location,
             "culprit": obj.culprit,
             "user": user and user.get_api_context(),

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -431,6 +431,8 @@ class ExternalEventSerializer(EventSerializer):
     """
 
     def serialize(self, obj, attrs, user):
+        from sentry.notifications.utils import get_group_title
+
         tags = [{"key": key.split("sentry:", 1)[-1], "value": value} for key, value in obj.tags]
         for tag in tags:
             query = convert_user_tag_to_query(tag["key"], tag["value"])
@@ -446,7 +448,7 @@ class ExternalEventSerializer(EventSerializer):
             # XXX for 'message' this doesn't do the proper resolution of logentry
             # etc. that _get_legacy_message_with_meta does.
             "message": obj.message,
-            "title": obj.title,
+            "title": get_group_title(obj.group, obj, 1024),
             "location": obj.location,
             "culprit": obj.culprit,
             "user": user and user.get_api_context(),

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping, Sequence
 from sentry.integrations.utils import where_should_sync
 from sentry.models import ExternalIssue, GroupLink, User, UserOption
 from sentry.notifications.utils import (
-    get_group_title,
+    get_notification_group_title,
     get_parent_and_repeating_spans,
     get_span_and_problem,
     get_span_evidence_value,
@@ -56,7 +56,7 @@ class IssueBasicMixin:
         return False
 
     def get_group_title(self, group, event, **kwargs):
-        return get_group_title(group, event, **kwargs)
+        return get_notification_group_title(group, event, **kwargs)
 
     def get_issue_url(self, key):
         """

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -14,9 +14,9 @@ from sentry.notifications.utils import (
     get_span_evidence_value,
     get_span_evidence_value_problem,
 )
+from sentry.notifications.utils import get_group_title
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.tasks.integrations import sync_status_inbound as sync_status_inbound_task
-from sentry.types.issues import GROUP_TYPE_TO_TEXT, GroupCategory
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
 
@@ -57,14 +57,7 @@ class IssueBasicMixin:
         return False
 
     def get_group_title(self, group, event, **kwargs):
-        if group.issue_category == GroupCategory.PERFORMANCE:
-            issue_type = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
-            transaction = get_performance_issue_alert_subtitle(event)
-            title = f"{issue_type}: {transaction}"
-            # Jira API will not accept a summary field over 255 chars
-            return (title[:253] + "..") if len(title) > 255 else title
-        else:
-            return event.title
+        return get_group_title(group, event, **kwargs)
 
     def get_issue_url(self, key):
         """

--- a/src/sentry/integrations/mixins/issues.py
+++ b/src/sentry/integrations/mixins/issues.py
@@ -8,13 +8,12 @@ from typing import Any, Mapping, Sequence
 from sentry.integrations.utils import where_should_sync
 from sentry.models import ExternalIssue, GroupLink, User, UserOption
 from sentry.notifications.utils import (
+    get_group_title,
     get_parent_and_repeating_spans,
-    get_performance_issue_alert_subtitle,
     get_span_and_problem,
     get_span_evidence_value,
     get_span_evidence_value_problem,
 )
-from sentry.notifications.utils import get_group_title
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.tasks.integrations import sync_status_inbound as sync_status_inbound_task
 from sentry.utils.http import absolute_uri

--- a/src/sentry/integrations/pagerduty/client.py
+++ b/src/sentry/integrations/pagerduty/client.py
@@ -33,7 +33,7 @@ class PagerDutyClient(ApiClient):
             group = data.group
             level = data.get_tag("level") or "error"
             custom_details = serialize(data, None, ExternalEventSerializer())
-            summary = (data.message or data.title)[:1024]
+            summary = custom_details["message"][:1024] or custom_details["title"]
             payload = {
                 "routing_key": self.integration_key,
                 "event_action": "trigger",

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -421,7 +421,8 @@ def get_group_title(group: Group, event: Event, max_length: int = 255, **kwargs:
         title = f"{issue_type}: {transaction}"
         return (title[: max_length - 2] + "..") if len(title) > max_length else title
     else:
-        return event.title
+        event_title: str = event.title
+        return event_title
 
 
 def send_activity_notification(notification: ActivityNotification | UserReportNotification) -> None:

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -414,7 +414,9 @@ def get_performance_issue_alert_subtitle(event: Event) -> str:
     return repeating_span_value.replace("`", '"')
 
 
-def get_group_title(group: Group, event: Event, max_length: int = 255, **kwargs: str) -> str:
+def get_notification_group_title(
+    group: Group, event: Event, max_length: int = 255, **kwargs: str
+) -> str:
     if group.issue_category == GroupCategory.PERFORMANCE:
         issue_type = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
         transaction = get_performance_issue_alert_subtitle(event)

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -45,6 +45,7 @@ from sentry.models import (
 )
 from sentry.notifications.notify import notify
 from sentry.notifications.utils.participants import split_participants_and_context
+from sentry.types.issues import GROUP_TYPE_TO_TEXT, GroupCategory
 from sentry.utils.committers import get_serialized_event_file_committers
 from sentry.utils.http import absolute_uri
 from sentry.utils.performance_issues.performance_detection import (
@@ -411,6 +412,16 @@ def get_performance_issue_alert_subtitle(event: Event) -> str:
         _, repeating_spans = get_parent_and_repeating_spans(spans, matched_problem)
         repeating_span_value = get_span_evidence_value(repeating_spans, include_op=False)
     return repeating_span_value.replace("`", '"')
+
+
+def get_group_title(group: Group, event: Event, max_length: int = 255, **kwargs: str) -> str:
+    if group.issue_category == GroupCategory.PERFORMANCE:
+        issue_type = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
+        transaction = get_performance_issue_alert_subtitle(event)
+        title = f"{issue_type}: {transaction}"
+        return (title[: max_length - 2] + "..") if len(title) > max_length else title
+    else:
+        return event.title
 
 
 def send_activity_notification(notification: ActivityNotification | UserReportNotification) -> None:


### PR DESCRIPTION
Update PagerDuty issue alerts for performance issues. The error issues didn't have the stacktrace data so I didn't add the span evidence data as we have for other integrations - I tried to keep it as consistent as possible. I also moved `get_notification_group_title` into a shared location since PD doesn't use the issue mixin and the data is generated in the client.

Here is what the details look like now for a performance issue:
<img width="1058" alt="Screen Shot 2022-11-09 at 11 36 14 AM" src="https://user-images.githubusercontent.com/29959063/200928017-32cd7ba6-186e-49f0-92c2-339c07a7da2f.png">

and here is what an error issue looks like for comparison:
<img width="1048" alt="Screen Shot 2022-11-09 at 10 48 19 AM" src="https://user-images.githubusercontent.com/29959063/200928099-1b7cd889-e1d6-4e00-bbc3-14c49bc48668.png">
