### PR TITLE
fix(replays): Adjust Replay Details layout(s) dimensions

### DIFF
--- a/static/app/utils/replays/hooks/useSplitPanelTracking.tsx
+++ b/static/app/utils/replays/hooks/useSplitPanelTracking.tsx
@@ -5,7 +5,7 @@ import useReplayLayout from 'sentry/utils/replays/hooks/useReplayLayout';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type CSSValuePct = `${number}%`;
-type CSSValueFR = `${number}fr`;
+type CSSValueFR = '1fr';
 
 type Options = {
   slideDirection: 'updown' | 'leftright';

--- a/static/app/utils/replays/hooks/useSplitPanelTracking.tsx
+++ b/static/app/utils/replays/hooks/useSplitPanelTracking.tsx
@@ -5,6 +5,7 @@ import useReplayLayout from 'sentry/utils/replays/hooks/useReplayLayout';
 import useOrganization from 'sentry/utils/useOrganization';
 
 type CSSValuePct = `${number}%`;
+type CSSValueFR = `${number}fr`;
 
 type Options = {
   slideDirection: 'updown' | 'leftright';
@@ -15,15 +16,20 @@ function useSplitPanelTracking({slideDirection}: Options) {
   const {getLayout} = useReplayLayout();
   const startSizeCSSRef = useRef<number>(0);
 
-  const setStartPosition = useCallback((startPosition: undefined | CSSValuePct) => {
-    startSizeCSSRef.current = Number(startPosition?.replace('%', '') || 0);
-  }, []);
+  const setStartPosition = useCallback(
+    (startPosition: undefined | CSSValuePct | CSSValueFR) => {
+      startSizeCSSRef.current = Number(startPosition?.replace('%', '') || 0);
+    },
+    []
+  );
 
   const logEndPosition = useCallback(
-    (endPosition: undefined | CSSValuePct) => {
+    (endPosition: undefined | CSSValuePct | CSSValueFR) => {
       const smaller = slideDirection === 'updown' ? 'toTop' : 'toLeft';
       const bigger = slideDirection === 'updown' ? 'toBottom' : 'toRight';
-      const endSizeCSS = Number(endPosition?.replace('%', '') || 0);
+      const endSizeCSS = Number(
+        endPosition?.endsWith('fr') ? '50' : endPosition?.replace('%', '') || 0
+      );
       trackAdvancedAnalyticsEvent('replay.details-resized-panel', {
         organization,
         layout: getLayout(),

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -163,7 +163,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
           }}
           right={{
             content: focusArea,
-            default: '50%',
+            default: '1fr',
             min: MIN_CONTENT_WIDTH,
           }}
         />

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -20,7 +20,8 @@ const MIN_VIDEO_WIDTH = {px: 325};
 const MIN_CONTENT_WIDTH = {px: 325};
 const MIN_SIDEBAR_WIDTH = {px: 325};
 const MIN_VIDEO_HEIGHT = {px: 200};
-const MIN_CONTENT_HEIGHT = {px: 200};
+const MIN_CONTENT_HEIGHT = {px: 180};
+const MIN_SIDEBAR_HEIGHT = {px: 120};
 
 type Props = {
   layout?: LayoutKey;
@@ -68,7 +69,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
           key={layout}
           left={{
             content: focusArea,
-            default: '75%',
+            default: '50%',
             min: MIN_CONTENT_WIDTH,
           }}
           right={{
@@ -103,7 +104,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
           key={layout}
           left={{
             content: mainSplit,
-            default: '75%',
+            default: '50%',
             min: MIN_CONTENT_WIDTH,
           }}
           right={{
@@ -125,7 +126,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
       }}
       bottom={{
         content: <SideCrumbsTags />,
-        min: MIN_SIDEBAR_WIDTH,
+        min: MIN_SIDEBAR_HEIGHT,
       }}
     />
   );
@@ -138,7 +139,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
           key={layout}
           left={{
             content: focusArea,
-            default: '60%',
+            default: '50%',
             min: MIN_CONTENT_WIDTH,
           }}
           right={{
@@ -162,7 +163,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
           }}
           right={{
             content: focusArea,
-            default: '60%',
+            default: '50%',
             min: MIN_CONTENT_WIDTH,
           }}
         />
@@ -187,7 +188,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
             <SplitPanel
               left={{
                 content: video,
-                default: '70%',
+                default: '50%',
                 min: MIN_VIDEO_WIDTH,
               }}
               right={{
@@ -200,7 +201,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
         }}
         bottom={{
           content: focusArea,
-          default: '60%',
+          default: '50%',
           min: MIN_CONTENT_HEIGHT,
         }}
       />

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -121,7 +121,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
       key={layout}
       top={{
         content: video,
-        default: '50%',
+        default: '65%',
         min: MIN_CONTENT_WIDTH,
       }}
       bottom={{

--- a/static/app/views/replays/detail/layout/index.tsx
+++ b/static/app/views/replays/detail/layout/index.tsx
@@ -69,7 +69,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
           key={layout}
           left={{
             content: focusArea,
-            default: '50%',
+            default: '1fr',
             min: MIN_CONTENT_WIDTH,
           }}
           right={{
@@ -87,7 +87,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
         key={layout + '_main'}
         top={{
           content: video,
-          default: '50%',
+          default: '65%',
           min: MIN_VIDEO_HEIGHT,
         }}
         bottom={{
@@ -104,7 +104,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
           key={layout}
           left={{
             content: mainSplit,
-            default: '50%',
+            default: '1fr',
             min: MIN_CONTENT_WIDTH,
           }}
           right={{
@@ -139,7 +139,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
           key={layout}
           left={{
             content: focusArea,
-            default: '50%',
+            default: '1fr',
             min: MIN_CONTENT_WIDTH,
           }}
           right={{
@@ -188,7 +188,7 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
             <SplitPanel
               left={{
                 content: video,
-                default: '50%',
+                default: '1fr',
                 min: MIN_VIDEO_WIDTH,
               }}
               right={{
@@ -196,12 +196,11 @@ function ReplayLayout({layout = LayoutKey.topbar}: Props) {
               }}
             />
           ),
-
+          default: '65%',
           min: MIN_VIDEO_HEIGHT,
         }}
         bottom={{
           content: focusArea,
-          default: '50%',
           min: MIN_CONTENT_HEIGHT,
         }}
       />

--- a/static/app/views/replays/detail/layout/splitPanel.tsx
+++ b/static/app/views/replays/detail/layout/splitPanel.tsx
@@ -14,7 +14,8 @@ const MOUSE_RELEASE_TIMEOUT_MS = 750;
 
 type CSSValuePX = `${number}px`;
 type CSSValuePct = `${number}%`;
-type CSSValue = CSSValuePX | CSSValuePct;
+type CSSValueFR = `${number}fr`;
+type CSSValue = CSSValuePX | CSSValuePct | CSSValueFR;
 type LimitValue =
   | {
       /**
@@ -31,7 +32,7 @@ type LimitValue =
 
 type Side = {
   content: ReactNode;
-  default?: CSSValuePct;
+  default?: CSSValuePct | CSSValueFR;
   max?: LimitValue;
   min?: LimitValue;
 };
@@ -106,7 +107,7 @@ function getMinMax(side: Side): {
 function SplitPanel(props: Props) {
   const [isMousedown, setIsMousedown] = useState(false);
   const [sizeCSS, setSizeCSS] = useState(getSplitDefault(props));
-  const sizeCSSRef = useRef<undefined | CSSValuePct>();
+  const sizeCSSRef = useRef<undefined | CSSValuePct | CSSValueFR>();
   sizeCSSRef.current = sizeCSS.a;
 
   const {setStartPosition, logEndPosition} = useSplitPanelTracking({

--- a/static/app/views/replays/detail/layout/splitPanel.tsx
+++ b/static/app/views/replays/detail/layout/splitPanel.tsx
@@ -14,7 +14,7 @@ const MOUSE_RELEASE_TIMEOUT_MS = 750;
 
 type CSSValuePX = `${number}px`;
 type CSSValuePct = `${number}%`;
-type CSSValueFR = `${number}fr`;
+type CSSValueFR = '1fr';
 type CSSValue = CSSValuePX | CSSValuePct | CSSValueFR;
 type LimitValue =
   | {


### PR DESCRIPTION
<!-- Describe your PR here. -->
### Changes
- All the main axis hav e a default dimension of 50% now
- Updated the min-height for the content and sidebar to be a shorter

Closes #41184 

### Test notes
- Tested the layout changes with all the layouts in different window resolutions

Loom video: 


https://user-images.githubusercontent.com/39612839/201776601-c7b3f611-e701-4e50-9eee-fa06035333f9.mp4




Updated initial layout dimensions:

![image](https://user-images.githubusercontent.com/39612839/201769112-39334dfd-4e6d-44b9-9a94-84cb04c8edf6.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
