### PR TITLE
feat(perf-issues): Add boolean project options for issue creation

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -94,16 +94,5 @@ register(key="sentry:span_attributes", epoch_defaults={1: ["exclusive-time"]})
 # Can be used to turn off a projects detection for users if there is a project-specific issue.
 register(key="sentry:performance_issue_creation_rate", default=1.0)
 
-# A dict containing all the specific detection thresholds and rates.
-register(
-    key="sentry:performance_issue_settings",
-    default={
-        "n_plus_one_db_detection_rate": 0,
-        "n_plus_one_db_issue_rate": 0,
-        "n_plus_one_db_count": 5,
-        "n_plus_one_db_duration_threshold": 500,
-    },
-)
-
 # Using simple bools instead of rates for disabling individual detectors
 register(key="sentry:performance_issue_creation_enabled_n_plus_one_db", default=True)

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -68,6 +68,12 @@ DETECTOR_TYPE_ISSUE_CREATION_TO_SYSTEM_OPTION = {
     DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: "performance.issues.n_plus_one_db_ext.problem-creation",
 }
 
+# Detector and the corresponding project options for more granular control of issue creation on a per-project basis, modifiable by users in their UI.
+DETECTOR_TYPE_ISSUE_CREATION_TO_PROJECT_OPTION_BOOLEANS = {
+    DetectorType.N_PLUS_ONE_DB_QUERIES: "sentry:performance_issue_creation_enabled_n_plus_one_db",
+    DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: "sentry:performance_issue_creation_enabled_n_plus_one_db",
+}
+
 
 @dataclass
 class PerformanceProblem:
@@ -198,40 +204,13 @@ def detect_performance_problems(data: Event) -> List[PerformanceProblem]:
 # Duration thresholds are in milliseconds.
 # Allowed span ops are allowed span prefixes. (eg. 'http' would work for a span with 'http.client' as its op)
 def get_detection_settings(project_id: Optional[str] = None):
-    default_project_settings = (
-        projectoptions.get_well_known_default(
-            "sentry:performance_issue_settings",
-            project=project_id,
-        )
-        if project_id
-        else {}
-    )
-
-    project_settings = (
-        ProjectOption.objects.get_value(
-            project_id, "sentry:performance_issue_settings", default_project_settings
-        )
-        if project_id
-        else {}
-    )
-
-    use_project_option_settings = default_project_settings != project_settings
-    merged_project_settings = {
-        **default_project_settings,
-        **project_settings,
-    }  # Merge saved project settings into default so updating the default to add new settings works in the future.
-
-    # Use project settings if they've been adjusted at all, to allow customization, otherwise fetch settings from system-wide options.
-    settings = (
-        merged_project_settings
-        if use_project_option_settings
-        else {
-            "n_plus_one_db_count": options.get("performance.issues.n_plus_one_db.count_threshold"),
-            "n_plus_one_db_duration_threshold": options.get(
-                "performance.issues.n_plus_one_db.duration_threshold"
-            ),
-        }
-    )
+    # Fetch default settings from system-wide options.
+    system_performance_issue_settings = {
+        "n_plus_one_db_count": options.get("performance.issues.n_plus_one_db.count_threshold"),
+        "n_plus_one_db_duration_threshold": options.get(
+            "performance.issues.n_plus_one_db.duration_threshold"
+        ),
+    }
 
     return {
         DetectorType.DUPLICATE_SPANS: [
@@ -285,12 +264,16 @@ def get_detection_settings(project_id: Optional[str] = None):
             }
         ],
         DetectorType.N_PLUS_ONE_DB_QUERIES: {
-            "count": settings["n_plus_one_db_count"],
-            "duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
+            "count": system_performance_issue_settings["n_plus_one_db_count"],
+            "duration_threshold": system_performance_issue_settings[
+                "n_plus_one_db_duration_threshold"
+            ],  # ms
         },
         DetectorType.N_PLUS_ONE_DB_QUERIES_EXTENDED: {
-            "count": settings["n_plus_one_db_count"],
-            "duration_threshold": settings["n_plus_one_db_duration_threshold"],  # ms
+            "count": system_performance_issue_settings["n_plus_one_db_count"],
+            "duration_threshold": system_performance_issue_settings[
+                "n_plus_one_db_duration_threshold"
+            ],  # ms
         },
     }
 
@@ -376,6 +359,23 @@ def get_allowed_issue_creation_detectors(project_id: str):
         rate = options.get(system_option)
         if rate and rate > random.random():
             allowed_detectors.add(detector_type)
+
+    for detector_type in list(allowed_detectors):
+        project_option_key = DETECTOR_TYPE_ISSUE_CREATION_TO_PROJECT_OPTION_BOOLEANS.get(
+            detector_type, None
+        )
+        if not project_option_key:
+            allowed_detectors.remove(detector_type)
+        else:
+            default_project_option = projectoptions.get_well_known_default(
+                project_option_key,
+                project=project_id,
+            )
+            allowed_on_project = ProjectOption.objects.get_value(
+                project_id, project_option_key, default_project_option
+            )
+            if not allowed_on_project:
+                allowed_detectors.remove(detector_type)
 
     return allowed_detectors
 

--- a/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
+++ b/tests/sentry/api/endpoints/test_project_performance_issue_settings.py
@@ -1,8 +1,6 @@
 from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
-from sentry import projectoptions
-from sentry.api.endpoints.project_performance_issue_settings import SETTINGS_PROJECT_OPTION_KEY
 from sentry.testutils import APITestCase
 from sentry.testutils.silo import region_silo_test
 
@@ -35,7 +33,7 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             response = self.client.get(self.url, format="json")
 
         assert response.status_code == 200, response.content
-        assert response.data["performance_issue_creation_enabled_n_plus_one_db"] == True
+        assert response.data["performance_issue_creation_enabled_n_plus_one_db"]
 
     def test_get_returns_error_without_feature_enabled(self):
         with self.feature({}):
@@ -52,13 +50,13 @@ class ProjectPerformanceIssueSettingsTest(APITestCase):
             )
 
         assert response.status_code == 200, response.content
-        assert response.data["performance_issue_creation_enabled_n_plus_one_db"] == False
+        assert not response.data["performance_issue_creation_enabled_n_plus_one_db"]
 
         with self.feature(PERFORMANCE_ISSUE_FEATURES):
             get_response = self.client.get(self.url, format="json")
 
         assert get_response.status_code == 200, response.content
-        assert get_response.data["performance_issue_creation_enabled_n_plus_one_db"] == False
+        assert not get_response.data["performance_issue_creation_enabled_n_plus_one_db"]
 
     def test_update_project_setting_check_validation(self):
         with self.feature(PERFORMANCE_ISSUE_FEATURES):


### PR DESCRIPTION
### Summary
This adds a map of detector type to boolean project options which can be set via the UI so users have more granular control over detectors if they have noisy issues. Simultaneously I'm removing the project options for specific detector settings since it's complicates the detection code, and we already handle the tuning of this via system options. We can always re-introduce project level detector settings if it seems useful to offer to users later.
