### PR TITLE
bug(replays): Fix render of replay count in tooltip

### DIFF
--- a/static/app/components/group/issueReplayCount.tsx
+++ b/static/app/components/group/issueReplayCount.tsx
@@ -5,7 +5,7 @@ import Link from 'sentry/components/links/link';
 import ReplayCountContext from 'sentry/components/replays/replayCountContext';
 import Tooltip from 'sentry/components/tooltip';
 import {IconPlay} from 'sentry/icons';
-import {tn} from 'sentry/locale';
+import {t, tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import useOrganization from 'sentry/utils/useOrganization';
 
@@ -25,15 +25,14 @@ function IssueReplayCount({groupId}: Props) {
   }
 
   const countDisplay = count > 50 ? '50+' : count;
-
+  const titleOver50 = t('This issue has 50+ replay available to view');
+  const title50OrLess = tn(
+    'This issue has %s replay available to view',
+    'This issue has %s replays available to view',
+    count
+  );
   return (
-    <StyledTooltip
-      title={tn(
-        'This issue has %s replay available to view',
-        'This issue has %s replays available to view',
-        countDisplay
-      )}
-    >
+    <StyledTooltip title={count > 50 ? titleOver50 : title50OrLess}>
       <ReplayCountLink
         to={`/organizations/${organization.slug}/issues/${groupId}/replays/`}
         aria-label="replay-count"


### PR DESCRIPTION
Fix the tooltip message so it doesn't always show `0`, it should show the same count as the trigger element.

Here are the variations:

<img width="258" alt="SCR-20221123-mvn" src="https://user-images.githubusercontent.com/187460/203668381-f1e39056-2834-4f3c-988f-af4d4bd72976.png">
<img width="259" alt="SCR-20221123-mvj" src="https://user-images.githubusercontent.com/187460/203668378-1d7e9f3e-6f0c-4617-ac17-21f610daecd4.png">
<img width="244" alt="SCR-20221123-mvk" src="https://user-images.githubusercontent.com/187460/203668379-f7d13617-b9b0-4ed9-9216-b8eca66b3abf.png">
