### PR TITLE
feat(profiling): Map message to transaction name for profiles search

### DIFF
--- a/src/sentry/search/events/datasets/profiles.py
+++ b/src/sentry/search/events/datasets/profiles.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, Mapping, Optional, Union
 
-from snuba_sdk import Direction, OrderBy
+from snuba_sdk import Condition, Direction, Op, OrderBy
 
 from sentry.api.event_search import SearchFilter
 from sentry.search.events import builder
-from sentry.search.events.constants import PROJECT_ALIAS, PROJECT_NAME_ALIAS
+from sentry.search.events.constants import EQUALITY_OPERATORS, PROJECT_ALIAS, PROJECT_NAME_ALIAS
 from sentry.search.events.datasets import field_aliases, filter_aliases
 from sentry.search.events.datasets.base import DatasetConfig
 from sentry.search.events.fields import (
@@ -90,6 +90,7 @@ COLUMNS = [
     # Snuba adds a time column for the dataset that rounds the timestamp.
     # The exact rounding depends on the granularity in the query.
     Column(alias="time", column="time", kind=Kind.DATE),
+    Column(alias="message", column="transaction_name", kind=Kind.STRING),
 ]
 
 COLUMN_MAP = {column.alias: column for column in COLUMNS}
@@ -161,9 +162,42 @@ class ProfilesDatasetConfig(DatasetConfig):
         self,
     ) -> Mapping[str, Callable[[SearchFilter], Optional[WhereType]]]:
         return {
+            "message": self._message_filter_converter,
             PROJECT_ALIAS: self._project_slug_filter_converter,
             PROJECT_NAME_ALIAS: self._project_slug_filter_converter,
         }
+
+    def _message_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
+        value = search_filter.value.value
+        if search_filter.value.is_wildcard():
+            # XXX: We don't want the '^$' values at the beginning and end of
+            # the regex since we want to find the pattern anywhere in the
+            # message. Strip off here
+            value = search_filter.value.value[1:-1]
+            return Condition(
+                Function("match", [self.builder.column("message"), f"(?i){value}"]),
+                Op(search_filter.operator),
+                1,
+            )
+        elif value == "":
+            operator = Op.EQ if search_filter.operator == "=" else Op.NEQ
+            return Condition(
+                Function("equals", [self.builder.column("message"), value]), operator, 1
+            )
+        else:
+            if search_filter.is_in_filter:
+                return Condition(
+                    self.builder.column("message"),
+                    Op(search_filter.operator),
+                    value,
+                )
+
+            # make message search case insensitive
+            return Condition(
+                Function("positionCaseInsensitive", [self.builder.column("message"), value]),
+                Op.NEQ if search_filter.operator in EQUALITY_OPERATORS else Op.EQ,
+                0,
+            )
 
     def _project_slug_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
         return filter_aliases.project_slug_converter(self.builder, search_filter)

--- a/tests/sentry/snuba/test_profiles.py
+++ b/tests/sentry/snuba/test_profiles.py
@@ -479,6 +479,17 @@ def is_null(column: str) -> Function:
             [Condition(Column("project_id"), Op.NEQ, 1)],
             id="!project_id:1",
         ),
+        pytest.param(
+            "foo",
+            [
+                Condition(
+                    Function("positionCaseInsensitive", [Column("transaction_name"), "foo"]),
+                    Op.NEQ,
+                    0,
+                )
+            ],
+            id="foo",
+        ),
     ],
 )
 @pytest.mark.django_db


### PR DESCRIPTION
When searching for a string with no key specified, it currently returns a 400. This adds a mapping for message to transaction_name which is used in this case.