### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for the Monitors product

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1172,32 +1172,62 @@ function buildRoutes() {
     </Route>
   );
 
-  const monitorsChildRoutes = (
-    <Fragment>
-      <IndexRoute component={make(() => import('sentry/views/monitors/monitors'))} />
-      <Route
-        path="/organizations/:orgId/monitors/create/"
-        component={make(() => import('sentry/views/monitors/create'))}
-      />
-      <Route
-        path="/organizations/:orgId/monitors/:monitorId/"
-        component={make(() => import('sentry/views/monitors/details'))}
-      />
-      <Route
-        path="/organizations/:orgId/monitors/:monitorId/edit/"
-        component={make(() => import('sentry/views/monitors/edit'))}
-      />
-    </Fragment>
-  );
+  const monitorsChildRoutes = ({forCustomerDomain}: {forCustomerDomain: boolean}) => {
+    return (
+      <Fragment>
+        <IndexRoute component={make(() => import('sentry/views/monitors/monitors'))} />
+        <Route
+          path={
+            forCustomerDomain
+              ? '/monitors/create/'
+              : '/organizations/:orgId/monitors/create/'
+          }
+          component={make(() => import('sentry/views/monitors/create'))}
+          key={forCustomerDomain ? 'orgless-monitors-create' : 'org-monitors-create'}
+        />
+        <Route
+          path={
+            forCustomerDomain
+              ? '/monitors/:monitorId/'
+              : '/organizations/:orgId/monitors/:monitorId/'
+          }
+          component={make(() => import('sentry/views/monitors/details'))}
+          key={
+            forCustomerDomain ? 'orgless-monitors-monitor-id' : 'org-monitors-monitor-id'
+          }
+        />
+        <Route
+          path={
+            forCustomerDomain
+              ? '/monitors/:monitorId/edit/'
+              : '/organizations/:orgId/monitors/:monitorId/edit/'
+          }
+          component={make(() => import('sentry/views/monitors/edit'))}
+          key={forCustomerDomain ? 'orgless-monitors-edit' : 'org-monitors-edit'}
+        />
+      </Fragment>
+    );
+  };
 
   const monitorsRoutes = (
-    <Route
-      path="/organizations/:orgId/monitors/"
-      component={make(() => import('sentry/views/monitors'))}
-      key="org-monitors"
-    >
-      {monitorsChildRoutes}
-    </Route>
+    <Fragment>
+      {usingCustomerDomain ? (
+        <Route
+          path="/monitors/"
+          component={withDomainRequired(make(() => import('sentry/views/monitors')))}
+          key="orgless-monitors-route"
+        >
+          {monitorsChildRoutes({forCustomerDomain: true})}
+        </Route>
+      ) : null}
+      <Route
+        path="/organizations/:orgId/monitors/"
+        component={withDomainRedirect(make(() => import('sentry/views/monitors')))}
+        key="org-monitors"
+      >
+        {monitorsChildRoutes({forCustomerDomain: false})}
+      </Route>
+    </Fragment>
   );
 
   const replayRoutes = (

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1172,11 +1172,8 @@ function buildRoutes() {
     </Route>
   );
 
-  const monitorsRoutes = (
-    <Route
-      path="/organizations/:orgId/monitors/"
-      component={make(() => import('sentry/views/monitors'))}
-    >
+  const monitorsChildRoutes = (
+    <Fragment>
       <IndexRoute component={make(() => import('sentry/views/monitors/monitors'))} />
       <Route
         path="/organizations/:orgId/monitors/create/"
@@ -1190,6 +1187,16 @@ function buildRoutes() {
         path="/organizations/:orgId/monitors/:monitorId/edit/"
         component={make(() => import('sentry/views/monitors/edit'))}
       />
+    </Fragment>
+  );
+
+  const monitorsRoutes = (
+    <Route
+      path="/organizations/:orgId/monitors/"
+      component={make(() => import('sentry/views/monitors'))}
+      key="org-monitors"
+    >
+      {monitorsChildRoutes}
     </Route>
   );
 


### PR DESCRIPTION
This adds the customer domain React routes for the Monitors product.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.
