### PR TITLE
fix(weekly-email): change sort logic for weekly email

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -612,7 +612,7 @@ def render_template_context(ctx, user):
         projects_associated_with_user = sorted(
             user_projects,
             reverse=True,
-            key=lambda item: item.accepted_error_count * item.accepted_transaction_count,
+            key=lambda item: item.accepted_error_count + item.accepted_transaction_count,
         )
         # Calculate total
         (


### PR DESCRIPTION
This PR fixes a bug where the project weight was the number of transactions times the number of errors rather than the sum of the two