### PR TITLE
fix(replays): improve sentry tracing

### DIFF
--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -68,7 +68,10 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
 
     @metrics.wraps("replays.process_recording.process_chunk")
     def _process_chunk(
-        self, message_dict: RecordingSegmentChunkMessage, message: Message[KafkaPayload]
+        self,
+        message_dict: RecordingSegmentChunkMessage,
+        message: Message[KafkaPayload],
+        current_transaction,
     ) -> None:
         cache_prefix = replay_recording_segment_cache_id(
             project_id=message_dict["project_id"],
@@ -77,7 +80,9 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
         )
 
         part = RecordingSegmentCache(cache_prefix)
-        part[message_dict["chunk_index"]] = message_dict["payload"]
+        with current_transaction.start_child(op="replays.process_recording.store_chunk"):
+            part[message_dict["chunk_index"]] = message_dict["payload"]
+        current_transaction.finish()
 
     @metrics.wraps("replays.process_recording.store_recording.process_headers")
     def _process_headers(
@@ -95,9 +100,10 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
         self,
         message_dict: RecordingSegmentMessage,
         parts: RecordingSegmentParts,
+        current_transaction,
     ) -> None:
-        with sentry_sdk.start_transaction(
-            op="replays.consumer", name="replays.consumer.flush_batch"
+        with current_transaction.start_child(
+            op="replays.process_recording.store_recording", description="store_recording"
         ):
             with metrics.timer("replays.process_recording.store_recording.read_segments"):
                 try:
@@ -204,10 +210,15 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
                     category=DataCategory.REPLAY,
                     quantity=1,
                 )
+        current_transaction.finish()
 
     def _process_recording(
-        self, message_dict: RecordingSegmentMessage, message: Message[KafkaPayload]
+        self,
+        message_dict: RecordingSegmentMessage,
+        message: Message[KafkaPayload],
+        current_transaction,
     ) -> None:
+
         cache_prefix = replay_recording_segment_cache_id(
             project_id=message_dict["project_id"],
             replay_id=message_dict["replay_id"],
@@ -225,6 +236,7 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
                     self._store,
                     message_dict=message_dict,
                     parts=parts,
+                    current_transaction=current_transaction,
                 ),
             )
         )
@@ -233,35 +245,37 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
     def submit(self, message: Message[KafkaPayload]) -> None:
         assert not self.__closed
 
+        current_transaction = sentry_sdk.start_transaction(
+            name="replays.consumer.process_recording",
+            op="replays.consumer",
+            sampled=random.random()
+            < getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0),
+        )
+
         try:
-            with sentry_sdk.start_transaction(
-                name="replays.consumer.process_recording",
-                op="replays.consumer",
-                sampled=random.random()
-                < getattr(settings, "SENTRY_REPLAY_RECORDINGS_CONSUMER_APM_SAMPLING", 0),
-            ):
+
+            with current_transaction.start_child(op="msg_unpack"):
                 message_dict = msgpack.unpackb(message.payload.value)
 
-                if message_dict["type"] == "replay_recording_chunk":
-                    if type(message_dict["payload"]) is str:
-                        # if the payload is uncompressed, we need to encode it as bytes
-                        # as msgpack will decode it as a utf-8 python string
-                        message_dict["payload"] = message_dict["payload"].encode("utf-8")
+            if message_dict["type"] == "replay_recording_chunk":
+                if type(message_dict["payload"]) is str:
+                    # if the payload is uncompressed, we need to encode it as bytes
+                    # as msgpack will decode it as a utf-8 python string
+                    message_dict["payload"] = message_dict["payload"].encode("utf-8")
 
-                    with sentry_sdk.start_span(op="replay_recording_chunk"):
-                        self._process_chunk(
-                            cast(RecordingSegmentChunkMessage, message_dict), message
-                        )
-                if message_dict["type"] == "replay_recording":
-                    with sentry_sdk.start_span(op="replay_recording"):
-                        self._process_recording(
-                            cast(RecordingSegmentMessage, message_dict), message
-                        )
+                self._process_chunk(
+                    cast(RecordingSegmentChunkMessage, message_dict), message, current_transaction
+                )
+            if message_dict["type"] == "replay_recording":
+                self._process_recording(
+                    cast(RecordingSegmentMessage, message_dict), message, current_transaction
+                )
         except Exception:
             # avoid crash looping on bad messsages for now
             logger.exception(
                 "Failed to process replay recording message", extra={"offset": message.offset}
             )
+            current_transaction.finish()
 
     def close(self) -> None:
         self.__closed = True

--- a/src/sentry/replays/consumers/recording/process_recording.py
+++ b/src/sentry/replays/consumers/recording/process_recording.py
@@ -18,6 +18,7 @@ from arroyo.processing.strategies.abstract import ProcessingStrategy
 from arroyo.types import Message, Position
 from django.conf import settings
 from django.db.utils import IntegrityError
+from sentry_sdk.tracing import Transaction
 
 from sentry.constants import DataCategory
 from sentry.models import File
@@ -71,7 +72,7 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
         self,
         message_dict: RecordingSegmentChunkMessage,
         message: Message[KafkaPayload],
-        current_transaction,
+        current_transaction: Transaction,
     ) -> None:
         cache_prefix = replay_recording_segment_cache_id(
             project_id=message_dict["project_id"],
@@ -100,7 +101,7 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
         self,
         message_dict: RecordingSegmentMessage,
         parts: RecordingSegmentParts,
-        current_transaction,
+        current_transaction: Transaction,
     ) -> None:
         with current_transaction.start_child(
             op="replays.process_recording.store_recording", description="store_recording"
@@ -216,7 +217,7 @@ class ProcessRecordingSegmentStrategy(ProcessingStrategy[KafkaPayload]):
         self,
         message_dict: RecordingSegmentMessage,
         message: Message[KafkaPayload],
-        current_transaction,
+        current_transaction: Transaction,
     ) -> None:
 
         cache_prefix = replay_recording_segment_cache_id(


### PR DESCRIPTION
- manage our own transaction stop and starting since we're using a threadpool. The docs also suggest to do this manually: https://docs.sentry.io/platforms/python/troubleshooting/
- re-organize our spans a bit.

This appears to give us better traces, especially in our store function (tested locally):
<img width="581" alt="Screen Shot 2022-11-16 at 2 54 24 PM" src="https://user-images.githubusercontent.com/1976777/202312069-cbb62c2c-3a6d-42ac-b206-b7e43d0ad157.png">
