### PR TITLE
feat(profiling): Add profiling onboarding for various frameworks

### DIFF
--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -206,6 +206,26 @@ export const withoutPerformanceSupport: Set<PlatformKey> = new Set([
   'minidump',
 ]);
 
+export const profiling = [
+  // mobile
+  'android',
+  'apple-ios',
+  // nodejs
+  'node',
+  'node-express',
+  'node-koa',
+  'node-connect',
+  // python, WSGI only
+  'python',
+  'python-django',
+  'python-flask',
+  'python-sanic',
+  'python-bottle',
+  'python-pylons',
+  'python-pyramid',
+  'python-tornado',
+];
+
 export const releaseHealth: PlatformKey[] = [
   // frontend
   'javascript',


### PR DESCRIPTION
Python and Node have various frameworks to choose from, so make sure the supported frameworks also get the same onboarding experience.