### PR TITLE
feat(hybrid-cloud): Add /releases/* Django route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -470,6 +470,8 @@ urlpatterns += [
     url(r"^discover/", react_page_view, name="discover"),
     # Request to join an organization
     url(r"^join-request/", react_page_view, name="join-request"),
+    # Releases
+    url(r"^releases/", react_page_view, name="releases"),
     # User Feedback
     url(r"^user-feedback/", react_page_view, name="user-feedback"),
     # Organizations


### PR DESCRIPTION
This adds `/releases/*` Django route so that `orgslug.sentry.io/releases/*` links work on pageload.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.