### PR TITLE
feat(sampling): Add /healthz to health check bias

### DIFF
--- a/src/sentry/dynamic_sampling/rules_generator.py
+++ b/src/sentry/dynamic_sampling/rules_generator.py
@@ -23,7 +23,15 @@ from sentry.models import Project, Release
 
 # https://kubernetes.io/docs/reference/using-api/health-checks/
 # Also it covers: livez, readyz
-HEALTH_CHECK_GLOBS = ["*healthcheck*", "*healthy*", "*live*", "*ready*", "*heartbeat*", "*/health"]
+HEALTH_CHECK_GLOBS = [
+    "*healthcheck*",
+    "*healthy*",
+    "*live*",
+    "*ready*",
+    "*heartbeat*",
+    "*/health",
+    "*/healthz",
+]
 
 
 def generate_uniform_rule(sample_rate: Optional[float]) -> BaseRule:


### PR DESCRIPTION
Adding `*/healthz` to the list of health check globs for our "Ignore health checks" bias.

Based on:
https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-6.0