### PR TITLE
chore: Add data-test-id to usage chart

### DIFF
--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -488,7 +488,7 @@ export class UsageChart extends Component<Props, State> {
     const {footer} = this.props;
 
     return (
-      <Panel id="usage-chart">
+      <Panel id="usage-chart" data-test-id="usage-chart">
         <ChartContainer>{this.renderChart()}</ChartContainer>
         {footer}
       </Panel>


### PR DESCRIPTION
Adding a data test id for an RTL test suite in `getsentry`.