### PR TITLE
ref(toArray): Introduce a `toArray()` helper function and use it

### DIFF
--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -7,6 +7,7 @@ import moment from 'moment';
 import BaseChart from 'sentry/components/charts/baseChart';
 import {DataPoint} from 'sentry/types/echarts';
 import {getFormattedDate, getTimeFormat} from 'sentry/utils/dates';
+import toArray from 'sentry/utils/toArray';
 
 import {truncationFormatter} from '../utils';
 
@@ -182,9 +183,7 @@ function getFormatter({
       ].join('');
     }
 
-    const seriesParams = Array.isArray(seriesParamsOrParam)
-      ? seriesParamsOrParam
-      : [seriesParamsOrParam];
+    const seriesParams = toArray(seriesParamsOrParam);
 
     // If axis, timestamp comes from axis, otherwise for a single item it is defined in the data attribute.
     // The data attribute is usually a list of [name, value] but can also be an object of {name, value} when

--- a/static/app/components/charts/eventsGeoRequest.tsx
+++ b/static/app/components/charts/eventsGeoRequest.tsx
@@ -6,6 +6,7 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import {TableData, TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import EventView from 'sentry/utils/discover/eventView';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
+import toArray from 'sentry/utils/toArray';
 
 interface ChildrenRenderProps {
   errored: boolean;
@@ -47,7 +48,7 @@ const EventsGeoRequest = ({
     id: undefined,
     name: '',
     version: 2,
-    fields: Array.isArray(yAxis) ? yAxis : [yAxis],
+    fields: toArray(yAxis),
     query,
     orderby: orderby ?? '',
     projects,

--- a/static/app/components/charts/percentageAreaChart.tsx
+++ b/static/app/components/charts/percentageAreaChart.tsx
@@ -3,6 +3,7 @@ import type {LineSeriesOption} from 'echarts';
 import moment from 'moment';
 
 import {Series, SeriesDataUnit} from 'sentry/types/echarts';
+import toArray from 'sentry/utils/toArray';
 
 import AreaSeries from './series/areaSeries';
 import BaseChart from './baseChart';
@@ -70,7 +71,7 @@ export default class PercentageAreaChart extends Component<Props> {
         tooltip={{
           formatter: seriesParams => {
             // `seriesParams` can be an array or an object :/
-            const series = Array.isArray(seriesParams) ? seriesParams : [seriesParams];
+            const series = toArray(seriesParams);
 
             // Filter series that have 0 counts
             const date =

--- a/static/app/components/compactSelect.tsx
+++ b/static/app/components/compactSelect.tsx
@@ -19,6 +19,7 @@ import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import space from 'sentry/styles/space';
 import {FormSize} from 'sentry/utils/theme';
+import toArray from 'sentry/utils/toArray';
 import useOverlay, {UseOverlayProps} from 'sentry/utils/useOverlay';
 
 interface Props<OptionType extends OptionTypeBase, MultipleType extends boolean>
@@ -200,7 +201,7 @@ function CompactSelect<
   // Keep track of the default trigger label when the value changes
   const defaultTriggerLabel = useMemo(() => {
     const newValue = valueProp ?? internalValue;
-    const valueSet = Array.isArray(newValue) ? newValue : [newValue];
+    const valueSet = toArray(newValue);
     const selectedOptions = valueSet
       .map(val => getSelectedOptions<OptionType, MultipleType>(options, val))
       .flat();

--- a/static/app/components/events/interfaces/performance/spanCountChart.tsx
+++ b/static/app/components/events/interfaces/performance/spanCountChart.tsx
@@ -12,6 +12,7 @@ import SpanCountHistogramQuery from 'sentry/utils/performance/histogram/spanCoun
 import {HistogramData} from 'sentry/utils/performance/histogram/types';
 import {formatHistogramData} from 'sentry/utils/performance/histogram/utils';
 import theme from 'sentry/utils/theme';
+import toArray from 'sentry/utils/toArray';
 
 interface Props {
   event: EventError;
@@ -52,7 +53,7 @@ export function SpanCountChart({issue, event, location, organization}: Props) {
     const colors = [theme.charts.previousPeriod, ...theme.charts.getColorPalette(4)];
     const tooltip = {
       formatter(series) {
-        const seriesData = Array.isArray(series) ? series : [series];
+        const seriesData = toArray(series);
         let contents: string[] = [];
 
         contents = seriesData.map(item => {

--- a/static/app/components/hotkeysLabel.tsx
+++ b/static/app/components/hotkeysLabel.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import space from 'sentry/styles/space';
 import {getKeyCode} from 'sentry/utils/getKeyCode';
+import toArray from 'sentry/utils/toArray';
 
 const macModifiers = {
   18: '⌥',
@@ -58,9 +59,7 @@ type Props = {
 
 const HotkeysLabel = ({value, forcePlatform}: Props) => {
   // Split by commas and then split by +, but allow escaped /+
-  const hotkeySets = (Array.isArray(value) ? value : [value]).map(o =>
-    o.trim().split('+')
-  );
+  const hotkeySets = toArray(value).map(o => o.trim().split('+'));
 
   const isMac = forcePlatform
     ? forcePlatform === 'macos'

--- a/static/app/components/organizations/pageFilters/parse.tsx
+++ b/static/app/components/organizations/pageFilters/parse.tsx
@@ -6,6 +6,7 @@ import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/constants/pageFilters';
 import {IntervalPeriod, PageFilters} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
+import toArray from 'sentry/utils/toArray';
 
 import {PageFiltersState} from './types';
 
@@ -146,11 +147,7 @@ function getEnvironment(maybe: ParamValue) {
     return undefined;
   }
 
-  if (Array.isArray(maybe)) {
-    return maybe;
-  }
-
-  return [maybe];
+  return toArray(maybe);
 }
 
 type InputParams = {

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -6,6 +6,7 @@ import isString from 'lodash/isString';
 import {sprintf} from 'sprintf-js';
 
 import localStorage from 'sentry/utils/localStorage';
+import toArray from 'sentry/utils/toArray';
 
 const markerStyles = {
   background: '#ff801790',
@@ -285,7 +286,7 @@ function mark(node: React.ReactNode): string {
     ref: null,
     props: {
       style: markerStyles,
-      children: Array.isArray(node) ? node : [node],
+      children: toArray(node),
     },
     _owner: null,
     _store: {},

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -12,6 +12,7 @@ import {
   GroupStats,
 } from 'sentry/types';
 import RequestError from 'sentry/utils/requestError/requestError';
+import toArray from 'sentry/utils/toArray';
 
 import SelectedGroupStore from './selectedGroupStore';
 import {CommonStoreDefinition} from './types';
@@ -147,9 +148,7 @@ const storeConfig: GroupStoreDefinition = {
    * If any items already exist, they will merged into the existing item index.
    */
   add(items) {
-    if (!Array.isArray(items)) {
-      items = [items];
-    }
+    items = toArray(items);
     const newItems = this.mergeItems(items);
 
     this.items = [...this.items, ...newItems];
@@ -162,9 +161,7 @@ const storeConfig: GroupStoreDefinition = {
    * If any items already exist, they will be moved to the front in the order provided.
    */
   addToFront(items) {
-    if (!Array.isArray(items)) {
-      items = [items];
-    }
+    items = toArray(items);
     const itemMap = items.reduce((acc, item) => ({...acc, [item.id]: item}), {});
 
     this.items = [...items, ...this.items.filter(item => !itemMap[item.id])];

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -10,6 +10,7 @@ import {
 import {Client} from 'sentry/api';
 import {Group, Organization, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
+import toArray from 'sentry/utils/toArray';
 
 import {CommonStoreDefinition} from './types';
 
@@ -228,7 +229,7 @@ const storeConfig: GroupingStoreDefinition = {
   },
 
   setStateForId(map, idOrIds, newState) {
-    const ids = Array.isArray(idOrIds) ? idOrIds : [idOrIds];
+    const ids = toArray(idOrIds);
 
     return ids.map(id => {
       const state = (map.has(id) && map.get(id)) || {};

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -43,6 +43,7 @@ import {
   TOP_N,
 } from 'sentry/utils/discover/types';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
+import toArray from 'sentry/utils/toArray';
 import {
   FieldValueKind,
   TableColumn,
@@ -251,9 +252,9 @@ const decodeTeams = (location: Location): ('myteams' | number)[] => {
     return [];
   }
   const value = location.query.team;
-  return (Array.isArray(value) ? value.map(decodeTeam) : [decodeTeam(value)]).filter(
-    team => team === 'myteams' || !isNaN(team)
-  );
+  return toArray(value)
+    .map(decodeTeam)
+    .filter(team => team === 'myteams' || !isNaN(team));
 };
 
 const decodeProjects = (location: Location): number[] => {
@@ -262,7 +263,7 @@ const decodeProjects = (location: Location): number[] => {
   }
 
   const value = location.query.project;
-  return Array.isArray(value) ? value.map(i => parseInt(i, 10)) : [parseInt(value, 10)];
+  return toArray(value).map(i => parseInt(i, 10));
 };
 
 const queryStringFromSavedQuery = (saved: NewQuery | SavedQuery): string => {

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -39,6 +39,7 @@ import {getShortEventId} from 'sentry/utils/events';
 import {formatFloat, formatPercentage} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import Projects from 'sentry/utils/projects';
+import toArray from 'sentry/utils/toArray';
 import {
   ContextType,
   QuickContextHoverWrapper,
@@ -288,7 +289,7 @@ export const FIELD_FORMATTERS: FieldFormatters = {
   array: {
     isSortable: true,
     renderFunc: (field, data) => {
-      const value = Array.isArray(data[field]) ? data[field] : [data[field]];
+      const value = toArray(data[field]);
       return <ArrayValue value={value} />;
     },
   },

--- a/static/app/utils/toArray.tsx
+++ b/static/app/utils/toArray.tsx
@@ -1,0 +1,3 @@
+export default function toArray<T>(val: T | T[]) {
+  return Array.isArray(val) ? val : [val];
+}

--- a/static/app/utils/useHotkeys.tsx
+++ b/static/app/utils/useHotkeys.tsx
@@ -1,5 +1,7 @@
 import {useCallback, useEffect, useMemo} from 'react';
 
+import toArray from 'sentry/utils/toArray';
+
 import {getKeyCode} from './getKeyCode';
 
 const isKeyPressed = (key: string, evt: KeyboardEvent): boolean => {
@@ -54,7 +56,7 @@ export function useHotkeys(hotkeys: Hotkey[], deps: React.DependencyList): void 
     (evt: KeyboardEvent) => {
       for (const hotkey of memoizedHotkeys) {
         const preventDefault = !hotkey.skipPreventDefault;
-        const keysets = Array.isArray(hotkey.match) ? hotkey.match : [hotkey.match];
+        const keysets = toArray(hotkey.match);
 
         for (const keyset of keysets) {
           const keys = keyset.split('+');

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -44,6 +44,7 @@ import {getDuration} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {MINUTES_THRESHOLD_TO_DISPLAY_SECONDS} from 'sentry/utils/sessions';
 import theme from 'sentry/utils/theme';
+import toArray from 'sentry/utils/toArray';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
 import {makeDefaultCta} from 'sentry/views/alerts/rules/metric/metricRulePresets';
 import {
@@ -350,9 +351,7 @@ class MetricChart extends PureComponent<Props, State> {
                     tooltip={{
                       formatter: seriesParams => {
                         // seriesParams can be object instead of array
-                        const pointSeries = Array.isArray(seriesParams)
-                          ? seriesParams
-                          : [seriesParams];
+                        const pointSeries = toArray(seriesParams);
                         const {marker, data: pointData, seriesName} = pointSeries[0];
                         const [pointX, pointY] = pointData as [number, number];
                         const pointYFormatted = alertTooltipValueFormatter(

--- a/static/app/views/alerts/utils/index.tsx
+++ b/static/app/views/alerts/utils/index.tsx
@@ -7,6 +7,7 @@ import {defined} from 'sentry/utils';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
+import toArray from 'sentry/utils/toArray';
 import {
   Dataset,
   Datasource,
@@ -192,9 +193,5 @@ export function getTeamParams(team?: string | string[]): string[] {
     return [];
   }
 
-  if (Array.isArray(team)) {
-    return team;
-  }
-
-  return [team];
+  return toArray(team);
 }

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -20,6 +20,7 @@ import space from 'sentry/styles/space';
 import {BaseGroup, Group, Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import toArray from 'sentry/utils/toArray';
 import withApi from 'sentry/utils/withApi';
 
 import ErrorMessage from './errorMessage';
@@ -153,7 +154,7 @@ function Grouping({api, groupId, location, organization, router, projSlug}: Prop
 
       const pageLinks = resp?.getResponseHeader?.('Link');
       setPagination(pageLinks ?? '');
-      setActiveGroupingLevelDetails(Array.isArray(data) ? data : [data]);
+      setActiveGroupingLevelDetails(toArray(data));
       setIsGroupingLevelDetailsLoading(false);
     } catch (err) {
       setIsGroupingLevelDetailsLoading(false);

--- a/static/app/views/organizationStats/teamInsights/teamReleases.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamReleases.tsx
@@ -19,6 +19,7 @@ import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {ColorOrAlias, Theme} from 'sentry/utils/theme';
+import toArray from 'sentry/utils/toArray';
 
 import {ProjectBadge, ProjectBadgeContainer} from './styles';
 import {barAxisLabel, groupByTrend, sortSeriesByDay} from './utils';
@@ -225,9 +226,7 @@ class TeamReleases extends AsyncComponent<Props, State> {
             tooltip={{
               formatter: seriesParams => {
                 // `seriesParams` can be an array or an object :/
-                const [series] = Array.isArray(seriesParams)
-                  ? seriesParams
-                  : [seriesParams];
+                const [series] = toArray(seriesParams);
 
                 const dateFormat = 'MMM D';
                 const startDate = moment(series.data[0]).format(dateFormat);

--- a/static/app/views/performance/landing/vitalsCards.tsx
+++ b/static/app/views/performance/landing/vitalsCards.tsx
@@ -34,6 +34,7 @@ import VitalsCardsDiscoverQuery, {
 } from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import {decodeList} from 'sentry/utils/queryString';
 import theme from 'sentry/utils/theme';
+import toArray from 'sentry/utils/toArray';
 import useApi from 'sentry/utils/useApi';
 
 import ColorBar from '../vitalDetail/colorBar';
@@ -390,7 +391,7 @@ export function VitalBar(props: VitalBarProps) {
     good: 0,
     total: 0,
   };
-  const vitals = Array.isArray(vital) ? vital : [vital];
+  const vitals = toArray(vital);
   vitals.forEach(vitalName => {
     const c = data?.[vitalName] ?? {};
     Object.keys(counts).forEach(countKey => (counts[countKey] += c[countKey]));

--- a/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/latencyChart/content.tsx
@@ -17,6 +17,7 @@ import {
   formatHistogramData,
 } from 'sentry/utils/performance/histogram/utils';
 import theme from 'sentry/utils/theme';
+import toArray from 'sentry/utils/toArray';
 
 import {ViewProps} from '../../../types';
 import {filterToColor, filterToField, SpanOperationBreakdownFilter} from '../../filter';
@@ -78,7 +79,7 @@ function Content({
     // the tooltip content entirely when zooming is no longer available.
     const tooltip = {
       formatter(series) {
-        const seriesData = Array.isArray(series) ? series : [series];
+        const seriesData = toArray(series);
         let contents: string[] = [];
         if (!zoomError) {
           // Replicate the necessary logic from sentry/components/charts/components/tooltip.jsx

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -19,6 +19,7 @@ import {TRACING_FIELDS} from 'sentry/utils/discover/fields';
 import {getDuration} from 'sentry/utils/formatters';
 import getCurrentSentryReactTransaction from 'sentry/utils/getCurrentSentryReactTransaction';
 import {decodeScalar} from 'sentry/utils/queryString';
+import toArray from 'sentry/utils/toArray';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 
 import {DEFAULT_MAX_DURATION} from './trends/utils';
@@ -327,9 +328,7 @@ export function getSelectedProjectPlatformsArray(
   projects: Project[]
 ) {
   const projectQuery = location.query.project;
-  const selectedProjectIdSet = Array.isArray(projectQuery)
-    ? new Set(projectQuery)
-    : new Set([projectQuery]);
+  const selectedProjectIdSet = new Set(toArray(projectQuery));
 
   const selectedProjectPlatforms = projects.reduce((acc: string[], project) => {
     if (selectedProjectIdSet.has(project.id)) {

--- a/static/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/static/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -4,6 +4,7 @@ import {Organization} from 'sentry/types';
 import EventView from 'sentry/utils/discover/eventView';
 import {WebVital} from 'sentry/utils/fields';
 import VitalsCardDiscoverQuery from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
+import toArray from 'sentry/utils/toArray';
 
 import {VitalBar} from '../landing/vitalsCards';
 
@@ -35,7 +36,7 @@ function VitalInfo({
   hideVitalThresholds,
   hideDurationDetail,
 }: Props) {
-  const vitals = Array.isArray(vital) ? vital : [vital];
+  const vitals = toArray(vital);
   const contentCommonProps = {
     vital,
     showBar: !hideBar,

--- a/static/app/views/projectsDashboard/utils.tsx
+++ b/static/app/views/projectsDashboard/utils.tsx
@@ -1,3 +1,5 @@
+import toArray from 'sentry/utils/toArray';
+
 /**
  * Noramlize a team slug from the query
  */
@@ -6,9 +8,5 @@ export function getTeamParams(team?: string | string[]): string[] {
     return [];
   }
 
-  if (Array.isArray(team)) {
-    return team;
-  }
-
-  return [team];
+  return toArray(team);
 }

--- a/tests/js/sentry-test/dropdownMenu.tsx
+++ b/tests/js/sentry-test/dropdownMenu.tsx
@@ -3,6 +3,8 @@ import {ReactWrapper} from 'enzyme'; // eslint-disable-line no-restricted-import
 
 import {triggerPress} from 'sentry-test/utils';
 
+import toArray from 'sentry/utils/toArray';
+
 type SelectDropdownItemProps = {
   /**
    * They key(s) of menu item(s) to select. If the item is nested inside a
@@ -81,7 +83,7 @@ export async function selectDropdownMenuItem({
 
   // Select menu item(s) via itemKey
   await act(async () => {
-    const keys = Array.isArray(itemKey) ? itemKey : [itemKey];
+    const keys = toArray(itemKey);
 
     for (const key of keys) {
       triggerPress(


### PR DESCRIPTION
I noticed a few spots where we ensure that a value is an array; but there's a few different ways that folks spell it out. 
So I created a simple helper method to do it, and hopefully make things more readable in the process.