### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for Performance

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1392,13 +1392,24 @@ function buildRoutes() {
   );
 
   const performanceRoutes = (
-    <Route
-      path="/organizations/:orgId/performance/"
-      component={make(() => import('sentry/views/performance'))}
-      key="org-performance"
-    >
-      {performanceChildRoutes}
-    </Route>
+    <Fragment>
+      {usingCustomerDomain ? (
+        <Route
+          path="/performance/"
+          component={withDomainRequired(make(() => import('sentry/views/performance')))}
+          key="orgless-performance-route"
+        >
+          {performanceChildRoutes}
+        </Route>
+      ) : null}
+      <Route
+        path="/organizations/:orgId/performance/"
+        component={withDomainRedirect(make(() => import('sentry/views/performance')))}
+        key="org-performance"
+      >
+        {performanceChildRoutes}
+      </Route>
+    </Fragment>
   );
 
   const userFeedbackRoutes = (

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1314,17 +1314,14 @@ function buildRoutes() {
     </Fragment>
   );
 
-  const performanceRoutes = (
-    <Route
-      path="/organizations/:orgId/performance/"
-      component={make(() => import('sentry/views/performance'))}
-    >
+  const performanceChildRoutes = (
+    <Fragment>
       <IndexRoute component={make(() => import('sentry/views/performance/content'))} />
       <Route
         path="trends/"
         component={make(() => import('sentry/views/performance/trends'))}
       />
-      <Route path="/organizations/:orgId/performance/summary/">
+      <Route path="summary/">
         <IndexRoute
           component={make(
             () =>
@@ -1391,6 +1388,16 @@ function buildRoutes() {
         path=":eventSlug/"
         component={make(() => import('sentry/views/performance/transactionDetails'))}
       />
+    </Fragment>
+  );
+
+  const performanceRoutes = (
+    <Route
+      path="/organizations/:orgId/performance/"
+      component={make(() => import('sentry/views/performance'))}
+      key="org-performance"
+    >
+      {performanceChildRoutes}
     </Route>
   );
 


### PR DESCRIPTION
This adds the customer domain React routes for the Performance product.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.