### PR TITLE
fix(issue-search): Remove issue short id filter

### DIFF
--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -611,6 +611,7 @@ export const TRACING_FIELDS = [
   FieldKey.TRANSACTION_DURATION,
   FieldKey.TRANSACTION_OP,
   FieldKey.TRANSACTION_STATUS,
+  FieldKey.ISSUE,
   AggregationKey.P50,
   AggregationKey.P75,
   AggregationKey.P95,


### PR DESCRIPTION
Along the way of going from Issue Event Details page -> Discover -> Transaction Summary -> Related Issues path, `issue:SHORT_ID` search filter gets added because that's how we find related transactions in Discover. But when that filter is retained in Related Issues Search, it breaks the issues search. Similar to how we're removing incompatible fields, we also need to remove `issue:SHORT_ID` filter