### PR TITLE
feat(replays): Link to replays from the Event>Tag Details table

### DIFF
--- a/static/app/views/organizationGroupDetails/groupTagValues.spec.jsx
+++ b/static/app/views/organizationGroupDetails/groupTagValues.spec.jsx
@@ -3,11 +3,25 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import GroupTagValues from 'sentry/views/organizationGroupDetails/groupTagValues';
 
-describe('GroupTagValues', () => {
-  const {routerContext, router, project} = initializeOrg({});
-  const group = TestStubs.Group();
-  const tags = TestStubs.Tags();
+const group = TestStubs.Group();
+const tags = TestStubs.Tags();
 
+function init(tagKey) {
+  return initializeOrg({
+    organization: {},
+    project: undefined,
+    projects: undefined,
+    router: {
+      location: {
+        query: {},
+        pathname: '/organizations/:orgId/issues/:groupId/tags/:tagKey/',
+      },
+      params: {orgId: 'org-slug', groupId: group.id, tagKey},
+    },
+  });
+}
+
+describe('GroupTagValues', () => {
   beforeEach(() => {
     MockApiClient.addMockResponse({
       url: '/issues/1/tags/user/',
@@ -20,20 +34,15 @@ describe('GroupTagValues', () => {
   });
 
   it('navigates to issue details events tab with correct query params', () => {
+    const {routerContext, router, project} = init('user');
+
     MockApiClient.addMockResponse({
       url: '/issues/1/tags/user/values/',
       body: TestStubs.TagValues(),
     });
-    render(
-      <GroupTagValues
-        group={group}
-        project={project}
-        environments={[]}
-        location={{query: {}}}
-        params={{orgId: 'org-slug', groupId: group.id, tagKey: 'user'}}
-      />,
-      {context: routerContext}
-    );
+    render(<GroupTagValues environments={[]} group={group} project={project} />, {
+      context: routerContext,
+    });
 
     userEvent.click(screen.getByLabelText('Show more'));
     userEvent.click(screen.getByText('Search All Issues with Tag Value'));
@@ -45,22 +54,14 @@ describe('GroupTagValues', () => {
   });
 
   it('renders an error message if no tag values are returned because of environment selection', () => {
+    const {routerContext, project} = init('user');
+
     MockApiClient.addMockResponse({
       url: '/issues/1/tags/user/values/',
       body: [],
     });
     const {container} = render(
-      <GroupTagValues
-        group={group}
-        project={project}
-        location={{query: {}}}
-        params={{
-          orgId: 'org-slug',
-          groupId: group.id,
-          tagKey: 'user',
-        }}
-        environments={['staging']}
-      />,
+      <GroupTagValues environments={['staging']} group={group} project={project} />,
       {context: routerContext}
     );
 

--- a/static/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/static/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -308,7 +308,7 @@ function ReplayButton({project, routes, orgId, tagValue}) {
     <RightAligned>
       <Tooltip title={t('View Replay')}>
         <Link to={target}>
-          <Button size="xs">
+          <Button size="xs" aria-label={t('View Replay')}>
             <IconPlay size="xs" />
           </Button>
         </Link>

--- a/static/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/static/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -1,5 +1,6 @@
 import {Fragment} from 'react';
-import {RouteComponentProps} from 'react-router';
+// eslint-disable-next-line no-restricted-imports
+import {RouteComponentProps, withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -17,12 +18,14 @@ import Link from 'sentry/components/links/link';
 import Pagination from 'sentry/components/pagination';
 import {PanelTable} from 'sentry/components/panels';
 import TimeSince from 'sentry/components/timeSince';
-import {IconArrow, IconEllipsis, IconMail, IconOpen} from 'sentry/icons';
+import Tooltip from 'sentry/components/tooltip';
+import {IconArrow, IconEllipsis, IconMail, IconOpen, IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Group, Project, SavedQueryVersions, Tag, TagValue} from 'sentry/types';
 import {isUrl, percent} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
+import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 
 type RouteParams = {
   groupId: string;
@@ -46,7 +49,7 @@ type State = {
 const DEFAULT_SORT = 'count';
 
 class GroupTagValues extends AsyncComponent<
-  Props & AsyncComponent['props'],
+  Props & AsyncComponent['props'] & WithRouterProps,
   State & AsyncComponent['state']
 > {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
@@ -72,6 +75,7 @@ class GroupTagValues extends AsyncComponent<
 
   renderResults() {
     const {
+      routes,
       baseUrl,
       project,
       environments: environment,
@@ -144,6 +148,14 @@ class GroupTagValues extends AsyncComponent<
                 <IconOpen size="xs" color="gray300" />
               </StyledExternalLink>
             )}
+            {key === 'replayId' ? (
+              <ReplayButton
+                project={project}
+                routes={routes}
+                orgId={orgId}
+                tagValue={tagValue}
+              />
+            ) : null}
           </NameColumn>
           <RightAlignColumn>{pct}</RightAlignColumn>
           <RightAlignColumn>{tagValue.count.toLocaleString()}</RightAlignColumn>
@@ -280,7 +292,30 @@ class GroupTagValues extends AsyncComponent<
   }
 }
 
-export default GroupTagValues;
+export default withRouter(GroupTagValues);
+
+function ReplayButton({project, routes, orgId, tagValue}) {
+  const replaySlug = `${project?.slug}:${tagValue.value}`;
+  const referrer = getRouteStringFromRoutes(routes);
+
+  const target = {
+    pathname: `/organizations/${orgId}/replays/${replaySlug}/`,
+    query: {
+      referrer,
+    },
+  };
+  return (
+    <RightAligned>
+      <Tooltip title={t('View Replay')}>
+        <Link to={target}>
+          <Button size="xs">
+            <IconPlay size="xs" />
+          </Button>
+        </Link>
+      </Tooltip>
+    </RightAligned>
+  );
+}
 
 const TitleWrapper = styled('div')`
   display: flex;
@@ -320,6 +355,12 @@ const StyledSortLink = styled(Link)`
   :hover {
     color: inherit;
   }
+`;
+
+const RightAligned = styled('div')`
+  display: block;
+  flex-grow: 1;
+  text-align: right;
 `;
 
 const StyledExternalLink = styled(ExternalLink)`

--- a/static/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/static/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -361,6 +361,7 @@ const RightAligned = styled('div')`
   display: block;
   flex-grow: 1;
   text-align: right;
+  padding-left: ${space(0.5)};
 `;
 
 const StyledExternalLink = styled(ExternalLink)`


### PR DESCRIPTION
This adds a Replay button, pushed out to the right of the value, on the Tags table.


<img width="1070" alt="Screen Shot 2022-11-18 at 12 11 21 PM" src="https://user-images.githubusercontent.com/187460/202794157-a6692d69-6943-477a-81d2-e2cc9c832307.png">



The existing blue link points to an Event/Transaction Search page, where we find all events that have the same tag value. For replayId it's not super useful generally... most replays won't have many errors, but they will have lots of transactions. So clicking that link gets you something.

The other direction folks might want to do is to see the replay itself, which is what we've added now.

Fixes #41566