### PR TITLE
feat(hybrid-cloud): Update DEFAULT_APP_ROUTE for customer domains

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -17,7 +17,9 @@ export const usingCustomerDomain =
 // to when the application does not have any further context
 //
 // e.g. loading app root or switching organization
-export const DEFAULT_APP_ROUTE = '/organizations/:orgSlug/issues/';
+export const DEFAULT_APP_ROUTE = usingCustomerDomain
+  ? '/issues/'
+  : '/organizations/:orgSlug/issues/';
 
 export const API_ACCESS_SCOPES = [
   'project:read',


### PR DESCRIPTION
Update `DEFAULT_APP_ROUTE` to be `/issues/` whenever a customer domain (i.e. `orgslug.sentry.io`) is being used.