### PR TITLE
ref(quickTrace): Convert <IssueQuickTrace> to a functional component

### DIFF
--- a/static/app/views/organizationGroupDetails/quickTrace/index.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/index.tsx
@@ -21,22 +21,23 @@ function QuickTrace({event, organization, location, isPerformanceIssue}: Props) 
   const hasTraceContext = Boolean(event.contexts?.trace?.trace_id);
   const quickTrace = useContext(QuickTraceContext);
 
-  if (hasPerformanceView && hasTraceContext) {
-    if (quickTrace?.isLoading) {
-      return <Placeholder height="24px" />;
-    }
-
-    return (
-      <IssueQuickTrace
-        organization={organization}
-        event={event}
-        location={location}
-        isPerformanceIssue={isPerformanceIssue}
-        quickTrace={quickTrace}
-      />
-    );
+  if (!hasPerformanceView || !hasTraceContext) {
+    return null;
   }
-  return null;
+
+  if (quickTrace?.isLoading) {
+    return <Placeholder height="24px" />;
+  }
+
+  return (
+    <IssueQuickTrace
+      organization={organization}
+      event={event}
+      location={location}
+      isPerformanceIssue={isPerformanceIssue}
+      quickTrace={quickTrace}
+    />
+  );
 }
 
 export default QuickTrace;

--- a/static/app/views/organizationGroupDetails/quickTrace/index.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/index.tsx
@@ -1,6 +1,7 @@
-import {Fragment, useContext} from 'react';
+import {useContext} from 'react';
 import {Location} from 'history';
 
+import Placeholder from 'sentry/components/placeholder';
 import {Group, Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
@@ -20,19 +21,22 @@ function QuickTrace({event, organization, location, isPerformanceIssue}: Props) 
   const hasTraceContext = Boolean(event.contexts?.trace?.trace_id);
   const quickTrace = useContext(QuickTraceContext);
 
-  return (
-    <Fragment>
-      {hasPerformanceView && hasTraceContext && (
-        <IssueQuickTrace
-          organization={organization}
-          event={event}
-          location={location}
-          isPerformanceIssue={isPerformanceIssue}
-          quickTrace={quickTrace!}
-        />
-      )}
-    </Fragment>
-  );
+  if (hasPerformanceView && hasTraceContext) {
+    if (quickTrace?.isLoading) {
+      return <Placeholder height="24px" />;
+    }
+
+    return (
+      <IssueQuickTrace
+        organization={organization}
+        event={event}
+        location={location}
+        isPerformanceIssue={isPerformanceIssue}
+        quickTrace={quickTrace}
+      />
+    );
+  }
+  return null;
 }
 
 export default QuickTrace;

--- a/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
@@ -35,7 +35,7 @@ function IssueQuickTrace({
   isPerformanceIssue,
 }: Props) {
   const {shouldShowPrompt, snoozePrompt} = usePromptCheck({
-    event,
+    projectId: event.projectID,
     feature: 'quick_trace_missing',
     organization,
   });

--- a/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/issueQuickTrace.tsx
@@ -1,15 +1,12 @@
-import {Component, Fragment} from 'react';
+import {useCallback} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import {promptsCheck, promptsUpdate} from 'sentry/actionCreators/prompts';
-import {Client} from 'sentry/api';
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import ExternalLink from 'sentry/components/links/externalLink';
 import Link from 'sentry/components/links/link';
-import Placeholder from 'sentry/components/placeholder';
 import QuickTrace from 'sentry/components/quickTrace';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {IconClose} from 'sentry/icons';
@@ -20,167 +17,121 @@ import {Event} from 'sentry/types/event';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {QuickTraceQueryChildrenProps} from 'sentry/utils/performance/quickTrace/types';
-import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
-import withApi from 'sentry/utils/withApi';
+import usePromptCheck from 'sentry/views/organizationGroupDetails/quickTrace/usePromptCheck';
 
 type Props = {
-  api: Client;
   event: Event;
   location: Location;
   organization: Organization;
-  quickTrace: QuickTraceQueryChildrenProps;
+  quickTrace: undefined | QuickTraceQueryChildrenProps;
   isPerformanceIssue?: boolean;
 };
 
-type State = {
-  shouldShow: boolean | null;
-};
+function IssueQuickTrace({
+  event,
+  location,
+  organization,
+  quickTrace,
+  isPerformanceIssue,
+}: Props) {
+  const {shouldShowPrompt, snoozePrompt} = usePromptCheck({
+    event,
+    feature: 'quick_trace_missing',
+    organization,
+  });
 
-class IssueQuickTrace extends Component<Props, State> {
-  state: State = {
-    shouldShow: null,
-  };
+  if (
+    !quickTrace ||
+    quickTrace.error ||
+    quickTrace.trace === null ||
+    quickTrace.trace.length === 0
+  ) {
+    if (!shouldShowPrompt) {
+      return null;
+    }
 
-  componentDidMount() {
-    this.promptsCheck();
-  }
+    trackAdvancedAnalyticsEvent('issue.quick_trace_status', {
+      organization,
+      status: quickTrace?.type === 'missing' ? 'transaction missing' : 'trace missing',
+      is_performance_issue: isPerformanceIssue ?? false,
+    });
 
-  shouldComponentUpdate(nextProps, nextState: State) {
     return (
-      this.props.event !== nextProps.event ||
-      this.state.shouldShow !== nextState.shouldShow ||
-      this.props.quickTrace !== nextProps.quickTrace
+      <StyledAlert
+        type="info"
+        showIcon
+        trailingItems={
+          <Button
+            priority="link"
+            size="zero"
+            title={t('Dismiss for a month')}
+            onClick={snoozePrompt}
+          >
+            <IconClose />
+          </Button>
+        }
+      >
+        {tct(
+          'The [type] for this event cannot be found. [link:Read the docs to understand why].',
+          {
+            type: quickTrace?.type === 'missing' ? t('transaction') : t('trace'),
+            link: (
+              <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#troubleshooting" />
+            ),
+          }
+        )}
+      </StyledAlert>
     );
   }
 
-  async promptsCheck() {
-    const {api, event, organization} = this.props;
+  trackAdvancedAnalyticsEvent('issue.quick_trace_status', {
+    organization,
+    status: 'success',
+    is_performance_issue: isPerformanceIssue ?? false,
+  });
 
-    const data = await promptsCheck(api, {
-      organizationId: organization.id,
-      projectId: event.projectID,
-      feature: 'quick_trace_missing',
-    });
+  return (
+    <ErrorBoundary mini>
+      {quickTrace.type !== 'empty' ? (
+        <TraceLink event={event} organization={organization} />
+      ) : null}
+      <QuickTraceWrapper>
+        <QuickTrace
+          event={event}
+          quickTrace={quickTrace}
+          location={location}
+          organization={organization}
+          anchor="left"
+          errorDest="issue"
+          transactionDest="performance"
+        />
+      </QuickTraceWrapper>
+    </ErrorBoundary>
+  );
+}
 
-    this.setState({shouldShow: !promptIsDismissed(data ?? {}, 30)});
-  }
+type TraceLinkProps = {
+  event: Event;
+  organization: Organization;
+};
 
-  handleTraceLink(organization: Organization) {
+function TraceLink({event, organization}: TraceLinkProps) {
+  const handleTraceLink = useCallback(() => {
     trackAnalyticsEvent({
       eventKey: 'quick_trace.trace_id.clicked',
       eventName: 'Quick Trace: Trace ID clicked',
       organization_id: parseInt(organization.id, 10),
       source: 'issues',
     });
-  }
+  }, [organization.id]);
 
-  renderTraceLink({isLoading, error, trace, type}) {
-    const {event, organization} = this.props;
-
-    if (isLoading || error !== null || trace === null || type === 'empty') {
-      return null;
-    }
-
-    return (
-      <LinkContainer>
-        <Link
-          to={generateTraceTarget(event, organization)}
-          onClick={() => this.handleTraceLink(organization)}
-        >
-          {t('View Full Trace')}
-        </Link>
-      </LinkContainer>
-    );
-  }
-
-  snoozePrompt = () => {
-    const {api, event, organization} = this.props;
-    const data = {
-      projectId: event.projectID,
-      organizationId: organization.id,
-      feature: 'quick_trace_missing',
-      status: 'snoozed' as const,
-    };
-    promptsUpdate(api, data).then(() => this.setState({shouldShow: false}));
-  };
-
-  renderQuickTrace(results: QuickTraceQueryChildrenProps) {
-    const {event, location, organization, isPerformanceIssue} = this.props;
-    const {shouldShow} = this.state;
-    const {isLoading, error, trace, type} = results;
-
-    if (isLoading) {
-      return <Placeholder height="24px" />;
-    }
-
-    if (error || trace === null || trace.length === 0) {
-      if (!shouldShow) {
-        return null;
-      }
-
-      trackAdvancedAnalyticsEvent('issue.quick_trace_status', {
-        organization,
-        status: type === 'missing' ? 'transaction missing' : 'trace missing',
-        is_performance_issue: isPerformanceIssue ?? false,
-      });
-
-      return (
-        <StyledAlert
-          type="info"
-          showIcon
-          trailingItems={
-            <Button
-              priority="link"
-              size="zero"
-              title={t('Dismiss for a month')}
-              onClick={this.snoozePrompt}
-            >
-              <IconClose />
-            </Button>
-          }
-        >
-          {tct(
-            'The [type] for this event cannot be found. [link:Read the docs to understand why].',
-            {
-              type: type === 'missing' ? t('transaction') : t('trace'),
-              link: (
-                <ExternalLink href="https://docs.sentry.io/product/sentry-basics/tracing/trace-view/#troubleshooting" />
-              ),
-            }
-          )}
-        </StyledAlert>
-      );
-    }
-
-    trackAdvancedAnalyticsEvent('issue.quick_trace_status', {
-      organization,
-      status: 'success',
-      is_performance_issue: isPerformanceIssue ?? false,
-    });
-
-    return (
-      <Fragment>
-        {this.renderTraceLink(results)}
-        <QuickTraceWrapper>
-          <QuickTrace
-            event={event}
-            quickTrace={results}
-            location={location}
-            organization={organization}
-            anchor="left"
-            errorDest="issue"
-            transactionDest="performance"
-          />
-        </QuickTraceWrapper>
-      </Fragment>
-    );
-  }
-
-  render() {
-    const {quickTrace} = this.props;
-
-    return <ErrorBoundary mini>{this.renderQuickTrace(quickTrace)}</ErrorBoundary>;
-  }
+  return (
+    <LinkContainer>
+      <Link to={generateTraceTarget(event, organization)} onClick={handleTraceLink}>
+        {t('View Full Trace')}
+      </Link>
+    </LinkContainer>
+  );
 }
 
 const LinkContainer = styled('span')`
@@ -207,4 +158,4 @@ const StyledAlert = styled(Alert)`
   margin: 0;
 `;
 
-export default withApi(IssueQuickTrace);
+export default IssueQuickTrace;

--- a/static/app/views/organizationGroupDetails/quickTrace/usePromptCheck.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/usePromptCheck.tsx
@@ -2,17 +2,16 @@ import {useCallback, useEffect, useState} from 'react';
 
 import {promptsCheck, promptsUpdate} from 'sentry/actionCreators/prompts';
 import {Organization} from 'sentry/types';
-import {Event} from 'sentry/types/event';
 import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
 import useApi from 'sentry/utils/useApi';
 
 type Opts = {
-  event: Event;
   feature: string;
   organization: Organization;
+  projectId: string;
 };
 
-function usePromptCheck({event, feature, organization}: Opts) {
+function usePromptCheck({feature, organization, projectId}: Opts) {
   const api = useApi();
 
   const [shouldShowPrompt, setShouldShow] = useState<boolean | null>(null);
@@ -20,23 +19,23 @@ function usePromptCheck({event, feature, organization}: Opts) {
   useEffect(() => {
     promptsCheck(api, {
       organizationId: organization.id,
-      projectId: event.projectID,
+      projectId,
       feature,
     }).then(data => {
       setShouldShow(!promptIsDismissed(data ?? {}, 30));
     });
-  }, [api, event, feature, organization]);
+  }, [api, feature, organization, projectId]);
 
   const snoozePrompt = useCallback(async () => {
     const data = {
-      projectId: event.projectID,
+      projectId,
       organizationId: organization.id,
       feature,
       status: 'snoozed' as const,
     };
     await promptsUpdate(api, data);
     setShouldShow(false);
-  }, [api, event, feature, organization]);
+  }, [api, feature, organization, projectId]);
 
   return {
     shouldShowPrompt,

--- a/static/app/views/organizationGroupDetails/quickTrace/usePromptCheck.tsx
+++ b/static/app/views/organizationGroupDetails/quickTrace/usePromptCheck.tsx
@@ -1,0 +1,47 @@
+import {useCallback, useEffect, useState} from 'react';
+
+import {promptsCheck, promptsUpdate} from 'sentry/actionCreators/prompts';
+import {Organization} from 'sentry/types';
+import {Event} from 'sentry/types/event';
+import {promptIsDismissed} from 'sentry/utils/promptIsDismissed';
+import useApi from 'sentry/utils/useApi';
+
+type Opts = {
+  event: Event;
+  feature: string;
+  organization: Organization;
+};
+
+function usePromptCheck({event, feature, organization}: Opts) {
+  const api = useApi();
+
+  const [shouldShowPrompt, setShouldShow] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    promptsCheck(api, {
+      organizationId: organization.id,
+      projectId: event.projectID,
+      feature,
+    }).then(data => {
+      setShouldShow(!promptIsDismissed(data ?? {}, 30));
+    });
+  }, [api, event, feature, organization]);
+
+  const snoozePrompt = useCallback(async () => {
+    const data = {
+      projectId: event.projectID,
+      organizationId: organization.id,
+      feature,
+      status: 'snoozed' as const,
+    };
+    await promptsUpdate(api, data);
+    setShouldShow(false);
+  }, [api, event, feature, organization]);
+
+  return {
+    shouldShowPrompt,
+    snoozePrompt,
+  };
+}
+
+export default usePromptCheck;


### PR DESCRIPTION
Refactor issueQuickTrace to make the conditions for when something is rendered/hidden easier to grok.

Precursor to #39708

Two interesting cases that still render as before are: 
1. The base case with the "View Full Trace" link and the "This Event" pill:
  
![Screen Shot 2022-11-16 at 1 14 06 PM](https://user-images.githubusercontent.com/187460/202302231-67d615c2-12f0-4f08-8408-83f5a69b01f7.png)


2. The "thing cannot be found" case:
  
![Screen Shot 2022-11-16 at 1 13 58 PM](https://user-images.githubusercontent.com/187460/202302164-9af5c527-0de7-450b-9f0c-79e24be4297a.png)

