### PR TITLE
feat(hybrid-cloud): Add /dashboards/* and /dashboard/* Django routes

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -462,6 +462,7 @@ urlpatterns += [
     # Projects
     url(r"^projects/", react_page_view, name="projects"),
     # Dashboards
+    url(r"^dashboard/", react_page_view, name="dashboard"),
     url(r"^dashboards/", react_page_view, name="dashboards"),
     # Discover
     url(r"^discover/", react_page_view, name="discover"),

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -461,6 +461,8 @@ urlpatterns += [
     ),
     # Projects
     url(r"^projects/", react_page_view, name="projects"),
+    # Dashboards
+    url(r"^dashboards/", react_page_view, name="dashboards"),
     # Discover
     url(r"^discover/", react_page_view, name="discover"),
     # Request to join an organization


### PR DESCRIPTION
This adds `/dashboards/*` and `/dashboard/*` Django routes, so that `orgslug.sentry.io/dashboards/*` and `orgslug.sentry.io/dashboard/*` links work on pageload respectively.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.