### PR TITLE
fix(all-events) 'os' appears twice on all events tab

### DIFF
--- a/static/app/views/organizationGroupDetails/allEventsTable.tsx
+++ b/static/app/views/organizationGroupDetails/allEventsTable.tsx
@@ -133,8 +133,8 @@ const getPlatformColumns = (
       columnTitles: [t('url')],
     },
     [PlatformCategory.DESKTOP]: {
-      fields: ['os'],
-      columnTitles: [t('os')],
+      fields: [],
+      columnTitles: [],
     },
     [PlatformCategory.OTHER]: {
       fields: [],


### PR DESCRIPTION
'os' is already a default column, 
https://github.com/getsentry/sentry/blob/18326a95a494f4f8f40ebdd243008ed48acdf4ee/static/app/views/organizationGroupDetails/allEventsTable.tsx#L77-L89
this was causing it to appear twice in the all events tab for desktop projects
<img width="566" alt="image" src="https://user-images.githubusercontent.com/44422760/203158300-6f8ca4cc-3cc5-493d-8b29-1c61ef661d34.png">
