### PR TITLE
ref: Add settings for LPQ cutoffs

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2775,6 +2775,19 @@ SENTRY_REALTIME_METRICS_OPTIONS = {
 # Tunable knobs for automatic LPQ eligibility.
 # The values here are sampled based on the `symbolicate-event.low-priority.metrics.submission-rate` option.
 # This sampling rate needs to be considered when tuning any of the cutoff rates.
+#
+# LPQ eligibility is based on two heuristics: recent spikes in the number of events and excessive
+# event processing times.
+#
+# A project is eligible for the LPQ based on event rate if
+# the event rate (events/s) over the `recent_event_period` is greater than `min_recent_event_rate` and
+# exceeds the project's average event rate (within `counter_time_window`) by a factor of `recent_event_multiple`. See
+# sentry.tasks.low_priority_symbolication.excessive_event_rate for the implementation of this heuristic.
+#
+# A project is eligible for the LPQ based on processing duration if it averages more than
+# `min_events_per_minute` events per minute over the `duration_time_window` and the 75th percentile
+# of event processing durations in that window exceeds `min_p75_duration` seconds. See
+# sentry.tasks.low_priority_symbolication.excessive_event_duration for the implementation of this heuristic.
 SENTRY_LPQ_OPTIONS = {
     # The period that is considered for "recent events".
     # Has to be a multiple of `counter_bucket_size` above.
@@ -2782,16 +2795,15 @@ SENTRY_LPQ_OPTIONS = {
     # The minimum rate of events *per second* a project needs to have
     # in the `recent_event_period` to be eligible for the LPQ.
     "min_recent_event_rate": 50,
-    # A project is considered for the LPQ if the recent event rate
-    # (as defined in `recent_event_period`) is a multiple of the average event
-    # rate (as defined in `counter_time_window` above).
+    # The ratio of recent event rate over average event rate above which a project is eligible
+    # for the LPQ.
     "recent_event_multiple": 5,
     # The minimum rate of events *per minute* a project needs to have
     # in the `duration_time_window` to be eligible for the LPQ.
     "min_events_per_minute": 15,
     # A project is considered for the LPQ if the p75 event processing time
     # exceeds configured value.
-    # This consideres events that *finished* during the last `duration_time_window`.
+    # This considers events that *finished* during the last `duration_time_window`.
     "min_p75_duration": 6 * 60,
 }
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2794,17 +2794,17 @@ SENTRY_LPQ_OPTIONS = {
     "recent_event_period": 60,
     # The minimum rate of events *per second* a project needs to have
     # in the `recent_event_period` to be eligible for the LPQ.
-    "min_recent_event_rate": 50,
+    "min_recent_event_rate": 5,
     # The ratio of recent event rate over average event rate above which a project is eligible
     # for the LPQ.
-    "recent_event_multiple": 5,
+    "recent_event_multiple": 4,
     # The minimum rate of events *per minute* a project needs to have
     # in the `duration_time_window` to be eligible for the LPQ.
     "min_events_per_minute": 15,
     # A project is considered for the LPQ if the p75 event processing time
     # exceeds configured value.
     # This considers events that *finished* during the last `duration_time_window`.
-    "min_p75_duration": 6 * 60,
+    "min_p75_duration": 30,
 }
 
 # XXX(meredith): Temporary metrics indexer

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2772,6 +2772,29 @@ SENTRY_REALTIME_METRICS_OPTIONS = {
     "backoff_timer": 5 * 60,
 }
 
+# Tunable knobs for automatic LPQ eligibility.
+# The values here are sampled based on the `symbolicate-event.low-priority.metrics.submission-rate` option.
+# This sampling rate needs to be considered when tuning any of the cutoff rates.
+SENTRY_LPQ_OPTIONS = {
+    # The period that is considered for "recent events".
+    # Has to be a multiple of `counter_bucket_size` above.
+    "recent_event_period": 60,
+    # The minimum rate of events *per second* a project needs to have
+    # in the `recent_event_period` to be eligible for the LPQ.
+    "min_recent_event_rate": 50,
+    # A project is considered for the LPQ if the recent event rate
+    # (as defined in `recent_event_period`) is a multiple of the average event
+    # rate (as defined in `counter_time_window` above).
+    "recent_event_multiple": 5,
+    # The minimum rate of events *per minute* a project needs to have
+    # in the `duration_time_window` to be eligible for the LPQ.
+    "min_events_per_minute": 15,
+    # A project is considered for the LPQ if the p75 event processing time
+    # exceeds configured value.
+    # This consideres events that *finished* during the last `duration_time_window`.
+    "min_p75_duration": 6 * 60,
+}
+
 # XXX(meredith): Temporary metrics indexer
 SENTRY_METRICS_INDEXER_REDIS_CLUSTER = "default"
 

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -119,7 +119,7 @@ def excessive_event_rate(project_id: int, event_counts: BucketedCounts) -> bool:
     metrics.gauge("symbolication.lpq.computation.rate.total", average_rate)
     metrics.gauge("symbolication.lpq.computation.rate.recent", recent_rate)
 
-    return (
+    return bool(
         recent_rate > options["min_recent_event_rate"]
         and recent_rate > options["recent_event_multiple"] * average_rate
     )
@@ -145,7 +145,7 @@ def excessive_event_duration(project_id: int, durations: BucketedDurationsHistog
     metrics.gauge("symbolication.lpq.computation.durations.p75", p75_duration)
     metrics.gauge("symbolication.lpq.computation.durations.events_per_minutes", events_per_minute)
 
-    return (
+    return bool(
         events_per_minute > options["min_events_per_minute"]
         and p75_duration > options["min_p75_duration"]
     )

--- a/src/sentry/tasks/low_priority_symbolication.py
+++ b/src/sentry/tasks/low_priority_symbolication.py
@@ -13,6 +13,7 @@ import time
 from typing import Literal
 
 import sentry_sdk
+from django.conf import settings
 
 from sentry import options
 from sentry.killswitches import normalize_value
@@ -107,23 +108,27 @@ def _update_lpq_eligibility(project_id: int, cutoff: int) -> None:
 
 def excessive_event_rate(project_id: int, event_counts: BucketedCounts) -> bool:
     """Whether the project is sending too many symbolication requests."""
-    total_rate = event_counts.rate(event_counts.TOTAL_PERIOD)
-    recent_rate = event_counts.rate(period=60)
+    options = settings.SENTRY_LPQ_OPTIONS
+
+    average_rate = event_counts.rate(event_counts.TOTAL_PERIOD)
+    recent_rate = event_counts.rate(period=options["recent_event_period"])
 
     # Note, We had these tagged with tags={"project_id": project_id} during our initial
     # evaluation, however the cardinality for this is really too high to leave that on
     # forever in production.
-    metrics.gauge("symbolication.lpq.computation.rate.total", total_rate)
+    metrics.gauge("symbolication.lpq.computation.rate.total", average_rate)
     metrics.gauge("symbolication.lpq.computation.rate.recent", recent_rate)
 
-    if recent_rate > 50 and recent_rate > 5 * total_rate:
-        return True
-    else:
-        return False
+    return (
+        recent_rate > options["min_recent_event_rate"]
+        and recent_rate > options["recent_event_multiple"] * average_rate
+    )
 
 
 def excessive_event_duration(project_id: int, durations: BucketedDurationsHistograms) -> bool:
     """Whether the project's symbolication requests are taking too long to process."""
+    options = settings.SENTRY_LPQ_OPTIONS
+
     total_histogram = DurationsHistogram(bucket_size=durations.histograms[0].bucket_size)
     for histogram in durations.histograms:
         total_histogram.incr_from(histogram)
@@ -140,10 +145,10 @@ def excessive_event_duration(project_id: int, durations: BucketedDurationsHistog
     metrics.gauge("symbolication.lpq.computation.durations.p75", p75_duration)
     metrics.gauge("symbolication.lpq.computation.durations.events_per_minutes", events_per_minute)
 
-    if events_per_minute > 15 and p75_duration > 6 * 60:
-        return True
-    else:
-        return False
+    return (
+        events_per_minute > options["min_events_per_minute"]
+        and p75_duration > options["min_p75_duration"]
+    )
 
 
 def _report_change(project_id: int, change: Literal["added", "removed"], reason: str) -> None:

--- a/tests/sentry/tasks/test_low_priority_symbolication.py
+++ b/tests/sentry/tasks/test_low_priority_symbolication.py
@@ -207,12 +207,12 @@ class TestExcessiveEventDuration:
         assert not excessive_event_duration(project_id=1, durations=durations)
 
     def test_normal_rate_normal_duration(self) -> None:
-        # 1 event/s for 3m, 1-5m durations
+        # 1 event/s for 3m, 1-15s durations
         histograms = []
         for _ in range(10 * 6 * 3):
             hist = DurationsHistogram(bucket_size=10)
-            hist.incr(duration=60, count=5)
-            hist.incr(duration=180, count=5)
+            hist.incr(duration=1, count=5)
+            hist.incr(duration=15, count=5)
             histograms.append(hist)
         durations = BucketedDurationsHistograms(timestamp=0, width=10, histograms=histograms)
 


### PR DESCRIPTION
This makes the cutoff values for LPQ eligibility configurable.

One of these influences a form of "spike protection" that considers spikes in event counts.

The other one considers the duration of *finished* events.

I have also tightened up the defaults here quite a bit.

Our normal symbolication rate is between 150-250 events per second across all of sentry, so a rate of 5 events per second for a single project is the threshold from which we consider them for lpq.

As for the processing time, the average for both symbolicate and minidump are below 1s, the p95 for minidumps is around the 10 second mark. Anything slower than 30s is now considered for the lpq.