### PR TITLE
feat(mobile-exp): Tags endpoint allow limit param

### DIFF
--- a/src/sentry/api/endpoints/group_tags.py
+++ b/src/sentry/api/endpoints/group_tags.py
@@ -27,10 +27,14 @@ class GroupTagsEndpoint(GroupEndpoint):  # type: ignore
         # There are 2 use-cases for this method. For the 'Tags' tab we
         # get the top 10 values, for the tag distribution bars we get 9
         # This should ideally just be specified by the client
-        if keys:
-            value_limit = 9
+        limit = request.GET.get("limit")
+        if limit is not None:
+            value_limit = int(limit)
         else:
-            value_limit = 10
+            if keys:
+                value_limit = 9
+            else:
+                value_limit = 10
 
         environment_ids = [e.id for e in get_environments(request, group.project.organization)]
 

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -240,3 +240,46 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         assert top_values[1]["readable"] == "iPhone 13 Pro Max"
         assert top_values[2]["value"] == "random-model"
         assert "readable" not in top_values[2]
+
+    def test_limit(self):
+        for _ in range(3):
+            self.store_event(
+                data={
+                    "fingerprint": ["group-1"],
+                    "tags": {"os": "iOS"},
+                    "timestamp": iso_format(before_now(minutes=1)),
+                },
+                project_id=self.project.id,
+            )
+        for _ in range(2):
+            self.store_event(
+                data={
+                    "fingerprint": ["group-1"],
+                    "tags": {"os": "android"},
+                    "timestamp": iso_format(before_now(minutes=1)),
+                },
+                project_id=self.project.id,
+            )
+        event = self.store_event(
+            data={
+                "fingerprint": ["group-1"],
+                "tags": {"os": "windows"},
+                "timestamp": iso_format(before_now(minutes=1)),
+            },
+            project_id=self.project.id,
+        )
+
+        self.login_as(user=self.user)
+
+        url = f"/api/0/issues/{event.group.id}/tags/?limit=2&key=os"
+        response = self.client.get(url, format="json")
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["key"] == "os"
+        assert response.data[0]["totalValues"] == 6
+
+        top_values = sorted(response.data[0]["topValues"], key=lambda r: r["value"])
+        assert len(top_values) == 2
+        assert top_values[0]["value"] == "android"
+        assert top_values[1]["value"] == "iOS"


### PR DESCRIPTION
Allows passing a limit query param to limit number of tag results. This will be used for tag summary.