### PR TITLE
feat(replays): add size to RecordingSegment in processor

### DIFF
--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -154,6 +154,7 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
                     project_id=message_dict["project_id"],
                     segment_id=headers["segment_id"],
                     file_id=file.id,
+                    size=len(recording_segment),
                 )
             except IntegrityError:
                 # Same message was encountered more than once.

--- a/tests/sentry/replays/consumers/recording_consumer/test_consumer.py
+++ b/tests/sentry/replays/consumers/recording_consumer/test_consumer.py
@@ -150,7 +150,8 @@ class TestRecordingsConsumerEndToEnd(TransactionTestCase):
 
         assert recording
         assert recording.checksum == sha1(b"testfoobar").hexdigest()
-        assert ReplayRecordingSegment.objects.get(replay_id=self.replay_id)
+        segment = ReplayRecordingSegment.objects.get(replay_id=self.replay_id)
+        assert segment.size == len(b"testfoobar")
 
         self.project.refresh_from_db()
         assert self.project.flags.has_replays


### PR DESCRIPTION
Adds the size of our bytes to the segment model. following up #41190 