### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for Profiling product.

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1779,11 +1779,8 @@ function buildRoutes() {
     </Route>
   );
 
-  const profilingRoutes = (
-    <Route
-      path="/organizations/:orgId/profiling/"
-      component={make(() => import('sentry/views/profiling'))}
-    >
+  const profilingChildRoutes = (
+    <Fragment>
       <IndexRoute component={make(() => import('sentry/views/profiling/content'))} />
       <Route
         path="summary/:projectId/"
@@ -1802,6 +1799,16 @@ function buildRoutes() {
           component={make(() => import('sentry/views/profiling/profileFlamechart'))}
         />
       </Route>
+    </Fragment>
+  );
+
+  const profilingRoutes = (
+    <Route
+      path="/organizations/:orgId/profiling/"
+      component={make(() => import('sentry/views/profiling'))}
+      key="org-profiling"
+    >
+      {profilingChildRoutes}
     </Route>
   );
 

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1803,13 +1803,24 @@ function buildRoutes() {
   );
 
   const profilingRoutes = (
-    <Route
-      path="/organizations/:orgId/profiling/"
-      component={make(() => import('sentry/views/profiling'))}
-      key="org-profiling"
-    >
-      {profilingChildRoutes}
-    </Route>
+    <Fragment>
+      {usingCustomerDomain ? (
+        <Route
+          path="/profiling/"
+          component={withDomainRequired(make(() => import('sentry/views/profiling')))}
+          key="orgless-profiling-route"
+        >
+          {profilingChildRoutes}
+        </Route>
+      ) : null}
+      <Route
+        path="/organizations/:orgId/profiling/"
+        component={withDomainRedirect(make(() => import('sentry/views/profiling')))}
+        key="org-profiling"
+      >
+        {profilingChildRoutes}
+      </Route>
+    </Fragment>
   );
 
   const organizationRoutes = (


### PR DESCRIPTION
This adds the customer domain React routes for the Profiling product.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.
