### PR TITLE
feat(metrics): Change rules schema for latest release

### DIFF
--- a/src/sentry/dynamic_sampling/rules_generator.py
+++ b/src/sentry/dynamic_sampling/rules_generator.py
@@ -113,9 +113,7 @@ def generate_boost_release_rules(project_id: int, sample_rate: float) -> List[Re
                             # When environment is None, it will be mapped to equivalent null in json.
                             # When Relay receives a rule with "value": null it will match it against events without
                             # the environment tag set.
-                            "value": [boosted_release.environment]
-                            if boosted_release.environment
-                            else None,
+                            "value": boosted_release.environment,
                         },
                     ],
                 },

--- a/src/sentry/dynamic_sampling/rules_generator.py
+++ b/src/sentry/dynamic_sampling/rules_generator.py
@@ -111,9 +111,11 @@ def generate_boost_release_rules(project_id: int, sample_rate: float) -> List[Re
                             "op": "eq",
                             "name": "trace.environment",
                             # When environment is None, it will be mapped to equivalent null in json.
-                            # When Relay receives a rule with "value": [null] it will match it against events without
+                            # When Relay receives a rule with "value": null it will match it against events without
                             # the environment tag set.
-                            "value": [boosted_release.environment],
+                            "value": [boosted_release.environment]
+                            if boosted_release.environment
+                            else None,
                         },
                     ],
                 },

--- a/src/sentry/dynamic_sampling/rules_generator.py
+++ b/src/sentry/dynamic_sampling/rules_generator.py
@@ -15,8 +15,6 @@ from sentry.dynamic_sampling.utils import (
     RELEASE_BOOST_FACTOR,
     RESERVED_IDS,
     BaseRule,
-    Condition,
-    Inner,
     ReleaseRule,
     RuleType,
 )
@@ -35,21 +33,6 @@ HEALTH_CHECK_GLOBS = [
 ]
 
 ALL_ENVIRONMENTS = "*"
-
-
-def _generate_environment_condition(environment: Optional[str]) -> Union[Condition, Inner]:
-    environment_condition = {
-        "op": "glob",
-        "name": "trace.environment",
-        "value": [environment if environment is not None else ALL_ENVIRONMENTS],
-    }
-
-    # In case we want to generate a rule for a trace without an environment we can use negations to express it as
-    # a trace that has an environment that doesn't match any environment.
-    if environment is None:
-        environment_condition = {"op": "not", "inner": environment_condition}  # type: ignore
-
-    return environment_condition  # type: ignore
 
 
 def generate_uniform_rule(sample_rate: Optional[float]) -> BaseRule:
@@ -120,11 +103,18 @@ def generate_boost_release_rules(project_id: int, sample_rate: float) -> List[Re
                     "op": "and",
                     "inner": [
                         {
-                            "op": "glob",
+                            "op": "eq",
                             "name": "trace.release",
                             "value": [boosted_release.version],
                         },
-                        _generate_environment_condition(boosted_release.environment),
+                        {
+                            "op": "eq",
+                            "name": "trace.environment",
+                            # When environment is None, it will be mapped to equivalent null in json.
+                            # When Relay receives a rule with "value": [null] it will match it against events without
+                            # the environment tag set.
+                            "value": [boosted_release.environment],
+                        },
                     ],
                 },
                 "id": RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE] + idx,

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -42,6 +42,8 @@ def test_generate_rules_capture_exception(get_blended_sample_rate, sentry_sdk):
     assert generate_rules(fake_project) == []
     get_blended_sample_rate.assert_called_with(fake_project)
     sentry_sdk.capture_exception.assert_called_with()
+    config_str = json.dumps({"rules": generate_rules(fake_project)})
+    validate_sampling_configuration(config_str)
 
 
 @patch(
@@ -70,6 +72,8 @@ def test_generate_rules_return_uniform_rules_with_rate(
     get_enabled_user_biases.assert_called_with(
         fake_project.get_option("sentry:dynamic_sampling_biases", None)
     )
+    config_str = json.dumps({"rules": generate_rules(fake_project)})
+    validate_sampling_configuration(config_str)
 
 
 @pytest.mark.django_db
@@ -122,6 +126,8 @@ def test_generate_rules_return_uniform_rules_and_env_rule(get_blended_sample_rat
         },
     ]
     get_blended_sample_rate.assert_called_with(default_project)
+    config_str = json.dumps({"rules": generate_rules(default_project)})
+    validate_sampling_configuration(config_str)
 
 
 @pytest.mark.django_db
@@ -176,6 +182,8 @@ def test_generate_rules_return_uniform_rules_and_key_transaction_rule(
         },
     ]
     get_blended_sample_rate.assert_called_with(default_project)
+    config_str = json.dumps({"rules": generate_rules(default_project)})
+    validate_sampling_configuration(config_str)
 
 
 @pytest.mark.django_db
@@ -239,6 +247,8 @@ def test_generate_rules_return_uniform_rules_and_key_transaction_rule_with_dups(
         },
     ]
     get_blended_sample_rate.assert_called_with(default_project)
+    config_str = json.dumps({"rules": generate_rules(default_project)})
+    validate_sampling_configuration(config_str)
 
 
 @pytest.mark.django_db
@@ -296,6 +306,8 @@ def test_generate_rules_return_uniform_rules_and_key_transaction_rule_with_many_
         },
     ]
     get_blended_sample_rate.assert_called_with(default_project)
+    config_str = json.dumps({"rules": generate_rules(default_project)})
+    validate_sampling_configuration(config_str)
 
 
 @patch("sentry.dynamic_sampling.rules_generator.quotas.get_blended_sample_rate")
@@ -316,6 +328,8 @@ def test_generate_rules_return_uniform_rule_with_100_rate_and_without_env_rule(
         },
     ]
     get_blended_sample_rate.assert_called_with(fake_project)
+    config_str = json.dumps({"rules": generate_rules(fake_project)})
+    validate_sampling_configuration(config_str)
 
 
 @freeze_time("2022-10-21 18:50:25+00:00")
@@ -379,6 +393,8 @@ def test_generate_rules_with_different_project_platforms(
         },
     ]
     assert generate_rules(default_project) == expected
+    config_str = json.dumps({"rules": generate_rules(default_project)})
+    validate_sampling_configuration(config_str)
 
 
 @pytest.mark.django_db
@@ -458,7 +474,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
     ]
 
     assert generate_rules(default_project) == expected
-    config_str = json.dumps({"rules": expected})
+    config_str = json.dumps({"rules": generate_rules(default_project)})
     validate_sampling_configuration(config_str)
 
 
@@ -480,6 +496,8 @@ def test_generate_rules_return_uniform_rule_with_100_rate_and_without_latest_rel
             "type": "trace",
         },
     ]
+    config_str = json.dumps({"rules": generate_rules(default_project)})
+    validate_sampling_configuration(config_str)
 
 
 @pytest.mark.django_db
@@ -501,6 +519,8 @@ def test_generate_rules_return_uniform_rule_with_non_existent_releases(
             "type": "trace",
         },
     ]
+    config_str = json.dumps({"rules": generate_rules(default_project)})
+    validate_sampling_configuration(config_str)
 
 
 @pytest.mark.django_db
@@ -553,5 +573,5 @@ def test_generate_rules_return_uniform_rule_with_more_releases_than_the_limit(
         },
     ]
     assert generate_rules(default_project) == expected
-    config_str = json.dumps({"rules": expected})
+    config_str = json.dumps({"rules": generate_rules(default_project)})
     validate_sampling_configuration(config_str)

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -442,7 +442,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
                 "op": "and",
                 "inner": [
                     {"op": "eq", "name": "trace.release", "value": ["1.0"]},
-                    {"op": "eq", "name": "trace.environment", "value": [None]},
+                    {"op": "eq", "name": "trace.environment", "value": None},
                 ],
             },
             "id": 1502,
@@ -533,7 +533,7 @@ def test_generate_rules_return_uniform_rule_with_more_releases_than_the_limit(
                     "op": "and",
                     "inner": [
                         {"op": "eq", "name": "trace.release", "value": [release.version]},
-                        {"op": "eq", "name": "trace.environment", "value": [None]},
+                        {"op": "eq", "name": "trace.environment", "value": None},
                     ],
                 },
                 "id": 1500 + index,

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -356,9 +356,9 @@ def test_generate_rules_with_different_project_platforms(
             "condition": {
                 "op": "and",
                 "inner": [
-                    {"op": "glob", "name": "trace.release", "value": [release.version]},
+                    {"op": "eq", "name": "trace.release", "value": [release.version]},
                     {
-                        "op": "glob",
+                        "op": "eq",
                         "name": "trace.environment",
                         "value": [environment],
                     },
@@ -413,8 +413,8 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             "condition": {
                 "op": "and",
                 "inner": [
-                    {"op": "glob", "name": "trace.release", "value": ["1.0"]},
-                    {"op": "glob", "name": "trace.environment", "value": ["prod"]},
+                    {"op": "eq", "name": "trace.release", "value": ["1.0"]},
+                    {"op": "eq", "name": "trace.environment", "value": ["prod"]},
                 ],
             },
             "id": 1500,
@@ -427,8 +427,8 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             "condition": {
                 "op": "and",
                 "inner": [
-                    {"op": "glob", "name": "trace.release", "value": ["1.0"]},
-                    {"op": "glob", "name": "trace.environment", "value": ["dev"]},
+                    {"op": "eq", "name": "trace.release", "value": ["1.0"]},
+                    {"op": "eq", "name": "trace.environment", "value": ["dev"]},
                 ],
             },
             "id": 1501,
@@ -441,15 +441,8 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
             "condition": {
                 "op": "and",
                 "inner": [
-                    {"op": "glob", "name": "trace.release", "value": ["1.0"]},
-                    {
-                        "op": "not",
-                        "inner": {
-                            "op": "glob",
-                            "name": "trace.environment",
-                            "value": ["*"],
-                        },
-                    },
+                    {"op": "eq", "name": "trace.release", "value": ["1.0"]},
+                    {"op": "eq", "name": "trace.environment", "value": [None]},
                 ],
             },
             "id": 1502,
@@ -539,15 +532,8 @@ def test_generate_rules_return_uniform_rule_with_more_releases_than_the_limit(
                 "condition": {
                     "op": "and",
                     "inner": [
-                        {"op": "glob", "name": "trace.release", "value": [release.version]},
-                        {
-                            "op": "not",
-                            "inner": {
-                                "op": "glob",
-                                "name": "trace.environment",
-                                "value": ["*"],
-                            },
-                        },
+                        {"op": "eq", "name": "trace.release", "value": [release.version]},
+                        {"op": "eq", "name": "trace.environment", "value": [None]},
                     ],
                 },
                 "id": 1500 + index,

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -374,7 +374,7 @@ def test_generate_rules_with_different_project_platforms(
                     {
                         "op": "eq",
                         "name": "trace.environment",
-                        "value": [environment],
+                        "value": environment,
                     },
                 ],
             },
@@ -430,7 +430,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
                 "op": "and",
                 "inner": [
                     {"op": "eq", "name": "trace.release", "value": ["1.0"]},
-                    {"op": "eq", "name": "trace.environment", "value": ["prod"]},
+                    {"op": "eq", "name": "trace.environment", "value": "prod"},
                 ],
             },
             "id": 1500,
@@ -444,7 +444,7 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
                 "op": "and",
                 "inner": [
                     {"op": "eq", "name": "trace.release", "value": ["1.0"]},
-                    {"op": "eq", "name": "trace.environment", "value": ["dev"]},
+                    {"op": "eq", "name": "trace.environment", "value": "dev"},
                 ],
             },
             "id": 1501,

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -533,7 +533,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                         {
                             "op": "eq",
                             "name": "trace.environment",
-                            "value": ["prod"],
+                            "value": "prod",
                         },
                     ],
                 },
@@ -554,7 +554,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                         {
                             "op": "eq",
                             "name": "trace.environment",
-                            "value": ["prod"],
+                            "value": "prod",
                         },
                     ],
                 },
@@ -575,7 +575,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                         {
                             "op": "eq",
                             "name": "trace.environment",
-                            "value": ["prod"],
+                            "value": "prod",
                         },
                     ],
                 },
@@ -596,7 +596,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                         {
                             "op": "eq",
                             "name": "trace.environment",
-                            "value": ["prod"],
+                            "value": "prod",
                         },
                     ],
                 },
@@ -617,7 +617,7 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                         {
                             "op": "eq",
                             "name": "trace.environment",
-                            "value": ["prod"],
+                            "value": "prod",
                         },
                     ],
                 },

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -529,9 +529,9 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                 "condition": {
                     "op": "and",
                     "inner": [
-                        {"op": "glob", "name": "trace.release", "value": ["3.0"]},
+                        {"op": "eq", "name": "trace.release", "value": ["3.0"]},
                         {
-                            "op": "glob",
+                            "op": "eq",
                             "name": "trace.environment",
                             "value": ["prod"],
                         },
@@ -550,9 +550,9 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                 "condition": {
                     "op": "and",
                     "inner": [
-                        {"op": "glob", "name": "trace.release", "value": ["4.0"]},
+                        {"op": "eq", "name": "trace.release", "value": ["4.0"]},
                         {
-                            "op": "glob",
+                            "op": "eq",
                             "name": "trace.environment",
                             "value": ["prod"],
                         },
@@ -571,9 +571,9 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                 "condition": {
                     "op": "and",
                     "inner": [
-                        {"op": "glob", "name": "trace.release", "value": ["5.0"]},
+                        {"op": "eq", "name": "trace.release", "value": ["5.0"]},
                         {
-                            "op": "glob",
+                            "op": "eq",
                             "name": "trace.environment",
                             "value": ["prod"],
                         },
@@ -592,9 +592,9 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                 "condition": {
                     "op": "and",
                     "inner": [
-                        {"op": "glob", "name": "trace.release", "value": ["6.0"]},
+                        {"op": "eq", "name": "trace.release", "value": ["6.0"]},
                         {
-                            "op": "glob",
+                            "op": "eq",
                             "name": "trace.environment",
                             "value": ["prod"],
                         },
@@ -613,9 +613,9 @@ def test_project_config_with_boosted_latest_releases_boost_in_dynamic_sampling_r
                 "condition": {
                     "op": "and",
                     "inner": [
-                        {"op": "glob", "name": "trace.release", "value": ["7.0"]},
+                        {"op": "eq", "name": "trace.release", "value": ["7.0"]},
                         {
-                            "op": "glob",
+                            "op": "eq",
                             "name": "trace.environment",
                             "value": ["prod"],
                         },


### PR DESCRIPTION
This PR aims at changing the rules schema for latest release boosting rules.

The new schema uses the `eq` operator and the `null` value instead of `glob` and `not`.