### PR TITLE
ref(processor): Use option to control JavaScriptSmCacheStacktraceProcessor rollout

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1246,8 +1246,6 @@ SENTRY_FEATURES = {
     "projects:rate-limits": True,
     # Enable functionality to trigger service hooks upon event ingestion.
     "projects:servicehooks": False,
-    # Enable use of symbolic-sourcemapcache for JavaScript Source Maps processing
-    "projects:sourcemapcache-processor": False,
     # Enable suspect resolutions feature
     "projects:suspect-resolutions": False,
     # Use Kafka (instead of Celery) for ingestion pipeline.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -226,7 +226,6 @@ default_manager.add("projects:similarity-indexing", ProjectFeature)
 default_manager.add("projects:similarity-indexing-v2", ProjectFeature)
 default_manager.add("projects:similarity-view", ProjectFeature)
 default_manager.add("projects:similarity-view-v2", ProjectFeature)
-default_manager.add("projects:sourcemapcache-processor", ProjectFeature)
 default_manager.add("projects:suspect-resolutions", ProjectFeature, True)
 
 # Project plugin features

--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -35,7 +35,11 @@ def generate_modules(data):
 
 # TODO(smcache): Remove after rollout.
 def _use_sourcemapcache(project_id: int) -> bool:
-    if project_id in (settings.SENTRY_FRONTEND_PROJECT, settings.SENTRY_PROJECT):
+    # Internal Sentry projects
+    # 11276 - sentry/javascript project for forced dogfooding
+    # SENTRY_PROJECT - default project for all installations
+    # SENTRY_FRONTEND_PROJECT - configurable default frontend project
+    if project_id in (11276, settings.SENTRY_PROJECT, settings.SENTRY_FRONTEND_PROJECT):
         return True
 
     return project_id % 1000 < options.get(PROCESSING_OPTION_SOURCEMAPCACHE, 0.0) * 1000

--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from sentry import options
 from sentry.plugins.base.v2 import Plugin2
 from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.utils.safe import get_path
@@ -8,6 +9,8 @@ from .errorlocale import translate_exception
 from .errormapping import rewrite_exception
 from .processor import JavaScriptStacktraceProcessor
 from .processor_smcache import JavaScriptSmCacheStacktraceProcessor
+
+PROCESSING_OPTION_SOURCEMAPCACHE = "processing.sourcemapcache-processor"
 
 
 def preprocess_event(data):
@@ -30,6 +33,14 @@ def generate_modules(data):
                 frame["module"] = generate_module(abs_path)
 
 
+# TODO(smcache): Remove after rollout.
+def _use_sourcemapcache(project_id: int) -> bool:
+    if project_id in (settings.SENTRY_FRONTEND_PROJECT, settings.SENTRY_PROJECT):
+        return True
+
+    return project_id % 1000 < options.get(PROCESSING_OPTION_SOURCEMAPCACHE, 0.0) * 1000
+
+
 class JavascriptPlugin(Plugin2):
     can_disable = False
 
@@ -44,9 +55,7 @@ class JavascriptPlugin(Plugin2):
         return []
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
-        # TODO(smcache): Implement gradual rollout
         if "javascript" in platforms or "node" in platforms:
-            for value in (settings.SENTRY_FRONTEND_PROJECT, settings.SENTRY_PROJECT):
-                if str(data["project"]) == str(value):
-                    return [JavaScriptSmCacheStacktraceProcessor]
+            if _use_sourcemapcache(data["project"]):
+                return [JavaScriptSmCacheStacktraceProcessor]
             return [JavaScriptStacktraceProcessor]

--- a/src/sentry/lang/javascript/processor_smcache.py
+++ b/src/sentry/lang/javascript/processor_smcache.py
@@ -1001,6 +1001,7 @@ class JavaScriptSmCacheStacktraceProcessor(StacktraceProcessor):
             processable_frame.data["token"] = token
 
             # Store original data in annotation
+            # TODO(smcache): Remove smcache key after successful rollout.
             new_frame["data"] = dict(
                 frame.get("data") or {}, sourcemap=sourcemap_label, smcache=True
             )

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -342,6 +342,10 @@ register("discover2.tags_facet_enable_sampling", default=True, flags=FLAG_PRIORI
 # disable datascrubbers.
 register("processing.can-use-scrubbers", default=True)
 
+# Enable use of symbolic-sourcemapcache for JavaScript Source Maps processing.
+# Set this value of the fraction of projects that you want to use it for.
+register("processing.sourcemapcache-processor", default=0.0)
+
 # Killswitch for sending internal errors to the internal project or
 # `SENTRY_SDK_CONFIG.relay_dsn`. Set to `0` to only send to
 # `SENTRY_SDK_CONFIG.dsn` (the "upstream transport") and nothing else.


### PR DESCRIPTION
This will always default to the new processor for `SENTRY_FRONTEND_PROJECT` and `SENTRY_PROJECT` and make a decision on which processor to use, based on `processing.sourcemapcache-processor` option.
This will allow us to do a gradual rollout for all projects.