### PR TITLE
feat(commit-context): Allow committers from outside the org to be Suspect Committers

### DIFF
--- a/src/sentry/api/endpoints/event_file_committers.py
+++ b/src/sentry/api/endpoints/event_file_committers.py
@@ -46,12 +46,12 @@ class EventFileCommittersEndpoint(ProjectEndpoint):
             if not owner:
                 return Response({"committers": []})
             commit = Commit.objects.get(id=owner.context.get("commitId"))
-
+            author = serialize(owner.user) if owner.user else {"email": commit.author.email}
             return Response(
                 {
                     "committers": [
                         {
-                            "author": serialize(owner.user),
+                            "author": author,
                             "commits": [
                                 serialize(commit, serializer=CommitSerializer(exclude=["author"]))
                             ],

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -100,7 +100,7 @@ class ActorTuple(namedtuple("Actor", "id type")):
         return f"{self.type.__name__.lower()}:{self.id}"
 
     @classmethod
-    def from_actor_identifier(cls, actor_identifier: Union[int, str]) -> "ActorTuple":
+    def from_actor_identifier(cls, actor_identifier: Union[int, str, None]) -> "ActorTuple":
         from sentry.models import Team, User
         from sentry.utils.auth import find_users
 
@@ -116,6 +116,10 @@ class ActorTuple(namedtuple("Actor", "id type")):
             "maiseythedog" -> look up User by username
             "maisey@dogsrule.com" -> look up User by primary email
         """
+
+        if actor_identifier is None:
+            return None
+
         # If we have an integer, fall back to assuming it's a User
         if isinstance(actor_identifier, int):
             return cls(actor_identifier, User)

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -265,23 +265,23 @@ class ProjectOwnership(Model):
                     "rule": (issue_owner.context or {}).get("rule", ""),
                 }
             )
-
-            assignment = GroupAssignee.objects.assign(
-                event.group,
-                owner.resolve(),
-                create_only=True,
-                extra=details,
-            )
-
-            if assignment["new_assignment"] or assignment["updated_assignment"]:
-                analytics.record(
-                    "codeowners.assignment"
-                    if details.get("integration") == ActivityIntegration.CODEOWNERS.value
-                    else "issueowners.assignment",
-                    organization_id=ownership.project.organization_id,
-                    project_id=project_id,
-                    group_id=event.group.id,
+            if owner and owner.resolve():
+                assignment = GroupAssignee.objects.assign(
+                    event.group,
+                    owner.resolve(),
+                    create_only=True,
+                    extra=details,
                 )
+
+                if assignment["new_assignment"] or assignment["updated_assignment"]:
+                    analytics.record(
+                        "codeowners.assignment"
+                        if details.get("integration") == ActivityIntegration.CODEOWNERS.value
+                        else "issueowners.assignment",
+                        organization_id=ownership.project.organization_id,
+                        project_id=project_id,
+                        group_id=event.group.id,
+                    )
 
     @classmethod
     def _matching_ownership_rules(

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -204,3 +204,43 @@ class TestCommitContext(TestCase):
             organization=self.event.project.organization,
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         ).exists()
+
+    @patch(
+        "sentry.integrations.github.GitHubIntegration.get_commit_context",
+        return_value={
+            "commitId": "somekey",
+            "committedDate": "",
+            "commitMessage": "placeholder commit message",
+            "commitAuthorName": "",
+            "commitAuthorEmail": "randomuser@sentry.io",
+        },
+    )
+    def test_commit_author_not_in_sentry(self, mock_get_commit_context):
+        self.commit_author_2 = self.create_commit_author(
+            project=self.project,
+        )
+        self.commit_2 = self.create_commit(
+            project=self.project,
+            repo=self.repo,
+            author=self.commit_author_2,
+            key="somekey",
+            message="placeholder commit message",
+        )
+
+        with self.tasks():
+            assert not GroupOwner.objects.filter(group=self.event.group).exists()
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+        assert GroupOwner.objects.filter(group=self.event.group).exists()
+        assert len(GroupOwner.objects.filter(group=self.event.group)) == 1
+        owner = GroupOwner.objects.get(group=self.event.group)
+        assert owner.type == GroupOwnerType.SUSPECT_COMMIT.value
+        assert owner.user is None
+        assert owner.team is None
+        assert owner.context == {"commitId": self.commit_2.id}

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1649,6 +1649,14 @@ class GroupListTest(APITestCase, SnubaTestCase):
             type=GroupOwnerType.CODEOWNERS.value,
             team=self.team,
         )
+        GroupOwner.objects.create(
+            group=event.group,
+            project=event.project,
+            organization=event.project.organization,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user=None,
+            team=None,
+        )
         response = self.get_response(sort_by="date", limit=10, query=query, expand="owners")
         assert response.status_code == 200
         assert len(response.data) == 1


### PR DESCRIPTION
## Objective

Follow up to the revert of https://github.com/getsentry/sentry/pull/41658

This PR also fixes the serialization of GroupOwner when both actors are null.

## Test Plan
I added updated a test for the Issue Stream endpoint to cover this case and validated locally that the Suspect Committer banner and the Issue Stream renders correctly
![committer-not-in-org](https://user-images.githubusercontent.com/10491193/203665182-0a69b4be-163f-457a-b734-76ee6f737a97.png)

