### PR TITLE
perf(perf-issues): apply hasAny on the group_ids column instead of arrayJoining and filter

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -959,7 +959,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
             conditions=[
                 [["hasAny", ["group_ids", ["array", group_ids]]], "=", 1],
             ]
-            + conditions,
+            + (conditions or []),
             filter_keys=filters,
             aggregations=aggregations,
             referrer="serializers.GroupSerializerSnuba._execute_perf_seen_stats_query",

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -948,7 +948,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
             ["max", "timestamp", "last_seen"],
             ["uniq", "tags[sentry:user]", "count"],
         ]
-        filters = {"project_id": project_ids, "group_id": group_ids}
+        filters = {"project_id": project_ids}
         if environment_ids:
             filters["environment"] = environment_ids
         return aliased_query(
@@ -956,7 +956,10 @@ class GroupSerializerSnuba(GroupSerializerBase):
             start=start,
             end=end,
             groupby=["group_id"],
-            conditions=conditions,
+            conditions=[
+                [["hasAny", ["group_ids", ["array", group_ids]]], "=", 1],
+            ]
+            + conditions,
             filter_keys=filters,
             aggregations=aggregations,
             referrer="serializers.GroupSerializerSnuba._execute_perf_seen_stats_query",

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -463,14 +463,17 @@ class SnubaTagStorage(TagStorage):
     def get_perf_group_list_tag_value(
         self, project_ids, group_id_list, environment_ids, key, value
     ):
-        filters = {"project_id": project_ids, "group_id": group_id_list}
+        filters = {"project_id": project_ids}
         if environment_ids:
             filters["environment"] = environment_ids
 
         result = snuba.query(
             dataset=Dataset.Transactions,
             groupby=["group_id"],
-            conditions=[[f"tags[{key}]", "=", value]],
+            conditions=[
+                [["hasAny", ["group_ids", ["array", group_id_list]]], "=", 1],
+                [f"tags[{key}]", "=", value],
+            ],
             filter_keys=filters,
             aggregations=[
                 ["arrayJoin", ["group_ids"], "group_id"],
@@ -736,7 +739,7 @@ class SnubaTagStorage(TagStorage):
     def get_perf_groups_user_counts(
         self, project_ids, group_ids, environment_ids, start=None, end=None
     ):
-        filters_keys = {"project_id": project_ids, "group_id": group_ids}
+        filters_keys = {"project_id": project_ids}
         if environment_ids:
             filters_keys["environment"] = environment_ids
 
@@ -744,6 +747,7 @@ class SnubaTagStorage(TagStorage):
             dataset=Dataset.Transactions,
             start=start,
             end=start,
+            conditions=[[["hasAny", ["group_ids", ["array", group_ids]]], "=", 1]],
             filter_keys=filters_keys,
             aggregations=[
                 ["arrayJoin", ["group_ids"], "group_id"],


### PR DESCRIPTION
Possible query optimization to do some filtering on the column before arrayJoining and filtering.

Before query:
```
SELECT (arrayJoin((group_ids AS _snuba_group_ids)) AS _snuba_group_id), _snuba_group_id, (count() AS _snuba_times_seen), (min((finish_ts AS _snuba_timestamp)) AS _snuba_first_seen), (max(_snuba_timestamp) AS _snuba_last_seen), (ifNull(uniq((user AS `_snuba_tags[sentry:user]`)), 0) AS _snuba_count)
  FROM transactions_local
 WHERE greaterOrEquals((finish_ts AS _snuba_finish_ts), toDateTime('2022-09-15T18:52:01', 'Universal'))
   AND less(_snuba_finish_ts, toDateTime('2022-09-16T18:52:01', 'Universal'))
   AND in((project_id AS _snuba_project_id), tuple(1))
   AND in(_snuba_project_id, tuple(1))
   AND in(_snuba_group_id, tuple(3571022555))
   AND in((environment AS _snuba_environment), tuple('prod'))
 GROUP BY _snuba_group_id
 LIMIT 1000
OFFSET 0
```

after:
```
SELECT (arrayJoin((group_ids AS _snuba_group_ids)) AS _snuba_group_id), _snuba_group_id, (count() AS _snuba_times_seen), (min((finish_ts AS _snuba_timestamp)) AS _snuba_first_seen), (max(_snuba_timestamp) AS _snuba_last_seen), (ifNull(uniq((user AS `_snuba_tags[sentry:user]`)), 0) AS _snuba_count)
  FROM transactions_local
 WHERE greaterOrEquals((finish_ts AS _snuba_finish_ts), toDateTime('2022-11-11T21:07:23', 'Universal'))
   AND less(_snuba_finish_ts, toDateTime('2022-11-11T23:07:23', 'Universal'))
   AND in((project_id AS _snuba_project_id), tuple(4550919112556546))
   AND equals(hasAny(_snuba_group_ids, [1]), 1)
   AND in(_snuba_project_id, tuple(4550919112556546))
   AND in((environment AS _snuba_environment), tuple('morally primary rooster'))
 GROUP BY _snuba_group_id
 LIMIT 1000
OFFSET 0
```
