### PR TITLE
feat(derive-code-mapping): Use extra kwarg when logging and minor changes

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -3,7 +3,7 @@ from typing import Dict, List, NamedTuple, Union
 
 from .repo import Repo, RepoTree
 
-logger = logging.getLogger("sentry.integrations.utils.code_mapping")
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
@@ -44,6 +44,7 @@ class FrameFilename:
         return self.full_path == other.full_path  # type: ignore
 
 
+# call generate_code_mappings() after you initialize CodeMappingTreesHelper
 class CodeMappingTreesHelper:
     def __init__(self, trees: Dict[str, RepoTree]):
         self.trees = trees
@@ -70,6 +71,12 @@ class CodeMappingTreesHelper:
         """This processes all stackframes and returns if a new code mapping has been generated"""
         reprocess = False
         for stackframe_root, stackframes in buckets.items():
+            if stackframe_root == NO_TOP_DIR:
+                logger.info(
+                    "We do not support top level files.",
+                    extra={"stackframes": stackframes},
+                )
+                continue
             if not self.code_mappings.get(stackframe_root):
                 for frame_filename in stackframes:
                     code_mapping = self._find_code_mapping(frame_filename)
@@ -187,7 +194,7 @@ class CodeMappingTreesHelper:
         #  src_file: "src/sentry/integrations/slack/client.py"
         #  frame_filename.full_path: "sentry/integrations/slack/client.py"
         split = src_file.split(frame_filename.file_and_dir_path)
-        if len(split) > 1:
+        if any(split) and len(split) > 1:
             # This is important because we only want stack frames to match when they
             # include the exact package name
             # e.g. raven/base.py stackframe should not match this source file: apostello/views/base.py

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -71,12 +71,6 @@ class CodeMappingTreesHelper:
         """This processes all stackframes and returns if a new code mapping has been generated"""
         reprocess = False
         for stackframe_root, stackframes in buckets.items():
-            if stackframe_root == NO_TOP_DIR:
-                logger.info(
-                    "We do not support top level files.",
-                    extra={"stackframes": stackframes},
-                )
-                continue
             if not self.code_mappings.get(stackframe_root):
                 for frame_filename in stackframes:
                     code_mapping = self._find_code_mapping(frame_filename)
@@ -194,7 +188,7 @@ class CodeMappingTreesHelper:
         #  src_file: "src/sentry/integrations/slack/client.py"
         #  frame_filename.full_path: "sentry/integrations/slack/client.py"
         split = src_file.split(frame_filename.file_and_dir_path)
-        if any(split) and len(split) > 1:
+        if len(split) > 1:
             # This is important because we only want stack frames to match when they
             # include the exact package name
             # e.g. raven/base.py stackframe should not match this source file: apostello/views/base.py

--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -20,7 +20,7 @@ from sentry.utils.safe import get_path
 ACTIVE_PROJECT_THRESHOLD = timedelta(days=7)
 GROUP_ANALYSIS_RANGE = timedelta(days=14)
 
-logger = logging.getLogger("sentry.tasks.derive_code_mappings")
+logger = logging.getLogger(__name__)
 
 
 @instrumented_task(  # type: ignore
@@ -84,7 +84,7 @@ def identify_stacktrace_paths(data: NodeData) -> List[str]:
             paths = {frame["filename"] for frame in stacktrace["frames"]}
             stacktrace_paths.update(paths)
         except Exception:
-            logger.exception("Error getting filenames for project {project.slug}")
+            logger.exception("Error getting filenames for project.")
     return list(stacktrace_paths)
 
 
@@ -192,4 +192,4 @@ def report_project_codemappings(
         msg = "derive_code_mappings: code mappings already exist."
         extra["existing_code_mappings"] = existing_code_mappings
 
-    logger.info(msg, extra)
+    logger.info(msg, extra=extra)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from sentry.eventstore.models import Event, GroupEvent
     from sentry.eventstream.base import GroupState, GroupStates
 
-logger = logging.getLogger("sentry")
+logger = logging.getLogger(__name__)
 
 locks = LockManager(build_instance_from_options(settings.SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS))
 

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -113,6 +113,14 @@ class TestDerivedCodeMappings(TestCase):
         code_mappings = self.code_mapping_helper.generate_code_mappings(stacktraces)
         assert code_mappings == []
 
+    def test_matches_top_src_file(self):
+        stacktraces = ["setup.py"]
+        code_mappings = self.code_mapping_helper.generate_code_mappings(stacktraces)
+        assert code_mappings == []
+
+        assert self._caplog.records[0].message == "We do not support top level files."
+        assert self._caplog.records[0].levelname == "INFO"
+
     def test_more_than_one_match_does_derive(self):
         stacktraces = [
             # More than one file matches for this, however, the package name is taken into account

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -113,14 +113,6 @@ class TestDerivedCodeMappings(TestCase):
         code_mappings = self.code_mapping_helper.generate_code_mappings(stacktraces)
         assert code_mappings == []
 
-    def test_matches_top_src_file(self):
-        stacktraces = ["setup.py"]
-        code_mappings = self.code_mapping_helper.generate_code_mappings(stacktraces)
-        assert code_mappings == []
-
-        assert self._caplog.records[0].message == "We do not support top level files."
-        assert self._caplog.records[0].levelname == "INFO"
-
     def test_more_than_one_match_does_derive(self):
         stacktraces = [
             # More than one file matches for this, however, the package name is taken into account


### PR DESCRIPTION
When logging with an extra JSON object we need to use the kwarg `extra` or it won't work.