### PR TITLE
fix(mobile-exp): Use unique value for key in tag breakdown

### DIFF
--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -138,7 +138,7 @@ export function TagFacets({
         event?.tags.find(({key}) => key === state.selectedTag)?.value === value;
       return {
         name,
-        value: name,
+        value,
         count,
         url,
         active: isTagValueOfCurrentEvent,

--- a/static/app/components/group/tagFacets/tagBreakdown.tsx
+++ b/static/app/components/group/tagFacets/tagBreakdown.tsx
@@ -35,7 +35,7 @@ function TagBreakdown({segments, maxItems, selectedTag, colors}: TagBreakdownPro
       />
       {visibleSegments.map((segment, index) => {
         return (
-          <BreakdownRow key={segment.name}>
+          <BreakdownRow key={segment.value}>
             <LegendIcon color={colors[index]} />
             <Tooltip title={segment.tooltip}>
               <TagLabel active={segment.active}>{segment.name}</TagLabel>


### PR DESCRIPTION
There are cases where the name is the same for multiple values, the data should use the payload value as the value and use that as the key to prevent items duplicating when changing tabs.

For testing this fix, use this issue: https://sentry.io/organizations/sentry-sdks/issues/3387483475/

If you click the `release` tab, there are two entries for `1.0` (expected), then clicking another tab (e.g. `devices`) will duplicate that value into that list. Going back to `release` will also show an extra `1.0` row

I also updated the mocked responses in the tests to always pass along a value, which is consistent with the endpoint