### PR TITLE
fix(profiling): Default profile summary should show device.arch

### DIFF
--- a/static/app/views/profiling/profileSummary/content.tsx
+++ b/static/app/views/profiling/profileSummary/content.tsx
@@ -178,7 +178,7 @@ const DEFAULT_FIELDS: FieldType[] = [
   'id',
   'timestamp',
   'release',
-  'device.model',
+  'device.arch',
   'profile.duration',
 ];
 


### PR DESCRIPTION
This was a typo. `device.model` is a mobile only field. It should be `device.arch` instead.