### PR TITLE
feat(replays): Redesign the Replay Scrubber below the player window

### DIFF
--- a/static/app/components/replays/player/scrubber.tsx
+++ b/static/app/components/replays/player/scrubber.tsx
@@ -101,8 +101,6 @@ export const TimelineScrubber = styled(Scrubber)`
 
   ${PlaybackTimeValue} {
     background: ${p => p.theme.purple100};
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
   }
 
   /**
@@ -121,25 +119,48 @@ export const TimelineScrubber = styled(Scrubber)`
 export const PlayerScrubber = styled(Scrubber)`
   height: ${space(0.5)};
 
-  :hover {
-    margin-block: -${space(0.25)};
-    height: ${space(1)};
-  }
-
   ${Meter} {
-    border-radius: ${p => p.theme.borderRadiusBottom};
+    border-radius: ${p => p.theme.borderRadius};
+    background: ${p => p.theme.surface400};
   }
 
   ${RangeWrapper} {
-    height: ${space(0.5)};
+    height: 32px;
+    top: -14px;
   }
-  :hover ${RangeWrapper} {
-    height: ${space(0.75)};
+  ${Range},
+  ${SliderAndInputWrapper} {
+    height: 100%;
+  }
+  input {
+    margin: 0;
   }
 
   ${PlaybackTimeValue} {
     background: ${p => p.theme.purple200};
-    border-bottom-left-radius: ${p => p.theme.borderRadius};
+    border-radius: ${p => p.theme.borderRadius};
+  }
+
+  ${MouseTrackingValue} {
+    background: ${p => p.theme.gray200};
+    border-radius: ${p => p.theme.borderRadius};
+  }
+
+  ${PlaybackTimeValue}:after,
+  ${MouseTrackingValue}:after {
+    content: '';
+    display: block;
+    width: ${space(2)};
+    height: ${space(2)}; /* equal to width */
+    pointer-events: none;
+    box-sizing: content-box;
+    border-radius: ${space(2)}; /* greater than or equal to width */
+    border: solid ${p => p.theme.white};
+    border-width: ${space(0.25)};
+    position: absolute;
+    top: -${space(1)}; /* Half of the height */
+    right: -${space(1.5)}; /* Half of (width + borderWidth) */
+    z-index: ${p => p.theme.zIndex.initial};
   }
 
   /**
@@ -149,25 +170,7 @@ export const PlayerScrubber = styled(Scrubber)`
    *           PlaybackTimeValue @ 20s
    */
   ${PlaybackTimeValue}:after {
-    content: '';
-    display: block;
-    width: ${space(2)};
-    height: ${space(2)}; /* equal to width */
-    z-index: ${p => p.theme.zIndex.initial};
-    pointer-events: none;
     background: ${p => p.theme.purple300};
-    box-sizing: content-box;
-    border-radius: ${space(2)}; /* greater than or equal to width */
-    border: solid ${p => p.theme.white};
-    border-width: ${space(0.5)};
-    position: absolute;
-    top: -${space(1)}; /* Half the width */
-    right: -${space(1.5)}; /* Half of (width + borderWidth) */
-    opacity: 0;
-    transition: opacity 0.1s ease;
-  }
-  :hover ${PlaybackTimeValue}:after {
-    opacity: 1;
   }
 
   /*
@@ -178,19 +181,6 @@ export const PlayerScrubber = styled(Scrubber)`
    *      MouseTrackingValue @ 10s
    */
   ${MouseTrackingValue}:after {
-    content: '';
-    display: block;
-    width: ${space(0.5)};
-    height: ${space(1.5)};
-    pointer-events: none;
-    background: ${p => p.theme.purple200};
-    box-sizing: content-box;
-    position: absolute;
-    top: -${space(0.5)};
-    right: -1px;
-  }
-  :hover ${MouseTrackingValue}:after {
-    height: ${space(2)};
-    top: -${space(0.5)};
+    background: ${p => p.theme.gray200};
   }
 `;

--- a/static/app/components/replays/player/scrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/scrubberMouseTracking.tsx
@@ -1,4 +1,5 @@
 import {useCallback} from 'react';
+import styled from '@emotion/styled';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useMouseTracking from 'sentry/utils/replays/hooks/useMouseTracking';
@@ -34,7 +35,13 @@ function ScrubberMouseTracking({children}: Props) {
     onPositionChange: handlePositionChange,
   });
 
-  return <div {...mouseTrackingProps}>{children}</div>;
+  return <MouseTracking {...mouseTrackingProps}>{children}</MouseTracking>;
 }
+
+const MouseTracking = styled('div')`
+  height: 32px;
+  display: flex;
+  align-items: center;
+`;
 
 export default ScrubberMouseTracking;

--- a/static/app/components/replays/player/scrubberMouseTracking.tsx
+++ b/static/app/components/replays/player/scrubberMouseTracking.tsx
@@ -1,14 +1,14 @@
 import {useCallback} from 'react';
-import styled from '@emotion/styled';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import useMouseTracking from 'sentry/utils/replays/hooks/useMouseTracking';
 
 type Props = {
   children: React.ReactNode;
+  className?: string;
 };
 
-function ScrubberMouseTracking({children}: Props) {
+function ScrubberMouseTracking({className, children}: Props) {
   const {replay, setCurrentHoverTime} = useReplayContext();
   const durationMs = replay?.getDurationMs();
 
@@ -35,13 +35,11 @@ function ScrubberMouseTracking({children}: Props) {
     onPositionChange: handlePositionChange,
   });
 
-  return <MouseTracking {...mouseTrackingProps}>{children}</MouseTracking>;
+  return (
+    <div className={className} {...mouseTrackingProps}>
+      {children}
+    </div>
+  );
 }
-
-const MouseTracking = styled('div')`
-  height: 32px;
-  display: flex;
-  align-items: center;
-`;
 
 export default ScrubberMouseTracking;

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -197,9 +197,9 @@ const ReplayControls = ({
       <ReplayPlayPauseBar />
       <TimeAndScrubber isCompact={isCompact}>
         <Time>{formatTime(currentTime)}</Time>
-        <ScrubberMouseTracking>
+        <StyledScrubber>
           <PlayerScrubber />
-        </ScrubberMouseTracking>
+        </StyledScrubber>
         <Time>{durationMs ? formatTime(durationMs) : '--:--'}</Time>
       </TimeAndScrubber>
       <ButtonBar>
@@ -242,6 +242,12 @@ const TimeAndScrubber = styled('div')<{isCompact: boolean}>`
 
 const Time = styled('span')`
   font-variant-numeric: tabular-nums;
+`;
+
+const StyledScrubber = styled(ScrubberMouseTracking)`
+  height: 32px;
+  display: flex;
+  align-items: center;
 `;
 
 export default ReplayControls;

--- a/static/app/components/replays/replayController.tsx
+++ b/static/app/components/replays/replayController.tsx
@@ -202,7 +202,7 @@ const ReplayControls = ({
         </StyledScrubber>
         <Time>{durationMs ? formatTime(durationMs) : '--:--'}</Time>
       </TimeAndScrubber>
-      <ButtonBar>
+      <ButtonBar gap={1}>
         <ReplayOptionsMenu speedOptions={speedOptions} />
         <Button
           size="sm"

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -1,12 +1,9 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {PlayerScrubber} from 'sentry/components/replays/player/scrubber';
-import ScrubberMouseTracking from 'sentry/components/replays/player/scrubberMouseTracking';
 import ReplayController from 'sentry/components/replays/replayController';
 import ReplayCurrentUrl from 'sentry/components/replays/replayCurrentUrl';
 import ReplayPlayer from 'sentry/components/replays/replayPlayer';
-import space from 'sentry/styles/space';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
 type Props = {
@@ -17,31 +14,20 @@ function ReplayView({toggleFullscreen}: Props) {
   return (
     <Fragment>
       <ReplayCurrentUrl />
-      <PlayerContainer>
+      <FluidHeight>
         <Panel>
           <ReplayPlayer />
         </Panel>
-        <ScrubberMouseTracking>
-          <PlayerScrubber />
-        </ScrubberMouseTracking>
-      </PlayerContainer>
+      </FluidHeight>
       <ReplayController toggleFullscreen={toggleFullscreen} />
     </Fragment>
   );
 }
 
-// Adjust the bottom spacing so that <PlayerScrubber> does not overflow outside
-// of <FluidHeight>
-const PlayerContainer = styled(FluidHeight)`
-  padding-bottom: ${space(1)};
-  margin-bottom: -${space(1)};
-`;
-
 const Panel = styled(FluidHeight)`
   background: ${p => p.theme.background};
-  border-radius: ${p => p.theme.borderRadiusTop};
+  border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.border};
-  border-bottom: none;
   box-shadow: ${p => p.theme.dropShadowLight};
 `;
 


### PR DESCRIPTION
Update the scrubber to sit below the replay video per figma's here: https://www.figma.com/file/OPFnT04z0uy8BEUms9OU4f/Specs%3A-Details-v3?node-id=634%3A20338&t=lLD9o31Rlnq071hw-0


| Case | Implementation Screen Shot |
| --- | --- |
| _Design Mock (from figma)_ | <img width="783" alt="200552122-5916b2b2-f94c-41af-964a-e3d0acf4745f" src="https://user-images.githubusercontent.com/187460/203240737-f58a8845-2c63-49ea-ae72-5390142c210e.png"> |
| Skinny | <img width="514" alt="SCR-20221122-hrm" src="https://user-images.githubusercontent.com/187460/203418132-a8ac2652-81fe-4f37-9e66-f11683807d26.png"> |
| Wide | <img width="652" alt="SCR-20221122-hri" src="https://user-images.githubusercontent.com/187460/203418131-5d0ad942-4d65-4ad5-b722-12c5b21a0d11.png"> |
| Dark Mode | <img width="356" alt="SCR-20221121-v8y" src="https://user-images.githubusercontent.com/187460/203241164-ee8d318e-129b-4db3-8050-b4be63d75f90.png"> |


Fixes #37241



