### PR TITLE
ref(processor): Fold occurences of property names in function_name

### DIFF
--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -1061,8 +1061,8 @@ class JavaScriptStacktraceProcessor(StacktraceProcessor):
                 # The tokens are 1-indexed.
                 new_frame["lineno"] = token.line
                 new_frame["colno"] = token.col
-                new_frame["function"] = get_function_for_token(
-                    new_frame, token, processable_frame.previous_frame
+                new_frame["function"] = fold_function_name(
+                    get_function_for_token(new_frame, token, processable_frame.previous_frame)
                 )
 
                 filename = token.src

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -7,6 +7,7 @@ import time
 import zlib
 from datetime import datetime
 from io import BytesIO
+from itertools import groupby
 from os.path import splitext
 from typing import IO, Optional, Tuple
 from urllib.parse import urlsplit
@@ -841,6 +842,36 @@ def get_function_for_token(frame, token, previous_frame=None):
 
     # Otherwise fallback to the old, minified name.
     return frame_function_name
+
+
+def fold_function_name(function_name):
+    """
+    Fold multiple consecutive occurences of the same property name into a single group, excluding the last component.
+
+    foo | foo
+    foo.foo | foo.foo
+    foo.foo.foo | {foo#2}.foo
+    bar.foo.foo | bar.foo.foo
+    bar.foo.foo.foo | bar.{foo#2}.foo
+    bar.foo.foo.onError | bar.{foo#2}.onError
+    bar.bar.bar.foo.foo.onError | {bar#3}.{foo#2}.onError
+    bar.foo.foo.bar.bar.onError | bar.{foo#2}.{bar#2}.onError
+    """
+
+    parts = function_name.split(".")
+
+    if len(parts) == 1:
+        return function_name
+
+    tail = parts.pop()
+    grouped = [list(g) for _, g in groupby(parts)]
+
+    def format_groups(p):
+        if len(p) == 1:
+            return p[0]
+        return f"\u007b{p[0]}#{len(p)}\u007d"
+
+    return f'{".".join(map(format_groups, grouped))}.{tail}'
 
 
 class JavaScriptStacktraceProcessor(StacktraceProcessor):


### PR DESCRIPTION
Fold multiple consecutive occurrences of the same property name into a single group, excluding the last component.

```
foo | foo
foo.foo | foo.foo
foo.foo.foo | {foo#2}.foo
bar.foo.foo | bar.foo.foo
bar.foo.foo.foo | bar.{foo#2}.foo
bar.foo.foo.onError | bar.{foo#2}.onError
bar.bar.bar.foo.foo.onError | {bar#3}.{foo#2}.onError
bar.foo.foo.bar.bar.onError | bar.{foo#2}.{bar#2}.onError
```

This is mostly done for React, where some frames have function name like `<object>.children.children.children.onSubmitError` when function is a prop passed down the component stack.