### PR TITLE
fix(ui): Use readable __400 accent colors for text & icons

### DIFF
--- a/docs-ui/components/doDont.tsx
+++ b/docs-ui/components/doDont.tsx
@@ -26,9 +26,9 @@ const Box = ({text, img, variant}: BoxProps) => (
     <Captions>
       <LabelWrap>
         {variant === 'do' ? (
-          <IconCheckmark color="green300" size="xs" />
+          <IconCheckmark color="successText" size="xs" />
         ) : (
-          <IconClose color="red300" size="xs" />
+          <IconClose color="dangerText" size="xs" />
         )}
         <Label className={variant === 'do' ? 'green' : 'red'}>
           {variant === 'do' ? 'DO' : "DON'T"}
@@ -105,10 +105,10 @@ const Label = styled('p')`
   margin-left: ${space(0.5)};
   margin-bottom: 0;
   &.green {
-    color: ${p => p.theme.green300};
+    color: ${p => p.theme.successText};
   }
   &.red {
-    color: ${p => p.theme.red300};
+    color: ${p => p.theme.errorText};
   }
 `;
 const Text = styled('p')`

--- a/static/app/components/alertBadge.tsx
+++ b/static/app/components/alertBadge.tsx
@@ -9,7 +9,7 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Color} from 'sentry/utils/theme';
+import {ColorOrAlias} from 'sentry/utils/theme';
 import {IncidentStatus} from 'sentry/views/alerts/types';
 
 type Props = {
@@ -21,19 +21,19 @@ type Props = {
 function AlertBadge({status, hideText = false, isIssue}: Props) {
   let statusText = t('Resolved');
   let Icon = IconCheckmark;
-  let color: Color = 'green300';
+  let color: ColorOrAlias = 'successText';
   if (isIssue) {
     statusText = t('Issue');
     Icon = IconIssues;
-    color = 'gray300';
+    color = 'subText';
   } else if (status === IncidentStatus.CRITICAL) {
     statusText = t('Critical');
     Icon = IconFire;
-    color = 'red300';
+    color = 'errorText';
   } else if (status === IncidentStatus.WARNING) {
     statusText = t('Warning');
     Icon = IconExclamation;
-    color = 'yellow300';
+    color = 'warningText';
   }
 
   return (
@@ -60,7 +60,7 @@ const Wrapper = styled('div')`
   align-items: center;
 `;
 
-const AlertIconWrapper = styled('div')<{color: Color; icon: React.ReactNode}>`
+const AlertIconWrapper = styled('div')<{color: ColorOrAlias; icon: React.ReactNode}>`
   width: 36px;
   height: 36px;
   position: relative;
@@ -77,7 +77,7 @@ const AlertIconWrapper = styled('div')<{color: Color; icon: React.ReactNode}>`
   }
 `;
 
-const AlertIconBackground = styled(IconDiamond)<{color: Color}>`
+const AlertIconBackground = styled(IconDiamond)<{color: ColorOrAlias}>`
   width: 36px;
   height: 36px;
 `;

--- a/static/app/components/alerts/toastIndicator.tsx
+++ b/static/app/components/alerts/toastIndicator.tsx
@@ -94,7 +94,7 @@ const Icon = styled('div', {shouldForwardProp: p => p !== 'type'})<{type: string
     display: block;
   }
 
-  color: ${p => (p.type === 'success' ? p.theme.green300 : p.theme.red300)};
+  color: ${p => (p.type === 'success' ? p.theme.successText : p.theme.errorText)};
 `;
 
 const Message = styled('div')`

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -384,7 +384,7 @@ export class AssigneeSelectorDropdown extends Component<
       >
         <MenuItemFooterWrapper>
           <IconContainer>
-            <IconAdd color="purple300" isCircled size="14px" />
+            <IconAdd color="activeText" isCircled size="14px" />
           </IconContainer>
           <Label>{t('Invite Member')}</Label>
         </MenuItemFooterWrapper>
@@ -461,7 +461,7 @@ export class AssigneeSelectorDropdown extends Component<
             <div>
               <MenuItemFooterWrapper role="button" onClick={this.clearAssignTo} py={0}>
                 <IconContainer>
-                  <IconClose color="purple300" isCircled size="14px" />
+                  <IconClose color="activeText" isCircled size="14px" />
                 </IconContainer>
                 <Label>{t('Clear Assignee')}</Label>
               </MenuItemFooterWrapper>
@@ -537,7 +537,7 @@ const MenuItemFooterWrapper = styled(MenuItemWrapper)`
   padding: ${space(0.25)} ${space(1)};
   border-top: 1px solid ${p => p.theme.innerBorder};
   background-color: ${p => p.theme.tag.highlight.background};
-  color: ${p => p.theme.active};
+  color: ${p => p.theme.activeText};
   :hover {
     color: ${p => p.theme.activeHover};
     svg {

--- a/static/app/components/commandLine.tsx
+++ b/static/app/components/commandLine.tsx
@@ -15,7 +15,7 @@ export default CommandLine;
 
 const Wrapper = styled('code')`
   padding: ${space(0.5)} ${space(1)};
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
   background: ${p => p.theme.pink100};
   border: 1px solid ${p => p.theme.pink200};
   font-family: ${p => p.theme.text.familyMono};

--- a/static/app/components/deprecatedforms/formField.tsx
+++ b/static/app/components/deprecatedforms/formField.tsx
@@ -175,5 +175,5 @@ export default class FormField<
 
 const ErrorMessage = styled('p')`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.errorText};
 `;

--- a/static/app/components/errors/detailedError.tsx
+++ b/static/app/components/errors/detailedError.tsx
@@ -39,7 +39,7 @@ function DetailedError({className, heading, message, onRetry, hideSupportLinks}:
   return (
     <Wrapper className={className}>
       <ErrorHeading>
-        <IconFlag size="md" color="red300" />
+        <IconFlag size="md" color="errorText" />
         {heading}
       </ErrorHeading>
 

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -82,7 +82,9 @@ function EventOrGroupExtraDetails({
         <CommentsLink to={`${issuesPath}${id}/activity/`} className="comments">
           <IconChat
             size="xs"
-            color={subscriptionDetails?.reason === 'mentioned' ? 'green300' : undefined}
+            color={
+              subscriptionDetails?.reason === 'mentioned' ? 'successText' : undefined
+            }
           />
           <span>{numComments}</span>
         </CommentsLink>

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -75,12 +75,12 @@ function EventOrGroupHeader({
         )}
         {!hideIcons && status === 'ignored' && (
           <IconWrapper>
-            <IconMute color="red300" />
+            <IconMute color="red400" />
           </IconWrapper>
         )}
         {!hideIcons && isBookmarked && (
           <IconWrapper>
-            <IconStar isSolid color="yellow300" />
+            <IconStar isSolid color="yellow400" />
           </IconWrapper>
         )}
         <ErrorBoundary customComponent={<EventTitleError />} mini>

--- a/static/app/components/events/eventVitals.tsx
+++ b/static/app/components/events/eventVitals.tsx
@@ -180,7 +180,7 @@ const WarningIconContainer = styled('span')<{size: IconSize | string}>`
   height: ${p => p.theme.iconSizes[p.size] ?? p.size};
   line-height: ${p => p.theme.iconSizes[p.size] ?? p.size};
   margin-left: ${space(0.5)};
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.errorText};
 `;
 
 const FireIconContainer = styled('span')<{size: IconSize | string}>`
@@ -188,12 +188,12 @@ const FireIconContainer = styled('span')<{size: IconSize | string}>`
   height: ${p => p.theme.iconSizes[p.size] ?? p.size};
   line-height: ${p => p.theme.iconSizes[p.size] ?? p.size};
   margin-right: ${space(0.5)};
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.errorText};
 `;
 
 const Value = styled('span')<{failedThreshold: boolean}>`
   font-size: ${p => p.theme.fontSizeExtraLarge};
-  ${p => p.failedThreshold && `color: ${p.theme.red300};`}
+  ${p => p.failedThreshold && `color: ${p.theme.errorText};`}
 `;
 
 export const EventVitalContainer = styled('div')``;

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -296,9 +296,9 @@ const VariantTitle = styled('h5')`
 
 const ContributionIcon = styled(({isContributing, ...p}) =>
   isContributing ? (
-    <IconCheckmark size="sm" isCircled color="green300" {...p} />
+    <IconCheckmark size="sm" isCircled color="successText" {...p} />
   ) : (
-    <IconClose size="sm" isCircled color="red300" {...p} />
+    <IconClose size="sm" isCircled color="dangerText" {...p} />
   )
 )`
   margin-right: ${space(1)};

--- a/static/app/components/events/interfaces/debugMeta/debugImage/processingIcon.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImage/processingIcon.tsx
@@ -18,7 +18,7 @@ function ProcessingIcon({status}: Props) {
           containerDisplayMode="inline-flex"
           title={t('The debug information file for this image could not be downloaded')}
         >
-          <IconWarning color="yellow300" size="xs" />
+          <IconWarning color="warningText" size="xs" />
         </Tooltip>
       );
     }
@@ -28,7 +28,7 @@ function ProcessingIcon({status}: Props) {
           containerDisplayMode="inline-flex"
           title={t('The debug information file for this image failed to process')}
         >
-          <IconWarning color="yellow300" size="xs" />
+          <IconWarning color="warningText" size="xs" />
         </Tooltip>
       );
     }
@@ -38,7 +38,7 @@ function ProcessingIcon({status}: Props) {
           containerDisplayMode="inline-flex"
           title={t('No debug information could be found in any of the specified sources')}
         >
-          <IconWarning color="yellow300" size="xs" />
+          <IconWarning color="warningText" size="xs" />
         </Tooltip>
       );
     }
@@ -50,7 +50,7 @@ function ProcessingIcon({status}: Props) {
             'Debug information for this image was found and successfully processed'
           )}
         >
-          <IconCheckmark color="green300" size="xs" />
+          <IconCheckmark color="successText" size="xs" />
         </Tooltip>
       );
     }
@@ -60,7 +60,7 @@ function ProcessingIcon({status}: Props) {
           containerDisplayMode="inline-flex"
           title={t('The image was not required for processing the stack trace')}
         >
-          <IconInfo color="gray200" size="xs" />
+          <IconInfo color="subText" size="xs" />
         </Tooltip>
       );
     }
@@ -70,7 +70,7 @@ function ProcessingIcon({status}: Props) {
           containerDisplayMode="inline-flex"
           title={t('An internal error occurred while handling this image')}
         >
-          <IconWarning color="yellow300" size="xs" />
+          <IconWarning color="warningText" size="xs" />
         </Tooltip>
       );
     }

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/information/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/information/index.tsx
@@ -211,7 +211,7 @@ function Information({
       <Fragment>
         <Tooltip title={tooltipDesc}>
           <TimeSinceWrapper>
-            {displayIcon && <IconWarning color="red300" size="xs" />}
+            {displayIcon && <IconWarning color="errorText" size="xs" />}
             {tct('Uploaded [timesince]', {
               timesince: <TimeSince disabledAbsoluteTooltip date={dateCreated} />,
             })}

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/information/processingIcon.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidate/information/processingIcon.tsx
@@ -14,12 +14,12 @@ type Props = {
 function ProcessingIcon({processingInfo}: Props) {
   switch (processingInfo.status) {
     case CandidateProcessingStatus.OK:
-      return <IconCheckmark color="green300" size="xs" />;
+      return <IconCheckmark color="successText" size="xs" />;
     case CandidateProcessingStatus.ERROR: {
       const {details} = processingInfo;
       return (
         <Tooltip title={details} disabled={!details}>
-          <IconClose color="red300" size="xs" />
+          <IconClose color="dangerText" size="xs" />
         </Tooltip>
       );
     }
@@ -27,7 +27,7 @@ function ProcessingIcon({processingInfo}: Props) {
       const {details} = processingInfo;
       return (
         <Tooltip title={details} disabled={!details}>
-          <IconWarning color="yellow300" size="xs" />
+          <IconWarning color="warningText" size="xs" />
         </Tooltip>
       );
     }

--- a/static/app/components/events/interfaces/frame/line.tsx
+++ b/static/app/components/events/interfaces/frame/line.tsx
@@ -416,7 +416,7 @@ const RepeatedFrames = styled('div')`
   border-width: thin;
   border-style: solid;
   border-color: ${p => p.theme.pink200};
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
   background-color: ${p => p.theme.backgroundSecondary};
   white-space: nowrap;
 `;

--- a/static/app/components/events/interfaces/frame/lineV2/default.tsx
+++ b/static/app/components/events/interfaces/frame/lineV2/default.tsx
@@ -108,7 +108,7 @@ const RepeatedFrames = styled('div')`
   border-width: thin;
   border-style: solid;
   border-color: ${p => p.theme.pink200};
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
   background-color: ${p => p.theme.backgroundSecondary};
   white-space: nowrap;
 `;

--- a/static/app/components/events/interfaces/frame/packageStatus.tsx
+++ b/static/app/components/events/interfaces/frame/packageStatus.tsx
@@ -13,12 +13,12 @@ function PackageStatus({status, tooltip}: Props) {
   const getIcon = () => {
     switch (status) {
       case 'success':
-        return <IconCheckmark isCircled color="green300" size="xs" />;
+        return <IconCheckmark isCircled color="successText" size="xs" />;
       case 'empty':
         return <IconCircle size="xs" />;
       case 'error':
       default:
-        return <IconFlag color="red300" size="xs" />;
+        return <IconFlag color="errorText" size="xs" />;
     }
   };
 

--- a/static/app/components/events/interfaces/frame/symbol.tsx
+++ b/static/app/components/events/interfaces/frame/symbol.tsx
@@ -159,7 +159,7 @@ const FileNameTooltip = styled(Tooltip)`
 `;
 
 const Filename = styled('span')`
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
 `;
 
 export const FunctionNameToggleIcon = styled(IconFilter, {

--- a/static/app/components/events/interfaces/frame/togglableAddress.tsx
+++ b/static/app/components/events/interfaces/frame/togglableAddress.tsx
@@ -79,7 +79,7 @@ function TogglableAddress({
           containerDisplayMode="inline-flex"
           delay={tooltipDelay}
         >
-          <AddressToggleIcon onClick={onToggle} size="xs" color="purple300" />
+          <AddressToggleIcon onClick={onToggle} size="xs" color="activeText" />
         </AddressIconTooltip>
       )}
       <Tooltip

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -29,7 +29,7 @@ import space from 'sentry/styles/space';
 import {Frame, PlatformType, SentryAppComponent} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
-import {Color} from 'sentry/utils/theme';
+import {ColorOrAlias} from 'sentry/utils/theme';
 import withSentryAppComponents from 'sentry/utils/withSentryAppComponents';
 
 import DebugImage from './debugMeta/debugImage';
@@ -236,18 +236,18 @@ function NativeFrame({
                   aria-label={t('Go to images loaded')}
                   icon={
                     status === 'error' ? (
-                      <IconQuestion size="sm" color="red300" />
+                      <IconQuestion size="sm" color="errorText" />
                     ) : (
-                      <IconWarning size="sm" color="red300" />
+                      <IconWarning size="sm" color="errorText" />
                     )
                   }
                   size="zero"
                   borderless
                 />
               ) : status === 'error' ? (
-                <IconQuestion size="sm" color="red300" />
+                <IconQuestion size="sm" color="errorText" />
               ) : (
-                <IconWarning size="sm" color="red300" />
+                <IconWarning size="sm" color="errorText" />
               ))}
           </StatusCell>
           <PackageCell>
@@ -267,9 +267,9 @@ function NativeFrame({
                 <Package
                   color={
                     status === undefined || status === 'error'
-                      ? 'red300'
+                      ? 'errorText'
                       : packageClickable
-                      ? 'blue300'
+                      ? 'linkColor'
                       : undefined
                   }
                   onClick={packageClickable ? handleGoToImagesLoaded : undefined}
@@ -294,7 +294,7 @@ function NativeFrame({
                 title={t('This frame appears in all other events related to this issue')}
                 containerDisplayMode="inline-flex"
               >
-                <IconInfo size="sm" color="gray300" />
+                <IconInfo size="sm" color="subText" />
               </Tooltip>
             )}
           </GroupingCell>
@@ -430,7 +430,7 @@ const ToggleButton = styled(Button)`
   height: 16px;
 `;
 
-const Package = styled('span')<{color?: Color}>`
+const Package = styled('span')<{color?: ColorOrAlias}>`
   border-bottom: 1px dashed ${p => p.theme.border};
   ${p => p.color && `color: ${p.theme[p.color]}`};
   ${p => p.onClick && `cursor: pointer;`}

--- a/static/app/components/events/interfaces/spans/measurementsPanel.tsx
+++ b/static/app/components/events/interfaces/spans/measurementsPanel.tsx
@@ -108,7 +108,7 @@ const Label = styled('div')<{
   transform: ${p => (p.isSingleLabel ? `translate(-50%, 15%)` : `translateY(15%)`)};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   font-weight: 600;
-  color: ${p => (p.failedThreshold ? `${p.theme.red300}` : `${p.theme.gray500}`)};
+  color: ${p => (p.failedThreshold ? `${p.theme.errorText}` : `${p.theme.textColor}`)};
   background: ${p => p.theme.white};
   border: 1px solid;
   border-color: ${p => (p.failedThreshold ? p.theme.red300 : p.theme.gray100)};

--- a/static/app/components/events/interfaces/threads/threadSelector/option.tsx
+++ b/static/app/components/events/interfaces/threads/threadSelector/option.tsx
@@ -5,7 +5,7 @@ import Tooltip from 'sentry/components/tooltip';
 import {IconFire} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {EntryData} from 'sentry/types';
-import {Color} from 'sentry/utils/theme';
+import {ColorOrAlias} from 'sentry/utils/theme';
 
 import {Grid, GridCell} from './styles';
 
@@ -40,10 +40,10 @@ const Option = ({id, details, name, crashed, crashedInfo}: Props) => {
                 disabled={!crashedInfo}
                 position="top"
               >
-                <IconFire color="red300" />
+                <IconFire color="errorText" />
               </Tooltip>
             ) : (
-              <IconFire color="red300" />
+              <IconFire color="errorText" />
             )}
           </InnerCell>
         )}
@@ -63,7 +63,7 @@ const Option = ({id, details, name, crashed, crashedInfo}: Props) => {
         </InnerCell>
       </GridCell>
       <GridCell>
-        <InnerCell color="blue300">
+        <InnerCell color="linkColor">
           <Tooltip title={label} position="top">
             <TextOverflow>{label}</TextOverflow>
           </Tooltip>
@@ -75,7 +75,11 @@ const Option = ({id, details, name, crashed, crashedInfo}: Props) => {
 
 export default Option;
 
-const InnerCell = styled('div')<{color?: Color; isBold?: boolean; isCentered?: boolean}>`
+const InnerCell = styled('div')<{
+  color?: ColorOrAlias;
+  isBold?: boolean;
+  isCentered?: boolean;
+}>`
   display: flex;
   align-items: center;
   justify-content: ${p => (p.isCentered ? 'center' : 'flex-start')};

--- a/static/app/components/events/meta/annotatedText/annotatedTextErrors.tsx
+++ b/static/app/components/events/meta/annotatedText/annotatedTextErrors.tsx
@@ -60,7 +60,7 @@ export function AnnotatedTextErrors({errors = []}: {errors: Array<MetaError>}) {
         )
       }
     >
-      <StyledIconWarning color="red300" />
+      <StyledIconWarning color="errorText" />
     </StyledTooltip>
   );
 }

--- a/static/app/components/group/inboxBadges/unhandledTag.tsx
+++ b/static/app/components/group/inboxBadges/unhandledTag.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 const UnhandledTag = () => (
   <Tooltip skipWrapper title={t('An unhandled error was detected in this Issue.')}>
     <UnhandledTagWrapper>
-      <StyledIconFatal size="xs" color="red300" />
+      <StyledIconFatal size="xs" color="errorText" />
       {t('Unhandled')}
     </UnhandledTagWrapper>
   </Tooltip>
@@ -19,7 +19,7 @@ const UnhandledTagWrapper = styled('div')`
   display: flex;
   align-items: center;
   white-space: nowrap;
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.errorText};
 `;
 
 const StyledIconFatal = styled(IconFatal)`

--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -333,5 +333,5 @@ const ButtonColumn = styled(Column)`
 `;
 
 const RedText = styled('span')`
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.errorText};
 `;

--- a/static/app/components/issueSyncListElement.tsx
+++ b/static/app/components/issueSyncListElement.tsx
@@ -139,7 +139,7 @@ export const IntegrationLink = styled('a')<{disabled?: boolean}>`
   text-overflow: ellipsis;
 
   &:hover {
-    color: ${({disabled, theme}) => (disabled ? theme.disabled : theme.blue300)};
+    color: ${({disabled, theme}) => (disabled ? theme.disabled : theme.linkColor)};
   }
 `;
 

--- a/static/app/components/modals/demoSignUp.tsx
+++ b/static/app/components/modals/demoSignUp.tsx
@@ -84,7 +84,7 @@ const Subheader = styled('h4')`
   margin-bottom: ${space(2)};
   text-transform: uppercase;
   font-weight: bold;
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
 `;
 

--- a/static/app/components/modals/demoSignUpV2.tsx
+++ b/static/app/components/modals/demoSignUpV2.tsx
@@ -111,7 +111,7 @@ const Subheader = styled('h4')`
   margin-bottom: ${space(2)};
   text-transform: uppercase;
   font-weight: bold;
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 

--- a/static/app/components/modals/inviteMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.tsx
@@ -505,10 +505,10 @@ const StatusMessage = styled('div')<{status?: 'success' | 'error'}>`
   gap: ${space(1)};
   align-items: center;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => (p.status === 'error' ? p.theme.red300 : p.theme.gray400)};
+  color: ${p => (p.status === 'error' ? p.theme.errorText : p.theme.textColor)};
 
   > :first-child {
-    ${p => p.status === 'success' && `color: ${p.theme.green300}`};
+    ${p => p.status === 'success' && `color: ${p.theme.successText}`};
   }
 `;
 

--- a/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/static/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -151,7 +151,7 @@ function getStyles(theme: Theme, inviteStatus: Props['inviteStatus']): StylesCon
         ...provided,
         ...(status?.error
           ? {
-              color: theme.red300,
+              color: theme.red400,
               border: `1px solid ${theme.red300}`,
               backgroundColor: theme.red100,
             }
@@ -163,7 +163,7 @@ function getStyles(theme: Theme, inviteStatus: Props['inviteStatus']): StylesCon
       return {
         ...provided,
         pointerEvents: 'all',
-        ...(status?.error ? {color: theme.red300} : {}),
+        ...(status?.error ? {color: theme.red400} : {}),
       };
     },
     multiValueRemove: (provided, {data}: MultiValueProps<SelectOption>) => {
@@ -173,7 +173,7 @@ function getStyles(theme: Theme, inviteStatus: Props['inviteStatus']): StylesCon
         ...(status?.error
           ? {
               borderLeft: `1px solid ${theme.red300}`,
-              ':hover': {backgroundColor: theme.red100, color: theme.red300},
+              ':hover': {backgroundColor: theme.red100, color: theme.red400},
             }
           : {}),
       };

--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -236,7 +236,7 @@ const Author = styled('div')`
 
 const DisabledNotice = styled(({reason, ...p}: {reason: React.ReactNode}) => (
   <div {...p}>
-    <IconFlag color="red300" size="1.5em" />
+    <IconFlag color="errorText" size="1.5em" />
     {reason}
   </div>
 ))`
@@ -244,7 +244,7 @@ const DisabledNotice = styled(({reason, ...p}: {reason: React.ReactNode}) => (
   align-items: center;
   flex: 1;
   grid-template-columns: max-content 1fr;
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.errorText};
   font-size: 0.9em;
 `;
 

--- a/static/app/components/mutedBox.tsx
+++ b/static/app/components/mutedBox.tsx
@@ -59,7 +59,7 @@ function MutedBox({statusDetails}: Props) {
   return (
     <BannerContainer priority="default">
       <BannerSummary>
-        <IconMute color="red300" size="sm" />
+        <IconMute color="dangerText" size="sm" />
         <span>
           {renderReason()}&nbsp;&mdash;&nbsp;
           {t(

--- a/static/app/components/onboardingWizard/modalTask.tsx
+++ b/static/app/components/onboardingWizard/modalTask.tsx
@@ -11,7 +11,7 @@ export default function ModalTask({title}: Props) {
   return (
     <TaskCard>
       <Title>
-        {<IconCheckmark isCircled color="green300" />}
+        {<IconCheckmark isCircled color="successText" />}
         {title}
       </Title>
     </TaskCard>

--- a/static/app/components/onboardingWizard/onboardingProjectsCard.tsx
+++ b/static/app/components/onboardingWizard/onboardingProjectsCard.tsx
@@ -97,7 +97,7 @@ export default function OnboardingProjectsCard({
 
 const Heading = styled(motion.div)`
   display: flex;
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   text-transform: uppercase;
   font-weight: 600;
@@ -170,7 +170,7 @@ const PulsingIndicator = styled('div')`
   margin-left: auto;
 `;
 const PulsingIndicatorText = styled('span')`
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: 0 ${space(1)};
 `;

--- a/static/app/components/onboardingWizard/sidebar.tsx
+++ b/static/app/components/onboardingWizard/sidebar.tsx
@@ -42,7 +42,7 @@ const COMPLETION_SEEN_TIMEOUT = 800;
 
 const Heading = styled(motion.div)`
   display: flex;
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   text-transform: uppercase;
   font-weight: 600;

--- a/static/app/components/onboardingWizard/task.tsx
+++ b/static/app/components/onboardingWizard/task.tsx
@@ -122,7 +122,7 @@ function Task(props: Props) {
         requisite: task.requisiteTasks[0].title,
       })}
     >
-      <IconLock color="pink300" isSolid />
+      <IconLock color="pink400" isSolid />
     </Tooltip>
   );
 
@@ -224,7 +224,7 @@ const InProgressIndicator = styled(({user, ...props}: InProgressIndicatorProps) 
 ))`
   font-size: ${p => p.theme.fontSizeMedium};
   font-weight: bold;
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
   display: grid;
   grid-template-columns: max-content max-content;
   align-items: center;
@@ -260,7 +260,7 @@ CompleteIndicator.defaultProps = {
 const SkippedIndicator = styled(IconClose)``;
 SkippedIndicator.defaultProps = {
   isCircled: true,
-  color: 'pink300',
+  color: 'pink400',
 };
 
 const completedItemAnimation = {

--- a/static/app/components/onboardingWizard/taskConfig.tsx
+++ b/static/app/components/onboardingWizard/taskConfig.tsx
@@ -433,5 +433,5 @@ const EventWaitingIndicator = styled(
   align-items: center;
   flex-grow: 1;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
 `;

--- a/static/app/components/organizations/pageFilterRow.tsx
+++ b/static/app/components/organizations/pageFilterRow.tsx
@@ -99,7 +99,7 @@ const Label = styled('div')<{multi: boolean}>`
 
   &:hover {
     text-decoration: ${p => (p.multi ? 'underline' : null)};
-    color: ${p => (p.multi ? p.theme.blue300 : null)};
+    color: ${p => (p.multi ? p.theme.linkColor : null)};
   }
 `;
 

--- a/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
+++ b/static/app/components/organizations/pageFilters/desyncedFiltersAlert.tsx
@@ -69,7 +69,7 @@ export default function DesyncedFilterAlert({
           <Button
             priority="link"
             size="zero"
-            icon={<IconClose color="purple300" />}
+            icon={<IconClose color="activeText" />}
             aria-label={t('Close Alert')}
             onClick={() => setHideAlert(true)}
           />
@@ -96,7 +96,7 @@ const RevertButton = styled(Button)`
   display: flex;
   font-weight: bold;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
 
   &:after {
     content: '|';

--- a/static/app/components/performance/waterfall/rowDivider.tsx
+++ b/static/app/components/performance/waterfall/rowDivider.tsx
@@ -66,8 +66,8 @@ const BadgeBorder = styled('div')<{borderColor: Color | keyof Aliases}>`
 
 export function ErrorBadge() {
   return (
-    <BadgeBorder borderColor="red300">
-      <IconFire color="red300" size="xs" />
+    <BadgeBorder borderColor="error">
+      <IconFire color="errorText" size="xs" />
     </BadgeBorder>
   );
 }

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -302,7 +302,7 @@ const TaskList = styled('div')`
 
 const Heading = styled('div')`
   display: flex;
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   text-transform: uppercase;
   font-weight: 600;
@@ -331,7 +331,7 @@ const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) =
   align-items: center;
   flex-grow: 1;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
 `;
 
 const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
@@ -344,7 +344,7 @@ const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) 
   align-items: center;
   flex-grow: 1;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.green300};
+  color: ${p => p.theme.successText};
 `;
 
 export default PerformanceOnboardingSidebar;

--- a/static/app/components/profiling/ProfilingOnboarding/proflingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/proflingOnboardingSidebar.tsx
@@ -224,7 +224,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
 
 const Heading = styled('div')`
   display: flex;
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   text-transform: uppercase;
   font-weight: 600;

--- a/static/app/components/profiling/arrayLinks.tsx
+++ b/static/app/components/profiling/arrayLinks.tsx
@@ -68,7 +68,7 @@ const ButtonContainer = styled('div')`
     outline: none;
     padding: 0;
     cursor: pointer;
-    color: ${p => p.theme.blue300};
+    color: ${p => p.theme.linkColor};
     margin-left: ${space(0.5)};
   }
 `;

--- a/static/app/components/projects/bookmarkStar.tsx
+++ b/static/app/components/projects/bookmarkStar.tsx
@@ -42,7 +42,7 @@ function BookmarkStar({className, organization, project, onToggle}: Props) {
       priority="link"
       className={className}
       icon={
-        <IconStar color={isBookmarked ? 'yellow300' : 'subText'} isSolid={isBookmarked} />
+        <IconStar color={isBookmarked ? 'yellow400' : 'subText'} isSolid={isBookmarked} />
       }
     />
   );

--- a/static/app/components/quickTrace/styles.tsx
+++ b/static/app/components/quickTrace/styles.tsx
@@ -28,7 +28,7 @@ const nodeColors = (theme: Theme) => ({
     border: theme.red300,
   },
   warning: {
-    color: theme.red300,
+    color: theme.errorText,
     background: theme.background,
     border: theme.red300,
   },

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -225,7 +225,7 @@ const TaskList = styled('div')`
 
 const Heading = styled('div')`
   display: flex;
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   text-transform: uppercase;
   font-weight: 600;
@@ -254,7 +254,7 @@ const EventWaitingIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) =
   align-items: center;
   flex-grow: 1;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.pink300};
+  color: ${p => p.theme.pink400};
 `;
 
 const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) => (
@@ -267,7 +267,7 @@ const EventReceivedIndicator = styled((p: React.HTMLAttributes<HTMLDivElement>) 
   align-items: center;
   flex-grow: 1;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.green300};
+  color: ${p => p.theme.successText};
 `;
 
 export default ReplaysOnboardingSidebar;

--- a/static/app/components/reprocessedBox.tsx
+++ b/static/app/components/reprocessedBox.tsx
@@ -78,10 +78,10 @@ class ReprocessedBox extends Component<Props, State> {
     return (
       <BannerContainer priority="success" className={className}>
         <StyledBannerSummary>
-          <IconCheckmark color="green300" isCircled />
+          <IconCheckmark color="successText" isCircled />
           <span>{this.renderMessage()}</span>
           <StyledIconClose
-            color="green300"
+            color="successText"
             aria-label={t('Dismiss')}
             isCircled
             onClick={this.handleBannerDismiss}

--- a/static/app/components/resolutionBox.tsx
+++ b/static/app/components/resolutionBox.tsx
@@ -118,7 +118,7 @@ function ResolutionBox({statusDetails, projectId, activities = []}: Props) {
   return (
     <BannerContainer priority="default">
       <BannerSummary>
-        <StyledIconCheckmark color="green300" />
+        <StyledIconCheckmark color="successText" />
         <span>{renderReason(statusDetails, projectId, activities)}</span>
       </BannerSummary>
     </BannerContainer>

--- a/static/app/components/scoreCard.tsx
+++ b/static/app/components/scoreCard.tsx
@@ -39,11 +39,11 @@ function ScoreCard({title, score, help, trend, trendStatus, className}: Props) {
 function getTrendColor(p: TrendProps & {theme: Theme}) {
   switch (p.trendStatus) {
     case 'good':
-      return p.theme.green300;
+      return p.theme.successText;
     case 'bad':
-      return p.theme.red300;
+      return p.theme.errorText;
     default:
-      return p.theme.gray300;
+      return p.theme.subText;
   }
 }
 

--- a/static/app/components/search/searchResult.tsx
+++ b/static/app/components/search/searchResult.tsx
@@ -114,7 +114,7 @@ const ExtraDetail = styled('div')`
 
 const BadgeDetail = styled('div')<{highlighted: boolean}>`
   line-height: 1.3;
-  color: ${p => (p.highlighted ? p.theme.purple300 : null)};
+  color: ${p => (p.highlighted ? p.theme.activeText : null)};
 `;
 
 const Wrapper = styled('div')`

--- a/static/app/components/search/searchResultWrapper.tsx
+++ b/static/app/components/search/searchResultWrapper.tsx
@@ -21,7 +21,7 @@ const SearchResultWrapper = styled(({highlighted, ...props}: Props) => (
   ${p =>
     p.highlighted &&
     css`
-      color: ${p.theme.purple300};
+      color: ${p.theme.activeText};
       background: ${p.theme.backgroundSecondary};
     `};
 

--- a/static/app/components/sidebar/serviceIncidents.tsx
+++ b/static/app/components/sidebar/serviceIncidents.tsx
@@ -172,15 +172,15 @@ function getStatusSymbol(status: Status) {
   return (
     <Tooltip skipWrapper title={startCase(status)}>
       {status === 'operational' ? (
-        <IconCheckmark size="sm" isCircled color="green300" />
+        <IconCheckmark size="sm" isCircled color="successText" />
       ) : status === 'major_outage' ? (
-        <IconFatal size="sm" color="red300" />
+        <IconFatal size="sm" color="errorText" />
       ) : status === 'degraded_performance' ? (
-        <IconWarning size="sm" color="yellow300" />
+        <IconWarning size="sm" color="warningText" />
       ) : status === 'partial_outage' ? (
-        <IconFire size="sm" color="yellow300" />
+        <IconFire size="sm" color="warningText" />
       ) : (
-        <IconInfo size="sm" color="gray300" />
+        <IconInfo size="sm" color="subText" />
       )}
     </Tooltip>
   );

--- a/static/app/components/sidebar/taskSidebar.tsx
+++ b/static/app/components/sidebar/taskSidebar.tsx
@@ -64,7 +64,7 @@ export const EventIndicator = styled(
   align-items: center;
   flex-grow: 1;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => (p.status === 'waiting' ? p.theme.pink300 : p.theme.green300)};
+  color: ${p => (p.status === 'waiting' ? p.theme.pink400 : p.theme.green400)};
 `;
 
 export const PulsingIndicator = styled('div')`

--- a/static/app/components/smartSearchBar/actions.tsx
+++ b/static/app/components/smartSearchBar/actions.tsx
@@ -175,7 +175,7 @@ export function makeSaveSearchAction({
 }
 
 export const ActionButton = styled(Button)<{isActive?: boolean}>`
-  color: ${p => (p.isActive ? p.theme.blue300 : p.theme.gray300)};
+  color: ${p => (p.isActive ? p.theme.linkColor : p.theme.subText)};
   width: 18px;
   height: 18px;
   padding: 2px;

--- a/static/app/utils/discover/arrayValue.tsx
+++ b/static/app/utils/discover/arrayValue.tsx
@@ -57,7 +57,7 @@ const ArrayContainer = styled('div')<{expanded: boolean}>`
     outline: none;
     padding: 0;
     cursor: pointer;
-    color: ${p => p.theme.blue300};
+    color: ${p => p.theme.linkColor};
     margin-left: ${space(0.5)};
   }
 `;

--- a/static/app/utils/discover/teamKeyTransactionField.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.tsx
@@ -14,7 +14,7 @@ function TitleStar({isOpen, keyedTeams, initialValue, ...props}: TitleProps) {
   const keyedTeamsCount = keyedTeams?.length ?? initialValue ?? 0;
   const star = (
     <IconStar
-      color={keyedTeamsCount ? 'yellow300' : 'gray200'}
+      color={keyedTeamsCount ? 'yellow400' : 'gray200'}
       isSolid={keyedTeamsCount > 0}
       data-test-id="team-key-transaction-column"
     />

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -208,6 +208,18 @@ const generateAliases = (colors: BaseColors) => ({
   errorText: colors.red400,
 
   /**
+   * A color that denotes danger, for dangerous actions like deletion
+   */
+  danger: colors.red300,
+  dangerText: colors.red400,
+
+  /**
+   * A color that denotes a warning
+   */
+  warning: colors.yellow300,
+  warningText: colors.yellow400,
+
+  /**
    * A color that indicates something is disabled where user can not interact or use
    * it in the usual manner (implies that there is an "enabled" state)
    */

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -23,7 +23,7 @@ import {IconArrow, IconChevron, IconEllipsis, IconUser} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Actor, Project} from 'sentry/types';
-import type {Color} from 'sentry/utils/theme';
+import type {ColorOrAlias} from 'sentry/utils/theme';
 import {getThresholdUnits} from 'sentry/views/alerts/rules/metric/constants';
 import {
   AlertRuleComparisonType,
@@ -125,7 +125,7 @@ function RuleListRow({
         ? criticalTrigger
         : warningTrigger ?? criticalTrigger;
 
-    let iconColor: Color = 'green300';
+    let iconColor: ColorOrAlias = 'successText';
     let iconDirection: 'up' | 'down' | undefined;
     let thresholdTypeText =
       activeIncident && rule.thresholdType === AlertRuleThresholdType.ABOVE
@@ -135,10 +135,10 @@ function RuleListRow({
     if (activeIncident) {
       iconColor =
         trigger?.label === AlertRuleTriggerType.CRITICAL
-          ? 'red300'
+          ? 'errorText'
           : trigger?.label === AlertRuleTriggerType.WARNING
-          ? 'yellow300'
-          : 'green300';
+          ? 'warningText'
+          : 'successText';
       iconDirection = rule.thresholdType === AlertRuleThresholdType.ABOVE ? 'up' : 'down';
     } else {
       // Use the Resolved threshold type, which is opposite of Critical

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -214,15 +214,15 @@ class MetricChart extends PureComponent<Props, State> {
           <SectionHeading>{t('Summary')}</SectionHeading>
           <StyledSectionValue>
             <ValueItem>
-              <IconCheckmark color="green300" isCircled />
+              <IconCheckmark color="successText" isCircled />
               {resolvedPercent ? resolvedPercent.toFixed(2) : 0}%
             </ValueItem>
             <ValueItem>
-              <IconWarning color="yellow300" />
+              <IconWarning color="warningText" />
               {warningPercent ? warningPercent.toFixed(2) : 0}%
             </ValueItem>
             <ValueItem>
-              <IconFire color="red300" />
+              <IconFire color="errorText" />
               {criticalPercent ? criticalPercent.toFixed(2) : 0}%
             </ValueItem>
           </StyledSectionValue>

--- a/static/app/views/alerts/rules/metric/details/sidebar.tsx
+++ b/static/app/views/alerts/rules/metric/details/sidebar.tsx
@@ -56,10 +56,10 @@ export default class Sidebar extends PureComponent<Props> {
 
     const statusIconColor =
       label === AlertRuleTriggerType.CRITICAL
-        ? 'red300'
+        ? 'errorText'
         : label === AlertRuleTriggerType.WARNING
-        ? 'yellow300'
-        : 'green300';
+        ? 'warningText'
+        : 'successText';
 
     const defaultAction = t('Change alert status to %s', status);
 

--- a/static/app/views/alerts/rules/metric/triggers/form.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/form.tsx
@@ -173,14 +173,14 @@ class TriggerFormContainer extends Component<TriggerFormContainerProps> {
 
   getIndicator(type: AlertRuleTriggerType) {
     if (type === AlertRuleTriggerType.CRITICAL) {
-      return <StyledIconDiamond color="red300" size="sm" />;
+      return <StyledIconDiamond color="errorText" size="sm" />;
     }
 
     if (type === AlertRuleTriggerType.WARNING) {
-      return <StyledIconDiamond color="yellow300" size="sm" />;
+      return <StyledIconDiamond color="warningText" size="sm" />;
     }
 
-    return <StyledIconDiamond color="green300" size="sm" />;
+    return <StyledIconDiamond color="successText" size="sm" />;
   }
 
   render() {

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -434,7 +434,7 @@ class CellAction extends Component<Props, State> {
           <Reference>
             {({ref}) => (
               <MenuButton ref={ref} onClick={this.handleMenuToggle}>
-                <IconEllipsis size="sm" data-test-id="cell-action" color="blue300" />
+                <IconEllipsis size="sm" data-test-id="cell-action" color="linkColor" />
               </MenuButton>
             )}
           </Reference>

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -666,7 +666,7 @@ class QueryField extends Component<Props> {
           />
           {error ? (
             <ArithmeticError title={error}>
-              <IconWarning color="red300" />
+              <IconWarning color="errorText" />
             </ArithmeticError>
           ) : null}
         </Container>
@@ -830,12 +830,12 @@ const BlankSpace = styled('div')`
   &:after {
     font-size: ${p => p.theme.fontSizeMedium};
     content: '${t('No parameter')}';
-    color: ${p => p.theme.gray300};
+    color: ${p => p.theme.subText};
   }
 `;
 
 const ArithmeticError = styled(Tooltip)`
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.errorText};
   animation: ${() => pulse(1.15)} 1s ease infinite;
   display: flex;
 `;

--- a/static/app/views/integrationPipeline/awsLambdaFailureDetails.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaFailureDetails.tsx
@@ -27,7 +27,7 @@ export default function AwsLambdaFailureDetails({
       <HeaderWithHelp docsUrl={baseDocsUrl} />
       <Wrapper>
         <div>
-          <StyledCheckmark isCircled color="green300" />
+          <StyledCheckmark isCircled color="successText" />
           <h3>
             {tn(
               'successfully updated %s function',
@@ -37,7 +37,7 @@ export default function AwsLambdaFailureDetails({
           </h3>
         </div>
         <div>
-          <StyledWarning color="red300" />
+          <StyledWarning color="errorText" />
           <h3>
             {tn(
               'Failed to update %s function',

--- a/static/app/views/monitors/checkInIcon.tsx
+++ b/static/app/views/monitors/checkInIcon.tsx
@@ -24,7 +24,7 @@ export default styled('div')<Props>`
             : p.status === 'ok'
             ? p.theme.success
             : p.status === 'missed'
-            ? p.theme.yellow300
+            ? p.theme.warning
             : p.theme.disabled
         };`};
 `;

--- a/static/app/views/monitors/monitorIcon.tsx
+++ b/static/app/views/monitors/monitorIcon.tsx
@@ -18,7 +18,7 @@ export default styled('div')<{size: number; status: Status}>`
             : p.status === 'ok'
             ? p.theme.success
             : p.status === 'missed_checkin'
-            ? p.theme.yellow300
+            ? p.theme.warning
             : p.theme.disabled
         };`};
 `;

--- a/static/app/views/onboarding/components/firstEventFooter.tsx
+++ b/static/app/views/onboarding/components/firstEventFooter.tsx
@@ -133,7 +133,7 @@ const AnimatedText = styled(motion.div, {
   shouldForwardProp: prop => prop !== 'errorReceived',
 })<{errorReceived: boolean}>`
   margin-left: ${space(1)};
-  color: ${p => (p.errorReceived ? p.theme.successText : p.theme.pink300)};
+  color: ${p => (p.errorReceived ? p.theme.successText : p.theme.pink400)};
 `;
 
 const indicatorAnimation: Variants = {

--- a/static/app/views/onboarding/components/projectSidebarSection.tsx
+++ b/static/app/views/onboarding/components/projectSidebarSection.tsx
@@ -79,7 +79,7 @@ const Title = styled('span')`
 `;
 
 const SubHeader = styled('div')<{errorReceived: boolean}>`
-  color: ${p => (p.errorReceived ? p.theme.successText : p.theme.pink300)};
+  color: ${p => (p.errorReceived ? p.theme.successText : p.theme.pink400)};
 `;
 
 const StyledPlatformIcon = styled(PlatformIcon)``;

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -370,7 +370,7 @@ const Content = styled(motion.div)`
 
   code {
     font-size: 87.5%;
-    color: ${p => p.theme.pink300};
+    color: ${p => p.theme.pink400};
   }
 
   pre code {

--- a/static/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/static/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -97,7 +97,7 @@ class GroupEventToolbar extends Component<Props> {
                 fixed: 'Dummy timestamp',
               })}
             />
-            {isOverLatencyThreshold && <StyledIconWarning color="yellow300" />}
+            {isOverLatencyThreshold && <StyledIconWarning color="warningText" />}
           </Tooltip>
           <StyledGlobalAppStoreConnectUpdateAlert
             project={project}

--- a/static/app/views/organizationGroupDetails/groupTags.tsx
+++ b/static/app/views/organizationGroupDetails/groupTags.tsx
@@ -160,7 +160,7 @@ const StyledPanel = styled(Panel)`
 const TagHeading = styled('h5')`
   font-size: ${p => p.theme.fontSizeLarge};
   margin-bottom: 0;
-  color: ${p => p.theme.blue300};
+  color: ${p => p.theme.linkColor};
 `;
 
 const UnstyledUnorderedList = styled('ul')`

--- a/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/static/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -430,7 +430,7 @@ const Name = styled('div')`
 `;
 
 const IconCloseCircle = styled(IconClose)`
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.dangerText};
   margin-right: ${space(1)};
 `;
 

--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -16,7 +16,7 @@ import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {formatPercentage} from 'sentry/utils/formatters';
-import {Color} from 'sentry/utils/theme';
+import {ColorOrAlias} from 'sentry/utils/theme';
 import {MetricRule} from 'sentry/views/alerts/rules/metric/types';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
@@ -102,7 +102,7 @@ class TeamAlertsTriggered extends AsyncComponent<Props, State> {
     }
 
     return (
-      <SubText color={diff <= 0 ? 'green300' : 'red300'}>
+      <SubText color={diff <= 0 ? 'successText' : 'errorText'}>
         {formatPercentage(Math.abs(diff / weeklyAvg), 0)}
         <PaddedIconArrow direction={diff <= 0 ? 'down' : 'up'} size="xs" />
       </SubText>
@@ -244,7 +244,7 @@ const PaddedIconArrow = styled(IconArrow)`
   margin: 0 ${space(0.5)};
 `;
 
-const SubText = styled('div')<{color: Color}>`
+const SubText = styled('div')<{color: ColorOrAlias}>`
   color: ${p => p.theme[p.color]};
 `;
 

--- a/static/app/views/organizationStats/teamInsights/teamMisery.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamMisery.tsx
@@ -21,7 +21,7 @@ import DiscoverQuery, {
 import EventView from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {QueryError} from 'sentry/utils/discover/genericDiscoverQuery';
-import type {Color} from 'sentry/utils/theme';
+import type {ColorOrAlias} from 'sentry/utils/theme';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
@@ -96,7 +96,7 @@ function TeamMisery({
             }
             headers={[
               <FlexCenter key="transaction">
-                <StyledIconStar isSolid color="yellow300" /> {t('Key transaction')}
+                <StyledIconStar isSolid color="yellow400" /> {t('Key transaction')}
               </FlexCenter>,
               t('Project'),
               tct('Last [period]', {period}),
@@ -129,7 +129,7 @@ function TeamMisery({
                 <Fragment key={idx}>
                   <KeyTransactionTitleWrapper>
                     <div>
-                      <StyledIconStar isSolid color="yellow300" />
+                      <StyledIconStar isSolid color="yellow400" />
                     </div>
                     <TransactionWrapper>
                       <Link
@@ -158,7 +158,7 @@ function TeamMisery({
                         {t('change')}
                       </SubText>
                     ) : (
-                      <TrendText color={trend >= 0 ? 'green300' : 'red300'}>
+                      <TrendText color={trend >= 0 ? 'successText' : 'errorText'}>
                         {`${trendValue}\u0025 `}
                         {trend >= 0 ? t('better') : t('worse')}
                       </TrendText>
@@ -329,6 +329,6 @@ const SubText = styled('div')`
   color: ${p => p.theme.subText};
 `;
 
-const TrendText = styled('div')<{color: Color}>`
+const TrendText = styled('div')<{color: ColorOrAlias}>`
   color: ${p => p.theme[p.color]};
 `;

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -18,7 +18,7 @@ import {IconArrow} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
-import {Color, Theme} from 'sentry/utils/theme';
+import {ColorOrAlias, Theme} from 'sentry/utils/theme';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
 import {barAxisLabel, groupByTrend, sortSeriesByDay} from './utils';
@@ -163,7 +163,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
     }
 
     return (
-      <SubText color={trend >= 0 ? 'green300' : 'red300'}>
+      <SubText color={trend >= 0 ? 'successText' : 'errorText'}>
         {`${round(Math.abs(trend), 3)}`}
         <PaddedIconArrow direction={trend >= 0 ? 'up' : 'down'} size="xs" />
       </SubText>
@@ -341,6 +341,6 @@ const PaddedIconArrow = styled(IconArrow)`
   margin: 0 ${space(0.5)};
 `;
 
-const SubText = styled('div')<{color: Color}>`
+const SubText = styled('div')<{color: ColorOrAlias}>`
   color: ${p => p.theme[p.color]};
 `;

--- a/static/app/views/organizationStats/teamInsights/teamStability.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamStability.tsx
@@ -24,7 +24,7 @@ import {
 } from 'sentry/types';
 import {formatFloat} from 'sentry/utils/formatters';
 import {getCountSeries, getCrashFreeRate, getSeriesSum} from 'sentry/utils/sessions';
-import {Color} from 'sentry/utils/theme';
+import {ColorOrAlias} from 'sentry/utils/theme';
 import {displayCrashFreePercent} from 'sentry/views/releases/utils';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
@@ -210,7 +210,7 @@ class TeamStability extends AsyncComponent<Props, State> {
     }
 
     return (
-      <SubText color={trend >= 0 ? 'green300' : 'red300'}>
+      <SubText color={trend >= 0 ? 'successText' : 'errorText'}>
         {`${round(Math.abs(trend), 3)}\u0025`}
         <PaddedIconArrow direction={trend >= 0 ? 'up' : 'down'} size="xs" />
       </SubText>
@@ -326,6 +326,6 @@ const PaddedIconArrow = styled(IconArrow)`
   margin: 0 ${space(0.5)};
 `;
 
-const SubText = styled('div')<{color: Color}>`
+const SubText = styled('div')<{color: ColorOrAlias}>`
   color: ${p => p.theme[p.color]};
 `;

--- a/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamUnresolvedIssues.tsx
@@ -13,7 +13,7 @@ import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {formatPercentage} from 'sentry/utils/formatters';
-import type {Color} from 'sentry/utils/theme';
+import type {ColorOrAlias} from 'sentry/utils/theme';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
 import {
@@ -206,10 +206,10 @@ class TeamUnresolvedIssues extends AsyncComponent<Props, State> {
                         <SubText
                           color={
                             totals.percentChange === 0
-                              ? 'gray300'
+                              ? 'subText'
                               : totals.percentChange > 0
-                              ? 'red300'
-                              : 'green300'
+                              ? 'errorText'
+                              : 'successText'
                           }
                         >
                           {formatPercentage(
@@ -270,6 +270,6 @@ const PaddedIconArrow = styled(IconArrow)`
   margin: 0 ${space(0.5)};
 `;
 
-const SubText = styled('div')<{color: Color}>`
+const SubText = styled('div')<{color: ColorOrAlias}>`
   color: ${p => p.theme[p.color]};
 `;

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -364,7 +364,7 @@ class _Table extends Component<Props, State> {
             <TeamKeyTransactionWrapper>
               <IconStar
                 key="keyTransaction"
-                color="yellow300"
+                color="yellow400"
                 isSolid
                 data-test-id="team-key-transaction-header"
               />

--- a/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
+++ b/static/app/views/performance/transactionSummary/teamKeyTransactionButton.tsx
@@ -26,7 +26,7 @@ class TitleButton extends Component<TitleProps> {
       <Button
         {...props}
         size="sm"
-        icon={keyedTeamsCount ? <IconStar color="yellow300" isSolid /> : <IconStar />}
+        icon={keyedTeamsCount ? <IconStar color="yellow400" isSolid /> : <IconStar />}
       >
         {keyedTeamsCount
           ? tn('Starred for Team', 'Starred for Teams', keyedTeamsCount)

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomaliesTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomaliesTable.tsx
@@ -113,10 +113,10 @@ const NumberCell = styled('div')`
 `;
 
 const LowConfidence = styled('div')`
-  color: ${p => p.theme.yellow300};
+  color: ${p => p.theme.yellow400};
 `;
 const HighConfidence = styled('div')`
-  color: ${p => p.theme.red300};
+  color: ${p => p.theme.red400};
 `;
 
 const ConfidenceCell = styled('div')`

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -301,7 +301,7 @@ class Table extends Component<Props, State> {
           const star = (
             <IconStar
               key="keyTransaction"
-              color="yellow300"
+              color="yellow400"
               isSolid
               data-test-id="key-transaction-header"
             />

--- a/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/static/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -282,9 +282,9 @@ function VitalDetailContent(props: Props) {
             {Object.values(Browser).map(browser => (
               <BrowserItem key={browser}>
                 {vitalSupportedBrowsers[vitalName]?.includes(browser) ? (
-                  <IconCheckmark color="green300" size="sm" />
+                  <IconCheckmark color="successText" size="sm" />
                 ) : (
-                  <IconClose color="red300" size="sm" />
+                  <IconClose color="dangerText" size="sm" />
                 )}
                 {browser}
               </BrowserItem>

--- a/static/app/views/projectDetail/projectLatestAlerts.tsx
+++ b/static/app/views/projectDetail/projectLatestAlerts.tsx
@@ -248,7 +248,7 @@ type StatusColorProps = {
 };
 
 const getStatusColor = ({isResolved, isWarning}: StatusColorProps) =>
-  isResolved ? 'green300' : isWarning ? 'yellow300' : 'red300';
+  isResolved ? 'successText' : isWarning ? 'warningText' : 'errorText';
 
 const AlertBadgeWrapper = styled('div')<{icon: React.ReactNode} & StatusColorProps>`
   display: flex;

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -48,14 +48,14 @@ const CRASH_FREE_WARNING_THRESHOLD = 99.5;
 
 function getCrashFreeIcon(crashFreePercent: number, iconSize: IconSize = 'sm') {
   if (crashFreePercent < CRASH_FREE_DANGER_THRESHOLD) {
-    return <IconFire color="red300" size={iconSize} />;
+    return <IconFire color="errorText" size={iconSize} />;
   }
 
   if (crashFreePercent < CRASH_FREE_WARNING_THRESHOLD) {
-    return <IconWarning color="yellow300" size={iconSize} />;
+    return <IconWarning color="warningText" size={iconSize} />;
   }
 
-  return <IconCheckmark isCircled color="green300" size={iconSize} />;
+  return <IconCheckmark isCircled color="successText" size={iconSize} />;
 }
 
 type Props = {

--- a/static/app/views/releases/list/releasesPromo.tsx
+++ b/static/app/views/releases/list/releasesPromo.tsx
@@ -287,7 +287,7 @@ const ReleasesPromo = ({organization, project}: Props) => {
                       >
                         <MenuItemFooterWrapper>
                           <IconContainer>
-                            <IconAdd color="purple300" isCircled size="14px" />
+                            <IconAdd color="activeText" isCircled size="14px" />
                           </IconContainer>
                           <Label>{t('Create New Integration')}</Label>
                         </MenuItemFooterWrapper>

--- a/static/app/views/settings/components/dataScrubbing/modals/form/eventIdField.spec.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/eventIdField.spec.tsx
@@ -62,7 +62,7 @@ describe('EventIdField', function () {
 
     expect(screen.queryByLabelText('Clear event ID')).not.toBeInTheDocument();
 
-    expect(screen.getByTestId('icon-check-mark')).toHaveAttribute('fill', theme.green300);
+    expect(screen.getByTestId('icon-check-mark')).toHaveAttribute('fill', theme.green400);
   });
 
   it('ERROR status', async function () {

--- a/static/app/views/settings/components/dataScrubbing/modals/form/eventIdFieldStatusIcon.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/eventIdFieldStatusIcon.tsx
@@ -27,7 +27,7 @@ const EventIdFieldStatusIcon = ({status, onClickIconClose}: Props) => {
     case EventIdStatus.LOADING:
       return <ControlState isSaving />;
     case EventIdStatus.LOADED:
-      return <IconCheckmark color="green300" />;
+      return <IconCheckmark color="successText" />;
     default:
       return null;
   }

--- a/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/uniformRateModal.tsx
@@ -471,7 +471,7 @@ export function UniformRateModal({
                     containerDisplayMode="inline-flex"
                   >
                     <IconWarning
-                      color="red300"
+                      color="errorText"
                       size="sm"
                       data-test-id="invalid-client-rate"
                     />
@@ -507,7 +507,7 @@ export function UniformRateModal({
                     containerDisplayMode="inline-flex"
                   >
                     <IconWarning
-                      color="red300"
+                      color="errorText"
                       size="sm"
                       data-test-id="invalid-server-rate"
                     />
@@ -521,7 +521,7 @@ export function UniformRateModal({
                       containerDisplayMode="inline-flex"
                     >
                       <IconWarning
-                        color="red300"
+                        color="errorText"
                         size="sm"
                         data-test-id="invalid-server-rate"
                       />

--- a/static/app/views/settings/project/server-side-sampling/rule.tsx
+++ b/static/app/views/settings/project/server-side-sampling/rule.tsx
@@ -280,7 +280,7 @@ const IconGrabbableWrapper = styled('div')`
 `;
 
 const ConditionEqualOperator = styled('div')`
-  color: ${p => p.theme.purple300};
+  color: ${p => p.theme.activeText};
 `;
 
 const Operator = styled('div')`

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/status.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/status.tsx
@@ -27,7 +27,7 @@ function Status({details, onEditRepository}: Props) {
 
   if (credentials.status === 'invalid') {
     return (
-      <Wrapper color={theme.red300} onClick={onEditRepository}>
+      <Wrapper color={theme.errorText} onClick={onEditRepository}>
         <StyledTooltip
           title={t('Re-check your App Store Credentials')}
           containerDisplayMode="inline-flex"
@@ -41,7 +41,7 @@ function Status({details, onEditRepository}: Props) {
 
   if (pendingDownloads) {
     return (
-      <Wrapper color={theme.gray400}>
+      <Wrapper color={theme.textColor}>
         <IconWrapper>
           <IconDownload size="sm" />
         </IconWrapper>
@@ -52,7 +52,7 @@ function Status({details, onEditRepository}: Props) {
 
   if (lastCheckedBuilds) {
     return (
-      <Wrapper color={theme.gray400}>
+      <Wrapper color={theme.textColor}>
         <IconWrapper>
           <IconRefresh size="sm" />
         </IconWrapper>

--- a/static/app/views/settings/settingsIndex.tsx
+++ b/static/app/views/settings/settingsIndex.tsx
@@ -172,7 +172,7 @@ function SettingsIndex({organization, ...props}: SettingsIndexProps) {
     <GridPanel>
       <HomePanelHeader>
         <SupportLink icon {...supportLinkProps}>
-          <HomeIconContainer color="purple300">
+          <HomeIconContainer color="activeText">
             <IconSupport size="lg" />
           </HomeIconContainer>
           {t('Support')}
@@ -300,10 +300,10 @@ const HomeIconContainer = styled('div')<{color?: string}>`
 `;
 
 const linkCss = ({theme}: {theme: Theme}) => css`
-  color: ${theme.purple300};
+  color: ${theme.activeText};
 
   &:hover {
-    color: ${theme.purple300};
+    color: ${theme.activeText};
   }
 `;
 


### PR DESCRIPTION
One example out of many:

**Before:**
<img width="276" alt="Screen Shot 2022-11-15 at 5 02 17 PM" src="https://user-images.githubusercontent.com/44172267/202057805-70f5e3f5-e790-4a77-95b8-b0ab8c259eb5.png">

**After:**
<img width="276" alt="Screen Shot 2022-11-15 at 5 02 22 PM" src="https://user-images.githubusercontent.com/44172267/202057807-c0b2d69a-5c50-4eb6-9e12-207a40200853.png">
