### PR TITLE
test(ui): Fix screenshot in replays empty state screenshot

### DIFF
--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.spec.tsx
@@ -129,22 +129,6 @@ describe('GroupReplays', () => {
     });
   });
 
-  it('should snapshot empty state', async () => {
-    MockApiClient.addMockResponse({
-      url: mockUrl,
-      body: {
-        data: [],
-      },
-      statusCode: 200,
-    });
-
-    const {container} = renderComponent();
-
-    await waitFor(() => {
-      expect(container).toSnapshot();
-    });
-  });
-
   it('should show empty message when no replays are found', async () => {
     const mockApi = MockApiClient.addMockResponse({
       url: mockUrl,
@@ -154,12 +138,11 @@ describe('GroupReplays', () => {
       statusCode: 200,
     });
 
-    renderComponent();
+    const {container} = renderComponent();
 
-    await waitFor(() => {
-      expect(mockApi).toHaveBeenCalledTimes(1);
-      expect(screen.getByText('There are no items to display')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('There are no items to display')).toBeInTheDocument();
+    expect(mockApi).toHaveBeenCalledTimes(1);
+    expect(container).toSnapshot();
   });
 
   it('should display error message when api call fails', async () => {


### PR DESCRIPTION
empty state screenshot is flakey https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/5b30e0a6ad074e7cd3469e67191614dd25513302/index.html

cut the number of empty state tests from 2 to 1