### PR TITLE
fix(perf): Allow sort by transaction on metrics query builder

### DIFF
--- a/src/sentry/search/events/builder/metrics.py
+++ b/src/sentry/search/events/builder/metrics.py
@@ -592,9 +592,7 @@ class MetricsQueryBuilder(QueryBuilder):
             if (
                 isinstance(orderby.exp, Column)
                 and orderby.exp.subscriptable in ["tags", "tags_raw"]
-            ) or (
-                isinstance(orderby.exp, Function) and orderby.exp.alias in ["transaction", "title"]
-            ):
+            ) or (isinstance(orderby.exp, Function) and orderby.exp.alias == "title"):
                 raise IncompatibleMetricsQuery("Can't orderby tags")
 
     def run_query(self, referrer: str, use_cache: bool = False) -> Any:

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -905,6 +905,22 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
 
     # TODO: multiple groupby with counter
 
+    def test_run_query_with_tag_orderby(self):
+        with pytest.raises(IncompatibleMetricsQuery):
+            query = MetricsQueryBuilder(
+                self.params,
+                dataset=Dataset.PerformanceMetrics,
+                selected_columns=[
+                    "transaction",
+                    "project",
+                    "p95(transaction.duration)",
+                ],
+                orderby="title",
+            )
+            query.run_query("test_query")
+
+    # TODO: multiple groupby with counter
+
     def test_run_query_with_events_per_aggregates(self):
         for i in range(5):
             self.store_transaction_metric(

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -911,7 +911,7 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
                 self.params,
                 dataset=Dataset.PerformanceMetrics,
                 selected_columns=[
-                    "transaction",
+                    "title",
                     "project",
                     "p95(transaction.duration)",
                 ],

--- a/tests/sentry/search/events/builder/test_metrics.py
+++ b/tests/sentry/search/events/builder/test_metrics.py
@@ -863,19 +863,45 @@ class MetricQueryBuilderTest(MetricBuilderBaseTest):
             "p95_transaction_duration": 100,
         }
 
-    def test_run_query_with_tag_orderby(self):
-        with pytest.raises(IncompatibleMetricsQuery):
-            query = MetricsQueryBuilder(
-                self.params,
-                dataset=Dataset.PerformanceMetrics,
-                selected_columns=[
-                    "transaction",
-                    "project",
-                    "p95(transaction.duration)",
-                ],
-                orderby="transaction",
+    def test_run_query_with_transactions_orderby(self):
+        for transaction_name in ["aaa", "zzz", "bbb"]:
+            self.store_transaction_metric(
+                100,
+                tags={"transaction": transaction_name},
+                project=self.project.id,
+                timestamp=self.start + datetime.timedelta(minutes=5),
             )
-            query.run_query("test_query")
+        query = MetricsQueryBuilder(
+            self.params,
+            dataset=Dataset.PerformanceMetrics,
+            selected_columns=[
+                "transaction",
+                "project",
+                "p95(transaction.duration)",
+            ],
+            orderby="-transaction",
+        )
+        result = query.run_query("test_query")
+        assert len(result["data"]) == 3
+        assert result["data"][0] == {
+            "transaction": resolve_tag_value(
+                UseCaseKey.PERFORMANCE,
+                self.organization.id,
+                "zzz",
+            ),
+            "project": self.project.id,
+            "p95_transaction_duration": 100,
+        }
+
+        assert result["data"][1] == {
+            "transaction": resolve_tag_value(
+                UseCaseKey.PERFORMANCE,
+                self.organization.id,
+                "bbb",
+            ),
+            "project": self.project.id,
+            "p95_transaction_duration": 100,
+        }
 
     # TODO: multiple groupby with counter
 


### PR DESCRIPTION
Sorting wasn't allowed previously on txn names
since they were stored as ints and mapped on 
the metrics indexer, but since they are stored 
as strings now, we can enable sort on transactions.