### PR TITLE
fix: add header to support cross-isolated cors policy

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -89,6 +89,7 @@ def allow_cors_options(func):
             "sentry-trace, baggage"
         )
         response["Access-Control-Expose-Headers"] = "X-Sentry-Error, Retry-After"
+        response["Cross-Origin-Resource-Policy"] = "cross-origin"
 
         if request.META.get("HTTP_ORIGIN") == "null":
             origin = "null"  # if ORIGIN header is explicitly specified as 'null' leave it alone


### PR DESCRIPTION
If I understand the code right, this header should apply to server API responses. The goal is to fix a resource sharing policy used for websites that are cross-origin isolated (for example those using SharedArrayBuffer) that require this extra header in the response in order to pass CORS.

I never wrote anything in python before, so forgive me if my syntax is bad. Somehow I think it's difficult to mess up something so simple though.