### PR TITLE
fix(stacktrace-link): Only code mappings that match should affect the API response

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping, Optional, Tuple
+from typing import Any, Mapping, Optional
 
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -15,8 +15,9 @@ from sentry.utils.event_frames import munged_filename_and_frames
 
 
 def get_link(
-    config: RepositoryProjectPathConfig, filepath: str, default: str, version: Optional[str] = None
-) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    config: RepositoryProjectPathConfig, filepath: str, version: Optional[str] = None
+) -> Any:
+    result = {}
     oi = config.organization_integration
     integration = oi.integration
     install = integration.get_installation(oi.organization_id)
@@ -25,7 +26,9 @@ def get_link(
 
     link, attempted_url, error = None, None, None
     try:
-        link = install.get_stacktrace_link(config.repository, formatted_path, default, version)
+        link = install.get_stacktrace_link(
+            config.repository, formatted_path, config.default_branch, version
+        )
     except ApiError as e:
         if e.code != 403:
             raise
@@ -34,8 +37,58 @@ def get_link(
     # If the link was not found, attach the URL that we attempted.
     if not link:
         error = error or "file_not_found"
-        attempted_url = install.format_source_url(config.repository, formatted_path, default)
-    return link, attempted_url, error
+        attempted_url = install.format_source_url(
+            config.repository, formatted_path, config.default_branch
+        )
+    result = {
+        "attemptedUrl": attempted_url,
+        "error": error,
+        "sourceUrl": link,
+    }
+    return result
+
+
+# This is to support mobile languages with non-fully-qualified file pathing.
+# We attempt to 'munge' the proper source-relative filepath based on the stackframe data.
+def generate_mobile_frame(parameters: Any) -> Any:
+    abs_path = parameters.get("absPath")
+    module = parameters.get("module")
+    package = parameters.get("package")
+    frame = {}
+    if abs_path:
+        frame["abs_path"] = abs_path
+    if module:
+        frame["module"] = module
+    if package:
+        frame["package"] = package
+    return frame
+
+
+def try_path_munging(
+    config: RepositoryProjectPathConfig,
+    filepath: str,
+    mobile_frame: Any,
+    ctx: Any,
+) -> Any:
+    result = {
+        "error": None,
+    }
+    mobile_frame["filename"] = filepath
+    munged_frames = munged_filename_and_frames(
+        ctx["platform"], [mobile_frame], "munged_filename", sdk_name=ctx["sdk_name"]
+    )
+    if munged_frames:
+        munged_frame: Mapping[str, Any] = munged_frames[1][0]
+        munged_filename = str(munged_frame.get("munged_filename"))
+        if munged_filename:
+            if not filepath.startswith(config.stack_root) and not munged_filename.startswith(
+                config.stack_root
+            ):
+                result["error"] = "stack_root_mismatch"
+
+            if not result["error"]:
+                result = get_link(config, munged_filename, ctx["commit_id"])
+    return result
 
 
 @region_silo_endpoint
@@ -56,24 +109,21 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
     """
 
     def get(self, request: Request, project) -> Response:
+        # import pprint
+
+        # pprint.pp(request)
         # should probably feature gate
         filepath = request.GET.get("file")
         if not filepath:
             return Response({"detail": "Filepath is required"}, status=400)
 
-        commit_id = request.GET.get("commitId")
-        platform = request.GET.get("platform")
-        sdk_name = request.GET.get("sdkName")
-        abs_path = request.GET.get("absPath")
-        module = request.GET.get("module")
-        package = request.GET.get("package")
-        frame = {}
-        if abs_path:
-            frame["abs_path"] = abs_path
-        if module:
-            frame["module"] = module
-        if package:
-            frame["package"] = package
+        ctx = {
+            "commit_id": request.GET.get("commitId"),
+            "platform": request.GET.get("platform"),
+            "sdk_name": request.GET.get("sdkName"),
+        }
+        mobile_frame = generate_mobile_frame(request.GET)
+
         result = {"config": None, "sourceUrl": None}
 
         integrations = Integration.objects.filter(organizations=project.organization_id)
@@ -85,7 +135,6 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
             if i.has_feature(IntegrationFeatures.STACKTRACE_LINK)
         ]
 
-        last_error = None
         # xxx(meredith): if there are ever any changes to this query, make
         # sure that we are still ordering by `id` because we want to make sure
         # the ordering is deterministic
@@ -93,61 +142,56 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         configs = RepositoryProjectPathConfig.objects.filter(
             project=project, organization_integration__isnull=False
         )
+        matched_code_mappings = []
+        found = False
         with configure_scope() as scope:
+            scope.set_tag("project.slug", project.slug)
+            scope.set_tag("organization.slug", project.organization.slug)
             for config in configs:
-                if not filepath.startswith(config.stack_root) and not frame:
-                    last_error = "stack_root_mismatch"
+                # The code mapping does not match and we're not dealing with a mobile platform
+                if not filepath.startswith(config.stack_root) and not mobile_frame:
                     continue
 
-                result["config"] = serialize(config, request.user)
+                result = get_link(config, filepath, ctx["commit_id"])
+
+                # For mobile we try a second time by munging the file path
+                if not result["sourceUrl"] and mobile_frame:
+                    result = try_path_munging(filepath, mobile_frame, ctx)
+
+                current_config = {
+                    "config": serialize(config, request.user),
+                    "result": result,
+                }
+
                 # use the provider key to be able to split up stacktrace
                 # link metrics by integration type
                 provider = result["config"]["provider"]["key"]
+                # print("ARMEN")
+                # print(provider)
                 scope.set_tag("integration_provider", provider)
-                scope.set_tag("stacktrace_link.platform", platform)
-
-                link, attempted_url, get_link_error = get_link(
-                    config, filepath, config.default_branch, commit_id
-                )
-
-                if not link and frame:
-                    frame["filename"] = filepath
-                    munged_frames = munged_filename_and_frames(
-                        platform, [frame], "munged_filename", sdk_name=sdk_name
-                    )
-                    if munged_frames:
-                        munged_frame: Mapping[str, Any] = munged_frames[1][0]
-                        munged_filename = str(munged_frame.get("munged_filename"))
-                        if munged_filename:
-                            if not filepath.startswith(
-                                config.stack_root
-                            ) and not munged_filename.startswith(config.stack_root):
-                                last_error = "stack_root_mismatch"
-                                continue
-
-                            link, attempted_url, error = get_link(
-                                config, munged_filename, config.default_branch, commit_id
-                            )
 
                 # it's possible for the link to be None, and in that
                 # case it means we could not find a match for the
                 # configuration
-                result["sourceUrl"] = link
-                if not link:
-                    last_error = get_link_error
-                    result["attemptedUrl"] = attempted_url
+                if not result["sourceUrl"]:
+                    matched_code_mappings.append(current_config)
                 else:
-                    scope.set_tag("stacktrace_link.found", True)
+                    found = True
                     # if we found a match, we can break
                     break
 
             # Post-processing before exiting scope context
-            if last_error:
-                result["error"] = last_error
-                if last_error == "stack_root_mismatch":
+            scope.set_tag("stacktrace_link.platform", ctx["platform"])
+            scope.set_tag("stacktrace_link.found", found)
+            if not found and matched_code_mappings:
+                # For backwards compatibality we return the error of the last matched code mapping
+                result["error"] = matched_code_mappings[-1]["error"]
+                result["config"] = matched_code_mappings[-1]["config"]
+                # Any code mapping that matches and its results will be returned
+                result["matched_code_mappings"] = matched_code_mappings
+                if result["error"] == "stack_root_mismatch":
                     scope.set_tag("stacktrace_link.error", "stack_root_mismatch")
                 else:
-                    scope.set_tag("stacktrace_link.found", False)
                     scope.set_tag("stacktrace_link.error", "file_not_found")
 
         if result["config"]:

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -116,10 +116,8 @@ class ProjectStacktraceLinkTest(APITestCase):
         )
         assert response.data["config"] == self.expected_configurations(self.code_mapping1)
         assert not response.data["sourceUrl"]
-        # XXX: This depends on what was the last attempted code mapping
-        assert response.data["error"] == "stack_root_mismatch"
+        assert response.data["error"] == "file_not_found"
         assert response.data["integrations"] == [serialized_integration(self.integration)]
-        # XXX: This depends on what was the last attempted code mapping
         assert (
             response.data["attemptedUrl"]
             == f"https://example.com/{self.repo.name}/blob/master/src/sentry/src/sentry/utils/safe.py"
@@ -166,14 +164,13 @@ class ProjectStacktraceLinkTest(APITestCase):
 
         assert response.data["config"] == self.expected_configurations(self.code_mapping2)
         assert not response.data["sourceUrl"]
-        # XXX: This depends on what was the last attempted code mapping
-        assert response.data["error"] == "file_not_found"
+        # XXX: Not sure
+        assert response.data["error"] is None
         assert response.data["integrations"] == [serialized_integration(self.integration)]
-        # XXX: This depends on what was the last attempted code mapping
-        assert (
-            response.data["attemptedUrl"]
-            == f"https://example.com/{self.repo.name}/blob/master/usr/src/getsrc/sentry/src/sentry/src/sentry/utils/safe.py"
-        )
+        # assert (
+        #     response.data["attemptedUrl"]
+        #     == f"https://example.com/{self.repo.name}/blob/master/usr/src/getsrc/sentry/src/sentry/src/sentry/utils/safe.py"
+        # )
 
     @mock.patch("sentry.api.endpoints.project_stacktrace_link.munged_filename_and_frames")
     @mock.patch.object(

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -164,13 +164,12 @@ class ProjectStacktraceLinkTest(APITestCase):
 
         assert response.data["config"] == self.expected_configurations(self.code_mapping2)
         assert not response.data["sourceUrl"]
-        # XXX: Not sure
-        assert response.data["error"] is None
+        assert response.data["error"] == "file_not_found"
         assert response.data["integrations"] == [serialized_integration(self.integration)]
-        # assert (
-        #     response.data["attemptedUrl"]
-        #     == f"https://example.com/{self.repo.name}/blob/master/usr/src/getsrc/sentry/src/sentry/src/sentry/utils/safe.py"
-        # )
+        assert (
+            response.data["attemptedUrl"]
+            == f"https://example.com/{self.repo.name}/blob/master/usr/src/getsrc/sentry/src/sentry/src/sentry/utils/safe.py"
+        )
 
     @mock.patch("sentry.api.endpoints.project_stacktrace_link.munged_filename_and_frames")
     @mock.patch.object(


### PR DESCRIPTION
Changes:
* Fix that the last code mapping would set the error information even if it didn't match
* Make the code readable
* Improve debuggability by returning all code mappings that match and associated results
* Add organization.slug and project.slug tags