### PR TITLE
ref(ci): Do not send transactions from pytest-sentry

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -82,6 +82,7 @@ runs:
         ### pytest-sentry configuration ###
         if [ "$GITHUB_REPOSITORY" = "getsentry/sentry" ]; then
           echo "PYTEST_SENTRY_DSN=https://6fd5cfea2d4d46b182ad214ac7810508@sentry.io/2423079" >> $GITHUB_ENV
+          echo "PYTEST_SENTRY_TRACES_SAMPLE_RATE=0" >> $GITHUB_ENV
 
           # This records failures on master to sentry in order to detect flakey tests, as it's
           # expected that people have failing tests on their PRs

--- a/requirements-dev-frozen.txt
+++ b/requirements-dev-frozen.txt
@@ -130,7 +130,7 @@ pytest==7.2.0
 pytest-cov==4.0.0
 pytest-django==4.4.0
 pytest-rerunfailures==10.2
-pytest-sentry==0.1.10
+pytest-sentry==0.1.11
 pytest-xdist==3.0.2
 python-dateutil==2.8.1
 python-memcached==1.59

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ pytest>=7.2
 pytest-cov>=4.0.0
 pytest-django>=4.4.0
 pytest-rerunfailures>=10
-pytest-sentry>=0.1.10
+pytest-sentry>=0.1.11
 pytest-xdist>=3
 responses>=0.21.0
 


### PR DESCRIPTION
Our developers are not using transactions or tracing for tests right now, since we use `pytest-sentry` just to report flakey and broken tests. 

Transactions sent from `pytest-sentry` frequently run into rate limits and create the second highest transaction volume in the sentry organization. Since we do not need them at all, we can disable them until there's more use for them. 
