### PR TITLE
bug(replays): Show zero count in the Issues>Replays tab after data is loaded

### DIFF
--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -1,0 +1,188 @@
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import {useLocation} from 'sentry/utils/useLocation';
+
+import useReplaysCount from './useReplaysCount';
+
+jest.mock('sentry/utils/useLocation');
+
+function getExpectedReqestParams({field, query}: {field: string[]; query: string}) {
+  return expect.objectContaining({
+    query: {
+      environment: [],
+      field,
+      per_page: 50,
+      project: [],
+      query,
+      statsPeriod: '14d',
+    },
+  });
+}
+
+describe('useReplaysCount', () => {
+  const MockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+
+  const mockGroupIds = ['123', '456'];
+  const mockTransactionNames = ['/home', '/profile'];
+
+  MockUseLocation.mockReturnValue({
+    pathname: '',
+    search: '',
+    query: {},
+    hash: '',
+    state: undefined,
+    action: 'PUSH',
+    key: '',
+  });
+
+  const organization = TestStubs.Organization({
+    features: ['session-replay-ui'],
+  });
+  const project = TestStubs.Project({
+    platform: 'javascript',
+  });
+
+  it('should throw if neither groupIds nor transactionNames is provided', () => {
+    const {result} = reactHooks.renderHook(useReplaysCount, {
+      initialProps: {
+        organization,
+        project,
+      },
+    });
+    expect(result.error).toBeTruthy();
+  });
+
+  it('should throw if both groupIds and transactionNames are provided', () => {
+    const {result} = reactHooks.renderHook(useReplaysCount, {
+      initialProps: {
+        organization,
+        project,
+        groupIds: [],
+        transactionNames: [],
+      },
+    });
+    expect(result.error).toBeTruthy();
+  });
+
+  it('should query for groupIds', async () => {
+    const countRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+      initialProps: {
+        organization,
+        project,
+        groupIds: mockGroupIds,
+      },
+    });
+
+    expect(result.current).toEqual({});
+    expect(countRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      getExpectedReqestParams({
+        field: ['count_unique(replayId)', 'issue.id'],
+        query: `!replayId:"" issue.id:[${mockGroupIds.join(',')}]`,
+      })
+    );
+
+    await waitForNextUpdate();
+  });
+
+  it('should return the count of each groupId, or zero if not included in the response', async () => {
+    const countRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            'count_unique(replayId)': 42,
+            'issue.id': 123,
+          },
+        ],
+      },
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+      initialProps: {
+        organization,
+        project,
+        groupIds: mockGroupIds,
+      },
+    });
+
+    expect(result.current).toEqual({});
+    expect(countRequest).toHaveBeenCalled();
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual({
+      '123': 42,
+      '456': 0,
+    });
+  });
+
+  it('should query for transactionNames', async () => {
+    const countRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {data: []},
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+      initialProps: {
+        organization,
+        project,
+        transactionNames: mockTransactionNames,
+      },
+    });
+
+    expect(result.current).toEqual({});
+    expect(countRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/events/',
+      getExpectedReqestParams({
+        field: ['count_unique(replayId)', 'transaction'],
+        query: `!replayId:"" event.type:transaction transaction:[${mockTransactionNames.join(
+          ','
+        )}]`,
+      })
+    );
+
+    await waitForNextUpdate();
+  });
+
+  it('should return the count of each transactionName, or zero if not included in the response', async () => {
+    const countRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      method: 'GET',
+      body: {
+        data: [
+          {
+            'count_unique(replayId)': 42,
+            transaction: '/home',
+          },
+        ],
+      },
+    });
+
+    const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
+      initialProps: {
+        organization,
+        project,
+        transactionNames: mockTransactionNames,
+      },
+    });
+
+    expect(result.current).toEqual({});
+    expect(countRequest).toHaveBeenCalled();
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual({
+      '/home': 42,
+      '/profile': 0,
+    });
+  });
+});

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -81,8 +81,8 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
       );
 
       const counts = data.data.reduce((obj, record) => {
-        const key = record[fieldName];
-        const val = record['count_unique(replayId)'];
+        const key = record[fieldName] as string;
+        const val = record['count_unique(replayId)'] as number;
         obj[key] = val;
         return obj;
       }, zeroCounts);

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -41,6 +41,11 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
     if (groupIds === undefined && transactionNames === undefined) {
       throw new Error('Missing groupId or transactionName in useReplaysCount()');
     }
+    if (groupIds !== undefined && transactionNames !== undefined) {
+      throw new Error(
+        'Unable to query both groupId and transactionName simultaneously in useReplaysCount()'
+      );
+    }
     if (groupIds && groupIds.length) {
       return [`issue.id:[${toArray(groupIds).join(',')}]`, 'issue.id'];
     }

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -28,13 +28,10 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
   const zeroCounts = useMemo(() => {
     const ids = toArray(groupIds || []);
     const names = toArray(transactionNames || []);
-    return ([] as string[])
-      .concat(ids)
-      .concat(names)
-      .reduce((record, key) => {
-        record[key] = 0;
-        return record;
-      }, {} as CountState);
+    return [...ids, ...names].reduce<CountState>((record, key) => {
+      record[key] = 0;
+      return record;
+    }, {});
   }, [groupIds, transactionNames]);
 
   const [condition, fieldName] = useMemo(() => {


### PR DESCRIPTION
**Before** we were always showing a loading placeholder in the Issues>Replay tab if the count was zero:
<img width="216" alt="SCR-20221122-cyq" src="https://user-images.githubusercontent.com/187460/203380085-9f598663-0f17-41fe-b53f-0b036258aac5.png">

**After:**
<img width="185" alt="SCR-20221122-cys" src="https://user-images.githubusercontent.com/187460/203380081-7b3d859c-9e0b-4052-9439-7e75d14effed.png">

The response included `query: !replayId:"" issue.id:[3755306451]`
But the server doesn't return the fields for `3755306451` if the count is zero.

Here's the response without any keys:
<img width="608" alt="SCR-20221122-cyf" src="https://user-images.githubusercontent.com/187460/203380088-041747f7-98c5-4ca7-bbab-9cc44e5a7987.png">

And here's the expected response, with the counts present:
<img width="547" alt="SCR-20221122-d19" src="https://user-images.githubusercontent.com/187460/203380550-614a5801-9b0c-4518-ba29-b19e8d2e3668.png">


Fixes #41653
