### PR TITLE
ref(stacktrace_linking): Do not return code mapping when there's no match

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -15,9 +15,8 @@ from sentry.utils.event_frames import munged_filename_and_frames
 
 
 def get_link(
-    config: RepositoryProjectPathConfig, filepath: str, version: Optional[str] = None
+    config: RepositoryProjectPathConfig, filepath: str, default: str, version: Optional[str] = None
 ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
-    default = config.default_branch
     oi = config.organization_integration
     integration = oi.integration
     install = integration.get_installation(oi.organization_id)
@@ -86,9 +85,6 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
             if i.has_feature(IntegrationFeatures.STACKTRACE_LINK)
         ]
 
-        latest_attempted_url = None
-        latest_error = None
-        found = False
         # xxx(meredith): if there are ever any changes to this query, make
         # sure that we are still ordering by `id` because we want to make sure
         # the ordering is deterministic
@@ -99,17 +95,20 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         with configure_scope() as scope:
             for config in configs:
                 if not filepath.startswith(config.stack_root) and not frame:
-                    latest_error = "stack_root_mismatch"
+                    scope.set_tag("stacktrace_link.error", "stack_root_mismatch")
+                    result["error"] = "stack_root_mismatch"
                     continue
 
                 result["config"] = serialize(config, request.user)
-                # use the provider key to be able to spilt up stacktrace
+                # use the provider key to be able to split up stacktrace
                 # link metrics by integration type
                 provider = result["config"]["provider"]["key"]
                 scope.set_tag("integration_provider", provider)
                 scope.set_tag("stacktrace_link.platform", platform)
 
-                link, attempted_url, error = get_link(config, filepath, commit_id)
+                link, attempted_url, error = get_link(
+                    config, filepath, config.default_branch, commit_id
+                )
 
                 if not link and frame:
                     frame["filename"] = filepath
@@ -123,11 +122,12 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                             if not filepath.startswith(
                                 config.stack_root
                             ) and not munged_filename.startswith(config.stack_root):
-                                latest_error = "stack_root_mismatch"
+                                scope.set_tag("stacktrace_link.error", "stack_root_mismatch")
+                                result["error"] = "stack_root_mismatch"
                                 continue
 
                             link, attempted_url, error = get_link(
-                                config, munged_filename, commit_id
+                                config, munged_filename, config.default_branch, commit_id
                             )
 
                 # it's possible for the link to be None, and in that
@@ -135,27 +135,14 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                 # configuration
                 result["sourceUrl"] = link
                 if not link:
-                    latest_error = "file_not_found"
-                    # It seems that in some places of the UI we use this even though it makes
-                    # no sense since we may try multiple code mappings
-                    latest_attempted_url = attempted_url
+                    scope.set_tag("stacktrace_link.found", False)
+                    scope.set_tag("stacktrace_link.error", "file_not_found")
+                    result["error"] = error
+                    result["attemptedUrl"] = attempted_url
                 else:
-                    found = True
+                    scope.set_tag("stacktrace_link.found", True)
                     # if we found a match, we can break
                     break
-
-            # Post-processing
-            scope.set_tag("stacktrace_link.found", found)
-            if latest_error == "stack_root_mismatch":
-                # This is the same as saying that no code mapping matched
-                scope.set_tag("stacktrace_link.error", "stack_root_mismatch")
-                result["error"] = "stack_root_mismatch"
-            elif latest_error == "file_not_found":
-                scope.set_tag("stacktrace_link.error", "file_not_found")
-                result["error"] = "file_not_found"
-
-            if latest_attempted_url:
-                result["attemptedUrl"] = latest_attempted_url
 
         if result["config"]:
             analytics.record(

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -116,7 +116,7 @@ class ProjectStacktraceLinkTest(APITestCase):
         response = self.get_success_response(
             self.organization.slug, self.project.slug, qs_params={"file": "wrong/file/path"}
         )
-        assert response.data["config"] == self.expected_configurations()
+        assert response.data["config"] is None
         assert not response.data["sourceUrl"]
         assert response.data["error"] == "stack_root_mismatch"
         assert response.data["integrations"] == [serialized_integration(self.integration)]


### PR DESCRIPTION
Before, the API would return the code mapping configuration of the latest code mapping it tried to match. This makes no sense since there can be more than one code mapping associated to a project.