### PR TITLE
feat(hybrid-cloud): Add /issues/* Django route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -459,6 +459,8 @@ urlpatterns += [
         react_page_view,
         name="integration-installation",
     ),
+    # Issues
+    url(r"^issues/", react_page_view, name="issues"),
     # Projects
     url(r"^projects/", react_page_view, name="projects"),
     # Dashboards


### PR DESCRIPTION
This adds `/issues/*` Django route so that `orgslug.sentry.io/issues/*` links work on pageload.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.