### PR TITLE
feat(onboarding): add default rule for creating project from onboarding

### DIFF
--- a/static/app/views/onboarding/components/createProjectsFooter.tsx
+++ b/static/app/views/onboarding/components/createProjectsFooter.tsx
@@ -59,7 +59,7 @@ export default function CreateProjectsFooter({
           .filter(platform => !persistedOnboardingState.platformToProjectIdMap[platform])
           .map(platform =>
             createProject(api, organization.slug, teams[0].slug, platform, platform, {
-              defaultRules: false,
+              defaultRules: true,
             })
           )
       );


### PR DESCRIPTION
If you create a project outside of onboarding we show an option to create an issue alert for your project which is selected by default. But our onboarding flow is more simple and doesn't have that. As a result, we should just always create an alert rule when creating a new project.