### PR TITLE
ref(selectControl): Add PanelProvider to Menu component

### DIFF
--- a/static/app/components/forms/controls/selectControl.tsx
+++ b/static/app/components/forms/controls/selectControl.tsx
@@ -20,6 +20,7 @@ import {IconChevron, IconClose} from 'sentry/icons';
 import space from 'sentry/styles/space';
 import {Choices, SelectValue} from 'sentry/types';
 import convertFromSelect2Choices from 'sentry/utils/convertFromSelect2Choices';
+import PanelProvider from 'sentry/utils/panelProvider';
 import {FormSize} from 'sentry/utils/theme';
 
 import Option from './selectOption';
@@ -89,6 +90,15 @@ const SingleValueWrap = styled('div')`
 const SingleValueLabel = styled('div')`
   ${p => p.theme.overflowEllipsis};
 `;
+
+const Menu = (props: React.ComponentProps<typeof selectComponents.Menu>) => {
+  const {children, ...otherProps} = props;
+  return (
+    <selectComponents.Menu {...otherProps}>
+      <PanelProvider>{children}</PanelProvider>
+    </selectComponents.Menu>
+  );
+};
 
 export type ControlProps<OptionType extends OptionTypeBase = GeneralSelectValue> = Omit<
   ReactSelectProps<OptionType>,
@@ -483,6 +493,7 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
     MultiValueRemove,
     LoadingIndicator: SelectLoadingIndicator,
     IndicatorSeparator: null,
+    Menu,
     Option,
   };
 


### PR DESCRIPTION
**Before:** menu items still have 6px border radii
<img width="508" alt="Screen Shot 2022-11-16 at 11 38 36 AM" src="https://user-images.githubusercontent.com/44172267/202277741-fb18b4f9-fb2d-464c-b5e8-5214ca7f956a.png">

**After:** the border radii are adjusted to 4px
<img width="508" alt="Screen Shot 2022-11-16 at 11 38 22 AM" src="https://user-images.githubusercontent.com/44172267/202277695-2549b532-622a-478d-99c1-5d31d1cc156c.png">
