### PR TITLE
fix(onboarding): mark onboarding as done if no more projects

### DIFF
--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -174,6 +174,11 @@ function SetupDocs({
       // If no projects remaining, then we can leave
       !project
     ) {
+      // marke onboarding as complete
+      setClientState({
+        ...clientState,
+        state: 'finished',
+      });
       browserHistory.push(
         `/organizations/${organization.slug}/issues/?referrer=onboarding-setup-docs-on-complete`
       );


### PR DESCRIPTION
If we ever get a situation whereupon we redirect the user to the issues page because there are no more projects left to instrument, we should mark onboarding as done.