### PR TITLE
fix(alert-preview): add date filter to snuba queries

### DIFF
--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -76,7 +76,7 @@ def preview(
         event_map = {}
         # if there is an event filter, retrieve event data
         if event_columns:
-            event_map = get_events(project, group_activity, event_columns)
+            event_map = get_events(project, group_activity, event_columns, start, end)
 
         if frequency_conditions:
             group_activity = apply_frequency_conditions(
@@ -232,6 +232,8 @@ def get_events(
     project: Project,
     group_activity: GroupActivityMap,
     columns: Dict[Dataset, List[str]],
+    start: datetime,
+    end: datetime,
 ) -> Dict[str, Any]:
     """
     Returns events that have caused issue state changes.
@@ -265,6 +267,8 @@ def get_events(
             continue
         kwargs = {
             "dataset": dataset,
+            "start": start,
+            "end": end,
             "filter_keys": {"project_id": [project.id]},
             "conditions": [("group_id", "IN", ids)],
             "orderby": ["group_id", "timestamp"],
@@ -300,6 +304,8 @@ def get_events(
         events.extend(
             raw_query(
                 dataset=dataset,
+                start=start,
+                end=end,
                 filter_keys={"project_id": [project.id]},
                 conditions=[("event_id", "IN", ids)],
                 selected_columns=columns[dataset],

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -528,7 +528,13 @@ class GetEventsTest(TestCase):
                 )
             ]
         }
-        events = get_events(self.project, activity, {Dataset.Events: []})
+        events = get_events(
+            self.project,
+            activity,
+            {Dataset.Events: []},
+            timezone.now() - timedelta(weeks=2),
+            timezone.now(),
+        )
 
         assert len(events) == 1
         assert event.event_id in events
@@ -560,7 +566,13 @@ class GetEventsTest(TestCase):
                 ),
             ]
         }
-        events = get_events(self.project, activity, {Dataset.Events: []})
+        events = get_events(
+            self.project,
+            activity,
+            {Dataset.Events: []},
+            timezone.now() - timedelta(weeks=2),
+            timezone.now(),
+        )
 
         assert len(events) == 2
         assert all([event.event_id in events for event in (regression_event, reappeared_event)])


### PR DESCRIPTION
By default snuba queries the last 90 days, this cuts the time range down to last 2 weeks and hopefully makes transaction queries faster. If it's not enough, we can also later add `transaction_name` to the filter.