### PR TITLE
fix(replays): Stop re-renders of Replay on Issue Details

### DIFF
--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -1,7 +1,8 @@
-import ErrorBoundary from 'sentry/components/errorBoundary';
-import {Event} from 'sentry/types/event';
+import {useCallback} from 'react';
 
-import ReplayContent from './replayContent';
+import ErrorBoundary from 'sentry/components/errorBoundary';
+import LazyLoad from 'sentry/components/lazyLoad';
+import {Event} from 'sentry/types/event';
 
 type Props = {
   event: Event;
@@ -11,9 +12,12 @@ type Props = {
 };
 
 export default function EventReplay({replayId, orgSlug, projectSlug, event}: Props) {
+  const component = useCallback(() => import('./replayContent'), []);
+
   return (
     <ErrorBoundary mini>
-      <ReplayContent
+      <LazyLoad
+        component={component}
         replaySlug={`${projectSlug}:${replayId}`}
         orgSlug={orgSlug}
         event={event}

--- a/static/app/components/events/eventReplay/index.tsx
+++ b/static/app/components/events/eventReplay/index.tsx
@@ -1,6 +1,7 @@
 import ErrorBoundary from 'sentry/components/errorBoundary';
-import LazyLoad from 'sentry/components/lazyLoad';
 import {Event} from 'sentry/types/event';
+
+import ReplayContent from './replayContent';
 
 type Props = {
   event: Event;
@@ -12,8 +13,7 @@ type Props = {
 export default function EventReplay({replayId, orgSlug, projectSlug, event}: Props) {
   return (
     <ErrorBoundary mini>
-      <LazyLoad
-        component={() => import('./replayContent')}
+      <ReplayContent
         replaySlug={`${projectSlug}:${replayId}`}
         orgSlug={orgSlug}
         event={event}


### PR DESCRIPTION

<!-- Describe your PR here. -->
### Changes
- Added `useCallback` hook for the component prop, so it doesn't trigger unnecessary re-renders in the` useMemo` hook inside `lazyLoad` component . Closes #40277

### Test notes
- Tested it with different issues and none of them where making repeated API requests


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
