### PR TITLE
feat(hybrid-cloud): Add customer domain React route for join-request

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -204,7 +204,10 @@ function buildRoutes() {
       ) : null}
       <Route
         path="/join-request/:orgId/"
-        component={make(() => import('sentry/views/organizationJoinRequest'))}
+        component={withDomainRedirect(
+          make(() => import('sentry/views/organizationJoinRequest'))
+        )}
+        key="org-join-request"
       />
       <Route
         path="/onboarding/:orgId/"

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -193,6 +193,15 @@ function buildRoutes() {
         path="/organizations/:orgId/disabled-member/"
         component={make(() => import('sentry/views/disabledMember'))}
       />
+      {usingCustomerDomain ? (
+        <Route
+          path="/join-request/"
+          component={withDomainRequired(
+            make(() => import('sentry/views/organizationJoinRequest'))
+          )}
+          key="orgless-join-request"
+        />
+      ) : null}
       <Route
         path="/join-request/:orgId/"
         component={make(() => import('sentry/views/organizationJoinRequest'))}


### PR DESCRIPTION
This adds the customer domain React routes for users to request to join an organization.

This depends on changes introduced in https://github.com/getsentry/sentry/pull/41201.

These changes were cherry picked from https://github.com/getsentry/sentry/pull/40215.