### PR TITLE
perf(users-endpoint): Improve users endpoint performance more

### DIFF
--- a/src/sentry/api/endpoints/organization_users.py
+++ b/src/sentry/api/endpoints/organization_users.py
@@ -37,7 +37,6 @@ class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     ).values_list("organizationmember_id", flat=True),
                 )
                 .select_related("user")
-                .prefetch_related("teams")
                 .order_by("user__email")
             )
 
@@ -51,7 +50,7 @@ class OrganizationUsersEndpoint(OrganizationEndpoint, EnvironmentMixin):
                 organization_members,
                 request.user,
                 serializer=OrganizationMemberWithProjectsSerializer(
-                    project_ids=[p.id for p in projects]
+                    projects=projects,
                 ),
             )
         )

--- a/src/sentry/api/serializers/models/organization_member/expand/projects.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/projects.py
@@ -24,9 +24,10 @@ class OrganizationMemberWithProjectsSerializer(OrganizationMemberSerializer):
         # Note that we're intentionally only working with `team_id`
         # to avoid having to fetch the team model as well.
         member_teams = OrganizationMemberTeam.objects.filter(
+            organizationmember_id__in=[om.id for om in item_list],
             team_id__in=ProjectTeam.objects.filter(
-                # make sure to filter only for teams that are visible
                 project_id__in=self.project_ids,
+                # make sure to filter only for teams that are visible
                 team__status=TeamStatus.VISIBLE,
             )
             .values_list("team_id", flat=True)

--- a/src/sentry/api/serializers/models/organization_member/expand/projects.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/projects.py
@@ -25,14 +25,8 @@ class OrganizationMemberWithProjectsSerializer(OrganizationMemberSerializer):
         # to avoid having to fetch the team model as well.
         member_teams = OrganizationMemberTeam.objects.filter(
             organizationmember_id__in=[om.id for om in item_list],
-            team_id__in=ProjectTeam.objects.filter(
-                project_id__in=self.project_ids,
-                # make sure to filter only for teams that are visible
-                team__status=TeamStatus.VISIBLE,
-            )
-            .values_list("team_id", flat=True)
-            .distinct(),
-        )
+            team__status=TeamStatus.VISIBLE,
+        ).values_list("team_id", "organizationmember_id", named=True)
 
         # The set of team ids, this will be used to filter down the `ProjectTeam` below
         team_ids = set()
@@ -60,7 +54,7 @@ class OrganizationMemberWithProjectsSerializer(OrganizationMemberSerializer):
         for project_team in ProjectTeam.objects.filter(
             project_id__in=self.project_ids,
             team_id__in=team_ids,
-        ):
+        ).values_list("team_id", "project_id", named=True):
             projects_by_team_id[project_team.team_id].append(self.projects[project_team.project_id])
 
         for org_member in item_list:

--- a/src/sentry/api/serializers/models/organization_member/expand/projects.py
+++ b/src/sentry/api/serializers/models/organization_member/expand/projects.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import Any, Mapping, MutableMapping, Sequence, cast
 
-from sentry.models import OrganizationMember, ProjectTeam, TeamStatus, User
+from sentry.models import OrganizationMember, OrganizationMemberTeam, ProjectTeam, TeamStatus, User
 
 from ..base import OrganizationMemberSerializer
 from ..response import OrganizationMemberWithProjectsResponse
@@ -9,42 +9,64 @@ from ..response import OrganizationMemberWithProjectsResponse
 
 class OrganizationMemberWithProjectsSerializer(OrganizationMemberSerializer):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self.project_ids = set(kwargs.pop("project_ids", []))
+        self.projects = {p.id: p for p in kwargs.pop("projects", [])}
+        self.project_ids = set(self.projects.keys())
         super().__init__(*args, **kwargs)
 
     def get_attrs(
         self, item_list: Sequence[OrganizationMember], user: User, **kwargs: Any
     ) -> MutableMapping[OrganizationMember, MutableMapping[str, Any]]:
-        """
-        Note: For this to be efficient, call
-        `.prefetch_related('teams')`
-        on your queryset before using this serializer
-        """
-
         attrs = super().get_attrs(item_list, user)
 
-        team_ids = set()
-        for org_member in item_list:
-            for team in org_member.teams.all():
-                team_ids.add(team.id)
+        # Get all the OrganizationMemberTeam relations so we can map
+        # the member id to the list of team ids
+        #
+        # Note that we're intentionally only working with `team_id`
+        # to avoid having to fetch the team model as well.
+        member_teams = OrganizationMemberTeam.objects.filter(
+            team_id__in=ProjectTeam.objects.filter(
+                # make sure to filter only for teams that are visible
+                project_id__in=self.project_ids,
+                team__status=TeamStatus.VISIBLE,
+            )
+            .values_list("team_id", flat=True)
+            .distinct(),
+        )
 
-        projects_by_team = defaultdict(list)
+        # The set of team ids, this will be used to filter down the `ProjectTeam` below
+        team_ids = set()
+
+        # Mapping from member id to team ids they belong to.
+        #
+        # Previously, we were using a `select_related` when fetching the OrganizationMember.
+        # This resulted in django trying to set the attributes for the many to many relation
+        # which was slow.
+        team_ids_by_member_id = defaultdict(list)
+
+        # Be very careful here. We are intentionally only using `team_id` and `organizationmember_id`.
+        # This is to stop django from fetching these models. We don't even want django to do
+        # any kind of prefetching here.
+        for member_team in member_teams:
+            team_ids.add(member_team.team_id)
+            team_ids_by_member_id[member_team.organizationmember_id].append(member_team.team_id)
+
+        # Mapping from team id to projects that belong to the team.
+        #
+        # We require the caller to pass in the list of projects (not just ids to avoid an extra query)
+        # Make sure we only work with `team_id` and not the team object so django doesn't fetching it.
+        projects_by_team_id = defaultdict(list)
 
         for project_team in ProjectTeam.objects.filter(
             project_id__in=self.project_ids,
             team_id__in=team_ids,
-        ).select_related("project"):
-            projects_by_team[project_team.team_id].append(project_team.project.slug)
+        ):
+            projects_by_team_id[project_team.team_id].append(self.projects[project_team.project_id])
 
         for org_member in item_list:
             projects = set()
-            for team in org_member.teams.all():
-                # Filter in python here so that we don't break the prefetch
-                if team.status != TeamStatus.VISIBLE:
-                    continue
-
-                for project in projects_by_team[team.id]:
-                    projects.add(project)
+            for team_id in team_ids_by_member_id[org_member.id]:
+                for project in projects_by_team_id[team_id]:
+                    projects.add(project.slug)
 
             projects_list = list(projects)
             projects_list.sort()

--- a/tests/sentry/api/endpoints/test_organization_users.py
+++ b/tests/sentry/api/endpoints/test_organization_users.py
@@ -25,7 +25,8 @@ class OrganizationMemberListTest(APITestCase):
         self.login_as(user=self.user_2)
 
     def test_simple(self):
-        projects_ids = [self.project_1.id, self.project_2.id]
+        projects = [self.project_1, self.project_2]
+        projects_ids = [p.id for p in projects]
         response = self.get_success_response(self.org.slug, project=projects_ids)
         expected = serialize(
             list(
@@ -34,15 +35,16 @@ class OrganizationMemberListTest(APITestCase):
                 )
             ),
             self.user_2,
-            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+            OrganizationMemberWithProjectsSerializer(projects=projects),
         )
         assert response.data == expected
 
-        projects_ids = [self.project_2.id]
+        projects = [self.project_2]
+        projects_ids = [p.id for p in projects]
         response = self.get_success_response(self.org.slug, project=projects_ids)
         expected = serialize(
             list(self.org.member_set.filter(user__in=[self.user_2]).order_by("user__email")),
             self.user_2,
-            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+            OrganizationMemberWithProjectsSerializer(projects=projects),
         )
         assert response.data == expected

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -30,22 +30,22 @@ class OrganizationMemberSerializerTest(TestCase):
 @region_silo_test
 class OrganizationMemberWithProjectsSerializerTest(OrganizationMemberSerializerTest):
     def test_simple(self):
-        projects_ids = [self.project.id, self.project_2.id]
+        projects = [self.project, self.project_2]
         org_members = self._get_org_members()
         result = serialize(
             org_members,
             self.user_2,
-            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+            OrganizationMemberWithProjectsSerializer(projects=projects),
         )
         expected_projects = [[self.project.slug, self.project_2.slug], [self.project.slug]]
         expected_projects[0].sort()
         assert [r["projects"] for r in result] == expected_projects
 
-        projects_ids = [self.project_2.id]
+        projects = [self.project_2]
         result = serialize(
             org_members,
             self.user_2,
-            OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
+            OrganizationMemberWithProjectsSerializer(projects=projects),
         )
         expected_projects = [[self.project_2.slug], []]
         assert [r["projects"] for r in result] == expected_projects


### PR DESCRIPTION
The last attempt in #41292 made a small dent to the p75 but not noticeable in the p95. Looking at it some more, the `select_related("teams")` was fetching a many to many relationship and reducing it in python which is currently the bottleneck. This change removes all uses of `select_related` and `prefetch_related` entirely in favour of a more granular control over the exact queries we make.

The total number of queries we make here is the same since we're just breaking out the queries that would've been made by `prefetch_related`. However, by manually constructing the final results from the queries, we're able to avoid the work django does to add the attributes on the models which was the true bottleneck here since we were working with 2 many to many relations here.