### PR TITLE
feat(hybrid-cloud): Add /profiling/* Django route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -461,6 +461,8 @@ urlpatterns += [
     ),
     # Issues
     url(r"^issues/", react_page_view, name="issues"),
+    # Profiling
+    url(r"^profiling/", react_page_view, name="profiling"),
     # Projects
     url(r"^projects/", react_page_view, name="projects"),
     # Dashboards


### PR DESCRIPTION
This adds `/profiling/*` Django route so that `orgslug.sentry.io/profiling/*` links work on pageload.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.