### PR TITLE
ref(metrics): Remove 'is_private' in favor of public naming layer [TET-12]

### DIFF
--- a/src/sentry/snuba/metrics/datasource.py
+++ b/src/sentry/snuba/metrics/datasource.py
@@ -313,7 +313,6 @@ def _fetch_tags_or_values_per_ids(
     if metric_names is not None:
         metric_mris = [get_mri(metric_name) for metric_name in metric_names]
 
-        # ToDo(ahmed): Hack out private derived metrics logic
         private_derived_metrics = set(get_derived_metrics(exclude_private=False).keys()) - set(
             get_derived_metrics(exclude_private=True).keys()
         )

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -62,7 +62,7 @@ from sentry.snuba.metrics.fields.snql import (
     tolerated_count_transaction,
     uniq_aggregation_on_metric,
 )
-from sentry.snuba.metrics.naming_layer.mapping import get_public_name_from_mri, is_mri_private
+from sentry.snuba.metrics.naming_layer.mapping import get_public_name_from_mri, is_private_mri
 from sentry.snuba.metrics.naming_layer.mri import SessionMRI, TransactionMRI
 from sentry.snuba.metrics.utils import (
     DEFAULT_AGGREGATES,
@@ -1645,7 +1645,7 @@ def get_derived_metrics(exclude_private: bool = True) -> Mapping[str, DerivedMet
         {
             mri: expression
             for (mri, expression) in DERIVED_METRICS.items()
-            if not is_mri_private(mri)
+            if not is_private_mri(mri)
         }
         if exclude_private
         else DERIVED_METRICS

--- a/src/sentry/snuba/metrics/naming_layer/mapping.py
+++ b/src/sentry/snuba/metrics/naming_layer/mapping.py
@@ -82,7 +82,7 @@ def get_public_name_from_mri(internal_name: Union[TransactionMRI, SessionMRI, st
         raise InvalidParams(f"Unable to find a mri reverse mapping for '{internal_name}'.")
 
 
-def is_mri_private(internal_name: Union[TransactionMRI, SessionMRI, str]) -> bool:
+def is_private_mri(internal_name: Union[TransactionMRI, SessionMRI, str]) -> bool:
     try:
         get_public_name_from_mri(internal_name)
         return False

--- a/src/sentry/snuba/metrics/naming_layer/mapping.py
+++ b/src/sentry/snuba/metrics/naming_layer/mapping.py
@@ -82,6 +82,14 @@ def get_public_name_from_mri(internal_name: Union[TransactionMRI, SessionMRI, st
         raise InvalidParams(f"Unable to find a mri reverse mapping for '{internal_name}'.")
 
 
+def is_mri_private(internal_name: Union[TransactionMRI, SessionMRI, str]) -> bool:
+    try:
+        get_public_name_from_mri(internal_name)
+        return False
+    except InvalidParams:
+        return True
+
+
 def extract_custom_measurement_alias(internal_name: str) -> Optional[str]:
     match = MRI_SCHEMA_REGEX.match(internal_name)
     if (

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -338,6 +338,12 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                     "unit": None,
                 },
                 {
+                    "name": "transaction.failure_count",
+                    "operations": [],
+                    "type": "numeric",
+                    "unit": "transactions",
+                },
+                {
                     "name": "transaction.failure_rate",
                     "type": "numeric",
                     "operations": [],

--- a/tests/sentry/snuba/metrics/test_naming_layer.py
+++ b/tests/sentry/snuba/metrics/test_naming_layer.py
@@ -2,9 +2,13 @@ import re
 
 import pytest
 
+from sentry.snuba.metrics.naming_layer import create_name_mapping_layers
+from sentry.snuba.metrics.naming_layer.mapping import MRI_TO_NAME, is_private_mri
 from sentry.snuba.metrics.naming_layer.mri import (
     MRI_SCHEMA_REGEX,
     ParsedMRI,
+    SessionMRI,
+    TransactionMRI,
     is_custom_measurement,
     parse_mri,
 )
@@ -140,3 +144,17 @@ def test_parse_mri(name, expected):
 )
 def test_is_custom_measurement(parsed_mri, expected):
     assert is_custom_measurement(parsed_mri) == expected
+
+
+def test_is_private_mri():
+    create_name_mapping_layers()
+
+    all_mris = list(TransactionMRI) + list(SessionMRI)
+    public_mris = set(MRI_TO_NAME.keys())
+
+    for mri in all_mris:
+        expected_private = True
+        if mri.value in public_mris:
+            expected_private = False
+
+        assert is_private_mri(mri) == expected_private


### PR DESCRIPTION
This PR aims at cleaning up the metrics layer with a removal of the `is_private` property of `DerivedMetricExpressionDefinition` which has now been substituted by the public naming layer which is access via the `get_public_name_from_mri()` function.