### PR TITLE
ref(alert-preview): refactor preview code

### DIFF
--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Sequence
+from typing import Any, Callable, Dict, List, Sequence, Tuple
 
 from django.utils import timezone
 
 from sentry.db.models import BaseQuerySet
 from sentry.models import Group, Project
-from sentry.rules import rules
+from sentry.rules import RuleBase, rules
 from sentry.rules.processor import get_match_function
 from sentry.snuba.dataset import Dataset
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.utils.snuba import raw_query
+
+Conditions = Sequence[Dict[str, Any]]
+ConditionFunc = Callable[[Sequence[bool]], bool]
+GroupActivityMap = Dict[str, List[ConditionActivity]]
 
 PREVIEW_TIME_RANGE = timedelta(weeks=2)
 # limit on number of ConditionActivity's a condition will return
@@ -21,12 +26,15 @@ CONDITION_ACTIVITY_LIMIT = 1000
 
 def preview(
     project: Project,
-    conditions: Sequence[Dict[str, Any]],
-    filters: Sequence[Dict[str, Any]],
+    conditions: Conditions,
+    filters: Conditions,
     condition_match: str,
     filter_match: str,
     frequency_minutes: int,
 ) -> BaseQuerySet | None:
+    """
+    Returns groups that would have triggered the given conditions and filters in the past 2 weeks
+    """
     end = timezone.now()
     start = end - PREVIEW_TIME_RANGE
 
@@ -37,71 +45,121 @@ def preview(
     elif len(conditions) > 1 and condition_match == "all":
         return Group.objects.none()
 
-    activity = []
+    try:
+        group_activity = get_group_activity(project, conditions, start, end)
+        filter_objects, filter_func, event_columns = get_filters(project, filters, filter_match)
+
+        event_map = {}
+        # if there is an event filter, retrieve event data
+        if event_columns:
+            event_map = get_events(project, group_activity, event_columns)
+
+        frequency = timedelta(minutes=frequency_minutes)
+        group_ids = get_fired_groups(
+            group_activity, filter_objects, filter_func, start, frequency, event_map
+        )
+
+        return Group.objects.filter(id__in=group_ids)
+    except PreviewException:
+        return None
+
+
+def get_group_activity(
+    project: Project, conditions: Conditions, start: datetime, end: datetime
+) -> GroupActivityMap:
+    """
+    Returns a list of issue state change activities for each active group in the given time range
+    """
+    group_activity = defaultdict(list)
     for condition in conditions:
         condition_cls = rules.get(condition["id"])
         if condition_cls is None:
-            return None
+            raise PreviewException
         # instantiates a EventCondition subclass and retrieves activities related to it
         condition_inst = condition_cls(project, data=condition)
         try:
-            activity.extend(condition_inst.get_activity(start, end, CONDITION_ACTIVITY_LIMIT))
+            activities = condition_inst.get_activity(start, end, CONDITION_ACTIVITY_LIMIT)
+            for activity in activities:
+                group_activity[activity.group_id].append(activity)
         except NotImplementedError:
-            return None
+            raise PreviewException
 
     k = lambda a: a.timestamp
-    activity.sort(key=k)
+    for activities in group_activity.values():
+        activities.sort(key=k)
 
+    return group_activity
+
+
+def get_filters(
+    project: Project, filters: Conditions, filter_match: str
+) -> Tuple[Sequence[RuleBase], ConditionFunc, List[str]]:
+    """
+    Returns instantiated filter objects, the filter match function, and relevant snuba columns used for answering event filters
+    """
     filter_objects = []
     event_columns = set()
     for filter in filters:
         filter_cls = rules.get(filter["id"])
         if filter_cls is None:
-            return None
+            raise PreviewException
         filter_object = filter_cls(project, data=filter)
         filter_objects.append(filter_object)
         event_columns.update(filter_object.get_event_columns())
 
     filter_func = get_match_function(filter_match)
     if filter_func is None:
-        return None
+        raise PreviewException
 
-    event_map = {}
-    # if there is an event filter, retrieve event data
-    if event_columns:
-        event_map = get_events(project, activity, list(event_columns))
+    return filter_objects, filter_func, list(event_columns)
 
-    frequency = timedelta(minutes=frequency_minutes)
-    group_last_fire: Dict[str, datetime] = {}
+
+def get_fired_groups(
+    group_activity: GroupActivityMap,
+    filter_objects: Sequence[RuleBase],
+    filter_func: ConditionFunc,
+    start: datetime,
+    frequency: timedelta,
+    event_map: Dict[str, Any],
+) -> Sequence[str]:
+    """
+    Applies filter objects to the condition activity, returns the group ids of activities that pass the filters
+    """
     group_ids = set()
-    for event in activity:
-        try:
-            passes = [f.passes_activity(event, event_map) for f in filter_objects]
-        except NotImplementedError:
-            return None
-        last_fire = group_last_fire.get(event.group_id, event.timestamp - frequency)
-        if last_fire <= event.timestamp - frequency and filter_func(passes):
-            group_ids.add(event.group_id)
-            group_last_fire[event.group_id] = event.timestamp
+    for group, activities in group_activity.items():
+        last_fire = start - frequency
+        for event in activities:
+            try:
+                passes = [f.passes_activity(event, event_map) for f in filter_objects]
+            except NotImplementedError:
+                raise PreviewException
+            if last_fire <= event.timestamp - frequency and filter_func(passes):
+                # XXX: we could break after adding the group, but we may potentially want the times of fires later
+                group_ids.add(group)
+                last_fire = event.timestamp
 
-    return Group.objects.filter(id__in=group_ids)
+    return list(group_ids)
 
 
 def get_events(
-    project: Project, condition_activity: Sequence[ConditionActivity], columns: List[str]
+    project: Project, group_activity: GroupActivityMap, columns: List[str]
 ) -> Dict[str, Any]:
     """
     Returns events that have caused issue state changes.
     """
     group_ids = []
     event_ids = []
-    for activity in condition_activity:
-        if activity.type == ConditionActivityType.CREATE_ISSUE:
-            group_ids.append(activity.group_id)
-        elif activity.type in (ConditionActivityType.REGRESSION, ConditionActivityType.REAPPEARED):
-            event_id = activity.data.get("event_id", None)
-            if event_id is not None:
-                event_ids.append(event_id)
+    for group, activities in group_activity.items():
+        for activity in activities:
+            if activity.type == ConditionActivityType.CREATE_ISSUE:
+                group_ids.append(activity.group_id)
+            elif activity.type in (
+                ConditionActivityType.REGRESSION,
+                ConditionActivityType.REAPPEARED,
+            ):
+                event_id = activity.data.get("event_id", None)
+                if event_id is not None:
+                    event_ids.append(event_id)
 
     columns.append("event_id")
     events = []
@@ -117,11 +175,12 @@ def get_events(
         )
         # store event_ids for CREATE_ISSUE condition activities
         group_map = {event["group_id"]: event["event_id"] for event in events}
-        for activity in condition_activity:
-            if activity.type == ConditionActivityType.CREATE_ISSUE:
-                event_id = group_map.get(activity.group_id, None)
+        for group, activities in group_activity.items():
+            # if there is a CREATE_ISSUE activity, it must be the first
+            if activities[0].type == ConditionActivityType.CREATE_ISSUE:
+                event_id = group_map.get(group, None)
                 if event_id is not None:
-                    activity.data = {"event_id": event_id}
+                    activities[0].data = {"event_id": event_id}
 
     if event_ids:
         events.extend(
@@ -140,3 +199,7 @@ def get_events(
             event["tags"] = {k: v for k, v in zip(keys, values)}
 
     return {event["event_id"]: event for event in events}
+
+
+class PreviewException(Exception):
+    pass

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -310,18 +310,20 @@ class GetEventsTest(TestCase):
         )
         event.group.update(first_seen=two_hours)
 
-        activity = [
-            ConditionActivity(
-                group_id=event.group.id,
-                type=ConditionActivityType.CREATE_ISSUE,
-                timestamp=prev_hour,
-            )
-        ]
+        activity = {
+            event.group.id: [
+                ConditionActivity(
+                    group_id=event.group.id,
+                    type=ConditionActivityType.CREATE_ISSUE,
+                    timestamp=prev_hour,
+                )
+            ]
+        }
         events = get_events(self.project, activity, [])
 
         assert len(events) == 1
         assert event.event_id in events
-        assert activity[0].data["event_id"] == event.event_id
+        assert activity[event.group.id][0].data["event_id"] == event.event_id
 
     def test_get_activity(self):
         prev_hour = timezone.now() - timedelta(hours=1)
@@ -333,20 +335,22 @@ class GetEventsTest(TestCase):
             project_id=self.project.id, data={"timestamp": iso_format(prev_hour)}
         )
 
-        activity = [
-            ConditionActivity(
-                group_id=group.id,
-                type=ConditionActivityType.REGRESSION,
-                timestamp=prev_hour,
-                data={"event_id": regression_event.event_id},
-            ),
-            ConditionActivity(
-                group_id=group.id,
-                type=ConditionActivityType.REAPPEARED,
-                timestamp=prev_hour,
-                data={"event_id": reappeared_event.event_id},
-            ),
-        ]
+        activity = {
+            group.id: [
+                ConditionActivity(
+                    group_id=group.id,
+                    type=ConditionActivityType.REGRESSION,
+                    timestamp=prev_hour,
+                    data={"event_id": regression_event.event_id},
+                ),
+                ConditionActivity(
+                    group_id=group.id,
+                    type=ConditionActivityType.REAPPEARED,
+                    timestamp=prev_hour,
+                    data={"event_id": reappeared_event.event_id},
+                ),
+            ]
+        }
         events = get_events(self.project, activity, [])
 
         assert len(events) == 2


### PR DESCRIPTION
Refactors the preview code and separates all of the logic into separate functions.

Other than that, the only difference is that instead of storing the condition activity all in one list,
```
[<ConditionActivity1, group_id=1>, <ConditionActivity2, group_id=2>, <ConditionActivity3, group_id=1>]
```
We separate the activities by group_id
```
{
  1: [<ConditionActivity1>, <ConditionActivity3>],
  2: [<ConditionActivity2>],
}
```
This is done so that we can process the activity of each group separately. This way we only need to store the data relevant to one group at a time in memory to support frequency conditions.