### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for Dashboards product.

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -10,6 +10,8 @@ import {DataCategory, OrgRole, PermissionResource, Scope} from 'sentry/types';
 // This is the element id where we render our React application to
 export const ROOT_ELEMENT = 'blk_router';
 
+export const usingCustomerDomain = Boolean(window.__initialData?.customerDomain);
+
 // This is considered the "default" route/view that users should be taken
 // to when the application does not have any further context
 //

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -10,7 +10,8 @@ import {DataCategory, OrgRole, PermissionResource, Scope} from 'sentry/types';
 // This is the element id where we render our React application to
 export const ROOT_ELEMENT = 'blk_router';
 
-export const usingCustomerDomain = Boolean(window.__initialData?.customerDomain);
+export const usingCustomerDomain =
+  typeof window !== 'undefined' ? Boolean(window?.__initialData?.customerDomain) : false;
 
 // This is considered the "default" route/view that users should be taken
 // to when the application does not have any further context

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -10,7 +10,7 @@ import {
 import memoize from 'lodash/memoize';
 
 import LazyLoad from 'sentry/components/lazyLoad';
-import {EXPERIMENTAL_SPA} from 'sentry/constants';
+import {EXPERIMENTAL_SPA, usingCustomerDomain} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import HookStore from 'sentry/stores/hookStore';
 import {HookName} from 'sentry/types/hooks';
@@ -142,8 +142,6 @@ function buildRoutes() {
   //   they have redirects for. A good rule here is to place 'helper' redirects
   //   next to the routes they redirect to, and place 'legacy route' redirects
   //   for routes that have completely changed in this tree.
-
-  const usingCustomerDomain = Boolean(window.__initialData.customerDomain);
 
   const experimentalSpaRoutes = EXPERIMENTAL_SPA ? (
     <Route path="/auth/login/" component={errorHandler(AuthLayout)}>

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -956,57 +956,136 @@ function buildRoutes() {
     </Fragment>
   );
 
-  const dashboardRoutes = (
+  const dashboardWidgetRoutes = (
     <Fragment>
       <Route
-        path="/organizations/:orgId/dashboards/"
-        component={make(() => import('sentry/views/dashboardsV2'))}
-      >
-        <IndexRoute component={make(() => import('sentry/views/dashboardsV2/manage'))} />
-      </Route>
+        path="widget/:widgetIndex/edit/"
+        component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
+      />
       <Route
-        path="/organizations/:orgId/dashboards/new/"
-        component={make(() => import('sentry/views/dashboardsV2/create'))}
-      >
-        <Route
-          path="widget/:widgetIndex/edit/"
-          component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
-        />
-        <Route
-          path="widget/new/"
-          component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
-        />
-      </Route>
+        path="widget/new/"
+        component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
+      />
       <Route
-        path="/organizations/:orgId/dashboards/new/:templateId"
-        component={make(() => import('sentry/views/dashboardsV2/create'))}
-      >
+        path="widget/:widgetId/"
+        component={make(() => import('sentry/views/dashboardsV2/view'))}
+      />
+    </Fragment>
+  );
+
+  const dashboardRoutes = (
+    <Fragment>
+      <Fragment>
+        {usingCustomerDomain ? (
+          <Route
+            path="/dashboards/"
+            component={withDomainRequired(
+              make(() => import('sentry/views/dashboardsV2'))
+            )}
+            key="orgless-dashboards-route"
+          >
+            <IndexRoute
+              component={make(() => import('sentry/views/dashboardsV2/manage'))}
+            />
+          </Route>
+        ) : null}
         <Route
-          path="widget/:widgetId/"
+          path="/organizations/:orgId/dashboards/"
+          component={make(() => import('sentry/views/dashboardsV2'))}
+          key="org-dashboards"
+        >
+          <IndexRoute
+            component={make(() => import('sentry/views/dashboardsV2/manage'))}
+          />
+        </Route>
+      </Fragment>
+      <Fragment>
+        {usingCustomerDomain ? (
+          <Route
+            path="/dashboards/new/"
+            component={withDomainRequired(
+              make(() => import('sentry/views/dashboardsV2/create'))
+            )}
+            key="orgless-dashboards-new-route"
+          >
+            <Route
+              path="widget/:widgetIndex/edit/"
+              component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
+            />
+            <Route
+              path="widget/new/"
+              component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
+            />
+          </Route>
+        ) : null}
+        <Route
+          path="/organizations/:orgId/dashboards/new/"
           component={make(() => import('sentry/views/dashboardsV2/create'))}
-        />
-      </Route>
+          key="org-dashboards-new"
+        >
+          <Route
+            path="widget/:widgetIndex/edit/"
+            component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
+          />
+          <Route
+            path="widget/new/"
+            component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
+          />
+        </Route>
+      </Fragment>
+      <Fragment>
+        {usingCustomerDomain ? (
+          <Route
+            path="/dashboards/new/:templateId"
+            component={withDomainRequired(
+              make(() => import('sentry/views/dashboardsV2/create'))
+            )}
+            key="orgless-dashboards-new-template-route"
+          >
+            <Route
+              path="widget/:widgetId/"
+              component={make(() => import('sentry/views/dashboardsV2/create'))}
+            />
+          </Route>
+        ) : null}
+        <Route
+          path="/organizations/:orgId/dashboards/new/:templateId"
+          component={make(() => import('sentry/views/dashboardsV2/create'))}
+          key="org-dashboards-new-template"
+        >
+          <Route
+            path="widget/:widgetId/"
+            component={make(() => import('sentry/views/dashboardsV2/create'))}
+          />
+        </Route>
+      </Fragment>
       <Redirect
         from="/organizations/:orgId/dashboards/:dashboardId/"
         to="/organizations/:orgId/dashboard/:dashboardId/"
       />
-      <Route
-        path="/organizations/:orgId/dashboard/:dashboardId/"
-        component={make(() => import('sentry/views/dashboardsV2/view'))}
-      >
+      {usingCustomerDomain ? (
+        <Redirect from="/dashboards/:dashboardId/" to="/dashboard/:dashboardId/" />
+      ) : null}
+      <Fragment>
+        {usingCustomerDomain ? (
+          <Route
+            path="/dashboard/:dashboardId/"
+            component={withDomainRequired(
+              make(() => import('sentry/views/dashboardsV2/view'))
+            )}
+            key="orgless-dashboards-dashboard-id-route"
+          >
+            {dashboardWidgetRoutes}
+          </Route>
+        ) : null}
         <Route
-          path="widget/:widgetIndex/edit/"
-          component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
-        />
-        <Route
-          path="widget/new/"
-          component={make(() => import('sentry/views/dashboardsV2/widgetBuilder'))}
-        />
-        <Route
-          path="widget/:widgetId/"
+          path="/organizations/:orgId/dashboard/:dashboardId/"
           component={make(() => import('sentry/views/dashboardsV2/view'))}
-        />
-      </Route>
+          key="org-dashboards-dashboard-id"
+        >
+          {dashboardWidgetRoutes}
+        </Route>
+      </Fragment>
     </Fragment>
   );
 

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -991,7 +991,7 @@ function buildRoutes() {
         ) : null}
         <Route
           path="/organizations/:orgId/dashboards/"
-          component={make(() => import('sentry/views/dashboardsV2'))}
+          component={withDomainRedirect(make(() => import('sentry/views/dashboardsV2')))}
           key="org-dashboards"
         >
           <IndexRoute
@@ -1020,7 +1020,9 @@ function buildRoutes() {
         ) : null}
         <Route
           path="/organizations/:orgId/dashboards/new/"
-          component={make(() => import('sentry/views/dashboardsV2/create'))}
+          component={withDomainRedirect(
+            make(() => import('sentry/views/dashboardsV2/create'))
+          )}
           key="org-dashboards-new"
         >
           <Route
@@ -1050,7 +1052,9 @@ function buildRoutes() {
         ) : null}
         <Route
           path="/organizations/:orgId/dashboards/new/:templateId"
-          component={make(() => import('sentry/views/dashboardsV2/create'))}
+          component={withDomainRedirect(
+            make(() => import('sentry/views/dashboardsV2/create'))
+          )}
           key="org-dashboards-new-template"
         >
           <Route
@@ -1080,7 +1084,9 @@ function buildRoutes() {
         ) : null}
         <Route
           path="/organizations/:orgId/dashboard/:dashboardId/"
-          component={make(() => import('sentry/views/dashboardsV2/view'))}
+          component={withDomainRedirect(
+            make(() => import('sentry/views/dashboardsV2/view'))
+          )}
           key="org-dashboards-dashboard-id"
         >
           {dashboardWidgetRoutes}

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -26,6 +26,7 @@ import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import ProjectPageFilter from 'sentry/components/projectPageFilter';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
+import {usingCustomerDomain} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
@@ -241,6 +242,18 @@ class DashboardDetail extends Component<Props, State> {
       `/organizations/${organization.slug}/dashboards/new/widget/${widgetIndex}/edit/`,
       `/organizations/${organization.slug}/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
     ];
+
+    if (usingCustomerDomain) {
+      // TODO: replace with url generation later on.
+      widgetBuilderRoutes.push(
+        ...[
+          `/dashboards/new/widget/new/`,
+          `/dashboard/${dashboardId}/widget/new/`,
+          `/dashboards/new/widget/${widgetIndex}/edit/`,
+          `/dashboard/${dashboardId}/widget/${widgetIndex}/edit/`,
+        ]
+      );
+    }
 
     return widgetBuilderRoutes.includes(location.pathname);
   }


### PR DESCRIPTION
This adds the customer domain React routes for the Dashboards product.

These changes was cherry picked from https://github.com/getsentry/sentry/pull/40215.
