### PR TITLE
bug(replays): Shutdown threadpool when close method is called

### DIFF
--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -258,10 +258,10 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
 
     def close(self) -> None:
         self.__closed = True
+        self.__threadpool.shutdown(wait=False)
 
     def terminate(self) -> None:
         self.close()
-        self.__threadpool.shutdown(wait=False)
 
     def join(self, timeout: Optional[float] = None) -> None:
         start = time.time()


### PR DESCRIPTION
closes: https://github.com/getsentry/replay-backend/issues/200