### PR TITLE
ref(derive-code-mapping): Do not process top level files

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -70,6 +70,12 @@ class CodeMappingTreesHelper:
         """This processes all stackframes and returns if a new code mapping has been generated"""
         reprocess = False
         for stackframe_root, stackframes in buckets.items():
+            if stackframe_root == NO_TOP_DIR:
+                logger.info(
+                    "We do not support top level files.",
+                    extra={"stackframes": stackframes},
+                )
+                continue
             if not self.code_mappings.get(stackframe_root):
                 for frame_filename in stackframes:
                     code_mapping = self._find_code_mapping(frame_filename)
@@ -187,7 +193,7 @@ class CodeMappingTreesHelper:
         #  src_file: "src/sentry/integrations/slack/client.py"
         #  frame_filename.full_path: "sentry/integrations/slack/client.py"
         split = src_file.split(frame_filename.file_and_dir_path)
-        if len(split) > 1:
+        if any(split) and len(split) > 1:
             # This is important because we only want stack frames to match when they
             # include the exact package name
             # e.g. raven/base.py stackframe should not match this source file: apostello/views/base.py

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -113,6 +113,15 @@ class TestDerivedCodeMappings(TestCase):
         code_mappings = self.code_mapping_helper.generate_code_mappings(stacktraces)
         assert code_mappings == []
 
+    def test_matches_top_src_file(self):
+        stacktraces = ["setup.py"]
+        code_mappings = self.code_mapping_helper.generate_code_mappings(stacktraces)
+        assert code_mappings == []
+
+        assert self._caplog.records[0].message == "We do not support top level files."
+        assert self._caplog.records[0].levelname == "INFO"
+        assert self._caplog.records[0].stackframes == [FrameFilename("setup.py")]
+
     def test_more_than_one_match_does_derive(self):
         stacktraces = [
             # More than one file matches for this, however, the package name is taken into account


### PR DESCRIPTION
Fixes SENTRY-WEX