### PR TITLE
feat(discover-quick-context): Fixed page break from opening aggregates

### DIFF
--- a/static/app/views/eventsV2/table/quickContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext.tsx
@@ -101,11 +101,13 @@ function getHoverHeader(dataRow: EventData, contextType: ContextType) {
       );
     case ContextType.EVENT:
       return (
-        <HoverHeader
-          title={t('Event ID')}
-          copyLabel={getShortEventId(dataRow.id)}
-          copyContent={dataRow.id}
-        />
+        dataRow.id && (
+          <HoverHeader
+            title={t('Event ID')}
+            copyLabel={getShortEventId(dataRow.id)}
+            copyContent={dataRow.id}
+          />
+        )
       );
     default:
       return null;


### PR DESCRIPTION
Problem: Undefined event id passed to helper.

Page breaks when you open group: [here](https://sentry.io/organizations/sentry/discover/homepage/?field=title&field=issue&field=count%28%29&id=16351&interval=15m&name=BlahBlah&project=1&query=event.type%3Aerror+issue%3ASENTRY-SFG&sort=-title&statsPeriod=24h&topEvents=5&yAxis=count%28%29)