### PR TITLE
chore(hybrid-cloud): Replace withRouter with hooks part 2

### DIFF
--- a/static/app/components/assigneeSelector.spec.jsx
+++ b/static/app/components/assigneeSelector.spec.jsx
@@ -285,7 +285,9 @@ describe('AssigneeSelector', () => {
 
   it('shows invite member button', async () => {
     MemberListStore.loadInitialData([USER_1, USER_2]);
-    render(<AssigneeSelectorComponent id={GROUP_1.id} />);
+    render(<AssigneeSelectorComponent id={GROUP_1.id} />, {
+      context: TestStubs.routerContext(),
+    });
     jest.spyOn(ConfigStore, 'get').mockImplementation(() => true);
 
     await openMenu();

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -377,7 +377,7 @@ export class AssigneeSelectorDropdown extends Component<
 
     return (
       <InviteMemberLink
-        to=""
+        to="#invite-member"
         data-test-id="invite-member"
         disabled={loading}
         onClick={() => openInviteMembersModal({source: 'assignee_selector'})}

--- a/static/app/components/commitRow.spec.tsx
+++ b/static/app/components/commitRow.spec.tsx
@@ -1,4 +1,4 @@
-import {fireEvent, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
@@ -58,7 +58,7 @@ describe('commitRow', () => {
       },
     } as Commit;
 
-    render(<CommitRow commit={commit} />);
+    render(<CommitRow commit={commit} />, {context: TestStubs.routerContext()});
     expect(
       screen.getByText(
         textWithMarkupMatcher(
@@ -67,7 +67,7 @@ describe('commitRow', () => {
       )
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText(/Invite/));
+    userEvent.click(screen.getByText(/Invite/));
 
     // @ts-ignore we are mocking this import
     expect(openInviteMembersModal.mock.calls[0][0].initialData[0].emails).toEqual(

--- a/static/app/components/createAlertButton.spec.jsx
+++ b/static/app/components/createAlertButton.spec.jsx
@@ -27,7 +27,9 @@ function renderComponent(organization, eventView) {
 }
 
 function renderSimpleComponent(organization, extraProps) {
-  return render(<CreateAlertButton organization={organization} {...extraProps} />);
+  return render(<CreateAlertButton organization={organization} {...extraProps} />, {
+    context: TestStubs.routerContext(),
+  });
 }
 
 describe('CreateAlertFromViewButton', () => {

--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {updateEnvironments} from 'sentry/actionCreators/pageFilters';
@@ -15,11 +13,11 @@ import {trimSlug} from 'sentry/utils/trimSlug';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 type EnvironmentSelectorProps = React.ComponentProps<typeof EnvironmentSelector>;
 
 type Props = {
-  router: WithRouterProps['router'];
   alignDropdown?: EnvironmentSelectorProps['alignDropdown'];
   disabled?: EnvironmentSelectorProps['disabled'];
   /**
@@ -35,13 +33,14 @@ type Props = {
 };
 
 function EnvironmentPageFilter({
-  router,
   resetParamsOnChange = [],
   alignDropdown,
   disabled,
   maxTitleLength = 20,
   size = 'md',
 }: Props) {
+  const {router} = useRouteContext();
+
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const organization = useOrganization();
   const {selection, isReady, desyncedFilters} = usePageFilters();
@@ -134,4 +133,4 @@ const DropdownTitle = styled('div')`
   min-width: 0;
 `;
 
-export default withRouter<Props>(EnvironmentPageFilter);
+export default EnvironmentPageFilter;

--- a/static/app/components/events/eventAttachments.spec.tsx
+++ b/static/app/components/events/eventAttachments.spec.tsx
@@ -17,11 +17,14 @@ describe('EventAttachments', function () {
   };
 
   it('shows attachments limit reached notice', function () {
-    render(<EventAttachments {...props} />);
+    render(<EventAttachments {...props} />, {context: routerContext});
 
     expect(screen.getByText('Attachments (0)')).toBeInTheDocument();
 
-    expect(screen.getByRole('link', {name: 'View crashes'})).toHaveAttribute('href', '');
+    expect(screen.getByRole('link', {name: 'View crashes'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/1/attachments/?types=event.minidump&types=event.applecrashreport'
+    );
 
     expect(screen.getByRole('link', {name: 'configure limit'})).toHaveAttribute(
       'href',

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -14,7 +14,7 @@ describe('Exception Content', function () {
       relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
     });
 
-    const {organization, router} = initializeOrg({
+    const {organization, router, routerContext} = initializeOrg({
       ...initializeOrg(),
       router: {
         location: {query: {project: '0'}},
@@ -115,7 +115,7 @@ describe('Exception Content', function () {
         values={event.entries[0].data.values}
         meta={event._meta.entries[0].data.values}
       />,
-      {organization, router}
+      {organization, router, context: routerContext}
     );
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);

--- a/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
+++ b/static/app/components/events/interfaces/frame/frameVariables.spec.tsx
@@ -12,7 +12,7 @@ describe('Frame Variables', function () {
       relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
     });
 
-    const {organization, router} = initializeOrg({
+    const {organization, router, routerContext} = initializeOrg({
       ...initializeOrg(),
       router: {
         location: {query: {project: '0'}},
@@ -65,7 +65,7 @@ describe('Frame Variables', function () {
           },
         }}
       />,
-      {organization, router}
+      {organization, router, context: routerContext}
     );
 
     expect(screen.getAllByText(/redacted/)).toHaveLength(2);

--- a/static/app/components/events/interfaces/message.spec.tsx
+++ b/static/app/components/events/interfaces/message.spec.tsx
@@ -4,6 +4,7 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import {Message} from 'sentry/components/events/interfaces/message';
 
 describe('Message entry', function () {
+  const routerContext = TestStubs.routerContext();
   it('display redacted data', async function () {
     const event = {
       ...TestStubs.Event(),
@@ -26,6 +27,7 @@ describe('Message entry', function () {
       },
     };
     render(<Message data={{formatted: null}} event={event} />, {
+      context: routerContext,
       organization: {
         relayPiiConfig: JSON.stringify(TestStubs.DataScrubbingRelayPiiConfig()),
       },

--- a/static/app/components/globalSelectionLink.spec.tsx
+++ b/static/app/components/globalSelectionLink.spec.tsx
@@ -5,7 +5,7 @@ import GlobalSelectionLink from 'sentry/components/globalSelectionLink';
 const path = 'http://some.url/';
 
 describe('GlobalSelectionLink', function () {
-  const getContext = (query: {environment: string; project: string[]}) =>
+  const getContext = (query?: {environment: string; project: string[]}) =>
     TestStubs.routerContext([
       {
         router: TestStubs.router({
@@ -37,7 +37,8 @@ describe('GlobalSelectionLink', function () {
 
   it('does not have global selection values in query', function () {
     const {container} = render(
-      <GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>
+      <GlobalSelectionLink to={path}>Go somewhere!</GlobalSelectionLink>,
+      {context: getContext()}
     );
 
     expect(screen.getByText('Go somewhere!')).toHaveAttribute('href', path);

--- a/static/app/components/group/issueReplayCount.spec.tsx
+++ b/static/app/components/group/issueReplayCount.spec.tsx
@@ -1,3 +1,4 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import IssueReplayCount from 'sentry/components/group/issueReplayCount';
@@ -7,7 +8,7 @@ jest.mock('sentry/components/replays/replayCountContext');
 
 describe('IssueReplayCount', function () {
   const groupId = '3363325111';
-  const organization = TestStubs.Organization();
+  const {organization, routerContext} = initializeOrg();
 
   it('does not render when a group has no replays', async function () {
     const mockReplaysCount = {};
@@ -31,7 +32,8 @@ describe('IssueReplayCount', function () {
     const {container} = render(
       <ReplayCountContext.Provider value={mockReplaysCount}>
         <IssueReplayCount groupId={groupId} />
-      </ReplayCountContext.Provider>
+      </ReplayCountContext.Provider>,
+      {context: routerContext}
     );
 
     await waitFor(() => {

--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -11,6 +11,7 @@ import {Event} from 'sentry/types/event';
 const {organization} = initializeOrg();
 describe('Tag Facets', function () {
   let tagsMock;
+  const routerContext = TestStubs.routerContext();
 
   beforeEach(function () {
     tagsMock = MockApiClient.addMockResponse({
@@ -197,6 +198,7 @@ describe('Tag Facets', function () {
         />,
         {
           organization,
+          context: routerContext,
         }
       );
       expect(await screen.findByRole('button', {name: 'Show All Tags'})).toHaveAttribute(
@@ -216,6 +218,7 @@ describe('Tag Facets', function () {
         />,
         {
           organization,
+          context: routerContext,
         }
       );
       expect(
@@ -453,6 +456,7 @@ describe('Tag Facets', function () {
         />,
         {
           organization,
+          context: routerContext,
         }
       );
       expect(await screen.findByRole('button', {name: 'View All Tags'})).toHaveAttribute(
@@ -472,6 +476,7 @@ describe('Tag Facets', function () {
         />,
         {
           organization,
+          context: routerContext,
         }
       );
       expect(

--- a/static/app/components/idBadge/memberBadge.spec.jsx
+++ b/static/app/components/idBadge/memberBadge.spec.jsx
@@ -4,12 +4,13 @@ import MemberBadge from 'sentry/components/idBadge/memberBadge';
 
 describe('MemberBadge', function () {
   let member;
+  const routerContext = TestStubs.routerContext();
   beforeEach(() => {
     member = TestStubs.Member();
   });
 
   it('renders with link when member and orgId are supplied', function () {
-    render(<MemberBadge member={member} orgId="orgId" />);
+    render(<MemberBadge member={member} orgId="orgId" />, {context: routerContext});
 
     expect(screen.getByTestId('letter_avatar-avatar')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Foo Bar'})).toBeInTheDocument();

--- a/static/app/components/idBadge/projectBadge.spec.tsx
+++ b/static/app/components/idBadge/projectBadge.spec.tsx
@@ -4,7 +4,8 @@ import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 
 describe('ProjectBadge', function () {
   it('renders with Avatar and team name', function () {
-    render(<ProjectBadge project={TestStubs.Project()} />);
+    const routerContext = TestStubs.routerContext();
+    render(<ProjectBadge project={TestStubs.Project()} />, {context: routerContext});
 
     expect(screen.getByRole('img')).toBeInTheDocument();
     expect(screen.getByRole('link')).toHaveAttribute(

--- a/static/app/components/links/link.tsx
+++ b/static/app/components/links/link.tsx
@@ -1,11 +1,11 @@
-import {forwardRef, useEffect} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {Link as RouterLink, withRouter, WithRouterProps} from 'react-router';
+import {forwardRef, useContext, useEffect} from 'react';
+import {Link as RouterLink} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {Location, LocationDescriptor} from 'history';
 
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import {RouteContext} from 'sentry/views/routeContext';
 
 import {linkStyles} from './styles';
 
@@ -36,27 +36,17 @@ export interface LinkProps
  * A context-aware version of Link (from react-router) that falls
  * back to <a> if there is no router present
  */
-
-interface WithRouterBaseLinkProps extends WithRouterProps, LinkProps {}
-
-function BaseLink({
-  location,
-  disabled,
-  to,
-  forwardedRef,
-  router: _router,
-  params: _params,
-  routes: _routes,
-  ...props
-}: WithRouterBaseLinkProps): React.ReactElement {
+function BaseLink({disabled, to, forwardedRef, ...props}: LinkProps): React.ReactElement {
+  const route = useContext(RouteContext);
+  const location = route?.location;
   useEffect(() => {
     // check if the router is present
-    if (!location) {
+    if (!(route && location)) {
       Sentry.captureException(
         new Error('The link component was rendered without being wrapped by a <Router />')
       );
     }
-  }, [location]);
+  }, [route, location]);
 
   to = normalizeUrl(to, location);
 
@@ -68,14 +58,12 @@ function BaseLink({
 }
 
 // Re-assign to Link to make auto-importing smarter
-const Link = withRouter(
-  styled(
-    forwardRef<HTMLAnchorElement, Omit<WithRouterBaseLinkProps, 'forwardedRef'>>(
-      (props, ref) => <BaseLink forwardedRef={ref} {...props} />
-    )
-  )`
-    ${linkStyles}
-  `
-);
+const Link = styled(
+  forwardRef<HTMLAnchorElement, Omit<LinkProps, 'forwardedRef'>>((props, ref) => (
+    <BaseLink forwardedRef={ref} {...props} />
+  ))
+)`
+  ${linkStyles}
+`;
 
 export default Link;

--- a/static/app/components/links/listLink.tsx
+++ b/static/app/components/links/listLink.tsx
@@ -1,45 +1,44 @@
-// eslint-disable-next-line no-restricted-imports
-import {Link as RouterLink, withRouter, WithRouterProps} from 'react-router';
+import {Link as RouterLink} from 'react-router';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import {LocationDescriptor} from 'history';
 import * as qs from 'query-string';
 
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 type LinkProps = Omit<React.ComponentProps<typeof RouterLink>, 'to'>;
 
-type Props = WithRouterProps &
-  LinkProps & {
-    /**
-     * Link target. We don't want to expose the ToLocationFunction on this component.
-     */
-    to: LocationDescriptor;
-    /**
-     * The class to apply when the link is 'active'
-     */
-    activeClassName?: string;
-    disabled?: boolean;
-    index?: boolean;
-    /**
-     * Should be should be supplied by the parent component
-     */
-    isActive?: (location: LocationDescriptor, indexOnly?: boolean) => boolean;
-    query?: string;
-  };
+type Props = LinkProps & {
+  /**
+   * Link target. We don't want to expose the ToLocationFunction on this component.
+   */
+  to: LocationDescriptor;
+  /**
+   * The class to apply when the link is 'active'
+   */
+  activeClassName?: string;
+  disabled?: boolean;
+  index?: boolean;
+  /**
+   * Should be should be supplied by the parent component
+   */
+  isActive?: (location: LocationDescriptor, indexOnly?: boolean) => boolean;
+  query?: string;
+};
 
 function ListLink({
   children,
   className,
   isActive,
   query,
-  router,
   to,
   activeClassName = 'active',
   index = false,
   disabled = false,
   ...props
 }: Props) {
+  const {router} = useRouteContext();
   const queryData = query ? qs.parse(query) : undefined;
   const targetLocation = typeof to === 'string' ? {pathname: to, query: queryData} : to;
   const target = normalizeUrl(targetLocation);
@@ -58,7 +57,7 @@ function ListLink({
   );
 }
 
-export default withRouter(ListLink);
+export default ListLink;
 
 const StyledLi = styled('li', {
   shouldForwardProp: prop => prop !== 'disabled',

--- a/static/app/components/modals/debugFileCustomRepository/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/index.tsx
@@ -1,6 +1,4 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {css} from '@emotion/react';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -13,6 +11,7 @@ import {getDebugSourceName} from 'sentry/data/debugFileSources';
 import {t, tct} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {AppStoreConnectStatusData, CustomRepoType} from 'sentry/types/debugFiles';
+import {useParams} from 'sentry/utils/useParams';
 
 import AppStoreConnect from './appStoreConnect';
 import Http from './http';
@@ -29,7 +28,7 @@ type RouteParams = {
   projectId: string;
 };
 
-type Props = WithRouterProps<RouteParams, {}> & {
+type Props = {
   appStoreConnectSourcesQuantity: number;
   /**
    * Callback invoked with the updated config value.
@@ -66,12 +65,12 @@ function DebugFileCustomRepository({
   onSave,
   sourceConfig,
   sourceType,
-  params: {orgId, projectId: projectSlug},
   appStoreConnectStatusData,
   closeModal,
   organization,
   appStoreConnectSourcesQuantity,
 }: Props) {
+  const {orgId, projectId: projectSlug} = useParams<RouteParams>();
   function handleSave(data?: Record<string, any>) {
     if (!data) {
       closeModal();
@@ -193,7 +192,7 @@ function DebugFileCustomRepository({
   );
 }
 
-export default withRouter(DebugFileCustomRepository);
+export default DebugFileCustomRepository;
 
 export const modalCss = css`
   width: 100%;

--- a/static/app/components/modals/emailVerificationModal.spec.tsx
+++ b/static/app/components/modals/emailVerificationModal.spec.tsx
@@ -3,6 +3,7 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import EmailVerificationModal from 'sentry/components/modals/emailVerificationModal';
 
 describe('Email Verification Modal', function () {
+  const routerContext = TestStubs.routerContext();
   it('renders', function () {
     MockApiClient.addMockResponse({
       url: '/users/me/emails/',
@@ -13,7 +14,8 @@ describe('Email Verification Modal', function () {
       <EmailVerificationModal
         Body={(p => p.children) as any}
         Header={(p => p.children) as any}
-      />
+      />,
+      {context: routerContext}
     );
     const message = screen.getByText('Please verify your email before');
     expect(message.parentElement).toHaveTextContent(

--- a/static/app/components/modals/emailVerificationModal.tsx
+++ b/static/app/components/modals/emailVerificationModal.tsx
@@ -1,6 +1,4 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {Client} from 'sentry/api';
@@ -10,11 +8,10 @@ import withApi from 'sentry/utils/withApi';
 import {EmailAddresses} from 'sentry/views/settings/account/accountEmails';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
-type Props = WithRouterProps &
-  Pick<ModalRenderProps, 'Body' | 'Header'> & {
-    api: Client;
-    actionMessage?: string;
-  };
+type Props = Pick<ModalRenderProps, 'Body' | 'Header'> & {
+  api: Client;
+  actionMessage?: string;
+};
 
 function EmailVerificationModal({
   Header,
@@ -41,5 +38,5 @@ function EmailVerificationModal({
   );
 }
 
-export default withRouter(withApi(EmailVerificationModal));
+export default withApi(EmailVerificationModal);
 export {EmailVerificationModal};

--- a/static/app/components/modals/recoveryOptionsModal.spec.jsx
+++ b/static/app/components/modals/recoveryOptionsModal.spec.jsx
@@ -6,6 +6,7 @@ describe('RecoveryOptionsModal', function () {
   const closeModal = jest.fn();
   const onClose = jest.fn();
   const mockId = TestStubs.Authenticators().Recovery().authId;
+  const routerContext = TestStubs.routerContext();
 
   beforeEach(function () {
     MockApiClient.clearMockResponses();
@@ -25,7 +26,8 @@ describe('RecoveryOptionsModal', function () {
         authenticatorName="Authenticator App"
         closeModal={closeModal}
         onClose={onClose}
-      />
+      />,
+      {context: routerContext}
     );
   }
 

--- a/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/profilingOnboardingModal.spec.tsx
@@ -162,7 +162,8 @@ describe('ProfilingOnboarding', function () {
     });
 
     render(
-      <ProfilingOnboardingModal organization={organization} {...MockRenderModalProps} />
+      <ProfilingOnboardingModal organization={organization} {...MockRenderModalProps} />,
+      {context: TestStubs.routerContext()}
     );
 
     selectProject(project);

--- a/static/app/components/replays/replayTagsTableRow.spec.tsx
+++ b/static/app/components/replays/replayTagsTableRow.spec.tsx
@@ -30,7 +30,10 @@ describe('ReplayTagsTableRow', () => {
   });
 
   it('Should render the tag value as a link if we get a link result from generateUrl', () => {
-    render(<ReplayTagsTableRow tag={genericTag} generateUrl={() => 'https://foo.bar'} />);
+    render(
+      <ReplayTagsTableRow tag={genericTag} generateUrl={() => 'https://foo.bar'} />,
+      {context: TestStubs.routerContext()}
+    );
 
     expect(screen.getByText('foo')).toBeInTheDocument();
     expect(screen.getByText('bar')).toBeInTheDocument();

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -1,6 +1,4 @@
 import {useCallback, useEffect, useMemo} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
@@ -16,6 +14,8 @@ import {t} from 'sentry/locale';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
+import {useParams} from 'sentry/utils/useParams';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {Result} from './sources/types';
 import List from './list';
@@ -26,7 +26,7 @@ type ListProps = React.ComponentProps<typeof List>;
 
 interface InputProps extends Pick<AutoCompleteOpts, 'getInputProps'> {}
 
-interface SearchProps extends WithRouterProps<{orgId: string}> {
+interface SearchProps {
   /**
    * For analytics
    */
@@ -81,9 +81,10 @@ function Search({
   resultFooter,
   searchOptions,
   sources,
-  router,
-  params,
 }: SearchProps): React.ReactElement {
+  const {router} = useRouteContext();
+
+  const params = useParams<{orgId: string}>();
   useEffect(() => {
     trackAdvancedAnalyticsEvent(`${entryPoint}.open`, {
       organization: null,
@@ -209,7 +210,7 @@ function Search({
   );
 }
 
-const WithRouterSearch = withRouter(Search);
+const WithRouterSearch = Search;
 export {WithRouterSearch as Search, SearchProps};
 
 const SearchWrapper = styled('div')`

--- a/static/app/components/search/searchResult.tsx
+++ b/static/app/components/search/searchResult.tsx
@@ -1,6 +1,4 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import DocIntegrationAvatar from 'sentry/components/avatar/docIntegrationAvatar';
@@ -10,10 +8,11 @@ import {IconInput, IconLink, IconSettings} from 'sentry/icons';
 import PluginIcon from 'sentry/plugins/components/pluginIcon';
 import space from 'sentry/styles/space';
 import highlightFuseMatches from 'sentry/utils/highlightFuseMatches';
+import {useParams} from 'sentry/utils/useParams';
 
 import {Result} from './sources/types';
 
-type Props = WithRouterProps<{orgId: string}> & {
+type Props = {
   highlighted: boolean;
   item: Result['item'];
   matches: Result['matches'];
@@ -38,7 +37,9 @@ function renderResultType({resultType, model}: Result['item']) {
   }
 }
 
-function SearchResult({item, matches, params, highlighted}: Props) {
+function SearchResult({item, matches, highlighted}: Props) {
+  const params = useParams<{orgId: string}>();
+
   const {sourceType, model, extra} = item;
 
   function renderContent() {
@@ -97,7 +98,7 @@ function SearchResult({item, matches, params, highlighted}: Props) {
   );
 }
 
-export default withRouter(SearchResult);
+export default SearchResult;
 
 const SearchDetail = styled('div')`
   font-size: 0.8em;

--- a/static/app/components/sidebar/index.spec.jsx
+++ b/static/app/components/sidebar/index.spec.jsx
@@ -9,7 +9,7 @@ import {PersistedStoreProvider} from 'sentry/stores/persistedStore';
 jest.mock('sentry/actionCreators/serviceIncidents');
 
 describe('Sidebar', function () {
-  const {organization, router} = initializeOrg();
+  const {organization, router, routerContext} = initializeOrg();
   const broadcast = TestStubs.Broadcast();
   const user = TestStubs.User();
   const apiMocks = {};
@@ -22,7 +22,7 @@ describe('Sidebar', function () {
     </PersistedStoreProvider>
   );
 
-  const renderSidebar = props => render(getElement(props));
+  const renderSidebar = props => render(getElement(props), {context: routerContext});
 
   beforeEach(function () {
     apiMocks.broadcasts = MockApiClient.addMockResponse({

--- a/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/switchOrganization.spec.tsx
@@ -3,6 +3,7 @@ import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {SwitchOrganization} from 'sentry/components/sidebar/sidebarDropdown/switchOrganization';
 
 describe('SwitchOrganization', function () {
+  const routerContext = TestStubs.routerContext();
   it('can list organizations', function () {
     jest.useFakeTimers();
     render(
@@ -12,7 +13,8 @@ describe('SwitchOrganization', function () {
           TestStubs.Organization({name: 'Organization 1'}),
           TestStubs.Organization({name: 'Organization 2', slug: 'org2'}),
         ]}
-      />
+      />,
+      {context: TestStubs.routerContext()}
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -52,7 +54,8 @@ describe('SwitchOrganization', function () {
             features: ['customer-domains'],
           }),
         ]}
-      />
+      />,
+      {context: routerContext}
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -90,7 +93,8 @@ describe('SwitchOrganization', function () {
             features: [],
           }),
         ]}
-      />
+      />,
+      {context: routerContext}
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -180,7 +184,7 @@ describe('SwitchOrganization', function () {
           }),
         ]}
       />,
-      {organization: currentOrg}
+      {organization: currentOrg, context: routerContext}
     );
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
@@ -203,7 +207,9 @@ describe('SwitchOrganization', function () {
 
   it('shows "Create an Org" if they have permission', function () {
     jest.useFakeTimers();
-    render(<SwitchOrganization canCreateOrganization organizations={[]} />);
+    render(<SwitchOrganization canCreateOrganization organizations={[]} />, {
+      context: routerContext,
+    });
 
     userEvent.hover(screen.getByTestId('sidebar-switch-org'));
     act(() => void jest.advanceTimersByTime(500));

--- a/static/app/components/stream/processingIssueHint.spec.jsx
+++ b/static/app/components/stream/processingIssueHint.spec.jsx
@@ -26,7 +26,8 @@ describe('ProcessingIssueHint', function () {
         orgId={orgId}
         projectId={projectId}
         showProject={showProject}
-      />
+      />,
+      {context: TestStubs.routerContext()}
     );
     container = result.container;
   }

--- a/static/app/components/tabs/index.spec.tsx
+++ b/static/app/components/tabs/index.spec.tsx
@@ -202,6 +202,7 @@ describe('Tabs', () => {
   });
 
   it('renders tab links', () => {
+    const routerContext = TestStubs.routerContext();
     render(
       <Tabs>
         <TabList>
@@ -216,7 +217,8 @@ describe('Tabs', () => {
             <Item key={tab.key}>{tab.content}</Item>
           ))}
         </TabPanels>
-      </Tabs>
+      </Tabs>,
+      {context: routerContext}
     );
 
     TABS.forEach(tab => {

--- a/static/app/components/tag.spec.tsx
+++ b/static/app/components/tag.spec.tsx
@@ -4,6 +4,7 @@ import Tag from 'sentry/components/tag';
 import {IconFire} from 'sentry/icons';
 
 describe('Tag', () => {
+  const routerContext = TestStubs.routerContext();
   it('basic', () => {
     render(<Tag>Text</Tag>);
     expect(screen.getByText('Text')).toBeInTheDocument();
@@ -52,7 +53,8 @@ describe('Tag', () => {
     render(
       <Tag type="highlight" to={to}>
         Internal link
-      </Tag>
+      </Tag>,
+      {context: routerContext}
     );
     expect(screen.getByText('Internal link')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'Internal link'})).toBeInTheDocument();

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -1,7 +1,7 @@
 import {customerDomain, usingCustomerDomain} from 'sentry/constants';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
-export function useParams() {
+export function useParams<P = Record<string, string>>(): P {
   const {params} = useRouteContext();
 
   if (usingCustomerDomain && customerDomain) {

--- a/static/app/views/eventsV2/index.spec.jsx
+++ b/static/app/views/eventsV2/index.spec.jsx
@@ -127,7 +127,9 @@ describe('EventsV2 > Landing', function () {
       features: [...features, 'discover-query-builder-as-landing-page'],
     });
 
-    render(<DiscoverLanding organization={org} location={{query: {}}} router={{}} />);
+    render(<DiscoverLanding organization={org} location={{query: {}}} router={{}} />, {
+      context: TestStubs.routerContext(),
+    });
 
     expect(screen.getByText('Discover')).toHaveAttribute(
       'href',

--- a/static/app/views/organizationIntegrations/integrationRow.spec.tsx
+++ b/static/app/views/organizationIntegrations/integrationRow.spec.tsx
@@ -1,9 +1,10 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import IntegrationRow from 'sentry/views/organizationIntegrations/integrationRow';
 
 describe('IntegrationRow', function () {
-  const org = TestStubs.Organization();
+  const {organization: org, routerContext} = initializeOrg();
 
   describe('SentryApp', function () {
     it('is an internal SentryApp', function () {
@@ -35,7 +36,8 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={0}
           categories={[]}
-        />
+        />,
+        {context: routerContext}
       );
       expect(screen.getByText('ClickUp')).toBeInTheDocument();
       expect(screen.getByText('ClickUp')).toHaveAttribute(
@@ -57,7 +59,8 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={1}
           categories={[]}
-        />
+        />,
+        {context: routerContext}
       );
       expect(screen.getByText('Bitbucket')).toBeInTheDocument();
       expect(screen.getByText('Bitbucket')).toHaveAttribute(
@@ -78,7 +81,8 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={3}
           categories={[]}
-        />
+        />,
+        {context: routerContext}
       );
       expect(screen.getByText('Installed')).toBeInTheDocument();
       expect(screen.getByText('Bitbucket')).toHaveAttribute(
@@ -99,7 +103,8 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={0}
           categories={[]}
-        />
+        />,
+        {context: routerContext}
       );
       expect(screen.getByText('Not Installed')).toBeInTheDocument();
       expect(screen.getByText('Github')).toHaveAttribute(
@@ -120,7 +125,8 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={1}
           categories={[]}
-        />
+        />,
+        {context: routerContext}
       );
       expect(screen.getByText('Installed')).toBeInTheDocument();
       expect(screen.getByText('1 Configuration')).toBeInTheDocument();
@@ -141,7 +147,8 @@ describe('IntegrationRow', function () {
           publishStatus="published"
           configurations={3}
           categories={[]}
-        />
+        />,
+        {context: routerContext}
       );
       expect(screen.getByText('Installed')).toBeInTheDocument();
       expect(screen.getByText('3 Configurations')).toBeInTheDocument();

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -488,7 +488,7 @@ export class UsageChart extends Component<Props, State> {
     const {footer} = this.props;
 
     return (
-      <Panel id="usage-chart">
+      <Panel id="usage-chart" data-test-id="usage-chart">
         <ChartContainer>{this.renderChart()}</ChartContainer>
         {footer}
       </Panel>

--- a/static/app/views/projectDetail/projectLatestAlerts.spec.jsx
+++ b/static/app/views/projectDetail/projectLatestAlerts.spec.jsx
@@ -6,7 +6,7 @@ import ProjectLatestAlerts from 'sentry/views/projectDetail/projectLatestAlerts'
 
 describe('ProjectDetail > ProjectLatestAlerts', function () {
   let endpointMock, rulesEndpointMock;
-  const {organization, project, router} = initializeOrg();
+  const {organization, project, router, routerContext} = initializeOrg();
 
   beforeEach(function () {
     endpointMock = MockApiClient.addMockResponse({
@@ -34,7 +34,8 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
         projectSlug={project.slug}
         location={router.location}
         isProjectStabilized
-      />
+      />,
+      {context: routerContext}
     );
 
     expect(endpointMock).toHaveBeenCalledTimes(2); // one for closed, one for open
@@ -111,7 +112,8 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
         projectSlug={project.slug}
         location={router.location}
         isProjectStabilized
-      />
+      />,
+      {context: routerContext}
     );
 
     expect(await screen.findByRole('button', {name: 'Create Alert'})).toHaveAttribute(

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbTitle.spec.tsx
@@ -1,8 +1,11 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {BreadcrumbContextProvider} from 'sentry-test/providers/breadcrumbContextProvider';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import SettingsBreadcrumb from 'sentry/views/settings/components/settingsBreadcrumb';
 import BreadcrumbTitle from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
+
+jest.unmock('sentry/utils/recreateRoute');
 
 describe('BreadcrumbTitle', function () {
   const testRoutes = [
@@ -12,11 +15,18 @@ describe('BreadcrumbTitle', function () {
   ];
 
   it('renders settings breadcrumbs and replaces title', function () {
+    const {routerContext} = initializeOrg({
+      router: {
+        routes: testRoutes,
+      },
+    } as any);
+
     render(
       <BreadcrumbContextProvider routes={testRoutes}>
         <SettingsBreadcrumb routes={testRoutes} params={{}} route={{}} />
         <BreadcrumbTitle routes={testRoutes} title="Last Title" />
-      </BreadcrumbContextProvider>
+      </BreadcrumbContextProvider>,
+      {context: routerContext}
     );
 
     const crumbs = screen.getAllByRole('link');
@@ -26,6 +36,12 @@ describe('BreadcrumbTitle', function () {
   });
 
   it('cleans up routes', () => {
+    const {routerContext} = initializeOrg({
+      router: {
+        routes: testRoutes,
+      },
+    } as any);
+
     let upOneRoutes = testRoutes.slice(0, -1);
 
     const {rerender} = render(
@@ -33,7 +49,8 @@ describe('BreadcrumbTitle', function () {
         <SettingsBreadcrumb routes={testRoutes} params={{}} route={{}} />
         <BreadcrumbTitle routes={upOneRoutes} title="Second Title" />
         <BreadcrumbTitle routes={testRoutes} title="Last Title" />
-      </BreadcrumbContextProvider>
+      </BreadcrumbContextProvider>,
+      {context: routerContext}
     );
 
     const crumbs = screen.getAllByRole('link');

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
@@ -1,3 +1,4 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {
@@ -92,9 +93,15 @@ describe('TeamMembers', function () {
   });
 
   it('can invite member from team dropdown with access', async function () {
-    const org = TestStubs.Organization({access: ['team:admin'], openMembership: false});
+    const {organization: org, routerContext} = initializeOrg({
+      organization: TestStubs.Organization({
+        access: ['team:admin'],
+        openMembership: false,
+      }),
+    });
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />
+      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      {context: routerContext}
     );
 
     userEvent.click((await screen.findAllByRole('button', {name: 'Add Member'}))[0]);
@@ -104,9 +111,15 @@ describe('TeamMembers', function () {
   });
 
   it('can invite member from team dropdown with access and `Open Membership` enabled', async function () {
-    const org = TestStubs.Organization({access: ['team:admin'], openMembership: true});
+    const {organization: org, routerContext} = initializeOrg({
+      organization: TestStubs.Organization({
+        access: ['team:admin'],
+        openMembership: true,
+      }),
+    });
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />
+      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      {context: routerContext}
     );
 
     userEvent.click((await screen.findAllByRole('button', {name: 'Add Member'}))[0]);
@@ -116,9 +129,12 @@ describe('TeamMembers', function () {
   });
 
   it('can invite member from team dropdown without access and `Open Membership` enabled', async function () {
-    const org = TestStubs.Organization({access: [], openMembership: true});
+    const {organization: org, routerContext} = initializeOrg({
+      organization: TestStubs.Organization({access: [], openMembership: true}),
+    });
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />
+      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      {context: routerContext}
     );
 
     userEvent.click((await screen.findAllByRole('button', {name: 'Add Member'}))[0]);
@@ -128,9 +144,12 @@ describe('TeamMembers', function () {
   });
 
   it('can invite member from team dropdown without access and `Open Membership` disabled', async function () {
-    const org = TestStubs.Organization({access: [], openMembership: false});
+    const {organization: org, routerContext} = initializeOrg({
+      organization: TestStubs.Organization({access: [], openMembership: false}),
+    });
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />
+      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      {context: routerContext}
     );
 
     userEvent.click((await screen.findAllByRole('button', {name: 'Add Member'}))[0]);

--- a/static/app/views/settings/project/projectTeams.spec.jsx
+++ b/static/app/views/settings/project/projectTeams.spec.jsx
@@ -1,3 +1,4 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   render,
   renderGlobalModal,
@@ -13,6 +14,7 @@ import ProjectTeams from 'sentry/views/settings/project/projectTeams';
 describe('ProjectTeams', function () {
   let org;
   let project;
+  let routerContext;
 
   const team1 = TestStubs.Team();
   const team2 = TestStubs.Team({
@@ -23,8 +25,10 @@ describe('ProjectTeams', function () {
   });
 
   beforeEach(function () {
-    org = TestStubs.Organization();
-    project = TestStubs.ProjectDetails();
+    const initialData = initializeOrg();
+    org = initialData.organization;
+    project = initialData.project;
+    routerContext = initialData.routerContext;
 
     TeamStore.loadInitialData([team1, team2]);
 
@@ -248,7 +252,8 @@ describe('ProjectTeams', function () {
         params={{orgId: org.slug, projectId: project.slug}}
         project={project}
         organization={org}
-      />
+      />,
+      {context: routerContext}
     );
 
     // Add new team

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -133,7 +133,7 @@ class ProjectTeams extends AsyncView<Props, State> {
           position="top"
         >
           <StyledCreateTeamLink
-            to=""
+            to="#create-team"
             disabled={!canCreateTeam}
             onClick={this.handleCreateTeam}
           >

--- a/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/modals/recommendedStepsModal.spec.tsx
@@ -23,9 +23,9 @@ describe('Server-Side Sampling - Recommended Steps Modal', function () {
   });
 
   it('render all recommended steps', function () {
-    const {organization, project} = getMockData();
+    const {organization, project, routerContext} = getMockData();
 
-    renderGlobalModal();
+    renderGlobalModal({context: routerContext});
 
     openModal(modalProps => (
       <RecommendedStepsModal

--- a/static/app/views/settings/project/server-side-sampling/samplingSDKUpgradesAlert.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingSDKUpgradesAlert.spec.tsx
@@ -26,7 +26,7 @@ describe('Server-Side Sampling - Sdk Upgrades Alert', function () {
   });
 
   it('renders content with update sdks info', function () {
-    const {organization, project} = getMockData();
+    const {organization, project, routerContext} = getMockData();
 
     render(
       <Fragment>
@@ -37,7 +37,8 @@ describe('Server-Side Sampling - Sdk Upgrades Alert', function () {
           onReadDocs={jest.fn()}
           recommendedSdkUpgrades={recommendedSdkUpgrades}
         />
-      </Fragment>
+      </Fragment>,
+      {context: routerContext}
     );
 
     expect(screen.getByTestId('recommended-sdk-upgrades-alert')).toBeInTheDocument();

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.spec.tsx
@@ -267,7 +267,7 @@ describe('Server-Side Sampling', function () {
   });
 
   it('display "update sdk versions" alert and open "recommended next step" modal', async function () {
-    const {organization, projects, router} = getMockData({
+    const {organization, projects, router, routerContext} = getMockData({
       projects: mockedProjects,
     });
 
@@ -282,7 +282,8 @@ describe('Server-Side Sampling', function () {
         project={projects[2]}
         router={router}
         withModal
-      />
+      />,
+      {context: routerContext}
     );
 
     expect(mockRequests.distribution).toHaveBeenCalled();


### PR DESCRIPTION
Requires https://github.com/getsentry/getsentry/pull/8975

This pull request is a continuation of https://github.com/getsentry/sentry/pull/41675 to replace `withRouter()` with hooks for function components.

My motivation for replacing `withRouter()` with hooks in this pull request is to make use of my patch of `useParams()` in https://github.com/getsentry/sentry/pull/41611.

I'm refactoring towards implicitly injecting org slugs in the customer domain world (i.e. `orgslug.sentry.io`)