### PR TITLE
fix(commit-context): Allow Suspect Committers who are not a member

### DIFF
--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -80,7 +80,7 @@ class GroupOwner(Model):
 
     def save(self, *args, **kwargs):
         keys = list(filter(None, [self.user_id, self.team_id]))
-        assert len(keys) == 1, "Must have team or user, not both"
+        assert len(keys) != 2, "Must have team or user or neither, not both"
         super().save(*args, **kwargs)
 
     def owner_id(self):

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -204,3 +204,43 @@ class TestCommitContext(TestCase):
             organization=self.event.project.organization,
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         ).exists()
+
+    @patch(
+        "sentry.integrations.github.GitHubIntegration.get_commit_context",
+        return_value={
+            "commitId": "somekey",
+            "committedDate": "",
+            "commitMessage": "placeholder commit message",
+            "commitAuthorName": "",
+            "commitAuthorEmail": "randomuser@sentry.io",
+        },
+    )
+    def test_commit_author_not_in_sentry(self, mock_get_commit_context):
+        self.commit_author_2 = self.create_commit_author(
+            project=self.project,
+        )
+        self.commit_2 = self.create_commit(
+            project=self.project,
+            repo=self.repo,
+            author=self.commit_author_2,
+            key="somekey",
+            message="placeholder commit message",
+        )
+
+        with self.tasks():
+            assert not GroupOwner.objects.filter(group=self.event.group).exists()
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+        assert GroupOwner.objects.filter(group=self.event.group).exists()
+        assert len(GroupOwner.objects.filter(group=self.event.group)) == 1
+        owner = GroupOwner.objects.get(group=self.event.group)
+        assert owner.type == GroupOwnerType.SUSPECT_COMMIT.value
+        assert owner.user is None
+        assert owner.team is None
+        assert owner.context == {"commitId": self.commit_2.id}


### PR DESCRIPTION
## Objective:
We want to allow Suspect Committers who authored commits in code but are not members in the Sentry organization.

Fixes SENTRY-W4E