### PR TITLE
fix: Reword Jira integration ignored fields help to state that name or id is needed

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -189,10 +189,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 "name": self.issues_ignored_fields_key,
                 "label": "Ignored Fields",
                 "type": "textarea",
-                "placeholder": _('e.g. "components, security, customfield_10006"'),
-                "help": _(
-                    "Comma-separated list of Jira fields that you don't want to show in issue creation form"
-                ),
+                "placeholder": _("components, security, customfield_10006"),
+                "help": _("Jira field ids or names that you want to hide."),
             },
         ]
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -190,7 +190,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 "label": "Ignored Fields",
                 "type": "textarea",
                 "placeholder": _("components, security, customfield_10006"),
-                "help": _("Jira field ids or names that you want to hide."),
+                "help": _("Comma-separated Jira field IDs that you want to hide."),
             },
         ]
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -353,7 +353,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                 "label": "Ignored Fields",
                 "type": "textarea",
                 "placeholder": _("components, security, customfield_10006"),
-                "help": _("Comma-separated Jira field IDs or names that you want to hide."),
+                "help": _("Comma-separated Jira field IDs that you want to hide."),
             },
         ]
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -353,7 +353,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                 "label": "Ignored Fields",
                 "type": "textarea",
                 "placeholder": _("components, security, customfield_10006"),
-                "help": _("Jira field ids or names that you want to hide."),
+                "help": _("Comma-separated Jira field IDs or names that you want to hide."),
             },
         ]
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -352,10 +352,8 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                 "name": self.issues_ignored_fields_key,
                 "label": "Ignored Fields",
                 "type": "textarea",
-                "placeholder": _('e.g. "components, security, customfield_10006"'),
-                "help": _(
-                    "Comma-separated list of Jira Server fields that you don't want to show in issue creation form"
-                ),
+                "placeholder": _("components, security, customfield_10006"),
+                "help": _("Jira field ids or names that you want to hide."),
             },
         ]
 


### PR DESCRIPTION
WOR-2280

The name or id (instead of the label) must be typed in the ignored fields text box in order for these fields to be correctly hidden.

Before: Users were typing the label of the field into the text box.

After: Users are told to put the name or id in the text box.

View the corresponding [doc change](https://github.com/getsentry/sentry-docs/pull/5794) that explains how to get the Jira field id or name.