### PR TITLE
feat(hybrid-cloud): Set /issues/ be default path when accessing orgslug.sentry.io

### DIFF
--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -8,12 +8,13 @@ from typing import FrozenSet, Sequence
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
 from django.db.models import QuerySet
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 
 from bitfield import BitField
 from sentry import features, roles
+from sentry.app import env
 from sentry.constants import (
     ALERTS_MEMBER_WRITE_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
@@ -32,7 +33,7 @@ from sentry.locks import locks
 from sentry.models.organizationmember import OrganizationMember
 from sentry.roles.manager import Role
 from sentry.services.hybrid_cloud.user import APIUser, user_service
-from sentry.utils.http import absolute_uri
+from sentry.utils.http import absolute_uri, is_using_customer_domain
 from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snowflake import SnowflakeIdMixin
 
@@ -513,11 +514,17 @@ class Organization(Model, SnowflakeIdMixin):
 
     @staticmethod
     def get_url_viewname():
+        request = env.request
+        if request and is_using_customer_domain(request):
+            return "issues"
         return "sentry-organization-issue-list"
 
     @staticmethod
     def get_url(slug: str) -> str:
-        return reverse(Organization.get_url_viewname(), args=[slug])
+        try:
+            return reverse(Organization.get_url_viewname(), args=[slug])
+        except NoReverseMatch:
+            return reverse(Organization.get_url_viewname())
 
     def get_scopes(self, role: Role) -> FrozenSet[str]:
         if role.priority > 0:

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -443,7 +443,7 @@ class AuthLoginCustomerDomainTest(TestCase):
         assert resp.status_code == 200
         assert resp.redirect_chain == [
             (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
-            ("/organizations/albertos-apples/issues/", 302),
+            ("/issues/", 302),
         ]
 
     def test_login_valid_credentials_invalid_customer_domain(self):
@@ -465,7 +465,7 @@ class AuthLoginCustomerDomainTest(TestCase):
             assert resp.redirect_chain == [
                 (f"http://invalid.testserver{reverse('sentry-login')}", 302),
                 ("http://albertos-apples.testserver/auth/login/", 302),
-                ("/organizations/albertos-apples/issues/", 302),
+                ("/issues/", 302),
             ]
 
     def test_login_valid_credentials_non_staff(self):
@@ -487,7 +487,7 @@ class AuthLoginCustomerDomainTest(TestCase):
             assert resp.status_code == 200
             assert resp.redirect_chain == [
                 (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
-                ("/organizations/albertos-apples/issues/", 302),
+                ("/issues/", 302),
             ]
 
     def test_login_valid_credentials_not_a_member(self):


### PR DESCRIPTION
When accessing orgslug.sentry.io, the default route should be `/issues/` instead of `/organizations/orgslug/issues/`.

React routes for `/issues/` already exists and was added in https://github.com/getsentry/sentry/pull/41335.