### PR TITLE
fix(event-tags): fix referrer being passed to tag link

### DIFF
--- a/static/app/components/events/eventTags/index.tsx
+++ b/static/app/components/events/eventTags/index.tsx
@@ -30,7 +30,7 @@ export function EventTags({event, organization, projectId, location}: Props) {
   }
 
   const orgSlug = organization.slug;
-  const streamPath = `/organizations/${orgSlug}/issues/?referrer=event-tags`;
+  const streamPath = `/organizations/${orgSlug}/issues/`;
 
   return (
     <StyledClippedBox clipHeight={150}>
@@ -41,7 +41,7 @@ export function EventTags({event, organization, projectId, location}: Props) {
             tag={tag}
             projectId={projectId}
             organization={organization}
-            query={generateQueryWithTag(location.query, tag)}
+            query={generateQueryWithTag({...location.query, referrer: 'event-tags'}, tag)}
             streamPath={streamPath}
             meta={meta?.[index]}
           />


### PR DESCRIPTION
This fixes a bug where we didn't construct the URL correctly when adding the referrer.
Before:

https://sentry.io/organizations/sentry/issues/?referrer=event-tags/?environment=prod&query=is%3Aunresolved%20logger%3Aroot&referrer=issue-stream

After:
https://sentry.io/organizations/sentry/issues/?environment=prod&project=1&query=is%3Aunresolved%20logger%3Aroot&referrer=event-tags
