### PR TITLE
fix(ecosystem): Display more stacktrace setup errors

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -104,7 +104,12 @@ function StacktraceLinkModal({
       closeModal();
       onSubmit();
     } catch (err) {
-      setError(err?.responseJSON?.sourceUrl?.[0] ?? t('Unable to save configuration'));
+      const errorJson = err?.responseJSON || {};
+      setError(
+        errorJson.sourceUrl?.[0] ??
+          errorJson.nonFieldErrors?.[0] ??
+          t('Unable to save configuration')
+      );
     }
   };
 


### PR DESCRIPTION
Show nonFieldErrors which might include "Code path config already exists with this project and stack trace root"
