### PR TITLE
ref(issue-alerts): simplify incompatible rule check logic

### DIFF
--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -533,7 +533,8 @@ describe('ProjectAlertsCreate', function () {
     const organization = TestStubs.Organization({
       features: ['issue-alert-incompatible-rules'],
     });
-    const errorText = 'These conditions conflict, please select different conditions.';
+    const errorText =
+      'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.';
 
     it('shows error for incompatible conditions', async () => {
       createWrapper({organization});

--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -3,7 +3,6 @@ import selectEvent from 'react-select-event';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {metric} from 'sentry/utils/analytics';
@@ -534,9 +533,8 @@ describe('ProjectAlertsCreate', function () {
     const organization = TestStubs.Organization({
       features: ['issue-alert-incompatible-rules'],
     });
-    const errorText = t(
-      'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.'
-    );
+    const errorText =
+      'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.';
 
     it('shows error for incompatible conditions', async () => {
       createWrapper({organization});

--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -3,6 +3,7 @@ import selectEvent from 'react-select-event';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TeamStore from 'sentry/stores/teamStore';
 import {metric} from 'sentry/utils/analytics';
@@ -533,8 +534,9 @@ describe('ProjectAlertsCreate', function () {
     const organization = TestStubs.Organization({
       features: ['issue-alert-incompatible-rules'],
     });
-    const errorText =
-      'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.';
+    const errorText = t(
+      'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.'
+    );
 
     it('shows error for incompatible conditions', async () => {
       createWrapper({organization});

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1496,19 +1496,13 @@ export const findIncompatibleRules = (
         }
       } else if (id.endsWith('AgeComparisonFilter')) {
         if (rule.filterMatch !== 'none') {
-          if (
-            (filter.comparison_type === 'older' && filter.value >= 0) ||
-            (filter.comparison_type === 'newer' && filter.value <= 0)
-          ) {
+          if (filter.comparison_type === 'older') {
             if (rule.filterMatch === 'all') {
               return {conditionIndices: [firstSeen], filterIndices: [i]};
             }
             incompatibleFilters += 1;
           }
-        } else if (
-          (filter.comparison_type === 'older' && filter.value < 0) ||
-          (filter.comparison_type === 'newer' && filter.value > 0)
-        ) {
+        } else if (filter.comparison_type === 'newer' && filter.value > 0) {
           return {conditionIndices: [firstSeen], filterIndices: [i]};
         }
       }

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -454,7 +454,9 @@ function RuleNode({
     }
     return (
       <MarginlessAlert type="error" showIcon>
-        {t('These conditions conflict, please select different conditions.')}
+        {t(
+          'The conditions highlighted in red are in conflict. They may prevent the alert from ever being triggered.'
+        )}
       </MarginlessAlert>
     );
   }


### PR DESCRIPTION
Vu's changes [here](https://github.com/getsentry/sentry/pull/41549) and [here](https://github.com/getsentry/sentry/pull/41552) will enforce a min value of 0 on the issue alert form number inputs, so we don't need to check those cases here anymore. Also updates the banner message