### PR TITLE
fix(replays): Fix timeline event node icons for Safari

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -52,6 +52,8 @@ const EventColumn = styled(Timeline.Col)<{column: number}>`
   grid-column: ${p => Math.floor(p.column)};
   place-items: stretch;
   display: grid;
+  align-items: center;
+  position: relative;
 
   &:hover {
     z-index: ${p => p.theme.zIndex.initial};
@@ -163,10 +165,6 @@ const IconPosition = styled('div')`
   position: absolute;
   transform: translate(-50%);
   margin-left: ${EVENT_STICK_MARKER_WIDTH / 2}px;
-  align-self: center;
-  display: grid;
-  /* We need to add the height here so safari recongnize the height */
-  height: 100%;
 `;
 
 const IconNode = styled('div')<{

--- a/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineEvents.tsx
@@ -165,6 +165,8 @@ const IconPosition = styled('div')`
   margin-left: ${EVENT_STICK_MARKER_WIDTH / 2}px;
   align-self: center;
   display: grid;
+  /* We need to add the height here so safari recongnize the height */
+  height: 100%;
 `;
 
 const IconNode = styled('div')<{


### PR DESCRIPTION


<!-- Describe your PR here. -->
### Changes
- Added `height` css property so safari recognize it and center the node icons correctly. Closes #40915 

![image](https://user-images.githubusercontent.com/39612839/202571271-68134d69-004f-4c02-89be-802f5a9b8021.png)


### Test notes
- QA the Replay Details page in Safari
- Made sure the new change didn't affect other browsers

### Additional notes
This issue was really the only broke thing that I could find, everything else seemed to be working as expected!

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
