### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for Stats

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1241,30 +1241,40 @@ function buildRoutes() {
     />
   );
 
+  const statsChildRoutes = ({forCustomerDomain}: {forCustomerDomain: boolean}) => {
+    return (
+      <Fragment>
+        <IndexRoute component={make(() => import('sentry/views/organizationStats'))} />
+        <Route
+          path="issues/"
+          component={make(() => import('sentry/views/organizationStats/teamInsights'))}
+        >
+          <IndexRoute
+            component={make(
+              () => import('sentry/views/organizationStats/teamInsights/issues')
+            )}
+          />
+        </Route>
+        <Route
+          path="health/"
+          component={make(() => import('sentry/views/organizationStats/teamInsights'))}
+        >
+          <IndexRoute
+            component={make(
+              () => import('sentry/views/organizationStats/teamInsights/health')
+            )}
+          />
+        </Route>
+        {forCustomerDomain ? null : (
+          <Redirect from="team/" to="/organizations/:orgId/stats/issues/" />
+        )}
+      </Fragment>
+    );
+  };
+
   const statsRoutes = (
-    <Route path="/organizations/:orgId/stats/">
-      <IndexRoute component={make(() => import('sentry/views/organizationStats'))} />
-      <Route
-        path="issues/"
-        component={make(() => import('sentry/views/organizationStats/teamInsights'))}
-      >
-        <IndexRoute
-          component={make(
-            () => import('sentry/views/organizationStats/teamInsights/issues')
-          )}
-        />
-      </Route>
-      <Route
-        path="health/"
-        component={make(() => import('sentry/views/organizationStats/teamInsights'))}
-      >
-        <IndexRoute
-          component={make(
-            () => import('sentry/views/organizationStats/teamInsights/health')
-          )}
-        />
-      </Route>
-      <Redirect from="team/" to="/organizations/:orgId/stats/issues/" />
+    <Route path="/organizations/:orgId/stats/" key="org-stats">
+      {statsChildRoutes({forCustomerDomain: false})}
     </Route>
   );
 

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1273,9 +1273,24 @@ function buildRoutes() {
   };
 
   const statsRoutes = (
-    <Route path="/organizations/:orgId/stats/" key="org-stats">
-      {statsChildRoutes({forCustomerDomain: false})}
-    </Route>
+    <Fragment>
+      {usingCustomerDomain ? (
+        <Route
+          path="/stats/"
+          component={withDomainRequired(NoOp)}
+          key="orgless-stats-route"
+        >
+          {statsChildRoutes({forCustomerDomain: true})}
+        </Route>
+      ) : null}
+      <Route
+        path="/organizations/:orgId/stats/"
+        component={withDomainRedirect(NoOp)}
+        key="org-stats"
+      >
+        {statsChildRoutes({forCustomerDomain: false})}
+      </Route>
+    </Fragment>
   );
 
   // TODO(mark) Long term this /queries route should go away and /discover


### PR DESCRIPTION
This adds the customer domain React routes for the Stats page.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.