### PR TITLE
feat(perf-issues): parametrize SAVEPOINTs in db span hashes

### DIFF
--- a/tests/sentry/spans/grouping/test_strategy.py
+++ b/tests/sentry/spans/grouping/test_strategy.py
@@ -213,6 +213,19 @@ def test_loose_normalized_db_span_in_condition_strategy(
             "SELECT count() FROM table WHERE id IN (?, ?, ?)",
             ["SELECT count() FROM table WHERE id IN (%s)"],
         ),
+        # supports SAVEPOINTS with unquoted, backtick-quoted (MySQL), or
+        # double-quoted (PostgreSQL) identifiers
+        ("SAVEPOINT unquoted_identifier", ["SAVEPOINT %s"]),
+        ("SAVEPOINT unquoted_identifier;", ["SAVEPOINT %s;"]),
+        ("savepoint unquoted_identifier", ["SAVEPOINT %s"]),
+        (
+            'SAVEPOINT "pg_quoted_identifier"',
+            ["SAVEPOINT %s"],
+        ),
+        (
+            "SAVEPOINT `mysql_quoted_identifier`",
+            ["SAVEPOINT %s"],
+        ),
     ],
 )
 def test_parametrize_db_span_strategy(query: str, fingerprint: Optional[List[str]]) -> None:


### PR DESCRIPTION
We found an instance in production of duplicate N+1s being created due to a SAVEPOINT operation with a dynamic identifier. The example found was specifically using double-quoted identifiers (PostgreSQL), but other possible styles are unquoted (PostgreSQL and MySQL) or backtick-quoted (MySQL).

Replace SAVEPOINT identifiers with a placeholder for the purposes of hashing, as two SAVEPOINT statements can be treated as logically equivalent for performance issue detection/fingerprinting purposes.