### PR TITLE
fix(stackTrace): Remove double border on StacktraceContentV3

### DIFF
--- a/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
+++ b/static/app/components/events/interfaces/crashContent/stackTrace/contentV3.tsx
@@ -241,8 +241,11 @@ function Content({
 export default Content;
 
 const Wrapper = styled(Panel)`
-  border-top-left-radius: 0;
-  position: relative;
+  && {
+    border-top-left-radius: 0;
+    position: relative;
+    border: 0;
+  }
 `;
 
 const Frames = styled('ul')<{isHoverPreviewed?: boolean}>`


### PR DESCRIPTION
**Before:**
<img width="815" alt="Screen Shot 2022-11-15 at 10 38 10 AM" src="https://user-images.githubusercontent.com/44172267/201999540-e02a7d2b-ebbb-4c46-9bd2-653fe3db1ad9.png">

**After:**
<img width="815" alt="Screen Shot 2022-11-15 at 10 38 33 AM" src="https://user-images.githubusercontent.com/44172267/201999545-33c8b720-0f27-43e1-a47d-6d122c0fe391.png">
