### PR TITLE
perf(events-stats): Use fromisoformat for events-stats zerofill

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -3,11 +3,10 @@ import math
 import random
 from collections import namedtuple
 from copy import deepcopy
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Sequence
 
 import sentry_sdk
-from dateutil.parser import parse as parse_datetime
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 from snuba_sdk.conditions import Condition, Op
 from snuba_sdk.function import Function
@@ -105,7 +104,11 @@ def zerofill(data, start, end, rollup, orderby):
     for obj in data:
         # This is needed for SnQL, and was originally done in utils.snuba.get_snuba_translators
         if isinstance(obj["time"], str):
-            obj["time"] = int(to_timestamp(parse_datetime(obj["time"])))
+            # `datetime.fromisoformat` is new in Python3.7 and before Python3.11, it is not a full
+            # ISO 8601 parser. It is only the inverse function of `datetime.isoformat`, which is
+            # the format returned by snuba. This is significantly faster when compared to other
+            # parsers like `dateutil.parser.parse` and `datetime.strptime`.
+            obj["time"] = int(to_timestamp(datetime.fromisoformat(obj["time"])))
         if obj["time"] in data_by_time:
             data_by_time[obj["time"]].append(obj)
         else:


### PR DESCRIPTION
Following up to #41241. Turns out the date time parsing was indeed very slow in the worst case.

Snuba returns a ISO 8601 timestamp using `datetime.isoformat()`. We parse it using `dateutil.parser.parse`. This is extremely slow in the worst case (10,000 timestamps), needing nearly a whole second. This change uses `datetime.fromisoformat` introduced in Python 3.7 to handle the parsing. This is not a full ISO 8601 parser, rather it is the inverse function of `datetime.isoformat()`. This is about 50-100X faster in the worst case.