### PR TITLE
chore(hybrid-cloud): Restore window.location for tests

### DIFF
--- a/static/app/utils/withDomainRedirect.spec.tsx
+++ b/static/app/utils/withDomainRedirect.spec.tsx
@@ -9,6 +9,8 @@ import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.unmock('sentry/utils/recreateRoute');
 
+const originalLocation = window.location;
+
 // /settings/:orgId/:projectId/(searches/:searchId/)alerts/
 const projectRoutes = [
   {path: '/', childRoutes: []},
@@ -55,6 +57,7 @@ describe('withDomainRedirect', function () {
 
   afterEach(function () {
     jest.resetAllMocks();
+    window.location = originalLocation;
   });
 
   it('renders MyComponent in non-customer domain world', function () {

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -5,6 +5,8 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import withDomainRequired from 'sentry/utils/withDomainRequired';
 
+const originalLocation = window.location;
+
 describe('withDomainRequired', function () {
   type Props = RouteComponentProps<{orgId: string}, {}>;
   const MyComponent = (props: Props) => {
@@ -34,6 +36,10 @@ describe('withDomainRequired', function () {
         sentryUrl: 'https://sentry.io',
       },
     } as any;
+  });
+
+  afterEach(function () {
+    window.location = originalLocation;
   });
 
   it('redirects to sentryUrl in non-customer domain world', function () {


### PR DESCRIPTION
Restore `window.location` to the original value for each test.