### PR TITLE
feat(derive-code-mappings): Support dynamic dry run rollout

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -535,3 +535,6 @@ register("dynamic-sampling:boost-latest-release", default=False)
 
 # Controls whether we should attempt to derive code mappings for projects during post processing.
 register("post_process.derive-code-mappings", default=True)
+# Allows adjusting the percentage of orgs we test under the dry run mode
+register("derive-code-mappings.dry-run.early-adopter-rollout", default=0.0)
+register("derive-code-mappings.dry-run.general-availability-rollout", default=0.0)


### PR DESCRIPTION
This allow us to change the percentage of orgs that will be testing the dry run mode in order to discover any scalability issues.

See related PR: https://github.com/getsentry/getsentry/pull/8878

Fixes WOR-2407