### PR TITLE
feat(replays): Make the Replay Details error count color not red when the count is zero

### DIFF
--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -58,13 +58,11 @@ function Page({children, crumbs, orgSlug, replayRecord}: Props) {
 }
 
 const Header = styled(Layout.Header)`
-  gap: 0 ${space(3)};
+  gap: ${space(1)};
+  padding-bottom: ${space(1.5)};
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
+    gap: 0 ${space(3)};
     padding: ${space(2)} ${space(2)} ${space(1.5)} ${space(2)};
-  }
-  @media (max-width: ${p => p.theme.breakpoints.medium}) {
-    gap: ${space(1)};
-    padding-bottom: ${space(1.5)};
   }
 `;
 

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -61,6 +61,7 @@ function Page({children, crumbs, orgSlug, replayRecord}: Props) {
 }
 
 const Header = styled(Layout.Header)`
+  gap: 0 ${space(3)};
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     padding: ${space(2)} ${space(2)} ${space(1.5)} ${space(2)};
   }
@@ -72,14 +73,12 @@ const HeaderContent = styled(Layout.HeaderContent)`
 
 // TODO(replay); This could make a lot of sense to put inside HeaderActions by default
 const ButtonActionsWrapper = styled(Layout.HeaderActions)`
-  display: grid;
-  grid-template-columns: repeat(3, max-content);
+  flex-direction: row;
   justify-content: flex-end;
   gap: ${space(1)};
 `;
 
 const MetaDataColumn = styled(Layout.HeaderActions)`
-  padding-left: ${space(3)};
   align-self: end;
 `;
 

--- a/static/app/views/replays/detail/page.tsx
+++ b/static/app/views/replays/detail/page.tsx
@@ -29,9 +29,8 @@ function Page({children, crumbs, orgSlug, replayRecord}: Props) {
 
   const header = (
     <Header>
-      <HeaderContent>
-        <DetailsPageBreadcrumbs orgSlug={orgSlug} replayRecord={replayRecord} />
-      </HeaderContent>
+      <DetailsPageBreadcrumbs orgSlug={orgSlug} replayRecord={replayRecord} />
+
       <ButtonActionsWrapper>
         <DeleteButton />
         <ChooseLayout />
@@ -44,9 +43,7 @@ function Page({children, crumbs, orgSlug, replayRecord}: Props) {
         <HeaderPlaceholder />
       )}
 
-      <MetaDataColumn>
-        <ReplayMetaData replayRecord={replayRecord} />
-      </MetaDataColumn>
+      <ReplayMetaData replayRecord={replayRecord} />
     </Header>
   );
 
@@ -65,10 +62,10 @@ const Header = styled(Layout.Header)`
   @media (min-width: ${p => p.theme.breakpoints.medium}) {
     padding: ${space(2)} ${space(2)} ${space(1.5)} ${space(2)};
   }
-`;
-
-const HeaderContent = styled(Layout.HeaderContent)`
-  margin-bottom: 0;
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    gap: ${space(1)};
+    padding-bottom: ${space(1.5)};
+  }
 `;
 
 // TODO(replay); This could make a lot of sense to put inside HeaderActions by default
@@ -76,10 +73,9 @@ const ButtonActionsWrapper = styled(Layout.HeaderActions)`
   flex-direction: row;
   justify-content: flex-end;
   gap: ${space(1)};
-`;
-
-const MetaDataColumn = styled(Layout.HeaderActions)`
-  align-self: end;
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    margin-bottom: 0;
+  }
 `;
 
 const FullViewport = styled('div')`

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -104,6 +104,10 @@ const KeyMetrics = styled('div')`
   align-items: center;
   justify-content: end;
   font-size: ${p => p.theme.fontSizeMedium};
+
+  @media (max-width: ${p => p.theme.breakpoints.medium}) {
+    justify-content: start;
+  }
 `;
 
 const KeyMetricData = styled('div')`

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -74,8 +74,13 @@ function ReplayMetaData({replayRecord}: Props) {
       <KeyMetricData>
         {replayRecord ? (
           <Fragment>
-            <ErrorTag to={errorsTabHref} icon={null} type="error">
-              {replayRecord?.countErrors}
+            <ErrorTag
+              to={errorsTabHref}
+              icon={null}
+              type={replayRecord.countErrors ? 'error' : 'white'}
+              level={replayRecord.countErrors ? 'fatal' : 'default'}
+            >
+              {replayRecord.countErrors}
             </ErrorTag>
             <Link to={errorsTabHref}>{t('Errors')}</Link>
           </Fragment>
@@ -114,9 +119,10 @@ const KeyMetricData = styled('div')`
   line-height: ${p => p.theme.text.lineHeightBody};
 `;
 
-const ErrorTag = styled(Tag)`
+const ErrorTag = styled(Tag)<{level: 'fatal' | 'default'}>`
   ${Background} {
-    background: ${p => p.theme.tag.error.iconColor};
+    background: ${p => p.theme.level[p.level]};
+    border-color: ${p => p.theme.level[p.level]};
     padding: 0 ${space(0.75)};
 
     span {

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -71,22 +71,21 @@ function ReplayMetaData({replayRecord}: Props) {
           <HeaderPlaceholder />
         )}
       </KeyMetricData>
-      <KeyMetricData>
-        {replayRecord ? (
-          <StyledLink to={errorsTabHref}>
-            <ErrorTag
-              icon={null}
-              type={replayRecord.countErrors ? 'error' : 'black'}
-              level={replayRecord.countErrors ? 'fatal' : 'default'}
-            >
-              {replayRecord.countErrors}
-            </ErrorTag>
-            {tn('Error', 'Errors', replayRecord.countErrors)}
-          </StyledLink>
-        ) : (
-          <HeaderPlaceholder />
-        )}
-      </KeyMetricData>
+
+      {replayRecord ? (
+        <StyledLink to={errorsTabHref}>
+          <ErrorTag
+            icon={null}
+            type={replayRecord.countErrors ? 'error' : 'black'}
+            level={replayRecord.countErrors ? 'fatal' : 'default'}
+          >
+            {replayRecord.countErrors}
+          </ErrorTag>
+          {tn('Error', 'Errors', replayRecord.countErrors)}
+        </StyledLink>
+      ) : (
+        <HeaderPlaceholder />
+      )}
     </KeyMetrics>
   );
 }

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -77,7 +77,7 @@ function ReplayMetaData({replayRecord}: Props) {
             <ErrorTag
               to={errorsTabHref}
               icon={null}
-              type={replayRecord.countErrors ? 'error' : 'white'}
+              type={replayRecord.countErrors ? 'error' : 'black'}
               level={replayRecord.countErrors ? 'fatal' : 'default'}
             >
               {replayRecord.countErrors}
@@ -126,10 +126,6 @@ const ErrorTag = styled(Tag)<{level: 'fatal' | 'default'}>`
     background: ${p => p.theme.level[p.level]};
     border-color: ${p => p.theme.level[p.level]};
     padding: 0 ${space(0.75)};
-
-    span {
-      color: white !important;
-    }
   }
 `;
 

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -73,19 +73,16 @@ function ReplayMetaData({replayRecord}: Props) {
       </KeyMetricData>
       <KeyMetricData>
         {replayRecord ? (
-          <Fragment>
+          <StyledLink to={errorsTabHref}>
             <ErrorTag
-              to={errorsTabHref}
               icon={null}
               type={replayRecord.countErrors ? 'error' : 'black'}
               level={replayRecord.countErrors ? 'fatal' : 'default'}
             >
               {replayRecord.countErrors}
             </ErrorTag>
-            <Link to={errorsTabHref}>
-              {tn('Error', 'Errors', replayRecord.countErrors)}
-            </Link>
-          </Fragment>
+            {tn('Error', 'Errors', replayRecord.countErrors)}
+          </StyledLink>
         ) : (
           <HeaderPlaceholder />
         )}
@@ -103,9 +100,8 @@ export const HeaderPlaceholder = styled(
 `;
 
 const KeyMetrics = styled('div')`
-  display: grid;
+  display: flex;
   gap: ${space(3)};
-  grid-template-columns: repeat(4, max-content);
   align-items: center;
   justify-content: end;
   font-size: ${p => p.theme.fontSizeMedium};
@@ -114,11 +110,15 @@ const KeyMetrics = styled('div')`
 const KeyMetricData = styled('div')`
   color: ${p => p.theme.textColor};
   font-weight: normal;
-  display: grid;
-  grid-template-columns: repeat(2, max-content);
+  display: flex;
   align-items: center;
   gap: ${space(1)};
   line-height: ${p => p.theme.text.lineHeightBody};
+`;
+
+const StyledLink = styled(Link)`
+  display: flex;
+  gap: ${space(1)};
 `;
 
 const ErrorTag = styled(Tag)<{level: 'fatal' | 'default'}>`

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -8,7 +8,7 @@ import Placeholder from 'sentry/components/placeholder';
 import Tag, {Background} from 'sentry/components/tag';
 import TimeSince from 'sentry/components/timeSince';
 import {IconCalendar, IconClock} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import useProjects from 'sentry/utils/useProjects';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
@@ -82,7 +82,9 @@ function ReplayMetaData({replayRecord}: Props) {
             >
               {replayRecord.countErrors}
             </ErrorTag>
-            <Link to={errorsTabHref}>{t('Errors')}</Link>
+            <Link to={errorsTabHref}>
+              {tn('Error', 'Errors', replayRecord.countErrors)}
+            </Link>
           </Fragment>
         ) : (
           <HeaderPlaceholder />


### PR DESCRIPTION
| Zero Errors | One Error | 
| --- | --- |
| <img width="99" alt="SCR-20221123-ne8" src="https://user-images.githubusercontent.com/187460/203670728-67aad5c9-759e-4133-a399-f55c81623726.png"> | <img width="91" alt="SCR-20221123-ni1" src="https://user-images.githubusercontent.com/187460/203670914-ad64f0d2-06a5-4ba8-b793-548d4540b65f.png"> |

Many Errors:
<img width="510" alt="SCR-20221123-nel" src="https://user-images.githubusercontent.com/187460/203670759-b7fc6b5e-9367-4780-bac2-eeb5985a9f68.png">

---

Also I ninja'd a bunch of the css, cut out some overrides that weren't needed and improved render on a narrow screen. The wide screen image is exactly the same, but underneath it's using flex and gap with fewer hacks/overrides. 

Checkout the snapshot results: https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/b10ecf9bcd77a24452af4d87922e9318420a6971/index.html

| Before | After |
| --- | --- |
| <img width="954" alt="SCR-20221123-ogg" src="https://user-images.githubusercontent.com/187460/203677193-9d1a7fb2-04c3-4c72-a4f0-efa42564fbac.png"> | <img width="955" alt="SCR-20221123-ogp" src="https://user-images.githubusercontent.com/187460/203677196-f904df6b-9668-4b9b-a85e-f7dbc7789e6a.png"> |
| <img width="891" alt="SCR-20221123-ogx" src="https://user-images.githubusercontent.com/187460/203677197-228deaad-bbfd-428d-84ed-c5fc286ec9a7.png"> | <img width="887" alt="SCR-20221123-ogu" src="https://user-images.githubusercontent.com/187460/203677191-0f2fab91-9e33-4ab1-9f24-494b0daa4706.png"> |


Fixes #39394