### PR TITLE
feat(onboarding): Update onboarding copy

### DIFF
--- a/static/app/components/onboardingWizard/progressHeader.tsx
+++ b/static/app/components/onboardingWizard/progressHeader.tsx
@@ -20,8 +20,8 @@ function ProgressHeader({allTasks, completedTasks}: Props) {
     title = t('Guided Tours');
     description = t('Take a guided tour to see what Sentry can do for you');
   } else {
-    title = t('Quick Start');
-    description = t('Walk through this guide to get the most out of Sentry right away.');
+    title = t('Quick Start Guide');
+    description = t("Here's how to get the most out of Sentry.");
   }
 
   const filteredTasks = allTasks.filter(task => !task.renderCard);

--- a/static/app/components/onboardingWizard/sidebar.tsx
+++ b/static/app/components/onboardingWizard/sidebar.tsx
@@ -55,7 +55,7 @@ Heading.defaultProps = {
   transition: testableTransition(),
 };
 
-const completeNowText = isDemoWalkthrough() ? t('Sentry Basics') : t('Next Steps');
+const completeNowText = isDemoWalkthrough() ? t('Sentry Basics') : '';
 
 const customizedTasksHeading = <Heading key="customized">{t('The Basics')}</Heading>;
 const completeNowHeading = <Heading key="now">{completeNowText}</Heading>;

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -142,7 +142,7 @@ export function getOnboardingTasks({
       task: OnboardingTaskKey.FIRST_EVENT,
       title: t('Capture your first error'),
       description: t(
-        "Time to test it out. Now that you've created a project, capture your first error. We've got an example you can fiddle with."
+        "Now that you've created a project, test it by capturing your first error. We've got an example you can fiddle with."
       ),
       skippable: false,
       requisites: [OnboardingTaskKey.FIRST_PROJECT],
@@ -167,7 +167,7 @@ export function getOnboardingTasks({
       task: OnboardingTaskKey.INVITE_MEMBER,
       title: t('Invite your team'),
       description: t(
-        'Assign issues and comment on shared errors with coworkers so you always know who to blame when sh*t hits the fan.'
+        'Assign issues to the right people and comment back-and-forth on shared errors with coworkers.'
       ),
       skippable: true,
       requisites: [],
@@ -179,7 +179,7 @@ export function getOnboardingTasks({
       task: OnboardingTaskKey.FIRST_INTEGRATION,
       title: t('Install any of our 40+ integrations'),
       description: t(
-        'Get alerted in Slack. Two-way sync issues between Sentry and Jira. Notify Sentry of releases from GitHub, Vercel, or Netlify.'
+        'Get alerts in Slack, sync Sentry and Jira, notify Sentry of releases from GitHub, Vercel, or Netlify.'
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
@@ -191,7 +191,7 @@ export function getOnboardingTasks({
       task: OnboardingTaskKey.SECOND_PLATFORM,
       title: t('Create another project'),
       description: t(
-        'Easy, right? Don’t stop at one. Set up another project and send it events to keep things running smoothly in both the frontend and backend.'
+        'Make it easy to quickly tell where errors are coming from by setting up separate Projects for your frontend and backend.'
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
@@ -289,7 +289,7 @@ export function getOnboardingTasks({
       task: OnboardingTaskKey.SOURCEMAPS,
       title: t('Upload source maps'),
       description: t(
-        "Deminify Javascript source code to debug with context. Seeing code in it's original form will help you debunk the ghosts of errors past."
+        'Make Javascript source code human readable and debug with greater context and speed. Seeing code in its original form will help you debunk the ghosts of errors past.'
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],
@@ -325,7 +325,7 @@ export function getOnboardingTasks({
       task: OnboardingTaskKey.ALERT_RULE,
       title: t('Configure an Issue Alert'),
       description: t(
-        'We all have issues. Get real-time error notifications by setting up alerts for issues that match your set criteria.'
+        'Get real-time error notifications by setting up Issue Alerts for what matters to you.'
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT],

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -167,7 +167,7 @@ export function getOnboardingTasks({
       task: OnboardingTaskKey.INVITE_MEMBER,
       title: t('Invite your team'),
       description: t(
-        'Assign issues to the right people and comment back-and-forth on shared errors with coworkers.'
+        'Assign issues and comment on shared errors with coworkers so you always know who to blame when sh*t hits the fan.'
       ),
       skippable: true,
       requisites: [],
@@ -289,7 +289,7 @@ export function getOnboardingTasks({
       task: OnboardingTaskKey.SOURCEMAPS,
       title: t('Upload source maps'),
       description: t(
-        'Make Javascript source code human readable and debug with greater context and speed. Seeing code in its original form will help you debunk the ghosts of errors past.'
+        'Unminify JavaScript source code and debug with context. Seeing code in its original form will help you debunk the ghosts of errors past.'
       ),
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT, OnboardingTaskKey.FIRST_EVENT],


### PR DESCRIPTION
Copy changes from @lizokm


Updated the header of the Quick start sidebar and removed the 'next up' section header (but not the other section heads)
<img width="455" alt="Screen Shot 2022-11-11 at 11 41 01 AM" src="https://user-images.githubusercontent.com/187460/201417552-29cb7081-eeef-4264-b345-5536022c6847.png">

And then some copy changes inside a few tasks.