### PR TITLE
fix(ui): add overflow-y support to dropdownMenu

### DIFF
--- a/static/app/components/dropdownMenu.tsx
+++ b/static/app/components/dropdownMenu.tsx
@@ -216,6 +216,8 @@ export default DropdownMenu;
 
 const StyledOverlay = styled(Overlay)`
   max-width: 24rem;
+  overflow-y: scroll;
+  max-height: 90vh;
   @media only screen and (max-width: calc(24rem + ${space(2)} * 2)) {
     max-width: calc(100vw - ${space(2)} * 2);
   }


### PR DESCRIPTION
Dropdown's that exceed the size of the viewport automatically close, the only way to navigate it is with a click+hold, which is far from ideal.

To fix this we now set a `max-height` and add `overflow-y`.

Before:

https://user-images.githubusercontent.com/7349258/202213598-b30e6b8b-3351-4d82-89a4-3613918bd4fa.mov

After:

https://user-images.githubusercontent.com/7349258/202214360-2441e483-769d-4aa4-b6c5-49cafc6172a2.mov

