### PR TITLE
feat(hybrid-cloud): Add /projects/* Django route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -459,6 +459,8 @@ urlpatterns += [
         react_page_view,
         name="integration-installation",
     ),
+    # Projects
+    url(r"^projects/", react_page_view, name="projects"),
     # Discover
     url(r"^discover/", react_page_view, name="discover"),
     # Request to join an organization


### PR DESCRIPTION
This adds `/projects/*` Django route so that `orgslug.sentry.io/projects/*` links work on pageload.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.