### PR TITLE
ref(tests): Convert `QueryList` tests to RTL

### DIFF
--- a/static/app/views/eventsV2/queryList.spec.jsx
+++ b/static/app/views/eventsV2/queryList.spec.jsx
@@ -1,7 +1,6 @@
 import {act} from 'react-dom/test-utils';
 import {browserHistory} from 'react-router';
 
-import {selectDropdownMenuItem} from 'sentry-test/dropdownMenu';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {

--- a/static/app/views/eventsV2/queryList.spec.jsx
+++ b/static/app/views/eventsV2/queryList.spec.jsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 
 import {selectDropdownMenuItem} from 'sentry-test/dropdownMenu';
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   screen,
@@ -29,6 +30,8 @@ describe('EventsV2 > QueryList', function () {
     queryChangeMock,
     updateHomepageMock,
     wrapper;
+
+  const {router, routerContext} = initializeOrg();
 
   beforeAll(async function () {
     await import('sentry/components/modals/widgetBuilder/addToDashboardModal');
@@ -172,22 +175,22 @@ describe('EventsV2 > QueryList', function () {
     expect(deleteMock).toHaveBeenCalled();
   });
 
-  it('returns short url location for saved query', function () {
-    wrapper = mountWithTheme(
+  it('redirects to Discover on card click', function () {
+    render(
       <QueryList
         organization={organization}
         savedQueries={savedQueries}
         pageLinks=""
         onQueryChange={queryChangeMock}
         location={location}
-      />
+      />,
+      {context: routerContext}
     );
-    const card = wrapper.find('QueryCard').last();
-    const link = card.find('Link').last().prop('to');
-    expect(link.pathname).toEqual('/organizations/org-slug/discover/results/');
-    expect(link.query).toEqual({
-      id: '2',
-      statsPeriod: '14d',
+
+    userEvent.click(screen.getAllByTestId(/card-*/).at(0));
+    expect(router.push).toHaveBeenLastCalledWith({
+      pathname: '/organizations/org-slug/discover/results/',
+      query: {id: '1', statsPeriod: '14d'},
     });
   });
 

--- a/static/app/views/eventsV2/queryList.spec.jsx
+++ b/static/app/views/eventsV2/queryList.spec.jsx
@@ -99,7 +99,7 @@ describe('EventsV2 > QueryList', function () {
   });
 
   it('renders pre-built queries and saved ones', function () {
-    wrapper = mountWithTheme(
+    render(
       <QueryList
         organization={organization}
         savedQueries={savedQueries}
@@ -110,9 +110,7 @@ describe('EventsV2 > QueryList', function () {
       />
     );
 
-    const content = wrapper.find('QueryCard');
-    // pre built + saved queries
-    expect(content).toHaveLength(5);
+    expect(screen.getAllByTestId(/card-.*/)).toHaveLength(5);
   });
 
   it('can duplicate and trigger change callback', async function () {

--- a/static/app/views/eventsV2/queryList.spec.jsx
+++ b/static/app/views/eventsV2/queryList.spec.jsx
@@ -149,7 +149,7 @@ describe('EventsV2 > QueryList', function () {
   });
 
   it('can delete and trigger change callback', async function () {
-    wrapper = mountWithTheme(
+    render(
       <QueryList
         organization={organization}
         savedQueries={savedQueries}
@@ -158,17 +158,18 @@ describe('EventsV2 > QueryList', function () {
         location={location}
       />
     );
-    const card = wrapper.find('QueryCard').last();
-    expect(card.find('QueryCardContent').text()).toEqual(savedQueries[1].name);
 
-    await selectDropdownMenuItem({
-      wrapper,
-      specifiers: {prefix: 'QueryCard', last: true},
-      itemKey: 'delete',
+    const card = screen.getAllByTestId(/card-*/).at(1);
+    const withinCard = within(card);
+
+    userEvent.click(withinCard.getByTestId('menu-trigger'));
+    userEvent.click(withinCard.getByText('Delete Query'));
+
+    await waitFor(() => {
+      expect(queryChangeMock).toHaveBeenCalled();
     });
 
     expect(deleteMock).toHaveBeenCalled();
-    expect(queryChangeMock).toHaveBeenCalled();
   });
 
   it('returns short url location for saved query', function () {

--- a/static/app/views/eventsV2/queryList.spec.jsx
+++ b/static/app/views/eventsV2/queryList.spec.jsx
@@ -1,8 +1,5 @@
-import {act} from 'react-dom/test-utils';
 import {browserHistory} from 'react-router';
-import {click} from '@testing-library/user-event/dist/click';
 
-import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
@@ -11,7 +8,6 @@ import {
   waitFor,
   within,
 } from 'sentry-test/reactTestingLibrary';
-import {triggerPress} from 'sentry-test/utils';
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
 import {DisplayModes} from 'sentry/utils/discover/types';

--- a/static/app/views/eventsV2/queryList.spec.jsx
+++ b/static/app/views/eventsV2/queryList.spec.jsx
@@ -84,7 +84,7 @@ describe('EventsV2 > QueryList', function () {
   });
 
   it('renders an empty list', function () {
-    wrapper = mountWithTheme(
+    render(
       <QueryList
         organization={organization}
         savedQueries={[]}
@@ -94,10 +94,8 @@ describe('EventsV2 > QueryList', function () {
         location={location}
       />
     );
-    const content = wrapper.find('QueryCard');
-    // No queries
-    expect(content).toHaveLength(0);
-    expect(wrapper.find('EmptyStateWarning')).toHaveLength(1);
+
+    expect(screen.getByText('No saved queries match that filter')).toBeInTheDocument();
   });
 
   it('renders pre-built queries and saved ones', function () {


### PR DESCRIPTION
I ran out of steam at the end, but didn't want to leave this hanging around. Converts the bulk of `QueryList` tests to RTL.
