### PR TITLE
fix(code-mappings): Always add a trailing backslash for codemappings

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -130,7 +130,8 @@ class CodeMappingTreesHelper:
         e.g. ssl.py -> raise NotImplementedError
         """
         if frame_filename.dir_path != "":
-            return src_file.rsplit(frame_filename.dir_path)[0].rstrip("/")
+            source_path = src_file.rsplit(frame_filename.dir_path)[0].rstrip("/")
+            return f"{source_path}/"
         else:
             raise NotImplementedError("We do not support top level files.")
 
@@ -150,7 +151,7 @@ class CodeMappingTreesHelper:
             [
                 CodeMapping(
                     repo=repo_tree.repo,
-                    stacktrace_root=frame_filename.root,  # sentry
+                    stacktrace_root=f"{frame_filename.root}/",  # sentry
                     source_path=self._get_code_mapping_source_path(
                         matched_files[0], frame_filename
                     ),

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -35,8 +35,12 @@ class TestDerivedCodeMappings(TestCase):
         )
 
         self.expected_code_mappings = [
-            CodeMapping(self.foo_repo, "sentry", "src/sentry"),
-            CodeMapping(self.foo_repo, "sentry_plugins", "src/sentry_plugins"),
+            CodeMapping(repo=self.foo_repo, stacktrace_root="sentry/", source_path="src/sentry/"),
+            CodeMapping(
+                repo=self.foo_repo,
+                stacktrace_root="sentry_plugins/",
+                source_path="src/sentry_plugins/",
+            ),
         ]
 
     def test_frame_filename_package_and_more_than_one_level(self):
@@ -120,8 +124,8 @@ class TestDerivedCodeMappings(TestCase):
         assert code_mappings == [
             CodeMapping(
                 repo=self.foo_repo,
-                stacktrace_root="sentry_plugins",
-                source_path="src/sentry_plugins",
+                stacktrace_root="sentry_plugins/",
+                source_path="src/sentry_plugins/",
             )
         ]
 


### PR DESCRIPTION
Always add a trailing backslash for generated code mappings.

WOR-2394