### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for onboarding

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -197,6 +197,18 @@ function buildRoutes() {
         path="/join-request/:orgId/"
         component={make(() => import('sentry/views/organizationJoinRequest'))}
       />
+      {usingCustomerDomain ? (
+        <Route
+          path="/onboarding/"
+          component={errorHandler(withDomainRequired(OrganizationContextContainer))}
+          key="orgless-onboarding"
+        >
+          <Route
+            path=":step/"
+            component={make(() => import('sentry/views/onboarding/onboarding'))}
+          />
+        </Route>
+      ) : null}
       <Route
         path="/onboarding/:orgId/"
         component={errorHandler(OrganizationContextContainer)}

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -211,7 +211,8 @@ function buildRoutes() {
       ) : null}
       <Route
         path="/onboarding/:orgId/"
-        component={errorHandler(OrganizationContextContainer)}
+        component={withDomainRedirect(errorHandler(OrganizationContextContainer))}
+        key="org-onboarding"
       >
         <IndexRedirect to="welcome/" />
         <Route


### PR DESCRIPTION
This adds the customer domain React routes for the onboarding flows.

This depends on changes introduced in https://github.com/getsentry/sentry/pull/41201.

These changes were cherry picked from https://github.com/getsentry/sentry/pull/40215.