### PR TITLE
fix(hybrid-cloud): Properly propagate organization_slug from the request object

### DIFF
--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -16,7 +16,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.serializers import serialize
-from sentry.api.utils import is_member_disabled_from_limit
+from sentry.api.utils import generate_organization_url, is_member_disabled_from_limit
 from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import Authenticator, Organization, Project, ProjectStatus, Team, TeamStatus
@@ -29,7 +29,7 @@ from sentry.silo import SiloMode
 from sentry.utils import auth
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.auth import is_valid_redirect, make_login_link_with_redirect
-from sentry.utils.http import absolute_uri
+from sentry.utils.http import absolute_uri, is_using_customer_domain
 from sentry.web.frontend.generic import FOREVER_CACHE
 from sentry.web.helpers import render_to_response
 from sudo.views import redirect_to_sudo
@@ -189,15 +189,33 @@ class OrganizationMixin:
     def redirect_to_org(self, request: Request):
         from sentry import features
 
+        using_customer_domain = request and is_using_customer_domain(request)
+
         # TODO(dcramer): deal with case when the user cannot create orgs
         if self.active_organization:
-            url = Organization.get_url(self.active_organization.organization.slug)
+            current_org_slug = self.active_organization.organization.slug
+            url = Organization.get_url(current_org_slug)
         elif not features.has("organizations:create"):
             return self.respond("sentry/no-organization-access.html", status=403)
         else:
+            org_exists = False
             url = "/organizations/new/"
-            if request.subdomain:
+            if using_customer_domain:
                 url = absolute_uri(url)
+
+            if using_customer_domain and request.user and request.user.is_authenticated:
+                organizations = organization_service.get_organizations(
+                    user_id=request.user.id, scope=None, only_visible=True
+                )
+                maybe_org = organization_service.get_organization_by_slug(
+                    user_id=None, slug=request.subdomain, only_visible=True
+                )
+                org_exists = maybe_org and maybe_org.organization
+                if org_exists and organizations:
+                    url = reverse("sentry-auth-organization", args=[request.subdomain])
+                    url_prefix = generate_organization_url(request.subdomain)
+                    url = absolute_uri(url, url_prefix=url_prefix)
+
         return HttpResponseRedirect(url)
 
 
@@ -237,7 +255,10 @@ class BaseView(View, OrganizationMixin):
 
         """
 
-        self.determine_active_organization(request, kwargs.get("organization_slug", None))
+        organization_slug = kwargs.get("organization_slug", None)
+        if request and is_using_customer_domain(request):
+            organization_slug = request.subdomain
+        self.determine_active_organization(request, organization_slug)
 
         if self.csrf_protect:
             if hasattr(self.dispatch.__func__, "csrf_exempt"):

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -508,9 +508,10 @@ class AuthLoginCustomerDomainTest(TestCase):
             assert resp.status_code == 200
             assert resp.redirect_chain == [
                 (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
-                (f"/organizations/{self.organization.slug}/issues/", 302),
-                ("/organizations/albertos-apples/issues/", 302),
-                ("/auth/login/albertos-apples/", 302),
+                (
+                    f"http://albertos-apples.testserver{reverse('sentry-auth-organization', args=['albertos-apples'])}",
+                    302,
+                ),
             ]
 
     def test_login_valid_credentials_orgless(self):


### PR DESCRIPTION
Whenever a customer domain is used, we need to properly propagate the organization slug into `self.determine_active_organization()`. Otherwise, we will incorrectly set the organization into `self.active_organization`, whose org slug will be mismatch from `request.subdomain`.

In addition, this is preparatory work for having `/issues/` as the default route for when `orgslug.sentry.io` is accessed. 

This was cherry-picked from https://github.com/getsentry/sentry/pull/40215. 