### PR TITLE
fix(theme): Use preferred browser color-scheme for favicon

### DIFF
--- a/static/app/utils/useColorscheme.tsx
+++ b/static/app/utils/useColorscheme.tsx
@@ -36,7 +36,7 @@ export function useColorscheme() {
   useEffect(() => {
     const theme = configuredTheme === 'system' ? preferredTheme : configuredTheme;
 
-    setFaviconTheme(theme);
+    setFaviconTheme(preferredTheme);
     ConfigStore.set('theme', theme);
   }, [configuredTheme, preferredTheme]);
 }


### PR DESCRIPTION
I have a dark system/browser theme but I'm using the light theme for sentry frontend. This makes the favicon barely visible in the browser tab bar:
<img width="806" alt="Screenshot 2022-11-24 at 16 01 01" src="https://user-images.githubusercontent.com/1411808/203814813-d4f0eb1c-9e3e-4382-8e6c-8f5a5f5d755a.png">

This PR fixes the visibility, by setting the favicon based on the preferred browser theme:
<img width="844" alt="Screenshot 2022-11-24 at 16 04 55" src="https://user-images.githubusercontent.com/1411808/203815548-ea2ecfd4-b857-4965-ae59-fb58a3e14bae.png">