### PR TITLE
feat(mobile-exp): enable new tag summary only for react native

### DIFF
--- a/static/app/components/group/sidebar.spec.jsx
+++ b/static/app/components/group/sidebar.spec.jsx
@@ -220,7 +220,7 @@ describe('GroupSidebar', function () {
       render(
         <GroupSidebar
           group={group}
-          project={{...project, platform: 'android'}}
+          project={{...project, platform: 'react-native'}}
           organization={{
             ...organization,
             features: [...organization.features, 'issue-details-tag-improvements'],

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -261,7 +261,7 @@ class BaseGroupSidebar extends Component<Props, State> {
           organization={organization}
           features={['issue-details-tag-improvements']}
         >
-          {isMobilePlatform(project.platform) && (
+          {isMobilePlatform(project.platform) && project.platform === 'react-native' && (
             <TagFacets
               environments={environments}
               groupId={group.id}

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -301,7 +301,9 @@ class BaseGroupSidebar extends Component<Props, State> {
         {this.renderPluginIssue()}
 
         {(!organization.features.includes('issue-details-tag-improvements') ||
-          !isMobilePlatform(project.platform)) && (
+          !(
+            isMobilePlatform(project.platform) && project.platform === 'react-native'
+          )) && (
           <SidebarSection.Wrap>
             <SidebarSection.Title>{t('Tag Summary')}</SidebarSection.Title>
             <SidebarSection.Content>

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -332,7 +332,7 @@ class BaseGroupSidebar extends Component<Props, State> {
                       group={group}
                       onTagClick={(title, value) => {
                         trackAdvancedAnalyticsEvent(
-                          'issue_group_details.tags.bar.clicked',
+                          'issue_group_details.tags_distribution.bar.clicked',
                           {
                             tag: title,
                             value: value.name,


### PR DESCRIPTION
Enables the new tag summary only for react native projects