### PR TITLE
ref(perf-issues): Remove http span from slow span detector

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -262,10 +262,6 @@ def get_detection_settings(project_id: Optional[str] = None):
                 "duration_threshold": 1000.0,  # ms
                 "allowed_span_ops": ["db"],
             },
-            {
-                "duration_threshold": 2000.0,  # ms
-                "allowed_span_ops": ["http"],
-            },
         ],
         DetectorType.LONG_TASK_SPANS: [
             {

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -326,7 +326,9 @@ class PerformanceDetectionTest(unittest.TestCase):
         )
 
     def test_calls_partial_span_op_allowed(self):
-        span_event = create_event([create_span("http.client", 2001.0, "http://example.com")] * 1)
+        span_event = create_event(
+            [create_span("db.query", 2001.0, "SELECT something FROM something_else")] * 1
+        )
 
         sdk_span_mock = Mock()
 


### PR DESCRIPTION
We're going to be focusing on slow db spans instead of looking at both db and http. DB spans are more actionable for a performance issue and we have some plans specific to issue creation for slow db spans 