### PR TITLE
feat(querybuilder): Use query builder in group events endpoint

### DIFF
--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -16,7 +16,7 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.events import (
     get_direct_hit_response,
     get_filter_for_group,
-    get_query_for_group,
+    get_query_builder_for_group,
 )
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
@@ -105,7 +105,9 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):  # type: ignore
 
         try:
             if use_builder:
-                snuba_query = get_query_for_group(request.GET.get("query", ""), params, group)
+                snuba_query = get_query_builder_for_group(
+                    request.GET.get("query", ""), params, group
+                )
             else:
                 snuba_filter, dataset = get_filter_for_group(
                     request.GET.get("query", None), params, group

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from functools import partial
 from typing import TYPE_CHECKING, Optional, Sequence, cast
 
 from django.utils import timezone
@@ -9,15 +8,20 @@ from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import eventstore
+from sentry import eventstore, features
 from sentry.api.base import EnvironmentMixin, region_silo_endpoint
 from sentry.api.bases import GroupEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.helpers.environments import get_environments
-from sentry.api.helpers.events import get_direct_hit_response, get_filter_for_group
+from sentry.api.helpers.events import (
+    get_direct_hit_response,
+    get_filter_for_group,
+    get_query_for_group,
+)
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
 from sentry.api.utils import InvalidParams, get_date_range_from_params
+from sentry.eventstore.models import Event
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.utils import InvalidQuery, parse_query
 
@@ -86,9 +90,12 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):  # type: ignore
             "end": end if end else default_end,
         }
         referrer = f"api.group-events.{group.issue_category.name.lower()}"
+        use_builder = features.has(
+            "organizations:events-use-querybuilder", group.project.organization, actor=request.user
+        )
 
         direct_hit_resp = get_direct_hit_response(
-            request, query, params, f"{referrer}.direct-hit", group
+            request, query, params, f"{referrer}.direct-hit", group, use_builder
         )
         if direct_hit_resp:
             return direct_hit_resp
@@ -97,19 +104,41 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):  # type: ignore
             params["environment"] = [env.name for env in environments]
 
         try:
-            snuba_filter, dataset = get_filter_for_group(
-                request.GET.get("query", None), params, group
-            )
+            if use_builder:
+                snuba_query = get_query_for_group(request.GET.get("query", ""), params, group)
+            else:
+                snuba_filter, dataset = get_filter_for_group(
+                    request.GET.get("query", None), params, group
+                )
         except InvalidSearchQuery as e:
             raise ParseError(detail=str(e))
 
         full = request.GET.get("full", False)
-        data_fn = partial(
-            eventstore.get_events if full else eventstore.get_unfetched_events,
-            referrer=referrer,
-            filter=snuba_filter,
-            dataset=dataset,
-        )
+
+        def data_fn(offset, limit):
+            if use_builder:
+                results = snuba_query.run_query(referrer=referrer)
+                results = [
+                    Event(
+                        event_id=evt["id"],
+                        project_id=evt["project.id"],
+                    )
+                    for evt in results["data"]
+                ]
+                if full:
+                    eventstore.bind_nodes(results)
+
+                return results
+            else:
+                if full:
+                    return eventstore.get_events(
+                        referrer=referrer, filter=snuba_filter, dataset=dataset
+                    )
+                else:
+                    return eventstore.get_unfetched_events(
+                        referrer=referrer, filter=snuba_filter, dataset=dataset
+                    )
+
         serializer = EventSerializer() if full else SimpleEventSerializer()
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Optional, Sequence, cast
+from typing import TYPE_CHECKING, Any, Optional, Sequence, cast
 
 from django.utils import timezone
 from rest_framework.exceptions import ParseError
@@ -115,7 +115,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):  # type: ignore
 
         full = request.GET.get("full", False)
 
-        def data_fn(offset, limit):
+        def data_fn(offset: int, limit: int) -> Any:
             if use_builder:
                 results = snuba_query.run_query(referrer=referrer)
                 results = [

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -7,7 +7,9 @@ from rest_framework.response import Response
 
 from sentry import eventstore
 from sentry.api.serializers import serialize
+from sentry.eventstore.models import Event
 from sentry.issues.query import apply_performance_conditions
+from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.filter import get_filter
 from sentry.snuba.dataset import Dataset
 from sentry.types.issues import GroupCategory
@@ -24,6 +26,7 @@ def get_direct_hit_response(
     snuba_params: Mapping[str, Any],
     referrer: str,
     group: Group,
+    use_builder: bool,
 ) -> Optional[Response]:
     """
     Checks whether a query is a direct hit for an event, and if so returns
@@ -31,14 +34,42 @@ def get_direct_hit_response(
     """
     event_id = normalize_event_id(query)
     if event_id:
-        snuba_filter, dataset = get_filter_for_group(f"id:{event_id}", snuba_params, group)
-        results = eventstore.get_events(referrer=referrer, filter=snuba_filter, dataset=dataset)
+        if use_builder:
+            snuba_query = get_query_for_group(f"id:{event_id}", snuba_params, group)
+            results = snuba_query.run_query(referrer=referrer)
+            results = [
+                Event(
+                    event_id=event_id,
+                    project_id=evt["project.id"],
+                )
+                for evt in results["data"]
+            ]
+            eventstore.bind_nodes(results)
+        else:
+            snuba_filter, dataset = get_filter_for_group(f"id:{event_id}", snuba_params, group)
+            results = eventstore.get_events(referrer=referrer, filter=snuba_filter, dataset=dataset)
 
         if len(results) == 1:
             response = Response(serialize(results, request.user))
             response["X-Sentry-Direct-Hit"] = "1"
             return response
     return None
+
+
+def get_query_for_group(
+    query: str, snuba_params: Mapping[str, Any], group: Group
+) -> Tuple[Filter, Dataset]:
+    dataset = Dataset.Events
+    if group.issue_category == GroupCategory.PERFORMANCE:
+        dataset = Dataset.Transactions
+    snuba_query = QueryBuilder(
+        dataset=dataset,
+        query=f"issue:{group.qualified_short_id} {query}",
+        params=snuba_params,
+        selected_columns=["id", "project.id"],
+    )
+
+    return snuba_query
 
 
 def get_filter_for_group(

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -56,20 +56,16 @@ def get_direct_hit_response(
     return None
 
 
-def get_query_for_group(
-    query: str, snuba_params: Mapping[str, Any], group: Group
-) -> Tuple[Filter, Dataset]:
+def get_query_for_group(query: str, snuba_params: Mapping[str, Any], group: Group) -> QueryBuilder:
     dataset = Dataset.Events
     if group.issue_category == GroupCategory.PERFORMANCE:
         dataset = Dataset.Transactions
-    snuba_query = QueryBuilder(
+    return QueryBuilder(
         dataset=dataset,
         query=f"issue:{group.qualified_short_id} {query}",
         params=snuba_params,
         selected_columns=["id", "project.id"],
     )
-
-    return snuba_query
 
 
 def get_filter_for_group(

--- a/src/sentry/api/helpers/events.py
+++ b/src/sentry/api/helpers/events.py
@@ -35,7 +35,7 @@ def get_direct_hit_response(
     event_id = normalize_event_id(query)
     if event_id:
         if use_builder:
-            snuba_query = get_query_for_group(f"id:{event_id}", snuba_params, group)
+            snuba_query = get_query_builder_for_group(f"id:{event_id}", snuba_params, group)
             results = snuba_query.run_query(referrer=referrer)
             results = [
                 Event(
@@ -56,7 +56,9 @@ def get_direct_hit_response(
     return None
 
 
-def get_query_for_group(query: str, snuba_params: Mapping[str, Any], group: Group) -> QueryBuilder:
+def get_query_builder_for_group(
+    query: str, snuba_params: Mapping[str, Any], group: Group
+) -> QueryBuilder:
     dataset = Dataset.Events
     if group.issue_category == GroupCategory.PERFORMANCE:
         dataset = Dataset.Transactions

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -82,6 +82,7 @@ default_manager.add("organizations:discover-frontend-use-events-endpoint", Organ
 default_manager.add("organizations:discover-query-builder-as-landing-page", OrganizationFeature, True)
 default_manager.add("organizations:dynamic-sampling-deprecated", OrganizationFeature, True)
 default_manager.add("organizations:dynamic-sampling-demo", OrganizationFeature, True)
+default_manager.add("organizations:events-use-querybuilder", OrganizationFeature, True)
 default_manager.add("organizations:enterprise-perf", OrganizationFeature)
 default_manager.add("organizations:grouping-stacktrace-ui", OrganizationFeature, True)
 default_manager.add("organizations:grouping-title-ui", OrganizationFeature, True)


### PR DESCRIPTION
- This adds a feature flag where the query buildere will be used so it can be gradually rolled out
- this is the last place that get_filter is being used, if this change is successful the entire get_filter function and all it depends on can be deleted