### PR TITLE
feat(useStacktraceLink): add hook to fetch stack trace link

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -11,14 +11,14 @@ import {IconInfo} from 'sentry/icons';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {
+import type {
+  Event,
   Frame,
-  Integration,
   Organization,
   Project,
   RepositoryProjectPathConfigWithIntegration,
+  StacktraceLinkResult,
 } from 'sentry/types';
-import {Event} from 'sentry/types/event';
 import {StacktraceLinkEvents} from 'sentry/utils/analytics/integrations/stacktraceLinkAnalyticsEvents';
 import {getAnalyicsDataForEvent} from 'sentry/utils/events';
 import handleXhrErrorResponse from 'sentry/utils/handleXhrErrorResponse';
@@ -41,23 +41,9 @@ type Props = AsyncComponent['props'] & {
   projects: Project[];
 };
 
-export type StacktraceErrorMessage =
-  | 'file_not_found'
-  | 'stack_root_mismatch'
-  | 'integration_link_forbidden';
-
-// format of the ProjectStacktraceLinkEndpoint response
-type StacktraceResultItem = {
-  integrations: Integration[];
-  attemptedUrl?: string;
-  config?: RepositoryProjectPathConfigWithIntegration;
-  error?: StacktraceErrorMessage;
-  sourceUrl?: string;
-};
-
 type State = AsyncComponent['state'] & {
   isDismissed: boolean;
-  match: StacktraceResultItem;
+  match: StacktraceLinkResult;
   promptLoaded: boolean;
 };
 
@@ -150,7 +136,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     ];
   }
 
-  onRequestSuccess(resp: {data: StacktraceResultItem; stateKey: 'match'}) {
+  onRequestSuccess(resp: {data: StacktraceLinkResult; stateKey: 'match'}) {
     const {config, sourceUrl} = resp.data;
     trackIntegrationAnalytics('integrations.stacktrace_link_viewed', {
       view: 'stacktrace_issue_details',

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -148,6 +148,19 @@ export type SentryAppSchemaStacktraceLink = {
   params?: Array<string>;
 };
 
+export type StacktraceLinkResult = {
+  integrations: Integration[];
+  attemptedUrl?: string;
+  config?: RepositoryProjectPathConfigWithIntegration;
+  error?: StacktraceErrorMessage;
+  sourceUrl?: string;
+};
+
+export type StacktraceErrorMessage =
+  | 'file_not_found'
+  | 'stack_root_mismatch'
+  | 'integration_link_forbidden';
+
 export type SentryAppSchemaElement =
   | SentryAppSchemaIssueLink
   | SentryAppSchemaStacktraceLink;

--- a/static/app/utils/analytics/integrations/stacktraceLinkAnalyticsEvents.ts
+++ b/static/app/utils/analytics/integrations/stacktraceLinkAnalyticsEvents.ts
@@ -1,4 +1,4 @@
-import {StacktraceErrorMessage} from 'sentry/components/events/interfaces/frame/stacktraceLink';
+import type {StacktraceErrorMessage} from 'sentry/types';
 import {PlatformType} from 'sentry/types';
 import {BaseEventAnalyticsParams} from 'sentry/utils/analytics/workflowAnalyticsEvents';
 

--- a/static/app/utils/useStackTraceLink.tsx
+++ b/static/app/utils/useStackTraceLink.tsx
@@ -1,0 +1,36 @@
+import type {Organization, Project, StacktraceLinkResult} from 'sentry/types';
+import {useQuery} from 'sentry/utils/queryClient';
+
+interface UseStackTraceLinkProps {
+  frame: {
+    absPath?: string;
+    filename?: string;
+    module?: string;
+    package?: string;
+  };
+  organization: Organization;
+  project: Project;
+  commitId?: string;
+  organizationSlug?: string;
+  platform?: string;
+  sdkName?: string;
+}
+
+export function useStackTraceLink(options: UseStackTraceLinkProps) {
+  const response = useQuery<StacktraceLinkResult>([
+    `/projects/${options.organization.slug}/${options.project.slug}/stacktrace-link/`,
+    {
+      query: {
+        file: options.frame.filename,
+        platform: options.platform,
+        commitId: options.commitId,
+        ...(options.sdkName && {sdkName: options.sdkName}),
+        ...(options.frame.absPath && {absPath: options.frame.absPath}),
+        ...(options.frame.module && {module: options.frame.module}),
+        ...(options.frame.package && {package: options.frame.package}),
+      },
+    },
+  ]);
+
+  return response;
+}

--- a/static/app/utils/useStackTraceLink.tsx
+++ b/static/app/utils/useStackTraceLink.tsx
@@ -1,7 +1,7 @@
 import type {Organization, Project, StacktraceLinkResult} from 'sentry/types';
 import {useQuery} from 'sentry/utils/queryClient';
 
-interface UseStackTraceLinkProps {
+interface UseStacktraceLinkProps {
   frame: {
     absPath?: string;
     filename?: string;
@@ -16,7 +16,7 @@ interface UseStackTraceLinkProps {
   sdkName?: string;
 }
 
-export function useStackTraceLink(options: UseStackTraceLinkProps) {
+export function useStacktraceLink(options: UseStacktraceLinkProps) {
   const response = useQuery<StacktraceLinkResult>([
     `/projects/${options.organization.slug}/${options.project.slug}/stacktrace-link/`,
     {


### PR DESCRIPTION
Adds a new hook that fetches the stack trace link. Also moved the message and result types to sentry/types/integrations as it seemed like a better place to keep them