### PR TITLE
feat(alert-preview): base for frequency conditions

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -111,22 +111,19 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
         super().__init__(*args, **kwargs)
 
-    def _get_options(self) -> Tuple[float, str] | None:
-        interval = self.get_option("interval")
+    def _get_options(self) -> Tuple[str | None, float | None]:
+        interval, value = None, None
         try:
             value = float(self.get_option("value"))
+            interval = self.get_option("interval")
         except (TypeError, ValueError):
-            return None
-
-        if not interval:
-            return None
-        return value, interval
+            pass
+        return interval, value
 
     def passes(self, event: GroupEvent, state: EventState) -> bool:
-        options = self._get_options()
-        if options is None:
+        interval, value = self._get_options()
+        if not (interval and value):
             return False
-        value, interval = options
 
         # TODO(mgaeta): Bug: Rule is optional.
         current_value = self.get_rate(event, interval, self.rule.environment_id)  # type: ignore
@@ -136,15 +133,14 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
     def passes_activity_frequency(
         self, activity: ConditionActivity, buckets: Dict[datetime, int]
     ) -> bool:
-        options = self._get_options()
-        if options is None:
+        interval, value = self._get_options()
+        if not (interval and value):
             return False
-        value, interval = options
         interval_delta = self.intervals[interval][1]
 
         # extrapolate if interval less than bucket size
         if interval_delta < FREQUENCY_CONDITION_BUCKET_SIZE:
-            value *= FREQUENCY_CONDITION_BUCKET_SIZE / interval_delta
+            value *= int(FREQUENCY_CONDITION_BUCKET_SIZE / interval_delta)
             interval_delta = FREQUENCY_CONDITION_BUCKET_SIZE
 
         interval_end = round_to_five_minute(activity.timestamp)

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -110,8 +110,8 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
     def _get_options(self) -> Tuple[str | None, float | None]:
         interval, value = None, None
         try:
-            value = float(self.get_option("value"))
             interval = self.get_option("interval")
+            value = float(self.get_option("value"))
         except (TypeError, ValueError):
             pass
         return interval, value

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, Mapping, Tuple
+from typing import Any, Dict, Mapping, Sequence, Tuple
 
 from django import forms
 from django.core.cache import cache
@@ -127,7 +127,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         return current_value > value
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: Dict[datetime, int]
+        self, activity: ConditionActivity, buckets: Sequence[Dict[str, Any]]
     ) -> bool:
         raise NotImplementedError
 
@@ -212,7 +212,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         return sums[event.group_id]
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: Dict[datetime, int]
+        self, activity: ConditionActivity, buckets: Sequence[Dict[str, Any]]
     ) -> bool:
         interval, value = self._get_options()
         if not (interval and value):

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -307,14 +307,14 @@ def apply_frequency_conditions(
                 except NotImplementedError:
                     raise PreviewException
 
-            for i in range(len(activities)):
-                if (
-                    pass_count[i]
-                    and condition_match == "any"
-                    or pass_count[i] == len(conditions)
-                    and condition_match == "all"
-                ):
-                    filtered_activity[group].append(activities[i])
+        for i in range(len(activities)):
+            if (
+                pass_count[i]
+                and condition_match == "any"
+                or pass_count[i] == len(conditions)
+                and condition_match == "all"
+            ):
+                filtered_activity[group].append(activities[i])
 
     return filtered_activity
 

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -324,7 +324,6 @@ def get_frequency_buckets(
 ) -> Sequence[Dict[str, Any]]:
     """
     Puts the events of a group into buckets, and returns the bucket counts.
-    The returned list contains the prefix sum of the buckets to support efficient range queries by frequency conditions.
     """
     # TODO: support counting of other issue types and fields (# of unique users, ...)
     bucket_counts: Sequence[Dict[str, Any]] = raw_query(

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -321,13 +321,13 @@ def apply_frequency_conditions(
 
 def get_frequency_buckets(
     project: Project, start: datetime, end: datetime, group_id: str
-) -> Dict[datetime, int]:
+) -> Sequence[Dict[str, Any]]:
     """
     Puts the events of a group into buckets, and returns the bucket counts.
     The returned list contains the prefix sum of the buckets to support efficient range queries by frequency conditions.
     """
     # TODO: support counting of other issue types and fields (# of unique users, ...)
-    bucket_counts = raw_query(
+    bucket_counts: Sequence[Dict[str, Any]] = raw_query(
         dataset=Dataset.Events,
         start=start,
         end=end,

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -11,8 +11,13 @@ from sentry.models import Group, Project
 from sentry.rules import RuleBase, rules
 from sentry.rules.processor import get_match_function
 from sentry.snuba.dataset import Dataset
-from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
-from sentry.utils.snuba import raw_query
+from sentry.types.condition_activity import (
+    FREQUENCY_CONDITION_BUCKET_SIZE,
+    ConditionActivity,
+    ConditionActivityType,
+    round_to_five_minute,
+)
+from sentry.utils.snuba import parse_snuba_datetime, raw_query
 
 Conditions = Sequence[Dict[str, Any]]
 ConditionFunc = Callable[[Sequence[bool]], bool]
@@ -22,6 +27,12 @@ PREVIEW_TIME_RANGE = timedelta(weeks=2)
 # limit on number of ConditionActivity's a condition will return
 # if limited, conditions should return the latest activity
 CONDITION_ACTIVITY_LIMIT = 1000
+FREQUENCY_CONDITION_GROUP_LIMIT = 10
+ISSUE_STATE_CONDITIONS = [
+    "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+    "sentry.rules.conditions.regression_event.RegressionEventCondition",
+    "sentry.rules.conditions.reappeared_event.ReappearedEventCondition",
+]
 
 
 def preview(
@@ -38,21 +49,35 @@ def preview(
     end = timezone.now()
     start = end - PREVIEW_TIME_RANGE
 
-    # must have at least one condition to filter activity
-    if len(conditions) == 0:
+    issue_state_conditions, frequency_conditions = categorize_conditions(conditions)
+
+    # must have at least one issue state condition to filter activity
+    # TODO: support cases where there are only freq conditions
+    if not issue_state_conditions:
         return None
-    # all the currently supported conditions are mutually exclusive
-    elif len(conditions) > 1 and condition_match == "all":
+    # all the issue state conditions are mutually exclusive
+    elif len(issue_state_conditions) > 1 and condition_match == "all":
         return Group.objects.none()
 
     try:
-        group_activity = get_group_activity(project, conditions, start, end)
+        group_activity = get_issue_state_activity(project, issue_state_conditions, start, end)
         filter_objects, filter_func, event_columns = get_filters(project, filters, filter_match)
+
+        # frequency conditions triggers are approximated, so they're not tied to an actual event object.
+        # We cannot get any event data and answer any event-related filters
+        if frequency_conditions and event_columns:
+            return None
 
         event_map = {}
         # if there is an event filter, retrieve event data
         if event_columns:
             event_map = get_events(project, group_activity, event_columns)
+
+        if frequency_conditions:
+            group_activity = get_top_groups(project, start, end, group_activity)
+            group_activity = apply_frequency_conditions(
+                project, start, end, group_activity, frequency_conditions, condition_match
+            )
 
         frequency = timedelta(minutes=frequency_minutes)
         group_ids = get_fired_groups(
@@ -64,7 +89,25 @@ def preview(
         return None
 
 
-def get_group_activity(
+def categorize_conditions(conditions: Conditions) -> Tuple[Conditions, Conditions]:
+    """
+    Categorizes conditions into issue state conditions or frequency conditions.
+    These two types of conditions are processed separately.
+
+    Also deduplicates conditions, mainly for issue state conditions since they don't have params
+    so there can be at most 3, and some of the preview logic after assumes they are unique.
+    """
+    issue_state_conditions = {}
+    frequency_conditions = []
+    for condition in conditions:
+        if condition["id"] in ISSUE_STATE_CONDITIONS:
+            issue_state_conditions[condition["id"]] = condition
+        else:
+            frequency_conditions.append(condition)
+    return list(issue_state_conditions.values()), frequency_conditions
+
+
+def get_issue_state_activity(
     project: Project, conditions: Conditions, start: datetime, end: datetime
 ) -> GroupActivityMap:
     """
@@ -141,6 +184,35 @@ def get_fired_groups(
     return list(group_ids)
 
 
+def get_top_groups(
+    project: Project, start: datetime, end: datetime, condition_activity: GroupActivityMap
+) -> GroupActivityMap:
+    """
+    Filters the activity to contain only groups that have the most events in the past 2 weeks.
+
+    Since frequency conditions require one snuba query per groups, we need to limit the number groups we process.
+    """
+    # TODO: Also check other datasets for top groups
+    groups = raw_query(
+        dataset=Dataset.Events,
+        start=start,
+        end=end,
+        filter_keys={"project_id": [project.id]},
+        conditions=[("group_id", "IN", list(condition_activity.keys()))],
+        aggregations=[("count", "group_id", "groupCount")],
+        groupby=["group_id"],
+        order_by="-groupCount",
+        seleted_columns=["group_id"],
+        limit=FREQUENCY_CONDITION_GROUP_LIMIT,
+    ).get("data", [])
+
+    top_groups = {group["group_id"] for group in groups}
+    top_activity = {
+        group: activity for group, activity in condition_activity.items() if group in top_groups
+    }
+    return top_activity
+
+
 def get_events(
     project: Project, group_activity: GroupActivityMap, columns: List[str]
 ) -> Dict[str, Any]:
@@ -199,6 +271,90 @@ def get_events(
             event["tags"] = {k: v for k, v in zip(keys, values)}
 
     return {event["event_id"]: event for event in events}
+
+
+def apply_frequency_conditions(
+    project: Project,
+    start: datetime,
+    end: datetime,
+    group_activity: GroupActivityMap,
+    frequency_conditions: Conditions,
+    condition_match: str,
+) -> GroupActivityMap:
+    """
+    Applies frequency conditions to issue state activity.
+    """
+    conditions = []
+    for condition_data in frequency_conditions:
+        condition_cls = rules.get(condition_data["id"])
+        if condition_cls is None:
+            raise PreviewException
+        conditions.append(condition_cls(project, data=condition_data))
+
+    filtered_activity = defaultdict(list)
+    for group, activities in group_activity.items():
+        # TODO: only EventFrequencyCondition is supported right now, so we can reuse the same query
+        buckets = get_frequency_buckets(project, start, end, group)
+        pass_count = [0] * len(activities)
+        for condition in conditions:
+            for i, activity in enumerate(activities):
+                try:
+                    if condition.passes_activity_frequency(activity, buckets):
+                        pass_count[i] += 1
+                except NotImplementedError:
+                    raise PreviewException
+
+            for i in range(len(activities)):
+                if (
+                    pass_count[i]
+                    and condition_match == "any"
+                    or pass_count[i] == len(conditions)
+                    and condition_match == "all"
+                ):
+                    filtered_activity[group].append(activities[i])
+
+    return filtered_activity
+
+
+def get_frequency_buckets(
+    project: Project, start: datetime, end: datetime, group_id: str
+) -> Dict[datetime, int]:
+    """
+    Puts the events of a group into buckets, and returns the bucket counts.
+    The returned list contains the prefix sum of the buckets to support efficient range queries by frequency conditions.
+    """
+    # TODO: support counting of other issue types and fields (# of unique users, ...)
+    bucket_counts = raw_query(
+        dataset=Dataset.Events,
+        start=start,
+        end=end,
+        filter_keys={"project_id": [project.id]},
+        conditions=[("group_id", "=", group_id)],
+        aggregations=[
+            ("toStartOfFiveMinute", "timestamp", "roundedTime"),
+            ("count", "roundedTime", "bucketCount"),
+        ],
+        groupby=["roundedTime"],
+        orderby=["-roundedTime"],
+        selected_columns=["roundedTime", "bucketCount"],
+        limit=PREVIEW_TIME_RANGE // FREQUENCY_CONDITION_BUCKET_SIZE + 1,  # at most ~4k
+    ).get("data", [])
+    for bucket in bucket_counts:
+        bucket["roundedTime"] = parse_snuba_datetime(bucket["roundedTime"])
+
+    rounded_time = round_to_five_minute(start)
+    rounded_end = round_to_five_minute(end)
+    cumulative_sum = 0
+    buckets = {}
+    # the query result only contains buckets that have a positive count
+    # here we fill in the empty buckets and accumulate the sum
+    while rounded_time <= rounded_end:
+        if bucket_counts and bucket_counts[-1]["roundedTime"] == rounded_time:
+            cumulative_sum += bucket_counts.pop()["bucketCount"]
+
+        buckets[rounded_time] = cumulative_sum
+        rounded_time += FREQUENCY_CONDITION_BUCKET_SIZE
+    return buckets
 
 
 class PreviewException(Exception):

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -74,9 +74,13 @@ def preview(
             event_map = get_events(project, group_activity, event_columns)
 
         if frequency_conditions:
-            group_activity = get_top_groups(project, start, end, group_activity)
             group_activity = apply_frequency_conditions(
-                project, start, end, group_activity, frequency_conditions, condition_match
+                project,
+                start,
+                end,
+                get_top_groups(project, start, end, group_activity),
+                frequency_conditions,
+                condition_match,
             )
 
         frequency = timedelta(minutes=frequency_minutes)
@@ -97,14 +101,14 @@ def categorize_conditions(conditions: Conditions) -> Tuple[Conditions, Condition
     Also deduplicates conditions, mainly for issue state conditions since they don't have params
     so there can be at most 3, and some of the preview logic after assumes they are unique.
     """
-    issue_state_conditions = {}
+    issue_state_conditions = set()
     frequency_conditions = []
     for condition in conditions:
         if condition["id"] in ISSUE_STATE_CONDITIONS:
-            issue_state_conditions[condition["id"]] = condition
+            issue_state_conditions.add(condition["id"])
         else:
             frequency_conditions.append(condition)
-    return list(issue_state_conditions.values()), frequency_conditions
+    return [{"id": condition_id} for condition_id in issue_state_conditions], frequency_conditions
 
 
 def get_issue_state_activity(

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -20,10 +20,3 @@ class ConditionActivity:
     type: ConditionActivityType
     timestamp: datetime
     data: Dict[str, Any] | None = None
-
-
-def round_to_five_minute(date: datetime) -> datetime:
-    floor = date - timedelta(
-        minutes=date.minute % 5, seconds=date.second, microseconds=date.microsecond
-    )
-    return floor

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict
+
+FREQUENCY_CONDITION_BUCKET_SIZE = timedelta(minutes=5)
 
 
 class ConditionActivityType(Enum):
@@ -15,7 +17,13 @@ class ConditionActivityType(Enum):
 @dataclass
 class ConditionActivity:
     group_id: str
-    # potentially can have multiple types if even more conditions are supported
     type: ConditionActivityType
     timestamp: datetime
     data: Dict[str, Any] | None = None
+
+
+def round_to_five_minute(date: datetime) -> datetime:
+    floor = date - timedelta(
+        minutes=date.minute % 5, seconds=date.second, microseconds=date.microsecond
+    )
+    return floor

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -18,6 +18,8 @@ from sentry.types.activity import ActivityType
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.types.issues import GroupType
 
+MATCH_ARGS = ("all", "all", 0)
+
 
 def get_hours(time: timedelta) -> int:
     return time.days * 24 + time.seconds // (60 * 60)
@@ -112,7 +114,7 @@ class ProjectRulePreviewTest(TestCase):
             else:
                 older.append(group)
 
-        result = preview(self.project, conditions, filters, "all", "all", 0)
+        result = preview(self.project, conditions, filters, *MATCH_ARGS)
         assert all(g in result for g in newer)
         assert all(g not in result for g in older)
 
@@ -144,7 +146,7 @@ class ProjectRulePreviewTest(TestCase):
             }
         ]
 
-        result = preview(self.project, conditions, filters, "all", "all", 0)
+        result = preview(self.project, conditions, filters, *MATCH_ARGS)
         for i in range(threshold + 1):
             assert groups[i] not in result
         for i in range(threshold + 1, hours):
@@ -178,7 +180,7 @@ class ProjectRulePreviewTest(TestCase):
                 "value": GroupType.ERROR.value,
             }
         ]
-        result = preview(self.project, conditions, filters, "all", "all", 0)
+        result = preview(self.project, conditions, filters, *MATCH_ARGS)
         assert all(group in result for group in errors)
         assert all(group not in result for group in n_plus_one)
 
@@ -187,16 +189,16 @@ class ProjectRulePreviewTest(TestCase):
 
         conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
         filters = [{"id": "sentry.rules.filters.level.LevelFilter", "level": "40", "match": "eq"}]
-        results = preview(self.project, conditions, filters, "all", "all", 0)
+        results = preview(self.project, conditions, filters, *MATCH_ARGS)
         assert event.group in results
 
         filters[0]["match"] = "gte"
         filters[0]["level"] = "50"
-        results = preview(self.project, conditions, filters, "all", "all", 0)
+        results = preview(self.project, conditions, filters, *MATCH_ARGS)
         assert event.group not in results
 
         filters[0]["match"] = "lte"
-        results = preview(self.project, conditions, filters, "all", "all", 0)
+        results = preview(self.project, conditions, filters, *MATCH_ARGS)
         assert event.group in results
 
     def test_tagged(self):
@@ -211,11 +213,11 @@ class ProjectRulePreviewTest(TestCase):
             }
         ]
 
-        results = preview(self.project, conditions, filters, "all", "all", 0)
+        results = preview(self.project, conditions, filters, *MATCH_ARGS)
         assert event.group in results
 
         filters[0]["value"] = "baz"
-        results = preview(self.project, conditions, filters, "all", "all", 0)
+        results = preview(self.project, conditions, filters, *MATCH_ARGS)
         assert event.group not in results
 
     def test_unsupported_conditions(self):
@@ -300,7 +302,7 @@ class ProjectRulePreviewTest(TestCase):
             {"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"},
             {"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"},
         ]
-        result = preview(self.project, conditions, [], "all", "all", 0)
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert result.count() == 0
 
 
@@ -356,15 +358,15 @@ class FrequencyConditionTest(TestCase):
                 "interval": "5m",
             },
         ]
-        result = preview(self.project, conditions, [], "all", "all", 0)
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert group in result
 
         conditions[1]["value"] = 5
-        result = preview(self.project, conditions, [], "all", "all", 0)
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert group not in result
 
         conditions[1]["interval"] = "1d"
-        result = preview(self.project, conditions, [], "all", "all", 0)
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert group in result
 
 


### PR DESCRIPTION
Adds preview logic for frequency conditions and support for `EventFrequencyCondition`.

After getting the condition activity from issue state change conditions, we apply the frequency conditions to each activity one group at a time. This is done by querying when the events of a group occurred, and organizing them into buckets that can be used to answer the frequency conditions approximately.