### PR TITLE
feat(profiling): add hasProfile support to event waiter

### DIFF
--- a/static/app/utils/eventWaiter.tsx
+++ b/static/app/utils/eventWaiter.tsx
@@ -33,7 +33,7 @@ type FirstIssue = null | boolean | Group;
 export interface EventWaiterProps {
   api: Client;
   children: (props: {firstIssue: FirstIssue}) => React.ReactNode;
-  eventType: 'error' | 'transaction' | 'replay';
+  eventType: 'error' | 'transaction' | 'replay' | 'profile';
   organization: Organization;
   project: Project;
   disabled?: boolean;
@@ -54,6 +54,8 @@ function getFirstEvent(eventType: EventWaiterProps['eventType'], resp: Project) 
       return resp.firstTransactionEvent;
     case 'replay':
       return resp.hasReplays;
+    case 'profile':
+      return resp.hasProfiles;
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

Adds the final  event waiting indicator at the bottom of the onboarding panel;

![image](https://user-images.githubusercontent.com/7349258/202298203-01b8454a-ffc0-4b98-9d6a-4ab2f867ba63.png)

![image](https://user-images.githubusercontent.com/7349258/202298173-d0400d55-2f28-4f3d-8a95-d852818f975f.png)
