### PR TITLE
bug(replays): Correctly extract DOM event HTML that is captured during FullSnapshot

### DIFF
--- a/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
@@ -149,7 +149,9 @@ class BreadcrumbReferencesPlugin {
   }
 
   handler(event: eventWithTime, _isSync: boolean, {replayer}: {replayer: Replayer}) {
-    if (event.type === EventType.IncrementalSnapshot) {
+    if (event.type === EventType.FullSnapshot) {
+      this.extractNextCrumb({replayer});
+    } else if (event.type === EventType.IncrementalSnapshot) {
       this.extractCurrentCrumb(event, {replayer});
       this.extractNextCrumb({replayer});
     }


### PR DESCRIPTION
When a FullSnapshot happens we should look ahead in the list of breadcrumbs for the next crumb, and then see if the `nodeId` for that next event is already in the page. If it is in the page, we'll cache that html.
Why? Well, say that DOM node is a button that gets removed when you click it. If we waited and tried to find the HTML after the click event happened, the HTML will already be gone! So we grab the element before it's gone, so we can match it up to the event no matter what.

See https://github.com/getsentry/sentry/pull/40421 for more descrption of the problem. That PR implemented the bulk of the fix, but it didn't handle the case where the DOM node is created during the initial FullSnapshot.

Fixes #40715