### PR TITLE
fix(stacktrace-link): Fix early adopter tag type

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -70,7 +70,8 @@ def set_top_tags(scope: Scope, project: Project) -> None:
     scope.set_tag("project.slug", project.slug)
     scope.set_tag("organization.slug", project.organization.slug)
     try:
-        scope.set_tag("organization.early_adopter", project.organization.flags.early_adopter)
+        ea_org: bool = project.organization.flags.early_adopter.is_set
+        scope.set_tag("organization.early_adopter", ea_org)
     except Exception:
         # If errors arise we can then follow up with a fix
         logger.exception("We failed to set the early adopter flag")


### PR DESCRIPTION
It is currently being stored as `<Bit: number=3, is_set=False>` rather than a boolean value.