### PR TITLE
feat(hybrid-cloud): Add /join-request/* Django route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -461,6 +461,8 @@ urlpatterns += [
     ),
     # Discover
     url(r"^discover/", react_page_view, name="discover"),
+    # Request to join an organization
+    url(r"^join-request/", react_page_view, name="join-request"),
     # Organizations
     url(r"^(?P<organization_slug>[\w_-]+)/$", react_page_view, name="sentry-organization-home"),
     url(


### PR DESCRIPTION
This adds `/join-request/*` Django route so that `orgslug.sentry.io/join-request/*` links work on pageload.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.