### PR TITLE
ref(locks): Make the default locks manager backend configurable

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2879,6 +2879,11 @@ SNOWFLAKE_VERSION_ID = 1
 SENTRY_SNOWFLAKE_EPOCH_START = datetime(2022, 8, 8, 0, 0).timestamp()
 SENTRY_USE_SNOWFLAKE = False
 
+SENTRY_DEFAULT_LOCKS_BACKEND_OPTIONS = {
+    "path": "sentry.utils.locking.backends.redis.RedisLockBackend",
+    "options": {"cluster": "default"},
+}
+
 SENTRY_POST_PROCESS_LOCKS_BACKEND_OPTIONS = {
     "path": "sentry.utils.locking.backends.redis.RedisLockBackend",
     "options": {"cluster": "default"},

--- a/src/sentry/locks.py
+++ b/src/sentry/locks.py
@@ -1,5 +1,6 @@
-from sentry.utils import redis
-from sentry.utils.locking.backends.redis import RedisLockBackend
-from sentry.utils.locking.manager import LockManager
+from django.conf import settings
 
-locks = LockManager(RedisLockBackend(redis.clusters.get("default")))
+from sentry.utils.locking.manager import LockManager
+from sentry.utils.services import build_instance_from_options
+
+locks = LockManager(build_instance_from_options(settings.SENTRY_DEFAULT_LOCKS_BACKEND_OPTIONS))


### PR DESCRIPTION
Allows migrating the default locks to different Redis clusters or using different backend implementations.