### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for Activity

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1235,10 +1235,24 @@ function buildRoutes() {
   );
 
   const activityRoutes = (
-    <Route
-      path="/organizations/:orgId/activity/"
-      component={make(() => import('sentry/views/organizationActivity'))}
-    />
+    <Fragment>
+      {usingCustomerDomain ? (
+        <Route
+          path="/activity/"
+          component={withDomainRequired(
+            make(() => import('sentry/views/organizationActivity'))
+          )}
+          key="orgless-activity-route"
+        />
+      ) : null}
+      <Route
+        path="/organizations/:orgId/activity/"
+        component={withDomainRedirect(
+          make(() => import('sentry/views/organizationActivity'))
+        )}
+        key="org-activity"
+      />
+    </Fragment>
   );
 
   const statsRoutes = (


### PR DESCRIPTION
This adds the customer domain React routes for the Activity page.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.
