### PR TITLE
ref(monitors): Introduce layout-thirds into monitors

### DIFF
--- a/static/app/views/monitors/create.tsx
+++ b/static/app/views/monitors/create.tsx
@@ -23,7 +23,7 @@ export default class CreateMonitor extends AsyncView<Props, AsyncView['state']> 
     return (
       <Layout.Body>
         <Layout.Main fullWidth>
-          <h1>New Monitor</h1>
+          <h1>{t('New Monitor')}</h1>
           <HelpText>
             {t(
               `Creating a monitor will allow you to track the executions of a scheduled

--- a/static/app/views/monitors/create.tsx
+++ b/static/app/views/monitors/create.tsx
@@ -1,7 +1,7 @@
-import {Fragment} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import AsyncView from 'sentry/views/asyncView';
 
@@ -21,23 +21,25 @@ export default class CreateMonitor extends AsyncView<Props, AsyncView['state']> 
 
   renderBody() {
     return (
-      <Fragment>
-        <h1>New Monitor</h1>
-        <HelpText>
-          {t(
-            `Creating a monitor will allow you to track the executions of a scheduled
+      <Layout.Body>
+        <Layout.Main fullWidth>
+          <h1>New Monitor</h1>
+          <HelpText>
+            {t(
+              `Creating a monitor will allow you to track the executions of a scheduled
              job in your organization. For example, ensure a cron job that is
              scheduled to run once a day executes and finishes within a specified
              duration.`
-          )}
-        </HelpText>
-        <MonitorForm
-          apiMethod="POST"
-          apiEndpoint={`/organizations/${this.props.params.orgId}/monitors/`}
-          onSubmitSuccess={this.onSubmitSuccess}
-          submitLabel={t('Next Steps')}
-        />
-      </Fragment>
+            )}
+          </HelpText>
+          <MonitorForm
+            apiMethod="POST"
+            apiEndpoint={`/organizations/${this.props.params.orgId}/monitors/`}
+            onSubmitSuccess={this.onSubmitSuccess}
+            submitLabel={t('Next Steps')}
+          />
+        </Layout.Main>
+      </Layout.Body>
     );
   }
 }

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -44,29 +43,27 @@ class MonitorDetails extends AsyncView<Props, State> {
     }
 
     return (
-      <Fragment>
-        <Layout.Body>
-          <Layout.Main fullWidth>
-            <MonitorHeader
-              monitor={monitor}
-              orgId={this.props.params.orgId}
-              onUpdate={this.onUpdate}
-            />
+      <Layout.Body>
+        <Layout.Main fullWidth>
+          <MonitorHeader
+            monitor={monitor}
+            orgId={this.props.params.orgId}
+            onUpdate={this.onUpdate}
+          />
 
-            {!monitor.lastCheckIn && <MonitorOnboarding monitor={monitor} />}
+          {!monitor.lastCheckIn && <MonitorOnboarding monitor={monitor} />}
 
-            <MonitorStats monitor={monitor} />
+          <MonitorStats monitor={monitor} />
 
-            <MonitorIssues monitor={monitor} orgId={this.props.params.orgId} />
+          <MonitorIssues monitor={monitor} orgId={this.props.params.orgId} />
 
-            <Panel>
-              <PanelHeader>{t('Recent Check-ins')}</PanelHeader>
+          <Panel>
+            <PanelHeader>{t('Recent Check-ins')}</PanelHeader>
 
-              <MonitorCheckIns monitor={monitor} />
-            </Panel>
-          </Layout.Main>
-        </Layout.Body>
-      </Fragment>
+            <MonitorCheckIns monitor={monitor} />
+          </Panel>
+        </Layout.Main>
+      </Layout.Body>
     );
   }
 }

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import {Panel, PanelHeader} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
 import AsyncView from 'sentry/views/asyncView';
@@ -44,23 +45,26 @@ class MonitorDetails extends AsyncView<Props, State> {
 
     return (
       <Fragment>
-        <MonitorHeader
-          monitor={monitor}
-          orgId={this.props.params.orgId}
-          onUpdate={this.onUpdate}
-        />
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <MonitorHeader
+              monitor={monitor}
+              orgId={this.props.params.orgId}
+              onUpdate={this.onUpdate}
+            />
+            {!monitor.lastCheckIn && <MonitorOnboarding monitor={monitor} />}
 
-        {!monitor.lastCheckIn && <MonitorOnboarding monitor={monitor} />}
+            <MonitorStats monitor={monitor} />
 
-        <MonitorStats monitor={monitor} />
+            <MonitorIssues monitor={monitor} orgId={this.props.params.orgId} />
 
-        <MonitorIssues monitor={monitor} orgId={this.props.params.orgId} />
+            <Panel>
+              <PanelHeader>{t('Recent Check-ins')}</PanelHeader>
 
-        <Panel>
-          <PanelHeader>{t('Recent Check-ins')}</PanelHeader>
-
-          <MonitorCheckIns monitor={monitor} />
-        </Panel>
+              <MonitorCheckIns monitor={monitor} />
+            </Panel>
+          </Layout.Main>
+        </Layout.Body>
       </Fragment>
     );
   }

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -52,6 +52,7 @@ class MonitorDetails extends AsyncView<Props, State> {
               orgId={this.props.params.orgId}
               onUpdate={this.onUpdate}
             />
+
             {!monitor.lastCheckIn && <MonitorOnboarding monitor={monitor} />}
 
             <MonitorStats monitor={monitor} />

--- a/static/app/views/monitors/edit.tsx
+++ b/static/app/views/monitors/edit.tsx
@@ -1,6 +1,7 @@
 import {browserHistory, RouteComponentProps} from 'react-router';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import {t} from 'sentry/locale';
 import AsyncView from 'sentry/views/asyncView';
 
 import MonitorForm from './monitorForm';
@@ -42,7 +43,7 @@ export default class EditMonitor extends AsyncView<Props, State> {
     return (
       <Layout.Body>
         <Layout.Main fullWidth>
-          <h1>Edit Monitor</h1>
+          <h1>{t('Edit Monitor')}</h1>
 
           <MonitorForm
             monitor={monitor}

--- a/static/app/views/monitors/edit.tsx
+++ b/static/app/views/monitors/edit.tsx
@@ -1,6 +1,6 @@
-import {Fragment} from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 
+import * as Layout from 'sentry/components/layouts/thirds';
 import AsyncView from 'sentry/views/asyncView';
 
 import MonitorForm from './monitorForm';
@@ -40,16 +40,18 @@ export default class EditMonitor extends AsyncView<Props, State> {
     }
 
     return (
-      <Fragment>
-        <h1>Edit Monitor</h1>
+      <Layout.Body>
+        <Layout.Main fullWidth>
+          <h1>Edit Monitor</h1>
 
-        <MonitorForm
-          monitor={monitor}
-          apiMethod="PUT"
-          apiEndpoint={`/monitors/${monitor.id}/`}
-          onSubmitSuccess={this.onSubmitSuccess}
-        />
-      </Fragment>
+          <MonitorForm
+            monitor={monitor}
+            apiMethod="PUT"
+            apiEndpoint={`/monitors/${monitor.id}/`}
+            onSubmitSuccess={this.onSubmitSuccess}
+          />
+        </Layout.Main>
+      </Layout.Body>
     );
   }
 }

--- a/static/app/views/monitors/index.tsx
+++ b/static/app/views/monitors/index.tsx
@@ -2,11 +2,10 @@ import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
-import {PageContent} from 'sentry/styles/organization';
 import withPageFilters from 'sentry/utils/withPageFilters';
 
 const Body = styled('div')`
-  background-color: ${p => p.theme.backgroundSecondary};
+  background-color: ${p => p.theme.background};
   flex-direction: column;
   flex: 1;
 `;
@@ -15,9 +14,7 @@ const MonitorsContainer: React.FC = ({children}) => {
   return (
     <Feature features={['monitors']} renderDisabled>
       <PageFiltersContainer>
-        <PageContent>
-          <Body>{children}</Body>
-        </PageContent>
+        <Body>{children}</Body>
       </PageFiltersContainer>
     </Feature>
   );

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -9,17 +9,16 @@ import onboardingImg from 'sentry-images/spot/onboarding-preview.svg';
 import Access from 'sentry/components/acl/access';
 import Button, {ButtonProps} from 'sentry/components/button';
 import FeatureBadge from 'sentry/components/featureBadge';
+import * as Layout from 'sentry/components/layouts/thirds';
 import Link from 'sentry/components/links/link';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
-import PageHeading from 'sentry/components/pageHeading';
 import Pagination from 'sentry/components/pagination';
 import {Panel, PanelBody, PanelItem} from 'sentry/components/panels';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SearchBar from 'sentry/components/searchBar';
 import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
-import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -105,68 +104,71 @@ class Monitors extends AsyncView<Props, State> {
 
     return (
       <Fragment>
-        <PageHeader>
-          <HeaderTitle>
-            <div>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <HeaderTitle>
               {t('Monitors')} <FeatureBadge type="beta" />
-            </div>
+            </HeaderTitle>
+          </Layout.HeaderContent>
+          <Layout.HeaderActions>
             <NewMonitorButton size="sm">{t('New Monitor')}</NewMonitorButton>
-          </HeaderTitle>
-        </PageHeader>
-        <Filters>
-          <ProjectPageFilter resetParamsOnChange={['cursor']} />
-          <SearchBar
-            query={decodeScalar(qs.parse(location.search)?.query, '')}
-            placeholder={t('Search for monitors.')}
-            onSearch={this.handleSearch}
-          />
-        </Filters>
-        {monitorList?.length ? (
-          <Fragment>
-            <Panel>
-              <PanelBody>
-                {monitorList?.map(monitor => (
-                  <PanelItemCentered key={monitor.id}>
-                    <MonitorIcon status={monitor.status} size={16} />
-                    <StyledLink
-                      to={`/organizations/${organization.slug}/monitors/${monitor.id}/`}
-                    >
-                      {monitor.name}
-                    </StyledLink>
-                    {monitor.nextCheckIn ? (
-                      <StyledTimeSince date={monitor.lastCheckIn} />
-                    ) : (
-                      t('n/a')
-                    )}
-                  </PanelItemCentered>
-                ))}
-              </PanelBody>
-            </Panel>
-            {monitorListPageLinks && (
-              <Pagination pageLinks={monitorListPageLinks} {...this.props} />
+          </Layout.HeaderActions>
+        </Layout.Header>
+        <Layout.Body>
+          <Layout.Main fullWidth>
+            <Filters>
+              <ProjectPageFilter resetParamsOnChange={['cursor']} />
+              <SearchBar
+                query={decodeScalar(qs.parse(location.search)?.query, '')}
+                placeholder={t('Search for monitors.')}
+                onSearch={this.handleSearch}
+              />
+            </Filters>
+            {monitorList?.length ? (
+              <Fragment>
+                <Panel>
+                  <PanelBody>
+                    {monitorList?.map(monitor => (
+                      <PanelItemCentered key={monitor.id}>
+                        <MonitorIcon status={monitor.status} size={16} />
+                        <StyledLink
+                          to={`/organizations/${organization.slug}/monitors/${monitor.id}/`}
+                        >
+                          {monitor.name}
+                        </StyledLink>
+                        {monitor.nextCheckIn ? (
+                          <StyledTimeSince date={monitor.lastCheckIn} />
+                        ) : (
+                          t('n/a')
+                        )}
+                      </PanelItemCentered>
+                    ))}
+                  </PanelBody>
+                </Panel>
+                {monitorListPageLinks && (
+                  <Pagination pageLinks={monitorListPageLinks} {...this.props} />
+                )}
+              </Fragment>
+            ) : (
+              <OnboardingPanel image={<img src={onboardingImg} />}>
+                <h3>{t('Monitor your recurring jobs')}</h3>
+                <p>
+                  {t(
+                    'Stop worrying about the status of your cron jobs. Let us notify you when your jobs take too long or do not execute on schedule.'
+                  )}
+                </p>
+                <NewMonitorButton>{t('Create a Monitor')}</NewMonitorButton>
+              </OnboardingPanel>
             )}
-          </Fragment>
-        ) : (
-          <OnboardingPanel image={<img src={onboardingImg} />}>
-            <h3>{t('Monitor your recurring jobs')}</h3>
-            <p>
-              {t(
-                'Stop worrying about the status of your cron jobs. Let us notify you when your jobs take too long or do not execute on schedule.'
-              )}
-            </p>
-            <NewMonitorButton>{t('Create a Monitor')}</NewMonitorButton>
-          </OnboardingPanel>
-        )}
+          </Layout.Main>
+        </Layout.Body>
       </Fragment>
     );
   }
 }
 
-const HeaderTitle = styled(PageHeading)`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex: 1;
+const HeaderTitle = styled(Layout.Title)`
+  margin-top: 0;
 `;
 
 const PanelItemCentered = styled(PanelItem)`


### PR DESCRIPTION
Refactoring to use thirds layout, most pages will look unchanged.

Before:
<img width="1439" alt="image" src="https://user-images.githubusercontent.com/9372512/201232331-f6b8da4a-c0cc-4646-a5f2-e63cf4238599.png">

After:
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/9372512/201232313-d6786cc3-938d-408c-a9fb-e14fe18e859d.png">

