### PR TITLE
feat(monitors): Graph missed checkins

### DIFF
--- a/static/app/views/monitors/monitorStats.tsx
+++ b/static/app/views/monitors/monitorStats.tsx
@@ -52,18 +52,24 @@ const MonitorStats = ({monitor}: Props) => {
     yAxisIndex: 0,
     data: [] as SeriesDataUnit[],
   };
+  const missed = {
+    seriesName: t('Missed'),
+    yAxisIndex: 0,
+    data: [] as SeriesDataUnit[],
+  };
   const durationData = [] as [number, number][];
 
   data.stats?.forEach(p => {
-    if (p.ok || p.error) {
+    if (p.ok || p.error || p.missed) {
       emptyStats = false;
     }
     const timestamp = p.ts * 1000;
     success.data.push({name: timestamp, value: p.ok});
     failed.data.push({name: timestamp, value: p.error});
+    missed.data.push({name: timestamp, value: p.missed});
     durationData.push([timestamp, Math.trunc(p.duration)]);
   });
-  const colors = [theme.green200, theme.red200];
+  const colors = [theme.green200, theme.red200, theme.yellow200];
 
   const durationTitle = t('Average Duration');
   const additionalSeries: LineSeriesOption[] = [
@@ -96,7 +102,7 @@ const MonitorStats = ({monitor}: Props) => {
           <BarChart
             isGroupedByDate
             showTimeInTooltip
-            series={[success, failed]}
+            series={[success, failed, missed]}
             stacked
             additionalSeries={additionalSeries}
             height={height}

--- a/static/app/views/monitors/monitorStats.tsx
+++ b/static/app/views/monitors/monitorStats.tsx
@@ -1,12 +1,11 @@
 import type {LineSeriesOption} from 'echarts';
 
-import {BarChart} from 'sentry/components/charts/barChart';
+import {BarChart, BarChartSeries} from 'sentry/components/charts/barChart';
 import {getYAxisMaxFn} from 'sentry/components/charts/miniBarChart';
 import LineSeries from 'sentry/components/charts/series/lineSeries';
 import EmptyMessage from 'sentry/components/emptyMessage';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
-import {SeriesDataUnit} from 'sentry/types/echarts';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {AggregationOutputType} from 'sentry/utils/discover/fields';
 import theme from 'sentry/utils/theme';
@@ -42,20 +41,20 @@ const MonitorStats = ({monitor}: Props) => {
   });
 
   let emptyStats = true;
-  const success = {
+  const success: BarChartSeries = {
     seriesName: t('Successful'),
     yAxisIndex: 0,
-    data: [] as SeriesDataUnit[],
+    data: [],
   };
-  const failed = {
+  const failed: BarChartSeries = {
     seriesName: t('Failed'),
     yAxisIndex: 0,
-    data: [] as SeriesDataUnit[],
+    data: [],
   };
-  const missed = {
+  const missed: BarChartSeries = {
     seriesName: t('Missed'),
     yAxisIndex: 0,
-    data: [] as SeriesDataUnit[],
+    data: [],
   };
   const durationData = [] as [number, number][];
 

--- a/static/app/views/monitors/types.tsx
+++ b/static/app/views/monitors/types.tsx
@@ -30,6 +30,7 @@ export type Monitor = {
 export type MonitorStat = {
   duration: number;
   error: number;
+  missed: number;
   ok: number;
   ts: number;
 };


### PR DESCRIPTION
Graph missed checkins provided by https://github.com/getsentry/sentry/pull/41293 previously only showing failed/success

Example:
<img width="1195" alt="image" src="https://user-images.githubusercontent.com/9372512/201442014-fdeda7ec-8f1d-41e0-9d0e-e57d7cc2026b.png">
