### PR TITLE
ref(hybrid-cloud): Move DeletedOrganization to region silo

### DIFF
--- a/src/sentry/models/deletedorganization.py
+++ b/src/sentry/models/deletedorganization.py
@@ -1,10 +1,10 @@
 from django.db import models
 
-from sentry.db.models import control_silo_with_replication_model, sane_repr
+from sentry.db.models import region_silo_only_model, sane_repr
 from sentry.models.deletedentry import DeletedEntry
 
 
-@control_silo_with_replication_model
+@region_silo_only_model
 class DeletedOrganization(DeletedEntry):
     """
     This model tracks an intent to delete. If an org is marked pending_delete


### PR DESCRIPTION
Moves the DeletedOrganization model to the region silo. This avoids region to control silo communication to log an intent to delete an organization. Writes are in the region silo and the model isn't used otherwise.