### PR TITLE
ref(stacktrace_link): Add more than one code mapping in the tests

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -85,6 +85,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
             if i.has_feature(IntegrationFeatures.STACKTRACE_LINK)
         ]
 
+        last_error = None
         # xxx(meredith): if there are ever any changes to this query, make
         # sure that we are still ordering by `id` because we want to make sure
         # the ordering is deterministic
@@ -95,18 +96,17 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         with configure_scope() as scope:
             for config in configs:
                 if not filepath.startswith(config.stack_root) and not frame:
-                    scope.set_tag("stacktrace_link.error", "stack_root_mismatch")
-                    result["error"] = "stack_root_mismatch"
+                    last_error = "stack_root_mismatch"
                     continue
 
-                result["config"] = serialize(config, request.user)
+                serialized_code_mapping = serialize(config, request.user)
                 # use the provider key to be able to split up stacktrace
                 # link metrics by integration type
-                provider = result["config"]["provider"]["key"]
+                provider = serialized_code_mapping["provider"]["key"]
                 scope.set_tag("integration_provider", provider)
                 scope.set_tag("stacktrace_link.platform", platform)
 
-                link, attempted_url, error = get_link(
+                link, attempted_url, get_link_error = get_link(
                     config, filepath, config.default_branch, commit_id
                 )
 
@@ -122,8 +122,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                             if not filepath.startswith(
                                 config.stack_root
                             ) and not munged_filename.startswith(config.stack_root):
-                                scope.set_tag("stacktrace_link.error", "stack_root_mismatch")
-                                result["error"] = "stack_root_mismatch"
+                                last_error = "stack_root_mismatch"
                                 continue
 
                             link, attempted_url, error = get_link(
@@ -135,14 +134,24 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                 # configuration
                 result["sourceUrl"] = link
                 if not link:
-                    scope.set_tag("stacktrace_link.found", False)
-                    scope.set_tag("stacktrace_link.error", "file_not_found")
-                    result["error"] = error
+                    last_error = get_link_error
                     result["attemptedUrl"] = attempted_url
                 else:
+                    # Only return code mapping when there's a match
+                    result["config"] = serialized_code_mapping
                     scope.set_tag("stacktrace_link.found", True)
                     # if we found a match, we can break
                     break
+
+            # Post-processing before exiting scope context
+            if result["config"] is None:
+                if last_error:
+                    result["error"] = last_error
+                    if last_error == "stack_root_mismatch":
+                        scope.set_tag("stacktrace_link.error", "stack_root_mismatch")
+                    else:
+                        scope.set_tag("stacktrace_link.found", False)
+                        scope.set_tag("stacktrace_link.error", "file_not_found")
 
         if result["config"]:
             analytics.record(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -531,7 +531,7 @@ class Factories:
     @staticmethod
     @exempt_from_silo_limits()
     def create_repo(project, name=None, provider=None, integration_id=None, url=None):
-        repo = Repository.objects.create(
+        repo, _ = Repository.objects.get_or_create(
             organization_id=project.organization_id,
             name=name
             or "{}-{}".format(petname.Generate(2, "", letters=10), random.randint(1000, 9999)),

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -51,38 +51,64 @@ class ProjectStacktraceLinkTest(APITestCase):
         self.repo.provider = "example"
         self.repo.save()
 
-        self.config = self.create_code_mapping(
+        self.code_mapping1 = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="sentry/",
+            source_root="src/sentry/",
+            automatically_generated=True,  # Created by the automation
+        )
+        self.code_mapping2 = self.create_code_mapping(
             organization_integration=self.oi,
             project=self.project,
             repo=self.repo,
             stack_root="usr/src/getsentry/",
             source_root="",
         )
+        self.code_mapping3 = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="",
+            source_root="",
+        )
+        self.code_mapping4 = self.create_code_mapping(
+            organization_integration=self.oi,
+            project=self.project,
+            repo=self.repo,
+            stack_root="sentry/integrations/",
+            source_root="src/sentry/integrations/",
+            automatically_generated=True,  # Created by the automation
+        )
 
         self.filepath = "usr/src/getsentry/src/sentry/src/sentry/utils/safe.py"
         self.login_as(self.user)
 
+    # You can use this if you're expecting the test to match the user generated code mapping
     def expected_configurations(self) -> Mapping[str, Any]:
         return {
             "defaultBranch": "master",
-            "id": str(self.config.id),
+            "id": str(self.code_mapping2.id),
             "integrationId": str(self.integration.id),
             "projectId": str(self.project.id),
             "projectSlug": self.project.slug,
             "provider": serialized_provider(),
             "repoId": str(self.repo.id),
             "repoName": self.repo.name,
-            "sourceRoot": self.config.source_root,
-            "stackRoot": self.config.stack_root,
+            "sourceRoot": self.code_mapping2.source_root,
+            "stackRoot": self.code_mapping2.stack_root,
         }
 
     def test_no_filepath(self):
+        """The file query search is missing"""
         response = self.get_error_response(
             self.organization.slug, self.project.slug, status_code=400
         )
         assert response.data == {"detail": "Filepath is required"}
 
     def test_no_configs(self):
+        """No code mappings have been set for this project"""
         # new project that has no configurations set up for it
         project = self.create_project(
             name="bloop",
@@ -100,19 +126,23 @@ class ProjectStacktraceLinkTest(APITestCase):
         }
 
     def test_file_not_found_error(self):
+        """File matches code mapping but it cannot be found in the source repository."""
         response = self.get_success_response(
             self.organization.slug, self.project.slug, qs_params={"file": self.filepath}
         )
-        assert response.data["config"] == self.expected_configurations()
+        assert response.data["config"] is None
         assert not response.data["sourceUrl"]
-        assert response.data["error"] == "file_not_found"
+        # XXX: This depends on what was the last attempted code mapping
+        assert response.data["error"] == "stack_root_mismatch"
         assert response.data["integrations"] == [serialized_integration(self.integration)]
+        # XXX: This depends on what was the last attempted code mapping
         assert (
             response.data["attemptedUrl"]
-            == f"https://example.com/{self.repo.name}/blob/master/src/sentry/src/sentry/utils/safe.py"
+            == f"https://example.com/{self.repo.name}/blob/master/usr/src/getsentry/src/sentry/src/sentry/utils/safe.py"
         )
 
     def test_stack_root_mismatch_error(self):
+        """Looking for a stacktrace file path that will not match any code mappings"""
         response = self.get_success_response(
             self.organization.slug, self.project.slug, qs_params={"file": "wrong/file/path"}
         )
@@ -122,6 +152,7 @@ class ProjectStacktraceLinkTest(APITestCase):
         assert response.data["integrations"] == [serialized_integration(self.integration)]
 
     def test_config_and_source_url(self):
+        """Having a different source url should also work"""
         with mock.patch.object(
             ExampleIntegration, "get_stacktrace_link", return_value="https://sourceurl.com/"
         ):
@@ -133,10 +164,7 @@ class ProjectStacktraceLinkTest(APITestCase):
             assert response.data["integrations"] == [serialized_integration(self.integration)]
 
     @mock.patch("sentry.api.endpoints.project_stacktrace_link.munged_filename_and_frames")
-    @mock.patch.object(
-        ExampleIntegration,
-        "get_stacktrace_link",
-    )
+    @mock.patch.object(ExampleIntegration, "get_stacktrace_link")
     def test_file_not_found_and_munge_frame_fallback_not_found(self, mock_integration, mock_munger):
         mock_integration.return_value = None
         mock_munger.return_value = None
@@ -152,13 +180,15 @@ class ProjectStacktraceLinkTest(APITestCase):
             },
         )
 
-        assert response.data["config"] == self.expected_configurations()
+        assert response.data["config"] is None
         assert not response.data["sourceUrl"]
+        # XXX: This depends on what was the last attempted code mapping
         assert response.data["error"] == "file_not_found"
         assert response.data["integrations"] == [serialized_integration(self.integration)]
+        # XXX: This depends on what was the last attempted code mapping
         assert (
             response.data["attemptedUrl"]
-            == f"https://example.com/{self.repo.name}/blob/master/src/sentry/src/sentry/utils/safe.py"
+            == f"https://example.com/{self.repo.name}/blob/master/usr/src/getsentry/src/sentry/src/sentry/utils/safe.py"
         )
 
     @mock.patch("sentry.api.endpoints.project_stacktrace_link.munged_filename_and_frames")
@@ -209,8 +239,8 @@ class ProjectStacktraceLinkTest(APITestCase):
                 "package": "any",
             },
         )
-        assert mock_integration.call_count == 1
-        assert response.data["config"] == self.expected_configurations()
+        assert mock_integration.call_count == 5  # As many code mappings there are for this project
+        assert response.data["config"] is None
         assert not response.data["sourceUrl"]
         assert response.data["error"] == "stack_root_mismatch"
         assert response.data["integrations"] == [serialized_integration(self.integration)]


### PR DESCRIPTION
Include more than one code mapping in the setup code. Cleaning up a bit how we tag the transactions.

This makes the PR for WOR-2395 a little easier to read.