### PR TITLE
feat(discover): allows passing a readable query param to return more readable device names when device is queried

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -5528,3 +5528,23 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         assert set(fields) == data_keys
         assert set(fields) == field_keys
         assert set(fields) == unit_keys
+
+    def test_readable_device_name(self):
+        data = self.load_data(
+            timestamp=before_now(minutes=1),
+        )
+        data["tags"] = {"device": "iPhone14,3"}
+        self.store_event(data, project_id=self.project.id)
+
+        query = {
+            "field": ["device"],
+            "query": "",
+            "project": [self.project.id],
+            "readable": True,
+        }
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["device"] == "iPhone14,3"
+        assert data[0]["readable"] == "iPhone 13 Pro Max"


### PR DESCRIPTION
Updates the `/events` endpoint to return readable device names (when queried) if readable=true is passed as a query param