### PR TITLE
fix(issue-stats): N+1 query in issue stats

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -78,7 +78,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
 
         else:
             groups = list(
-                Group.objects.filter(id__in=group_ids, project_id__in=project_ids).prefetch_related(
+                Group.objects.filter(id__in=group_ids, project_id__in=project_ids).select_related(
                     "project"
                 )
             )


### PR DESCRIPTION
Spotted a N+1 query in the /issues-stats endpoint. 

https://sentry.io/organizations/sentry/discover/sentry:e914974e31344fae970955ece23309d2/

![image](https://user-images.githubusercontent.com/10239353/200946222-4793e8de-a1dc-47e3-bc9f-d21542d0048a.png)

Looking at the profile, it looks to be this query set on the `Group` accessing the project in a loop without prefetching.

![Screen Shot 2022-11-09 at 4 47 49 PM](https://user-images.githubusercontent.com/10239353/200948870-9fcce678-bf99-4618-9f18-c3493c199d3b.png)
