### PR TITLE
fix: Remove tags from alert details page when no tags are selected

### DIFF
--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -20,7 +20,7 @@ from sentry.utils import json, metrics
 class SlackNotifyServiceAction(IntegrationEventAction):
     id = "sentry.integrations.slack.notify_action.SlackNotifyServiceAction"
     form_cls = SlackNotifyServiceForm
-    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}) and show tags {tags} in notification"
+    label = "Send a notification to the {workspace} Slack workspace to {channel} (optionally, an ID: {channel_id}){tags}"
     prompt = "Send a Slack notification"
     provider = "slack"
     integration_key = "workspace"
@@ -90,7 +90,9 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             workspace=self.get_integration_name(),
             channel=self.get_option("channel"),
             channel_id=self.get_option("channel_id"),
-            tags="[{}]".format(", ".join(tags)),
+            tags=" and show tags " + "[{}]".format(", ".join(tags)) + " in notification"
+            if tags != [""]
+            else "",
         )
 
     def get_tags_list(self) -> Sequence[str]:

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -89,7 +89,7 @@ class SlackNotifyActionTest(RuleTestCase):
         label = rule.render_label()
         assert (
             label
-            == "Send a notification to the [removed] Slack workspace to #my-channel (optionally, an ID: ) and show tags [] in notification"
+            == "Send a notification to the [removed] Slack workspace to #my-channel (optionally, an ID: )"
         )
 
     @responses.activate


### PR DESCRIPTION
WOR-2431

Before: Alert details page stated " and show tags [] in notification" when no tags were selected

After: Alert details page does not show " and show tags [] in notification" when no tags were selected
