### PR TITLE
feat(relay): Enable total sampling for beta organizations [INGEST-1715]

### DIFF
--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -178,11 +178,7 @@ def get_dynamic_sampling_config(project: Project) -> Optional[Mapping[str, Any]]
                         )
                     active_rules.append(rule)
 
-            config = {"rules": active_rules}
-
-            if features.has("organizations:dynamic-sampling-deprecated", project.organization):
-                config["mode"] = "total"
-            return config
+            return {"rules": active_rules, "mode": "total"}
 
     return None
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -178,7 +178,11 @@ def get_dynamic_sampling_config(project: Project) -> Optional[Mapping[str, Any]]
                         )
                     active_rules.append(rule)
 
-            return {"rules": active_rules}
+            config = {"rules": active_rules}
+
+            if features.has("organizations:dynamic-sampling-deprecated", project.organization):
+                config["mode"] = "total"
+            return config
 
     return None
 

--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -267,6 +267,7 @@ def dyn_sampling_data():
     # return a function that returns fresh config so we don't accidentally get tests interfering with each other
     def inner(active=True):
         return {
+            "mode": "total",
             "rules": [
                 {
                     "sampleRate": 0.7,
@@ -280,7 +281,7 @@ def dyn_sampling_data():
                         ],
                     },
                 }
-            ]
+            ],
         }
 
     return inner

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -263,7 +263,7 @@ def test_project_config_filters_out_non_active_rules_in_dynamic_sampling(
     if active:
         assert dynamic_sampling == dyn_sampling_data(active)
     else:
-        assert dynamic_sampling == {"rules": []}
+        assert dynamic_sampling == {"mode": "total", "rules": []}
 
 
 @pytest.mark.django_db
@@ -346,7 +346,7 @@ def test_project_config_with_latest_release_in_dynamic_sampling_rules(default_pr
         (
             True,
             True,
-            {"rules": []},
+            {"mode": "total", "rules": []},
             {
                 "rules": [
                     DEFAULT_ENVIRONMENT_RULE,
@@ -365,6 +365,7 @@ def test_project_config_with_latest_release_in_dynamic_sampling_rules(default_pr
             True,
             True,
             {
+                "mode": "total",
                 "rules": [
                     {
                         "sampleRate": 0.1,
@@ -373,7 +374,7 @@ def test_project_config_with_latest_release_in_dynamic_sampling_rules(default_pr
                         "condition": {"op": "and", "inner": []},
                         "id": 1000,
                     }
-                ]
+                ],
             },
             {
                 "rules": [
@@ -393,7 +394,7 @@ def test_project_config_with_latest_release_in_dynamic_sampling_rules(default_pr
             True,
             False,
             {"rules": []},
-            {"rules": []},
+            {"mode": "total", "rules": []},
         ),
         (
             True,
@@ -413,7 +414,7 @@ def test_project_config_with_latest_release_in_dynamic_sampling_rules(default_pr
                 ]
             },
         ),
-        (False, False, {"rules": []}, None),
+        (False, False, {"mode": "total", "rules": []}, None),
     ],
 )
 def test_project_config_with_uniform_rules_based_on_plan_in_dynamic_sampling_rules(


### PR DESCRIPTION
Relay will switch dynamic sampling to "received" mode, which applies the
dynamic sampling rate independent of client side sampling. Prior to
this, the server-side sampling rate compensated for client side
sampling. That latter strategy is now called "total" sampling.

To retain behavior for sample rates set during the DS beta, we enable
total mode for these organizations. All other organizations with dynamic
sampling will switch to "received" sampling once Relay is deployed.

See https://github.com/getsentry/relay/pull/1591 for more details.
