### PR TITLE
test(ingest): Generate random group ID [INGEST-1644]

### DIFF
--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -79,13 +79,11 @@ def random_group_id():
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.parametrize("run", range(10))  # FIXME: Remove before merging
 @pytest.mark.parametrize(
     "executor",
     [pytest.param(None, id="synchronous"), pytest.param(ThreadPoolExecutor(), id="asynchronous")],
 )
 def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
-    run,
     executor,
     task_runner,
     kafka_producer,

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -78,19 +78,21 @@ def random_group_id():
     return f"test-consumer-{random.randint(0, 2 ** 16)}"
 
 
-@pytest.mark.skip(reason="flaky: INGEST-1644")
 @pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("run", range(10))  # FIXME: Remove before merging
 @pytest.mark.parametrize(
     "executor",
     [pytest.param(None, id="synchronous"), pytest.param(ThreadPoolExecutor(), id="asynchronous")],
 )
 def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
+    run,
     executor,
     task_runner,
     kafka_producer,
     kafka_admin,
     default_project,
     get_test_message,
+    random_group_id,
 ):
     topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)
 


### PR DESCRIPTION
The integration test `test_ingest_consumer_reads_from_topic_and_calls_celery_task` did not declare pytest fixture `random_group_id` as an argument, so we accidentally passed the _function_ as group ID to Kafka. Because they were now using the same consumer group ID, the two parameterizations of this test were not independent, resulting in flaky behavior.

Fixes [SENTRY-TESTS-3QA](https://sentry.io/organizations/sentry/issues/3616300100).