### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for the Data Export pages

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -183,9 +183,21 @@ function buildRoutes() {
         path="/organizations/new/"
         component={make(() => import('sentry/views/organizationCreate'))}
       />
+      {usingCustomerDomain ? (
+        <Route
+          path="/data-export/:dataExportId"
+          component={withDomainRequired(
+            make(() => import('sentry/views/dataExport/dataDownload'))
+          )}
+          key="orgless-data-export-route"
+        />
+      ) : null}
       <Route
         path="/organizations/:orgId/data-export/:dataExportId"
-        component={make(() => import('sentry/views/dataExport/dataDownload'))}
+        component={withDomainRedirect(
+          make(() => import('sentry/views/dataExport/dataDownload'))
+        )}
+        key="org-data-export"
       />
       <Route
         path="/organizations/:orgId/disabled-member/"


### PR DESCRIPTION
This adds the customer domain React routes for the Data Export pages.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.
