### PR TITLE
feat(hybrid-cloud): Add customer domain React routes for Disabled Member page

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -187,9 +187,19 @@ function buildRoutes() {
         path="/organizations/:orgId/data-export/:dataExportId"
         component={make(() => import('sentry/views/dataExport/dataDownload'))}
       />
+      {usingCustomerDomain ? (
+        <Route
+          path="/disabled-member/"
+          component={withDomainRequired(
+            make(() => import('sentry/views/disabledMember'))
+          )}
+          key="orgless-disabled-member-route"
+        />
+      ) : null}
       <Route
         path="/organizations/:orgId/disabled-member/"
-        component={make(() => import('sentry/views/disabledMember'))}
+        component={withDomainRedirect(make(() => import('sentry/views/disabledMember')))}
+        key="org-disabled-member"
       />
       {usingCustomerDomain ? (
         <Route


### PR DESCRIPTION
This adds the customer domain React routes for the Disabled Member page.

This was cherry picked from https://github.com/getsentry/sentry/pull/40215.
