### PR TITLE
ref(debug view): Clean up repeated code

### DIFF
--- a/fixtures/emails/alert.txt
+++ b/fixtures/emails/alert.txt
@@ -1,7 +1,7 @@
 Details
 -------
 
-http://testserver/organizations/example/issues/1/?referrer=alert_email&amp;alert_type=email&amp;alert_timestamp=1337&amp;alert_rule_id=1
+http://testserver/organizations/sentry/issues/1/?referrer=alert_email&amp;alert_type=email&amp;alert_timestamp=1337&amp;alert_rule_id=1
 
 
 Suspect Commits

--- a/fixtures/emails/assigned.txt
+++ b/fixtures/emails/assigned.txt
@@ -1,13 +1,13 @@
 # Assigned
 
-foo@example.com assigned PROJECT-1 to foo@example.com
+foo@example.com assigned INTERNAL-1 to foo@example.com
 
 
 ## Issue Details
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=assigned_activity-email
+http://testserver/organizations/sentry/issues/1/?referrer=assigned_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/fixtures/emails/assigned_self.txt
+++ b/fixtures/emails/assigned_self.txt
@@ -1,13 +1,13 @@
 # Assigned
 
-foo@example.com assigned PROJECT-1 to themselves
+foo@example.com assigned INTERNAL-1 to themselves
 
 
 ## Issue Details
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=assigned_activity-email
+http://testserver/organizations/sentry/issues/1/?referrer=assigned_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/fixtures/emails/note.txt
+++ b/fixtures/emails/note.txt
@@ -9,6 +9,6 @@ sincerely gobbler epic immensely katydid beloved stunning falcon mainly actively
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/activity/?referrer=note_activity-email
+http://testserver/organizations/sentry/issues/1/activity/?referrer=note_activity-email
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/fixtures/emails/regression.txt
+++ b/fixtures/emails/regression.txt
@@ -1,13 +1,13 @@
 # Regression
 
-Sentry marked PROJECT-1 as a regression
+Sentry marked INTERNAL-1 as a regression
 
 
 ## Issue Details
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=regression_activity-email
+http://testserver/organizations/sentry/issues/1/?referrer=regression_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/fixtures/emails/regression_with_version.txt
+++ b/fixtures/emails/regression_with_version.txt
@@ -1,13 +1,13 @@
 # Regression
 
-Sentry marked PROJECT-1 as a regression in abcdef
+Sentry marked INTERNAL-1 as a regression in abcdef
 
 
 ## Issue Details
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=regression_activity-email
+http://testserver/organizations/sentry/issues/1/?referrer=regression_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/fixtures/emails/resolved.txt
+++ b/fixtures/emails/resolved.txt
@@ -1,13 +1,13 @@
 # Resolved Issue
 
-Sentry marked PROJECT-1 as resolved
+Sentry marked INTERNAL-1 as resolved
 
 
 ## Issue Details
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=resolved_activity-email
+http://testserver/organizations/sentry/issues/1/?referrer=resolved_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/fixtures/emails/resolved_in_release.txt
+++ b/fixtures/emails/resolved_in_release.txt
@@ -1,13 +1,13 @@
 # Resolved Issue
 
-Sentry marked PROJECT-1 as resolved in abcdef
+Sentry marked INTERNAL-1 as resolved in abcdef
 
 
 ## Issue Details
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=resolved_in_release_activity-email
+http://testserver/organizations/sentry/issues/1/?referrer=resolved_in_release_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/fixtures/emails/resolved_in_release_upcoming.txt
+++ b/fixtures/emails/resolved_in_release_upcoming.txt
@@ -1,13 +1,13 @@
 # Resolved Issue
 
-Sentry marked PROJECT-1 as resolved in an upcoming release
+Sentry marked INTERNAL-1 as resolved in an upcoming release
 
 
 ## Issue Details
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=resolved_in_release_activity-email
+http://testserver/organizations/sentry/issues/1/?referrer=resolved_in_release_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/fixtures/emails/unassigned.txt
+++ b/fixtures/emails/unassigned.txt
@@ -1,13 +1,13 @@
 # Unassigned
 
-foo@example.com unassigned PROJECT-1
+foo@example.com unassigned INTERNAL-1
 
 
 ## Issue Details
 
 goose smiling gobbler sterling feline
 
-http://testserver/organizations/organization/issues/1/?referrer=unassigned_activity-email
+http://testserver/organizations/sentry/issues/1/?referrer=unassigned_activity-email
 
 
 Unsubscribe: javascript:alert("This is a preview page, what did you expect to happen?");

--- a/src/sentry/web/frontend/debug/debug_performance_issue.py
+++ b/src/sentry/web/frontend/debug/debug_performance_issue.py
@@ -1,56 +1,25 @@
-import datetime
-
-import pytz
 from django.utils.safestring import mark_safe
 from django.views.generic import View
 
-from sentry.event_manager import EventManager
 from sentry.models import Project, Rule
 from sentry.notifications.utils import (
-    get_group_settings_link,
     get_interface_list,
     get_performance_issue_alert_subtitle,
-    get_rules,
     get_transaction_data,
 )
-from sentry.testutils.helpers import override_options
 from sentry.types.issues import GROUP_TYPE_TO_TEXT
 from sentry.utils import json
-from sentry.utils.samples import load_data
 
-from .mail import COMMIT_EXAMPLE, MailPreview
+from .mail import COMMIT_EXAMPLE, MailPreview, get_shared_context, make_performance_event
 
 
 class DebugPerformanceIssueEmailView(View):
-    @override_options({"performance.issues.all.problem-creation": 1.0})
-    @override_options({"performance.issues.all.problem-detection": 1.0})
-    @override_options({"performance.issues.n_plus_one_db.problem-creation": 1.0})
     def get(self, request):
         project = Project.objects.first()
         org = project.organization
         project.update_option("sentry:performance_issue_creation_rate", 1.0)
-        with override_options(
-            {
-                "performance.issues.all.problem-creation": 1.0,
-                "performance.issues.all.problem-detection": 1.0,
-                "performance.issues.n_plus_one_db.problem-creation": 1.0,
-            }
-        ):
-            # make this consistent for acceptance tests
-            perf_data = dict(
-                load_data(
-                    "transaction-n-plus-one",
-                    timestamp=datetime.datetime(2022, 11, 11, 21, 39, 23, 30723),
-                )
-            )
-            perf_data["event_id"] = "44f1419e73884cd2b45c79918f4b6dc4"
-            perf_event_manager = EventManager(perf_data)
-            perf_event_manager.normalize()
-            perf_data = perf_event_manager.get_data()
-            perf_event = perf_event_manager.save(project.id)
-
-        perf_event = perf_event.for_group(perf_event.groups[0])
-        perf_event.group.id = 1  # hard code to 1 for acceptance tests
+        perf_event = make_performance_event(project)
+        perf_event.group.id = 1  # hard code to 1 for acceptance tests. comment this line out for debug view. yeah, it's stupid.
         perf_group = perf_event.group
 
         rule = Rule(id=1, label="Example performance rule")
@@ -62,18 +31,8 @@ class DebugPerformanceIssueEmailView(View):
             html_template="sentry/emails/performance.html",
             text_template="sentry/emails/performance.txt",
             context={
-                "rule": rule,
-                "rules": get_rules([rule], org, project),
-                "group": perf_group,
-                "event": perf_event,
-                "timezone": pytz.timezone("Europe/Vienna"),
-                # http://testserver/organizations/example/issues/<issue-id>/?referrer=alert_email
-                #       &alert_type=email&alert_timestamp=<ts>&alert_rule_id=1
-                "link": get_group_settings_link(
-                    perf_group, None, get_rules([rule], org, project), 1337
-                ),
+                **get_shared_context(rule, org, project, perf_group, perf_event),
                 "interfaces": interface_list,
-                "tags": perf_event.tags,
                 "project_label": project.slug,
                 "commits": json.loads(COMMIT_EXAMPLE),
                 "transaction_data": [("Span Evidence", mark_safe(transaction_data), None)],

--- a/src/sentry/web/frontend/debug/debug_performance_issue.py
+++ b/src/sentry/web/frontend/debug/debug_performance_issue.py
@@ -19,7 +19,8 @@ class DebugPerformanceIssueEmailView(View):
         org = project.organization
         project.update_option("sentry:performance_issue_creation_rate", 1.0)
         perf_event = make_performance_event(project)
-        perf_event.group.id = 1  # hard code to 1 for acceptance tests. comment this line out for debug view. yeah, it's stupid.
+        if request.GET.get("is_test", False):
+            perf_event.group.id = 1
         perf_group = perf_event.group
 
         rule = Rule(id=1, label="Example performance rule")

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -15,7 +15,6 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
-from django.utils.safestring import mark_safe
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from rest_framework.request import Request
@@ -159,6 +158,33 @@ def make_group_generator(random, project):
         yield group
 
 
+def make_event(request, project, platform):
+    group = next(make_group_generator(get_random(request), project))
+
+    data = dict(load_data(platform))
+    data["message"] = group.message
+    data.pop("logentry", None)
+    data["event_id"] = "44f1419e73884cd2b45c79918f4b6dc4"
+    data["environment"] = "prod"
+    data["tags"] = [
+        ("logger", "javascript"),
+        ("environment", "prod"),
+        ("level", "error"),
+        ("device", "Other"),
+    ]
+
+    event_manager = EventManager(data)
+    event_manager.normalize()
+    data = event_manager.get_data()
+    event = event_manager.save(project.id)
+    # Prevent CI screenshot from constantly changing
+    event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
+    group.message = event.search_message
+    event_type = get_event_type(event.data)
+    group.data = {"type": event_type.key, "metadata": event_type.get_metadata(data)}
+    return event
+
+
 def add_unsubscribe_link(context):
     if "unsubscribe_link" not in context:
         context[
@@ -282,26 +308,12 @@ class ActivityMailDebugView(View):
     def get(self, request: Request) -> Response:
         org = Organization(id=1, slug="organization", name="My Company")
         project = Project(id=1, organization=org, slug="project", name="My Project")
+        platform = request.GET.get("platform", "python")
+        event = make_event(request, project, platform)
 
-        group = next(make_group_generator(get_random(request), project))
-
-        data = dict(load_data("python"))
-        data["message"] = group.message
-        data.pop("logentry", None)
-
-        event_manager = EventManager(data)
-        event_manager.normalize()
-        data = event_manager.get_data()
-        event_type = get_event_type(data)
-
-        event = eventstore.create_event(
-            event_id="a" * 32, group_id=group.id, project_id=project.id, data=data.data
+        activity = Activity(
+            group=event.group, project=event.project, **self.get_activity(request, event)
         )
-
-        group.message = event.search_message
-        group.data = {"type": event_type.key, "metadata": event_type.get_metadata(data)}
-
-        activity = Activity(group=group, project=event.project, **self.get_activity(request, event))
 
         return render_to_response(
             "sentry/debug/mail/preview.html",
@@ -318,34 +330,10 @@ def alert(request):
     org = Organization(id=1, slug="example", name="Example")
     project = Project(id=1, slug="example", name="Example", organization=org)
 
-    random = get_random(request)
-    group = next(make_group_generator(random, project))
-
-    data = dict(load_data(platform))
-    data["message"] = group.message
-    data["event_id"] = "44f1419e73884cd2b45c79918f4b6dc4"
-    data.pop("logentry", None)
-    data["environment"] = "prod"
-    data["tags"] = [
-        ("logger", "javascript"),
-        ("environment", "prod"),
-        ("level", "error"),
-        ("device", "Other"),
-    ]
-
-    event_manager = EventManager(data)
-    event_manager.normalize()
-    data = event_manager.get_data()
-    event = event_manager.save(project.id)
-    # Prevent CI screenshot from constantly changing
-    event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
-    event_type = get_event_type(event.data)
-
-    group.message = event.search_message
-    group.data = {"type": event_type.key, "metadata": event_type.get_metadata(data)}
+    event = make_event(request, project, platform)
+    group = event.group
 
     rule = Rule(id=1, label="An example rule")
-    interface_list = get_interface_list(event)
 
     return MailPreview(
         html_template="sentry/emails/error.html",
@@ -359,7 +347,7 @@ def alert(request):
             # http://testserver/organizations/example/issues/<issue-id>/?referrer=alert_email
             #       &alert_type=email&alert_timestamp=<ts>&alert_rule_id=1
             "link": get_group_settings_link(group, None, get_rules([rule], org, project), 1337),
-            "interfaces": interface_list,
+            "interfaces": get_interface_list(event),
             "tags": event.tags,
             "project_label": project.slug,
             "commits": json.loads(COMMIT_EXAMPLE),
@@ -373,49 +361,12 @@ def release_alert(request):
     org = Organization(id=1, slug="example", name="Example")
     project = Project(id=1, slug="example", name="Example", organization=org, platform="python")
 
-    random = get_random(request)
-    group = next(make_group_generator(random, project))
-
-    data = dict(load_data(platform))
-    data["message"] = group.message
-    data["event_id"] = "44f1419e73884cd2b45c79918f4b6dc4"
-    data.pop("logentry", None)
-    data["environment"] = "prod"
-    data["tags"] = [
-        ("logger", "javascript"),
-        ("environment", "prod"),
-        ("level", "error"),
-        ("device", "Other"),
-    ]
-
-    event_manager = EventManager(data)
-    event_manager.normalize()
-    data = event_manager.get_data()
-    event = event_manager.save(project.id)
-    # Prevent CI screenshot from constantly changing
-    event.data["timestamp"] = 1504656000.0  # datetime(2017, 9, 6, 0, 0)
-    event_type = get_event_type(event.data)
-    # In non-debug context users_seen we get users_seen from group.count_users_seen()
-    users_seen = random.randint(0, 100 * 1000)
-
-    group.message = event.search_message
-    group.data = {"type": event_type.key, "metadata": event_type.get_metadata(data)}
+    event = make_event(request, project, platform)
+    group = event.group
 
     rule = Rule(id=1, label="An example rule")
-
-    # XXX: this interface_list code needs to be the same as in
-    #      src/sentry/mail/adapter.py
-    interfaces = {}
-    for interface in event.interfaces.values():
-        body = interface.to_email_html(event)
-        if not body:
-            continue
-        text_body = interface.to_string(event)
-        interfaces[interface.get_title()] = {
-            "label": interface.get_title(),
-            "html": mark_safe(body),
-            "body": text_body,
-        }
+    # In non-debug context users_seen we get users_seen from group.count_users_seen()
+    users_seen = get_random(request).randint(0, 100 * 1000)
 
     contexts = event.data["contexts"].items() if "contexts" in event.data else None
     event_user = event.data["event_user"] if "event_user" in event.data else None
@@ -430,7 +381,7 @@ def release_alert(request):
             "event_user": event_user,
             "timezone": pytz.timezone("Europe/Vienna"),
             "link": get_group_settings_link(group, None, get_rules([rule], org, project), 1337),
-            "interfaces": interfaces,
+            "interfaces": get_interface_list(event),
             "tags": event.tags,
             "contexts": contexts,
             "users_seen": users_seen,

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -43,7 +43,7 @@ def read_txt_email_fixture(name: str) -> str:
 
 
 def build_url(path: str, format: str = "html") -> str:
-    return f"{path}?{urlencode({'format': format, 'seed': b'123'})}"
+    return f"{path}?{urlencode({'format': format, 'seed': b'123', 'is_test': True})}"
 
 
 class EmailTestCase(AcceptanceTestCase):


### PR DESCRIPTION
Create shared methods to clean up repeated code in the email debug view code. 

I can use this in https://github.com/getsentry/sentry/pull/41343 once merged too :) 