### PR TITLE
feat(profiling): remove implicit scoping to node

### DIFF
--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -493,8 +493,8 @@ function FlamegraphZoomView({
       if (lastInteraction === 'click') {
         if (
           hoveredNode &&
-          flamegraphState.profiles.selectedRoot &&
-          hoveredNode === flamegraphState.profiles.selectedRoot
+          selectedFramesRef.current?.length === 1 &&
+          selectedFramesRef.current[0] === hoveredNode
         ) {
           // If double click is fired on a node, then zoom into it
           canvasPoolManager.dispatch('zoom at frame', [hoveredNode, 'exact']);
@@ -508,20 +508,12 @@ function FlamegraphZoomView({
           hoveredNode ? [hoveredNode] : null,
           'selected',
         ]);
-        dispatch({type: 'set selected root', payload: hoveredNode});
       }
 
       setLastInteraction(null);
       setStartPanVector(null);
     },
-    [
-      configSpaceCursor,
-      flamegraphState.profiles.selectedRoot,
-      dispatch,
-      hoveredNode,
-      canvasPoolManager,
-      lastInteraction,
-    ]
+    [configSpaceCursor, dispatch, hoveredNode, canvasPoolManager, lastInteraction]
   );
 
   const onMouseDrag = useCallback(


### PR DESCRIPTION
This implicit scoping *sounded* smart, but in reality it just gets in the way as we start to add more interactions. A click on a frame is really not a strong enough indicator to warrant that pattern - especially as folks often just click around the flamechart as they explore it. This PR preserves all of the behavior we previously had (like zooming into the frame) without scoping the call tree to that node - the reducer state is kept as we think of the best way to expose that action.