### PR TITLE
feat(stats): Use 5m granularity for stats less than 6 hours

### DIFF
--- a/static/app/components/charts/utils.spec.jsx
+++ b/static/app/components/charts/utils.spec.jsx
@@ -92,9 +92,10 @@ describe('Chart Utils', function () {
 
       expect(getSeriesApiInterval({period: '29d'})).toBe('1h');
       expect(getSeriesApiInterval({period: '7h'})).toBe('1h');
-
       expect(getSeriesApiInterval({period: '6h'})).toBe('1h');
-      expect(getSeriesApiInterval({period: '1h'})).toBe('1h');
+
+      expect(getSeriesApiInterval({period: '3h'})).toBe('5m');
+      expect(getSeriesApiInterval({period: '1h'})).toBe('5m');
     });
   });
 

--- a/static/app/components/charts/utils.tsx
+++ b/static/app/components/charts/utils.tsx
@@ -136,6 +136,11 @@ export function getSeriesApiInterval(datetimeObj: DateTimeObject) {
     return '4h';
   }
 
+  if (diffInMinutes < SIX_HOURS) {
+    // Less than 6 hours
+    return '5m';
+  }
+
   return '1h';
 }
 


### PR DESCRIPTION
This PR converts the stats page to use 5m granularity at time intervals less than 6 hours.

Old (lol)

<img width="1474" alt="image" src="https://user-images.githubusercontent.com/35509934/202326016-3915be4a-4b0e-4501-aa84-3ccb870d5365.png">

New:

<img width="1281" alt="image" src="https://user-images.githubusercontent.com/35509934/202325851-c9268675-c453-4d40-bbee-bec5a09a9030.png">


