### PR TITLE
chore(msteams): Add test for performance issue alerts

### DIFF
--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -3,10 +3,15 @@ import time
 
 import responses
 
+from sentry.event_manager import EventManager
 from sentry.integrations.msteams import MsTeamsNotifyServiceAction
 from sentry.models import Integration
 from sentry.testutils.cases import RuleTestCase
+from sentry.testutils.helpers import override_options
+from sentry.testutils.helpers.datetime import before_now
+from sentry.types.issues import GroupType
 from sentry.utils import json
+from sentry.utils.samples import load_data
 
 
 class MsTeamsNotifyActionTest(RuleTestCase):
@@ -63,6 +68,62 @@ class MsTeamsNotifyActionTest(RuleTestCase):
         title_card = attachments[0]["content"]["body"][0]
         title_pattern = r"\[%s\](.*)" % event.title
         assert re.match(title_pattern, title_card["text"])
+
+    @responses.activate
+    def test_applies_correctly_performance_issue(self):
+        event_data = load_data(
+            "transaction-n-plus-one",
+            timestamp=before_now(minutes=10),
+            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE.value}-group1"],
+        )
+        perf_event_manager = EventManager(event_data)
+        perf_event_manager.normalize()
+        with override_options(
+            {
+                "performance.issues.all.problem-creation": 1.0,
+                "performance.issues.all.problem-detection": 1.0,
+                "performance.issues.n_plus_one_db.problem-creation": 1.0,
+            }
+        ), self.feature(
+            [
+                "organizations:performance-issues-ingest",
+                "projects:performance-suspect-spans-ingestion",
+            ]
+        ):
+            event = perf_event_manager.save(self.project.id)
+        event = event.for_group(event.groups[0])
+
+        rule = self.get_rule(
+            data={"team": self.integration.id, "channel": "Naboo", "channel_id": "nb"}
+        )
+        results = list(rule.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+
+        responses.add(
+            method=responses.POST,
+            url="https://smba.trafficmanager.net/amer/v3/conversations/nb/activities",
+            status=200,
+            json={},
+        )
+
+        with self.feature("organizations:performance-issues"):
+            results[0].callback(event, futures=[])
+
+        data = json.loads(responses.calls[0].request.body)
+        assert "attachments" in data
+        attachments = data["attachments"]
+        assert len(attachments) == 1
+
+        title_card = attachments[0]["content"]["body"][0]
+        description = attachments[0]["content"]["body"][1]
+        assert (
+            title_card["text"]
+            == f"[N+1 Query](http://testserver/organizations/{self.organization.slug}/issues/{event.group_id}/?referrer=msteams)"
+        )
+        assert (
+            description["text"]
+            == "db - SELECT `books\\_author`.`id`, `books\\_author`.`name` FROM `books\\_author` WHERE `books\\_author`.`id` = %s LIMIT 21"
+        )
 
     def test_render_label(self):
         rule = self.get_rule(data={"team": self.integration.id, "channel": "Tatooine"})


### PR DESCRIPTION
Updating [Slack for performance issue alerts](https://github.com/getsentry/sentry/pull/40150) gave us MSTeams for performance issue alerts for free since they both use the message builder and are built on the notification platform, but I hadn't added tests for MSTeams then. This PR adds a test to ensure performance issues show up properly in MSTeams. Here's what it looks like:

<img width="905" alt="Screen Shot 2022-11-04 at 11 12 23 AM" src="https://user-images.githubusercontent.com/29959063/200969567-b8ebb7ce-ed79-450a-9bdc-8b7baa7cf996.png">
