### PR TITLE
ref: Avoid JSON serialize for metrics

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -588,7 +588,7 @@ class SymbolicatorSession:
 
                     if json["status"] != "pending":
                         metrics.timing(
-                            "events.symbolicator.response.completed.size", len(response.content())
+                            "events.symbolicator.response.completed.size", len(response.content)
                         )
                 else:
                     with sentry_sdk.push_scope():

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -199,9 +199,6 @@ class Symbolicator:
                 # Once we arrive here, we are done processing. Clean up the
                 # task id from the cache.
                 default_cache.delete(self.task_id_cache_key)
-                metrics.timing(
-                    "events.symbolicator.response.completed.size", len(json.dumps(json_response))
-                )
                 return json_response
 
     def process_minidump(self, minidump):
@@ -588,6 +585,11 @@ class SymbolicatorSession:
 
                 if response.ok:
                     json = response.json()
+
+                    if json["status"] != "pending":
+                        metrics.timing(
+                            "events.symbolicator.response.completed.size", len(response.content())
+                        )
                 else:
                     with sentry_sdk.push_scope():
                         sentry_sdk.set_extra("symbolicator_response", response.text)


### PR DESCRIPTION
Previously, the symbolication worker would json-serialize the symbolicator response just to count json bytes. The metrics is now collected when we still have access to the raw response content that we count, avoiding a needless JSON serialize.