### PR TITLE
feat(mobile-exp): Refactor and revert to bars in mobile issue tags

### DIFF
--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -257,25 +257,19 @@ class BaseGroupSidebar extends Component<Props, State> {
 
         {event && <SuggestedOwners project={project} group={group} event={event} />}
 
-        <Feature
-          organization={organization}
-          features={['issue-details-tag-improvements']}
-        >
-          {isMobilePlatform(project.platform) && (
-            <TagFacets
-              environments={environments}
-              groupId={group.id}
-              tagKeys={MOBILE_TAGS}
-              event={event}
-              title={
-                <div>
-                  {t('Tag Summary')} <FeatureBadge type="alpha" />
-                </div>
-              }
-              tagFormatter={MOBILE_TAGS_FORMATTER}
-            />
-          )}
-        </Feature>
+        <TagFacets
+          environments={environments}
+          groupId={group.id}
+          tagKeys={MOBILE_TAGS}
+          event={event}
+          title={
+            <div>
+              {t('Tag Summary')} <FeatureBadge type="alpha" />
+            </div>
+          }
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="bars"
+        />
 
         <GroupReleaseStats
           organization={organization}

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -257,19 +257,26 @@ class BaseGroupSidebar extends Component<Props, State> {
 
         {event && <SuggestedOwners project={project} group={group} event={event} />}
 
-        <TagFacets
-          environments={environments}
-          groupId={group.id}
-          tagKeys={MOBILE_TAGS}
-          event={event}
-          title={
-            <div>
-              {t('Tag Summary')} <FeatureBadge type="alpha" />
-            </div>
-          }
-          tagFormatter={MOBILE_TAGS_FORMATTER}
-          style="bars"
-        />
+        <Feature
+          organization={organization}
+          features={['issue-details-tag-improvements']}
+        >
+          {isMobilePlatform(project.platform) && (
+            <TagFacets
+              environments={environments}
+              groupId={group.id}
+              tagKeys={MOBILE_TAGS}
+              event={event}
+              title={
+                <div>
+                  {t('Tag Summary')} <FeatureBadge type="alpha" />
+                </div>
+              }
+              tagFormatter={MOBILE_TAGS_FORMATTER}
+              style="bars"
+            />
+          )}
+        </Feature>
 
         <GroupReleaseStats
           organization={organization}

--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -84,252 +84,521 @@ describe('Tag Facets', function () {
     MockApiClient.clearMockResponses();
   });
 
-  it('does not display anything if no tag values recieved', async function () {
-    tagsMock = MockApiClient.addMockResponse({
-      url: '/issues/1/tags/',
-      body: {},
-    });
-    render(<TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} />, {
-      organization,
-    });
-    await waitFor(() => {
-      expect(tagsMock).toHaveBeenCalled();
-    });
-    expect(screen.queryByText('os')).not.toBeInTheDocument();
-    expect(screen.queryByText('device')).not.toBeInTheDocument();
-    expect(screen.queryByText('release')).not.toBeInTheDocument();
-  });
-
-  it('displays os, device, and release tags', async function () {
-    render(<TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} />, {
-      organization,
-    });
-    await waitFor(() => {
-      expect(tagsMock).toHaveBeenCalled();
-    });
-    expect(screen.getByText('os')).toBeInTheDocument();
-    expect(screen.getByText('device')).toBeInTheDocument();
-    expect(screen.getByText('release')).toBeInTheDocument();
-    expect(screen.getByText('66%')).toBeInTheDocument();
-    expect(screen.getByText('Android 12')).toBeInTheDocument();
-    expect(screen.getByText('33%')).toBeInTheDocument();
-    expect(screen.getByText('iOS 16.0')).toBeInTheDocument();
-
-    userEvent.click(screen.getByText('device'));
-    expect(screen.getByText('10%')).toBeInTheDocument();
-    expect(screen.getByText('iPhone15')).toBeInTheDocument();
-    expect(screen.getByText('15%')).toBeInTheDocument();
-    expect(screen.getByText('Android Phone')).toBeInTheDocument();
-    expect(screen.getByText('20%')).toBeInTheDocument();
-    expect(screen.getByText('iPhone12')).toBeInTheDocument();
-    expect(screen.getByText('23%')).toBeInTheDocument();
-    expect(screen.getByText('iPhone11')).toBeInTheDocument();
-    expect(screen.getByText('27%')).toBeInTheDocument();
-    expect(screen.getByText('iPhone10')).toBeInTheDocument();
-    expect(screen.getByText('3%')).toBeInTheDocument();
-    expect(screen.getByText('Other')).toBeInTheDocument();
-
-    userEvent.click(screen.getByText('release'));
-    expect(screen.getByText('100%')).toBeInTheDocument();
-    expect(screen.getByText('org.mozilla.ios.Fennec@106.0')).toBeInTheDocument();
-  });
-
-  it('shows tooltip', async function () {
-    render(
-      <TagFacets
-        environments={[]}
-        groupId="1"
-        tagKeys={MOBILE_TAGS}
-        event={{tags: [{key: 'os', value: 'Android 12'}]} as Event}
-      />,
-      {
-        organization,
-      }
-    );
-    await waitFor(() => {
-      expect(tagsMock).toHaveBeenCalled();
+  describe('Tag Bars', function () {
+    it('does not display anything if no tag values recieved', async function () {
+      tagsMock = MockApiClient.addMockResponse({
+        url: '/issues/1/tags/',
+        body: {},
+      });
+      render(
+        <TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} style="bars" />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+      expect(screen.queryByText('os')).not.toBeInTheDocument();
+      expect(screen.queryByText('device')).not.toBeInTheDocument();
+      expect(screen.queryByText('release')).not.toBeInTheDocument();
     });
 
-    userEvent.hover(screen.getByText('Android 12'));
-    await waitFor(() =>
+    it('displays os, device, and release tags', async function () {
+      render(
+        <TagFacets environments={[]} groupId="1" tagKeys={MOBILE_TAGS} style="bars" />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+      expect(screen.getByText('os')).toBeInTheDocument();
+      expect(screen.getByText('device')).toBeInTheDocument();
+      expect(screen.getByText('release')).toBeInTheDocument();
+      expect(screen.getByText('67%')).toBeInTheDocument();
+      expect(screen.getByText('Android 12')).toBeInTheDocument();
+      expect(screen.getByText('33%')).toBeInTheDocument();
+      expect(screen.getByText('iOS 16.0')).toBeInTheDocument();
+
+      userEvent.click(screen.getByText('device'));
+      expect(screen.getByText('11%')).toBeInTheDocument();
+      expect(screen.getByText('iPhone15')).toBeInTheDocument();
+      expect(screen.getByText('15%')).toBeInTheDocument();
+      expect(screen.getByText('Android Phone')).toBeInTheDocument();
+      expect(screen.getByText('20%')).toBeInTheDocument();
+      expect(screen.getByText('iPhone12')).toBeInTheDocument();
+      expect(screen.getByText('23%')).toBeInTheDocument();
+      expect(screen.getByText('iPhone11')).toBeInTheDocument();
+      expect(screen.getByText('28%')).toBeInTheDocument();
+      expect(screen.getByText('iPhone10')).toBeInTheDocument();
+
+      userEvent.click(screen.getByText('release'));
+      expect(screen.getByText('100%')).toBeInTheDocument();
+      expect(screen.getByText('org.mozilla.ios.Fennec@106.0')).toBeInTheDocument();
+    });
+
+    it('shows tooltip', async function () {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          event={{tags: [{key: 'os', value: 'Android 12'}]} as Event}
+          style="bars"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+
+      userEvent.hover(screen.getByText('Android 12'));
+      await waitFor(() =>
+        expect(
+          screen.getByText('The tag value of the current event.')
+        ).toBeInTheDocument()
+      );
+    });
+
+    it('format tag values when given a tagFormatter', async function () {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="bars"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+
+      userEvent.click(screen.getByText('release'));
+      expect(screen.getByText('100%')).toBeInTheDocument();
+      expect(screen.getByText('106.0')).toBeInTheDocument();
+    });
+
+    it('renders a Show All Tags button to navigate to the tags page', async () => {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="bars"
+        />,
+        {
+          organization,
+        }
+      );
+      expect(await screen.findByRole('button', {name: 'Show All Tags'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/issues/1/tags/'
+      );
+    });
+
+    it('renders a tag value bars that link to the tag', async () => {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="bars"
+        />,
+        {
+          organization,
+        }
+      );
       expect(
-        screen.getByText('This is also the tag value of the error event you are viewing.')
-      ).toBeInTheDocument()
-    );
-  });
-
-  it('format tag values when given a tagFormatter', async function () {
-    render(
-      <TagFacets
-        environments={[]}
-        groupId="1"
-        tagKeys={MOBILE_TAGS}
-        tagFormatter={MOBILE_TAGS_FORMATTER}
-      />,
-      {
-        organization,
-      }
-    );
-    await waitFor(() => {
-      expect(tagsMock).toHaveBeenCalled();
+        await screen.findByRole('link', {
+          name: 'Add Android 12 to the search query',
+        })
+      ).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/issues/1/tags/os/?referrer=tag-distribution-meter'
+      );
     });
 
-    userEvent.click(screen.getByText('release'));
-    expect(screen.getByText('100%')).toBeInTheDocument();
-    expect(screen.getByText('106.0')).toBeInTheDocument();
-  });
-
-  it('renders a View all button to navigate to the tags page', async () => {
-    render(
-      <TagFacets
-        environments={[]}
-        groupId="1"
-        tagKeys={MOBILE_TAGS}
-        tagFormatter={MOBILE_TAGS_FORMATTER}
-      />,
-      {
-        organization,
-      }
-    );
-    expect(await screen.findByRole('button', {name: 'View All Tags'})).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/issues/1/tags/'
-    );
-  });
-
-  it('renders a breakdown bar with segments that link to the tag', async () => {
-    render(
-      <TagFacets
-        environments={[]}
-        groupId="1"
-        tagKeys={MOBILE_TAGS}
-        tagFormatter={MOBILE_TAGS_FORMATTER}
-      />,
-      {
-        organization,
-      }
-    );
-    expect(
-      await screen.findByRole('link', {
-        name: 'Add the os Android 12 segment tag to the search query',
-      })
-    ).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/issues/1/tags/os/?referrer=tag-distribution-meter'
-    );
-  });
-
-  it('does not render other if visible tags renders 100%', async () => {
-    render(
-      <TagFacets
-        environments={[]}
-        groupId="1"
-        tagKeys={MOBILE_TAGS}
-        tagFormatter={MOBILE_TAGS_FORMATTER}
-      />,
-      {
-        organization,
-      }
-    );
-    userEvent.click(await screen.findByText('release'));
-    expect(screen.getByText('100%')).toBeInTheDocument();
-    expect(screen.queryByText('Other')).not.toBeInTheDocument();
-  });
-
-  it('renders readable device name when available', async () => {
-    tagsMock = MockApiClient.addMockResponse({
-      url: '/issues/1/tags/',
-      body: {
-        device: {
-          key: 'device',
-          topValues: [
-            {
-              name: 'abcdef123456',
-              value: 'abcdef123456',
-              readable: 'Galaxy S22',
-              count: 2,
-            },
-          ],
+    it('renders readable device name when available', async () => {
+      tagsMock = MockApiClient.addMockResponse({
+        url: '/issues/1/tags/',
+        body: {
+          device: {
+            key: 'device',
+            topValues: [
+              {
+                name: 'abcdef123456',
+                value: 'abcdef123456',
+                readable: 'Galaxy S22',
+                count: 2,
+              },
+            ],
+          },
         },
-      },
-    });
-    render(
-      <TagFacets
-        environments={[]}
-        groupId="1"
-        tagKeys={MOBILE_TAGS}
-        tagFormatter={MOBILE_TAGS_FORMATTER}
-      />,
-      {
-        organization,
-      }
-    );
-    await waitFor(() => {
-      expect(tagsMock).toHaveBeenCalled();
+      });
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="bars"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+
+      userEvent.click(screen.getByText('device'));
+      expect(screen.getByText('Galaxy S22')).toBeInTheDocument();
+      expect(screen.getByText('100%')).toBeInTheDocument();
     });
 
-    userEvent.click(screen.getByText('device'));
-    expect(screen.getByText('Galaxy S22')).toBeInTheDocument();
-    expect(screen.getByText('100%')).toBeInTheDocument();
+    it('does not duplicate release values with same name', async function () {
+      tagsMock = MockApiClient.addMockResponse({
+        url: '/issues/1/tags/',
+        body: {
+          release: {
+            key: 'release',
+            topValues: [
+              {
+                name: '1.0',
+                value: 'something@1.0',
+                count: 30,
+              },
+              {
+                name: '1.0',
+                value: '1.0',
+                count: 10,
+              },
+            ],
+          },
+          os: {
+            key: 'os',
+            topValues: [
+              {
+                name: 'Android 12',
+                value: 'Android 12',
+                count: 20,
+              },
+            ],
+          },
+        },
+      });
+
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="bars"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+
+      expect(screen.getByText('Android 12')).toBeInTheDocument();
+      userEvent.click(screen.getByText('release'));
+      expect(screen.getAllByText('1.0')).toHaveLength(2);
+
+      // Test that the tag isn't being duplicated to the os tab
+      userEvent.click(screen.getByText('os'));
+      expect(screen.queryByText('1.0')).not.toBeInTheDocument();
+
+      // Test that the tag hasn't been duplicated in the release tab
+      userEvent.click(screen.getByText('release'));
+      expect(screen.getAllByText('1.0')).toHaveLength(2);
+    });
   });
 
-  it('does not duplicate release values with same name', async function () {
-    tagsMock = MockApiClient.addMockResponse({
-      url: '/issues/1/tags/',
-      body: {
-        release: {
-          key: 'release',
-          topValues: [
-            {
-              name: '1.0',
-              value: 'something@1.0',
-              count: 30,
-            },
-            {
-              name: '1.0',
-              value: '1.0',
-              count: 10,
-            },
-          ],
-        },
-        os: {
-          key: 'os',
-          topValues: [
-            {
-              name: 'Android 12',
-              value: 'Android 12',
-              count: 20,
-            },
-          ],
-        },
-      },
+  describe('Tag Breakdowns', function () {
+    it('does not display anything if no tag values recieved', async function () {
+      tagsMock = MockApiClient.addMockResponse({
+        url: '/issues/1/tags/',
+        body: {},
+      });
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          style="breakdowns"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+      expect(screen.queryByText('os')).not.toBeInTheDocument();
+      expect(screen.queryByText('device')).not.toBeInTheDocument();
+      expect(screen.queryByText('release')).not.toBeInTheDocument();
     });
 
-    render(
-      <TagFacets
-        environments={[]}
-        groupId="1"
-        tagKeys={MOBILE_TAGS}
-        tagFormatter={MOBILE_TAGS_FORMATTER}
-      />,
-      {
-        organization,
-      }
-    );
-    await waitFor(() => {
-      expect(tagsMock).toHaveBeenCalled();
+    it('displays os, device, and release tags', async function () {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          style="breakdowns"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+      expect(screen.getByText('os')).toBeInTheDocument();
+      expect(screen.getByText('device')).toBeInTheDocument();
+      expect(screen.getByText('release')).toBeInTheDocument();
+      expect(screen.getByText('66%')).toBeInTheDocument();
+      expect(screen.getByText('Android 12')).toBeInTheDocument();
+      expect(screen.getByText('33%')).toBeInTheDocument();
+      expect(screen.getByText('iOS 16.0')).toBeInTheDocument();
+
+      userEvent.click(screen.getByText('device'));
+      expect(screen.getByText('10%')).toBeInTheDocument();
+      expect(screen.getByText('iPhone15')).toBeInTheDocument();
+      expect(screen.getByText('15%')).toBeInTheDocument();
+      expect(screen.getByText('Android Phone')).toBeInTheDocument();
+      expect(screen.getByText('20%')).toBeInTheDocument();
+      expect(screen.getByText('iPhone12')).toBeInTheDocument();
+      expect(screen.getByText('23%')).toBeInTheDocument();
+      expect(screen.getByText('iPhone11')).toBeInTheDocument();
+      expect(screen.getByText('27%')).toBeInTheDocument();
+      expect(screen.getByText('iPhone10')).toBeInTheDocument();
+      expect(screen.getByText('3%')).toBeInTheDocument();
+      expect(screen.getByText('Other')).toBeInTheDocument();
+
+      userEvent.click(screen.getByText('release'));
+      expect(screen.getByText('100%')).toBeInTheDocument();
+      expect(screen.getByText('org.mozilla.ios.Fennec@106.0')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Android 12')).toBeInTheDocument();
-    userEvent.click(screen.getByText('release'));
-    expect(screen.getAllByText('1.0')).toHaveLength(2);
+    it('shows tooltip', async function () {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          event={{tags: [{key: 'os', value: 'Android 12'}]} as Event}
+          style="breakdowns"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
 
-    // Test that the tag isn't being duplicated to the os tab
-    userEvent.click(screen.getByText('os'));
-    expect(screen.queryByText('1.0')).not.toBeInTheDocument();
+      userEvent.hover(screen.getByText('Android 12'));
+      await waitFor(() =>
+        expect(
+          screen.getByText('The tag value of the current event.')
+        ).toBeInTheDocument()
+      );
+    });
 
-    // Test that the tag hasn't been duplicated in the release tab
-    userEvent.click(screen.getByText('release'));
-    expect(screen.getAllByText('1.0')).toHaveLength(2);
+    it('format tag values when given a tagFormatter', async function () {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="breakdowns"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+
+      userEvent.click(screen.getByText('release'));
+      expect(screen.getByText('100%')).toBeInTheDocument();
+      expect(screen.getByText('106.0')).toBeInTheDocument();
+    });
+
+    it('renders a View all button to navigate to the tags page', async () => {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="breakdowns"
+        />,
+        {
+          organization,
+        }
+      );
+      expect(await screen.findByRole('button', {name: 'View All Tags'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/issues/1/tags/'
+      );
+    });
+
+    it('renders a breakdown bar with segments that link to the tag', async () => {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="breakdowns"
+        />,
+        {
+          organization,
+        }
+      );
+      expect(
+        await screen.findByRole('link', {
+          name: 'Add the os Android 12 segment tag to the search query',
+        })
+      ).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/issues/1/tags/os/?referrer=tag-distribution-meter'
+      );
+    });
+
+    it('does not render other if visible tags renders 100%', async () => {
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="breakdowns"
+        />,
+        {
+          organization,
+        }
+      );
+      userEvent.click(await screen.findByText('release'));
+      expect(screen.getByText('100%')).toBeInTheDocument();
+      expect(screen.queryByText('Other')).not.toBeInTheDocument();
+    });
+
+    it('renders readable device name when available', async () => {
+      tagsMock = MockApiClient.addMockResponse({
+        url: '/issues/1/tags/',
+        body: {
+          device: {
+            key: 'device',
+            topValues: [
+              {
+                name: 'abcdef123456',
+                value: 'abcdef123456',
+                readable: 'Galaxy S22',
+                count: 2,
+              },
+            ],
+          },
+        },
+      });
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="breakdowns"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+
+      userEvent.click(screen.getByText('device'));
+      expect(screen.getByText('Galaxy S22')).toBeInTheDocument();
+      expect(screen.getByText('100%')).toBeInTheDocument();
+    });
+
+    it('does not duplicate release values with same name', async function () {
+      tagsMock = MockApiClient.addMockResponse({
+        url: '/issues/1/tags/',
+        body: {
+          release: {
+            key: 'release',
+            topValues: [
+              {
+                name: '1.0',
+                value: 'something@1.0',
+                count: 30,
+              },
+              {
+                name: '1.0',
+                value: '1.0',
+                count: 10,
+              },
+            ],
+          },
+          os: {
+            key: 'os',
+            topValues: [
+              {
+                name: 'Android 12',
+                value: 'Android 12',
+                count: 20,
+              },
+            ],
+          },
+        },
+      });
+
+      render(
+        <TagFacets
+          environments={[]}
+          groupId="1"
+          tagKeys={MOBILE_TAGS}
+          tagFormatter={MOBILE_TAGS_FORMATTER}
+          style="breakdowns"
+        />,
+        {
+          organization,
+        }
+      );
+      await waitFor(() => {
+        expect(tagsMock).toHaveBeenCalled();
+      });
+
+      expect(screen.getByText('Android 12')).toBeInTheDocument();
+      userEvent.click(screen.getByText('release'));
+      expect(screen.getAllByText('1.0')).toHaveLength(2);
+
+      // Test that the tag isn't being duplicated to the os tab
+      userEvent.click(screen.getByText('os'));
+      expect(screen.queryByText('1.0')).not.toBeInTheDocument();
+
+      // Test that the tag hasn't been duplicated in the release tab
+      userEvent.click(screen.getByText('release'));
+      expect(screen.getAllByText('1.0')).toHaveLength(2);
+    });
   });
 });

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -1,23 +1,9 @@
-import {ReactNode, useEffect, useState} from 'react';
-import {useTheme} from '@emotion/react';
-import styled from '@emotion/styled';
-import keyBy from 'lodash/keyBy';
-
-import {TagSegment} from 'sentry/actionCreators/events';
-import Placeholder from 'sentry/components/placeholder';
-import * as SidebarSection from 'sentry/components/sidebarSection';
-import {t} from 'sentry/locale';
-import space from 'sentry/styles/space';
-import {Environment, TagWithTopValues} from 'sentry/types';
-import {Event} from 'sentry/types/event';
+import {TagWithTopValues} from 'sentry/types';
 import {formatVersion} from 'sentry/utils/formatters';
-import useApi from 'sentry/utils/useApi';
-import useOrganization from 'sentry/utils/useOrganization';
 
-import Button from '../../button';
-import ButtonBar from '../../buttonBar';
-
-import TagBreakdown from './tagBreakdown';
+import TagFacetsBars from './tagFacetsBars';
+import TagFacetsBreakdowns from './tagFacetsBreakdowns';
+import {TagFacetsProps} from './tagFacetsTypes';
 
 export const MOBILE_TAGS = ['os', 'device', 'release'];
 
@@ -52,165 +38,12 @@ export function MOBILE_TAGS_FORMATTER(tagsData: Record<string, TagWithTopValues>
   return transformedTagsData;
 }
 
-type Props = {
-  environments: Environment[];
-  groupId: string;
-  tagKeys: string[];
-  event?: Event;
-  tagFormatter?: (
-    tagsData: Record<string, TagWithTopValues>
-  ) => Record<string, TagWithTopValues>;
-  title?: ReactNode;
-};
+type TagFacetsStyles = 'bars' | 'breakdowns';
 
-type State = {
-  loading: boolean;
-  selectedTag: string;
-  showMore: boolean;
-  tagsData: Record<string, TagWithTopValues>;
-};
-
-const MAX_ITEMS = 5;
-
-export function TagFacets({
-  groupId,
-  tagKeys,
-  environments,
-  event,
-  tagFormatter,
-  title,
-}: Props) {
-  const [state, setState] = useState<State>({
-    tagsData: {},
-    selectedTag: tagKeys.length > 0 ? tagKeys[0] : '',
-    loading: true,
-    showMore: false,
-  });
-  const api = useApi();
-  const organization = useOrganization();
-  const theme = useTheme();
-
-  useEffect(() => {
-    const fetchData = async () => {
-      // Fetch the top values for the current group's top tags.
-      const data = await api.requestPromise(`/issues/${groupId}/tags/`, {
-        query: {
-          key: tagKeys,
-          environment: environments.map(env => env.name),
-          readable: true,
-        },
-      });
-      const tagsData = keyBy(data, 'key');
-      const defaultSelectedTag = tagKeys.find(tagKey =>
-        Object.keys(tagsData).includes(tagKey)
-      );
-      setState({
-        ...state,
-        tagsData,
-        loading: false,
-        selectedTag: defaultSelectedTag ?? state.selectedTag,
-      });
-    };
-    setState({...state, loading: true});
-    fetchData().catch(() => {
-      setState({...state, tagsData: {}, loading: false});
-    });
-    // Don't want to requery everytime state changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [api, JSON.stringify(environments), groupId, tagKeys]);
-
-  const breakdownBarColors = [
-    theme.purple400,
-    theme.red400,
-    theme.green400,
-    theme.yellow400,
-    theme.blue400,
-    theme.translucentGray100,
-  ];
-
-  const availableTagKeys = tagKeys.filter(tagKey => !!state.tagsData[tagKey]);
-  // Format tagsData if the component was given a tagFormatter
-  const tagsData = tagFormatter?.(state.tagsData) ?? state.tagsData;
-  const url = `/organizations/${organization.slug}/issues/${groupId}/tags/${state.selectedTag}/?referrer=tag-distribution-meter`;
-  const segments: TagSegment[] =
-    tagsData[state.selectedTag]?.topValues.map(({name, value, count}) => {
-      const isTagValueOfCurrentEvent =
-        event?.tags.find(({key}) => key === state.selectedTag)?.value === value;
-      return {
-        name,
-        value,
-        count,
-        url,
-        active: isTagValueOfCurrentEvent,
-        tooltip: isTagValueOfCurrentEvent
-          ? t('This is also the tag value of the error event you are viewing.')
-          : undefined,
-      };
-    }) ?? [];
-
-  if (state.loading) {
-    return <Placeholder height="60px" />;
-  }
-  if (availableTagKeys.length > 0) {
-    return (
-      <SidebarSection.Wrap>
-        <Title>
-          {title ?? t('Tag Summary')}
-          <Button
-            size="xs"
-            to={`/organizations/${organization.slug}/issues/${groupId}/tags/`}
-          >
-            {t('View All Tags')}
-          </Button>
-        </Title>
-        <TagFacetsContainer>
-          <StyledButtonBar merged active={state.selectedTag}>
-            {availableTagKeys.map(tagKey => {
-              return (
-                <Button
-                  size="sm"
-                  key={tagKey}
-                  barId={tagKey}
-                  onClick={() => {
-                    setState({...state, selectedTag: tagKey, showMore: false});
-                  }}
-                >
-                  {tagKey}
-                </Button>
-              );
-            })}
-          </StyledButtonBar>
-          <BreakdownContainer>
-            <TagBreakdown
-              segments={segments}
-              maxItems={MAX_ITEMS}
-              colors={breakdownBarColors}
-              selectedTag={state.selectedTag}
-            />
-          </BreakdownContainer>
-        </TagFacetsContainer>
-      </SidebarSection.Wrap>
-    );
-  }
-  return null;
+export function TagFacets(props: TagFacetsProps & {style: TagFacetsStyles}) {
+  return props.style === 'breakdowns' ? (
+    <TagFacetsBreakdowns {...props} />
+  ) : (
+    <TagFacetsBars {...props} />
+  );
 }
-
-const TagFacetsContainer = styled('div')`
-  margin-top: ${space(2)};
-`;
-
-const BreakdownContainer = styled('div')`
-  margin-top: ${space(2)};
-  overflow: hidden;
-`;
-
-const StyledButtonBar = styled(ButtonBar)`
-  display: flex;
-`;
-
-const Title = styled(SidebarSection.Title)`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 0;
-`;

--- a/static/app/components/group/tagFacets/tagFacetsBars.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsBars.tsx
@@ -1,0 +1,274 @@
+import {Fragment, useEffect, useState} from 'react';
+import styled from '@emotion/styled';
+import keyBy from 'lodash/keyBy';
+
+import Placeholder from 'sentry/components/placeholder';
+import * as SidebarSection from 'sentry/components/sidebarSection';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {TagWithTopValues} from 'sentry/types';
+import {formatPercentage, formatVersion} from 'sentry/utils/formatters';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import Button from '../../button';
+import ButtonBar from '../../buttonBar';
+
+import {TagFacetsProps} from './tagFacetsTypes';
+
+export const MOBILE_TAGS = ['os', 'device', 'release'];
+
+export function MOBILE_TAGS_FORMATTER(tagsData: Record<string, TagWithTopValues>) {
+  // For "release" tag keys, format the release tag value to be more readable (ie removing version prefix)
+  const transformedTagsData = {};
+  Object.keys(tagsData).forEach(tagKey => {
+    if (tagKey === 'release') {
+      transformedTagsData[tagKey] = {
+        ...tagsData[tagKey],
+        topValues: tagsData[tagKey].topValues.map(topValue => {
+          return {
+            ...topValue,
+            name: formatVersion(topValue.name),
+          };
+        }),
+      };
+    } else if (tagKey === 'device') {
+      transformedTagsData[tagKey] = {
+        ...tagsData[tagKey],
+        topValues: tagsData[tagKey].topValues.map(topValue => {
+          return {
+            ...topValue,
+            name: topValue.readable ?? topValue.name,
+          };
+        }),
+      };
+    } else {
+      transformedTagsData[tagKey] = tagsData[tagKey];
+    }
+  });
+  return transformedTagsData;
+}
+
+type State = {
+  loading: boolean;
+  selectedTag: string;
+  showMore: boolean;
+  tagsData: Record<string, TagWithTopValues>;
+};
+
+const MAX_ITEMS = 5;
+
+export default function TagFacetsBars({
+  groupId,
+  tagKeys,
+  environments,
+  event,
+  tagFormatter,
+  title,
+}: TagFacetsProps) {
+  const [state, setState] = useState<State>({
+    tagsData: {},
+    selectedTag: tagKeys.length > 0 ? tagKeys[0] : '',
+    loading: true,
+    showMore: false,
+  });
+  const api = useApi();
+  const organization = useOrganization();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      // Fetch the top values for the current group's top tags.
+      const data = await api.requestPromise(`/issues/${groupId}/tags/`, {
+        query: {
+          key: tagKeys,
+          environment: environments.map(env => env.name),
+          readable: true,
+        },
+      });
+      const tagsData = keyBy(data, 'key');
+      const defaultSelectedTag = tagKeys.find(tagKey =>
+        Object.keys(tagsData).includes(tagKey)
+      );
+      setState({
+        ...state,
+        tagsData,
+        loading: false,
+        selectedTag: defaultSelectedTag ?? state.selectedTag,
+      });
+    };
+    setState({...state, loading: true});
+    fetchData().catch(() => {
+      setState({...state, tagsData: {}, loading: false});
+    });
+    // Don't want to requery everytime state changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, JSON.stringify(environments), groupId, tagKeys]);
+
+  const availableTagKeys = tagKeys.filter(tagKey => !!state.tagsData[tagKey]);
+  // Format tagsData if the component was given a tagFormatter
+  const tagsData = tagFormatter?.(state.tagsData) ?? state.tagsData;
+  const url = `/organizations/${organization.slug}/issues/${groupId}/tags/${state.selectedTag}/?referrer=tag-distribution-meter`;
+  const points =
+    tagsData[state.selectedTag]?.topValues.map(({name, value, count}) => {
+      const isTagValueOfCurrentEvent =
+        event?.tags.find(({key}) => key === state.selectedTag)?.value === value;
+      return {
+        label: name,
+        value: count,
+        url,
+        active: isTagValueOfCurrentEvent,
+        tooltip: isTagValueOfCurrentEvent
+          ? t('The tag value of the current event.')
+          : undefined,
+      };
+    }) ?? [];
+
+  if (state.loading) {
+    return <Placeholder height="60px" />;
+  }
+  if (availableTagKeys.length > 0) {
+    return (
+      <SidebarSection.Wrap>
+        <SidebarSection.Title>{title ?? t('Tag Summary')}</SidebarSection.Title>
+        <TagFacetsContainer>
+          <StyledButtonBar merged active={state.selectedTag}>
+            {availableTagKeys.map(tagKey => {
+              return (
+                <Button
+                  size="xs"
+                  key={tagKey}
+                  barId={tagKey}
+                  onClick={() => {
+                    setState({...state, selectedTag: tagKey, showMore: false});
+                  }}
+                >
+                  {tagKey}
+                </Button>
+              );
+            })}
+          </StyledButtonBar>
+          <BreakdownBars data={points} maxItems={MAX_ITEMS} />
+          <Button size="xs" to={getTagUrl(organization.slug, groupId)}>
+            {t('Show All Tags')}
+          </Button>
+        </TagFacetsContainer>
+      </SidebarSection.Wrap>
+    );
+  }
+  return null;
+}
+
+function getTagUrl(orgSlug: string, groupId: string) {
+  return `/organizations/${orgSlug}/issues/${groupId}/tags/`;
+}
+
+import Link from 'sentry/components/links/link';
+import Tooltip from 'sentry/components/tooltip';
+
+type Point = {
+  label: string;
+  value: number;
+  active?: boolean;
+  onClick?: () => void;
+  tooltip?: string;
+  url?: string;
+};
+
+type Props = {
+  /**
+   * The data to display. The caller should order the points
+   * in the order they want bars displayed.
+   */
+  data: Point[];
+  maxItems?: number;
+};
+
+function BreakdownBars({data, maxItems}: Props) {
+  const total = data.reduce((sum, point) => point.value + sum, 0);
+  return (
+    <BreakdownGrid>
+      {(maxItems ? data.slice(0, maxItems) : data).map((point, i) => {
+        let bar = (
+          <Fragment>
+            <Bar
+              style={{width: `${((point.value / total) * 100).toFixed(2)}%`}}
+              active={point.active}
+            />
+            <Label>
+              {point.label}
+              <Percentage>{formatPercentage(point.value / total, 0)}</Percentage>
+            </Label>
+          </Fragment>
+        );
+        if (point.url) {
+          bar = (
+            <Link
+              to={point.url}
+              aria-label={t('Add %s to the search query', point.label)}
+            >
+              {bar}
+            </Link>
+          );
+        }
+        return (
+          <Fragment key={`${i}:${point.label}`}>
+            <BarContainer
+              data-test-id={`status-${point.label}`}
+              cursor={point.onClick ? 'pointer' : 'default'}
+              onClick={point.onClick}
+            >
+              {point.tooltip ? <Tooltip title={point.tooltip}>{bar}</Tooltip> : bar}
+            </BarContainer>
+          </Fragment>
+        );
+      })}
+    </BreakdownGrid>
+  );
+}
+
+const BreakdownGrid = styled('div')`
+  display: grid;
+  row-gap: ${space(1)};
+  margin-bottom: ${space(2)};
+`;
+
+const BarContainer = styled('div')<{cursor: 'pointer' | 'default'}>`
+  padding-left: ${space(0.5)};
+  padding-right: ${space(0.5)};
+  position: relative;
+  cursor: ${p => p.cursor};
+  display: flex;
+  align-items: center;
+`;
+
+const Label = styled('span')`
+  position: relative;
+  color: ${p => p.theme.textColor};
+  z-index: 2;
+  font-size: ${p => p.theme.fontSizeSmall};
+  padding: ${space(0.25)} 0;
+`;
+
+const Percentage = styled('span')`
+  color: ${p => p.theme.subText};
+  margin-left: ${space(0.5)};
+`;
+
+const Bar = styled('div')<{active?: boolean}>`
+  background-color: ${p => (p.active ? p.theme.purple200 : p.theme.gray100)};
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+  height: 100%;
+  width: 0%;
+`;
+
+const TagFacetsContainer = styled('div')`
+  margin-top: ${space(2)};
+`;
+
+const StyledButtonBar = styled(ButtonBar)`
+  display: flex;
+  margin-bottom: ${space(1)};
+`;

--- a/static/app/components/group/tagFacets/tagFacetsBars.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsBars.tsx
@@ -7,7 +7,7 @@ import * as SidebarSection from 'sentry/components/sidebarSection';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {TagWithTopValues} from 'sentry/types';
-import {formatPercentage, formatVersion} from 'sentry/utils/formatters';
+import {formatPercentage} from 'sentry/utils/formatters';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -15,39 +15,6 @@ import Button from '../../button';
 import ButtonBar from '../../buttonBar';
 
 import {TagFacetsProps} from './tagFacetsTypes';
-
-export const MOBILE_TAGS = ['os', 'device', 'release'];
-
-export function MOBILE_TAGS_FORMATTER(tagsData: Record<string, TagWithTopValues>) {
-  // For "release" tag keys, format the release tag value to be more readable (ie removing version prefix)
-  const transformedTagsData = {};
-  Object.keys(tagsData).forEach(tagKey => {
-    if (tagKey === 'release') {
-      transformedTagsData[tagKey] = {
-        ...tagsData[tagKey],
-        topValues: tagsData[tagKey].topValues.map(topValue => {
-          return {
-            ...topValue,
-            name: formatVersion(topValue.name),
-          };
-        }),
-      };
-    } else if (tagKey === 'device') {
-      transformedTagsData[tagKey] = {
-        ...tagsData[tagKey],
-        topValues: tagsData[tagKey].topValues.map(topValue => {
-          return {
-            ...topValue,
-            name: topValue.readable ?? topValue.name,
-          };
-        }),
-      };
-    } else {
-      transformedTagsData[tagKey] = tagsData[tagKey];
-    }
-  });
-  return transformedTagsData;
-}
 
 type State = {
   loading: boolean;

--- a/static/app/components/group/tagFacets/tagFacetsBreakdowns.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsBreakdowns.tsx
@@ -1,0 +1,205 @@
+import {useEffect, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+import keyBy from 'lodash/keyBy';
+
+import {TagSegment} from 'sentry/actionCreators/events';
+import Placeholder from 'sentry/components/placeholder';
+import * as SidebarSection from 'sentry/components/sidebarSection';
+import {t} from 'sentry/locale';
+import space from 'sentry/styles/space';
+import {TagWithTopValues} from 'sentry/types';
+import {formatVersion} from 'sentry/utils/formatters';
+import useApi from 'sentry/utils/useApi';
+import useOrganization from 'sentry/utils/useOrganization';
+
+import Button from '../../button';
+import ButtonBar from '../../buttonBar';
+
+import TagBreakdown from './tagBreakdown';
+import {TagFacetsProps} from './tagFacetsTypes';
+
+export const MOBILE_TAGS = ['os', 'device', 'release'];
+
+export function MOBILE_TAGS_FORMATTER(tagsData: Record<string, TagWithTopValues>) {
+  // For "release" tag keys, format the release tag value to be more readable (ie removing version prefix)
+  const transformedTagsData = {};
+  Object.keys(tagsData).forEach(tagKey => {
+    if (tagKey === 'release') {
+      transformedTagsData[tagKey] = {
+        ...tagsData[tagKey],
+        topValues: tagsData[tagKey].topValues.map(topValue => {
+          return {
+            ...topValue,
+            name: formatVersion(topValue.name),
+          };
+        }),
+      };
+    } else if (tagKey === 'device') {
+      transformedTagsData[tagKey] = {
+        ...tagsData[tagKey],
+        topValues: tagsData[tagKey].topValues.map(topValue => {
+          return {
+            ...topValue,
+            name: topValue.readable ?? topValue.name,
+          };
+        }),
+      };
+    } else {
+      transformedTagsData[tagKey] = tagsData[tagKey];
+    }
+  });
+  return transformedTagsData;
+}
+
+type State = {
+  loading: boolean;
+  selectedTag: string;
+  showMore: boolean;
+  tagsData: Record<string, TagWithTopValues>;
+};
+
+const MAX_ITEMS = 5;
+
+export default function TagFacetsBreakdowns({
+  groupId,
+  tagKeys,
+  environments,
+  event,
+  tagFormatter,
+  title,
+}: TagFacetsProps) {
+  const [state, setState] = useState<State>({
+    tagsData: {},
+    selectedTag: tagKeys.length > 0 ? tagKeys[0] : '',
+    loading: true,
+    showMore: false,
+  });
+  const api = useApi();
+  const organization = useOrganization();
+  const theme = useTheme();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      // Fetch the top values for the current group's top tags.
+      const data = await api.requestPromise(`/issues/${groupId}/tags/`, {
+        query: {
+          key: tagKeys,
+          environment: environments.map(env => env.name),
+          readable: true,
+        },
+      });
+      const tagsData = keyBy(data, 'key');
+      const defaultSelectedTag = tagKeys.find(tagKey =>
+        Object.keys(tagsData).includes(tagKey)
+      );
+      setState({
+        ...state,
+        tagsData,
+        loading: false,
+        selectedTag: defaultSelectedTag ?? state.selectedTag,
+      });
+    };
+    setState({...state, loading: true});
+    fetchData().catch(() => {
+      setState({...state, tagsData: {}, loading: false});
+    });
+    // Don't want to requery everytime state changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, JSON.stringify(environments), groupId, tagKeys]);
+
+  const breakdownBarColors = [
+    theme.purple400,
+    theme.red400,
+    theme.green400,
+    theme.yellow400,
+    theme.blue400,
+    theme.translucentGray100,
+  ];
+
+  const availableTagKeys = tagKeys.filter(tagKey => !!state.tagsData[tagKey]);
+  // Format tagsData if the component was given a tagFormatter
+  const tagsData = tagFormatter?.(state.tagsData) ?? state.tagsData;
+  const url = `/organizations/${organization.slug}/issues/${groupId}/tags/${state.selectedTag}/?referrer=tag-distribution-meter`;
+  const segments: TagSegment[] =
+    tagsData[state.selectedTag]?.topValues.map(({name, value, count}) => {
+      const isTagValueOfCurrentEvent =
+        event?.tags.find(({key}) => key === state.selectedTag)?.value === value;
+      return {
+        name,
+        value,
+        count,
+        url,
+        active: isTagValueOfCurrentEvent,
+        tooltip: isTagValueOfCurrentEvent
+          ? t('The tag value of the current event.')
+          : undefined,
+      };
+    }) ?? [];
+
+  if (state.loading) {
+    return <Placeholder height="60px" />;
+  }
+  if (availableTagKeys.length > 0) {
+    return (
+      <SidebarSection.Wrap>
+        <Title>
+          {title ?? t('Tag Summary')}
+          <Button
+            size="xs"
+            to={`/organizations/${organization.slug}/issues/${groupId}/tags/`}
+          >
+            {t('View All Tags')}
+          </Button>
+        </Title>
+        <TagFacetsContainer>
+          <StyledButtonBar merged active={state.selectedTag}>
+            {availableTagKeys.map(tagKey => {
+              return (
+                <Button
+                  size="sm"
+                  key={tagKey}
+                  barId={tagKey}
+                  onClick={() => {
+                    setState({...state, selectedTag: tagKey, showMore: false});
+                  }}
+                >
+                  {tagKey}
+                </Button>
+              );
+            })}
+          </StyledButtonBar>
+          <BreakdownContainer>
+            <TagBreakdown
+              segments={segments}
+              maxItems={MAX_ITEMS}
+              colors={breakdownBarColors}
+              selectedTag={state.selectedTag}
+            />
+          </BreakdownContainer>
+        </TagFacetsContainer>
+      </SidebarSection.Wrap>
+    );
+  }
+  return null;
+}
+
+const TagFacetsContainer = styled('div')`
+  margin-top: ${space(2)};
+`;
+
+const BreakdownContainer = styled('div')`
+  margin-top: ${space(2)};
+  overflow: hidden;
+`;
+
+const StyledButtonBar = styled(ButtonBar)`
+  display: flex;
+`;
+
+const Title = styled(SidebarSection.Title)`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0;
+`;

--- a/static/app/components/group/tagFacets/tagFacetsBreakdowns.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsBreakdowns.tsx
@@ -9,7 +9,6 @@ import * as SidebarSection from 'sentry/components/sidebarSection';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {TagWithTopValues} from 'sentry/types';
-import {formatVersion} from 'sentry/utils/formatters';
 import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -18,39 +17,6 @@ import ButtonBar from '../../buttonBar';
 
 import TagBreakdown from './tagBreakdown';
 import {TagFacetsProps} from './tagFacetsTypes';
-
-export const MOBILE_TAGS = ['os', 'device', 'release'];
-
-export function MOBILE_TAGS_FORMATTER(tagsData: Record<string, TagWithTopValues>) {
-  // For "release" tag keys, format the release tag value to be more readable (ie removing version prefix)
-  const transformedTagsData = {};
-  Object.keys(tagsData).forEach(tagKey => {
-    if (tagKey === 'release') {
-      transformedTagsData[tagKey] = {
-        ...tagsData[tagKey],
-        topValues: tagsData[tagKey].topValues.map(topValue => {
-          return {
-            ...topValue,
-            name: formatVersion(topValue.name),
-          };
-        }),
-      };
-    } else if (tagKey === 'device') {
-      transformedTagsData[tagKey] = {
-        ...tagsData[tagKey],
-        topValues: tagsData[tagKey].topValues.map(topValue => {
-          return {
-            ...topValue,
-            name: topValue.readable ?? topValue.name,
-          };
-        }),
-      };
-    } else {
-      transformedTagsData[tagKey] = tagsData[tagKey];
-    }
-  });
-  return transformedTagsData;
-}
 
 type State = {
   loading: boolean;

--- a/static/app/components/group/tagFacets/tagFacetsTypes.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsTypes.tsx
@@ -1,0 +1,15 @@
+import {ReactNode} from 'react';
+
+import {Environment, TagWithTopValues} from 'sentry/types';
+import {Event} from 'sentry/types/event';
+
+export type TagFacetsProps = {
+  environments: Environment[];
+  groupId: string;
+  tagKeys: string[];
+  event?: Event;
+  tagFormatter?: (
+    tagsData: Record<string, TagWithTopValues>
+  ) => Record<string, TagWithTopValues>;
+  title?: ReactNode;
+};


### PR DESCRIPTION
Splits up bar and segment breakdown implementations of issue tags.
Updates mobile issue tags to use bars.
Refactors the bar implementation to match newer design. 
![image](https://user-images.githubusercontent.com/83961295/201711094-86df33ea-f74c-401b-ab6f-b7ddb225a9ab.png)