### PR TITLE
feat(monitors): Display Missed Checkins

### DIFF
--- a/src/sentry/models/monitor.py
+++ b/src/sentry/models/monitor.py
@@ -184,6 +184,9 @@ class Monitor(Model):
         if reason == MonitorFailure.MISSED_CHECKIN:
             new_status = MonitorStatus.MISSED_CHECKIN
 
+        new_status = MonitorStatus.ERROR
+        if reason == MonitorFailure.MISSED_CHECKIN:
+            new_status = MonitorStatus.MISSED_CHECKIN
         affected = (
             type(self)
             .objects.filter(

--- a/src/sentry/models/monitor.py
+++ b/src/sentry/models/monitor.py
@@ -184,9 +184,6 @@ class Monitor(Model):
         if reason == MonitorFailure.MISSED_CHECKIN:
             new_status = MonitorStatus.MISSED_CHECKIN
 
-        new_status = MonitorStatus.ERROR
-        if reason == MonitorFailure.MISSED_CHECKIN:
-            new_status = MonitorStatus.MISSED_CHECKIN
         affected = (
             type(self)
             .objects.filter(

--- a/static/app/views/monitors/checkInIcon.tsx
+++ b/static/app/views/monitors/checkInIcon.tsx
@@ -1,8 +1,10 @@
 import styled from '@emotion/styled';
 
+import {CheckInStatus} from './types';
+
 type Props = {
   size: number | string;
-  status: 'error' | 'ok';
+  status: CheckInStatus;
   color?: string;
 };
 
@@ -21,6 +23,8 @@ export default styled('div')<Props>`
             ? p.theme.error
             : p.status === 'ok'
             ? p.theme.success
+            : p.status === 'missed'
+            ? p.theme.yellow300
             : p.theme.disabled
         };`};
 `;

--- a/static/app/views/monitors/monitorCheckIns.tsx
+++ b/static/app/views/monitors/monitorCheckIns.tsx
@@ -7,7 +7,7 @@ import Tooltip from 'sentry/components/tooltip';
 import {tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import useApiRequests from 'sentry/utils/useApiRequests';
-import {Monitor} from 'sentry/views/monitors/types';
+import {CheckInStatus, Monitor} from 'sentry/views/monitors/types';
 
 import CheckInIcon from './checkInIcon';
 
@@ -15,7 +15,7 @@ type CheckIn = {
   dateCreated: string;
   duration: number;
   id: string;
-  status: 'ok' | 'error' | 'missed';
+  status: CheckInStatus;
 };
 
 type Props = {

--- a/static/app/views/monitors/monitorCheckIns.tsx
+++ b/static/app/views/monitors/monitorCheckIns.tsx
@@ -3,6 +3,8 @@ import styled from '@emotion/styled';
 import Duration from 'sentry/components/duration';
 import {PanelBody, PanelItem} from 'sentry/components/panels';
 import TimeSince from 'sentry/components/timeSince';
+import Tooltip from 'sentry/components/tooltip';
+import {tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import useApiRequests from 'sentry/utils/useApiRequests';
 import {Monitor} from 'sentry/views/monitors/types';
@@ -13,7 +15,7 @@ type CheckIn = {
   dateCreated: string;
   duration: number;
   id: string;
-  status: 'ok' | 'error';
+  status: 'ok' | 'error' | 'missed';
 };
 
 type Props = {
@@ -36,7 +38,13 @@ const MonitorCheckIns = ({monitor}: Props) => {
       {data.checkInList?.map(checkIn => (
         <PanelItem key={checkIn.id}>
           <CheckInIconWrapper>
-            <CheckInIcon status={checkIn.status} size={16} />
+            <Tooltip
+              title={tct('Check In Status: [status]', {
+                status: checkIn.status,
+              })}
+            >
+              <CheckInIcon status={checkIn.status} size={16} />
+            </Tooltip>
           </CheckInIconWrapper>
           <TimeSinceWrapper>
             <TimeSince date={checkIn.dateCreated} />

--- a/static/app/views/monitors/monitorIcon.tsx
+++ b/static/app/views/monitors/monitorIcon.tsx
@@ -17,6 +17,8 @@ export default styled('div')<{size: number; status: Status}>`
             ? p.theme.error
             : p.status === 'ok'
             ? p.theme.success
+            : p.status === 'missed_checkin'
+            ? p.theme.yellow300
             : p.theme.disabled
         };`};
 `;

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -1,6 +1,8 @@
 import {Project} from 'sentry/types';
 
-export type Status = 'ok' | 'error' | 'disabled' | 'active';
+export type Status = 'ok' | 'error' | 'disabled' | 'active' | 'missed_checkin';
+
+export type CheckInStatus = 'ok' | 'error' | 'missed';
 
 export type MonitorTypes = 'cron_job';
 


### PR DESCRIPTION
Following from https://github.com/getsentry/sentry/pull/41162 display the missed checkin info

<img width="1188" alt="image" src="https://user-images.githubusercontent.com/9372512/200975042-79fb1558-9f15-45a0-a299-73f431b4e2d4.png">
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/9372512/200975077-85a90c1f-4eaa-4f91-ad5e-9e96a8b25030.png">
