### PR TITLE
feat(replays): Make the empty state of Console/Dom/Network tabs consistent

### DIFF
--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -1,8 +1,8 @@
-import {useRef} from 'react';
+import {useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import CompactSelect from 'sentry/components/compactSelect';
-import EmptyMessage from 'sentry/components/emptyMessage';
+import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {Panel} from 'sentry/components/panels';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
@@ -23,7 +23,6 @@ interface Props {
 }
 
 function Console({breadcrumbs, startTimestampMs = 0}: Props) {
-  const {currentHoverTime, currentTime} = useReplayContext();
   const containerRef = useRef<HTMLDivElement>(null);
   useCurrentItemScroller(containerRef);
 
@@ -31,40 +30,6 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
     useConsoleFilters({
       breadcrumbs,
     });
-
-  const currentUserAction = getPrevReplayEvent({
-    items,
-    targetTimestampMs: startTimestampMs + currentTime,
-    allowExact: true,
-    allowEqual: true,
-  });
-
-  const closestUserAction =
-    currentHoverTime !== undefined
-      ? getPrevReplayEvent({
-          items,
-          targetTimestampMs: startTimestampMs + (currentHoverTime ?? 0),
-          allowExact: true,
-          allowEqual: true,
-        })
-      : undefined;
-
-  const isOcurring = (breadcrumb: Crumb, closestBreadcrumb?: Crumb): boolean => {
-    if (!defined(currentHoverTime) || !defined(closestBreadcrumb)) {
-      return false;
-    }
-
-    const isCurrentBreadcrumb = closestBreadcrumb.id === breadcrumb.id;
-
-    // We don't want to hightlight the breadcrumb if it's more than 1 second away from the current hover time
-    const isMoreThanASecondOfDiff =
-      Math.trunc(currentHoverTime / 1000) >
-      Math.trunc(
-        relativeTimeInMs(closestBreadcrumb.timestamp || '', startTimestampMs) / 1000
-      );
-
-    return isCurrentBreadcrumb && !isMoreThanASecondOfDiff;
-  };
 
   return (
     <ConsoleContainer>
@@ -86,31 +51,96 @@ function Console({breadcrumbs, startTimestampMs = 0}: Props) {
         />
       </ConsoleFilters>
       <ConsoleMessageContainer ref={containerRef}>
-        {items.length > 0 ? (
-          <ConsoleTable>
-            {items.map((breadcrumb, i) => {
-              return (
-                <ConsoleMessage
-                  isActive={closestUserAction?.id === breadcrumb.id}
-                  isCurrent={currentUserAction?.id === breadcrumb.id}
-                  isOcurring={isOcurring(breadcrumb, closestUserAction)}
-                  startTimestampMs={startTimestampMs}
-                  key={breadcrumb.id}
-                  isLast={i === breadcrumbs.length - 1}
-                  breadcrumb={breadcrumb}
-                  hasOccurred={
-                    currentTime >=
-                    relativeTimeInMs(breadcrumb?.timestamp || '', startTimestampMs)
-                  }
-                />
-              );
-            })}
-          </ConsoleTable>
-        ) : (
-          <StyledEmptyMessage title={t('No results found.')} />
-        )}
+        <ConsoleContent
+          breadcrumbs={breadcrumbs}
+          items={items}
+          startTimestampMs={startTimestampMs}
+        />
       </ConsoleMessageContainer>
     </ConsoleContainer>
+  );
+}
+
+type ContentProps = {
+  breadcrumbs: Extract<Crumb, BreadcrumbTypeDefault>[];
+  items: Extract<Crumb, BreadcrumbTypeDefault>[];
+  startTimestampMs: number;
+};
+
+function ConsoleContent({items, breadcrumbs, startTimestampMs}: ContentProps) {
+  const {currentHoverTime, currentTime} = useReplayContext();
+
+  const currentUserAction = getPrevReplayEvent({
+    items,
+    targetTimestampMs: startTimestampMs + currentTime,
+    allowExact: true,
+    allowEqual: true,
+  });
+
+  const closestUserAction =
+    currentHoverTime !== undefined
+      ? getPrevReplayEvent({
+          items,
+          targetTimestampMs: startTimestampMs + (currentHoverTime ?? 0),
+          allowExact: true,
+          allowEqual: true,
+        })
+      : undefined;
+
+  const isOcurring = useCallback(
+    (breadcrumb: Crumb, closestBreadcrumb?: Crumb): boolean => {
+      if (!defined(currentHoverTime) || !defined(closestBreadcrumb)) {
+        return false;
+      }
+
+      const isCurrentBreadcrumb = closestBreadcrumb.id === breadcrumb.id;
+
+      // We don't want to hightlight the breadcrumb if it's more than 1 second away from the current hover time
+      const isMoreThanASecondOfDiff =
+        Math.trunc(currentHoverTime / 1000) >
+        Math.trunc(
+          relativeTimeInMs(closestBreadcrumb.timestamp || '', startTimestampMs) / 1000
+        );
+
+      return isCurrentBreadcrumb && !isMoreThanASecondOfDiff;
+    },
+    [startTimestampMs, currentHoverTime]
+  );
+
+  if (breadcrumbs.length === 0) {
+    return (
+      <EmptyStateWarning withIcon={false} small>
+        {t('No console messages recorded')}
+      </EmptyStateWarning>
+    );
+  }
+  if (items.length === 0) {
+    return (
+      <EmptyStateWarning withIcon small>
+        {t('No results found')}
+      </EmptyStateWarning>
+    );
+  }
+  return (
+    <ConsoleTable>
+      {items.map((breadcrumb, i) => {
+        return (
+          <ConsoleMessage
+            isActive={closestUserAction?.id === breadcrumb.id}
+            isCurrent={currentUserAction?.id === breadcrumb.id}
+            isOcurring={isOcurring(breadcrumb, closestUserAction)}
+            startTimestampMs={startTimestampMs}
+            key={breadcrumb.id}
+            isLast={i === breadcrumbs.length - 1}
+            breadcrumb={breadcrumb}
+            hasOccurred={
+              currentTime >=
+              relativeTimeInMs(breadcrumb?.timestamp || '', startTimestampMs)
+            }
+          />
+        );
+      })}
+    </ConsoleTable>
   );
 }
 
@@ -134,10 +164,6 @@ const ConsoleMessageContainer = styled(FluidHeight)`
   border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.border};
   box-shadow: ${p => p.theme.dropShadowLight};
-`;
-
-const StyledEmptyMessage = styled(EmptyMessage)`
-  align-items: center;
 `;
 
 const ConsoleTable = styled(Panel)`

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -153,11 +153,17 @@ function DomMutations({replay}: Props) {
                 height={height}
                 overscanRowCount={5}
                 rowCount={items.length}
-                noRowsRenderer={() => (
-                  <EmptyStateWarning withIcon={false} small>
-                    {t('No related DOM Events recorded')}
-                  </EmptyStateWarning>
-                )}
+                noRowsRenderer={() =>
+                  actions.length === 0 ? (
+                    <EmptyStateWarning withIcon={false} small>
+                      {t('No related DOM events recorded')}
+                    </EmptyStateWarning>
+                  ) : (
+                    <EmptyStateWarning withIcon small>
+                      {t('No results found')}
+                    </EmptyStateWarning>
+                  )
+                }
                 rowHeight={cache.rowHeight}
                 rowRenderer={renderRow}
                 width={width}

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -347,11 +347,17 @@ function NetworkList({replayRecord, networkSpans}: Props) {
                   setScrollBarWidth(0);
                 }
               }}
-              noContentRenderer={() => (
-                <EmptyStateWarning withIcon small>
-                  {t('No related network requests found.')}
-                </EmptyStateWarning>
-              )}
+              noContentRenderer={() =>
+                networkSpans.length === 0 ? (
+                  <EmptyStateWarning withIcon={false} small>
+                    {t('No related network requests recorded')}
+                  </EmptyStateWarning>
+                ) : (
+                  <EmptyStateWarning withIcon small>
+                    {t('No results found')}
+                  </EmptyStateWarning>
+                )
+              }
             />
           )}
         </AutoSizer>


### PR DESCRIPTION
All three custom tabs are consistent in showing "nothing recorded" messages or "no search results". If nothing is recorded and you do a search, you'll still see "nothing recorded".

| Nothing Captured | No search results |
| --- | --- |
| <img width="677" alt="SCR-20221122-rmz" src="https://user-images.githubusercontent.com/187460/203466566-7214681c-ee85-4fe6-92d8-a86cde31caeb.png"> | <img width="679" alt="SCR-20221122-rn9" src="https://user-images.githubusercontent.com/187460/203466563-66737784-fcea-4d85-9766-4aafe59850c7.png"> |
| <img width="679" alt="SCR-20221122-rmx" src="https://user-images.githubusercontent.com/187460/203466574-4f135ea9-f979-437e-a0de-11fcc40d109e.png"> | <img width="679" alt="SCR-20221122-rn6" src="https://user-images.githubusercontent.com/187460/203466576-ce266988-1eca-4a28-8940-dcf677d1cae8.png"> |
| <img width="691" alt="SCR-20221122-rmv" src="https://user-images.githubusercontent.com/187460/203466579-17a2a138-33f5-47fb-bd9e-48ad7a669890.png"> | <img width="678" alt="SCR-20221122-rn4" src="https://user-images.githubusercontent.com/187460/203466581-e51763dd-6cd5-4c9b-8a67-1ae1ad5be09a.png"> |


Fixes #41406

