### PR TITLE
fix(ecosystem): Hide stacktrace link for minified javascript

### DIFF
--- a/static/app/components/events/interfaces/frame/context.tsx
+++ b/static/app/components/events/interfaces/frame/context.tsx
@@ -68,6 +68,11 @@ const Context = ({
     : frame.context.filter(l => l[0] === frame.lineNo);
 
   const startLineNo = hasContextSource ? frame.context[0][0] : undefined;
+  const hasStacktraceLink =
+    frame.inApp &&
+    !!frame.filename &&
+    isExpanded &&
+    organization?.features.includes('integrations-stacktrace-link');
 
   return (
     <Wrapper
@@ -84,6 +89,8 @@ const Context = ({
         contextLines.map((line, index) => {
           const isActive = frame.lineNo === line[0];
           const hasComponents = isActive && components.length > 0;
+          const showStacktraceLink = hasStacktraceLink && isActive;
+
           return (
             <StyledContextLine key={index} line={line} isActive={isActive}>
               {hasComponents && (
@@ -96,20 +103,17 @@ const Context = ({
                   />
                 </ErrorBoundary>
               )}
-              {organization?.features.includes('integrations-stacktrace-link') &&
-                isActive &&
-                isExpanded &&
-                frame.inApp &&
-                frame.filename && (
-                  <ErrorBoundary customComponent={null}>
-                    <StacktraceLink
-                      key={index}
-                      lineNo={line[0]}
-                      frame={frame}
-                      event={event}
-                    />
-                  </ErrorBoundary>
-                )}
+              {showStacktraceLink && (
+                <ErrorBoundary customComponent={null}>
+                  <StacktraceLink
+                    key={index}
+                    line={line[1]}
+                    lineNo={line[0]}
+                    frame={frame}
+                    event={event}
+                  />
+                </ErrorBoundary>
+              )}
             </StyledContextLine>
           );
         })}

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.jsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.jsx
@@ -34,6 +34,7 @@ describe('StacktraceLink', function () {
         event={event}
         projects={[project]}
         organization={org}
+        line="foo()"
         lineNo={frame.lineNo}
       />,
       {context: TestStubs.routerContext()}
@@ -55,6 +56,7 @@ describe('StacktraceLink', function () {
         event={event}
         projects={[project]}
         organization={org}
+        line="foo()"
         lineNo={frame.lineNo}
       />,
       {context: TestStubs.routerContext()}
@@ -79,6 +81,7 @@ describe('StacktraceLink', function () {
         event={event}
         projects={[project]}
         organization={org}
+        line="foo()"
         lineNo={frame.lineNo}
       />,
       {context: TestStubs.routerContext()}
@@ -88,5 +91,29 @@ describe('StacktraceLink', function () {
         name: 'Fix code mapping to see suspect commits and more',
       })
     ).toBeInTheDocument();
+  });
+
+  it('should hide stacktrace link error state on minified javascript frames', function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: frame.filename, commitId: 'master', platform},
+      body: {
+        config,
+        sourceUrl: null,
+        integrations: [integration],
+      },
+    });
+    const {container} = render(
+      <StacktraceLink
+        frame={frame}
+        event={{...event, platform: 'javascript'}}
+        projects={[project]}
+        organization={org}
+        line="{snip} somethingInsane=e.IsNotFound {snip}"
+        lineNo={frame.lineNo}
+      />,
+      {context: TestStubs.routerContext()}
+    );
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -36,6 +36,7 @@ import StacktraceLinkModal from './stacktraceLinkModal';
 type Props = AsyncComponent['props'] & {
   event: Event;
   frame: Frame;
+  line: string;
   lineNo: number;
   organization: Organization;
   projects: Project[];
@@ -278,19 +279,24 @@ class StacktraceLink extends AsyncComponent<Props, State> {
   renderBody() {
     const {config, error, sourceUrl, integrations} = this.state.match || {};
     const {isDismissed, promptLoaded} = this.state;
+    const {event, line} = this.props;
 
     // Success state
     if (config && sourceUrl) {
       return this.renderLink();
     }
 
+    // Hide stacktrace link errors if the stacktrace might be minified javascript
+    // Check if the line starts and ends with {snip}
+    const hideErrors = event.platform === 'javascript' && /(\{snip\}).*\1/.test(line);
+
     // Code mapping does not match
     // Has integration but no code mappings
-    if (error || integrations.length > 0) {
+    if (!hideErrors && (error || integrations.length > 0)) {
       return this.renderNoMatch();
     }
 
-    if (!promptLoaded || (promptLoaded && isDismissed)) {
+    if (hideErrors || !promptLoaded || (promptLoaded && isDismissed)) {
       return null;
     }
 


### PR DESCRIPTION
stop showing the stacktrace link error state for minified javascript errors

example line where we would stop showing the "fix your code mapping or add integration"
![image](https://user-images.githubusercontent.com/1400464/202819780-81ca5f85-318a-4192-a325-26a76a45317d.png)

fixes https://getsentry.atlassian.net/browse/WOR-2420