### PR TITLE
ref(contexts): Update Runtime Context to latest spec

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -465,10 +465,10 @@ export interface RuntimeContext
   extends Partial<Record<RuntimeContextKey, unknown>>,
     BaseContext {
   type: 'runtime';
-  build?: string;
-  name?: string;
-  raw_description?: string;
-  version?: number;
+  [RuntimeContextKey.BUILD]?: string;
+  [RuntimeContextKey.NAME]?: string;
+  [RuntimeContextKey.RAW_DESCRIPTION]?: string;
+  [RuntimeContextKey.VERSION]?: number;
 }
 
 type OSContext = {

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -453,13 +453,23 @@ export interface DeviceContext
   timezone?: string;
 }
 
-type RuntimeContext = {
+export enum RuntimeContextKey {
+  BUILD = 'build',
+  NAME = 'name',
+  RAW_DESCRIPTION = 'raw_description',
+  VERSION = 'version',
+}
+
+// https://develop.sentry.dev/sdk/event-payloads/contexts/#runtime-context
+export interface RuntimeContext
+  extends Partial<Record<RuntimeContextKey, unknown>>,
+    BaseContext {
   type: 'runtime';
   build?: string;
   name?: string;
   raw_description?: string;
   version?: number;
-};
+}
 
 type OSContext = {
   build: string;

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -453,7 +453,7 @@ export interface DeviceContext
   timezone?: string;
 }
 
-export enum RuntimeContextKey {
+enum RuntimeContextKey {
   BUILD = 'build',
   NAME = 'name',
   RAW_DESCRIPTION = 'raw_description',
@@ -461,7 +461,7 @@ export enum RuntimeContextKey {
 }
 
 // https://develop.sentry.dev/sdk/event-payloads/contexts/#runtime-context
-export interface RuntimeContext
+interface RuntimeContext
   extends Partial<Record<RuntimeContextKey, unknown>>,
     BaseContext {
   type: 'runtime';


### PR DESCRIPTION
Generally matches https://github.com/getsentry/sentry/pull/41637

Runtime is not used anywhere, but documenting it so we stay aligned.

https://develop.sentry.dev/sdk/event-payloads/contexts/#runtime-context

https://github.com/getsentry/relay/blob/master/relay-general/src/protocol/contexts/runtime.rs

