### PR TITLE
chore(hybrid-cloud): Replace withRouter with hooks

### DIFF
--- a/static/app/components/createAlertButton.spec.jsx
+++ b/static/app/components/createAlertButton.spec.jsx
@@ -92,7 +92,11 @@ describe('CreateAlertFromViewButton', () => {
     userEvent.click(screen.getByRole('button'));
     expect(navigateTo).toHaveBeenCalledWith(
       `/organizations/org-slug/alerts/wizard/?`,
-      undefined
+      expect.objectContaining({
+        params: {
+          orgId: 'org-slug',
+        },
+      })
     );
   });
 

--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -1,6 +1,4 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {updateDateTime} from 'sentry/actionCreators/pageFilters';
@@ -19,19 +17,20 @@ import {
 } from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 type Props = Omit<
   React.ComponentProps<typeof TimeRangeSelector>,
   'organization' | 'start' | 'end' | 'utc' | 'relative' | 'onUpdate'
-> &
-  WithRouterProps & {
-    /**
-     * Reset these URL params when we fire actions (custom routing only)
-     */
-    resetParamsOnChange?: string[];
-  };
+> & {
+  /**
+   * Reset these URL params when we fire actions (custom routing only)
+   */
+  resetParamsOnChange?: string[];
+};
 
-function DatePageFilter({router, resetParamsOnChange, disabled, ...props}: Props) {
+function DatePageFilter({resetParamsOnChange, disabled, ...props}: Props) {
+  const {router} = useRouteContext();
   const {selection, desyncedFilters} = usePageFilters();
   const organization = useOrganization();
   const {start, end, period, utc} = selection.datetime;
@@ -119,4 +118,4 @@ const DropdownTitle = styled('div')`
   min-width: 0;
 `;
 
-export default withRouter(DatePageFilter);
+export default DatePageFilter;

--- a/static/app/components/eventOrGroupExtraDetails.tsx
+++ b/static/app/components/eventOrGroupExtraDetails.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import EventAnnotation from 'sentry/components/events/eventAnnotation';
@@ -18,9 +16,10 @@ import space from 'sentry/styles/space';
 import {Group, Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
+import {useParams} from 'sentry/utils/useParams';
 import withOrganization from 'sentry/utils/withOrganization';
 
-type Props = WithRouterProps<{orgId: string}> & {
+type Props = {
   data: Event | Group;
   organization: Organization;
   showAssignee?: boolean;
@@ -30,10 +29,10 @@ type Props = WithRouterProps<{orgId: string}> & {
 function EventOrGroupExtraDetails({
   data,
   showAssignee,
-  params,
   showInboxTime,
   organization,
 }: Props) {
+  const params = useParams();
   const {
     id,
     lastSeen,
@@ -169,4 +168,4 @@ const LoggerAnnotation = styled(AnnotationNoMargin)`
   color: ${p => p.theme.textColor};
 `;
 
-export default withRouter(withOrganization(EventOrGroupExtraDetails));
+export default withOrganization(EventOrGroupExtraDetails);

--- a/static/app/components/eventOrGroupHeader.spec.tsx
+++ b/static/app/components/eventOrGroupHeader.spec.tsx
@@ -32,7 +32,7 @@ const event = TestStubs.Event({
 });
 
 describe('EventOrGroupHeader', function () {
-  const {organization, router} = initializeOrg({
+  const {organization, router, routerContext} = initializeOrg({
     router: {orgId: 'orgId'},
   } as Parameters<typeof initializeOrg>[0]);
 
@@ -166,7 +166,6 @@ describe('EventOrGroupHeader', function () {
     it('hides level tag', function () {
       const {container} = render(
         <EventOrGroupHeader
-          projectId="projectId"
           hideLevel
           organization={organization}
           data={{
@@ -177,7 +176,6 @@ describe('EventOrGroupHeader', function () {
               title: 'metadata title',
             },
           }}
-          {...router}
         />
       );
       expect(container).toSnapshot();
@@ -191,15 +189,20 @@ describe('EventOrGroupHeader', function () {
             ...event,
             type: EventOrGroupType.DEFAULT,
           }}
-          {...router}
-          location={{
-            ...router.location,
-            query: {
-              ...router.location.query,
-              sort: 'freq',
+        />,
+        {
+          context: routerContext,
+          router: {
+            ...router,
+            location: {
+              ...router.location,
+              query: {
+                ...router.location.query,
+                sort: 'freq',
+              },
             },
-          }}
-        />
+          },
+        }
       );
 
       expect(screen.getByRole('link')).toHaveAttribute(
@@ -208,7 +211,7 @@ describe('EventOrGroupHeader', function () {
       );
     });
 
-    it('lack of project adds allp parameter', function () {
+    it('lack of project adds all parameter', function () {
       render(
         <EventOrGroupHeader
           organization={organization}
@@ -216,12 +219,17 @@ describe('EventOrGroupHeader', function () {
             ...event,
             type: EventOrGroupType.DEFAULT,
           }}
-          {...router}
-          location={{
-            ...router.location,
-            query: {},
-          }}
-        />
+        />,
+        {
+          context: routerContext,
+          router: {
+            ...router,
+            location: {
+              ...router.location,
+              query: {},
+            },
+          },
+        }
       );
 
       expect(screen.getByRole('link')).toHaveAttribute(

--- a/static/app/components/eventOrGroupHeader.tsx
+++ b/static/app/components/eventOrGroupHeader.tsx
@@ -1,6 +1,4 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import capitalize from 'lodash/capitalize';
@@ -15,6 +13,8 @@ import space from 'sentry/styles/space';
 import {Group, GroupTombstone, Level, Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {getLocation, getMessage} from 'sentry/utils/events';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
 import withOrganization from 'sentry/utils/withOrganization';
 import {TagAndMessageWrapper} from 'sentry/views/organizationGroupDetails/unhandledTag';
 
@@ -22,7 +22,7 @@ import EventTitleError from './eventTitleError';
 
 type Size = 'small' | 'normal';
 
-type Props = WithRouterProps<{orgId: string}> & {
+type Props = {
   data: Event | Group | GroupTombstone;
   organization: Organization;
   className?: string;
@@ -46,7 +46,6 @@ function EventOrGroupHeader({
   data,
   index,
   organization,
-  params,
   query,
   onClick,
   className,
@@ -56,8 +55,10 @@ function EventOrGroupHeader({
   size = 'normal',
   grouping = false,
   source,
-  ...props
 }: Props) {
+  const params = useParams();
+  const location = useLocation();
+
   const hasGroupingTreeUI = !!organization.features?.includes('grouping-tree-ui');
 
   function getTitleChildren() {
@@ -102,7 +103,6 @@ function EventOrGroupHeader({
 
     const {id, status} = data as Group;
     const {eventID, groupID} = data as Event;
-    const {location} = props;
 
     const commonEleProps = {
       'data-test-id': status === 'resolved' ? 'resolved-issue' : null,
@@ -142,7 +142,7 @@ function EventOrGroupHeader({
     return <span {...commonEleProps}>{getTitleChildren()}</span>;
   }
 
-  const location = getLocation(data);
+  const eventLocation = getLocation(data);
   const message = getMessage(data);
 
   return (
@@ -150,7 +150,7 @@ function EventOrGroupHeader({
       <Title size={size} hasGroupingTreeUI={hasGroupingTreeUI}>
         {getTitle()}
       </Title>
-      {location && <Location size={size}>{location}</Location>}
+      {eventLocation && <Location size={size}>{eventLocation}</Location>}
       {message && (
         <StyledTagAndMessageWrapper size={size}>
           {message && <Message>{message}</Message>}
@@ -246,7 +246,7 @@ const GroupLevel = styled('div')<{level: Level}>`
   background-color: ${p => p.theme.level[p.level] ?? p.theme.level.default};
 `;
 
-export default withRouter(withOrganization(EventOrGroupHeader));
+export default withOrganization(EventOrGroupHeader);
 
 const StyledEventOrGroupTitle = styled(EventOrGroupTitle)<{
   hasSeen: boolean;

--- a/static/app/components/globalSelectionLink.tsx
+++ b/static/app/components/globalSelectionLink.tsx
@@ -1,12 +1,11 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {LocationDescriptor} from 'history';
 import * as qs from 'query-string';
 
 import Link, {LinkProps} from 'sentry/components/links/link';
 import {extractSelectionParameters} from 'sentry/components/organizations/pageFilters/utils';
+import {useLocation} from 'sentry/utils/useLocation';
 
-interface Props extends WithRouterProps {
+interface Props {
   /**
    * Location that is being linked to
    */
@@ -34,7 +33,8 @@ interface Props extends WithRouterProps {
  * Falls back to <a> if there is no router present.
  */
 function GlobalSelectionLink(props: Props) {
-  const {location, to} = props;
+  const {to} = props;
+  const location = useLocation();
 
   const globalQuery = extractSelectionParameters(location?.query);
   const hasGlobalQuery = Object.keys(globalQuery).length > 0;
@@ -73,4 +73,4 @@ function GlobalSelectionLink(props: Props) {
   return <a {...props} href={url} />;
 }
 
-export default withRouter(GlobalSelectionLink);
+export default GlobalSelectionLink;

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -1,6 +1,4 @@
 import {Fragment, memo, useEffect, useMemo, useRef, useState} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {components} from 'react-select';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -49,6 +47,8 @@ import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metr
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {decodeInteger, decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
+import {useParams} from 'sentry/utils/useParams';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
 import {
@@ -95,7 +95,7 @@ export interface WidgetViewerModalOptions {
   totalIssuesCount?: string;
 }
 
-interface Props extends ModalRenderProps, WithRouterProps, WidgetViewerModalOptions {
+interface Props extends ModalRenderProps, WidgetViewerModalOptions {
   organization: Organization;
   selection: PageFilters;
 }
@@ -157,21 +157,19 @@ function WidgetViewerModal(props: Props) {
     organization,
     widget,
     selection,
-    location,
     Footer,
     Body,
     Header,
     closeModal,
     onEdit,
-    router,
-    routes,
-    params,
     seriesData,
     tableData,
     totalIssuesCount,
     pageLinks: defaultPageLinks,
     seriesResultsType,
   } = props;
+  const {location, router, routes} = useRouteContext();
+  const params = useParams();
   const shouldShowSlider = organization.features.includes('widget-viewer-modal-minimap');
   // Get widget zoom from location
   // We use the start and end query params for just the initial state
@@ -467,6 +465,7 @@ function WidgetViewerModal(props: Props) {
           grid={{
             renderHeadCell: renderDiscoverGridHeaderCell({
               ...props,
+              location,
               widget: tableWidget,
               tableData: tableResults?.[0],
               onHeaderClick: () => {
@@ -481,6 +480,7 @@ function WidgetViewerModal(props: Props) {
             }) as (column: GridColumnOrder, columnIndex: number) => React.ReactNode,
             renderBodyCell: renderGridBodyCell({
               ...props,
+              location,
               tableData: tableResults?.[0],
               isFirstPage,
             }),
@@ -608,6 +608,7 @@ function WidgetViewerModal(props: Props) {
           grid={{
             renderHeadCell: renderReleaseGridHeaderCell({
               ...props,
+              location,
               widget: tableWidget,
               tableData: tableResults?.[0],
               onHeaderClick: () => {
@@ -621,6 +622,7 @@ function WidgetViewerModal(props: Props) {
             }) as (column: GridColumnOrder, columnIndex: number) => React.ReactNode,
             renderBodyCell: renderGridBodyCell({
               ...props,
+              location,
               tableData: tableResults?.[0],
               isFirstPage,
             }),
@@ -1145,4 +1147,4 @@ const EmptyQueryContainer = styled('span')`
   color: ${p => p.theme.disabled};
 `;
 
-export default withRouter(withPageFilters(WidgetViewerModal));
+export default withPageFilters(WidgetViewerModal);

--- a/static/app/components/organizations/environmentSelector.tsx
+++ b/static/app/components/organizations/environmentSelector.tsx
@@ -1,6 +1,4 @@
 import {Fragment, useEffect, useRef, useState} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
@@ -22,8 +20,9 @@ import {Organization, Project} from 'sentry/types';
 import {analytics} from 'sentry/utils/analytics';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import theme from 'sentry/utils/theme';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
-type Props = WithRouterProps & {
+type Props = {
   customDropdownButton: (config: {
     actions: MenuActions;
     isOpen: boolean;
@@ -65,8 +64,8 @@ function EnvironmentSelector({
   customDropdownButton,
   customLoadingIndicator,
   disabled,
-  router,
 }: Props) {
+  const {router} = useRouteContext();
   const [selectedEnvs, setSelectedEnvs] = useState(value);
   const hasChanges = !isEqual(selectedEnvs, value);
 
@@ -239,7 +238,7 @@ function EnvironmentSelector({
   );
 }
 
-export default withRouter(EnvironmentSelector);
+export default EnvironmentSelector;
 
 const StyledDropdownAutoComplete = styled(DropdownAutoComplete)`
   background: ${p => p.theme.background};

--- a/static/app/components/organizations/pageFilters/container.spec.jsx
+++ b/static/app/components/organizations/pageFilters/container.spec.jsx
@@ -28,7 +28,7 @@ jest.mock('sentry/utils/localStorage', () => ({
   setItem: jest.fn(),
 }));
 
-function renderComponnent(component, routerContext, organization) {
+function renderComponent(component, routerContext, organization) {
   return render(component, {context: routerContext, organization});
 }
 
@@ -77,7 +77,7 @@ describe('PageFiltersContainer', function () {
   });
 
   it('does not update router if there is custom routing', function () {
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer hasCustomRouting />,
       routerContext,
       organization
@@ -86,7 +86,7 @@ describe('PageFiltersContainer', function () {
   });
 
   it('does not update router if org in URL params is different than org in context/props', function () {
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer hasCustomRouting />,
       {
         ...routerContext,
@@ -101,13 +101,13 @@ describe('PageFiltersContainer', function () {
   });
 
   it('does not replace URL with values from store when mounted with no query params', function () {
-    renderComponnent(<PageFiltersContainer />, routerContext, organization);
+    renderComponent(<PageFiltersContainer />, routerContext, organization);
 
     expect(router.replace).not.toHaveBeenCalled();
   });
 
   it('only updates GlobalSelection store when mounted with query params', async function () {
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer params={{orgId: organization.slug}} />,
       changeQuery(routerContext, {statsPeriod: '7d'}),
       organization
@@ -130,7 +130,7 @@ describe('PageFiltersContainer', function () {
   });
 
   it('updates GlobalSelection store with default period', async function () {
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer />,
       changeQuery(routerContext, {
         environment: 'prod',
@@ -161,7 +161,7 @@ describe('PageFiltersContainer', function () {
   });
 
   it('updates GlobalSelection store with empty dates in URL', async function () {
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer />,
       changeQuery(routerContext, {
         statsPeriod: null,
@@ -189,7 +189,7 @@ describe('PageFiltersContainer', function () {
   });
 
   it('resets start&end if showAbsolute prop is false', async function () {
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer showAbsolute={false} />,
       changeQuery(routerContext, {
         start: '2020-05-05T07:26:53.000',
@@ -221,7 +221,7 @@ describe('PageFiltersContainer', function () {
    * I don't think this test is really applicable anymore
    */
   it('does not update store if url params have not changed', async function () {
-    const {rerender} = renderComponnent(
+    const {rerender} = renderComponent(
       <PageFiltersContainer />,
       changeQuery(routerContext, {statsPeriod: '7d'}),
       organization
@@ -279,7 +279,7 @@ describe('PageFiltersContainer', function () {
       },
     });
 
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer />,
       initializationObj.routerContext,
       initializationObj.organization
@@ -316,7 +316,7 @@ describe('PageFiltersContainer', function () {
       },
     });
 
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer />,
       initializationObj.routerContext,
       initializationObj.organization
@@ -342,7 +342,7 @@ describe('PageFiltersContainer', function () {
       },
     });
 
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer />,
       initializationObj.routerContext,
       initializationObj.organization
@@ -368,7 +368,7 @@ describe('PageFiltersContainer', function () {
       },
     });
 
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer />,
       initializationObj.routerContext,
       initializationObj.organization
@@ -402,7 +402,7 @@ describe('PageFiltersContainer', function () {
 
     OrganizationStore.onUpdate(initializationObj.organization);
 
-    renderComponnent(
+    renderComponent(
       <PageFiltersContainer hideGlobalHeader />,
       initializationObj.routerContext,
       initializationObj.organization
@@ -469,7 +469,7 @@ describe('PageFiltersContainer', function () {
 
       // This can happen when you switch organization so params.orgId !== the
       // current org in context In this case params.orgId = 'org-slug'
-      const {rerender} = renderComponnent(
+      const {rerender} = renderComponent(
         <PageFiltersContainer />,
         initialData.routerContext,
         initialData.organization
@@ -515,7 +515,7 @@ describe('PageFiltersContainer', function () {
         },
       });
 
-      renderComponnent(
+      renderComponent(
         <PageFiltersContainer />,
         initializationObj.routerContext,
         initializationObj.organization
@@ -542,7 +542,7 @@ describe('PageFiltersContainer', function () {
         },
       });
 
-      renderComponnent(
+      renderComponent(
         <PageFiltersContainer />,
         initializationObj.routerContext,
         initializationObj.organization
@@ -578,7 +578,7 @@ describe('PageFiltersContainer', function () {
     });
 
     it('replaces URL with project', function () {
-      renderComponnent(
+      renderComponent(
         <PageFiltersContainer
           shouldForceProject
           forceProject={initialData.projects[0]}
@@ -614,7 +614,7 @@ describe('PageFiltersContainer', function () {
     });
 
     it('does not add forced project to URL', async function () {
-      renderComponnent(
+      renderComponent(
         <PageFiltersContainer
           skipInitializeUrlParams
           shouldForceProject
@@ -656,7 +656,7 @@ describe('PageFiltersContainer', function () {
       }
 
       function renderForNonGlobalView(props) {
-        const result = renderComponnent(
+        const result = renderComponent(
           getComponentForNonGlobalView(props),
           initialData.routerContext,
           initialData.organization
@@ -751,7 +751,7 @@ describe('PageFiltersContainer', function () {
 
       it('appends projectId to URL when mounted with `forceProject`', function () {
         // forceProject generally starts undefined
-        renderComponnent(
+        renderComponent(
           <PageFiltersContainer
             params={{orgId: initialData.organization.slug}}
             shouldForceProject
@@ -794,7 +794,7 @@ describe('PageFiltersContainer', function () {
       }
 
       function renderForGlobalView(props, ctx) {
-        const result = renderComponnent(
+        const result = renderComponent(
           getComponentForGlobalView(props),
           {
             ...initialData.routerContext,

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -1,6 +1,4 @@
 import {Fragment, useEffect, useRef} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 
@@ -16,6 +14,7 @@ import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {PageContent} from 'sentry/styles/organization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import {getDatetimeFromState, getStateFromQuery} from './parse';
@@ -26,22 +25,21 @@ type InitializeUrlStateProps = Omit<
   'memberProjects' | 'queryParams' | 'router' | 'shouldEnforceSingleProject'
 >;
 
-type Props = WithRouterProps &
-  InitializeUrlStateProps & {
-    children?: React.ReactNode;
-    /**
-     * Custom alert message for the desynced filter state.
-     */
-    desyncedAlertMessage?: string;
-    /**
-     * Whether to hide the revert button in the desynced filter alert.
-     */
-    hideDesyncRevertButton?: boolean;
-    /**
-     * Slugs of projects to display in project selector
-     */
-    specificProjectSlugs?: string[];
-  };
+type Props = InitializeUrlStateProps & {
+  children?: React.ReactNode;
+  /**
+   * Custom alert message for the desynced filter state.
+   */
+  desyncedAlertMessage?: string;
+  /**
+   * Whether to hide the revert button in the desynced filter alert.
+   */
+  hideDesyncRevertButton?: boolean;
+  /**
+   * Slugs of projects to display in project selector
+   */
+  specificProjectSlugs?: string[];
+};
 
 /**
  * The page filters container handles initialization of page filters for the
@@ -49,8 +47,6 @@ type Props = WithRouterProps &
  */
 function Container({skipLoadLastUsed, children, ...props}: Props) {
   const {
-    location,
-    router,
     forceProject,
     organization,
     defaultSelection,
@@ -61,6 +57,7 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     desyncedAlertMessage,
     hideDesyncRevertButton,
   } = props;
+  const {location, router} = useRouteContext();
 
   const {isReady} = usePageFilters();
 
@@ -183,6 +180,6 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
   );
 }
 
-const PageFiltersContainer = withOrganization(withRouter(Container));
+const PageFiltersContainer = withOrganization(Container);
 
 export default PageFiltersContainer;

--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -1,6 +1,4 @@
 import {Fragment, useMemo, useRef, useState} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
@@ -16,11 +14,12 @@ import {Organization, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import theme from 'sentry/utils/theme';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import ProjectSelectorFooter from './footer';
 import SelectorItem from './selectorItem';
 
-type Props = WithRouterProps & {
+type Props = {
   /**
    * Used to render a custom dropdown button for the DropdownAutoComplete
    */
@@ -80,10 +79,10 @@ function ProjectSelector({
   onApplyChange,
   onChange,
   organization,
-  router,
   value,
   disabled,
 }: Props) {
+  const {router} = useRouteContext();
   // Used to determine if we should show the 'apply' changes button
   const [hasChanges, setHasChanges] = useState(false);
 
@@ -328,7 +327,7 @@ function ProjectSelector({
   );
 }
 
-export default withRouter(ProjectSelector);
+export default ProjectSelector;
 
 const StyledDropdownAutocomplete = styled(DropdownAutoComplete)`
   background-color: ${p => p.theme.background};

--- a/static/app/components/pagination.tsx
+++ b/static/app/components/pagination.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Query} from 'history';
 
@@ -9,6 +8,7 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
+import {useLocation} from 'sentry/utils/useLocation';
 
 /**
  * @param cursor The string cursor value
@@ -24,7 +24,7 @@ export type CursorHandler = (
   delta: number
 ) => void;
 
-type Props = WithRouterProps & {
+type Props = {
   caption?: React.ReactNode;
   className?: string;
   disabled?: boolean;
@@ -43,7 +43,6 @@ const defaultOnCursor: CursorHandler = (cursor, path, query, _direction) =>
 
 const Pagination = ({
   to,
-  location,
   className,
   onCursor = defaultOnCursor,
   paginationAnalyticsEvent,
@@ -52,6 +51,7 @@ const Pagination = ({
   caption,
   disabled = false,
 }: Props) => {
+  const location = useLocation();
   if (!pageLinks) {
     return null;
   }
@@ -106,4 +106,4 @@ const PaginationCaption = styled('span')`
   margin-right: ${space(2)};
 `;
 
-export default withRouter(Pagination);
+export default Pagination;

--- a/static/app/components/profiling/breadcrumb.spec.tsx
+++ b/static/app/components/profiling/breadcrumb.spec.tsx
@@ -1,10 +1,11 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {Breadcrumb} from 'sentry/components/profiling/breadcrumb';
 
 describe('Breadcrumb', function () {
   it('renders the profiling link', function () {
-    const organization = TestStubs.Organization();
+    const {organization, routerContext} = initializeOrg();
     render(
       <Breadcrumb
         organization={organization}
@@ -21,12 +22,13 @@ describe('Breadcrumb', function () {
             },
           },
         ]}
-      />
+      />,
+      {context: routerContext}
     );
     expect(screen.getByText('Profiling')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Profiling'})).toHaveAttribute(
       'href',
-      `/organizations/${organization.slug}/profiling/`
+      `/organizations/${organization.slug}/profiling/?`
     );
     expect(screen.getByText('foo')).toBeInTheDocument();
   });

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -1,6 +1,4 @@
 import {useEffect, useState} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 import partition from 'lodash/partition';
@@ -22,10 +20,11 @@ import {trimSlug} from 'sentry/utils/trimSlug';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 type ProjectSelectorProps = React.ComponentProps<typeof ProjectSelector>;
 
-type Props = WithRouterProps & {
+type Props = {
   disabled?: ProjectSelectorProps['disabled'];
   /**
    * Message to display at the bottom of project list
@@ -80,13 +79,14 @@ type Props = WithRouterProps & {
 };
 
 function ProjectPageFilter({
-  router,
   specificProjectSlugs,
   maxTitleLength = 30,
   resetParamsOnChange = [],
   disabled,
   ...otherProps
 }: Props) {
+  const {router} = useRouteContext();
+
   const [currentSelectedProjects, setCurrentSelectedProjects] = useState<number[] | null>(
     null
   );
@@ -236,4 +236,4 @@ const StyledBadge = styled(Badge)`
   flex-shrink: 0;
 `;
 
-export default withRouter(ProjectPageFilter);
+export default ProjectPageFilter;

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -1,6 +1,4 @@
 import {Fragment, isValidElement} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -13,6 +11,7 @@ import {Organization} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import localStorage from 'sentry/utils/localStorage';
 import {Theme} from 'sentry/utils/theme';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {SidebarOrientation} from './types';
 
@@ -21,7 +20,7 @@ const LabelHook = HookOrDefault({
   defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
 });
 
-type Props = WithRouterProps & {
+type Props = {
   /**
    * Icon to display
    */
@@ -84,7 +83,6 @@ type Props = WithRouterProps & {
 };
 
 const SidebarItem = ({
-  router,
   id,
   href,
   to,
@@ -104,6 +102,7 @@ const SidebarItem = ({
   onClick,
   ...props
 }: Props) => {
+  const {router} = useRouteContext();
   // label might be wrapped in a guideAnchor
   let labelString = label;
   if (isValidElement(label)) {
@@ -194,7 +193,7 @@ const SidebarItem = ({
   );
 };
 
-export default withRouter(SidebarItem);
+export default SidebarItem;
 
 const getActiveStyle = ({active, theme}: {active?: string; theme?: Theme}) => {
   if (!active) {

--- a/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/content.spec.tsx
@@ -14,7 +14,6 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 import {SpanOperationBreakdownFilter} from 'sentry/views/performance/transactionSummary/filter';
 import EventsPageContent from 'sentry/views/performance/transactionSummary/transactionEvents/content';
 import {EventsDisplayFilterName} from 'sentry/views/performance/transactionSummary/transactionEvents/utils';
-import {RouteContext} from 'sentry/views/routeContext';
 
 function initializeData() {
   const organization = TestStubs.Organization({
@@ -157,24 +156,22 @@ describe('Performance Transaction Events Content', function () {
 
   it('basic rendering', function () {
     render(
-      <RouteContext.Provider value={initialData.routerContext}>
-        <OrganizationContext.Provider value={initialData.organization}>
-          <EventsPageContent
-            totalEventCount={totalEventCount}
-            eventView={eventView}
-            organization={initialData.organization}
-            location={initialData.router.location}
-            transactionName={transactionName}
-            spanOperationBreakdownFilter={SpanOperationBreakdownFilter.None}
-            onChangeSpanOperationBreakdownFilter={() => {}}
-            eventsDisplayFilterName={EventsDisplayFilterName.p100}
-            onChangeEventsDisplayFilter={() => {}}
-            setError={() => {}}
-            projectId="123"
-            projects={[]}
-          />
-        </OrganizationContext.Provider>
-      </RouteContext.Provider>,
+      <OrganizationContext.Provider value={initialData.organization}>
+        <EventsPageContent
+          totalEventCount={totalEventCount}
+          eventView={eventView}
+          organization={initialData.organization}
+          location={initialData.router.location}
+          transactionName={transactionName}
+          spanOperationBreakdownFilter={SpanOperationBreakdownFilter.None}
+          onChangeSpanOperationBreakdownFilter={() => {}}
+          eventsDisplayFilterName={EventsDisplayFilterName.p100}
+          onChangeEventsDisplayFilter={() => {}}
+          setError={() => {}}
+          projectId="123"
+          projects={[]}
+        />
+      </OrganizationContext.Provider>,
       {context: initialData.routerContext}
     );
 
@@ -200,25 +197,23 @@ describe('Performance Transaction Events Content', function () {
 
   it('rendering with webvital selected', function () {
     render(
-      <RouteContext.Provider value={initialData.routerContext}>
-        <OrganizationContext.Provider value={initialData.organization}>
-          <EventsPageContent
-            totalEventCount={totalEventCount}
-            eventView={eventView}
-            organization={initialData.organization}
-            location={initialData.router.location}
-            transactionName={transactionName}
-            spanOperationBreakdownFilter={SpanOperationBreakdownFilter.None}
-            onChangeSpanOperationBreakdownFilter={() => {}}
-            eventsDisplayFilterName={EventsDisplayFilterName.p100}
-            onChangeEventsDisplayFilter={() => {}}
-            webVital={WebVital.LCP}
-            setError={() => {}}
-            projectId="123"
-            projects={[]}
-          />
-        </OrganizationContext.Provider>
-      </RouteContext.Provider>,
+      <OrganizationContext.Provider value={initialData.organization}>
+        <EventsPageContent
+          totalEventCount={totalEventCount}
+          eventView={eventView}
+          organization={initialData.organization}
+          location={initialData.router.location}
+          transactionName={transactionName}
+          spanOperationBreakdownFilter={SpanOperationBreakdownFilter.None}
+          onChangeSpanOperationBreakdownFilter={() => {}}
+          eventsDisplayFilterName={EventsDisplayFilterName.p100}
+          onChangeEventsDisplayFilter={() => {}}
+          webVital={WebVital.LCP}
+          setError={() => {}}
+          projectId="123"
+          projects={[]}
+        />
+      </OrganizationContext.Provider>,
       {context: initialData.routerContext}
     );
 

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -240,6 +240,7 @@ class ProjectDetail extends AsyncView<Props, State> {
                     size="sm"
                     organization={organization}
                     projectSlug={params.projectId}
+                    aria-label={t('Create Alert')}
                   />
                   <Button
                     size="sm"

--- a/static/app/views/releases/list/index.spec.jsx
+++ b/static/app/views/releases/list/index.spec.jsx
@@ -14,7 +14,6 @@ import ReleasesList from 'sentry/views/releases/list/';
 import {ReleasesDisplayOption} from 'sentry/views/releases/list/releasesDisplayOptions';
 import {ReleasesSortOption} from 'sentry/views/releases/list/releasesSortOptions';
 import {ReleasesStatusOption} from 'sentry/views/releases/list/releasesStatusOptions';
-import {RouteContext} from 'sentry/views/routeContext';
 
 describe('ReleasesList', () => {
   const {organization, routerContext, router} = initializeOrg();
@@ -122,13 +121,11 @@ describe('ReleasesList', () => {
     // does not have releases set up and no releases
     location = {query: {}};
     const {rerender} = render(
-      <RouteContext.Provider value={routerContext}>
-        <ReleasesList
-          location={location}
-          {...props}
-          selection={{...props.selection, projects: [4]}}
-        />
-      </RouteContext.Provider>,
+      <ReleasesList
+        location={location}
+        {...props}
+        selection={{...props.selection, projects: [4]}}
+      />,
       {
         context: routerContext,
         organization,

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -108,8 +108,13 @@ function makeAllTheProviders({context, ...initializeOrgOptions}: ProviderOptions
  * render(<TestedComponent />, {context: routerContext, organization});
  */
 function render(ui: React.ReactElement, options?: Options) {
-  const {context, organization, project, projects, router, ...otherOptions} =
-    options ?? {};
+  options = options ?? {};
+  const {context, organization, project, projects, ...otherOptions} = options;
+  let {router} = options;
+
+  if (router === undefined && context?.context?.router) {
+    router = context.context.router;
+  }
 
   const AllTheProviders = makeAllTheProviders({
     context,


### PR DESCRIPTION
This pull request replaces `withRouter()` with hooks for some React components. 

I will divide the replacement work for a chunk of React components at a time so that they're easier to review.