### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for Replays product

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1193,16 +1193,22 @@ function buildRoutes() {
     </Route>
   );
 
-  const replayRoutes = (
-    <Route
-      path="/organizations/:orgId/replays/"
-      component={make(() => import('sentry/views/replays'))}
-    >
+  const replayChildRoutes = (
+    <Fragment>
       <IndexRoute component={make(() => import('sentry/views/replays/replays'))} />
       <Route
         path=":replaySlug/"
         component={make(() => import('sentry/views/replays/details'))}
       />
+    </Fragment>
+  );
+
+  const replayRoutes = (
+    <Route
+      path="/organizations/:orgId/replays/"
+      component={make(() => import('sentry/views/replays'))}
+    >
+      {replayChildRoutes}
     </Route>
   );
 

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1204,12 +1204,24 @@ function buildRoutes() {
   );
 
   const replayRoutes = (
-    <Route
-      path="/organizations/:orgId/replays/"
-      component={make(() => import('sentry/views/replays'))}
-    >
-      {replayChildRoutes}
-    </Route>
+    <Fragment>
+      {usingCustomerDomain ? (
+        <Route
+          path="/replays/"
+          component={withDomainRequired(make(() => import('sentry/views/replays')))}
+          key="orgless-replays-route"
+        >
+          {replayChildRoutes}
+        </Route>
+      ) : null}
+      <Route
+        path="/organizations/:orgId/replays/"
+        component={withDomainRedirect(make(() => import('sentry/views/replays')))}
+        key="org-replays"
+      >
+        {replayChildRoutes}
+      </Route>
+    </Fragment>
   );
 
   const releasesRoutes = (


### PR DESCRIPTION
This adds the customer domain React routes for the Replays product.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.