### PR TITLE
feat(hybrid-cloud): Add /settings/* Django route

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -426,6 +426,71 @@ urlpatterns += [
                     name="sentry-customer-domain-organization-settings",
                 ),
                 url(
+                    r"^projects/",
+                    react_page_view,
+                    name="sentry-customer-domain-projects-settings",
+                ),
+                url(
+                    r"^teams/",
+                    react_page_view,
+                    name="sentry-customer-domain-teams-settings",
+                ),
+                url(
+                    r"^members/",
+                    react_page_view,
+                    name="sentry-customer-domain-members-settings",
+                ),
+                url(
+                    r"^security-and-privacy/",
+                    react_page_view,
+                    name="sentry-customer-domain-security-and-privacy-settings",
+                ),
+                url(
+                    r"^auth/",
+                    react_page_view,
+                    name="sentry-customer-domain-auth-settings",
+                ),
+                url(
+                    r"^audit-log/",
+                    react_page_view,
+                    name="sentry-customer-domain-audit-log-settings",
+                ),
+                url(
+                    r"^relay/",
+                    react_page_view,
+                    name="sentry-customer-domain-relay-settings",
+                ),
+                url(
+                    r"^repos/",
+                    react_page_view,
+                    name="sentry-customer-domain-repos-settings",
+                ),
+                url(
+                    r"^integrations/",
+                    react_page_view,
+                    name="sentry-customer-domain-integrations-settings",
+                ),
+                url(
+                    r"^developer-settings/",
+                    react_page_view,
+                    name="sentry-customer-domain-developer-settings-settings",
+                ),
+                url(
+                    r"^billing/",
+                    react_page_view,
+                    name="sentry-customer-domain-billing-settings",
+                ),
+                url(
+                    r"^subscription/",
+                    react_page_view,
+                    name="sentry-customer-domain-subscription-settings",
+                ),
+                url(
+                    r"^legal/",
+                    react_page_view,
+                    name="sentry-customer-domain-legal-settings",
+                ),
+                url(
                     r"^(?P<organization_slug>[\w_-]+)/$",
                     react_page_view,
                     name="sentry-organization-settings",

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -421,6 +421,11 @@ urlpatterns += [
                 ),
                 url(r"^account/", generic_react_page_view),
                 url(
+                    r"^organization/",
+                    react_page_view,
+                    name="sentry-customer-domain-organization-settings",
+                ),
+                url(
                     r"^(?P<organization_slug>[\w_-]+)/$",
                     react_page_view,
                     name="sentry-organization-settings",


### PR DESCRIPTION
This adds `/settings/*` Django sub-routes so that `orgslug.sentry.io/settings/*` links work on pageload.

I had to hardcode the names of the sub-routes so that `/settings/<org_slug>/` does not get matched.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.