### PR TITLE
fix: done-bootstraping: command not found

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -203,7 +203,6 @@ bootstrap() {
     # Load mocks requires a super user to exist, thus, we execute after create-user
     bin/load-mocks
     build-platform-assets
-    done-bootstraping
     echo "--> Finished bootstrapping. Have a nice day."
 }
 


### PR DESCRIPTION
This PR fixes:
```
--> Building platform assets
16:12:40 [WARNING] sentry.utils.geo: settings.GEOIP_PATH_MMDB not configured.
16:12:41 [INFO] sentry.plugins.github: apps-not-configured
/Users/andrii/work/sentry/scripts/lib.sh: line 206: done-bootstraping: command not found
make: *** [bootstrap] Error 127
```

Tested on fresh env:
```
...
%4|1669047716.775|TERMINATE|rdkafka#producer-1| [thrd:app]: Producer terminating with 64 messages (11584 bytes) still in queue or transit: use flush() to wait for outstanding message delivery
**--> Finished bootstrapping. Have a nice day.**
```