### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for the post-project creation pages.

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1674,11 +1674,8 @@ function buildRoutes() {
     </Route>
   );
 
-  const gettingStartedRoutes = (
-    <Route
-      path="/:orgId/:projectId/getting-started/"
-      component={make(() => import('sentry/views/projectInstall/gettingStarted'))}
-    >
+  const gettingStartedChildRoutes = (
+    <Fragment>
       <IndexRoute
         component={make(() => import('sentry/views/projectInstall/overview'))}
       />
@@ -1688,6 +1685,16 @@ function buildRoutes() {
           () => import('sentry/views/projectInstall/platformOrIntegration')
         )}
       />
+    </Fragment>
+  );
+
+  const gettingStartedRoutes = (
+    <Route
+      path="/:orgId/:projectId/getting-started/"
+      component={make(() => import('sentry/views/projectInstall/gettingStarted'))}
+      key="cd-getting-started"
+    >
+      {gettingStartedChildRoutes}
     </Route>
   );
 

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1689,13 +1689,28 @@ function buildRoutes() {
   );
 
   const gettingStartedRoutes = (
-    <Route
-      path="/:orgId/:projectId/getting-started/"
-      component={make(() => import('sentry/views/projectInstall/gettingStarted'))}
-      key="cd-getting-started"
-    >
-      {gettingStartedChildRoutes}
-    </Route>
+    <Fragment>
+      {usingCustomerDomain ? (
+        <Route
+          path="/:projectId/getting-started/"
+          component={withDomainRequired(
+            make(() => import('sentry/views/projectInstall/gettingStarted'))
+          )}
+          key="orgless-getting-started-route"
+        >
+          {gettingStartedChildRoutes}
+        </Route>
+      ) : null}
+      <Route
+        path="/:orgId/:projectId/getting-started/"
+        component={withDomainRedirect(
+          make(() => import('sentry/views/projectInstall/gettingStarted'))
+        )}
+        key="org-getting-started"
+      >
+        {gettingStartedChildRoutes}
+      </Route>
+    </Fragment>
   );
 
   // Support for deprecated URLs (pre-Sentry 10). We just redirect users to new


### PR DESCRIPTION
This adds the customer domain React routes for the post-project creation pages.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.
