### PR TITLE
fix(replays): decode replay as bytes if str from cache

### DIFF
--- a/src/sentry/replays/cache.py
+++ b/src/sentry/replays/cache.py
@@ -45,7 +45,7 @@ class RecordingSegmentParts:
         """Iterate over each recording segment part."""
         part = RecordingSegmentCache(self.prefix)
         for i in range(self.num_parts):
-            yield part[i]
+            yield part[i].encode("utf-8") if type(part[i]) is str else part[i]
 
     def drop(self):
         """Delete all the parts associated with the recording segment."""


### PR DESCRIPTION
Trying to fix SENTRY-WDT, we first did #41111, which ensures that we always receive the payload as bytes. however, depending on cache configuration the cache can also return a string, which causes this error to still happen. Given that, when we retrieve our segment part from cache, we'll encode it if it's a string. 

We'll likely want to compress this value for the cache which will always render it un-encodable, so we can remove this check if we do that.