### PR TITLE
ref(ui): Tweak usage of `tn()` so they are translatable

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -296,7 +296,7 @@ class SpanDetail extends Component<Props, State> {
       <Alert type={getCumulativeAlertLevelFromErrors(relatedErrors)} system>
         <ErrorMessageTitle>
           {tn(
-            'An error event occurred in this span.',
+            '%s error event occurred in this span.',
             '%s error events occurred in this span.',
             relatedErrors.length
           )}

--- a/static/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/static/app/views/performance/traceDetails/transactionDetail.tsx
@@ -78,7 +78,7 @@ class TransactionDetail extends Component<Props> {
       >
         <ErrorMessageTitle>
           {tn(
-            'An error event occurred in this transaction.',
+            '%s error event occurred in this transaction.',
             '%s error events occurred in this transaction.',
             errors.length
           )}


### PR DESCRIPTION
When using `tn()`, we *must* have the same number of placeholders in each parameter. This is because different languages are different (pluralization is not uniform across languages).
