### PR TITLE
feat(hybrid-cloud): Add /disabled-member/* sub-page Django routes

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -472,6 +472,12 @@ urlpatterns += [
     url(r"^join-request/", react_page_view, name="join-request"),
     # User Feedback
     url(r"^user-feedback/", react_page_view, name="user-feedback"),
+    # Disabled Member
+    url(
+        r"^disabled-member/",
+        DisabledMemberView.as_view(),
+        name="sentry-customer-domain-organization-disabled-member",
+    ),
     # Organizations
     url(r"^(?P<organization_slug>[\w_-]+)/$", react_page_view, name="sentry-organization-home"),
     url(


### PR DESCRIPTION
This adds `/disabled-member/*` Django route so that `orgslug.sentry.io/disabled-member/*` links work on pageload.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.