### PR TITLE
feat(profiling): add inline indicator to tooltip

### DIFF
--- a/static/app/components/profiling/FlamegraphTooltip/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/FlamegraphTooltip/flamegraphTooltip.tsx
@@ -25,12 +25,12 @@ export function formatWeightToProfileDuration(
 
 function formatFileNameAndLineColumn(frame: FlamegraphFrame): string | null {
   if (!frame.frame.file) {
-    return null;
+    return '<unknown file>';
   }
-  if (frame.frame.line && frame.frame.column) {
+  if (typeof frame.frame.line === 'number' && typeof frame.frame.column === 'number') {
     return `${frame.frame.file}:${frame.frame.line}:${frame.frame.column}`;
   }
-  if (frame.frame.line) {
+  if (typeof frame.frame.line === 'number') {
     return `${frame.frame.file}:${frame.frame.line}`;
   }
   return `${frame.frame.file}:<unknown line>`;

--- a/static/app/components/profiling/FlamegraphTooltip/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/FlamegraphTooltip/flamegraphTooltip.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 
+import {IconLightning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
@@ -20,6 +21,19 @@ export function formatWeightToProfileDuration(
   flamegraph: Flamegraph
 ) {
   return `(${Math.round((frame.totalWeight / flamegraph.profile.duration) * 100)}%)`;
+}
+
+function formatFileNameAndLineColumn(frame: FlamegraphFrame): string | null {
+  if (!frame.frame.file) {
+    return null;
+  }
+  if (frame.frame.line && frame.frame.column) {
+    return `${frame.frame.file}:${frame.frame.line}:${frame.frame.column}`;
+  }
+  if (frame.frame.line) {
+    return `${frame.frame.file}:${frame.frame.line}`;
+  }
+  return `${frame.frame.file}:<unknown line>`;
 }
 
 export interface FlamegraphTooltipProps {
@@ -52,20 +66,46 @@ export function FlamegraphTooltip(props: FlamegraphTooltipProps) {
           )}{' '}
           {props.frame.frame.name}
         </FlamegraphTooltipFrameMainInfo>
-        {defined(props.frame.frame.file) && (
-          <FlamegraphTooltipTimelineInfo>
-            {props.frame.frame.file}:{props.frame.frame.line ?? t('<unknown line>')}
-          </FlamegraphTooltipTimelineInfo>
-        )}
+        <FlamegraphTooltipTimelineInfo>
+          {defined(props.frame.frame.file) && (
+            <Fragment>
+              {t('source')}:{formatFileNameAndLineColumn(props.frame)}
+            </Fragment>
+          )}
+        </FlamegraphTooltipTimelineInfo>
         <FlamegraphTooltipTimelineInfo>
           {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.start)}{' '}
           {' \u2014 '}
           {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.end)}
+          {props.frame.frame.inline ? (
+            <FlamegraphInlineIndicator>
+              <IconLightning width={10} />
+              {t('inline frame')}
+            </FlamegraphInlineIndicator>
+          ) : (
+            ''
+          )}
         </FlamegraphTooltipTimelineInfo>
       </Fragment>
     </BoundTooltip>
   );
 }
+
+const FlamegraphInlineIndicator = styled('span')`
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+  padding: ${space(0.25)} ${space(0.25)};
+  line-height: 12px;
+  margin: 0 ${space(0.5)};
+  align-self: flex-end;
+
+  svg {
+    width: 10px;
+    height: 10px;
+    transform: translateY(1px);
+  }
+`;
 
 export const FlamegraphTooltipTimelineInfo = styled('div')`
   color: ${p => p.theme.subText};

--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -119,6 +119,7 @@ declare namespace Profiling {
     image?: string;
     resource?: string;
     threadId?: number;
+    inline?: boolean;
 
     // nodejs only
     columnNumber?: number;

--- a/static/app/utils/profiling/frame.tsx
+++ b/static/app/utils/profiling/frame.tsx
@@ -12,6 +12,7 @@ export class Frame extends WeightedNode {
   readonly image?: string;
   readonly resource?: string;
   readonly threadId?: number;
+  readonly inline?: boolean;
 
   static Root = new Frame(
     {
@@ -34,6 +35,7 @@ export class Frame extends WeightedNode {
     this.is_application = !!frameInfo.is_application;
     this.image = frameInfo.image;
     this.threadId = frameInfo.threadId;
+    this.inline = frameInfo.inline || false;
 
     // We are remapping some of the keys as they differ between platforms.
     // This is a temporary solution until we adopt a unified format.


### PR DESCRIPTION
Add new inline frame indicator to profiling tooltip 
<img width="515" alt="CleanShot 2022-11-15 at 12 26 15@2x" src="https://user-images.githubusercontent.com/9317857/201986227-3b1d8d28-2c43-4060-bb54-cb32f02357e5.png">
