### PR TITLE
fix(dashboards): Spread custom measurements properly

### DIFF
--- a/static/app/components/events/searchBar.tsx
+++ b/static/app/components/events/searchBar.tsx
@@ -73,7 +73,7 @@ const getMeasurementTags = (
 
   return Object.keys(customMeasurements).reduce((tags, key) => {
     tags[key] = {
-      ...measurements[key],
+      ...customMeasurements[key],
       kind: FieldKind.MEASUREMENT,
     };
     return tags;


### PR DESCRIPTION
Since we're reducing over the keys in customMeasurements, we should also be spreading the object from customMeasurements, not measurements where there is no data.

This fixes issues with the tag key being undefined in the search bar in the widget builder.

Fixes JAVASCRIPT-2B98