### PR TITLE
fix(perf-issue): concat title and location together for the search message

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2214,6 +2214,13 @@ def _save_grouphash_and_group(
     return group, created
 
 
+def _message_from_metadata(meta: Mapping[str, str]) -> str:
+    title = meta.get("title", "")
+    location = meta.get("location", "")
+    seperator = ": " if title and location else ""
+    return f"{title}{seperator}{location}"
+
+
 @metrics.wraps("save_event.save_aggregate_performance")
 def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: ProjectsMapping) -> None:
 
@@ -2309,8 +2316,11 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
                         group_kwargs["data"]["metadata"] = inject_performance_problem_metadata(
                             group_kwargs["data"]["metadata"], problem
                         )
-                        if group_kwargs["data"]["metadata"].get("title"):
-                            group_kwargs["message"] = group_kwargs["data"]["metadata"].get("title")
+
+                        if group_kwargs["data"]["metadata"]:
+                            group_kwargs["message"] = _message_from_metadata(
+                                group_kwargs["data"]["metadata"]
+                            )
 
                         group, is_new = _save_grouphash_and_group(
                             project, event, new_grouphash, **group_kwargs
@@ -2355,7 +2365,9 @@ def _save_aggregate_performance(jobs: Sequence[PerformanceJob], projects: Projec
                         group_kwargs["data"]["metadata"], problem
                     )
                     if group_kwargs["data"]["metadata"].get("title"):
-                        group_kwargs["message"] = group_kwargs["data"]["metadata"].get("title")
+                        group_kwargs["message"] = _message_from_metadata(
+                            group_kwargs["data"]["metadata"]
+                        )
 
                     is_regression = _process_existing_aggregate(
                         group=group, event=job["event"], data=group_kwargs, release=job["release"]

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2162,6 +2162,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
             data = event.data
             expected_hash = "e714d718cb4e7d3ce1ad800f7f33d223"
             assert event.get_event_type() == "transaction"
+            assert event.transaction == "/books/"
             assert data["span_grouping_config"]["id"] == "default:2022-10-27"
             assert data["hashes"] == [expected_hash]
             span_hashes = [span["hash"] for span in data["spans"]]
@@ -2193,7 +2194,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin):
             assert len(event.groups) == 1
             group = event.groups[0]
             assert group.title == "N+1 Query"
-            assert group.message == "N+1 Query"
+            assert group.message == "N+1 Query: /books/"
             assert group.culprit == "/books/"
             assert group.get_event_type() == "transaction"
             description = "SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"


### PR DESCRIPTION
Forgot to concat the title and location together to form the search message for performance issues. This adds support for users to search for perf issues with the message that looks like `N+1 Query: /api/0/events` and a search term that looks like `is:unresolved N+1` or `is:unresolved events`