### PR TITLE
bug(replays): Make sure replays are shown on the All Events table

### DIFF
--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -46,6 +46,8 @@ const AllEventsTable = (props: Props) => {
     return <LoadingError message={error} />;
   }
 
+  const isReplayEnabled = organization.features.includes('session-replay-ui');
+
   return (
     <EventsTable
       eventView={eventView}
@@ -61,6 +63,7 @@ const AllEventsTable = (props: Props) => {
       transactionName=""
       columnTitles={columnTitles.slice()}
       referrer="api.issues.issue_events"
+      showReplayCol={isReplayEnabled}
     />
   );
 };

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.spec.tsx
@@ -176,6 +176,7 @@ describe('Performance GridEditable Table', function () {
         setError={() => {}}
         columnTitles={transactionsListTitles}
         transactionName={transactionName}
+        showReplayCol={false}
       />,
       {context: initialData.routerContext}
     );
@@ -220,7 +221,7 @@ describe('Performance GridEditable Table', function () {
       initialData.router.location
     );
 
-    render(
+    const {container} = render(
       <EventsTable
         totalEventCount={totalEventCount}
         eventView={eventView}
@@ -230,6 +231,7 @@ describe('Performance GridEditable Table', function () {
         setError={() => {}}
         columnTitles={transactionsListTitles}
         transactionName={transactionName}
+        showReplayCol={false}
       />,
       {context: initialData.routerContext}
     );
@@ -238,6 +240,7 @@ describe('Performance GridEditable Table', function () {
     expect(screen.queryByText(SPAN_OP_RELATIVE_BREAKDOWN_FIELD)).not.toBeInTheDocument();
     expect(screen.queryByTestId('relative-ops-breakdown')).not.toBeInTheDocument();
     expect(screen.queryByTestId('grid-head-cell-static')).not.toBeInTheDocument();
+    expect(container).toSnapshot();
   });
 
   it('renders event id and trace id url', async function () {
@@ -265,6 +268,7 @@ describe('Performance GridEditable Table', function () {
         setError={() => {}}
         columnTitles={transactionsListTitles}
         transactionName={transactionName}
+        showReplayCol={false}
       />,
       {context: initialData.routerContext}
     );
@@ -278,5 +282,45 @@ describe('Performance GridEditable Table', function () {
       'href',
       '/organizations/org-slug/performance/trace/1234/?'
     );
+  });
+
+  it('renders replay id', async function () {
+    const initialData = initializeData({features: ['session-replay-ui']});
+
+    fields.push('replayId');
+    data.forEach(result => {
+      result.replayId = 'mock_replay_id';
+    });
+
+    const eventView = EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        version: 2,
+        name: 'transactionName',
+        fields,
+        query,
+        projects: [],
+        orderby: '-timestamp',
+      },
+      initialData.router.location
+    );
+
+    const {container} = render(
+      <EventsTable
+        totalEventCount={totalEventCount}
+        eventView={eventView}
+        organization={organization}
+        routes={initialData.router.routes}
+        location={initialData.router.location}
+        setError={() => {}}
+        columnTitles={transactionsListTitles}
+        transactionName={transactionName}
+        showReplayCol
+      />,
+      {context: initialData.routerContext}
+    );
+
+    expect(await screen.getAllByRole('columnheader')).toHaveLength(7);
+    expect(container).toSnapshot();
   });
 });

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -84,6 +84,7 @@ type Props = {
   organization: Organization;
   routes: RouteContextInterface['routes'];
   setError: (msg: string | undefined) => void;
+  showReplayCol: boolean;
   transactionName: string;
   columnTitles?: string[];
   customColumns?: ('attachments' | 'minidump')[];
@@ -91,7 +92,6 @@ type Props = {
   issueId?: string;
   projectSlug?: string;
   referrer?: string;
-  showReplayCol?: boolean;
   totalEventCount?: string;
 };
 


### PR DESCRIPTION
Something messed up the rendering of the replay column, we need to pass in the prop to let the table know that a) it's possible, and b) we want to see replays

**Before:**
<img width="312" alt="SCR-20221121-i2f" src="https://user-images.githubusercontent.com/187460/203157365-5f18835f-757a-429c-a8a1-dddc874ac6f4.png">

**After:**
<img width="381" alt="SCR-20221121-i2p" src="https://user-images.githubusercontent.com/187460/203157386-30f7afbf-fe12-4969-bec8-b323a75640d2.png">
