### PR TITLE
perf(users-endpoint): Improve users endpoint performance

### DIFF
--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -37,11 +37,10 @@ class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     ).values_list("organizationmember_id", flat=True),
                 )
                 .select_related("user")
-                .prefetch_related(
-                    "teams", "teams__projectteam_set", "teams__projectteam_set__project"
-                )
+                .prefetch_related("teams")
                 .order_by("user__email")
             )
+
             organization_members = list(qs)
 
             span.set_data("Project Count", len(projects))


### PR DESCRIPTION
This endpoint relied on the query set to prefetch nested models from OrganizationMember -> Team -> ProjectTeam -> Project. There's a lot of redundancies in this many to many relationship so when prefetching, django is doing a lot of processing to actually join the data in python. If there are `a` members, each member is on `b` teams, and each team has `c` projects, then django needs iterate `a` members, for each member, `b` teams, and for teach team `c` projects, resulting in `a * b * c` operations in the worst case where every member is on every team and every team has every project. This change aims to improve this by splitting the query into 2 stages and manually perform the lookups within the serializer instead of relying on django to construct all the relationships and traversing them all.

Looking at the transaction for the users endpoint, we see that the `OrganizationUsersEndpoint.get_members` span is taking a long time but we can also see that the actual database queries were fast.

![image](https://user-images.githubusercontent.com/10239353/201440969-e93a7354-2e74-4732-8b9e-9d330217e30e.png)

Looking at the [profile](https://sentry.io/organizations/sentry/profiling/profile/sentry/65220d4907494b7d9f56f833d93d1736/flamechart/?colorCoding=by+symbol+name&fov=0%2C84%2C2019290624%2C38&query=&sorting=call+order&tid=140587047032576&view=top+down&xAxis=standalone), we can see that we're taking a long time inside the `prefetch_related_objects` frame.

![image](https://user-images.githubusercontent.com/10239353/201685140-b3cd8179-b013-4be1-bfd0-7fa1f593b88f.png)

Looking closely at the query, we can see that we're fetching multiple levels of nested relations that django is trying to join together.