### PR TITLE
bug(issues): Remove the cursor query param when navigating Issue tabs

### DIFF
--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.spec.tsx
@@ -1,0 +1,119 @@
+import {browserHistory} from 'react-router';
+import type {Location} from 'history';
+
+import {reactHooks} from 'sentry-test/reactTestingLibrary';
+
+import useCleanQueryParamsOnRouteLeave, {
+  handleRouteLeave,
+} from './useCleanQueryParamsOnRouteLeave';
+import {useLocation} from './useLocation';
+
+jest.mock('react-router');
+jest.mock('./useLocation');
+
+const MockBrowserHistoryListen = browserHistory.listen as jest.MockedFunction<
+  typeof browserHistory.listen
+>;
+const MockBrowserHistoryReplace = browserHistory.replace as jest.MockedFunction<
+  typeof browserHistory.replace
+>;
+
+const MockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
+
+MockUseLocation.mockReturnValue({
+  pathname: '/home',
+} as Location);
+
+type QueryParams = {cursor: string; limit: number; project: string};
+
+describe('useCleanQueryParamsOnRouteLeave', () => {
+  beforeEach(() => {
+    MockBrowserHistoryListen.mockReset();
+    MockBrowserHistoryReplace.mockReset();
+  });
+
+  it('should listen to browserHistory changes and stop on unmount', () => {
+    const unsubscriber = jest.fn();
+    MockBrowserHistoryListen.mockReturnValue(unsubscriber);
+
+    const {unmount} = reactHooks.renderHook(useCleanQueryParamsOnRouteLeave, {
+      initialProps: {
+        fieldsToClean: ['cursor'],
+      },
+    });
+
+    expect(MockBrowserHistoryListen).toHaveBeenCalled();
+    expect(unsubscriber).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(unsubscriber).toHaveBeenCalled();
+  });
+
+  it('should not update the history if the pathname is unchanged', () => {
+    handleRouteLeave({
+      fieldsToClean: ['cursor'],
+      newLocation: {
+        pathname: '/home',
+        query: {},
+      } as Location,
+      oldPathname: '/home',
+    });
+
+    expect(MockBrowserHistoryReplace).not.toHaveBeenCalled();
+  });
+
+  it('should not update the history if the pathname is changing, but fieldsToClean are undefined', () => {
+    handleRouteLeave({
+      fieldsToClean: ['cursor'],
+      newLocation: {
+        pathname: '/next',
+        query: {},
+      } as Location,
+      oldPathname: '/home',
+    });
+
+    expect(MockBrowserHistoryReplace).not.toHaveBeenCalled();
+  });
+
+  it('should update the history when the path is changing and some fieldsToClean are set', () => {
+    handleRouteLeave({
+      fieldsToClean: ['cursor', 'limit'],
+      newLocation: {
+        pathname: '/next',
+        query: {
+          cursor: '0:1:0',
+          limit: 5,
+        },
+      } as Location<QueryParams>,
+      oldPathname: '/home',
+    });
+
+    expect(MockBrowserHistoryReplace).toHaveBeenCalledWith({
+      pathname: '/next',
+      query: {},
+    });
+  });
+
+  it('should leave other query params alone when the path is changing and something is filtered out', () => {
+    handleRouteLeave({
+      fieldsToClean: ['cursor', 'limit'],
+      newLocation: {
+        pathname: '/next',
+        query: {
+          cursor: '0:1:0',
+          limit: 5,
+          project: '123',
+        },
+      } as Location<QueryParams>,
+      oldPathname: '/home',
+    });
+
+    expect(MockBrowserHistoryReplace).toHaveBeenCalledWith({
+      pathname: '/next',
+      query: {
+        project: '123',
+      },
+    });
+  });
+});

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect} from 'react';
 import {browserHistory} from 'react-router';
-import {Location} from 'history';
+import type {Location} from 'history';
 
 import {useLocation} from 'sentry/utils/useLocation';
 
@@ -25,7 +25,7 @@ export function handleRouteLeave<Q extends object>({
     newLocation.pathname === oldPathname ||
     (newLocation.pathname !== oldPathname && !hasSomeValues)
   ) {
-    return true;
+    return;
   }
 
   // Removes fields from the URL on route leave so that the parameters will
@@ -42,8 +42,6 @@ export function handleRouteLeave<Q extends object>({
     pathname: newLocation.pathname,
     query,
   });
-
-  return false;
 }
 
 function useCleanQueryParamsOnRouteLeave({fieldsToClean}: Opts) {
@@ -51,7 +49,7 @@ function useCleanQueryParamsOnRouteLeave({fieldsToClean}: Opts) {
 
   const onRouteLeave = useCallback(
     newLocation => {
-      return handleRouteLeave({
+      handleRouteLeave({
         fieldsToClean,
         newLocation,
         oldPathname: location.pathname,

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -1,0 +1,68 @@
+import {useCallback, useEffect} from 'react';
+import {browserHistory} from 'react-router';
+import {Location} from 'history';
+
+import {useLocation} from 'sentry/utils/useLocation';
+
+type Opts = {
+  fieldsToClean: string[];
+};
+
+export function handleRouteLeave<Q extends object>({
+  fieldsToClean,
+  newLocation,
+  oldPathname,
+}: {
+  fieldsToClean: string[];
+  newLocation: Location<Q>;
+  oldPathname: string;
+}) {
+  const hasSomeValues = fieldsToClean.some(
+    field => newLocation.query[field] !== undefined
+  );
+
+  if (
+    newLocation.pathname === oldPathname ||
+    (newLocation.pathname !== oldPathname && !hasSomeValues)
+  ) {
+    return true;
+  }
+
+  // Removes fields from the URL on route leave so that the parameters will
+  // not interfere with other pages
+  const query = fieldsToClean.reduce(
+    (newQuery, field) => {
+      newQuery[field] = undefined;
+      return newQuery;
+    },
+    {...newLocation.query}
+  );
+
+  browserHistory.replace({
+    pathname: newLocation.pathname,
+    query,
+  });
+
+  return false;
+}
+
+function useCleanQueryParamsOnRouteLeave({fieldsToClean}: Opts) {
+  const location = useLocation();
+
+  const onRouteLeave = useCallback(
+    newLocation => {
+      return handleRouteLeave({
+        fieldsToClean,
+        newLocation,
+        oldPathname: location.pathname,
+      });
+    },
+    [location.pathname, fieldsToClean]
+  );
+
+  useEffect(() => {
+    return browserHistory.listen(onRouteLeave);
+  }, [onRouteLeave]);
+}
+
+export default useCleanQueryParamsOnRouteLeave;

--- a/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
+++ b/static/app/utils/useCleanQueryParamsOnRouteLeave.tsx
@@ -21,10 +21,7 @@ export function handleRouteLeave<Q extends object>({
     field => newLocation.query[field] !== undefined
   );
 
-  if (
-    newLocation.pathname === oldPathname ||
-    (newLocation.pathname !== oldPathname && !hasSomeValues)
-  ) {
+  if (newLocation.pathname === oldPathname || !hasSomeValues) {
     return;
   }
 

--- a/static/app/views/organizationGroupDetails/groupEvents.tsx
+++ b/static/app/views/organizationGroupDetails/groupEvents.tsx
@@ -19,6 +19,7 @@ import space from 'sentry/styles/space';
 import {Group, Organization} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import parseApiError from 'sentry/utils/parseApiError';
+import {handleRouteLeave} from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 
@@ -76,6 +77,22 @@ class GroupEvents extends Component<Props, State> {
       );
     }
   }
+
+  UNSAFE_componentDidMount() {
+    this._unsubscribeHandleRouteLeave = browserHistory.listen(newLocation =>
+      handleRouteLeave({
+        fieldsToClean: ['cursor'],
+        newLocation,
+        oldPathname: this.props.location.pathname,
+      })
+    );
+  }
+
+  UNSAFE_componentWillUnmount() {
+    this._unsubscribeHandleRouteLeave?.();
+  }
+
+  _unsubscribeHandleRouteLeave: undefined | ReturnType<typeof browserHistory.listen>;
 
   handleSearch = (query: string) => {
     const targetQueryParams = {...this.props.location.query};

--- a/static/app/views/organizationGroupDetails/grouping/grouping.tsx
+++ b/static/app/views/organizationGroupDetails/grouping/grouping.tsx
@@ -1,5 +1,5 @@
 import {Fragment, useEffect, useState} from 'react';
-import {browserHistory, InjectedRouter} from 'react-router';
+import {InjectedRouter} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 import debounce from 'lodash/debounce';
@@ -21,6 +21,7 @@ import {BaseGroup, Group, Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import toArray from 'sentry/utils/toArray';
+import useCleanQueryParamsOnRouteLeave from 'sentry/utils/useCleanQueryParamsOnRouteLeave';
 import withApi from 'sentry/utils/withApi';
 
 import ErrorMessage from './errorMessage';
@@ -73,46 +74,22 @@ function Grouping({api, groupId, location, organization, router, projSlug}: Prop
 
   const [pagination, setPagination] = useState('');
 
+  useCleanQueryParamsOnRouteLeave({fieldsToClean: ['cursor', 'level']});
   useEffect(() => {
     fetchGroupingLevels();
-    return browserHistory.listen(handleRouteLeave);
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     setSecondGrouping();
-  }, [groupingLevels]);
+  }, [groupingLevels]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     updateUrlWithNewLevel();
-  }, [activeGroupingLevel]);
+  }, [activeGroupingLevel]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     fetchGroupingLevelDetails();
-  }, [activeGroupingLevel, cursor]);
-
-  function handleRouteLeave(newLocation: Location<{cursor?: string; level?: number}>) {
-    if (
-      newLocation.pathname === location.pathname ||
-      (newLocation.pathname !== location.pathname &&
-        newLocation.query.cursor === undefined &&
-        newLocation.query.level === undefined)
-    ) {
-      return true;
-    }
-
-    // Removes cursor and level from the URL on route leave
-    // so that the parameters will not interfere with other pages
-    browserHistory.replace({
-      pathname: newLocation.pathname,
-      query: {
-        ...newLocation.query,
-        cursor: undefined,
-        level: undefined,
-      },
-    });
-
-    return false;
-  }
+  }, [activeGroupingLevel, cursor]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleSetActiveGroupingLevel = debounce((groupingLevelId: number | '') => {
     setActiveGroupingLevel(Number(groupingLevelId));


### PR DESCRIPTION
Fixes issue where switching in/out of the Issue>All Events tab can cause query params to persist on the next page.

**Context**
These three tabs all use the `?cursor=` query param: 'All Events', 'Grouping', Replays'. When you switch between the tabs the cursor needs to be reset; otherwise you could be looking at page 10 of the All Events tab, but there aren't even 10 pages in the Grouping table.

**Current State**
To solve this problem the Grouping tab had two bits of code: the `handleRouteLeave()` callback and also `updateUrlWithNewLevel()`. This meant that moving _out_ of "Grouping" into another Tab would strip the grouping specific query params. Also mvoing _into_ "Grouping" would reset the params if both were not set, so Grouping could start over.

This worked when only All Events and Grouping used the same query param. But now that Replays tab is here there are more combinations of to/from links. 
For example, a weird interaction that's happening right now is:
1. Visit 'All Events' Tab
  - Paginate to to the next set of data
2. Visit 'Merged Issues' Tab 
  - notice that `?cursor` is still in the url
3. Go back to 'All Events' 
  - notice that you're still on page 2!
4. Visit 'Grouping'
  - notice you're at page 1
  - Paginate to the next set of data (might need use the "more issues" slider)
5. Visit 'Merged Issues' again
  - notice that `?cursor` is _not_ in the url
6. Go back to 'Grouping'
  - notice that you're back on page 1


**What's changed**
This PR makes it so that each of these three pages adopts the `handleRouteLeave()` method so that query params don't bleed from one tab to the next.

All three tabs need to use this, but i'll add it to Replays in a followup PR because there's some other issues with pagination there right now. #merge-conflicts

Fixes #41791