### PR TITLE
fix(alerts): Remove request for specific project slug

### DIFF
--- a/static/app/views/alerts/builder/projectProvider.tsx
+++ b/static/app/views/alerts/builder/projectProvider.tsx
@@ -32,14 +32,7 @@ function AlertBuilderProjectProvider(props: Props) {
   const projectId = params.projectId || props.location.query.project;
   const useFirstProject = projectId === undefined;
 
-  // calling useProjects() without args fetches all projects
-  const {projects, initiallyLoaded, fetching, fetchError} = useProjects(
-    useFirstProject
-      ? undefined
-      : {
-          slugs: [projectId],
-        }
-  );
+  const {projects, initiallyLoaded, fetching, fetchError} = useProjects();
   const project = useFirstProject
     ? projects.find(p => p.isMember) ?? (projects.length && projects[0])
     : projects.find(({slug}) => slug === projectId);


### PR DESCRIPTION
We already load all projects on page load, we don't need to make another request for a specific project slug on page load. I think this is causing a race condition for orgs with many projects