### PR TITLE
feat(alert-preview): frequency conditions for transactions

### DIFF
--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -236,7 +236,8 @@ def get_top_groups(
             kwargs["aggregations"].append(("arrayJoin", ["group_ids"], "group_id"))
         groups.extend(raw_query(**kwargs).get("data", []))
 
-    sorted_groups = sorted(groups, key=lambda x: x["groupCount"], reverse=True)
+    k = lambda x: x["groupCount"]
+    sorted_groups = sorted(groups, key=k, reverse=True)
 
     top_groups = {group["group_id"] for group in sorted_groups[:FREQUENCY_CONDITION_GROUP_LIMIT]}
     top_activity = {

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -236,7 +236,7 @@ def get_top_groups(
         query_params.append(SnubaQueryParams(**kwargs))
 
     groups = []
-    for result in bulk_raw_query(query_params, use_cache=True):
+    for result in bulk_raw_query(query_params):
         groups.extend(result.get("data", []))
 
     sorted_groups = sorted(groups, key=lambda x: int(x["groupCount"]), reverse=True)

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -244,10 +244,9 @@ def get_top_groups(
     sorted_groups = sorted(groups, key=k, reverse=True)
 
     top_groups = {group["group_id"] for group in sorted_groups[:FREQUENCY_CONDITION_GROUP_LIMIT]}
-    top_activity = {
+    return {
         group: activity for group, activity in condition_activity.items() if group in top_groups
     }
-    return top_activity
 
 
 def get_group_dataset(condition_activity: GroupActivityMap) -> Dict[int, Dataset]:
@@ -258,11 +257,10 @@ def get_group_dataset(condition_activity: GroupActivityMap) -> Dict[int, Dataset
     group_categories = Group.objects.filter(id__in=condition_activity.keys()).values_list(
         "id", "type"
     )
-    dataset_map = {
+    return {
         group[0]: GROUP_CATEGORY_TO_DATASET.get(GROUP_TYPE_TO_CATEGORY.get(GroupType(group[1])))
         for group in group_categories
     }
-    return dataset_map
 
 
 def get_events(

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -248,7 +248,8 @@ def get_top_groups(
 
 def get_group_dataset(condition_activity: GroupActivityMap) -> Dict[str, Dataset]:
     """
-    Returns a dict that maps each group to its dataset
+    Returns a dict that maps each group to its dataset. Assumes each group is mapped to a single dataset.
+    If the dataset is not found/supported, it is mapped to None.
     """
     group_categories = Group.objects.filter(id__in=condition_activity.keys()).values_list(
         "id", "type"

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -231,6 +231,7 @@ def get_top_groups(
             "limit": FREQUENCY_CONDITION_GROUP_LIMIT,
         }
         if dataset == Dataset.Transactions:
+            kwargs["having"] = kwargs["conditions"]
             kwargs["conditions"] = [[["hasAny", ["group_ids", ["array", group_ids]]], "=", 1]]
             kwargs["aggregations"].append(("arrayJoin", ["group_ids"], "group_id"))
         query_params.append(SnubaQueryParams(**kwargs))
@@ -310,8 +311,9 @@ def get_events(
         if dataset.value == Dataset.Transactions.value:
             # this query cannot be made until https://getsentry.atlassian.net/browse/SNS-1891 is fixed
             """
+            kwargs["having"] = kwargs["conditions"]
+            kwargs["conditions"] = [[["hasAny", ["group_ids", ["array", group_ids]]], "=", 1]]
             kwargs["aggregations"] = [("arrayJoin", ["group_ids"], "group_id")]
-            kwargs["having"] = kwargs.pop("conditions")
             """
             continue
         query_params.append(SnubaQueryParams(**kwargs))

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -227,7 +227,7 @@ def get_top_groups(
             "aggregations": [("count", "group_id", "groupCount")],
             "groupby": ["group_id"],
             "order_by": "-groupCount",
-            "seleted_columns": ["group_id"],
+            "selected_columns": ["group_id", "groupCount"],
             "limit": FREQUENCY_CONDITION_GROUP_LIMIT,
         }
         if dataset == Dataset.Transactions:

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -138,9 +138,8 @@ def get_issue_state_activity(
         except NotImplementedError:
             raise PreviewException
 
-    k = lambda a: a.timestamp
     for activities in group_activity.values():
-        activities.sort(key=k)
+        activities.sort(key=lambda a: a.timestamp)
 
     return group_activity
 
@@ -240,8 +239,7 @@ def get_top_groups(
     for result in bulk_raw_query(query_params, use_cache=True):
         groups.extend(result.get("data", []))
 
-    k = lambda x: x["groupCount"]
-    sorted_groups = sorted(groups, key=k, reverse=True)
+    sorted_groups = sorted(groups, key=lambda x: int(x["groupCount"]), reverse=True)
 
     top_groups = {group["group_id"] for group in sorted_groups[:FREQUENCY_CONDITION_GROUP_LIMIT]}
     return {

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -30,6 +30,12 @@ def get_hours(time: timedelta) -> int:
 @freeze_time()
 @region_silo_test
 class ProjectRulePreviewTest(TestCase):
+    def setUp(self):
+        self.transaction_data = load_data(
+            "transaction",
+            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
+        )
+
     def _set_up_first_seen(self):
         hours = get_hours(PREVIEW_TIME_RANGE)
         for i in range(hours):
@@ -328,10 +334,7 @@ class ProjectRulePreviewTest(TestCase):
 
     def test_transactions(self):
         prev_hour = timezone.now() - timedelta(hours=1)
-        event = load_data(
-            "transaction",
-            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
-        ).copy()
+        event = self.transaction_data.copy()
         event.update(
             {
                 "start_timestamp": iso_format(prev_hour - timedelta(minutes=1)),
@@ -404,10 +407,7 @@ class ProjectRulePreviewTest(TestCase):
         issue = error.group
         issue.update(first_seen=prev_hour)
 
-        event = load_data(
-            "transaction",
-            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
-        ).copy()
+        event = self.transaction_data.copy()
         event.update(
             {
                 "start_timestamp": iso_format(prev_hour - timedelta(minutes=1)),
@@ -446,6 +446,12 @@ class ProjectRulePreviewTest(TestCase):
 @freeze_time()
 @region_silo_test
 class FrequencyConditionTest(TestCase):
+    def setUp(self):
+        self.transaction_data = load_data(
+            "transaction",
+            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
+        )
+
     def test_top_groups(self):
         prev_hour = timezone.now() - timedelta(hours=1)
         activity = {i: [] for i in range(FREQUENCY_CONDITION_GROUP_LIMIT + 1)}
@@ -515,10 +521,7 @@ class FrequencyConditionTest(TestCase):
 
     def test_transaction(self):
         prev_hour = timezone.now() - timedelta(hours=1)
-        event = load_data(
-            "transaction",
-            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
-        ).copy()
+        event = self.transaction_data.copy()
         event.update(
             {
                 "start_timestamp": iso_format(prev_hour - timedelta(minutes=1)),

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -556,6 +556,19 @@ class FrequencyConditionTest(TestCase):
         result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert group not in result
 
+    def test_no_activity_event_filter(self):
+        conditions = [
+            {"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"},
+            {
+                "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+                "value": 0,
+                "interval": "5m",
+            },
+        ]
+
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
+        assert not result
+
 
 @freeze_time()
 @region_silo_test


### PR DESCRIPTION
Adds support for frequency conditions. 
- passes around a dict that maps groups to their `Dataset`
- considers every relevant dataset when computing top groups
- queries the group's dataset for frequency buckets
- uses bulk query in `get_top_groups` and `get_events` for querying multiple datasets