### PR TITLE
fix(profiling): Always use release render for profile details

### DIFF
--- a/static/app/components/profiling/FrameStack/profileDetails.tsx
+++ b/static/app/components/profiling/FrameStack/profileDetails.tsx
@@ -198,8 +198,9 @@ export function ProfileDetails(props: ProfileDetailsProps) {
               }
             }
 
-            if (key === 'release' && props.profileGroup.metadata.release) {
-              const release = props.profileGroup.metadata.release;
+            if (key === 'release' && value) {
+              const release = value;
+
               // If a release only contains a version key, then we cannot link to it and
               // fallback to just displaying the raw version value.
               if (
@@ -232,6 +233,8 @@ export function ProfileDetails(props: ProfileDetailsProps) {
               );
             }
 
+            // This final fallback is only capabable of rendering a string/undefined/null.
+            // If the value is some other type, make sure not to let it reach here.
             return (
               <DetailsRow key={key}>
                 <strong>{label}:</strong>

--- a/static/app/components/profiling/FrameStack/profileDetails.tsx
+++ b/static/app/components/profiling/FrameStack/profileDetails.tsx
@@ -198,15 +198,14 @@ export function ProfileDetails(props: ProfileDetailsProps) {
               }
             }
 
-            if (
-              key === 'release' &&
-              organization &&
-              props.profileGroup.metadata.release
-            ) {
+            if (key === 'release' && props.profileGroup.metadata.release) {
               const release = props.profileGroup.metadata.release;
               // If a release only contains a version key, then we cannot link to it and
               // fallback to just displaying the raw version value.
-              if (Object.keys(release).length <= 1 && release.version) {
+              if (
+                !organization ||
+                (Object.keys(release).length <= 1 && release.version)
+              ) {
                 return (
                   <DetailsRow key={key}>
                     <strong>{label}:</strong>


### PR DESCRIPTION
This is a wild guess but there's a chance that organization isn't defined at some point then we fall through to the default rendering of metadata values which leads to the error.

The error itself seems to point to a completely different line but the message led me here.

Fixes JAVASCRIPT-2BA3