### PR TITLE
fix(issue-stream): Fix issue stream reloading after initial load

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -247,7 +247,8 @@ class IssueListOverview extends Component<Props, State> {
       prevQuery.query !== newQuery.query ||
       prevQuery.statsPeriod !== newQuery.statsPeriod ||
       prevQuery.groupStatsPeriod !== newQuery.groupStatsPeriod ||
-      prevProps.savedSearch !== this.props.savedSearch
+      prevProps.savedSearch?.query !== this.props.savedSearch?.query ||
+      prevProps.savedSearch?.sort !== this.props.savedSearch?.sort
     ) {
       this.fetchData(selectionChanged);
     } else if (

--- a/static/app/views/issueList/utils/useSelectedSavedSearch.tsx
+++ b/static/app/views/issueList/utils/useSelectedSavedSearch.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import isNil from 'lodash/isNil';
 
 import {t} from 'sentry/locale';
@@ -30,10 +31,14 @@ export const useSelectedSavedSearch = (): SavedSearch | null => {
       ? savedSearches?.find(search => search.isPinned)
       : savedSearches?.find(({id}) => id === selectedSearchId);
 
-  return selectedSavedSearch?.isPinned
-    ? {
-        ...selectedSavedSearch,
-        name: PINNED_SEARCH_NAME,
-      }
-    : selectedSavedSearch ?? null;
+  return useMemo(
+    () =>
+      selectedSavedSearch?.isPinned
+        ? {
+            ...selectedSavedSearch,
+            name: PINNED_SEARCH_NAME,
+          }
+        : selectedSavedSearch ?? null,
+    [selectedSavedSearch]
+  );
 };


### PR DESCRIPTION
To reproduce:

- Set a default on the issues page
- Go to another page
- Return to issues page, wait for issues to load, then wait a bit longer and see that another load is triggered later on

The issue is that the component was checking referential equality for the selected saved search, which was being modified in `useSelectedSavedSearch` (to change the name to "My Default Search".

I made two changes - a `useMemo` to avoid making a new savedSearch object on each render, and avoided a referential check in `overview.tsx` by checking for differing query/sort on the saved search instead.