### PR TITLE
feat(profiling): flamechart search ui enhancements

### DIFF
--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -339,7 +339,7 @@ function FlamegraphSearch({
               borderless
               icon={<IconChevron size="xs" />}
               aria-label={t('Next')}
-              onClick={onNextSearchClick}
+              onClick={onPreviousSearchClick}
             />
             <SearchBarTrailingButton
               type="button"
@@ -347,7 +347,7 @@ function FlamegraphSearch({
               borderless
               icon={<IconChevron size="xs" direction="down" />}
               aria-label={t('Previous')}
-              onClick={onPreviousSearchClick}
+              onClick={onNextSearchClick}
             />
           </Fragment>
         )

--- a/static/app/components/profiling/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraphSearch.tsx
@@ -2,7 +2,6 @@ import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import Fuse from 'fuse.js';
-import debounce from 'lodash/debounce';
 
 import SearchBar, {SearchBarTrailingButton} from 'sentry/components/searchBar';
 import {IconChevron} from 'sentry/icons';
@@ -201,6 +200,7 @@ function FlamegraphSearch({
   const search = useFlamegraphSearch();
   const dispatch = useDispatchFlamegraphState();
   const [didInitialSearch, setDidInitialSearch] = useState(!search.query);
+
   const allFrames = useMemo(() => {
     if (Array.isArray(flamegraphs)) {
       return flamegraphs.reduce(
@@ -242,26 +242,21 @@ function FlamegraphSearch({
     }
   }, [search.results, search.index, onZoomIntoFrame]);
 
-  const handleChange = useMemo(
-    () =>
-      debounce(value => {
-        if (!value) {
-          dispatch({type: 'clear search'});
-          return;
-        }
-        dispatch({
-          type: 'set results',
-          payload: {
-            results: frameSearch(value, allFrames, searchIndex),
-            query: value,
-          },
-        });
+  const handleChange: (value: string) => void = useCallback(
+    value => {
+      if (!value) {
+        dispatch({type: 'clear search'});
+        return;
+      }
 
-        dispatch({
-          type: 'set search index position',
-          payload: 0,
-        });
-      }),
+      dispatch({
+        type: 'set results',
+        payload: {
+          results: frameSearch(value, allFrames, searchIndex),
+          query: value,
+        },
+      });
+    },
     [dispatch, allFrames, searchIndex]
   );
 

--- a/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
@@ -4,6 +4,7 @@ import {mat3, vec2} from 'gl-matrix';
 
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {useFlamegraphSearch} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphSearch';
 import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
@@ -44,6 +45,7 @@ function FlamegraphZoomViewMinimap({
   >(null);
 
   const dispatch = useDispatchFlamegraphState();
+  const flamegraphSearch = useFlamegraphSearch();
 
   const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
 
@@ -90,7 +92,7 @@ function FlamegraphZoomViewMinimap({
     const drawRectangles = () => {
       flamegraphMiniMapRenderer.draw(
         flamegraphMiniMapView.fromConfigSpace(flamegraphMiniMapCanvas.physicalSpace),
-        new Map()
+        flamegraphSearch.results
       );
     };
 
@@ -104,6 +106,7 @@ function FlamegraphZoomViewMinimap({
     flamegraphMiniMapRenderer,
     scheduler,
     flamegraphMiniMapView,
+    flamegraphSearch.results,
   ]);
 
   useEffect(() => {
@@ -146,6 +149,7 @@ function FlamegraphZoomViewMinimap({
     flamegraphMiniMapView,
     scheduler,
     positionIndicatorRenderer,
+    flamegraphSearch.results,
   ]);
 
   const previousInteraction = usePrevious(lastInteraction);

--- a/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
@@ -4,7 +4,6 @@ import {mat3, vec2} from 'gl-matrix';
 
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
-import {useFlamegraphSearch} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphSearch';
 import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
@@ -45,7 +44,6 @@ function FlamegraphZoomViewMinimap({
   >(null);
 
   const dispatch = useDispatchFlamegraphState();
-  const flamegraphSearch = useFlamegraphSearch();
 
   const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
 
@@ -92,7 +90,7 @@ function FlamegraphZoomViewMinimap({
     const drawRectangles = () => {
       flamegraphMiniMapRenderer.draw(
         flamegraphMiniMapView.fromConfigSpace(flamegraphMiniMapCanvas.physicalSpace),
-        flamegraphSearch.results
+        new Map()
       );
     };
 
@@ -106,7 +104,6 @@ function FlamegraphZoomViewMinimap({
     flamegraphMiniMapRenderer,
     scheduler,
     flamegraphMiniMapView,
-    flamegraphSearch.results,
   ]);
 
   useEffect(() => {
@@ -149,7 +146,6 @@ function FlamegraphZoomViewMinimap({
     flamegraphMiniMapView,
     scheduler,
     positionIndicatorRenderer,
-    flamegraphSearch.results,
   ]);
 
   const previousInteraction = usePrevious(lastInteraction);

--- a/static/app/components/searchBar.tsx
+++ b/static/app/components/searchBar.tsx
@@ -19,6 +19,7 @@ interface SearchBarProps extends Omit<InputProps, 'onChange'> {
   onChange?: (query: string) => void;
   onSearch?: (query: string) => void;
   query?: string;
+  trailing?: React.ReactNode;
   width?: string;
 }
 
@@ -30,6 +31,7 @@ function SearchBar({
   width,
   size,
   className,
+  trailing,
   ...inputProps
 }: SearchBarProps) {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -86,8 +88,9 @@ function SearchBar({
           size={size}
         />
         <InputTrailingItems>
+          {trailing}
           {!!query && (
-            <SearchClearButton
+            <SearchBarTrailingButton
               type="button"
               size="zero"
               borderless
@@ -111,7 +114,7 @@ const StyledInput = styled(Input)`
   ${p => p.width && `width: ${p.width};`}
 `;
 
-const SearchClearButton = styled(Button)`
+export const SearchBarTrailingButton = styled(Button)`
   color: ${p => p.theme.subText};
   padding: ${space(0.5)};
 `;


### PR DESCRIPTION
## Summary

This PR contains some minor UI enhancements to improve the `flamechart` search ux.

~~- debounces the search input as it would previously block the event loop causing the UI to hang~~
- adds search result cycling  similar to `cmd+f` in chrome
~~- highlights searchResults in minimap~~

Closes: https://github.com/getsentry/team-profiling/issues/104

Note: after some exploration, `fuse.search` seems to be the bottleneck causing jank. its problematic with an increasingly large query where fuse needs to take more of a fuzzy approach. attempts to make the fuzzy matching stricter doesn't improve performance and also changes the behaviour of highlihting substrings. 

tldr; either we always debounce, debounce under certain conditions (this can get a bit out of control), or we explore something other than fuse.

Before w/ jank:

https://user-images.githubusercontent.com/7349258/202803171-a2edf865-1f70-4b09-990c-c672d93f4eb2.mov

After - debounced w/o jank + search result cycling:

https://user-images.githubusercontent.com/7349258/202803264-2d053a9e-4a84-40a2-882e-a8411068a24f.mov

