### PR TITLE
test(js): Convert performance Table to RTL

### DIFF
--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -373,7 +373,7 @@ class GridEditable<
       : [];
 
     return (
-      <GridRow key={row}>
+      <GridRow key={row} data-test-id="grid-body-row">
         {prependColumns &&
           prependColumns.map((item, i) => (
             <GridBodyCell data-test-id="grid-body-cell" key={`prepend-${i}`}>

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -452,6 +452,7 @@ class CellAction extends Component<Props, State> {
       <Container
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
+        data-test-id="cell-action-container"
       >
         {children}
         {isHovering && this.renderMenu()}

--- a/static/app/views/performance/table.spec.tsx
+++ b/static/app/views/performance/table.spec.tsx
@@ -1,8 +1,9 @@
 import {browserHistory} from 'react-router';
 
-import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeData as _initializeData} from 'sentry-test/performance/initializePerformanceData';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
+import ProjectsStore from 'sentry/stores/projectsStore';
 import EventView from 'sentry/utils/discover/eventView';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
@@ -40,19 +41,6 @@ const WrappedComponent = ({data, ...rest}) => {
     </OrganizationContext.Provider>
   );
 };
-
-function openContextMenu(wrapper, cellIndex) {
-  const menu = wrapper.find('CellAction').at(cellIndex);
-  // Hover over the menu
-  menu.find('Container > div').at(0).simulate('mouseEnter');
-  wrapper.update();
-
-  // Open the menu
-  wrapper.find('MenuButton').simulate('click');
-
-  // Return the menu wrapper so we can interact with it.
-  return wrapper.find('CellAction').at(cellIndex).find('Menu');
-}
 
 function mockEventView(data) {
   const eventView = new EventView({
@@ -195,57 +183,56 @@ describe('Performance > Table', function () {
         query: 'event.type:transaction transaction:/api*',
       });
 
-      const wrapper = mountWithTheme(
+      ProjectsStore.loadInitialData(data.organization.projects);
+
+      render(
         <WrappedComponent
           data={data}
           eventView={mockEventView(data)}
           setError={jest.fn()}
           summaryConditions=""
           projects={data.projects}
-        />
+        />,
+        {context: data.routerContext}
       );
 
-      await tick();
-      wrapper.update();
-      const firstRow = wrapper.find('GridBody').find('GridRow').at(0);
-      const transactionCell = firstRow.find('GridBodyCell').at(1);
-      expect(transactionCell.find('Link').prop('to')).toEqual({
-        pathname: '/organizations/org-slug/performance/summary/',
-        query: {
-          transaction: '/apple/cart',
-          project: '2',
-          environment: [],
-          statsPeriod: '14d',
-          start: '2019-10-01T00:00:00',
-          end: '2019-10-02T00:00:00',
-          query: '', // drops 'transaction:/api*' and 'event.type:transaction' from the query
-          referrer: 'performance-transaction-summary',
-          unselectedSeries: 'p100()',
-          showTransactions: undefined,
-          display: undefined,
-          trendFunction: undefined,
-          trendColumn: undefined,
-        },
+      const rows = await screen.findAllByTestId('grid-body-row');
+      const transactionCells = within(rows[0]).getAllByTestId('grid-body-cell');
+      const transactionCell = transactionCells[1];
+      const link = within(transactionCell).getByRole('link', {name: '/apple/cart'});
+      expect(link).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/summary/?end=2019-10-02T00%3A00%3A00&project=2&query=&referrer=performance-transaction-summary&start=2019-10-01T00%3A00%3A00&statsPeriod=14d&transaction=%2Fapple%2Fcart&unselectedSeries=p100%28%29'
+      );
+
+      const cellActionContainers = screen.getAllByTestId('cell-action-container');
+      expect(cellActionContainers).toHaveLength(18); // 9 cols x 2 rows
+      userEvent.hover(cellActionContainers[8]);
+      const cellActions = await screen.findByTestId('cell-action');
+      expect(cellActions).toBeInTheDocument();
+      userEvent.click(cellActions);
+
+      expect(await screen.findByTestId('add-to-filter')).toBeInTheDocument();
+      expect(screen.getByTestId('exclude-from-filter')).toBeInTheDocument();
+
+      userEvent.hover(cellActionContainers[0]); // Transaction name
+      const transactionCellActions = await screen.findAllByTestId('cell-action');
+      expect(transactionCellActions[0]).toBeInTheDocument();
+      userEvent.click(transactionCellActions[0]);
+
+      expect(browserHistory.push).toHaveBeenCalledTimes(0);
+      userEvent.click(screen.getByTestId('add-to-filter'));
+
+      expect(browserHistory.push).toHaveBeenCalledTimes(1);
+      expect(browserHistory.push).toHaveBeenNthCalledWith(1, {
+        pathname: undefined,
+        query: expect.objectContaining({
+          query: 'transaction:/apple/cart',
+        }),
       });
-      const userMiseryCell = firstRow.find('GridBodyCell').at(9);
-      const cellAction = userMiseryCell.find('CellAction');
-
-      expect(cellAction.prop('allowActions')).toEqual([
-        'add',
-        'exclude',
-        'show_greater_than',
-        'show_less_than',
-        'edit_threshold',
-      ]);
-
-      const menu = openContextMenu(wrapper, 8); // User Misery Cell Action
-      expect(menu.find('MenuButtons').find('ActionItem')).toHaveLength(3);
-      expect(menu.find('MenuButtons').find('ActionItem').at(2).text()).toEqual(
-        'Edit threshold (300ms)'
-      );
     });
 
-    it('hides cell actions when withStaticFilters is true', async function () {
+    it('hides cell actions when withStaticFilters is true', function () {
       const data = initializeData(
         {
           query: 'event.type:transaction transaction:/api*',
@@ -253,7 +240,7 @@ describe('Performance > Table', function () {
         ['performance-frontend-use-events-endpoint']
       );
 
-      const wrapper = mountWithTheme(
+      render(
         <WrappedComponent
           data={data}
           eventView={mockEventView(data)}
@@ -264,16 +251,11 @@ describe('Performance > Table', function () {
         />
       );
 
-      await tick();
-      wrapper.update();
-      const firstRow = wrapper.find('GridBody').find('GridRow').at(0);
-      const userMiseryCell = firstRow.find('GridBodyCell').at(9);
-      const cellAction = userMiseryCell.find('CellAction');
-
-      expect(cellAction.prop('allowActions')).toEqual([]);
+      const cellActionContainers = screen.queryByTestId('cell-action-container');
+      expect(cellActionContainers).not.toBeInTheDocument();
     });
 
-    it('sends MEP param when setting enabled', async function () {
+    it('sends MEP param when setting enabled', function () {
       const data = initializeData(
         {
           query: 'event.type:transaction transaction:/api*',
@@ -281,7 +263,7 @@ describe('Performance > Table', function () {
         ['performance-use-metrics']
       );
 
-      const wrapper = mountWithTheme(
+      render(
         <WrappedComponent
           data={data}
           eventView={mockEventView(data)}
@@ -291,9 +273,6 @@ describe('Performance > Table', function () {
           isMEPEnabled
         />
       );
-
-      await tick();
-      wrapper.update();
 
       expect(eventsV2Mock).toHaveBeenCalledTimes(1);
       expect(eventsV2Mock).toHaveBeenNthCalledWith(
@@ -337,57 +316,56 @@ describe('Performance > Table', function () {
         ['performance-frontend-use-events-endpoint']
       );
 
-      const wrapper = mountWithTheme(
+      ProjectsStore.loadInitialData(data.organization.projects);
+
+      render(
         <WrappedComponent
           data={data}
           eventView={mockEventView(data)}
           setError={jest.fn()}
           summaryConditions=""
           projects={data.projects}
-        />
+        />,
+        {context: data.routerContext}
       );
 
-      await tick();
-      wrapper.update();
-      const firstRow = wrapper.find('GridBody').find('GridRow').at(0);
-      const transactionCell = firstRow.find('GridBodyCell').at(1);
-      expect(transactionCell.find('Link').prop('to')).toEqual({
-        pathname: '/organizations/org-slug/performance/summary/',
-        query: {
-          transaction: '/apple/cart',
-          project: '2',
-          environment: [],
-          statsPeriod: '14d',
-          start: '2019-10-01T00:00:00',
-          end: '2019-10-02T00:00:00',
-          query: '', // drops 'transaction:/api*' and 'event.type:transaction' from the query
-          referrer: 'performance-transaction-summary',
-          unselectedSeries: 'p100()',
-          showTransactions: undefined,
-          display: undefined,
-          trendFunction: undefined,
-          trendColumn: undefined,
-        },
+      const rows = await screen.findAllByTestId('grid-body-row');
+      const transactionCells = within(rows[0]).getAllByTestId('grid-body-cell');
+      const transactionCell = transactionCells[1];
+      const link = within(transactionCell).getByRole('link', {name: '/apple/cart'});
+      expect(link).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/performance/summary/?end=2019-10-02T00%3A00%3A00&project=2&query=&referrer=performance-transaction-summary&start=2019-10-01T00%3A00%3A00&statsPeriod=14d&transaction=%2Fapple%2Fcart&unselectedSeries=p100%28%29'
+      );
+
+      const cellActionContainers = screen.getAllByTestId('cell-action-container');
+      expect(cellActionContainers).toHaveLength(18); // 9 cols x 2 rows
+      userEvent.hover(cellActionContainers[8]);
+      const cellActions = await screen.findByTestId('cell-action');
+      expect(cellActions).toBeInTheDocument();
+      userEvent.click(cellActions);
+
+      expect(await screen.findByTestId('add-to-filter')).toBeInTheDocument();
+      expect(screen.getByTestId('exclude-from-filter')).toBeInTheDocument();
+
+      userEvent.hover(cellActionContainers[0]); // Transaction name
+      const transactionCellActions = await screen.findAllByTestId('cell-action');
+      expect(transactionCellActions[0]).toBeInTheDocument();
+      userEvent.click(transactionCellActions[0]);
+
+      expect(browserHistory.push).toHaveBeenCalledTimes(0);
+      userEvent.click(screen.getByTestId('add-to-filter'));
+
+      expect(browserHistory.push).toHaveBeenCalledTimes(1);
+      expect(browserHistory.push).toHaveBeenNthCalledWith(1, {
+        pathname: undefined,
+        query: expect.objectContaining({
+          query: 'transaction:/apple/cart',
+        }),
       });
-      const userMiseryCell = firstRow.find('GridBodyCell').at(9);
-      const cellAction = userMiseryCell.find('CellAction');
-
-      expect(cellAction.prop('allowActions')).toEqual([
-        'add',
-        'exclude',
-        'show_greater_than',
-        'show_less_than',
-        'edit_threshold',
-      ]);
-
-      const menu = openContextMenu(wrapper, 8); // User Misery Cell Action
-      expect(menu.find('MenuButtons').find('ActionItem')).toHaveLength(3);
-      expect(menu.find('MenuButtons').find('ActionItem').at(2).text()).toEqual(
-        'Edit threshold (300ms)'
-      );
     });
 
-    it('hides cell actions when withStaticFilters is true', async function () {
+    it('hides cell actions when withStaticFilters is true', function () {
       const data = initializeData(
         {
           query: 'event.type:transaction transaction:/api*',
@@ -395,7 +373,7 @@ describe('Performance > Table', function () {
         ['performance-frontend-use-events-endpoint']
       );
 
-      const wrapper = mountWithTheme(
+      render(
         <WrappedComponent
           data={data}
           eventView={mockEventView(data)}
@@ -406,16 +384,11 @@ describe('Performance > Table', function () {
         />
       );
 
-      await tick();
-      wrapper.update();
-      const firstRow = wrapper.find('GridBody').find('GridRow').at(0);
-      const userMiseryCell = firstRow.find('GridBodyCell').at(9);
-      const cellAction = userMiseryCell.find('CellAction');
-
-      expect(cellAction.prop('allowActions')).toEqual([]);
+      const cellActionContainers = screen.queryByTestId('cell-action-container');
+      expect(cellActionContainers).not.toBeInTheDocument();
     });
 
-    it('sends MEP param when setting enabled', async function () {
+    it('sends MEP param when setting enabled', function () {
       const data = initializeData(
         {
           query: 'event.type:transaction transaction:/api*',
@@ -423,7 +396,7 @@ describe('Performance > Table', function () {
         ['performance-use-metrics', 'performance-frontend-use-events-endpoint']
       );
 
-      const wrapper = mountWithTheme(
+      render(
         <WrappedComponent
           data={data}
           eventView={mockEventView(data)}
@@ -433,9 +406,6 @@ describe('Performance > Table', function () {
           isMEPEnabled
         />
       );
-
-      await tick();
-      wrapper.update();
 
       expect(eventsMock).toHaveBeenCalledTimes(1);
       expect(eventsMock).toHaveBeenNthCalledWith(


### PR DESCRIPTION
Converts the perf table to RTL rewriting most of the cell actions prop checks to actual user events instead.
