### PR TITLE
fix(tests): escape `.` in regex passed to findByText

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
@@ -167,7 +167,7 @@ describe('ProfilingOnboarding', function () {
 
     selectProject(project);
 
-    const link = (await screen.findByText(/sentry.cocoa@9.0.0/)) as HTMLAnchorElement;
+    const link = (await screen.findByText(/sentry\.cocoa@9\.0\.0/)) as HTMLAnchorElement;
     expect(link).toBeInTheDocument();
     expect(link.href).toBe('http://test/fake-slug');
   });
@@ -204,7 +204,7 @@ describe('ProfilingOnboarding', function () {
 
     selectProject(project);
 
-    const link = screen.queryByText(/sentry.java@9.0.0/);
+    const link = screen.queryByText(/sentry\.java@9\.0\.0/);
     expect(link).not.toBeInTheDocument();
   });
 
@@ -241,7 +241,7 @@ describe('ProfilingOnboarding', function () {
     selectProject(project);
 
     expect(
-      await screen.findByText(/http:\/\/fake-public-dsn.ingest.sentry.io/)
+      await screen.findByText(/http:\/\/fake-public-dsn\.ingest\.sentry\.io/)
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The `.`'s here were not escaped and were matching on all characters.
