### PR TITLE
bug(replays): Properly translate single/plural replay counts

### DIFF
--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -5,7 +5,7 @@ import Link from 'sentry/components/links/link';
 import ReplayCountContext from 'sentry/components/replays/replayCountContext';
 import Tooltip from 'sentry/components/tooltip';
 import {IconPlay} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -27,7 +27,13 @@ function IssueReplayCount({groupId}: Props) {
   const countDisplay = count > 50 ? '50+' : count;
 
   return (
-    <StyledTooltip title={t('This issue has %s replays available to view', countDisplay)}>
+    <StyledTooltip
+      title={tn(
+        'This issue has %s replay available to view',
+        'This issue has %s replays available to view',
+        countDisplay
+      )}
+    >
       <ReplayCountLink
         to={`/organizations/${organization.slug}/issues/${groupId}/replays/`}
         aria-label="replay-count"


### PR DESCRIPTION


<img width="278" alt="Screen Shot 2022-11-18 at 10 10 52 AM" src="https://user-images.githubusercontent.com/187460/202774087-6b577b4d-06e6-4019-beaf-00913d5a684f.png">


<img width="250" alt="Screen Shot 2022-11-18 at 10 10 55 AM" src="https://user-images.githubusercontent.com/187460/202774086-5b13ab25-27ae-4d3b-96fe-93205e7e4672.png">
