### PR TITLE
feat(replays): Add worker limit to recording processor threadpool

### DIFF
--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -61,7 +61,7 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
     ) -> None:
         self.__closed = False
         self.__futures: Deque[ReplayRecordingMessageFuture] = deque()
-        self.__threadpool = concurrent.futures.ThreadPoolExecutor()
+        self.__threadpool = concurrent.futures.ThreadPoolExecutor(max_workers=16)
         self.__commit = commit
         self.__commit_data: MutableMapping[Partition, Position] = {}
         self.__last_committed: float = 0


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/197