### PR TITLE
feat(all-events) add project type to column mapping

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -3,6 +3,15 @@
 
 import {t} from 'sentry/locale';
 
+export enum PlatformCategory {
+  frontend,
+  mobile,
+  backend,
+  serverless,
+  desktop,
+  other,
+}
+
 export const popularPlatformCategories = [
   'javascript',
   'javascript-react',

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -4,12 +4,12 @@
 import {t} from 'sentry/locale';
 
 export enum PlatformCategory {
-  frontend,
-  mobile,
-  backend,
-  serverless,
-  desktop,
-  other,
+  FRONTEND,
+  MOBILE,
+  BACKEND,
+  SERVERLESS,
+  DESKTOP,
+  OTHER,
 }
 
 export const popularPlatformCategories = [

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -18,8 +18,8 @@ desktop.forEach(platform => (platformCategoryMap[platform] = PlatformCategory.ba
 
 /**
  *
- * @param platform - a SDK platform, for example javacsript
- * @returns - the platform category
+ * @param platform - a SDK platform, for example `node-express`, `javascript-react`
+ * @returns - the platform category, for example `backend`, `serverless`
  */
 export function platformToCategory(platform: string | undefined): PlatformCategory {
   if (!platform || !platformCategoryMap[platform]) {

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -1,4 +1,33 @@
-import {mobile} from 'sentry/data/platformCategories';
+import {
+  backend,
+  desktop,
+  frontend,
+  mobile,
+  PlatformCategory,
+  serverless,
+} from 'sentry/data/platformCategories';
+
+export function platformToCategory(platform: string | undefined): PlatformCategory {
+  if (!platform) {
+    return PlatformCategory.other;
+  }
+  if (([...mobile] as string[]).includes(platform)) {
+    return PlatformCategory.mobile;
+  }
+  if (([...frontend] as string[]).includes(platform)) {
+    return PlatformCategory.frontend;
+  }
+  if (([...backend] as string[]).includes(platform)) {
+    return PlatformCategory.backend;
+  }
+  if (([...serverless] as string[]).includes(platform)) {
+    return PlatformCategory.serverless;
+  }
+  if (([...desktop] as string[]).includes(platform)) {
+    return PlatformCategory.desktop;
+  }
+  return PlatformCategory.other;
+}
 
 export function isNativePlatform(platform: string | undefined) {
   switch (platform) {

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -4,28 +4,35 @@ import {
   frontend,
   mobile,
   PlatformCategory,
+  PlatformKey,
   serverless,
 } from 'sentry/data/platformCategories';
-
-const platformCategoryMap = {};
-mobile.forEach(platform => (platformCategoryMap[platform] = PlatformCategory.mobile));
-frontend.forEach(platform => (platformCategoryMap[platform] = PlatformCategory.frontend));
-backend.forEach(platform => (platformCategoryMap[platform] = PlatformCategory.backend));
-serverless.forEach(
-  platform => (platformCategoryMap[platform] = PlatformCategory.backend)
-);
-desktop.forEach(platform => (platformCategoryMap[platform] = PlatformCategory.backend));
 
 /**
  *
  * @param platform - a SDK platform, for example `node-express`, `javascript-react`
  * @returns - the platform category, for example `backend`, `serverless`
  */
-export function platformToCategory(platform: string | undefined): PlatformCategory {
-  if (!platform || !platformCategoryMap[platform]) {
-    return PlatformCategory.other;
+export function platformToCategory(platform: PlatformKey | undefined): PlatformCategory {
+  if (!platform) {
+    return PlatformCategory.OTHER;
   }
-  return platformCategoryMap[platform];
+  if (([...frontend] as string[]).includes(platform)) {
+    return PlatformCategory.FRONTEND;
+  }
+  if (([...backend] as string[]).includes(platform)) {
+    return PlatformCategory.BACKEND;
+  }
+  if (([...serverless] as string[]).includes(platform)) {
+    return PlatformCategory.SERVERLESS;
+  }
+  if (([...mobile] as string[]).includes(platform)) {
+    return PlatformCategory.MOBILE;
+  }
+  if (([...desktop] as string[]).includes(platform)) {
+    return PlatformCategory.DESKTOP;
+  }
+  return PlatformCategory.OTHER;
 }
 
 export function isNativePlatform(platform: string | undefined) {

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -7,26 +7,25 @@ import {
   serverless,
 } from 'sentry/data/platformCategories';
 
+const platformCategoryMap = {};
+mobile.forEach(platform => (platformCategoryMap[platform] = PlatformCategory.mobile));
+frontend.forEach(platform => (platformCategoryMap[platform] = PlatformCategory.frontend));
+backend.forEach(platform => (platformCategoryMap[platform] = PlatformCategory.backend));
+serverless.forEach(
+  platform => (platformCategoryMap[platform] = PlatformCategory.backend)
+);
+desktop.forEach(platform => (platformCategoryMap[platform] = PlatformCategory.backend));
+
+/**
+ *
+ * @param platform - a SDK platform, for example javacsript
+ * @returns - the platform category
+ */
 export function platformToCategory(platform: string | undefined): PlatformCategory {
-  if (!platform) {
+  if (!platform || !platformCategoryMap[platform]) {
     return PlatformCategory.other;
   }
-  if (([...mobile] as string[]).includes(platform)) {
-    return PlatformCategory.mobile;
-  }
-  if (([...frontend] as string[]).includes(platform)) {
-    return PlatformCategory.frontend;
-  }
-  if (([...backend] as string[]).includes(platform)) {
-    return PlatformCategory.backend;
-  }
-  if (([...serverless] as string[]).includes(platform)) {
-    return PlatformCategory.serverless;
-  }
-  if (([...desktop] as string[]).includes(platform)) {
-    return PlatformCategory.desktop;
-  }
-  return PlatformCategory.other;
+  return platformCategoryMap[platform];
 }
 
 export function isNativePlatform(platform: string | undefined) {

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -117,23 +117,23 @@ const getPlatformColumns = (
   const replayColumnTitle = options.isReplayEnabled ? [t('replay')] : [];
 
   const categoryToColumnMap: {[key: string]: ColumnInfo} = {
-    [PlatformCategory.frontend]: {
+    [PlatformCategory.FRONTEND]: {
       fields: ['url', 'browser', ...replayField],
       columnTitles: [t('url'), t('browser'), ...replayColumnTitle],
     },
-    [PlatformCategory.backend]: {
+    [PlatformCategory.BACKEND]: {
       fields: ['url', 'runtime'],
       columnTitles: [t('url'), t('runtime')],
     },
-    [PlatformCategory.mobile]: {
+    [PlatformCategory.MOBILE]: {
       fields: ['url'],
       columnTitles: [t('url')],
     },
-    [PlatformCategory.desktop]: {
+    [PlatformCategory.DESKTOP]: {
       fields: ['os'],
       columnTitles: [t('os')],
     },
-    [PlatformCategory.other]: {
+    [PlatformCategory.OTHER]: {
       fields: [],
       columnTitles: [],
     },
@@ -142,8 +142,8 @@ const getPlatformColumns = (
   let platformCategory = platformToCategory(platform);
 
   // backend end serverless have the same columns
-  if (platformCategory === PlatformCategory.serverless) {
-    platformCategory = PlatformCategory.backend;
+  if (platformCategory === PlatformCategory.SERVERLESS) {
+    platformCategory = PlatformCategory.BACKEND;
   }
 
   return categoryToColumnMap[platformCategory];

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -116,7 +116,7 @@ const getPlatformColumns = (
   const replayField = options.isReplayEnabled ? ['replayId'] : [];
   const replayColumnTitle = options.isReplayEnabled ? [t('replay')] : [];
 
-  const categoryToColumnMap: {[key: string]: ColumnInfo} = {
+  const categoryToColumnMap: Record<PlatformCategory, ColumnInfo> = {
     [PlatformCategory.FRONTEND]: {
       fields: ['url', 'browser', ...replayField],
       columnTitles: [t('url'), t('browser'), ...replayColumnTitle],

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -116,14 +116,17 @@ const getPlatformColumns = (
   const replayField = options.isReplayEnabled ? ['replayId'] : [];
   const replayColumnTitle = options.isReplayEnabled ? [t('replay')] : [];
 
+  const backendServerlessColumnInfo = {
+    fields: ['url', 'runtime'],
+    columnTitles: [t('url'), t('runtime')],
+  };
+
   const categoryToColumnMap: Record<PlatformCategory, ColumnInfo> = {
+    [PlatformCategory.BACKEND]: backendServerlessColumnInfo,
+    [PlatformCategory.SERVERLESS]: backendServerlessColumnInfo,
     [PlatformCategory.FRONTEND]: {
       fields: ['url', 'browser', ...replayField],
       columnTitles: [t('url'), t('browser'), ...replayColumnTitle],
-    },
-    [PlatformCategory.BACKEND]: {
-      fields: ['url', 'runtime'],
-      columnTitles: [t('url'), t('runtime')],
     },
     [PlatformCategory.MOBILE]: {
       fields: ['url'],
@@ -139,12 +142,7 @@ const getPlatformColumns = (
     },
   };
 
-  let platformCategory = platformToCategory(platform);
-
-  // backend end serverless have the same columns
-  if (platformCategory === PlatformCategory.SERVERLESS) {
-    platformCategory = PlatformCategory.BACKEND;
-  }
+  const platformCategory = platformToCategory(platform);
 
   return categoryToColumnMap[platformCategory];
 };

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -86,7 +86,6 @@ const getColumns = (group: Group, organization: Organization): ColumnInfo => {
     ...platformSpecificFields,
     ...(isPerfIssue ? ['transaction.duration'] : []),
     'timestamp',
-    ...(isReplayEnabled ? ['replayId'] : []),
   ];
 
   const columnTitles: string[] = [
@@ -102,7 +101,6 @@ const getColumns = (group: Group, organization: Organization): ColumnInfo => {
     ...(isPerfIssue ? [t('total duration')] : []),
     t('timestamp'),
     t('minidump'),
-    ...(isReplayEnabled ? ['replayId'] : []),
   ];
 
   return {

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -2,50 +2,28 @@ import {useState} from 'react';
 import {Location} from 'history';
 
 import LoadingError from 'sentry/components/loadingError';
+import {PlatformCategory, PlatformKey} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
-import {Organization} from 'sentry/types';
+import {Group, IssueCategory, Organization} from 'sentry/types';
 import EventView, {decodeSorts} from 'sentry/utils/discover/eventView';
+import {platformToCategory} from 'sentry/utils/platform';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import EventsTable from 'sentry/views/performance/transactionSummary/transactionEvents/eventsTable';
 
 export interface Props {
-  isPerfIssue: boolean;
+  group: Group;
   issueId: string;
   location: Location;
   organization: Organization;
-  projectId: string;
-  projectSlug: string;
   excludedTags?: string[];
-  totalEventCount?: string;
 }
 
 const AllEventsTable = (props: Props) => {
-  const {
-    location,
-    organization,
-    issueId,
-    isPerfIssue,
-    excludedTags,
-    projectSlug,
-    projectId,
-    totalEventCount,
-  } = props;
+  const {location, organization, issueId, excludedTags, group} = props;
   const [error, setError] = useState<string>('');
   const routes = useRoutes();
 
-  const isReplayEnabled = organization.features.includes('session-replay-ui');
-
-  const fields: string[] = [
-    'id',
-    'transaction',
-    'trace',
-    'release',
-    'environment',
-    'user.display',
-    ...(isPerfIssue ? ['transaction.duration'] : []),
-    'timestamp',
-    ...(isReplayEnabled ? ['replayId'] : []),
-  ];
+  const {fields, columnTitles} = getColumns(group, organization);
 
   const eventView: EventView = EventView.fromLocation(props.location);
   eventView.fields = fields.map(fieldName => ({field: fieldName}));
@@ -56,25 +34,13 @@ const AllEventsTable = (props: Props) => {
     eventView.sorts = [{field: 'timestamp', kind: 'desc'}];
   }
 
-  const idQuery = isPerfIssue
-    ? `performance.issue_ids:${issueId} event.type:transaction`
-    : `issue.id:${issueId}`;
-  eventView.project = [parseInt(projectId, 10)];
+  const idQuery =
+    group.issueCategory === IssueCategory.PERFORMANCE
+      ? `performance.issue_ids:${issueId} event.type:transaction`
+      : `issue.id:${issueId}`;
+  eventView.project = [parseInt(group.project.id, 10)];
   eventView.query = `${idQuery} ${props.location.query.query || ''}`;
   eventView.statsPeriod = '90d';
-
-  const columnTitles: Readonly<string[]> = [
-    t('event id'),
-    t('transaction'),
-    t('trace id'),
-    t('release'),
-    t('environment'),
-    t('user'),
-    ...(isPerfIssue ? [t('total duration')] : []),
-    t('timestamp'),
-    ...(isReplayEnabled ? [t('replay')] : []),
-    t('minidump'),
-  ];
 
   if (error) {
     return <LoadingError message={error} />;
@@ -88,8 +54,8 @@ const AllEventsTable = (props: Props) => {
       organization={organization}
       routes={routes}
       excludedTags={excludedTags}
-      projectSlug={projectSlug}
-      totalEventCount={totalEventCount}
+      projectSlug={group.project.slug}
+      totalEventCount={group.count}
       customColumns={['minidump']}
       setError={(msg: string | undefined) => setError(msg ?? '')}
       transactionName=""
@@ -97,6 +63,94 @@ const AllEventsTable = (props: Props) => {
       referrer="api.issues.issue_events"
     />
   );
+};
+
+type ColumnInfo = {columnTitles: string[]; fields: string[]};
+
+const getColumns = (group: Group, organization: Organization): ColumnInfo => {
+  const isPerfIssue = group.issueCategory === IssueCategory.PERFORMANCE;
+  const isReplayEnabled = organization.features.includes('session-replay-ui');
+
+  const {fields, columnTitles} = getPlatformColumns(
+    group.project.platform ?? group.platform,
+    {isReplayEnabled}
+  );
+
+  const baseFields: string[] = [
+    'id',
+    'transaction',
+    'title',
+    'release',
+    'environment',
+    'user.display',
+    'device',
+    'os',
+    ...fields,
+    ...(isPerfIssue ? ['transaction.duration'] : []),
+    'timestamp',
+    ...(isReplayEnabled ? ['replayId'] : []),
+  ];
+
+  const baseColumnTitles: string[] = [
+    t('event id'),
+    t('transaction'),
+    t('title'),
+    t('release'),
+    t('environment'),
+    t('user'),
+    t('device'),
+    t('os'),
+    ...columnTitles,
+    ...(isPerfIssue ? [t('total duration')] : []),
+    t('timestamp'),
+    t('minidump'),
+    ...(isReplayEnabled ? ['replayId'] : []),
+  ];
+
+  return {
+    fields: baseFields,
+    columnTitles: baseColumnTitles,
+  };
+};
+
+const getPlatformColumns = (
+  platform: PlatformKey | undefined,
+  options: {isReplayEnabled: boolean}
+): ColumnInfo => {
+  const replayField = options.isReplayEnabled ? ['replayId'] : [];
+  const replayColumnTitle = options.isReplayEnabled ? [t('replay')] : [];
+
+  const categoryToColumnMap: {[key: string]: ColumnInfo} = {
+    [PlatformCategory.frontend]: {
+      fields: ['url', 'browser', ...replayField],
+      columnTitles: [t('url'), t('browser'), ...replayColumnTitle],
+    },
+    [PlatformCategory.backend]: {
+      fields: ['url', 'runtime'],
+      columnTitles: [t('url'), t('runtime')],
+    },
+    [PlatformCategory.mobile]: {
+      fields: ['url'],
+      columnTitles: [t('url')],
+    },
+    [PlatformCategory.desktop]: {
+      fields: ['os'],
+      columnTitles: [t('os')],
+    },
+    [PlatformCategory.other]: {
+      fields: [],
+      columnTitles: [],
+    },
+  };
+
+  let platformCategory = platformToCategory(platform);
+
+  // backend end serverless have the same columns
+  if (platformCategory === PlatformCategory.serverless) {
+    platformCategory = PlatformCategory.backend;
+  }
+
+  return categoryToColumnMap[platformCategory];
 };
 
 export default AllEventsTable;

--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -71,12 +71,10 @@ const getColumns = (group: Group, organization: Organization): ColumnInfo => {
   const isPerfIssue = group.issueCategory === IssueCategory.PERFORMANCE;
   const isReplayEnabled = organization.features.includes('session-replay-ui');
 
-  const {fields, columnTitles} = getPlatformColumns(
-    group.project.platform ?? group.platform,
-    {isReplayEnabled}
-  );
+  const {fields: platformSpecificFields, columnTitles: platformSpecificColumnTitles} =
+    getPlatformColumns(group.project.platform ?? group.platform, {isReplayEnabled});
 
-  const baseFields: string[] = [
+  const fields: string[] = [
     'id',
     'transaction',
     'title',
@@ -85,13 +83,13 @@ const getColumns = (group: Group, organization: Organization): ColumnInfo => {
     'user.display',
     'device',
     'os',
-    ...fields,
+    ...platformSpecificFields,
     ...(isPerfIssue ? ['transaction.duration'] : []),
     'timestamp',
     ...(isReplayEnabled ? ['replayId'] : []),
   ];
 
-  const baseColumnTitles: string[] = [
+  const columnTitles: string[] = [
     t('event id'),
     t('transaction'),
     t('title'),
@@ -100,7 +98,7 @@ const getColumns = (group: Group, organization: Organization): ColumnInfo => {
     t('user'),
     t('device'),
     t('os'),
-    ...columnTitles,
+    ...platformSpecificColumnTitles,
     ...(isPerfIssue ? [t('total duration')] : []),
     t('timestamp'),
     t('minidump'),
@@ -108,8 +106,8 @@ const getColumns = (group: Group, organization: Organization): ColumnInfo => {
   ];
 
   return {
-    fields: baseFields,
-    columnTitles: baseColumnTitles,
+    fields,
+    columnTitles,
   };
 };
 

--- a/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.spec.jsx
@@ -234,14 +234,9 @@ describe('groupEvents', function () {
       await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
       const eventIdATag = screen.getByText('id123').closest('a');
-      const traceIdATag = screen.getByText('trace123').closest('a');
       expect(eventIdATag).toHaveAttribute(
         'href',
         '/organizations/org-slug/issues/1/events/id123/'
-      );
-      expect(traceIdATag).toHaveAttribute(
-        'href',
-        '/organizations/org-slug/performance/trace/trace123/?'
       );
     });
 
@@ -468,6 +463,38 @@ describe('groupEvents', function () {
       await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
       expect(screen.getByTestId('loading-error')).toHaveTextContent('Internal Error');
+    });
+
+    it('requests for backend columns if backend project', async () => {
+      group.project.platform = 'node-express';
+      render(
+        <GroupEvents
+          organization={org.organization}
+          api={new MockApiClient()}
+          params={{orgId: 'orgId', projectId: 'projectId', groupId: '1'}}
+          group={group}
+          location={{query: {environment: ['prod', 'staging']}}}
+        />,
+        {context: routerContext, organization}
+      );
+
+      await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+      expect(discoverRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            field: expect.arrayContaining(['url', 'runtime']),
+          }),
+        })
+      );
+      expect(discoverRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            field: expect.not.arrayContaining(['browser']),
+          }),
+        })
+      );
     });
   });
 

--- a/static/app/views/organizationGroupDetails/groupEvents.tsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.tsx
@@ -16,7 +16,7 @@ import {Panel, PanelBody} from 'sentry/components/panels';
 import SearchBar from 'sentry/components/searchBar';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {Group, IssueCategory, Organization} from 'sentry/types';
+import {Group, Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import parseApiError from 'sentry/utils/parseApiError';
 import withApi from 'sentry/utils/withApi';
@@ -142,12 +142,9 @@ class GroupEvents extends Component<Props, State> {
     return (
       <AllEventsTable
         issueId={this.props.group.id}
-        isPerfIssue={this.props.group.issueCategory === IssueCategory.PERFORMANCE}
         location={this.props.location}
         organization={this.props.organization}
-        projectId={this.props.group.project.id}
-        projectSlug={this.props.group.project.slug}
-        totalEventCount={this.props.group.count}
+        group={this.props.group}
         excludedTags={excludedTags}
       />
     );


### PR DESCRIPTION
fixes PERF-1803

Adds a mapping between the platformCategory and columns, to display more relevant data. The full column mapping can be found in the spreadsheet on the ticket.

Note: InstallerStore, isSideLoaded and attachments is not included as it is not a field in discover, it will be looked into in the future