### PR TITLE
ref(theme): Use more readable accent colors in dark mode

### DIFF
--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -202,7 +202,7 @@ const colorType = (p: FilterProps) =>
 const Filter = styled('span')<FilterProps>`
   --token-bg: ${p => p.theme.searchTokenBackground[colorType(p)]};
   --token-border: ${p => p.theme.searchTokenBorder[colorType(p)]};
-  --token-value-color: ${p => (p.invalid ? p.theme.red300 : p.theme.blue300)};
+  --token-value-color: ${p => (p.invalid ? p.theme.red400 : p.theme.blue400)};
 
   position: relative;
   animation-name: ${shakeAnimation};
@@ -221,7 +221,7 @@ const Negation = styled('span')`
   margin-left: -2px;
   font-weight: bold;
   border-radius: 2px 0 0 2px;
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.red400};
 `;
 
 const Key = styled('span')<{negated: boolean}>`
@@ -259,7 +259,7 @@ const Operator = styled('span')`
   border-left: none;
   border-right: none;
   margin: -1px 0;
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
 `;
 
 const Value = styled('span')`
@@ -273,7 +273,7 @@ const Value = styled('span')`
 
 const Unit = styled('span')`
   font-weight: bold;
-  color: ${p => p.theme.green300};
+  color: ${p => p.theme.green400};
 `;
 
 const LogicBoolean = styled('span')`
@@ -282,11 +282,11 @@ const LogicBoolean = styled('span')`
 `;
 
 const Boolean = styled('span')`
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
 `;
 
 const DateTime = styled('span')`
-  color: ${p => p.theme.green300};
+  color: ${p => p.theme.green400};
 `;
 
 const ListComma = styled('span')`
@@ -297,16 +297,16 @@ const InList = styled('span')`
   &:before {
     content: '[';
     font-weight: bold;
-    color: ${p => p.theme.purple300};
+    color: ${p => p.theme.purple400};
   }
   &:after {
     content: ']';
     font-weight: bold;
-    color: ${p => p.theme.purple300};
+    color: ${p => p.theme.purple400};
   }
 
   ${Value} {
-    color: ${p => p.theme.purple300};
+    color: ${p => p.theme.purple400};
   }
 `;
 
@@ -325,7 +325,7 @@ const LogicGroup = styled(({children, ...props}) => (
     &:before {
       position: absolute;
       top: -5px;
-      color: ${p => p.theme.pink300};
+      color: ${p => p.theme.pink400};
       font-size: 16px;
       font-weight: bold;
     }

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -87,35 +87,35 @@ export const darkColors = {
   translucentGray200: 'rgba(218, 184, 245, 0.18)',
   translucentGray100: 'rgba(208, 168, 240, 0.1)',
 
-  purple400: '#6859CF',
+  purple400: '#A397F7',
   purple300: '#7669D3',
-  purple200: 'rgba(108, 95, 199, 0.6)',
-  purple100: 'rgba(118, 105, 211, 0.1)',
+  purple200: 'rgba(118, 105, 211, 0.27)',
+  purple100: 'rgba(118, 105, 211, 0.12)',
 
-  blue400: '#4284FF',
-  blue300: '#5C95FF',
-  blue200: 'rgba(92, 149, 255, 0.4)',
-  blue100: 'rgba(92, 149, 255, 0.1)',
+  blue400: '#70A2FF',
+  blue300: '#3070E8',
+  blue200: 'rgba(48, 112, 232, 0.25)',
+  blue100: 'rgba(48, 112, 232, 0.12)',
 
-  green400: '#26B593',
-  green300: '#2AC8A3',
-  green200: 'rgba(42, 200, 163, 0.4)',
-  green100: 'rgba(42, 200, 163, 0.1)',
+  green400: '#1AB792',
+  green300: '#1D876E',
+  green200: 'rgba(29, 135, 110, 0.3)',
+  green100: 'rgba(29, 135, 110, 0.14)',
 
-  yellow400: '#F5B000',
-  yellow300: '#FFC227',
-  yellow200: 'rgba(255, 194, 39, 0.35)',
-  yellow100: 'rgba(255, 194, 39, 0.07)',
+  yellow400: '#E5A500',
+  yellow300: '#B28000',
+  yellow200: 'rgba(178, 128, 0, 0.25)',
+  yellow100: 'rgba(178, 128, 0, 0.1)',
 
-  red400: '#FA2E34',
-  red300: '#FA4F54',
-  red200: 'rgba(250, 79, 84, 0.4)',
-  red100: 'rgba(250, 79, 84, 0.1)',
+  red400: '#F87277',
+  red300: '#E12D33',
+  red200: 'rgba(225, 45, 51, 0.25)',
+  red100: 'rgba(225, 45, 51, 0.12)',
 
-  pink400: '#C4317A',
-  pink300: '#D1478C',
-  pink200: 'rgba(209, 71, 140, 0.55)',
-  pink100: 'rgba(209, 71, 140, 0.13)',
+  pink400: '#E674AD',
+  pink300: '#CE3B85',
+  pink200: 'rgba(206, 59, 133, 0.25)',
+  pink100: 'rgba(206, 59, 133, 0.1)',
 };
 
 const lightShadows = {
@@ -241,8 +241,8 @@ const generateAliases = (colors: BaseColors) => ({
   /**
    * Link color indicates that something is clickable
    */
-  linkColor: colors.blue300,
-  linkHoverColor: colors.blue300,
+  linkColor: colors.blue400,
+  linkHoverColor: colors.blue400,
   linkUnderline: colors.blue200,
   linkFocus: colors.blue300,
 
@@ -369,7 +369,7 @@ const generateAlertTheme = (colors: BaseColors, alias: Aliases) => ({
     backgroundLight: colors.blue100,
     border: colors.blue200,
     borderHover: colors.blue300,
-    iconColor: colors.blue300,
+    iconColor: colors.blue400,
     iconHoverColor: colors.blue400,
   },
   warning: {
@@ -377,7 +377,7 @@ const generateAlertTheme = (colors: BaseColors, alias: Aliases) => ({
     backgroundLight: colors.yellow100,
     border: colors.yellow200,
     borderHover: colors.yellow300,
-    iconColor: colors.yellow300,
+    iconColor: colors.yellow400,
     iconHoverColor: colors.yellow400,
   },
   success: {
@@ -385,7 +385,7 @@ const generateAlertTheme = (colors: BaseColors, alias: Aliases) => ({
     backgroundLight: colors.green100,
     border: colors.green200,
     borderHover: colors.green300,
-    iconColor: colors.green300,
+    iconColor: colors.green400,
     iconHoverColor: colors.green400,
   },
   error: {
@@ -393,7 +393,7 @@ const generateAlertTheme = (colors: BaseColors, alias: Aliases) => ({
     backgroundLight: colors.red100,
     border: colors.red200,
     borderHover: colors.red300,
-    iconColor: colors.red300,
+    iconColor: colors.red400,
     iconHoverColor: colors.red400,
     textLight: colors.red200,
   },
@@ -441,32 +441,32 @@ const generateTagTheme = (colors: BaseColors) => ({
   promotion: {
     background: colors.pink100,
     border: colors.pink200,
-    iconColor: colors.pink300,
+    iconColor: colors.pink400,
   },
   highlight: {
     background: colors.purple100,
     border: colors.purple200,
-    iconColor: colors.purple300,
+    iconColor: colors.purple400,
   },
   warning: {
     background: colors.yellow100,
     border: colors.yellow200,
-    iconColor: colors.yellow300,
+    iconColor: colors.yellow400,
   },
   success: {
     background: colors.green100,
     border: colors.green200,
-    iconColor: colors.green300,
+    iconColor: colors.green400,
   },
   error: {
     background: colors.red100,
     border: colors.red200,
-    iconColor: colors.red300,
+    iconColor: colors.red400,
   },
   info: {
     background: colors.purple100,
     border: colors.purple200,
-    iconColor: colors.purple300,
+    iconColor: colors.purple400,
   },
   white: {
     background: colors.white,
@@ -528,8 +528,8 @@ const generateButtonTheme = (colors: BaseColors, alias: Aliases) => ({
     focusShadow: colors.red200,
   },
   link: {
-    color: colors.blue300,
-    colorActive: colors.blue300,
+    color: alias.linkColor,
+    colorActive: alias.linkHoverColor,
     background: 'transparent',
     backgroundActive: 'transparent',
     border: 'transparent',


### PR DESCRIPTION
2 things:
* Update accent colors in dark mode for better readability
* Update color aliases: use ___400 accent colors for text

**Before:**
<img width="825" alt="Screen Shot 2022-11-15 at 11 38 47 AM" src="https://user-images.githubusercontent.com/44172267/202010756-7622b0d4-ca60-45aa-878c-39251209227b.png">
<img width="245" alt="Screen Shot 2022-11-15 at 11 39 32 AM" src="https://user-images.githubusercontent.com/44172267/202010753-35dbd439-ba14-4ac5-9d93-1a41fb35e048.png">


**After:**
<img width="825" alt="Screen Shot 2022-11-15 at 11 38 59 AM" src="https://user-images.githubusercontent.com/44172267/202010754-5c6d6e93-6c49-46c8-a916-db3a230677a0.png">
<img width="245" alt="Screen Shot 2022-11-15 at 11 40 13 AM" src="https://user-images.githubusercontent.com/44172267/202010749-7ec16339-7517-49b8-a5d4-b8e0e2ec8dd0.png">

