### PR TITLE
feat(profiling): dont disable empty thread profiles

### DIFF
--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -30,7 +30,6 @@ function ThreadMenuSelector({
           ? `tid (${profile.threadId}): ${profile.name}`
           : `tid (${profile.threadId})`,
         value: profile.threadId,
-        disabled: profile.samples.length === 0,
         details: (
           <ThreadLabelDetails
             duration={makeFormatter(profile.unit)(profile.duration)}

--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import CompactSelect from 'sentry/components/compactSelect';
 import {IconList} from 'sentry/icons';
-import {tn} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {SelectValue} from 'sentry/types';
 import {defined} from 'sentry/utils';
@@ -23,9 +23,16 @@ function ThreadMenuSelector({
   onThreadIdChange,
   profileGroup,
 }: ThreadSelectorProps) {
-  const options: SelectValue<number>[] = useMemo(() => {
-    return [...profileGroup.profiles].sort(compareProfiles).map(profile => {
-      return {
+  const [profileOptions, emptyProfileOptions]: [
+    SelectValue<number>[],
+    SelectValue<number>[]
+  ] = useMemo(() => {
+    const profiles: SelectValue<number>[] = [];
+    const emptyProfiles: SelectValue<number>[] = [];
+    const sortedProfiles = [...profileGroup.profiles].sort(compareProfiles);
+
+    sortedProfiles.forEach(profile => {
+      const option = {
         label: profile.name
           ? `tid (${profile.threadId}): ${profile.name}`
           : `tid (${profile.threadId})`,
@@ -39,7 +46,15 @@ function ThreadMenuSelector({
           />
         ),
       };
+
+      if (profile.rawWeights.length > 0) {
+        profiles.push(option);
+        return;
+      }
+      emptyProfiles.push(option);
+      return;
     });
+    return [profiles, emptyProfiles];
   }, [profileGroup]);
 
   const handleChange: (opt: SelectValue<number>) => void = useCallback(
@@ -57,7 +72,21 @@ function ThreadMenuSelector({
         icon: <IconList size="xs" />,
         size: 'xs',
       }}
-      options={options}
+      options={[
+        {
+          // TODO: fix CompactSelect types to better represent usage.
+          // this value has no effect on the selection, it's simply to satisfy the types..
+          // tried modifying the types but it creates a lot of errors
+          value: threadId || 0,
+          label: t('Profiles'),
+          options: profileOptions,
+        },
+        {
+          value: threadId || 0,
+          label: t('Empty Profiles'),
+          options: emptyProfileOptions,
+        },
+      ]}
       value={threadId}
       onChange={handleChange}
       isSearchable


### PR DESCRIPTION
Closes: https://github.com/getsentry/team-profiling/issues/59

Empty profiles in the thread selector were previously disabled. We now allow them to be selected and default to the empty state view within the flamechart.

![image](https://user-images.githubusercontent.com/7349258/202257301-ac42f8a0-10a2-42c1-adf1-58b3cfb732fe.png)


![image](https://user-images.githubusercontent.com/7349258/202553438-15cc155a-4c81-438d-ac85-d83f258e18cb.png)

