### PR TITLE
fix(ecosystem): Use integration key instead of name in link

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.spec.tsx
@@ -128,5 +128,9 @@ describe('StacktraceLinkModal', () => {
     expect(
       screen.getByText('We don’t have access to that', {exact: false})
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'add your repo.'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/integrations/github/1/'
+    );
   });
 });

--- a/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLinkModal.tsx
@@ -132,7 +132,7 @@ function StacktraceLinkModal({
                           onClick={onManualSetup}
                           to={
                             hasOneSourceCodeIntegration
-                              ? `/settings/${organization.slug}/integrations/${sourceCodeProviders[0].provider.name}/${sourceCodeProviders[0].id}/`
+                              ? `/settings/${organization.slug}/integrations/${sourceCodeProviders[0].provider.key}/${sourceCodeProviders[0].id}/`
                               : `/settings/${organization.slug}/integrations/`
                           }
                         />


### PR DESCRIPTION
name is `GitHub` while key is `github`, we wanted the key here.
