### PR TITLE
style(replays): Replace network colors in timeline for dark mode

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineSpans.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {divide, flattenSpans} from 'sentry/components/replays/utils';
 import Tooltip from 'sentry/components/tooltip';
 import {tn} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
 import space from 'sentry/styles/space';
 import useActiveReplayTab from 'sentry/utils/replays/hooks/useActiveReplayTab';
 import type {ReplaySpan} from 'sentry/views/replays/types';
@@ -61,6 +62,7 @@ function ReplayTimelineEvents({className, durationMs, spans, startTimestampMs}: 
             position="bottom"
           >
             <Span
+              isDark={ConfigStore.get('theme') === 'dark'}
               startPct={startPct}
               widthPct={widthPct}
               onClick={() => setActiveTab('network')}
@@ -84,7 +86,7 @@ const Spans = styled('ul')`
   pointer-events: none;
 `;
 
-const Span = styled('li')<{startPct: number; widthPct: number}>`
+const Span = styled('li')<{isDark: boolean; startPct: number; widthPct: number}>`
   cursor: pointer;
   display: block;
   position: absolute;
@@ -92,7 +94,7 @@ const Span = styled('li')<{startPct: number; widthPct: number}>`
   min-width: 1px;
   width: ${p => p.widthPct * 100}%;
   height: 100%;
-  background: ${p => p.theme.charts.colors[0]};
+  background: ${p => (p.isDark ? p.theme.charts.colors[5] : p.theme.charts.colors[0])};
   border-radius: 2px;
   pointer-events: auto;
 `;


### PR DESCRIPTION


<!-- Describe your PR here. -->
### Changes
- Replaced the Network Span color in the dark mode. Closes #37242

Dark mode:
![image](https://user-images.githubusercontent.com/39612839/202046165-faa83649-7a23-4be2-a5e2-5cc726e4129a.png)

Light mode:
![image](https://user-images.githubusercontent.com/39612839/202046234-7e798aaa-074f-4026-ae1c-b8e0e643fb36.png)


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
