### PR TITLE
ref: print stack when Hub client is None in relay sdk test

### DIFF
--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -21,18 +21,33 @@ def post_event_with_sdk(settings, relay_server, wait_for_ingest_consumer):
     configure_sdk()
     hub = Hub.current  # XXX: Hub.current gets reset, this is a workaround
 
-    wait_for_ingest_consumer = wait_for_ingest_consumer(settings)
+    def bind_client(self, new, *, _orig=Hub.bind_client):
+        if new is None:
+            import sys
+            import traceback
 
-    def inner(*args, **kwargs):
-        event_id = hub.capture_event(*args, **kwargs)
-        hub.client.flush()
+            print("!!! Hub client was reset to None !!!", file=sys.stderr)  # noqa: S002
+            traceback.print_stack()
+            print("!!!", file=sys.stderr)  # noqa: S002
 
-        with push_scope():
-            return wait_for_ingest_consumer(
-                lambda: eventstore.get_event_by_id(settings.SENTRY_PROJECT, event_id)
-            )
+        return _orig(self, new)
 
-    return inner
+    # XXX: trying to figure out why it gets reset
+    with mock.patch.object(Hub, "bind_client", bind_client):
+        wait_for_ingest_consumer = wait_for_ingest_consumer(settings)
+
+        def inner(*args, **kwargs):
+            assert Hub.current.client is not None
+
+            event_id = hub.capture_event(*args, **kwargs)
+            hub.client.flush()
+
+            with push_scope():
+                return wait_for_ingest_consumer(
+                    lambda: eventstore.get_event_by_id(settings.SENTRY_PROJECT, event_id)
+                )
+
+        yield inner
 
 
 @override_settings(SENTRY_PROJECT=1)


### PR DESCRIPTION
diff is best viewed with [?w=1](https://github.com/getsentry/sentry/pull/41320/files?w=1)
<!-- Describe your PR here. -->