### PR TITLE
feat(alert-previews): event filters for transactions

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1023,7 +1023,7 @@ SENTRY_FEATURES = {
     # Enable issue alert incompatible rule check
     "organizations:issue-alert-incompatible-rules": False,
     # Enable issue alert previews
-    "organizations:issue-alert-preview": True,
+    "organizations:issue-alert-preview": False,
     # Enable issue alert test notifications
     "organizations:issue-alert-test-notifications": False,
     # Whether to allow issue only search on the issue list

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1023,7 +1023,7 @@ SENTRY_FEATURES = {
     # Enable issue alert incompatible rule check
     "organizations:issue-alert-incompatible-rules": False,
     # Enable issue alert previews
-    "organizations:issue-alert-preview": False,
+    "organizations:issue-alert-preview": True,
     # Enable issue alert test notifications
     "organizations:issue-alert-test-notifications": False,
     # Whether to allow issue only search on the issue list

--- a/src/sentry/rules/base.py
+++ b/src/sentry/rules/base.py
@@ -9,6 +9,7 @@ from django import forms
 
 from sentry.eventstore.models import GroupEvent
 from sentry.models import Project, Rule
+from sentry.snuba.dataset import Dataset
 from sentry.types.condition_activity import ConditionActivity
 from sentry.types.rules import RuleFuture
 
@@ -104,8 +105,8 @@ class RuleBase(abc.ABC):
     ) -> CallbackFuture:
         return CallbackFuture(callback=callback, key=key, kwargs=kwargs)
 
-    def get_event_columns(self) -> Sequence[str]:
-        return []
+    def get_event_columns(self) -> Dict[Dataset, Sequence[str]]:
+        return {}
 
     def passes_activity(
         self, condition_activity: ConditionActivity, event_map: Dict[str, Any]

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -118,7 +118,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
     def passes(self, event: GroupEvent, state: EventState) -> bool:
         interval, value = self._get_options()
-        if not (interval and value):
+        if not (interval and value is not None):
             return False
 
         # TODO(mgaeta): Bug: Rule is optional.
@@ -215,7 +215,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         self, activity: ConditionActivity, buckets: Sequence[Dict[str, Any]]
     ) -> bool:
         interval, value = self._get_options()
-        if not (interval and value):
+        if not (interval and value is not None):
             return False
         interval_delta = self.intervals[interval][1]
 

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -9,7 +9,9 @@ from sentry.eventstore.models import GroupEvent
 from sentry.rules import LEVEL_MATCH_CHOICES as MATCH_CHOICES
 from sentry.rules import EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
-from sentry.types.condition_activity import ConditionActivity
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.events import Columns
+from sentry.types.condition_activity import ConditionActivity, get_dataset_columns
 
 key: Callable[[Tuple[int, str]], int] = lambda x: x[0]
 LEVEL_CHOICES = {f"{k}": v for k, v in sorted(LOG_LEVELS.items(), key=key, reverse=True)}
@@ -62,8 +64,11 @@ class LevelCondition(EventCondition):
         }
         return self.label.format(**data)
 
-    def get_event_columns(self) -> Sequence[str]:
-        return ["tags.key", "tags.value"]
+    def get_event_columns(self) -> Dict[Dataset, Sequence[str]]:
+        columns: Dict[Dataset, Sequence[str]] = get_dataset_columns(
+            [Columns.TAGS_KEY, Columns.TAGS_VALUE]
+        )
+        return columns
 
     def passes_activity(
         self, condition_activity: ConditionActivity, event_map: Dict[str, Any]

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -8,7 +8,9 @@ from sentry import tagstore
 from sentry.eventstore.models import GroupEvent
 from sentry.rules import MATCH_CHOICES, EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
-from sentry.types.condition_activity import ConditionActivity
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.events import Columns
+from sentry.types.condition_activity import ConditionActivity, get_dataset_columns
 
 
 class TaggedEventForm(forms.Form):  # type: ignore
@@ -145,5 +147,8 @@ class TaggedEventCondition(EventCondition):
         }
         return self.label.format(**data)
 
-    def get_event_columns(self) -> Sequence[str]:
-        return ["tags.key", "tags.value"]
+    def get_event_columns(self) -> Dict[Dataset, Sequence[str]]:
+        columns: Dict[Dataset, Sequence[str]] = get_dataset_columns(
+            [Columns.TAGS_KEY, Columns.TAGS_VALUE]
+        )
+        return columns

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
+
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.events import Column
 
 FREQUENCY_CONDITION_BUCKET_SIZE = timedelta(minutes=5)
 
@@ -19,4 +22,26 @@ class ConditionActivity:
     group_id: str
     type: ConditionActivityType
     timestamp: datetime
-    data: Dict[str, Any] | None = None
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+# Map of supported datasets for preview
+DATASET_TO_COLUMN_NAME = {
+    Dataset.Events: "event_name",
+    Dataset.Transactions: "transaction_name",
+}
+
+
+def get_dataset_columns(columns: Sequence[Column]) -> Dict[Dataset, Sequence[str]]:
+    """
+    Given a list of Column Enum objects, return their actual column name in each dataset that is supported
+    """
+    dataset_columns = {}
+    for dataset, column_name in DATASET_TO_COLUMN_NAME.items():
+        dataset_columns[dataset] = [
+            getattr(column.value, column_name)
+            for column in columns
+            if getattr(column.value, column_name) is not None
+        ]
+
+    return dataset_columns

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -234,11 +234,11 @@ class ProjectRulePreviewTest(TestCase):
             }
         ]
 
-        results = preview(self.project, conditions, filters, MATCH_ARGS)
+        results = preview(self.project, conditions, filters, *MATCH_ARGS)
         assert event.group in results
 
         filters[0]["value"] = "goodbye world"
-        results = preview(self.project, conditions, filters, MATCH_ARGS)
+        results = preview(self.project, conditions, filters, *MATCH_ARGS)
         assert event.group not in results
 
     def test_unsupported_conditions(self):

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -11,12 +11,14 @@ from sentry.rules.history.preview import (
     get_top_groups,
     preview,
 )
+from sentry.snuba.dataset import Dataset
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
 from sentry.types.condition_activity import ConditionActivity, ConditionActivityType
 from sentry.types.issues import GroupType
+from sentry.utils.samples import load_data
 
 MATCH_ARGS = ("all", "all", 0)
 
@@ -232,11 +234,11 @@ class ProjectRulePreviewTest(TestCase):
             }
         ]
 
-        results = preview(self.project, conditions, filters, "all", "all", 0)
+        results = preview(self.project, conditions, filters, MATCH_ARGS)
         assert event.group in results
 
         filters[0]["value"] = "goodbye world"
-        results = preview(self.project, conditions, filters, "all", "all", 0)
+        results = preview(self.project, conditions, filters, MATCH_ARGS)
         assert event.group not in results
 
     def test_unsupported_conditions(self):
@@ -324,6 +326,122 @@ class ProjectRulePreviewTest(TestCase):
         result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert result.count() == 0
 
+    def test_transactions(self):
+        prev_hour = timezone.now() - timedelta(hours=1)
+        event = load_data(
+            "transaction",
+            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
+        ).copy()
+        event.update(
+            {
+                "start_timestamp": iso_format(prev_hour - timedelta(minutes=1)),
+                "timestamp": iso_format(prev_hour),
+                "tags": {"foo": "bar"},
+                "transaction": "this is where a transaction's 'message' is stored",
+            }
+        )
+        transaction = self.store_event(project_id=self.project.id, data=event)
+        self.store_event(project_id=self.project.id, data=event)
+
+        perf_issue = transaction.groups[0]
+        perf_issue.update(first_seen=prev_hour)
+        Activity.objects.create(
+            project=self.project,
+            group=perf_issue,
+            type=ActivityType.SET_REGRESSION.value,
+            datetime=prev_hour,
+            data={"event_id": transaction.event_id},
+        )
+        conditions = [{"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"}]
+        filters = [
+            {
+                "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+                "key": "foo",
+                "match": "eq",
+                "value": "bar",
+            }
+        ]
+        result = preview(self.project, conditions, filters, "all", "all", 0)
+        assert perf_issue in result
+
+        filters[0]["value"] = "baz"
+        result = preview(self.project, conditions, filters, "all", "all", 0)
+        assert perf_issue not in result
+
+        filters = [
+            {
+                "id": "sentry.rules.filters.event_attribute.EventAttributeFilter",
+                "attribute": "message",
+                "match": "eq",
+                "value": "this is where a transaction's 'message' is stored",
+            }
+        ]
+        result = preview(self.project, conditions, filters, "all", "all", 0)
+        assert perf_issue in result
+
+        filters[0]["value"] = "wrong message"
+        result = preview(self.project, conditions, filters, "all", "all", 0)
+        assert perf_issue not in result
+        # this can be tested when SNS-1891 is fixed
+        """
+        conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
+        filters = [{
+            "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+            "key": "foo",
+            "match": "eq",
+            "value": "bar",
+        }]
+        result = preview(self.project, conditions, filters, "all", "all", 0)
+        assert perf_issue in result
+        """
+
+    def test_errors_transactions_together(self):
+        prev_hour = timezone.now() - timedelta(hours=1)
+        error = self.store_event(
+            project_id=self.project.id,
+            data={"timestamp": iso_format(prev_hour), "tags": {"foo": "bar"}},
+        )
+        issue = error.group
+        issue.update(first_seen=prev_hour)
+
+        event = load_data(
+            "transaction",
+            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
+        ).copy()
+        event.update(
+            {
+                "start_timestamp": iso_format(prev_hour - timedelta(minutes=1)),
+                "timestamp": iso_format(prev_hour),
+                "tags": {"foo": "bar"},
+            }
+        )
+        transaction = self.store_event(project_id=self.project.id, data=event)
+
+        perf_issue = transaction.groups[0]
+        perf_issue.update(first_seen=timezone.now() - timedelta(weeks=3))
+        Activity.objects.create(
+            project=self.project,
+            group=perf_issue,
+            type=ActivityType.SET_REGRESSION.value,
+            datetime=prev_hour,
+            data={"event_id": transaction.event_id},
+        )
+
+        conditions = [
+            {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+            {"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"},
+        ]
+        filters = [
+            {
+                "id": "sentry.rules.filters.tagged_event.TaggedEventFilter",
+                "key": "foo",
+                "match": "eq",
+                "value": "bar",
+            }
+        ]
+        result = preview(self.project, conditions, filters, "any", "all", 0)
+        assert issue in result and perf_issue in result
+
 
 @freeze_time()
 @region_silo_test
@@ -410,7 +528,7 @@ class GetEventsTest(TestCase):
                 )
             ]
         }
-        events = get_events(self.project, activity, [])
+        events = get_events(self.project, activity, {Dataset.Events: []})
 
         assert len(events) == 1
         assert event.event_id in events
@@ -442,7 +560,7 @@ class GetEventsTest(TestCase):
                 ),
             ]
         }
-        events = get_events(self.project, activity, [])
+        events = get_events(self.project, activity, {Dataset.Events: []})
 
         assert len(events) == 2
         assert all([event.event_id in events for event in (regression_event, reappeared_event)])


### PR DESCRIPTION
Adds support to query transactions for event filters. Datasets sometimes have different column names, so `get_event_columns` needs to return a separate column list for each supported dataset.