### PR TITLE
fix(mobile-exp): Only render pagination for multiple screenshots

### DIFF
--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.spec.tsx
@@ -182,4 +182,36 @@ describe('Modals -> ScreenshotModal', function () {
     // This pagination doesn't use page links
     expect(getAttachmentsMock).not.toHaveBeenCalled();
   });
+
+  it('does not render pagination buttons when only one screenshot', function () {
+    const eventAttachment = TestStubs.EventAttachment();
+    const attachments = [eventAttachment];
+    render(
+      <Modal
+        Header={stubEl}
+        Footer={stubEl as ModalRenderProps['Footer']}
+        Body={stubEl as ModalRenderProps['Body']}
+        CloseButton={stubEl}
+        closeModal={() => undefined}
+        onDelete={jest.fn()}
+        onDownload={jest.fn()}
+        orgSlug={initialData.organization.slug}
+        projectSlug={project.slug}
+        eventAttachment={eventAttachment}
+        downloadUrl=""
+        attachments={attachments}
+        attachmentIndex={0}
+        groupId="group-id"
+        enablePagination
+      />,
+      {
+        context: initialData.routerContext,
+        organization: initialData.organization,
+      }
+    );
+
+    expect(screen.queryByRole('button', {name: 'Previous'})).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pagination-header-text')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Next'})).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -129,7 +129,7 @@ function Modal({
     };
   } else if (
     memoizedAttachments &&
-    memoizedAttachments.length &&
+    memoizedAttachments.length > 1 &&
     defined(currentAttachmentIndex)
   ) {
     paginationProps = {
@@ -152,9 +152,9 @@ function Modal({
 
   return (
     <Fragment>
-      <StyledHeaderWrapper>
+      <StyledHeaderWrapper hasPagination={defined(paginationProps)}>
         <Header closeButton>{t('Screenshot')}</Header>
-        {paginationProps && (
+        {defined(paginationProps) && (
           <Header>
             <ScreenshotPagination {...paginationProps} />
           </Header>
@@ -234,7 +234,10 @@ function Modal({
 
 export default Modal;
 
-const StyledHeaderWrapper = styled('div')`
+const StyledHeaderWrapper = styled('div')<{hasPagination: boolean}>`
+  ${p =>
+    p.hasPagination &&
+    `
   header {
     margin-bottom: 0;
   }
@@ -243,6 +246,7 @@ const StyledHeaderWrapper = styled('div')`
     margin-top: 0;
     margin-bottom: ${space(3)};
   }
+  `}
 `;
 
 const GeneralInfo = styled('div')`


### PR DESCRIPTION
Only renders pagination buttons for the screenshots modal in issue details if there are more than 1 screenshot