### PR TITLE
feature(hybrid-cloud): hybrid clouud access for views

### DIFF
--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -177,9 +177,6 @@ class Access(abc.ABC):
     def has_any_project_scope(self, project: Project, scopes: Collection[str]) -> bool:
         pass
 
-    def to_django_context(self) -> Mapping[str, bool]:
-        return {s.replace(":", "_"): self.has_scope(s) for s in settings.SENTRY_SCOPES}
-
 
 @dataclass
 class DbAccess(Access):

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import abc
 import logging
 from typing import Any, Mapping, Protocol
 
@@ -29,7 +30,6 @@ from sentry.services.hybrid_cloud.organization import (
     ApiUserOrganizationContext,
     organization_service,
 )
-from sentry.silo import SiloMode
 from sentry.utils import auth
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.auth import is_valid_redirect, make_login_link_with_redirect
@@ -407,28 +407,31 @@ class BaseView(View, OrganizationMixin):  # type: ignore[misc]
 
 class OrganizationView(BaseView):
     """
-    Any view acting on behalf of an organization should inherit from this base.
-
-    The 'organization' keyword argument is automatically injected into the
-    resulting dispatch.
+    A deprecated view used by endpoints that act on behalf of an organization.
+    In the future, we should move endpoints to either of the subclasses, RegionSilo* or ControlSilo*, and
+    move out any ORM specific logic into the correct silo view.  This will likely become an ABC that shares some
+    common logic.
+    The 'organization' keyword argument is automatically injected into the resulting dispatch, but currently the
+    typing of 'organization' will vary based on the subclass.  It may either be an ApiOrganization or an orm
+    Organization based on the subclass.  Be mindful during this transition of the typing.
     """
 
     required_scope: str | None = None
     valid_sso_required = True
 
-    def get_access(self, request: Request, organization: Organization, *args: Any, **kwargs: Any) -> access.Access:  # type: ignore[override]
-        if organization is None:
+    def get_access(self, request: Request, *args: Any, **kwargs: Any) -> access.Access:  # type: ignore[override]
+        if self.active_organization is None:
             return access.DEFAULT
-        return access.from_request(request, organization)
+        return access.from_request_org_and_scopes(
+            request=request, api_user_org_context=self.active_organization
+        )
 
-    def get_context_data(self, request: Request, organization: Organization, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
+    def get_context_data(self, request: Request, organization: ApiOrganization | Organization, **kwargs: Any) -> dict[str, Any]:  # type: ignore[override]
         context = super().get_context_data(request)
         context["organization"] = organization
-        context["TEAM_LIST"] = self.get_team_list(request.user, organization)
-        context["ACCESS"] = request.access.to_django_context()
         return context
 
-    def has_permission(self, request: Request, organization: Organization, *args: Any, **kwargs: Any) -> bool:  # type: ignore[override]
+    def has_permission(self, request: Request, organization: ApiOrganization | Organization, *args: Any, **kwargs: Any) -> bool:  # type: ignore[override]
         if organization is None:
             return False
         if self.valid_sso_required:
@@ -471,7 +474,7 @@ class OrganizationView(BaseView):
 
         return False
 
-    def handle_permission_required(self, request: Request, organization: Organization, *args: Any, **kwargs: Any) -> HttpResponse:  # type: ignore[override]
+    def handle_permission_required(self, request: Request, organization: Organization | ApiOrganization, *args: Any, **kwargs: Any) -> HttpResponse:  # type: ignore[override]
         if self.needs_sso(request, organization):
             logger.info(
                 "access.must-sso",
@@ -493,7 +496,7 @@ class OrganizationView(BaseView):
             redirect_uri = self.get_no_permission_url(request, *args, **kwargs)
         return self.redirect(redirect_uri)
 
-    def needs_sso(self, request: Request, organization: Organization) -> bool:
+    def needs_sso(self, request: Request, organization: Organization | ApiOrganization) -> bool:
         if not organization:
             return False
         # XXX(dcramer): this branch should really never hit
@@ -509,26 +512,60 @@ class OrganizationView(BaseView):
             return True
         return False
 
+    def _lookup_orm_org(self) -> Organization | None:
+        """
+        Used by convert_args to convert the hybrid cloud safe active_organization object into an org ORM.
+        This should really only be used by the Region or Monolith silo modes -- calling this in a Control silo
+        endpoint or codepath will result in exceptions.
+        :return:
+        """
+        organization: Organization | None = None
+        if self.active_organization:
+            try:
+                organization = Organization.objects.get(id=self.active_organization.organization.id)
+            except Organization.DoesNotExist:
+                pass
+        return organization
+
     def convert_args(
         self, request: Request, organization_slug: str | None = None, *args: Any, **kwargs: Any
     ) -> tuple[tuple[Any, ...], dict[str, Any]]:
-        # TODO:  Extract separate view base classes based on control vs region / monolith,
-        # with distinct convert_args implementation.
-        if SiloMode.get_current_mode() == SiloMode.CONTROL:
-            assert self.active_organization is not None
-            kwargs["organization"] = self.active_organization.organization
-        else:
-            organization: Organization | None = None
-            if self.active_organization:
-                for org in Organization.objects.filter(id=self.active_organization.organization.id):
-                    organization = org
+        if "organization" not in kwargs:
+            kwargs["organization"] = self._lookup_orm_org()
 
-            kwargs["organization"] = organization
-
-        return (args, kwargs)
+        return args, kwargs
 
 
-class ProjectView(OrganizationView):
+class RegionSiloOrganizationView(OrganizationView, abc.ABC):
+    """
+    A view which has direct ORM access to organization objects.  In practice, **only endpoints that exist in the
+    region silo should use this class**.  When All endpoints have been convert / tested against region silo compliance,
+    the base class (OrganizationView) will likely disappear and only either ControlSilo* or RegionSilo* classes will
+    remain.
+    """
+
+    def convert_args(self, request, organization_slug=None, *args, **kwargs):
+        if "organization" not in kwargs:
+            kwargs["organization"] = self._lookup_orm_org()
+
+        return args, kwargs
+
+    @abc.abstractmethod
+    def handle(self, request, organization: Organization, *args, **kwargs) -> HttpResponse:
+        pass
+
+
+class ControlSiloOrganizationView(OrganizationView, abc.ABC):
+    def convert_args(self, request, *args, **kwargs):
+        kwargs["organization"] = self.active_organization.organization
+        return super().convert_args(request, *args, **kwargs)
+
+    @abc.abstractmethod
+    def handle(self, request, organization: ApiOrganization, *args, **kwargs) -> HttpResponse:
+        pass
+
+
+class ProjectView(RegionSiloOrganizationView):
     """
     Any view acting on behalf of a project should inherit from this base and the
     matching URL pattern must pass 'org_slug' as well as 'project_slug'.
@@ -572,20 +609,17 @@ class ProjectView(OrganizationView):
         organization: Organization | None = None
         active_project: Project | None = None
         if self.active_organization:
-            for org in Organization.objects.filter(id=self.active_organization.organization.id):
-                organization = org
+            organization = self._lookup_orm_org()
 
             if organization:
                 active_project = self.get_active_project(
                     request=request, organization=organization, project_slug=project_slug
                 )
-        else:
-            active_project = None
 
         kwargs["project"] = active_project
         kwargs["organization"] = organization
 
-        return (args, kwargs)
+        return args, kwargs
 
 
 class AvatarPhotoView(View):  # type: ignore[misc]

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import abc
 import logging
 from typing import Any, Mapping, Protocol
 
@@ -536,7 +535,7 @@ class OrganizationView(BaseView):
         return args, kwargs
 
 
-class RegionSiloOrganizationView(OrganizationView, abc.ABC):
+class RegionSiloOrganizationView(OrganizationView):
     """
     A view which has direct ORM access to organization objects.  In practice, **only endpoints that exist in the
     region silo should use this class**.  When All endpoints have been convert / tested against region silo compliance,
@@ -550,19 +549,11 @@ class RegionSiloOrganizationView(OrganizationView, abc.ABC):
 
         return args, kwargs
 
-    @abc.abstractmethod
-    def handle(self, request, organization: Organization, *args, **kwargs) -> HttpResponse:
-        pass
 
-
-class ControlSiloOrganizationView(OrganizationView, abc.ABC):
+class ControlSiloOrganizationView(OrganizationView):
     def convert_args(self, request, *args, **kwargs):
         kwargs["organization"] = self.active_organization.organization
         return super().convert_args(request, *args, **kwargs)
-
-    @abc.abstractmethod
-    def handle(self, request, organization: ApiOrganization, *args, **kwargs) -> HttpResponse:
-        pass
 
 
 class ProjectView(RegionSiloOrganizationView):

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -418,7 +418,7 @@ class OrganizationView(BaseView):
     required_scope: str | None = None
     valid_sso_required = True
 
-    def get_access(self, request: Request, *args: Any, **kwargs: Any) -> access.Access:  # type: ignore[override]
+    def get_access(self, request: Request, *args: Any, **kwargs: Any) -> access.Access:
         if self.active_organization is None:
             return access.DEFAULT
         return access.from_request_org_and_scopes(
@@ -543,7 +543,9 @@ class RegionSiloOrganizationView(OrganizationView):
     remain.
     """
 
-    def convert_args(self, request, organization_slug=None, *args, **kwargs):
+    def convert_args(
+        self, request: Any, organization_slug: str | None = None, *args: Any, **kwargs: Any
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
         if "organization" not in kwargs:
             kwargs["organization"] = self._lookup_orm_org()
 
@@ -551,8 +553,12 @@ class RegionSiloOrganizationView(OrganizationView):
 
 
 class ControlSiloOrganizationView(OrganizationView):
-    def convert_args(self, request, *args, **kwargs):
-        kwargs["organization"] = self.active_organization.organization
+    def convert_args(
+        self, request: Any, *args: Any, **kwargs: Any
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        kwargs["organization"] = (
+            self.active_organization.organization if self.active_organization else None
+        )
         return super().convert_args(request, *args, **kwargs)
 
 

--- a/src/sentry/web/helpers.py
+++ b/src/sentry/web/helpers.py
@@ -4,96 +4,22 @@ import logging
 from typing import Any, Mapping
 
 import pytz
-from django.conf import settings
-from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest, HttpResponse
 from django.template import loader
 from django.utils import timezone
 
-from sentry.auth import access
-from sentry.models import Team
 from sentry.utils.auth import get_login_url  # NOQA: backwards compatibility
-from sentry.utils.settings import is_self_hosted
 
 logger = logging.getLogger("sentry")
-
-
-def get_default_context(
-    request: HttpRequest | None,
-    existing_context: Mapping[str, Any] | None = None,
-    team: Team | None = None,
-) -> dict[str, Any]:
-    from sentry import options
-    from sentry.plugins.base import plugins
-
-    context = {
-        "URL_PREFIX": options.get("system.url-prefix"),
-        "SINGLE_ORGANIZATION": settings.SENTRY_SINGLE_ORGANIZATION,
-        "PLUGINS": plugins,
-        # Maintain ONPREMISE key for backcompat (plugins?). TBH context could
-        # probably be removed entirely: github.com/getsentry/sentry/pull/30970.
-        "ONPREMISE": is_self_hosted(),
-        "SELF_HOSTED": is_self_hosted(),
-    }
-
-    if existing_context:
-        if team is None and "team" in existing_context:
-            team = existing_context["team"]
-
-        if "project" in existing_context:
-            project = existing_context["project"]
-        else:
-            project = None
-    else:
-        project = None
-
-    if team:
-        organization = team.organization
-    elif project:
-        organization = project.organization
-    else:
-        organization = None
-
-    if request:
-        if (not existing_context or "TEAM_LIST" not in existing_context) and team:
-            context["TEAM_LIST"] = Team.objects.get_for_user(
-                organization=team.organization, user=request.user, with_projects=True
-            )
-
-        user = request.user
-    else:
-        user = AnonymousUser()
-
-    if not existing_context or "ACCESS" not in existing_context:
-        if request:
-            context["ACCESS"] = access.from_request(
-                request=request, organization=organization
-            ).to_django_context()
-        else:
-            context["ACCESS"] = access.from_user(
-                user=user, organization=organization
-            ).to_django_context()
-
-    return context
 
 
 def render_to_string(
     template: str, context: Mapping[str, Any] | None = None, request: HttpRequest | None = None
 ) -> str:
-
-    # HACK: set team session value for dashboard redirect
-    if context and "team" in context and isinstance(context["team"], Team):
-        team = context["team"]
-    else:
-        team = None
-
-    default_context = get_default_context(request, context, team=team)
-
     if context is None:
-        context = default_context
+        context = dict()
     else:
         context = dict(context)
-        context.update(default_context)
 
     if "timezone" in context and context["timezone"] in pytz.all_timezones_set:
         timezone.activate(context["timezone"])


### PR DESCRIPTION
1.  Hookup the new hybrid cloud compatible access.  This new access is already tested equivalently against the existing db access.  See `test_access.py`.
2.  Remove a TON of unneeded django complete context.  Validated both in sentry and getsentry that these values were not referenced in any template whatsoever.