### PR TITLE
fix(test): Add sentry modal back

### DIFF
--- a/tests/js/sentry-test/modal.jsx
+++ b/tests/js/sentry-test/modal.jsx
@@ -5,9 +5,8 @@ import GlobalModal from 'sentry/components/globalModal';
 const mountedModals = [];
 
 /**
-* @deprecated only use this with enzyme (still used in getsentry)
-*/
-
+ * @deprecated only use this with enzyme (still used in getsentry)
+ */
 export async function mountGlobalModal(context) {
   const modal = mountWithTheme(<GlobalModal />, context);
   mountedModals.push(modal);

--- a/tests/js/sentry-test/modal.jsx
+++ b/tests/js/sentry-test/modal.jsx
@@ -1,0 +1,27 @@
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import GlobalModal from 'sentry/components/globalModal';
+
+const mountedModals = [];
+
+/**
+ * @deprecated only use this with enzyme (still used in getsentry)
+ */
+export async function mountGlobalModal(context) {
+  const modal = mountWithTheme(<GlobalModal />, context);
+  mountedModals.push(modal);
+  await tick();
+  modal.update();
+
+  return modal;
+}
+
+afterEach(() => {
+  while (mountedModals.length) {
+    const modal = mountedModals.pop();
+    if (modal.exists()) {
+      // modal is still mounted
+      modal.unmount();
+    }
+  }
+});


### PR DESCRIPTION
Adding this file back as this is still being used in `getsentry`.

wondering why the `getsentry` tests passed in the PR https://github.com/getsentry/sentry/pull/41431