### PR TITLE
bug(replays): Replay Breadcrumb title should not be empty

### DIFF
--- a/static/app/components/replays/breadcrumbs/utils.tsx
+++ b/static/app/components/replays/breadcrumbs/utils.tsx
@@ -30,14 +30,16 @@ export function getDescription(crumb: Crumb, startTimestampMs?: number) {
  * Get title of breadcrumb
  */
 export function getTitle(crumb: Crumb) {
-  const [type, action] = crumb.category?.split('.') || [];
-
   // Supports replay specific breadcrumbs
-  if (crumb.data && 'label' in crumb.data) {
+  if (crumb.data && 'label' in crumb.data && crumb.data.label) {
     return crumb.data.label;
   }
 
-  return `${type === 'ui' ? 'User' : type} ${action || ''}`;
+  const [type, action] = crumb.category?.split('.') || [];
+  if (type === 'ui') {
+    return `User ${action || ''}`;
+  }
+  return `${type} ${action || ''}`;
 }
 
 /**


### PR DESCRIPTION
**Before:**
<img width="718" alt="Screen Shot 2022-11-18 at 12 59 27 PM" src="https://user-images.githubusercontent.com/187460/202801470-d6b10d5f-4c72-46ae-bed7-bf605a476895.png">

**After:**
<img width="715" alt="Screen Shot 2022-11-18 at 12 59 33 PM" src="https://user-images.githubusercontent.com/187460/202801487-77a4e528-81d0-4c00-9e35-f020ff17b54d.png">

