### PR TITLE
fix(test): Fix performance issue alert email test

### DIFF
--- a/src/sentry/web/frontend/debug/debug_performance_issue.py
+++ b/src/sentry/web/frontend/debug/debug_performance_issue.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytz
 from django.utils.safestring import mark_safe
 from django.views.generic import View
@@ -12,7 +14,6 @@ from sentry.notifications.utils import (
     get_transaction_data,
 )
 from sentry.testutils.helpers import override_options
-from sentry.testutils.helpers.datetime import before_now
 from sentry.types.issues import GROUP_TYPE_TO_TEXT
 from sentry.utils import json
 from sentry.utils.samples import load_data
@@ -35,7 +36,14 @@ class DebugPerformanceIssueEmailView(View):
                 "performance.issues.n_plus_one_db.problem-creation": 1.0,
             }
         ):
-            perf_data = load_data("transaction-n-plus-one", timestamp=before_now(minutes=10))
+            # make this consistent for acceptance tests
+            perf_data = dict(
+                load_data(
+                    "transaction-n-plus-one",
+                    timestamp=datetime.datetime(2022, 11, 11, 21, 39, 23, 30723),
+                )
+            )
+            perf_data["event_id"] = "44f1419e73884cd2b45c79918f4b6dc4"
             perf_event_manager = EventManager(perf_data)
             perf_event_manager.normalize()
             perf_data = perf_event_manager.get_data()

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -19,7 +19,7 @@ EMAILS = (
     ("/debug/mail/unable-to-fetch-commits/", "unable to fetch commits"),
     ("/debug/mail/unable-to-delete-repo/", "unable to delete repo"),
     ("/debug/mail/error-alert/", "alert"),
-    # ("/debug/mail/performance-alert/", "performance"), #TODO(ceo) this is flaky
+    ("/debug/mail/performance-alert/", "performance"),
     ("/debug/mail/digest/", "digest"),
     ("/debug/mail/invalid-identity/", "invalid identity"),
     ("/debug/mail/invitation/", "invitation"),


### PR DESCRIPTION
Another stab at fixing this flaky performance issue alert email test - see https://github.com/getsentry/sentry/pull/40467 for links to previous attempts. 