### PR TITLE
feat(hybrid-cloud): Add isValidOrgSlug

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -280,5 +280,3 @@ export const SENTRY_RELEASE_VERSION = process.env.SENTRY_RELEASE_VERSION;
 export const DEFAULT_ERROR_JSON = {
   detail: t('Unknown error. Please try again.'),
 };
-
-export const ORG_SLUG_REGEX = new RegExp('^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$');

--- a/static/app/utils/isValidOrgSlug.spec.tsx
+++ b/static/app/utils/isValidOrgSlug.spec.tsx
@@ -1,0 +1,14 @@
+import isValidOrgSlug from './isValidOrgSlug';
+
+describe('isValidOrgSlug', function () {
+  it('validates org slugs', function () {
+    // valid org slugs
+    expect(isValidOrgSlug('CaNaDa')).toBe(true);
+    expect(isValidOrgSlug('foobar123')).toBe(true);
+    expect(isValidOrgSlug('albertos-apples')).toBe(true);
+
+    expect(isValidOrgSlug('albertos_apples')).toBe(false);
+    expect(isValidOrgSlug('sentry-')).toBe(false);
+    expect(isValidOrgSlug('-sentry')).toBe(false);
+  });
+});

--- a/static/app/utils/isValidOrgSlug.spec.tsx
+++ b/static/app/utils/isValidOrgSlug.spec.tsx
@@ -13,5 +13,6 @@ describe('isValidOrgSlug', function () {
     expect(isValidOrgSlug('-sentry')).toBe(false);
     expect(isValidOrgSlug('-')).toBe(false);
     expect(isValidOrgSlug('_')).toBe(false);
+    expect(isValidOrgSlug('')).toBe(false);
   });
 });

--- a/static/app/utils/isValidOrgSlug.spec.tsx
+++ b/static/app/utils/isValidOrgSlug.spec.tsx
@@ -3,6 +3,7 @@ import isValidOrgSlug from './isValidOrgSlug';
 describe('isValidOrgSlug', function () {
   it('validates org slugs', function () {
     // valid org slugs
+    expect(isValidOrgSlug('a')).toBe(true);
     expect(isValidOrgSlug('CaNaDa')).toBe(true);
     expect(isValidOrgSlug('foobar123')).toBe(true);
     expect(isValidOrgSlug('albertos-apples')).toBe(true);
@@ -10,5 +11,7 @@ describe('isValidOrgSlug', function () {
     expect(isValidOrgSlug('albertos_apples')).toBe(false);
     expect(isValidOrgSlug('sentry-')).toBe(false);
     expect(isValidOrgSlug('-sentry')).toBe(false);
+    expect(isValidOrgSlug('-')).toBe(false);
+    expect(isValidOrgSlug('_')).toBe(false);
   });
 });

--- a/static/app/utils/isValidOrgSlug.tsx
+++ b/static/app/utils/isValidOrgSlug.tsx
@@ -2,7 +2,7 @@
 // See: https://bugs.webkit.org/show_bug.cgi?id=174931
 //
 // The ^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$ regex should almost match the above regex.
-const ORG_SLUG_REGEX = new RegExp('^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$');
+const ORG_SLUG_REGEX = new RegExp('^[a-zA-Z0-9][a-zA-Z0-9-]*$');
 
 function isValidOrgSlug(orgSlug: string): boolean {
   return (

--- a/static/app/utils/isValidOrgSlug.tsx
+++ b/static/app/utils/isValidOrgSlug.tsx
@@ -1,0 +1,16 @@
+// The isValidOrgSlug function should match the behaviour of this regular expression: ^[a-zA-Z0-9][a-zA-Z0-9-]*(?<!-)$
+// See: https://bugs.webkit.org/show_bug.cgi?id=174931
+//
+// The ^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$ regex should almost match the above regex.
+const ORG_SLUG_REGEX = new RegExp('^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$');
+
+function isValidOrgSlug(orgSlug: string): boolean {
+  return (
+    !orgSlug.startsWith('-') &&
+    !orgSlug.endsWith('-') &&
+    !orgSlug.includes('_') &&
+    ORG_SLUG_REGEX.test(orgSlug)
+  );
+}
+
+export default isValidOrgSlug;

--- a/static/app/utils/isValidOrgSlug.tsx
+++ b/static/app/utils/isValidOrgSlug.tsx
@@ -6,6 +6,7 @@ const ORG_SLUG_REGEX = new RegExp('^[a-zA-Z0-9][a-zA-Z0-9-]*$');
 
 function isValidOrgSlug(orgSlug: string): boolean {
   return (
+    orgSlug.length > 0 &&
     !orgSlug.startsWith('-') &&
     !orgSlug.endsWith('-') &&
     !orgSlug.includes('_') &&

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -12,12 +12,13 @@ import {initApiClientErrorHandling} from 'sentry/api';
 import ErrorBoundary from 'sentry/components/errorBoundary';
 import GlobalModal from 'sentry/components/globalModal';
 import Indicators from 'sentry/components/indicators';
-import {DEPLOY_PREVIEW_CONFIG, EXPERIMENTAL_SPA, ORG_SLUG_REGEX} from 'sentry/constants';
+import {DEPLOY_PREVIEW_CONFIG, EXPERIMENTAL_SPA} from 'sentry/constants';
 import AlertStore from 'sentry/stores/alertStore';
 import ConfigStore from 'sentry/stores/configStore';
 import HookStore from 'sentry/stores/hookStore';
 import OrganizationsStore from 'sentry/stores/organizationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import isValidOrgSlug from 'sentry/utils/isValidOrgSlug';
 import {onRenderCallback} from 'sentry/utils/performanceForSentry';
 import useApi from 'sentry/utils/useApi';
 import {useColorscheme} from 'sentry/utils/useColorscheme';
@@ -100,7 +101,7 @@ function App({children, params}: Props) {
 
   const {sentryUrl} = ConfigStore.get('links');
   const {orgId} = params;
-  const isOrgSlugValid = orgId ? ORG_SLUG_REGEX.test(orgId) : true;
+  const isOrgSlugValid = orgId ? isValidOrgSlug(orgId) : true;
 
   useEffect(() => {
     if (orgId === undefined) {


### PR DESCRIPTION
This pull request adds the `isValidOrgSlug` utility function that is used in favour of `ORG_SLUG_REGEX` that was added in https://github.com/getsentry/sentry/pull/41547.

We do this since negative lookbacks are not supported in Safari. See: https://bugs.webkit.org/show_bug.cgi?id=174931

Fixes JAVASCRIPT-2BCD