### PR TITLE
fix(discover): Event detail page missing timestamp ui fix.

### DIFF
--- a/static/app/views/organizationGroupDetails/eventCreatedTooltip.tsx
+++ b/static/app/views/organizationGroupDetails/eventCreatedTooltip.tsx
@@ -36,16 +36,22 @@ export default function EventCreatedTooltip({event}: Props) {
   const user = ConfigStore.get('user');
   const options = user?.options ?? {};
   const format = options.clock24Hours ? 'HH:mm:ss z' : 'LTS z';
-  const dateCreated = moment(event.dateCreated);
+  const dateCreated = event.dateCreated ? moment(event.dateCreated) : null;
   const dateReceived = event.dateReceived ? moment(event.dateReceived) : null;
 
   return (
     <DescriptionList>
       <dt>{t('Occurred')}</dt>
       <dd>
-        {dateCreated.format('ll')}
-        <br />
-        {dateCreated.format(format)}
+        {dateCreated ? (
+          <Fragment>
+            {dateCreated.format('ll')}
+            <br />
+            {dateCreated.format(format)}
+          </Fragment>
+        ) : (
+          <NotApplicableText>{t('n/a')}</NotApplicableText>
+        )}
       </dd>
       {dateReceived && (
         <Fragment>
@@ -55,10 +61,20 @@ export default function EventCreatedTooltip({event}: Props) {
             <br />
             {dateReceived.format(format)}
           </dd>
-          <dt>{t('Latency')}</dt>
-          <dd>{formatDateDelta(dateCreated, dateReceived)}</dd>
         </Fragment>
       )}
+      {
+        <Fragment>
+          <dt>{t('Latency')}</dt>
+          <dd>
+            {dateCreated && dateReceived ? (
+              formatDateDelta(dateCreated, dateReceived)
+            ) : (
+              <NotApplicableText>{t('n/a')}</NotApplicableText>
+            )}
+          </dd>
+        </Fragment>
+      }
     </DescriptionList>
   );
 }
@@ -69,4 +85,8 @@ const DescriptionList = styled('dl')`
   gap: ${space(0.75)} ${space(1)};
   text-align: left;
   margin: 0;
+`;
+
+const NotApplicableText = styled('span')`
+  color: ${p => p.theme.subText};
 `;

--- a/static/app/views/organizationGroupDetails/eventCreatedTooltip.tsx
+++ b/static/app/views/organizationGroupDetails/eventCreatedTooltip.tsx
@@ -61,20 +61,16 @@ export default function EventCreatedTooltip({event}: Props) {
             <br />
             {dateReceived.format(format)}
           </dd>
-        </Fragment>
-      )}
-      {
-        <Fragment>
           <dt>{t('Latency')}</dt>
           <dd>
-            {dateCreated && dateReceived ? (
+            {dateCreated ? (
               formatDateDelta(dateCreated, dateReceived)
             ) : (
               <NotApplicableText>{t('n/a')}</NotApplicableText>
             )}
           </dd>
         </Fragment>
-      }
+      )}
     </DescriptionList>
   );
 }

--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -100,7 +100,16 @@ class EventMetas extends Component<Props, State> {
     const timestamp = (
       <TimeSince
         tooltipBody={getDynamicText({
-          value: <EventCreatedTooltip event={event} />,
+          value: (
+            <EventCreatedTooltip
+              event={{
+                ...event,
+                dateCreated:
+                  event.dateCreated ||
+                  new Date((event.endTimestamp || 0) * 1000).toISOString(),
+              }}
+            />
+          ),
           fixed: 'Event Created Tooltip',
         })}
         date={event.dateCreated || (event.endTimestamp || 0) * 1000}


### PR DESCRIPTION
Some events dont have a dateCreated timestamp. Display n/a.
<img width="340" alt="image" src="https://user-images.githubusercontent.com/83961295/203356077-93a79cca-18d3-413d-8ddd-a7c32d0e31fe.png">