### PR TITLE
feat(hybrid-cloud): Add /user-feedback/* Django route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -468,6 +468,8 @@ urlpatterns += [
     url(r"^discover/", react_page_view, name="discover"),
     # Request to join an organization
     url(r"^join-request/", react_page_view, name="join-request"),
+    # User Feedback
+    url(r"^user-feedback/", react_page_view, name="user-feedback"),
     # Organizations
     url(r"^(?P<organization_slug>[\w_-]+)/$", react_page_view, name="sentry-organization-home"),
     url(


### PR DESCRIPTION
This adds `/user-feedback/*` Django route so that `orgslug.sentry.io/user-feedback/*` links work on pageload.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.