### PR TITLE
plugin(twilio): update twilio plugin info

### DIFF
--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -95,8 +95,6 @@ class TwilioConfigurationForm(forms.Form):
 
 
 class TwilioPlugin(CorePluginMixin, NotificationPlugin):
-    author = "Matt Robenolt"
-    author_url = "https://github.com/mattrobenolt"
     version = sentry.VERSION
     description = DESCRIPTION
     resource_links = (


### PR DESCRIPTION
Updates the Twilio plugin information to use our defaults pointing to the Sentry Team and our repo.

(Inherited from the base class)
https://github.com/getsentry/sentry/blob/c5f0f421feee7e94bf4638647945452ae8072cf4/src/sentry_plugins/base.py#L19-L20
