### PR TITLE
feat(replays): Setup frontend tasks for session replay onboarding

### DIFF
--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -276,7 +276,7 @@ export function getOnboardingTasks({
     },
     {
       task: OnboardingTaskKey.SESSION_REPLAY,
-      title: t('Enable Session Replay'),
+      title: t('See a video-like reproduction'),
       description: t(
         'Get to the root cause of error or latency issues faster by seeing all the technical details related to those issues in video-like reproductions of your user sessions.'
       ),
@@ -296,7 +296,7 @@ export function getOnboardingTasks({
             eventType="replay"
             onIssueReceived={() => !taskIsDone(task) && onCompleteTask()}
           >
-            {() => <EventWaitingIndicator text={t('Waiting for session')} />}
+            {() => <EventWaitingIndicator text={t('Waiting for user session')} />}
           </EventWaiter>
         ) : null
       ),

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -276,9 +276,9 @@ export function getOnboardingTasks({
     },
     {
       task: OnboardingTaskKey.SESSION_REPLAY,
-      title: t('Enable replay sessions'),
+      title: t('Enable Session Replay'),
       description: t(
-        'Get to the root cause of an error or latency issue faster by seeing all the technical details related to that issue in one visual replay of your web application.'
+        'Get to the root cause of error or latency issues faster by seeing all the technical details related to those issues in video-like reproductions of your user sessions.'
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -210,7 +210,8 @@ export function getOnboardingTasks({
       requisites: [OnboardingTaskKey.FIRST_PROJECT],
       actionType: 'action',
       action: ({router}) => {
-        if (!organization.features.includes('performance-onboarding-checklist')) {
+        // Use `features?.` because getsentry has a different `Organization` type/payload
+        if (!organization.features?.includes('performance-onboarding-checklist')) {
           window.open(
             'https://docs.sentry.io/product/performance/getting-started/',
             '_blank'
@@ -285,7 +286,8 @@ export function getOnboardingTasks({
       actionType: 'app',
       location: `/organizations/${organization.slug}/replays/#replay-sidequest`,
       display:
-        organization.features.includes('session-replay-ui') &&
+        // Use `features?.` because getsentry has a different `Organization` type/payload
+        organization.features?.includes('session-replay-ui') &&
         Boolean(projects?.some(projectSupportsReplay)),
       SupplementComponent: withApi(({api, task, onCompleteTask}: FirstEventWaiterProps) =>
         !!projects?.length && task.requisiteTasks.length === 0 && !task.completionSeen ? (
@@ -371,7 +373,8 @@ export function getOnboardingTasks({
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_TRANSACTION],
       actionType: 'app',
       location: getMetricAlertUrl({projects, organization, onboardingState}),
-      display: organization.features.includes('incidents'),
+      // Use `features?.` because getsentry has a different `Organization` type/payload
+      display: organization.features?.includes('incidents'),
     },
     {
       task: OnboardingTaskKey.USER_SELECTED_PROJECTS,

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -69,7 +69,7 @@ function ReplaysOnboardingSidebar(props: CommonSidebarProps) {
     >
       <TopRightBackgroundImage src={HighlightTopRightPattern} />
       <TaskList>
-        <Heading>{t('Replay Sessions')}</Heading>
+        <Heading>{t('Getting Started with Replays')}</Heading>
         <DropdownMenuControl
           items={items}
           triggerLabel={

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -247,7 +247,7 @@ const PulsingIndicator = styled('div')`
 const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
   <div {...p}>
     <PulsingIndicator />
-    {t("Waiting for this project's first replay event")}
+    {t("Waiting for this project's first user session")}
   </div>
 ))`
   display: flex;
@@ -260,7 +260,7 @@ const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) =
 const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
   <div {...p}>
     {'🎉 '}
-    {t("We've received this project's first replay event!")}
+    {t("We've received this project's first user session!")}
   </div>
 ))`
   display: flex;

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -247,7 +247,7 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         icon={<IconPlay size="md" />}
-        label={t('Replays')}
+        label={t('Session Replay')}
         to={`/organizations/${organization.slug}/replays/`}
         id="replays"
         isBeta

--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -247,7 +247,7 @@ function Sidebar({location, organization}: Props) {
       <SidebarItem
         {...sidebarItemProps}
         icon={<IconPlay size="md" />}
-        label={t('Session Replay')}
+        label={t('Replays')}
         to={`/organizations/${organization.slug}/replays/`}
         id="replays"
         isBeta

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -23,6 +23,7 @@ export enum OnboardingTaskKey {
   INTEGRATIONS = 'integrations',
   /// Regular card that tells the user to setup integrations if no integrations were selected during onboarding
   FIRST_INTEGRATION = 'setup_integrations',
+  SESSION_REPLAY = 'setup_session_replay',
   /// Demo New Walkthrough Tasks
   SIDEBAR_GUIDE = 'sidebar_guide',
   ISSUE_GUIDE = 'issue_guide',


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/40928 being deployed first

cc @lizokm

**The new task card:**
<img width="418" alt="Screen Shot 2022-11-11 at 11 47 10 AM" src="https://user-images.githubusercontent.com/187460/201419439-434f91f8-321f-4f56-ba0c-f4bf1351ffca.png">



Clicking "Start" will open the existing onboarding installation steps on the replays list page, which has some copy changes:
<img width="450" alt="Screen Shot 2022-11-11 at 11 43 43 AM" src="https://user-images.githubusercontent.com/187460/201417945-4c626849-fecf-4143-a250-1309af1ed358.png">


Fixes #40787