### PR TITLE
Revert "feat(processor): Use JavaScriptSmCacheStacktraceProcessor by default for all projects"

### DIFF
--- a/src/sentry/lang/javascript/plugin.py
+++ b/src/sentry/lang/javascript/plugin.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+
+from sentry import options
 from sentry.plugins.base.v2 import Plugin2
 from sentry.stacktraces.processing import find_stacktraces_in_data
 from sentry.utils.safe import get_path
@@ -5,6 +8,9 @@ from sentry.utils.safe import get_path
 from .errorlocale import translate_exception
 from .errormapping import rewrite_exception
 from .processor import JavaScriptStacktraceProcessor
+from .processor_smcache import JavaScriptSmCacheStacktraceProcessor
+
+PROCESSING_OPTION_SOURCEMAPCACHE = "processing.sourcemapcache-processor"
 
 
 def preprocess_event(data):
@@ -27,6 +33,18 @@ def generate_modules(data):
                 frame["module"] = generate_module(abs_path)
 
 
+# TODO(smcache): Remove after rollout.
+def _use_sourcemapcache(project_id: int) -> bool:
+    # Internal Sentry projects
+    # 11276 - sentry/javascript project for forced dogfooding
+    # SENTRY_PROJECT - default project for all installations
+    # SENTRY_FRONTEND_PROJECT - configurable default frontend project
+    if project_id in (11276, settings.SENTRY_PROJECT, settings.SENTRY_FRONTEND_PROJECT):
+        return True
+
+    return project_id % 1000 < options.get(PROCESSING_OPTION_SOURCEMAPCACHE, 0.0) * 1000
+
+
 class JavascriptPlugin(Plugin2):
     can_disable = False
 
@@ -42,4 +60,6 @@ class JavascriptPlugin(Plugin2):
 
     def get_stacktrace_processors(self, data, stacktrace_infos, platforms, **kwargs):
         if "javascript" in platforms or "node" in platforms:
+            if _use_sourcemapcache(data["project"]):
+                return [JavaScriptSmCacheStacktraceProcessor]
             return [JavaScriptStacktraceProcessor]

--- a/src/sentry/lang/javascript/processor_smcache.py
+++ b/src/sentry/lang/javascript/processor_smcache.py
@@ -16,7 +16,7 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.encoding import force_bytes, force_text
 from requests.utils import get_encoding_from_headers
-from symbolic import SourceMapView
+from symbolic import SourceMapCache as SmCache
 
 from sentry import features, http, options
 from sentry.event_manager import set_tag
@@ -38,7 +38,7 @@ from sentry.utils.urls import non_standard_url_join
 
 from .cache import SourceCache, SourceMapCache
 
-__all__ = ["JavaScriptStacktraceProcessor"]
+__all__ = ["JavaScriptSmCacheStacktraceProcessor"]
 
 
 # number of surrounding lines (on each side) to fetch
@@ -120,7 +120,7 @@ def trim_line(line, column=0):
     return line
 
 
-def get_source_context(source, lineno, colno, context=LINES_OF_CONTEXT):
+def get_source_context(source, lineno, context=LINES_OF_CONTEXT):
     if not source:
         return None, None, None
 
@@ -133,17 +133,17 @@ def get_source_context(source, lineno, colno, context=LINES_OF_CONTEXT):
     upper_bound = min(lineno + 1 + context, len(source))
 
     try:
-        pre_context = [trim_line(x) for x in source[lower_bound:lineno]]
+        pre_context = source[lower_bound:lineno]
     except IndexError:
         pre_context = []
 
     try:
-        context_line = trim_line(source[lineno], colno)
+        context_line = source[lineno]
     except IndexError:
         context_line = ""
 
     try:
-        post_context = [trim_line(x) for x in source[(lineno + 1) : upper_bound]]
+        post_context = source[(lineno + 1) : upper_bound]
     except IndexError:
         post_context = []
 
@@ -250,7 +250,7 @@ def fetch_and_cache_artifact(filename, fetch_fn, cache_key, cache_key_meta, head
                 return None, fp.read()
             else:
                 with sentry_sdk.start_span(
-                    op="JavaScriptStacktraceProcessor.fetch_and_cache_artifact.compress"
+                    op="JavaScriptSmCacheStacktraceProcessor.fetch_and_cache_artifact.compress"
                 ):
                     return compress_fn(fp)
 
@@ -369,7 +369,7 @@ def fetch_release_file(filename, release, dist=None):
             )
 
             with sentry_sdk.start_span(
-                op="JavaScriptStacktraceProcessor.fetch_release_file.fetch_and_cache"
+                op="JavaScriptSmCacheStacktraceProcessor.fetch_release_file.fetch_and_cache"
             ):
                 result = fetch_and_cache_artifact(
                     filename,
@@ -542,7 +542,7 @@ def fetch_release_artifact(url, release, dist):
 
     start = time.monotonic()
     with sentry_sdk.start_span(
-        op="JavaScriptStacktraceProcessor.fetch_release_artifact.fetch_release_archive_for_url"
+        op="JavaScriptSmCacheStacktraceProcessor.fetch_release_artifact.fetch_release_archive_for_url"
     ):
         archive_file = fetch_release_archive_for_url(release, dist, url)
     if archive_file is not None:
@@ -594,7 +594,7 @@ def fetch_release_artifact(url, release, dist):
     # Fall back to maintain compatibility with old releases and versions of
     # sentry-cli which upload files individually
     with sentry_sdk.start_span(
-        op="JavaScriptStacktraceProcessor.fetch_release_artifact.fetch_release_file"
+        op="JavaScriptSmCacheStacktraceProcessor.fetch_release_artifact.fetch_release_file"
     ):
         result = fetch_release_file(url, release, dist)
 
@@ -618,7 +618,7 @@ def fetch_file(url, project=None, release=None, dist=None, allow_scraping=True):
     # if we've got a release to look on, try that first (incl associated cache)
     if release:
         with sentry_sdk.start_span(
-            op="JavaScriptStacktraceProcessor.fetch_file.fetch_release_artifact"
+            op="JavaScriptSmCacheStacktraceProcessor.fetch_file.fetch_release_artifact"
         ):
             result = fetch_release_artifact(url, release, dist)
     else:
@@ -659,10 +659,10 @@ def fetch_file(url, project=None, release=None, dist=None, allow_scraping=True):
                 headers[token_header] = token
 
         with metrics.timer("sourcemaps.fetch"):
-            with sentry_sdk.start_span(op="JavaScriptStacktraceProcessor.fetch_file.http"):
+            with sentry_sdk.start_span(op="JavaScriptSmCacheStacktraceProcessor.fetch_file.http"):
                 result = http.fetch_file(url, headers=headers, verify_ssl=verify_ssl)
             with sentry_sdk.start_span(
-                op="JavaScriptStacktraceProcessor.fetch_file.compress_for_cache"
+                op="JavaScriptSmCacheStacktraceProcessor.fetch_file.compress_for_cache"
             ):
                 z_body = zlib.compress(result.body)
             cache.set(
@@ -754,7 +754,7 @@ def fetch_sourcemap(url, source=b"", project=None, release=None, dist=None, allo
     else:
         # look in the database and, if not found, optionally try to scrape the web
         with sentry_sdk.start_span(
-            op="JavaScriptStacktraceProcessor.fetch_sourcemap.fetch_file"
+            op="JavaScriptSmCacheStacktraceProcessor.fetch_sourcemap.fetch_file"
         ) as span:
             span.set_data("url", url)
             result = fetch_file(
@@ -767,9 +767,9 @@ def fetch_sourcemap(url, source=b"", project=None, release=None, dist=None, allo
         body = result.body
     try:
         with sentry_sdk.start_span(
-            op="JavaScriptStacktraceProcessor.fetch_sourcemap.SourceMapView.from_json_bytes"
+            op="JavaScriptSmCacheStacktraceProcessor.fetch_sourcemap.SmCache.from_bytes"
         ):
-            return SourceMapView.from_json_bytes(body)
+            return SmCache.from_bytes(source, body)
 
     except Exception as exc:
         # This is in debug because the product shows an error already.
@@ -812,12 +812,44 @@ def is_valid_frame(frame):
     return frame is not None and frame.get("lineno") is not None
 
 
-class JavaScriptStacktraceProcessor(StacktraceProcessor):
+def get_function_for_token(frame, token, previous_frame=None):
     """
-    Attempts to fetch source code for javascript frames.
+    Get function name for a given frame based on the token resolved by symbolic.
+    It tries following paths in order:
+    - return token function name if we have a usable value (filtered through `USELESS_FN_NAMES` list),
+    - return mapped name of the caller (previous frame) token if it had,
+    - return token function name, including filtered values if it mapped to anything in the first place,
+    - return current frames function name as a fallback
+    """
+
+    frame_function_name = frame.get("function")
+    token_function_name = token.function_name
+
+    # Try to use the function name we got from sourcemap-cache, filtering useless names.
+    if token_function_name not in USELESS_FN_NAMES:
+        return token_function_name
+
+    # If not found, ask the callsite (previous token) for function name if possible.
+    if previous_frame is not None:
+        last_token = previous_frame.data.get("token")
+        if last_token is not None and last_token.name not in ("", None):
+            return last_token.name
+
+    # If there was no minified name at all, return even useless, filtered one from the original token.
+    if not frame_function_name:
+        return token_function_name
+
+    # Otherwise fallback to the old, minified name.
+    return frame_function_name
+
+
+class JavaScriptSmCacheStacktraceProcessor(StacktraceProcessor):
+    """
+    Modern SourceMap processor using symbolic-sourcemapcache.
+    Attempts to fetch source code for javascript frames,
+    and map their minified positions to original location.
 
     Frames must match the following requirements:
-
     - lineno >= 0
     - colno >= 0
     - abs_path is the HTTP URI to the source
@@ -871,7 +903,9 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             )
             return False
 
-        with sentry_sdk.start_span(op="JavaScriptStacktraceProcessor.preprocess_step.get_release"):
+        with sentry_sdk.start_span(
+            op="JavaScriptSmCacheStacktraceProcessor.preprocess_step.get_release"
+        ):
             self.release = self.get_release(create=True)
             if self.data.get("dist") and self.release:
                 timestamp = self.data.get("timestamp")
@@ -879,7 +913,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 self.dist = self.release.add_dist(self.data["dist"], date)
 
         with sentry_sdk.start_span(
-            op="JavaScriptStacktraceProcessor.preprocess_step.populate_source_cache"
+            op="JavaScriptSmCacheStacktraceProcessor.preprocess_step.populate_source_cache"
         ):
             self.populate_source_cache(frames)
 
@@ -922,21 +956,24 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         if errors:
             all_errors.extend(errors)
 
-        # This might fail but that's okay, we try with a different path a
-        # bit later down the road.
+        # `source` is used for pre/post and `context_line` frame expansion.
+        # Here it's pointing to minified source, however the variable can be shadowed with the original sourceview
+        # (or `None` if the token doesnt provide us with the `context_line`) down the road.
         source = self.get_sourceview(frame["abs_path"])
+        source_context = None
 
         in_app = None
         new_frame = dict(frame)
         raw_frame = dict(frame)
 
-        sourcemap_url, sourcemap_view = sourcemaps.get_link(frame["abs_path"])
+        sourcemap_url, sourcemap_cache = sourcemaps.get_link(frame["abs_path"])
         self.sourcemaps_touched.add(sourcemap_url)
-        if sourcemap_view and frame.get("colno") is None:
+
+        if sourcemap_cache and frame.get("colno") is None:
             all_errors.append(
                 {"type": EventError.JS_NO_COLUMN, "url": http.expose_url(frame["abs_path"])}
             )
-        elif sourcemap_view:
+        elif sourcemap_cache:
             if is_data_uri(sourcemap_url):
                 sourcemap_label = frame["abs_path"]
             else:
@@ -944,19 +981,10 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
 
             sourcemap_label = http.expose_url(sourcemap_label)
 
-            if frame.get("function"):
-                minified_function_name = frame["function"]
-                minified_source = self.get_sourceview(frame["abs_path"])
-            else:
-                minified_function_name = minified_source = None
-
             try:
-                # Errors are 1-indexed in the frames, so we need to -1 to get
-                # zero-indexed value from tokens.
+                # Errors are 1-indexed in the frames.
                 assert frame["lineno"] > 0, "line numbers are 1-indexed"
-                token = sourcemap_view.lookup(
-                    frame["lineno"] - 1, frame["colno"] - 1, minified_function_name, minified_source
-                )
+                token = sourcemap_cache.lookup(frame["lineno"], frame["colno"], LINES_OF_CONTEXT)
             except Exception:
                 token = None
                 all_errors.append(
@@ -973,19 +1001,27 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             processable_frame.data["token"] = token
 
             # Store original data in annotation
+            # TODO(smcache): Remove smcache key after successful rollout.
             new_frame["data"] = dict(
-                frame.get("data") or {}, sourcemap=sourcemap_label, smcache=False
+                frame.get("data") or {}, sourcemap=sourcemap_label, smcache=True
             )
 
             sourcemap_applied = True
 
             if token is not None:
-                abs_path = non_standard_url_join(sourcemap_url, token.src)
+                if token.src is not None:
+                    abs_path = non_standard_url_join(sourcemap_url, token.src)
+                else:
+                    abs_path = frame["abs_path"]
 
                 logger.debug(
                     "Mapping compressed source %r to mapping in %r", frame["abs_path"], abs_path
                 )
-                source = self.get_sourceview(abs_path)
+
+                if token.context_line is not None:
+                    source_context = token.pre_context, token.context_line, token.post_context
+                else:
+                    source = self.get_sourceview(abs_path)
 
                 if source is None:
                     errors = cache.get_errors(abs_path)
@@ -996,31 +1032,12 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                             {"type": EventError.JS_MISSING_SOURCE, "url": http.expose_url(abs_path)}
                         )
 
-                # the tokens are zero indexed, so offset correctly
-                new_frame["lineno"] = token.src_line + 1
-                new_frame["colno"] = token.src_col + 1
-
-                # Try to use the function name we got from symbolic
-                original_function_name = token.function_name
-
-                # In the ideal case we can use the function name from the
-                # frame and the location to resolve the original name
-                # through the heuristics in our sourcemap library.
-                if original_function_name is None:
-                    last_token = None
-
-                    # Find the previous token for function name handling as a
-                    # fallback.
-                    if (
-                        processable_frame.previous_frame
-                        and processable_frame.previous_frame.processor is self
-                    ):
-                        last_token = processable_frame.previous_frame.data.get("token")
-                        if last_token:
-                            original_function_name = last_token.name
-
-                if original_function_name is not None:
-                    new_frame["function"] = original_function_name
+                # The tokens are 1-indexed.
+                new_frame["lineno"] = token.line
+                new_frame["colno"] = token.col
+                new_frame["function"] = get_function_for_token(
+                    new_frame, token, processable_frame.previous_frame
+                )
 
                 filename = token.src
                 # special case webpack support
@@ -1079,9 +1096,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 new_frame.get("data") or {}, sourcemap=http.expose_url(sourcemap_url)
             )
 
-        # TODO: theoretically a minified source could point to
-        # another mapped, minified source
-        changed_frame = self.expand_frame(new_frame, source=source)
+        changed_frame = self.expand_frame(new_frame, source_context=source_context, source=source)
 
         # If we did not manage to match but we do have a line or column
         # we want to report an error here.
@@ -1114,7 +1129,13 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             new_frames = [new_frame]
             raw_frames = [raw_frame] if changed_raw else None
 
-            self.tag_suspected_console_errors(new_frames)
+            try:
+                if features.has(
+                    "organizations:javascript-console-error-tag", self.organization, actor=None
+                ):
+                    self.tag_suspected_console_errors(new_frames)
+            except Exception as exc:
+                logger.exception("Failed to tag suspected console errors", exc_info=exc)
             return new_frames, raw_frames, all_errors
 
     def tag_suspected_console_errors(self, new_frames):
@@ -1145,23 +1166,32 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         except Exception as exc:
             logger.exception("Failed to tag suspected console errors", exc_info=exc)
 
-    def expand_frame(self, frame, source=None):
+    def expand_frame(self, frame, source_context=None, source=None):
         """
         Mutate the given frame to include pre- and post-context lines.
         """
 
-        if frame.get("lineno") is not None:
-            if source is None:
-                source = self.get_sourceview(frame["abs_path"])
-                if source is None:
-                    logger.debug("No source found for %s", frame["abs_path"])
-                    return False
+        if frame.get("lineno") is None:
+            return False
 
-            frame["pre_context"], frame["context_line"], frame["post_context"] = get_source_context(
-                source=source, lineno=frame["lineno"], colno=frame.get("colno") or 0
-            )
-            return True
-        return False
+        if source_context is None:
+            source = source or self.get_sourceview(frame["abs_path"])
+            if source is None:
+                logger.debug("No source found for %s", frame["abs_path"])
+                return False
+
+        (pre_context, context_line, post_context) = source_context or get_source_context(
+            source=source, lineno=frame["lineno"]
+        )
+
+        if pre_context is not None and len(pre_context) > 0:
+            frame["pre_context"] = [trim_line(x) for x in pre_context]
+        if context_line is not None:
+            frame["context_line"] = trim_line(context_line, frame.get("colno") or 0)
+        if post_context is not None and len(post_context) > 0:
+            frame["post_context"] = [trim_line(x) for x in post_context]
+
+        return True
 
     def get_sourceview(self, filename):
         if filename not in self.cache:
@@ -1188,7 +1218,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         try:
             # this both looks in the database and tries to scrape the internet
             with sentry_sdk.start_span(
-                op="JavaScriptStacktraceProcessor.cache_source.fetch_file"
+                op="JavaScriptSmCacheStacktraceProcessor.cache_source.fetch_file"
             ) as span:
                 span.set_data("filename", filename)
                 result = fetch_file(
@@ -1226,7 +1256,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
         # pull down sourcemap
         try:
             with sentry_sdk.start_span(
-                op="JavaScriptStacktraceProcessor.cache_source.fetch_sourcemap"
+                op="JavaScriptSmCacheStacktraceProcessor.cache_source.fetch_sourcemap"
             ) as span:
                 span.set_data("sourcemap_url", sourcemap_url)
                 sourcemap_view = fetch_sourcemap(
@@ -1248,15 +1278,9 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
             return
 
         with sentry_sdk.start_span(
-            op="JavaScriptStacktraceProcessor.cache_source.cache_sourcemap_view"
+            op="JavaScriptSmCacheStacktraceProcessor.cache_source.cache_sourcemap_view"
         ) as span:
             sourcemaps.add(sourcemap_url, sourcemap_view)
-            span.set_data("source_count", sourcemap_view.source_count)
-            # cache any inlined sources
-            for src_id, source_name in sourcemap_view.iter_sources():
-                source_view = sourcemap_view.get_sourceview(src_id)
-                if source_view is not None:
-                    self.cache.add(non_standard_url_join(sourcemap_url, source_name), source_view)
 
     def populate_source_cache(self, frames):
         """
@@ -1281,7 +1305,7 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
 
         for idx, filename in enumerate(pending_file_list):
             with sentry_sdk.start_span(
-                op="JavaScriptStacktraceProcessor.populate_source_cache.cache_source"
+                op="JavaScriptSmCacheStacktraceProcessor.populate_source_cache.cache_source"
             ) as span:
                 span.set_data("filename", filename)
                 self.cache_source(filename=filename)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -344,7 +344,7 @@ register("processing.can-use-scrubbers", default=True)
 
 # Enable use of symbolic-sourcemapcache for JavaScript Source Maps processing.
 # Set this value of the fraction of projects that you want to use it for.
-register("processing.sourcemapcache-processor", default=0.0)  # unused
+register("processing.sourcemapcache-processor", default=0.0)
 
 # Killswitch for sending internal errors to the internal project or
 # `SENTRY_SDK_CONFIG.relay_dsn`. Set to `0` to only send to

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -476,10 +476,21 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
 
         assert len(frame_list) == 1
         frame = frame_list[0]
-        assert frame.abs_path == "app:///nofiles.js"
-        assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
-        assert frame.context_line == "\treturn a + b; // fôo"
-        assert frame.post_context == ["}", ""]
+        assert frame.abs_path == "app:///nofiles.js.map"
+        assert frame.pre_context == ["function multiply(a, b) {", '\t"use strict";']
+        assert frame.context_line == "\treturn a * b;"
+        assert frame.post_context == [
+            "}",
+            "function divide(a, b) {",
+            '\t"use strict";',
+            "\ttry {",
+            "\t\treturn multiply(add(a, b), a, b) / c;",
+        ]
+        # TODO(smcache): Assertions below are the one that're correct. Use it when migrating from legacy processor.
+        # assert frame.abs_path == "app:///nofiles.js"
+        # assert frame.pre_context == ["function add(a, b) {", '\t"use strict";']
+        # assert frame.context_line == "\treturn a + b; // fôo"
+        # assert frame.post_context == ["}", ""]
 
     @responses.activate
     def test_indexed_sourcemap_source_expansion(self):
@@ -1337,7 +1348,9 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         assert frame_list[2].function == "App"
         assert frame_list[2].lineno == 2
 
-        assert frame_list[3].abs_path == "webpack:///webpack/bootstrap d9a5a31d9276b73873d3"
+        assert frame_list[3].abs_path == "app:///dist.bundle.js"
+        # TODO(smcache): Assertion below is the one that's correct. Use it when migrating from legacy processor.
+        # assert frame_list[3].abs_path == "webpack:///webpack/bootstrap d9a5a31d9276b73873d3"
         assert frame_list[3].function == "Object.<anonymous>"
         assert frame_list[3].lineno == 1
 

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -9,6 +9,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 import pytest
 import responses
 from requests.exceptions import RequestException
+from symbolic import SourceMapTokenMatch
 
 from sentry import http, options
 from sentry.event_manager import get_tag
@@ -25,13 +26,14 @@ from sentry.lang.javascript.processor import (
     fetch_release_file,
     fetch_sourcemap,
     generate_module,
-    get_function_for_token,
     get_max_age,
     get_release_file_cache_key,
     get_release_file_cache_key_meta,
     should_retry_fetch,
     trim_line,
 )
+from sentry.lang.javascript.processor_smcache import fetch_sourcemap as fetch_sourcemap_smcache
+from sentry.lang.javascript.processor_smcache import get_function_for_token
 from sentry.models import EventError, File, Release, ReleaseFile
 from sentry.models.releasefile import ARTIFACT_INDEX_FILENAME, update_artifact_index
 from sentry.stacktraces.processing import ProcessableFrame, find_stacktraces_in_data
@@ -1144,8 +1146,27 @@ class GetFunctionForTokenTest(unittest.TestCase):
 
 
 class FetchSourcemapTest(TestCase):
+    # TODO(smcache): Remove non-`_smcache` tests once we migrate to smcache only.
     def test_simple_base64(self):
         smap_view = fetch_sourcemap(base64_sourcemap)
+        tokens = [SourceMapTokenMatch(0, 0, 1, 0, src="/test.js", src_id=0)]
+
+        assert list(smap_view) == tokens
+        sv = smap_view.get_sourceview(0)
+        assert sv.get_source() == 'console.log("hello, World!")'
+        assert smap_view.get_source_name(0) == "/test.js"
+
+    def test_base64_without_padding(self):
+        smap_view = fetch_sourcemap(base64_sourcemap.rstrip("="))
+        tokens = [SourceMapTokenMatch(0, 0, 1, 0, src="/test.js", src_id=0)]
+
+        assert list(smap_view) == tokens
+        sv = smap_view.get_sourceview(0)
+        assert sv.get_source() == 'console.log("hello, World!")'
+        assert smap_view.get_source_name(0) == "/test.js"
+
+    def test_simple_base64_smcache(self):
+        smap_view = fetch_sourcemap_smcache(base64_sourcemap)
         token = smap_view.lookup(1, 1, 0)
 
         assert token.src == "/test.js"
@@ -1153,8 +1174,8 @@ class FetchSourcemapTest(TestCase):
         assert token.col == 1
         assert token.context_line == 'console.log("hello, World!")'
 
-    def test_base64_without_padding(self):
-        smap_view = fetch_sourcemap(base64_sourcemap.rstrip("="))
+    def test_base64_without_padding_smcache(self):
+        smap_view = fetch_sourcemap_smcache(base64_sourcemap.rstrip("="))
         token = smap_view.lookup(1, 1, 0)
 
         assert token.src == "/test.js"


### PR DESCRIPTION
Reverts getsentry/sentry#41492

Due to a change in `js-source-scope`, we are failing one test which prevents the deploy. Revert for now https://github.com/getsentry/sentry/actions/runs/3513763488/jobs/5886974016