### PR TITLE
feat(discover-quick-context) Events design changes.

### DIFF
--- a/static/app/views/eventsV2/table/quickContext.spec.tsx
+++ b/static/app/views/eventsV2/table/quickContext.spec.tsx
@@ -598,7 +598,6 @@ describe('Quick Context', function () {
         body: makeEvent({type: EventOrGroupType.ERROR, entries: []}),
       });
 
-      delete defaultRow.title;
       renderQuickContextContent(defaultRow, ContextType.EVENT);
 
       userEvent.hover(screen.getByText('Text from Child'));

--- a/static/app/views/eventsV2/table/quickContext.spec.tsx
+++ b/static/app/views/eventsV2/table/quickContext.spec.tsx
@@ -367,7 +367,9 @@ describe('Quick Context', function () {
       expect(await screen.findByText(/Release/i)).toBeInTheDocument();
       expect(screen.getByText(/22.10.0/i)).toBeInTheDocument();
       expect(screen.getByText(/(aaf33944f93d)/i)).toBeInTheDocument();
-      expect(screen.getByTestId('version-hover-header-copy-icon')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('quick-context-hover-header-copy-icon')
+      ).toBeInTheDocument();
     });
 
     it('Renders Release details for release', async () => {
@@ -589,6 +591,25 @@ describe('Quick Context', function () {
       ).toBeInTheDocument();
     });
 
+    it('Renders event id header', async () => {
+      jest.spyOn(ConfigStore, 'get').mockImplementation(() => null);
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/events/sentry:6b43e285de834ec5b5fe30d62d549b20/',
+        body: makeEvent({type: EventOrGroupType.ERROR, entries: []}),
+      });
+
+      delete defaultRow.title;
+      renderQuickContextContent(defaultRow, ContextType.EVENT);
+
+      userEvent.hover(screen.getByText('Text from Child'));
+
+      expect(await screen.findByText(/Event ID/i)).toBeInTheDocument();
+      expect(screen.getByText(/6b43e285/i)).toBeInTheDocument();
+      expect(
+        screen.getByTestId('quick-context-hover-header-copy-icon')
+      ).toBeInTheDocument();
+    });
+
     it('Renders stack trace as context', async () => {
       const frame: Frame = {
         colNo: 0,
@@ -642,16 +663,39 @@ describe('Quick Context', function () {
         ],
       } as EventError;
 
+      mockUseLocation.mockReturnValueOnce(
+        TestStubs.location({
+          query: {
+            field: ['issue', 'transaction.duration'],
+          },
+        })
+      );
+
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/events/sentry:6b43e285de834ec5b5fe30d62d549b20/',
         body: makeEvent(errorEvent),
       });
 
+      delete defaultRow.title;
       renderQuickContextContent(defaultRow, ContextType.EVENT);
 
       userEvent.hover(screen.getByText('Text from Child'));
 
       expect(await screen.findByTestId('stack-trace-content')).toBeInTheDocument();
+
+      const addAsColumnButton = screen.getByTestId('quick-context-title-add-button');
+      expect(addAsColumnButton).toBeInTheDocument();
+      expect(screen.getByText(/Title/i)).toBeInTheDocument();
+
+      userEvent.click(addAsColumnButton);
+      expect(browserHistory.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pathname: '/mock-pathname/',
+          query: expect.objectContaining({
+            field: ['issue', 'transaction.duration', 'title'],
+          }),
+        })
+      );
     });
   });
 });

--- a/static/app/views/eventsV2/table/quickContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext.tsx
@@ -94,7 +94,7 @@ function getHoverHeader(dataRow: EventData, contextType: ContextType) {
     case ContextType.RELEASE:
       return (
         <HoverHeader
-          title="Release"
+          title={t('Release')}
           copyLabel={<StyledVersion version={dataRow.release} truncate anchor={false} />}
           copyContent={dataRow.release}
         />
@@ -102,7 +102,7 @@ function getHoverHeader(dataRow: EventData, contextType: ContextType) {
     case ContextType.EVENT:
       return (
         <HoverHeader
-          title="Event ID"
+          title={t('Event ID')}
           copyLabel={getShortEventId(dataRow.id)}
           copyContent={dataRow.id}
         />
@@ -687,7 +687,7 @@ const NoContextWrapper = styled('div')`
   color: ${p => p.theme.subText};
   height: 50px;
   padding: ${space(1)};
-  font-size: ${p => p.theme.fontSizeLarge};
+  font-size: ${p => p.theme.fontSizeMedium};
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/static/app/views/eventsV2/table/quickContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext.tsx
@@ -1,14 +1,14 @@
-import {useEffect} from 'react';
+import {Fragment, useEffect} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import {Client} from 'sentry/api';
 import AvatarList from 'sentry/components/avatar/avatarList';
+import Clipboard from 'sentry/components/clipboard';
 import {QuickContextCommitRow} from 'sentry/components/discover/quickContextCommitRow';
 import EventCause from 'sentry/components/events/eventCause';
 import {CauseHeader, DataSection} from 'sentry/components/events/styles';
-import FeatureBadge from 'sentry/components/featureBadge';
 import AssignedTo from 'sentry/components/group/assignedTo';
 import {
   getStacktrace,
@@ -20,14 +20,15 @@ import {Panel} from 'sentry/components/panels';
 import * as SidebarSection from 'sentry/components/sidebarSection';
 import TimeSince from 'sentry/components/timeSince';
 import Tooltip from 'sentry/components/tooltip';
-import {VersionHoverHeader} from 'sentry/components/versionHoverCard';
-import {IconAdd, IconCheckmark, IconMute, IconNot} from 'sentry/icons';
+import Version from 'sentry/components/version';
+import {IconAdd, IconCheckmark, IconCopy, IconMute, IconNot} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
 import GroupStore from 'sentry/stores/groupStore';
 import space from 'sentry/styles/space';
 import {Event, Group, Organization, Project, ReleaseWithHealth, User} from 'sentry/types';
 import EventView, {EventData} from 'sentry/utils/discover/eventView';
+import {getShortEventId} from 'sentry/utils/events';
 import {getDuration} from 'sentry/utils/formatters';
 import TraceMetaQuery from 'sentry/utils/performance/quickTrace/traceMetaQuery';
 import {getTraceTimeRangeFromEvent} from 'sentry/utils/performance/quickTrace/utils';
@@ -47,10 +48,6 @@ export enum ContextType {
 }
 
 const HOVER_DELAY: number = 400;
-
-function isReleaseContext(contextType: ContextType): boolean {
-  return contextType === ContextType.RELEASE;
-}
 
 function getHoverBody(
   api: Client,
@@ -93,9 +90,26 @@ function getHoverBody(
 
 // NOTE: Will be adding switch cases as more contexts require headers.
 function getHoverHeader(dataRow: EventData, contextType: ContextType) {
-  return isReleaseContext(contextType) ? (
-    <VersionHoverHeader releaseVersion={dataRow.release} />
-  ) : null;
+  switch (contextType) {
+    case ContextType.RELEASE:
+      return (
+        <HoverHeader
+          title="Release"
+          copyLabel={<StyledVersion version={dataRow.release} truncate anchor={false} />}
+          copyContent={dataRow.release}
+        />
+      );
+    case ContextType.EVENT:
+      return (
+        <HoverHeader
+          title="Event ID"
+          copyLabel={getShortEventId(dataRow.id)}
+          copyContent={dataRow.id}
+        />
+      );
+    default:
+      return null;
+  }
 }
 
 const addFieldAsColumn = (
@@ -115,6 +129,39 @@ const addFieldAsColumn = (
 };
 
 const fiveMinutesInMs = 5 * 60 * 1000;
+
+type HoverHeaderProps = {
+  title: string;
+  copyContent?: string;
+  copyLabel?: React.ReactNode;
+  hideCopy?: boolean;
+};
+
+function HoverHeader({
+  title,
+  hideCopy = false,
+  copyLabel,
+  copyContent,
+}: HoverHeaderProps) {
+  return (
+    <HoverHeaderWrapper>
+      {title}
+      <HoverHeaderContent>
+        {copyLabel}
+
+        {!hideCopy && copyContent && (
+          <Clipboard value={copyContent}>
+            <IconCopy
+              cursor="pointer"
+              data-test-id="quick-context-hover-header-copy-icon"
+              size="xs"
+            />
+          </Clipboard>
+        )}
+      </HoverHeaderContent>
+    </HoverHeaderWrapper>
+  );
+}
 
 type IssueContextProps = {
   api: Client;
@@ -147,10 +194,7 @@ function IssueContext(props: IssueContextProps) {
   const renderStatus = () =>
     data && (
       <IssueContextContainer data-test-id="quick-context-issue-status-container">
-        <ContextHeader>
-          {statusTitle}
-          <FeatureBadge type="alpha" />
-        </ContextHeader>
+        <ContextHeader>{statusTitle}</ContextHeader>
         <ContextBody>
           {data.status === 'ignored' ? (
             <IconMute
@@ -404,7 +448,6 @@ function EventContext(props: EventContextProps) {
                 </Tooltip>
               )}
             </Title>
-            <FeatureBadge type="alpha" />
           </ContextHeader>
           <EventContextBody>
             {getDuration(data.endTimestamp - data.startTimestamp, 2, true)}
@@ -464,9 +507,35 @@ function EventContext(props: EventContextProps) {
   const stackTrace = getStacktrace(data);
 
   return stackTrace ? (
-    <StackTraceWrapper>
-      <StackTracePreviewContent event={data} stacktrace={stackTrace} />
-    </StackTraceWrapper>
+    <Fragment>
+      {!props.dataRow.title && (
+        <ErrorTitleContainer>
+          <ContextHeader>
+            <Title>
+              {t('Title')}
+              {!('title' in props.dataRow) && (
+                <Tooltip skipWrapper title={t('Add title as a column')} position="right">
+                  <IconAdd
+                    data-test-id="quick-context-title-add-button"
+                    cursor="pointer"
+                    onClick={() =>
+                      addFieldAsColumn('title', props.location, props.eventView)
+                    }
+                    color="gray300"
+                    size="xs"
+                    isCircled
+                  />
+                </Tooltip>
+              )}
+            </Title>
+          </ContextHeader>
+          <ErrorTitleBody>{data.title}</ErrorTitleBody>
+        </ErrorTitleContainer>
+      )}
+      <StackTraceWrapper>
+        <StackTracePreviewContent event={data} stacktrace={stackTrace} />
+      </StackTraceWrapper>
+    </Fragment>
   ) : (
     <NoContextWrapper>
       {t('There is no stack trace available for this event.')}
@@ -580,6 +649,16 @@ const ContextBody = styled('div')`
   align-items: center;
 `;
 
+const ErrorTitleContainer = styled(ContextContainer)`
+  padding: ${space(1.5)};
+`;
+
+const ErrorTitleBody = styled(ContextBody)`
+  margin: 0;
+  max-width: 450px;
+  ${p => p.theme.overflowEllipsis}
+`;
+
 const ReleaseBody = styled(ContextBody)<{}>`
   font-size: 13px;
   color: ${p => p.theme.subText};
@@ -614,6 +693,7 @@ const NoContextWrapper = styled('div')`
   align-items: center;
   justify-content: center;
   white-space: nowrap;
+  min-width: 320px;
 `;
 
 const ReleaseContextContainer = styled(ContextContainer)`
@@ -676,4 +756,22 @@ const Title = styled('div')`
 
 const HttpStatusWrapper = styled('span')`
   margin-left: ${space(0.5)};
+`;
+
+const HoverHeaderWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const HoverHeaderContent = styled('div')`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${space(0.5)};
+`;
+
+const StyledVersion = styled(Version)`
+  max-width: 190px;
 `;


### PR DESCRIPTION
1. Added copyable event id to context header.
2. Added title with stacktrace for errors, if title not already in the results table.
3. Updated tests.