### PR TITLE
feat(hybrid-cloud): Add /discover/* Django route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -459,6 +459,8 @@ urlpatterns += [
         react_page_view,
         name="integration-installation",
     ),
+    # Discover
+    url(r"^discover/", react_page_view, name="discover"),
     # Organizations
     url(r"^(?P<organization_slug>[\w_-]+)/$", react_page_view, name="sentry-organization-home"),
     url(


### PR DESCRIPTION
This adds `/discover/*` Django route so that `orgslug.sentry.io/discover/*` links work on pageload.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.