### PR TITLE
perf(issue-search): optimize querying on perf issues by using hasAny on transaction.group_id 

### DIFF
--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -171,6 +171,9 @@ def _query_params_for_perf(
                 ],
                 *selected_columns,
             ]
+        else:
+            aggregations = list(aggregations).copy() if aggregations else []
+            aggregations.insert(0, ["arrayJoin", ["group_ids"], "group_id"])
 
         params = query_partial(
             dataset=snuba.Dataset.Discover,

--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -18,7 +18,6 @@ ALL_ISSUE_TYPES = {gt.value for gt in GroupType}
 class IntermediateSearchQueryPartial(Protocol):
     def __call__(
         self,
-        # selected_columns: Sequence[str],
         groupby: Sequence[str],
         having: Sequence[Any],
         orderby: Sequence[str],

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -246,8 +246,6 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             SearchQueryPartial,
             functools.partial(
                 query_partial,
-                filter_keys=filters,
-                selected_columns=selected_columns,
                 groupby=["group_id"],
                 having=having,
                 orderby=orderby,
@@ -256,6 +254,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
 
         return SEARCH_STRATEGIES[group_category](
             pinned_query_partial,
+            selected_columns,
             aggregations,
             organization_id,
             project_ids,
@@ -296,9 +295,6 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                     organization_id=organization_id, id__in=environment_ids
                 ).values_list("name", flat=True)
             )
-
-        if group_ids:
-            filters["group_id"] = sorted(group_ids)
 
         referrer = "search_sample" if get_sample else "search"
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -199,6 +199,8 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
         organization_id: int,
         project_ids: Sequence[int],
         environments: Optional[Sequence[str]],
+        group_ids: Optional[Sequence[int]],
+        filters: Mapping[str, Sequence[int]],
         search_filters: Sequence[SearchFilter],
         sort_field: str,
         start: datetime,
@@ -244,6 +246,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             SearchQueryPartial,
             functools.partial(
                 query_partial,
+                filter_keys=filters,
                 selected_columns=selected_columns,
                 groupby=["group_id"],
                 having=having,
@@ -257,6 +260,8 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             organization_id,
             project_ids,
             environments,
+            group_ids,
+            filters,
             conditions,
         )
 
@@ -314,7 +319,6 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                 limit=limit,
                 offset=offset,
                 referrer=referrer,
-                filter_keys=filters,
                 totals=True,  # Needs to have totals_mode=after_having_exclusive so we get groups matching HAVING only
                 turbo=get_sample,  # Turn off FINAL when in sampling mode
                 sample=1,  # Don't use clickhouse sampling, even when in turbo mode.
@@ -329,6 +333,8 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                 organization_id,
                 project_ids,
                 environments,
+                group_ids,
+                filters,
                 snuba_search_filters,
                 sort_field,
                 start,

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -154,6 +154,7 @@ OPERATOR_TO_FUNCTION = {
     ">=": "greaterOrEquals",
     "<=": "lessOrEquals",
     "IS NULL": "isNull",
+    "hasAny": "hasAny",
 }
 FUNCTION_TO_OPERATOR = {v: k for k, v in OPERATOR_TO_FUNCTION.items()}
 
@@ -375,7 +376,7 @@ def get_snuba_column_name(name, dataset=Dataset.Events):
     the column is assumed to be a tag. If name is falsy or name is a quoted literal
     (e.g. "'name'"), leave unchanged.
     """
-    no_conversion = {"group_id", "project_id", "start", "end"}
+    no_conversion = {"group_id", "group_ids", "project_id", "start", "end"}
 
     if name in no_conversion:
         return name


### PR DESCRIPTION
Special optimization for searching on transactions for performance issues by doing a `hasAny` check instead of arrayJoining `group_ids` column and applying a filter after.

before query:
```
 SELECT (arrayJoin((group_ids AS _snuba_group_ids)) AS _snuba_group_id), _snuba_group_id, (multiply(toUInt64(max((finish_ts AS _snuba_timestamp))), 1000) AS _snuba_last_seen), (ifNull(uniq(_snuba_group_id), 0) AS _snuba_total)
  FROM transactions_local SAMPLE 1.0
 WHERE greaterOrEquals((finish_ts AS _snuba_finish_ts), toDateTime('2022-08-26T02:02:49', 'Universal'))
   AND less(_snuba_finish_ts, toDateTime('2022-11-24T02:03:49', 'Universal'))
   AND in((project_id AS _snuba_project_id), tuple(4550959674425346))
   AND equals(('transaction' AS _snuba_type), 'transaction')
   AND in(_snuba_project_id, tuple(4550959674425346))
   AND in(_snuba_group_id, (1, 2))
 GROUP BY _snuba_group_id WITH TOTALS
 ORDER BY _snuba_last_seen DESC,
          _snuba_group_id ASC
 LIMIT 150
OFFSET 0
```

after query:
```
SELECT (arrayJoin(arrayIntersect([1, 2], (group_ids AS _snuba_group_ids))) AS _snuba_group_id), (multiply(toUInt64(max((finish_ts AS _snuba_timestamp))), 1000) AS _snuba_last_seen), (ifNull(uniq(_snuba_group_id), 0) AS _snuba_total), _snuba_group_id
  FROM transactions_local SAMPLE 1.0
 WHERE greaterOrEquals((finish_ts AS _snuba_finish_ts), toDateTime('2022-08-26T02:01:32', 'Universal'))
   AND less(_snuba_finish_ts, toDateTime('2022-11-24T02:02:32', 'Universal'))
   AND in((project_id AS _snuba_project_id), tuple(4550959669379074))
   AND equals(hasAny(_snuba_group_ids, [1, 2]), 1)
   AND equals(('transaction' AS _snuba_type), 'transaction')
   AND in(_snuba_project_id, tuple(4550959669379074))
 GROUP BY _snuba_group_id WITH TOTALS
 ORDER BY _snuba_last_seen DESC,
          _snuba_group_id ASC
 LIMIT 150
OFFSET 0
```