### PR TITLE
test(js): Ignore "Can't perform a React state update" console warning in tests

### DIFF
--- a/tests/js/setupFramework.ts
+++ b/tests/js/setupFramework.ts
@@ -37,6 +37,16 @@ failOnConsole({
       return true;
     }
 
+    // This warning was removed in React 18, can be ignored in most cases
+    // https://github.com/reactwg/react-18/discussions/82
+    if (
+      /Warning: Can't perform a React state update on an unmounted component/.test(
+        errorMessage
+      )
+    ) {
+      return true;
+    }
+
     return false;
   },
 });


### PR DESCRIPTION
I'm noticing some component tests with React Query flake due to this console warning. This is a known issue that the library doesn't guard against since React 18 removed that warning and it wasn't ever a real issue anyway:

https://github.com/TanStack/query/issues/3586#issuecomment-1118863664

