### PR TITLE
ref(profiling): Clarify suspect functions are total time

### DIFF
--- a/static/app/components/profiling/functionsTable.spec.tsx
+++ b/static/app/components/profiling/functionsTable.spec.tsx
@@ -80,13 +80,13 @@ describe('FunctionsTable', function () {
     expect(screen.getByText('Package')).toBeInTheDocument();
     expect(screen.getByText('bar')).toBeInTheDocument();
 
-    expect(screen.getByText('Count')).toBeInTheDocument();
+    expect(screen.getByText('Total Occurrences')).toBeInTheDocument();
     expect(screen.getByText('10')).toBeInTheDocument();
 
-    expect(screen.getByText('P75 Duration')).toBeInTheDocument();
+    expect(screen.getByText('P75 Total Duration')).toBeInTheDocument();
     expect(screen.getByText('10.00ms')).toBeInTheDocument();
 
-    expect(screen.getByText('P99 Duration')).toBeInTheDocument();
+    expect(screen.getByText('P99 Total Duration')).toBeInTheDocument();
     expect(screen.getByText('12.50ms')).toBeInTheDocument();
   });
 

--- a/static/app/components/profiling/functionsTable.tsx
+++ b/static/app/components/profiling/functionsTable.tsx
@@ -224,7 +224,7 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
   },
   count: {
     key: 'count',
-    name: t('Count'),
+    name: t('Total Occurrences'),
     width: COL_WIDTH_UNDEFINED,
   },
   examples: {

--- a/static/app/components/profiling/functionsTable.tsx
+++ b/static/app/components/profiling/functionsTable.tsx
@@ -214,12 +214,12 @@ const COLUMNS: Record<TableColumnKey, TableColumn> = {
   },
   p75: {
     key: 'p75',
-    name: t('P75 Duration'),
+    name: t('P75 Total Duration'),
     width: COL_WIDTH_UNDEFINED,
   },
   p99: {
     key: 'p99',
-    name: t('P99 Duration'),
+    name: t('P99 Total Duration'),
     width: COL_WIDTH_UNDEFINED,
   },
   count: {


### PR DESCRIPTION
Suspect functions use total time, make that clear in the table headers.

Closes getsentry/team-profiling#102
Closes getsentry/team-profiling#110