### PR TITLE
feat(hybrid-cloud): Redirect to sentryUrl on invalid org slugs

### DIFF
--- a/static/app/components/modals/helpSearchModal.spec.tsx
+++ b/static/app/components/modals/helpSearchModal.spec.tsx
@@ -50,9 +50,23 @@ describe('Docs Search Modal', function () {
   });
 
   it('can open help search modal', async function () {
-    const {routerContext} = initializeOrg();
+    const {routerContext, router, route} = initializeOrg();
 
-    render(<App>{<div>placeholder content</div>}</App>, {context: routerContext});
+    render(
+      <App
+        location={router.location}
+        routes={router.routes}
+        route={route}
+        router={router}
+        params={{}}
+        routeParams={router.params}
+      >
+        {<div>placeholder content</div>}
+      </App>,
+      {
+        context: routerContext,
+      }
+    );
 
     // No Modal
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();

--- a/static/app/components/modals/sudoModal.spec.jsx
+++ b/static/app/components/modals/sudoModal.spec.jsx
@@ -1,3 +1,4 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {Client} from 'sentry/api';
@@ -42,9 +43,21 @@ describe('Sudo Modal', function () {
   });
 
   it('can delete an org with sudo flow', async function () {
+    const {router, route} = initializeOrg();
     setHasPasswordAuth(true);
 
-    render(<App>{<div>placeholder content</div>}</App>);
+    render(
+      <App
+        location={router.location}
+        routes={router.routes}
+        route={route}
+        router={router}
+        params={{}}
+        routeParams={router.params}
+      >
+        {<div>placeholder content</div>}
+      </App>
+    );
 
     const api = new Client();
     const successCb = jest.fn();
@@ -108,9 +121,21 @@ describe('Sudo Modal', function () {
   });
 
   it('shows button to redirect if user does not have password auth', async function () {
+    const {router, route} = initializeOrg();
     setHasPasswordAuth(false);
 
-    render(<App>{<div>placeholder content</div>}</App>);
+    render(
+      <App
+        location={router.location}
+        routes={router.routes}
+        route={route}
+        router={router}
+        params={{}}
+        routeParams={router.params}
+      >
+        {<div>placeholder content</div>}
+      </App>
+    );
 
     const api = new Client();
     const successCb = jest.fn();

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -280,3 +280,5 @@ export const SENTRY_RELEASE_VERSION = process.env.SENTRY_RELEASE_VERSION;
 export const DEFAULT_ERROR_JSON = {
   detail: t('Unknown error. Please try again.'),
 };
+
+export const ORG_SLUG_REGEX = new RegExp('^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$');

--- a/static/app/views/app/index.spec.jsx
+++ b/static/app/views/app/index.spec.jsx
@@ -26,6 +26,16 @@ describe('App', function () {
       url: '/internal/options/?query=is:required',
       body: TestStubs.InstallWizard(),
     });
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        replace: jest.fn(),
+      },
+    });
+  });
+
+  afterEach(function () {
+    jest.resetAllMocks();
   });
 
   it('renders', function () {
@@ -36,6 +46,7 @@ describe('App', function () {
     );
 
     expect(screen.getByText('placeholder content')).toBeInTheDocument();
+    expect(window.location.replace).not.toHaveBeenCalled();
   });
 
   it('renders NewsletterConsent', async function () {
@@ -73,5 +84,19 @@ describe('App', function () {
       'Complete setup by filling out the required configuration.'
     );
     expect(completeSetup).toBeInTheDocument();
+  });
+
+  it('redirects to sentryUrl on invalid org slug', function () {
+    const {sentryUrl} = ConfigStore.get('links');
+    render(
+      <App params={{orgId: 'albertos%2fapples'}}>
+        <div>placeholder content</div>
+      </App>
+    );
+
+    expect(screen.queryByText('placeholder content')).not.toBeInTheDocument();
+    expect(sentryUrl).toEqual('https://sentry.io');
+    expect(window.location.replace).toHaveBeenCalledWith('https://sentry.io');
+    expect(window.location.replace).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/app/index.spec.jsx
+++ b/static/app/views/app/index.spec.jsx
@@ -3,6 +3,8 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import ConfigStore from 'sentry/stores/configStore';
 import App from 'sentry/views/app';
 
+const originalLocation = window.location;
+
 describe('App', function () {
   beforeEach(function () {
     MockApiClient.addMockResponse({
@@ -36,6 +38,7 @@ describe('App', function () {
 
   afterEach(function () {
     jest.resetAllMocks();
+    window.location = originalLocation;
   });
 
   it('renders', function () {


### PR DESCRIPTION
This pull request adds org slug validation at the top-level React route root component.  We want to do this since we have some pages where we render the React app on invalid org slugs.

For all invalid org slugs, we redirect the browser to the `sentryUrl`, which will be `https://sentry.io` in SaaS.

Refs SEC-12636.