### PR TITLE
perf(projects): Correctly lazy load project cards [UP-212]

### DIFF
--- a/static/app/__mocks__/react-lazyload.tsx
+++ b/static/app/__mocks__/react-lazyload.tsx
@@ -1,0 +1,11 @@
+/**
+ * Auto-mock of the react-lazyload library for jest
+ *
+ * These mocks are simple no-ops to make testing lazy-loaded components simpler.
+ */
+
+const LazyLoad = ({children}) => children;
+
+export const forceCheck = jest.fn();
+
+export default LazyLoad;

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -321,6 +321,7 @@ const HeaderRow = styled('div')`
 
 const StyledProjectCard = styled(Panel)`
   min-height: 330px;
+  margin: 0;
 `;
 
 const FooterWrapper = styled('div')`

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -91,10 +91,6 @@ jest.mock('react-router', function reactRouterMockFactory() {
     },
   };
 });
-jest.mock('react-lazyload', function reactLazyLoadMockFactory() {
-  const LazyLoadMock = ({children}) => children;
-  return LazyLoadMock;
-});
 
 jest.mock('react-virtualized', function reactVirtualizedMockFactory() {
   const ActualReactVirtualized = jest.requireActual('react-virtualized');


### PR DESCRIPTION
Orgs with many projects have an unusable projects page due to the number of rendered elements. There was a LazyLoad component, but it incorrectly wrapped the entire results div, not individual project cards. This rectifies that and makes the projects page usable again.

We should still probably paginate that page, but this is a quick fix that at least makes things tenable in the meantime.