### PR TITLE
chore(hybrid-cloud): Map /:orgId/:projectId/getting-started/* to /getting-started/:projectId/*

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1941,7 +1941,16 @@ function buildRoutes() {
       <Route
         path="/:orgId/:projectId/getting-started/"
         component={withDomainRedirect(
-          make(() => import('sentry/views/projectInstall/gettingStarted'))
+          make(() => import('sentry/views/projectInstall/gettingStarted')),
+          {
+            redirect: [
+              {
+                // If /:orgId/:projectId/getting-started/* is encountered, then redirect to /getting-started/:projectId/*
+                from: '/:orgId/:projectId/getting-started/',
+                to: '/getting-started/:projectId/',
+              },
+            ],
+          }
         )}
         key="org-getting-started"
       >

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1929,7 +1929,7 @@ function buildRoutes() {
     <Fragment>
       {usingCustomerDomain ? (
         <Route
-          path="/:projectId/getting-started/"
+          path="/getting-started/:projectId/"
           component={withDomainRequired(
             make(() => import('sentry/views/projectInstall/gettingStarted'))
           )}

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -72,9 +72,10 @@ function withDomainRedirect<P extends RouteComponentProps<{}, {}>>(
       }
 
       if (options && options.redirect) {
-        const result = options.redirect.find(needle => needle.from === fullRoute);
+        const result = options.redirect.find(needle => fullRoute.startsWith(needle.from));
         if (result) {
-          orglessSlugRoute = result.to;
+          const rest = fullRoute.slice(result.from.length);
+          orglessSlugRoute = `${result.to}${rest}`;
         }
       }
 


### PR DESCRIPTION
The route `/:projectId/getting-started/*` might collide with other routes where the project slug is legal. For example `/user-feedback/getting-started/`.

To resolve this, we map `/:orgId/:projectId/getting-started/*` to `/getting-started/:projectId/*`.

-----

I've also tweaked the redirect option behaviour for `withDomainRedirect()` such that we match at the beginning of the parameterized routes. For example, with the following configuration:

```js
{
  // If /:orgId/:projectId/getting-started/* is encountered, then redirect to /getting-started/:projectId/*
  from: '/:orgId/:projectId/getting-started/',
  to: '/getting-started/:projectId/',
}
```

The route `/:orgId/:projectId/getting-started/` will match paths that begin with it, such as `/:orgId/:projectId/getting-started/:platform/`, and will create a redirect to `/getting-started/:projectId/:platform/` while preserving the remaining path segments.