### PR TITLE
test(ecosystem): Use static plugin version for screenshots

### DIFF
--- a/static/app/views/settings/projectPlugins/details.tsx
+++ b/static/app/views/settings/projectPlugins/details.tsx
@@ -13,6 +13,7 @@ import PluginConfig from 'sentry/components/pluginConfig';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Plugin, Project} from 'sentry/types';
+import getDynamicText from 'sentry/utils/getDynamicText';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
 import withPlugins from 'sentry/utils/withPlugins';
 import AsyncView from 'sentry/views/asyncView';
@@ -213,7 +214,12 @@ class ProjectPluginDetails extends AsyncView<Props, State> {
                   </div>
                 )}
                 <dt>{t('Version')}</dt>
-                <dd>{pluginDetails.version}</dd>
+                <dd>
+                  {getDynamicText({
+                    value: pluginDetails.version,
+                    fixed: '1.0.0',
+                  })}
+                </dd>
               </dl>
 
               {pluginDetails.description && (


### PR DESCRIPTION
Instead of showing current version, show fixed text instead so that it doesn't change in screenshots every time the version changes

fixes diffs like these https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/085a5de98a19289f3a622b11a925f0679ae187fc/index.html