### PR TITLE
feat(hybrid-cloud): Add /getting-started/:project-slug/* sub-page Django routes

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -566,6 +566,12 @@ urlpatterns += [
         DisabledMemberView.as_view(),
         name="sentry-customer-domain-organization-disabled-member",
     ),
+    # Project on-boarding
+    url(
+        r"^(?P<project_slug>[\w_-]+)/getting-started",
+        react_page_view,
+        name="project-getting-started",
+    ),
     # Organizations
     url(r"^(?P<organization_slug>[\w_-]+)/$", react_page_view, name="sentry-organization-home"),
     url(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -567,8 +567,9 @@ urlpatterns += [
         name="sentry-customer-domain-organization-disabled-member",
     ),
     # Project on-boarding
+    # We map /:orgid/:projectid/getting-started/* to /getting-started/:projectid/*
     url(
-        r"^(?P<project_slug>[\w_-]+)/getting-started",
+        r"^getting-started/(?P<project_slug>[\w_-]+)/",
         react_page_view,
         name="project-getting-started",
     ),


### PR DESCRIPTION
This adds `/getting-started/<project_slug>/*` Django route so that `orgslug.sentry.io/getting-started/<project_slug>/*` links work on pageload.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.