### PR TITLE
feat(perf): Add a feature flag for new widget designs

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1140,6 +1140,8 @@ SENTRY_FEATURES = {
     "organizations:performance-issues-post-process-group": False,
     # Enable internal view for bannerless MEP view
     "organizations:performance-mep-bannerless-ui": False,
+    # Enable updated landing page widget designs
+    "organizations:organizations:new-widget-designs": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable populating suggested assignees with release committers

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1141,7 +1141,7 @@ SENTRY_FEATURES = {
     # Enable internal view for bannerless MEP view
     "organizations:performance-mep-bannerless-ui": False,
     # Enable updated landing page widget designs
-    "organizations:organizations:new-widget-designs": False,
+    "organizations:performance-new-widget-designs": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable populating suggested assignees with release committers

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -136,7 +136,7 @@ default_manager.add("organizations:performance-use-metrics", OrganizationFeature
 default_manager.add("organizations:performance-vitals-inp", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, True)
-default_manager.add("organizations:new-widget-designs", OrganizationFeature, True)
+default_manager.add("organizations:performance-new-widget-designs", OrganizationFeature, True)
 default_manager.add("organizations:profiling", OrganizationFeature)
 default_manager.add("organizations:profiling-onboarding-checklist", OrganizationFeature, True)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -136,6 +136,7 @@ default_manager.add("organizations:performance-use-metrics", OrganizationFeature
 default_manager.add("organizations:performance-vitals-inp", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-bannerless-ui", OrganizationFeature, True)
 default_manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, True)
+default_manager.add("organizations:new-widget-designs", OrganizationFeature, True)
 default_manager.add("organizations:profiling", OrganizationFeature)
 default_manager.add("organizations:profiling-onboarding-checklist", OrganizationFeature, True)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)


### PR DESCRIPTION
This PR adds a feature flag to enable new designs for vitals, line chart and trends widgets. Flagr: https://flagr.getsentry.net/#/flags/285

Fixes PERF-1837