### PR TITLE
fix(routes): Ensure route path segments end with a trailing slash

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2102,7 +2102,7 @@ function buildRoutes() {
         component={make(() => import('sentry/views/profiling/profileSummary'))}
       />
       <Route
-        path="profile/:projectId/:eventId"
+        path="profile/:projectId/:eventId/"
         component={make(() => import('sentry/views/profiling/profileGroupProvider'))}
       >
         <Route

--- a/static/app/utils/recreateRoute.spec.tsx
+++ b/static/app/utils/recreateRoute.spec.tsx
@@ -16,7 +16,7 @@ const projectRoutes = [
   {childRoutes: []},
   {path: '/settings/', name: 'Settings', indexRoute: {}, childRoutes: []},
   {name: 'Organizations', path: ':orgId/', childRoutes: []},
-  {name: 'Projects', path: ':projectId/', childRoutes: []},
+  {name: 'Projects', path: ':projectId', childRoutes: []},
   {name: 'Alerts', path: 'alerts/'},
 ];
 
@@ -59,7 +59,7 @@ describe('recreateRoute', function () {
       {path: 'api-keys/', name: 'API Key'},
     ];
 
-    expect(recreateRoute(r[4], {routes: r, params})).toBe('/foo/bar');
+    expect(recreateRoute(r[4], {routes: r, params})).toBe('/foo/bar/');
   });
 
   it('returns correct path to a string (at the end of the routes)', function () {

--- a/static/app/utils/recreateRoute.tsx
+++ b/static/app/utils/recreateRoute.tsx
@@ -29,7 +29,13 @@ type Options = {
  */
 export default function recreateRoute(to: string | PlainRoute, options: Options): string {
   const {routes, params, location, stepBack} = options;
-  const paths = routes.map(({path}) => path || '');
+  const paths = routes.map(({path}) => {
+    path = path || '';
+    if (path.length > 0 && !path.endsWith('/')) {
+      path = `${path}/`;
+    }
+    return path;
+  });
   let lastRootIndex: number;
   let routeIndex: number | undefined;
 


### PR DESCRIPTION
When using `recreateRoute()` to reconstruct route paths, we're not guaranteed that the `path` prop ends in a trailing slash.

I've gone ahead and added a trailing slash for `profile/:projectId/:eventId/`.

-----

For customer domains, we attempt to reconstruct the route path, strip out `/organizations/:orgId/`, and perform the redirect to the new route path. Thus, we transformed `/organizations/:orgId/profiling/profile/:projectId/:eventId/flamechart/` to `/profiling/profile/:projectId/:eventIdflamechart/`, which is incorrect.

Fixes JAVASCRIPT-2BBY.