### PR TITLE
ref(perf-issues): Add projectoption for enabling individual detector

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -104,3 +104,6 @@ register(
         "n_plus_one_db_duration_threshold": 500,
     },
 )
+
+# Using simple bools instead of rates for disabling individual detectors
+register(key="sentry:performance_issue_enabled_n_plus_one_db", default=True)

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -106,4 +106,4 @@ register(
 )
 
 # Using simple bools instead of rates for disabling individual detectors
-register(key="sentry:performance_issue_enabled_n_plus_one_db", default=True)
+register(key="sentry:performance_issue_creation_enabled_n_plus_one_db", default=True)


### PR DESCRIPTION
### Summary
The settings for detectors are too complicated and we only really want to expose a simple toggle. I plan on adding this new project option and removing the old project option settings for independent threshold changes, to make this system a little more simple. Basically all detectors will have their issue creation gated by a series of project options booleans.


