### PR TITLE
fix(discover): Fix flakey events meps backend tests

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -13,6 +13,8 @@ from sentry.models.transaction_threshold import (
     TransactionMetric,
 )
 from sentry.search.events import constants
+from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
+from sentry.snuba.metrics.naming_layer.public import TransactionMetricKey
 from sentry.testutils import MetricsEnhancedPerformanceTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
@@ -1307,6 +1309,12 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             "per_page": 50,
         }
 
+        self.wait_for_metric_count(
+            self.project,
+            1,
+            metric="measurements.something_custom",
+            mri="d:transactions/measurements.something_custom@millisecond",
+        )
         response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
@@ -1400,6 +1408,12 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             "per_page": 50,
         }
 
+        self.wait_for_metric_count(
+            self.project,
+            1,
+            metric=TransactionMetricKey.MEASUREMENTS_CLS.value,
+            mri=TransactionMRI.MEASUREMENTS_CLS.value,
+        )
         response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
@@ -1603,6 +1617,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             "per_page": 50,
         }
 
+        self.wait_for_metric_count(self.project, 2)
         response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1
@@ -1640,6 +1655,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             "per_page": 50,
         }
 
+        self.wait_for_metric_count(self.project, 2)
         response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 2
@@ -1913,6 +1929,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
             "per_page": 50,
         }
 
+        self.wait_for_metric_count(self.project, 3)
         response = self.do_request(query)
         assert response.status_code == 200, response.content
         assert len(response.data["data"]) == 1


### PR DESCRIPTION
Updates some of the more flakey tests to wait for clickhouse to be populated before running test queries. The suspicion is that because clickhouse isnt synchronous, there's a small chance that test queries are being run before metrics are fully written, which can cause flakes.