### PR TITLE
feat(growth): consolidate analytics events to use route analytics

### DIFF
--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -60,7 +60,6 @@ type IntegrationInstallationInputValueChangeEventParams = {
 // Event key to payload mappings
 export type IntegrationEventParameters = {
   'integrations.cloudformation_link_clicked': SingleIntegrationEventParams;
-  'integrations.code_mappings_viewed': SingleIntegrationEventParams;
   'integrations.config_saved': SingleIntegrationEventParams;
   'integrations.details_viewed': SingleIntegrationEventParams;
   'integrations.directory_category_selected': IntegrationCategorySelectEventParams;
@@ -106,7 +105,6 @@ export const integrationEventMap: Record<IntegrationAnalyticsKey, string> = {
     'Integrations: Plugin Add to Project Clicked',
   'integrations.resolve_now_clicked': 'Integrations: Resolve Now Clicked',
   'integrations.request_install': 'Integrations: Request Install',
-  'integrations.code_mappings_viewed': 'Integrations: Code Mappings Viewed',
   'integrations.details_viewed': 'Integrations: Details Viewed',
   'integrations.index_viewed': 'Integrations: Index Page Viewed',
   'integrations.directory_item_searched': 'Integrations: Directory Item Searched',

--- a/static/app/utils/analytics/monitorsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/monitorsAnalyticsEvents.tsx
@@ -1,9 +1,5 @@
-export type MonitorsEventParameters = {
-  'monitors.page_viewed': {};
-};
+export type MonitorsEventParameters = {};
 
 type MonitorsAnalyticsKey = keyof MonitorsEventParameters;
 
-export const monitorsEventMap: Record<MonitorsAnalyticsKey, string> = {
-  'monitors.page_viewed': 'Monitors: Page Viewed',
-};
+export const monitorsEventMap: Record<MonitorsAnalyticsKey, string> = {};

--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -64,10 +64,6 @@ export type PerformanceEventParameters = {
     project_platforms: string;
   };
   'performance_views.overview.search': {};
-  'performance_views.overview.view': {
-    project_platforms: string;
-    show_onboarding: boolean;
-  };
   'performance_views.project_transaction_threshold.change': {
     from: string;
     key: string;
@@ -79,9 +75,6 @@ export type PerformanceEventParameters = {
   };
   'performance_views.span_summary.change_chart': {
     change_to_display: string;
-  };
-  'performance_views.span_summary.view': {
-    project_platforms: string;
   };
   'performance_views.spans.change_op': {
     operation_name?: string;
@@ -169,7 +162,6 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
     'Performance Views: Landing Page Transactions Table Page Changed',
   'performance_views.span_summary.change_chart':
     'Performance Views: Span Summary displayed chart changed',
-  'performance_views.span_summary.view': 'Performance Views: Span Summary page viewed',
   'performance_views.spans.change_op': 'Performance Views: Change span operation name',
   'performance_views.spans.change_sort': 'Performance Views: Change span sort column',
   'performance_views.summary.tag_explorer.tag_value':
@@ -181,7 +173,6 @@ export const performanceEventMap: Record<PerformanceEventKey, string | null> = {
   'performance_views.summary.tag_explorer.change_page':
     'Performance Views: Tag Explorer Change Page',
   'performance_views.summary.tag_explorer.sort': 'Performance Views: Tag Explorer Sorted',
-  'performance_views.overview.view': 'Performance Views: Transaction overview view',
   'performance_views.overview.search': 'Performance Views: Transaction overview search',
   'performance_views.project_transaction_threshold.change':
     'Project Transaction Threshold: Changed',

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -99,18 +99,11 @@ export type TeamInsightsEventParameters = {
       project_has_replay?: boolean;
       project_platform?: string;
     };
-  'new_alert_rule.viewed': RuleViewed & {
-    duplicate_rule: string;
-    session_id: string;
-    wizard_v3: string;
-  };
   'project_creation_page.created': {
     issue_alert: 'Default' | 'Custom' | 'No Rule';
     project_id: string;
     rule_id: string;
   };
-  'project_creation_page.viewed': {};
-  'team_insights.viewed': {};
 };
 
 export type TeamInsightsEventKey = keyof TeamInsightsEventParameters;
@@ -154,8 +147,5 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'issue_details.suspect_commits.pull_request_clicked':
     'Issue Details: Suspect Pull Request Clicked',
   'issue_details.tab_changed': 'Issue Details: Tab Changed',
-  'new_alert_rule.viewed': 'New Alert Rule: Viewed',
-  'team_insights.viewed': 'Team Insights: Viewed',
-  'project_creation_page.viewed': 'Project Create: Creation page viewed',
   'project_creation_page.created': 'Project Create: Project Created',
 };

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -7,9 +7,11 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {Member, Organization, Project} from 'sentry/types';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView from 'sentry/utils/discover/eventView';
 import {uniqueId} from 'sentry/utils/guid';
+import withRouteAnalytics, {
+  WithRouteAnalyticsProps,
+} from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import Teams from 'sentry/utils/teams';
 import BuilderBreadCrumbs from 'sentry/views/alerts/builder/builderBreadCrumbs';
 import IssueRuleEditor from 'sentry/views/alerts/rules/issue';
@@ -30,12 +32,13 @@ type RouteParams = {
   projectId?: string;
 };
 
-type Props = RouteComponentProps<RouteParams, {}> & {
-  hasMetricAlerts: boolean;
-  members: Member[] | undefined;
-  organization: Organization;
-  project: Project;
-};
+type Props = RouteComponentProps<RouteParams, {}> &
+  WithRouteAnalyticsProps & {
+    hasMetricAlerts: boolean;
+    members: Member[] | undefined;
+    organization: Organization;
+    project: Project;
+  };
 
 type State = {
   alertType: AlertRuleType;
@@ -72,7 +75,7 @@ class Create extends Component<Props, State> {
   componentDidMount() {
     const {organization, project} = this.props;
 
-    trackAdvancedAnalyticsEvent('new_alert_rule.viewed', {
+    this.props.setRouteAnalyticsParams({
       organization,
       project_id: project.id,
       session_id: this.sessionId,
@@ -80,6 +83,7 @@ class Create extends Component<Props, State> {
       duplicate_rule: this.isDuplicateRule ? 'true' : 'false',
       wizard_v3: 'true',
     });
+    this.props.setEventNames('new_alert_rule.viewed', 'New Alert Rule: Viewed');
   }
 
   /** Used to track analytics within one visit to the creation page */
@@ -199,4 +203,4 @@ const Body = styled(Layout.Body)`
   }
 `;
 
-export default Create;
+export default withRouteAnalytics(Create);

--- a/static/app/views/alerts/create.tsx
+++ b/static/app/views/alerts/create.tsx
@@ -73,10 +73,9 @@ class Create extends Component<Props, State> {
   }
 
   componentDidMount() {
-    const {organization, project} = this.props;
+    const {project} = this.props;
 
     this.props.setRouteAnalyticsParams({
-      organization,
       project_id: project.id,
       session_id: this.sessionId,
       alert_type: this.state.alertType,

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -21,8 +21,10 @@ import TimeSince from 'sentry/components/timeSince';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {decodeScalar} from 'sentry/utils/queryString';
+import withRouteAnalytics, {
+  WithRouteAnalyticsProps,
+} from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
@@ -31,6 +33,7 @@ import MonitorIcon from './monitorIcon';
 import {Monitor} from './types';
 
 type Props = AsyncView['props'] &
+  WithRouteAnalyticsProps &
   WithRouterProps<{orgId: string}> & {
     organization: Organization;
   };
@@ -82,11 +85,8 @@ class Monitors extends AsyncView<Props, State> {
   }
 
   componentDidMount() {
-    trackAdvancedAnalyticsEvent('monitors.page_viewed', {
-      organization: this.props.organization.id,
-    });
+    this.props.setEventNames('monitors.page_viewed', 'Monitors: Page Viewed');
   }
-
   handleSearch = (query: string) => {
     const {location, router} = this.props;
     router.push({
@@ -194,4 +194,4 @@ const Filters = styled('div')`
   margin-bottom: ${space(2)};
 `;
 
-export default withRouter(withOrganization(Monitors));
+export default withRouteAnalytics(withRouter(withOrganization(Monitors)));

--- a/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
-import * as qs from 'query-string';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
@@ -32,15 +31,19 @@ import {
   getIntegrationIcon,
   trackIntegrationAnalytics,
 } from 'sentry/utils/integrationUtil';
+import withRouteAnalytics, {
+  WithRouteAnalyticsProps,
+} from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProjects from 'sentry/utils/withProjects';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-type Props = AsyncComponent['props'] & {
-  integration: Integration;
-  organization: Organization;
-  projects: Project[];
-};
+type Props = AsyncComponent['props'] &
+  WithRouteAnalyticsProps & {
+    integration: Integration;
+    organization: Organization;
+    projects: Project[];
+  };
 
 type State = AsyncComponent['state'] & {
   pathConfigs: RepositoryProjectPathConfig[];
@@ -92,19 +95,14 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
   }
 
   componentDidMount() {
-    const {referrer} = qs.parse(window.location.search) || {};
-    // We don't start new session if the user was coming from choosing
-    // the manual setup option flow from the issue details page
-    const startSession = referrer === 'stacktrace-issue-details' ? false : true;
-    trackIntegrationAnalytics(
+    this.props.setEventNames(
       'integrations.code_mappings_viewed',
-      {
-        integration: this.props.integration.provider.key,
-        integration_type: 'first_party',
-        organization: this.props.organization,
-      },
-      {startSession}
+      'Integrations: Code Mappings Viewed'
     );
+    this.props.setRouteAnalyticsParams({
+      integration: this.props.integration.provider.key,
+      integration_type: 'first_party',
+    });
   }
 
   handleDelete = async (pathConfig: RepositoryProjectPathConfig) => {
@@ -281,7 +279,9 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
   }
 }
 
-export default withProjects(withOrganization(IntegrationCodeMappings));
+export default withRouteAnalytics(
+  withProjects(withOrganization(IntegrationCodeMappings))
+);
 
 const Layout = styled('div')`
   display: grid;

--- a/static/app/views/organizationStats/teamInsights/health.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -8,8 +8,8 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {TeamWithProjects} from 'sentry/types';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import localStorage from 'sentry/utils/localStorage';
+import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useOrganization from 'sentry/utils/useOrganization';
 import useTeams from 'sentry/utils/useTeams';
 
@@ -29,6 +29,8 @@ function TeamStatsHealth({location, router}: Props) {
   const organization = useOrganization();
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
 
+  useRouteAnalyticsEventNames('team_insights.viewed', 'Team Insights: Viewed');
+
   const query = location?.query ?? {};
   const localStorageKey = `teamInsightsSelectedTeamId:${organization.slug}`;
 
@@ -42,12 +44,6 @@ function TeamStatsHealth({location, router}: Props) {
     | TeamWithProjects
     | undefined;
   const projects = currentTeam?.projects ?? [];
-
-  useEffect(() => {
-    trackAdvancedAnalyticsEvent('team_insights.viewed', {
-      organization,
-    });
-  }, [organization]);
 
   const {period, start, end, utc} = dataDatetime(query);
 

--- a/static/app/views/organizationStats/teamInsights/issues.tsx
+++ b/static/app/views/organizationStats/teamInsights/issues.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -8,8 +8,8 @@ import NoProjectMessage from 'sentry/components/noProjectMessage';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {TeamWithProjects} from 'sentry/types';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import localStorage from 'sentry/utils/localStorage';
+import useRouteAnalyticsEventNames from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import useOrganization from 'sentry/utils/useOrganization';
 import useTeams from 'sentry/utils/useTeams';
 
@@ -29,6 +29,8 @@ function TeamStatsIssues({location, router}: Props) {
   const organization = useOrganization();
   const {teams, initiallyLoaded} = useTeams({provideUserTeams: true});
 
+  useRouteAnalyticsEventNames('team_insights.viewed', 'Team Insights: Viewed');
+
   const query = location?.query ?? {};
   const localStorageKey = `teamInsightsSelectedTeamId:${organization.slug}`;
 
@@ -43,12 +45,6 @@ function TeamStatsIssues({location, router}: Props) {
     | undefined;
   const projects = currentTeam?.projects ?? [];
   const environment = query.environment;
-
-  useEffect(() => {
-    trackAdvancedAnalyticsEvent('team_insights.viewed', {
-      organization,
-    });
-  }, [organization]);
 
   const {period, start, end, utc} = dataDatetime(query);
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/content.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {setTag} from '@sentry/react';
 import {Location} from 'history';
@@ -8,7 +8,6 @@ import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
-import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import DiscoverQuery from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import SpanExamplesQuery, {
@@ -56,16 +55,6 @@ export default function SpanDetailsContentWrapper(props: Props) {
   useRouteAnalyticsParams({
     project_platforms: project ? getSelectedProjectPlatforms(location, [project]) : '',
   });
-
-  useEffect(() => {
-    // TODO: remove once we set this flag to true for everyone
-    if (project && !organization.features.includes('auto-capture-page-load-analytics')) {
-      trackAdvancedAnalyticsEvent('performance_views.span_summary.view', {
-        organization,
-        project_platforms: getSelectedProjectPlatforms(location, [project]),
-      });
-    }
-  }, [organization, project, location]);
 
   return (
     <Fragment>

--- a/static/app/views/projectInstall/createProject.spec.jsx
+++ b/static/app/views/projectInstall/createProject.spec.jsx
@@ -18,6 +18,7 @@ describe('CreateProject', function () {
       projectId: '',
       orgId: 'testOrg',
     },
+    setEventNames: jest.fn(),
   };
 
   beforeEach(() => {

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -20,6 +20,9 @@ import space from 'sentry/styles/space';
 import {Organization, Team} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import getPlatformName from 'sentry/utils/getPlatformName';
+import withRouteAnalytics, {
+  WithRouteAnalyticsProps,
+} from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import slugify from 'sentry/utils/slugify';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
@@ -29,11 +32,12 @@ import IssueAlertOptions from 'sentry/views/projectInstall/issueAlertOptions';
 const getCategoryName = (category?: string) =>
   categoryList.find(({id}) => id === category)?.id;
 
-type Props = WithRouterProps & {
-  api: any;
-  organization: Organization;
-  teams: Team[];
-};
+type Props = WithRouterProps &
+  WithRouteAnalyticsProps & {
+    api: any;
+    organization: Organization;
+    teams: Team[];
+  };
 
 type PlatformName = React.ComponentProps<typeof PlatformIcon>['platform'];
 type IssueAlertFragment = Parameters<
@@ -71,9 +75,10 @@ class CreateProject extends Component<Props, State> {
   }
 
   componentDidMount() {
-    trackAdvancedAnalyticsEvent('project_creation_page.viewed', {
-      organization: this.props.organization,
-    });
+    this.props.setEventNames(
+      'project_creation_page.viewed',
+      'Project Create: Creation page viewed'
+    );
   }
 
   get defaultCategory() {
@@ -304,7 +309,9 @@ class CreateProject extends Component<Props, State> {
 }
 
 // TODO(davidenwang): change to functional component and replace withTeams with useTeams
-export default withApi(withRouter(withOrganization(withTeams(CreateProject))));
+export default withRouteAnalytics(
+  withApi(withRouter(withOrganization(withTeams(CreateProject))))
+);
 export {CreateProject};
 
 const CreateProjectForm = styled('form')`


### PR DESCRIPTION
this pr moves over some old analytics events to be using the new route analytics system, so instead of sending duplicate events for page loads, we will only send one.