### PR TITLE
feat(replays): Add a Tooltip to the Replay CurrentUrl bar

### DIFF
--- a/static/app/components/replays/replayCurrentUrl.tsx
+++ b/static/app/components/replays/replayCurrentUrl.tsx
@@ -5,6 +5,7 @@ import TextCopyInput, {
   StyledCopyButton,
   StyledInput,
 } from 'sentry/components/textCopyInput';
+import Tooltip from 'sentry/components/tooltip';
 import space from 'sentry/styles/space';
 import getCurrentUrl from 'sentry/utils/replays/getCurrentUrl';
 
@@ -21,10 +22,11 @@ function ReplayCurrentUrl() {
   const replayRecord = replay.getReplay();
   const crumbs = replay.getRawCrumbs();
 
+  const url = getCurrentUrl(replayRecord, crumbs, currentTime);
   return (
-    <UrlCopyInput size="sm">
-      {getCurrentUrl(replayRecord, crumbs, currentTime)}
-    </UrlCopyInput>
+    <Tooltip title={url} isHoverable showOnlyOnOverflow>
+      <UrlCopyInput size="sm">{url}</UrlCopyInput>
+    </Tooltip>
   );
 }
 


### PR DESCRIPTION
<img width="685" alt="SCR-20221122-rue" src="https://user-images.githubusercontent.com/187460/203617385-11c6d321-3cb6-4c6c-b48a-7211d6eee57d.png">

Fixes #41297

