### PR TITLE
fix(derive-code-mappings): Various fixes

### DIFF
--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -116,10 +116,13 @@ class CodeMappingTreesHelper:
                         self.trees[repo_full_name], frame_filename
                     )
                 )
-            except Exception:
-                logger.exception(
-                    f"Code mapping failed for {frame_filename} in {repo_full_name}. Processing continues."
+            except NotImplementedError:
+                logger.warning(
+                    "Code mapping failed for module with no package name. Processing continues.",
+                    extra={"frame_filename": frame_filename, "repo_full_name": repo_full_name},
                 )
+            except Exception:
+                logger.exception("Unexpected error. Processing continues.")
 
         if len(_code_mappings) == 0:
             logger.warning(f"No files matched for {frame_filename.full_path}")
@@ -133,12 +136,15 @@ class CodeMappingTreesHelper:
 
     def _get_code_mapping_source_path(self, src_file: str, frame_filename: FrameFilename) -> str:
         """Generate the source path of a code mapping
-        e.g. src/sentry/identity/oauth2.py -> src/sentry
+        e.g. src/sentry/identity/oauth2.py (sentry/identity/oauth2.py) -> src/sentry
+        e.g. src/sentry/wsgi.py (sentry/wsgi.py) -> src/sentry
         e.g. ssl.py -> raise NotImplementedError
         """
         if frame_filename.dir_path != "":
             source_path = src_file.rsplit(frame_filename.dir_path)[0].rstrip("/")
             return f"{source_path}/"
+        elif frame_filename.root != "":
+            return src_file.rsplit(frame_filename.file_name)[0]
         else:
             raise NotImplementedError("We do not support top level files.")
 
@@ -193,11 +199,16 @@ class CodeMappingTreesHelper:
         # For instance:
         #  src_file: "src/sentry/integrations/slack/client.py"
         #  frame_filename.full_path: "sentry/integrations/slack/client.py"
-        split = src_file.split(frame_filename.file_and_dir_path)
+        # This should not match:
+        #  src_file: "src/sentry/utils/uwsgi.py"
+        #  frame_filename: "sentry/wsgi.py"
+        split = src_file.split(f"/{frame_filename.file_and_dir_path}")
         if any(split) and len(split) > 1:
             # This is important because we only want stack frames to match when they
             # include the exact package name
             # e.g. raven/base.py stackframe should not match this source file: apostello/views/base.py
-            match = split[0].rfind(f"{frame_filename.root}/") > -1
+            match = (
+                split[0].rfind(f"/{frame_filename.root}") > -1 or split[0] == frame_filename.root
+            )
 
         return match

--- a/src/sentry/integrations/utils/code_mapping.py
+++ b/src/sentry/integrations/utils/code_mapping.py
@@ -117,9 +117,8 @@ class CodeMappingTreesHelper:
                     )
                 )
             except NotImplementedError:
-                logger.warning(
-                    "Code mapping failed for module with no package name. Processing continues.",
-                    extra={"frame_filename": frame_filename, "repo_full_name": repo_full_name},
+                logger.exception(
+                    "Code mapping failed for module with no package name. Processing continues."
                 )
             except Exception:
                 logger.exception("Unexpected error. Processing continues.")

--- a/tests/sentry/integrations/utils/test_code_mapping.py
+++ b/tests/sentry/integrations/utils/test_code_mapping.py
@@ -30,7 +30,7 @@ class TestDerivedCodeMappings(TestCase):
         self.code_mapping_helper = CodeMappingTreesHelper(
             {
                 self.foo_repo.name: RepoTree(self.foo_repo, files=sentry_files),
-                self.bar_repo.name: RepoTree(self.bar_repo, files=["getsentry/web/urls.py"]),
+                self.bar_repo.name: RepoTree(self.bar_repo, files=["sentry/web/urls.py"]),
             }
         )
 
@@ -122,6 +122,16 @@ class TestDerivedCodeMappings(TestCase):
         assert self._caplog.records[0].levelname == "INFO"
         assert self._caplog.records[0].stackframes == [FrameFilename("setup.py")]
 
+    def test_no_dir_depth_match(self):
+        code_mappings = self.code_mapping_helper.generate_code_mappings(["sentry/wsgi.py"])
+        assert code_mappings == [
+            CodeMapping(
+                repo=Repo(name="Test-Organization/foo", branch="master"),
+                stacktrace_root="sentry/",
+                source_path="src/sentry/",
+            )
+        ]
+
     def test_more_than_one_match_does_derive(self):
         stacktraces = [
             # More than one file matches for this, however, the package name is taken into account
@@ -163,7 +173,7 @@ class TestDerivedCodeMappings(TestCase):
     def test_more_than_one_repo_match(self):
         # XXX: There's a chance that we could infer package names but that is risky
         # repo 1: src/sentry/web/urls.py
-        # repo 2: getsentry/web/urls.py
+        # repo 2: sentry/web/urls.py
         stacktraces = ["sentry/web/urls.py"]
         code_mappings = self.code_mapping_helper.generate_code_mappings(stacktraces)
         # The file appears in more than one repo, thus, we are unable to determine the code mapping


### PR DESCRIPTION
The previous fix for SENTRY-WEX allowed seeing reduced the noise and I discovered the case where `path/python_module.py` would not be considered for deriving code mappings.

There's various fixes in this PR that increases the chances of creating code mappings.