### PR TITLE
feature(hybrid-cloud): hybrid compatible auth middleware

### DIFF
--- a/src/sentry/auth/system.py
+++ b/src/sentry/auth/system.py
@@ -8,9 +8,9 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http.request import HttpRequest
 from django.utils.crypto import constant_time_compare
-from typing_extensions import TypeGuard
 
 from sentry import options
+from sentry.services.hybrid_cloud.auth import AuthenticatedToken
 from sentry.utils.cache import memoize
 
 INTERNAL_NETWORKS = [
@@ -87,6 +87,8 @@ class SystemToken:
         pass
 
 
-def is_system_auth(auth: object) -> TypeGuard[SystemToken]:
+def is_system_auth(auth: object) -> bool:
     """:returns True when Sentry itself is hitting the API."""
+    if isinstance(auth, AuthenticatedToken):
+        return auth.kind == "system"
     return isinstance(auth, SystemToken)

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import base64
+
 from django.contrib.auth import get_user as auth_get_user
 from django.contrib.auth.models import AnonymousUser
 from django.utils.deprecation import MiddlewareMixin
@@ -8,8 +12,11 @@ from rest_framework.request import Request
 
 from sentry.api.authentication import ApiKeyAuthentication, TokenAuthentication
 from sentry.models import UserIP
+from sentry.services.hybrid_cloud.auth import AuthenticationRequest, auth_service
+from sentry.silo import SiloMode
 from sentry.utils.auth import AuthUserPasswordExpired, logger
-from sentry.utils.linksign import process_signature
+from sentry.utils.linksign import find_signature, process_signature
+from sentry.utils.types import Any
 
 
 def get_user(request):
@@ -35,12 +42,27 @@ def get_user(request):
                 )
                 user = AnonymousUser()
             else:
-                UserIP.log(user, request.META["REMOTE_ADDR"])
+                if SiloMode.get_current_mode() == SiloMode.MONOLITH:
+                    UserIP.log(user, request.META["REMOTE_ADDR"])
         request._cached_user = user
     return request._cached_user
 
 
 class AuthenticationMiddleware(MiddlewareMixin):
+    @property
+    def impl(self) -> Any:
+        if SiloMode.get_current_mode() == SiloMode.MONOLITH:
+            return RequestAuthenticationMiddleware()
+        return HybridCloudAuthenticationMiddleware()
+
+    def process_request(self, request: Request):
+        return self.impl.process_request(request)
+
+    def process_exception(self, request: Request, exception):
+        return self.impl.process_exception(request, exception)
+
+
+class RequestAuthenticationMiddleware(MiddlewareMixin):
     def process_request(self, request: Request):
         request.user_from_signed_request = False
 
@@ -80,3 +102,43 @@ class AuthenticationMiddleware(MiddlewareMixin):
             from sentry.web.frontend.accounts import expired
 
             return expired(request, exception.user)
+
+
+class HybridCloudAuthenticationMiddleware(MiddlewareMixin):
+    def process_request(self, request: Request):
+        from sentry.web.frontend.accounts import expired
+
+        auth_result = auth_service.authenticate(request=authentication_request_from(request))
+        request.user_from_signed_request = auth_result.user_from_signed_request
+
+        if auth_result.auth is not None:
+            request.auth = auth_result.auth
+        if auth_result.expired:
+            return expired(request, auth_result.user)
+        elif auth_result.user is not None:
+            request.user = auth_result.user
+            UserIP.log(auth_result.user, request.META["REMOTE_ADDR"])
+        else:
+            request.user = AnonymousUser()
+
+
+def authentication_request_from(request: Request) -> AuthenticationRequest:
+    return AuthenticationRequest(
+        backend=request.session.get("_auth_user_backend", None),
+        user_id=request.session.get("_auth_user_id", None),
+        user_hash=request.session.get("_auth_user_hash", None),
+        nonce=request.session.get("_nonce", None),
+        remote_addr=request.META["REMOTE_ADDR"],
+        signature=find_signature(request),
+        absolute_url=request.build_absolute_uri(),
+        path=request.path,
+        authorization_b64=_normalize_to_b64(request.META.get("HTTP_AUTHORIZATION")),
+    )
+
+
+def _normalize_to_b64(input: str | bytes | None) -> str | None:
+    if input is None:
+        return None
+    if isinstance(input, str):
+        input = input.encode("utf8")
+    return base64.b64encode(input).decode("utf8")

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -11,7 +11,7 @@ from sentry.db.models import (
     BoundedPositiveIntegerField,
     FlexibleForeignKey,
     Model,
-    region_silo_only_model,
+    control_silo_only_model,
     sane_repr,
 )
 
@@ -22,7 +22,7 @@ class ApiKeyStatus:
     INACTIVE = 1
 
 
-@region_silo_only_model
+@control_silo_only_model
 class ApiKey(Model):
     __include_in_export__ = True
 

--- a/src/sentry/models/apitoken.py
+++ b/src/sentry/models/apitoken.py
@@ -9,7 +9,7 @@ from sentry.db.models import (
     BaseManager,
     FlexibleForeignKey,
     Model,
-    region_silo_only_model,
+    control_silo_only_model,
     sane_repr,
 )
 from sentry.models.apiscopes import HasApiScopes
@@ -25,7 +25,7 @@ def generate_token():
     return uuid4().hex + uuid4().hex
 
 
-@region_silo_only_model
+@control_silo_only_model
 class ApiToken(Model, HasApiScopes):
     __include_in_export__ = True
 

--- a/src/sentry/ratelimits/utils.py
+++ b/src/sentry/ratelimits/utils.py
@@ -65,11 +65,11 @@ def get_rate_limit_key(
 
     from django.contrib.auth.models import AnonymousUser
 
-    from sentry.auth.system import SystemToken
+    from sentry.auth.system import is_system_auth
     from sentry.models import ApiKey, ApiToken
 
     # Don't Rate Limit System Token Requests
-    if isinstance(request_auth, SystemToken):
+    if is_system_auth(request_auth):
         return None
 
     if isinstance(request_auth, ApiToken) and request_user:

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import abc
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, List
+import contextlib
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Generator, List, Mapping, Type
+
+from django.contrib.auth.models import AnonymousUser
 
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
 from sentry.services.hybrid_cloud.organization import ApiOrganizationMember
+from sentry.services.hybrid_cloud.user import APIUser
 from sentry.silo import SiloMode
 
 if TYPE_CHECKING:
@@ -13,6 +17,10 @@ if TYPE_CHECKING:
 
 
 class AuthService(InterfaceWithLifecycle):
+    @abc.abstractmethod
+    def authenticate(self, *, request: AuthenticationRequest) -> AuthenticationResponse:
+        pass
+
     @abc.abstractmethod
     def get_user_auth_state(
         self,
@@ -43,19 +51,6 @@ def impl_with_db() -> AuthService:
     return DatabaseBackedAuthService()
 
 
-auth_service: AuthService = silo_mode_delegation(
-    {
-        SiloMode.MONOLITH: impl_with_db,
-        SiloMode.CONTROL: stubbed(
-            impl_with_db, SiloMode.MONOLITH
-        ),  # This eventually must become a DatabaseBackedAuthService, but use the new org member mapping table
-        SiloMode.REGION: stubbed(
-            impl_with_db, SiloMode.MONOLITH
-        ),  # this must eventually be purely RPC
-    }
-)
-
-
 @dataclass
 class ApiAuthState:
     sso_state: ApiMemberSsoState
@@ -66,3 +61,125 @@ class ApiAuthState:
 class ApiMemberSsoState:
     is_required: bool = False
     is_valid: bool = False
+
+
+@dataclass
+class AuthenticationRequest:
+    backend: str | None = None
+    user_id: str | None = None
+    user_hash: str | None = None
+    nonce: str | None = None
+    remote_addr: str | None = None
+    signature: str | None = None
+    absolute_url: str = ""
+    path: str = ""
+    authorization_b64: str | None = None
+
+
+@dataclass(eq=True)
+class AuthenticatedToken:
+    entity_id: int | None = None
+    kind: str = "system"
+    organization_id: int | None = None
+    allowed_origins: List[str] = field(default_factory=list)
+    audit_log_data: Dict[str, Any] = field(default_factory=dict)
+    scopes: List[str] = field(default_factory=list)
+
+    @classmethod
+    def from_token(cls, token: Any) -> AuthenticatedToken | None:
+        if token is None:
+            return None
+
+        if isinstance(token, AuthenticatedToken):
+            return token
+
+        for kind, kind_cls in cls.get_kinds().items():
+            if isinstance(token, kind_cls):
+                break
+        else:
+            raise KeyError(f"Token {token} is a not a registered AuthenticatedToken type!")
+
+        return cls(
+            entity_id=getattr(token, "id", None),
+            kind=kind,
+            organization_id=getattr(token, "organization_id", None),
+            allowed_origins=token.get_allowed_origins(),
+            audit_log_data=token.get_audit_log_data(),
+            scopes=token.get_scopes(),
+        )
+
+    @classmethod
+    def get_kinds(cls) -> Mapping[str, Type[Any]]:
+        return getattr(cls, "_kinds", {})
+
+    @classmethod
+    def register_kind(cls, kind_name: str, t: Type[Any]) -> None:
+        kind_map = getattr(cls, "_kinds", {})
+        if kind_name in kind_map:
+            raise ValueError(f"Conflict detected, kind {kind_name} registered twice!")
+        kind_map[kind_name] = t
+        setattr(cls, "_kinds", kind_map)
+
+    def get_audit_log_data(self) -> Mapping[str, Any]:
+        return self.audit_log_data
+
+    def get_allowed_origins(self) -> List[str]:
+        return self.allowed_origins
+
+    def get_scopes(self) -> list[str]:
+        return self.scopes
+
+    def has_scope(self, scope: str) -> bool:
+        if self.kind == "system":
+            return True
+        return scope in self.get_scopes()
+
+
+@dataclass
+class AuthenticationContext:
+    auth: AuthenticatedToken | None = None
+    user: APIUser | None = None
+
+    @contextlib.contextmanager
+    def applied_to_request(self, request: Any = None) -> Generator[None, None, None]:
+        """
+        Some code still reaches for the global 'env' object when determining user or auth behaviors.  This bleeds the
+        current request context into that code, but makes it difficult to carry RPC authentication context in an
+        isolated, controlled way.  This method allows for a context handling an RPC or inter silo behavior to assume
+        the correct user and auth context provided explicitly in a context.
+        """
+        from sentry.app import env
+
+        if request is None:
+            request = env.request
+
+        if request is None:
+            # Contexts that lack a request
+            # Note -- if a request is setup in the env after this context manager, you run the risk of bugs.
+            yield
+            return
+
+        old_user = request.user
+        old_auth = request.auth
+        request.user = self.user or AnonymousUser()
+        request.auth = self.auth
+        yield
+        request.user = old_user
+        request.auth = old_auth
+
+
+@dataclass
+class AuthenticationResponse(AuthenticationContext):
+    expired: bool = False
+    user_from_signed_request: bool = False
+
+
+auth_service: AuthService = silo_mode_delegation(
+    {
+        SiloMode.MONOLITH: impl_with_db,
+        SiloMode.CONTROL: impl_with_db,  # This eventually must become a DatabaseBackedAuthService, but use the new org member mapping table
+        SiloMode.REGION: stubbed(
+            impl_with_db, SiloMode.CONTROL
+        ),  # this must eventually be purely RPC
+    }
+)

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -159,13 +159,25 @@ class AuthenticationContext:
             yield
             return
 
-        old_user = request.user
-        old_auth = request.auth
+        has_user = hasattr(request, "user")
+        has_auth = hasattr(request, "auth")
+
+        old_user = getattr(request, "user", None)
+        old_auth = getattr(request, "auth", None)
         request.user = self.user or AnonymousUser()
         request.auth = self.auth
+
         yield
-        request.user = old_user
-        request.auth = old_auth
+
+        if has_user:
+            request.user = old_user
+        else:
+            delattr(request, "user")
+
+        if has_auth:
+            request.auth = old_auth
+        else:
+            delattr(request, "auth")
 
 
 @dataclass

--- a/src/sentry/services/hybrid_cloud/auth/__init__.py
+++ b/src/sentry/services/hybrid_cloud/auth/__init__.py
@@ -137,6 +137,10 @@ class AuthenticatedToken:
 
 @dataclass
 class AuthenticationContext:
+    """
+    The default of all values should be a valid, non authenticated context.
+    """
+
     auth: AuthenticatedToken | None = None
     user: APIUser | None = None
 

--- a/src/sentry/services/hybrid_cloud/auth/impl.py
+++ b/src/sentry/services/hybrid_cloud/auth/impl.py
@@ -1,14 +1,28 @@
 from __future__ import annotations
 
-from typing import List
+import base64
+from typing import List, Mapping
 
+from django.contrib.auth.models import AnonymousUser
 from django.db.models import F
 
 from sentry import roles
 from sentry.auth.access import get_permissions_for_user
-from sentry.models import AuthIdentity, AuthProvider, OrganizationMember
-from sentry.services.hybrid_cloud.auth import ApiAuthState, ApiMemberSsoState, AuthService
+from sentry.auth.system import SystemToken
+from sentry.middleware.auth import RequestAuthenticationMiddleware
+from sentry.models import ApiKey, ApiToken, AuthIdentity, AuthProvider, OrganizationMember, User
+from sentry.services.hybrid_cloud.auth import (
+    ApiAuthState,
+    ApiMemberSsoState,
+    AuthenticatedToken,
+    AuthenticationRequest,
+    AuthenticationResponse,
+    AuthService,
+)
 from sentry.services.hybrid_cloud.organization import ApiOrganizationMember
+from sentry.services.hybrid_cloud.user import user_service
+from sentry.silo import SiloMode
+from sentry.utils.auth import AuthUserPasswordExpired
 from sentry.utils.types import Any
 
 _SSO_BYPASS = ApiMemberSsoState(False, True)
@@ -59,15 +73,30 @@ def query_sso_state(
             # allow bypassing SSO if there are no other
             # owners with SSO enabled.
             if member.role == roles.get_top_dog().id:
+
+                def get_user_ids(org_id: int, mem_id: int) -> Any:
+                    return (
+                        org_member_class.objects.filter(
+                            organization_id=org_id,
+                            role=roles.get_top_dog().id,
+                            user__is_active=True,
+                        )
+                        .exclude(id=mem_id)
+                        .values_list("user_id")
+                    )
+
+                if SiloMode.get_current_mode() != SiloMode.MONOLITH:
+                    # Giant hack for now until we have control silo org membership table.
+                    from sentry.testutils.silo import exempt_from_silo_limits
+
+                    with exempt_from_silo_limits():
+                        user_ids = get_user_ids(member.organization_id, member.id)
+                else:
+                    user_ids = get_user_ids(member.organization_id, member.id)
+
                 requires_sso = AuthIdentity.objects.filter(
                     auth_provider=auth_provider,
-                    user__in=org_member_class.objects.filter(
-                        organization_id=member.organization_id,
-                        role=roles.get_top_dog().id,
-                        user__is_active=True,
-                    )
-                    .exclude(id=member.id)
-                    .values_list("user_id"),
+                    user__in=user_ids,
                 ).exists()
         else:
             sso_is_valid = auth_identity.is_valid(member)
@@ -76,8 +105,33 @@ def query_sso_state(
 
 
 class DatabaseBackedAuthService(AuthService):
-    # Monolith implementation that uses OrganizationMember and User tables freely, but in silo world
-    # this won't be possible.
+    def authenticate(self, *, request: AuthenticationRequest) -> AuthenticationResponse:
+        fake_request = FakeAuthenticationRequest(request)
+        handler: Any = RequestAuthenticationMiddleware()
+        expired_user: User | None = None
+        try:
+            handler.process_request(fake_request)
+        except AuthUserPasswordExpired as e:
+            expired_user = e.user
+        except Exception as e:
+            raise Exception("Unexpected error processing handler") from e
+
+        auth: AuthenticatedToken | None = None
+        if fake_request.auth is not None:
+            auth = AuthenticatedToken.from_token(fake_request.auth)
+
+        result = AuthenticationResponse(
+            auth=auth, user_from_signed_request=fake_request.user_from_signed_request
+        )
+
+        if expired_user is not None:
+            result.user = user_service.serialize_user(expired_user)
+            result.expired = True
+        elif fake_request.user is not None and not fake_request.user.is_anonymous:
+            result.user = user_service.serialize_user(fake_request.user)
+
+        return result
+
     def get_user_auth_state(
         self,
         *,
@@ -114,3 +168,76 @@ class DatabaseBackedAuthService(AuthService):
                 flags=F("flags").bitor(AuthProvider.flags.scim_enabled)
             ).values_list("organization_id", flat=True)
         )
+
+
+class FakeRequestDict:
+    d: Mapping[str, str | bytes | None]
+
+    def __init__(self, **d: Any):
+        self.d = d
+
+    def __getitem__(self, item: str) -> str | bytes:
+        result = self.d[item]
+        if result is None:
+            raise KeyError(f"Key '{item}' does not exist")
+        return result
+
+    def __contains__(self, item: str) -> bool:
+        return self.d.get(item, None) is not None
+
+    def get(self, key: str, default: str | bytes | None = None) -> str | bytes | None:
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+
+class FakeAuthenticationRequest:
+    session: FakeRequestDict
+    GET: FakeRequestDict
+    POST: FakeRequestDict
+    req: AuthenticationRequest
+    user: User | AnonymousUser | None
+    user_from_signed_request: bool = False
+    auth: Any
+
+    def build_absolute_uri(self) -> str:
+        return self.req.absolute_url
+
+    def __init__(self, req: AuthenticationRequest) -> None:
+        self.auth = None
+        self.req = req
+        self.session = FakeRequestDict(
+            _auth_user_id=req.user_id,
+            _auth_user_backend=req.backend,
+            _auth_user_hash=req.user_hash,
+            _nonce=req.nonce,
+        )
+        self.POST = FakeRequestDict(
+            _sentry_request_signature=req.signature,
+        )
+
+        self.GET = FakeRequestDict(
+            _=req.signature,
+        )
+
+        self.META = FakeRequestDict(
+            HTTP_AUTHORIZATION=_unwrap_b64(req.authorization_b64), REMOTE_ADDR=req.remote_addr
+        )
+        self.user_from_signed_request = False
+
+    @property
+    def path(self) -> str:
+        return self.req.path
+
+
+def _unwrap_b64(input: str | None) -> bytes | None:
+    if input is None:
+        return None
+
+    return base64.b64decode(input.encode("utf8"))
+
+
+AuthenticatedToken.register_kind("system", SystemToken)
+AuthenticatedToken.register_kind("api_token", ApiToken)
+AuthenticatedToken.register_kind("api_key", ApiKey)

--- a/src/sentry/services/hybrid_cloud/user/impl.py
+++ b/src/sentry/services/hybrid_cloud/user/impl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Iterable, List, Optional
 
 from sentry.api.serializers import serialize

--- a/src/sentry/utils/linksign.py
+++ b/src/sentry/utils/linksign.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from urllib.parse import urlencode
 
 from django.core import signing
@@ -36,11 +38,15 @@ def generate_signed_link(user, viewname, referrer=None, args=None, kwargs=None):
     return signed_link
 
 
+def find_signature(request) -> str | None:
+    return request.GET.get("_") or request.POST.get("_sentry_request_signature")
+
+
 def process_signature(request, max_age=60 * 60 * 24 * 10):
     """Given a request object this validates the signature from the
     current request and returns the user.
     """
-    sig = request.GET.get("_") or request.POST.get("_sentry_request_signature")
+    sig = find_signature(request)
     if not sig or sig.count(":") < 2:
         return None
 

--- a/tests/sentry/middleware/test_auth.py
+++ b/tests/sentry/middleware/test_auth.py
@@ -1,7 +1,7 @@
 import base64
 from typing import cast
 
-from django.test import RequestFactory, override_settings
+from django.test import RequestFactory
 from django.utils import timezone
 from exam import fixture
 from freezegun import freeze_time
@@ -12,13 +12,47 @@ from sentry.region_to_control.producer import (
     MockRegionToControlMessageService,
     region_to_control_message_service,
 )
+from sentry.services.hybrid_cloud.auth import AuthenticatedToken
+from sentry.services.hybrid_cloud.user import user_service
 from sentry.silo import SiloMode
 from sentry.testutils import TestCase
+from sentry.testutils.silo import all_silo_test, exempt_from_silo_limits
 from sentry.utils.auth import login
 
 
+@all_silo_test(stable=True)
 class AuthenticationMiddlewareTestCase(TestCase):
     middleware = fixture(AuthenticationMiddleware)
+
+    def assert_user_equals(self, request):
+        if SiloMode.get_current_mode() == SiloMode.MONOLITH:
+            assert request.user == self.user
+        else:
+            assert request.user == user_service.serialize_user(self.user)
+
+    def assert_user_ip(self, request):
+        if SiloMode.get_current_mode() == SiloMode.REGION:
+            cast(
+                MockRegionToControlMessageService, region_to_control_message_service
+            ).mock.write_region_to_control_message.assert_called_with(
+                dict(
+                    user_ip_event=dict(
+                        user_id=self.user.id,
+                        ip_address="127.0.0.1",
+                        last_seen=timezone.now(),
+                        country_code=None,
+                        region_code=None,
+                    ),
+                    audit_log_event=None,
+                ),
+                False,
+            )
+            with exempt_from_silo_limits():
+                assert not UserIP.objects.filter(user=self.user, ip_address="127.0.0.1").exists()
+        else:
+            # Force the user object to materialize
+            request.user.id  # noqa
+            assert UserIP.objects.filter(user=self.user, ip_address="127.0.0.1").exists()
 
     def setUp(self):
         from django.core.cache import cache
@@ -39,60 +73,35 @@ class AuthenticationMiddlewareTestCase(TestCase):
 
     def test_process_request_user(self):
         request = self.request
-        assert login(request, self.user)
-        self.middleware.process_request(request)
-        assert request.user.is_authenticated
-        assert request.user == self.user
-        assert "_nonce" not in request.session
-        assert UserIP.objects.filter(user=self.user, ip_address="127.0.0.1").exists()
-
-    def test_process_request_user_in_region_mode(self):
-        request = self.request
-        assert login(request, self.user)
-
-        with override_settings(SILO_MODE=SiloMode.REGION), freeze_time("2000-01-01"):
+        with exempt_from_silo_limits():
+            assert login(request, self.user)
+        with freeze_time("2000-01-01"):
             self.middleware.process_request(request)
+            self.assert_user_ip(request)
 
-            # User is still authenticated,
-            assert request.user.is_authenticated
-            assert request.user == self.user
-
-            cast(
-                MockRegionToControlMessageService, region_to_control_message_service
-            ).mock.write_region_to_control_message.assert_called_with(
-                dict(
-                    user_ip_event=dict(
-                        user_id=self.user.id,
-                        ip_address="127.0.0.1",
-                        last_seen=timezone.now(),
-                        country_code=None,
-                        region_code=None,
-                    ),
-                    audit_log_event=None,
-                ),
-                False,
-            )
-
-        # But no ip logging occurs.
-        assert not UserIP.objects.filter(user=self.user, ip_address="127.0.0.1").exists()
+        assert request.user.is_authenticated
+        self.assert_user_equals(request)
+        assert "_nonce" not in request.session
 
     def test_process_request_good_nonce(self):
         request = self.request
         user = self.user
         user.session_nonce = "xxx"
-        user.save()
-        assert login(request, user)
+        with exempt_from_silo_limits():
+            user.save()
+            assert login(request, user)
         self.middleware.process_request(request)
         assert request.user.is_authenticated
-        assert request.user == self.user
+        self.assert_user_equals(request)
         assert request.session["_nonce"] == "xxx"
 
     def test_process_request_missing_nonce(self):
         request = self.request
         user = self.user
         user.session_nonce = "xxx"
-        user.save()
-        assert login(request, user)
+        with exempt_from_silo_limits():
+            user.save()
+            assert login(request, user)
         del request.session["_nonce"]
         self.middleware.process_request(request)
         assert request.user.is_anonymous
@@ -101,19 +110,21 @@ class AuthenticationMiddlewareTestCase(TestCase):
         request = self.request
         user = self.user
         user.session_nonce = "xxx"
-        user.save()
-        assert login(request, user)
+        with exempt_from_silo_limits():
+            user.save()
+            assert login(request, user)
         request.session["_nonce"] = "gtfo"
         self.middleware.process_request(request)
         assert request.user.is_anonymous
 
     def test_process_request_valid_authtoken(self):
-        token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
+        with exempt_from_silo_limits():
+            token = ApiToken.objects.create(user=self.user, scope_list=["event:read", "org:read"])
         request = self.make_request(method="GET")
         request.META["HTTP_AUTHORIZATION"] = f"Bearer {token.token}"
         self.middleware.process_request(request)
-        assert request.user == self.user
-        assert request.auth == token
+        self.assert_user_equals(request)
+        assert AuthenticatedToken.from_token(request.auth) == AuthenticatedToken.from_token(token)
 
     def test_process_request_invalid_authtoken(self):
         request = self.make_request(method="GET")
@@ -124,17 +135,17 @@ class AuthenticationMiddlewareTestCase(TestCase):
         assert request.auth is None
 
     def test_process_request_valid_apikey(self):
-        apikey = ApiKey.objects.create(organization=self.organization, allowed_origins="*")
-
-        request = self.make_request(method="GET")
-        request.META["HTTP_AUTHORIZATION"] = b"Basic " + base64.b64encode(
-            apikey.key.encode("utf-8")
-        )
+        with exempt_from_silo_limits():
+            apikey = ApiKey.objects.create(organization=self.organization, allowed_origins="*")
+            request = self.make_request(method="GET")
+            request.META["HTTP_AUTHORIZATION"] = b"Basic " + base64.b64encode(
+                apikey.key.encode("utf-8")
+            )
 
         self.middleware.process_request(request)
         # ApiKey is tied to an organization not user
         assert request.user.is_anonymous
-        assert request.auth == apikey
+        assert AuthenticatedToken.from_token(request.auth) == AuthenticatedToken.from_token(apikey)
 
     def test_process_request_invalid_apikey(self):
         request = self.make_request(method="GET")


### PR DESCRIPTION
Implements a hybrid cloud compatible AuthenticationMiddleware.

This implementation *has no effect on the behavior of existing SaaS and monolith deployments*!  It is 100% safe with no side effects.

When running in Silo modes, however, `request.user` becomes an `APIUser` instance and `request.auth` becomes an `AuthenticatedToken` instance.  Tests validate compatibility of existing and new authentication middleware.