### PR TITLE
fix(issue-stream): Hide chart and assignee columns sooner when sidebar is open

### DIFF
--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -12,16 +12,10 @@ type Props = {
 const GroupListHeader = ({withChart = true, narrowGroups = false}: Props) => (
   <PanelHeader disablePadding>
     <IssueWrapper>{t('Issue')}</IssueWrapper>
-    {withChart && (
-      <ChartWrapper className={`hidden-xs hidden-sm ${narrowGroups ? 'hidden-md' : ''}`}>
-        {t('Graph')}
-      </ChartWrapper>
-    )}
+    {withChart && <ChartWrapper narrowGroups={narrowGroups}>{t('Graph')}</ChartWrapper>}
     <EventUserWrapper>{t('events')}</EventUserWrapper>
     <EventUserWrapper>{t('users')}</EventUserWrapper>
-    <AssigneeWrapper className="hidden-xs hidden-sm toolbar-header">
-      {t('Assignee')}
-    </AssigneeWrapper>
+    <AssigneeWrapper narrowGroups={narrowGroups}>{t('Assignee')}</AssigneeWrapper>
   </PanelHeader>
 );
 
@@ -52,12 +46,22 @@ const EventUserWrapper = styled(Heading)`
   }
 `;
 
-const ChartWrapper = styled(Heading)`
+const ChartWrapper = styled(Heading)<{narrowGroups: boolean}>`
   justify-content: space-between;
   width: 160px;
+
+  @media (max-width: ${p =>
+      p.narrowGroups ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
+    display: none;
+  }
 `;
 
-const AssigneeWrapper = styled(Heading)`
+const AssigneeWrapper = styled(Heading)<{narrowGroups: boolean}>`
   justify-content: flex-end;
   width: 80px;
+
+  @media (max-width: ${p =>
+      p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+    display: none;
+  }
 `;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -456,9 +456,7 @@ function BaseGroupRow({
       {hasGuideAnchor && issueStreamAnchor}
 
       {withChart && !displayReprocessingLayout && (
-        <ChartWrapper
-          className={`hidden-xs hidden-sm ${narrowGroups ? 'hidden-md' : ''}`}
-        >
+        <ChartWrapper narrowGroups={narrowGroups}>
           {!group.filtered?.stats && !group.stats ? (
             <Placeholder height="24px" />
           ) : (
@@ -477,7 +475,7 @@ function BaseGroupRow({
         <Fragment>
           <EventCountsWrapper>{groupCount}</EventCountsWrapper>
           <EventCountsWrapper>{groupUsersCount}</EventCountsWrapper>
-          <AssigneeWrapper className="hidden-xs hidden-sm">
+          <AssigneeWrapper narrowGroups={narrowGroups}>
             <AssigneeSelector
               id={group.id}
               memberList={memberList}
@@ -641,9 +639,14 @@ const MenuItemText = styled('div')`
   color: ${p => p.theme.textColor};
 `;
 
-const ChartWrapper = styled('div')`
+const ChartWrapper = styled('div')<{narrowGroups: boolean}>`
   width: 200px;
   align-self: center;
+
+  @media (max-width: ${p =>
+      p.narrowGroups ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
+    display: none;
+  }
 `;
 
 const EventCountsWrapper = styled('div')`
@@ -658,10 +661,15 @@ const EventCountsWrapper = styled('div')`
   }
 `;
 
-const AssigneeWrapper = styled('div')`
+const AssigneeWrapper = styled('div')<{narrowGroups: boolean}>`
   width: 80px;
   margin: 0 ${space(2)};
   align-self: center;
+
+  @media (max-width: ${p =>
+      p.narrowGroups ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+    display: none;
+  }
 `;
 
 // Reprocessing

--- a/static/app/views/issueList/actions/headers.tsx
+++ b/static/app/views/issueList/actions/headers.tsx
@@ -12,6 +12,7 @@ type Props = {
   selection: PageFilters;
   statsPeriod: string;
   anySelected?: boolean;
+  isSavedSearchesOpen?: boolean;
 };
 
 function Headers({
@@ -19,6 +20,7 @@ function Headers({
   statsPeriod,
   onSelectStatsPeriod,
   isReprocessingQuery,
+  isSavedSearchesOpen,
 }: Props) {
   return (
     <Fragment>
@@ -30,7 +32,7 @@ function Headers({
         </Fragment>
       ) : (
         <Fragment>
-          <GraphHeaderWrapper className="hidden-xs hidden-sm hidden-md">
+          <GraphHeaderWrapper isSavedSearchesOpen={isSavedSearchesOpen}>
             <GraphHeader>
               <StyledToolbarHeader>{t('Graph:')}</StyledToolbarHeader>
               {selection.datetime.period !== '24h' && (
@@ -51,7 +53,7 @@ function Headers({
           </GraphHeaderWrapper>
           <EventsOrUsersLabel>{t('Events')}</EventsOrUsersLabel>
           <EventsOrUsersLabel>{t('Users')}</EventsOrUsersLabel>
-          <AssigneesLabel className="hidden-xs hidden-sm">
+          <AssigneesLabel isSavedSearchesOpen={isSavedSearchesOpen}>
             <ToolbarHeader>{t('Assignee')}</ToolbarHeader>
           </AssigneesLabel>
         </Fragment>
@@ -62,11 +64,16 @@ function Headers({
 
 export default Headers;
 
-const GraphHeaderWrapper = styled('div')`
+const GraphHeaderWrapper = styled('div')<{isSavedSearchesOpen?: boolean}>`
   width: 160px;
   margin-left: ${space(2)};
   margin-right: ${space(2)};
   animation: 0.25s FadeIn linear forwards;
+
+  @media (max-width: ${p =>
+      p.isSavedSearchesOpen ? p.theme.breakpoints.xlarge : p.theme.breakpoints.large}) {
+    display: none;
+  }
 
   @keyframes FadeIn {
     0% {
@@ -111,12 +118,17 @@ const EventsOrUsersLabel = styled(ToolbarHeader)`
   }
 `;
 
-const AssigneesLabel = styled('div')`
+const AssigneesLabel = styled('div')<{isSavedSearchesOpen?: boolean}>`
   justify-content: flex-end;
   text-align: right;
   width: 80px;
   margin-left: ${space(2)};
   margin-right: ${space(2)};
+
+  @media (max-width: ${p =>
+      p.isSavedSearchesOpen ? p.theme.breakpoints.large : p.theme.breakpoints.medium}) {
+    display: none;
+  }
 `;
 
 // Reprocessing

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -219,6 +219,7 @@ function IssueListActions({
           selection={selection}
           statsPeriod={statsPeriod}
           isReprocessingQuery={displayReprocessingActions}
+          isSavedSearchesOpen={isSavedSearchesOpen}
         />
       </StyledFlex>
       {!allResultsVisible && pageSelected && (


### PR DESCRIPTION
Not happy with having to line up the header and the body in separate files, would rather have a better way of syncing the two. But we will implementing new designs soon hopefully so I'm just putting these in as quick fixes.

Before:

![CleanShot 2022-11-11 at 14 31 39](https://user-images.githubusercontent.com/10888943/201439763-55b9cb6e-fe1d-4ea7-bcf0-48264bc56f21.png)


After:

![CleanShot 2022-11-11 at 14 30 48](https://user-images.githubusercontent.com/10888943/201439708-84d04a37-fa9e-4bdc-a6aa-d982c80a89c2.png)
