### PR TITLE
feat(perf-issues): Prepare to ship render-blocking assets detector

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -527,6 +527,9 @@ register("performance.issues.n_plus_one_db_ext.problem-creation", default=0.0)
 # System-wide options for default performance detection settings for any org opted into the performance-issues-ingest feature. Meant for rollout.
 register("performance.issues.n_plus_one_db.count_threshold", default=5)
 register("performance.issues.n_plus_one_db.duration_threshold", default=100.0)
+register("performance.issues.render_blocking_assets.fcp_minimum_threshold", default=2000.0)
+register("performance.issues.render_blocking_assets.fcp_maximum_threshold", default=10000.0)
+register("performance.issues.render_blocking_assets.fcp_ratio_threshold", default=0.33)
 
 # Dynamic Sampling system wide options
 # Killswitch to disable new dynamic sampling behavior specifically new dynamic sampling biases

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -102,6 +102,9 @@ register(
         "n_plus_one_db_issue_rate": 0,
         "n_plus_one_db_count": 5,
         "n_plus_one_db_duration_threshold": 500,
+        "render_blocking_fcp_min": 2000.0,
+        "render_blocking_fcp_max": 10000.0,
+        "render_blocking_fcp_ratio": 0.33,
     },
 )
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -232,6 +232,15 @@ def get_detection_settings(project_id: Optional[str] = None):
             "n_plus_one_db_duration_threshold": options.get(
                 "performance.issues.n_plus_one_db.duration_threshold"
             ),
+            "render_blocking_fcp_min": options.get(
+                "performance.issues.render_blocking_assets.fcp_minimum_threshold"
+            ),
+            "render_blocking_fcp_max": options.get(
+                "performance.issues.render_blocking_assets.fcp_maximum_threshold"
+            ),
+            "render_blocking_fcp_ratio": options.get(
+                "performance.issues.render_blocking_assets.fcp_ratio_threshold"
+            ),
         }
     )
 
@@ -270,10 +279,9 @@ def get_detection_settings(project_id: Optional[str] = None):
             }
         ],
         DetectorType.RENDER_BLOCKING_ASSET_SPAN: {
-            "fcp_minimum_threshold": 2000.0,  # ms
-            "fcp_maximum_threshold": 10000.0,  # ms
-            "fcp_ratio_threshold": 0.25,
-            "allowed_span_ops": ["resource.link", "resource.script"],
+            "fcp_minimum_threshold": settings["render_blocking_fcp_min"],  # ms
+            "fcp_maximum_threshold": settings["render_blocking_fcp_max"],  # ms
+            "fcp_ratio_threshold": settings["render_blocking_fcp_ratio"],  # in the range [0, 1]
         },
         DetectorType.N_PLUS_ONE_SPANS: [
             {
@@ -774,15 +782,22 @@ class RenderBlockingAssetSpanDetector(PerformanceDetector):
             return
 
         op = span.get("op", None)
-        allowed_span_ops = self.settings.get("allowed_span_ops")
-        if op not in allowed_span_ops:
+        if op not in ["resource.link", "resource.script"]:
             return False
 
         if self._is_blocking_render(span):
             span_id = span.get("span_id", None)
             fingerprint = fingerprint_span(span)
             if span_id and fingerprint:
-                self.stored_problems[fingerprint] = PerformanceSpanProblem(span_id, op, [span_id])
+                self.stored_problems[fingerprint] = PerformanceProblem(
+                    fingerprint=fingerprint,
+                    op=op,
+                    desc=span.get("description") or "",
+                    type=GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN,
+                    offender_span_ids=[span_id],
+                    parent_span_ids=[],
+                    cause_span_ids=[],
+                )
 
         # If we visit a span that starts after FCP, then we know we've already
         # seen all possible render-blocking resource spans.

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -603,7 +603,7 @@ class PerformanceDetectionTest(unittest.TestCase):
         assert sdk_span_mock.containing_transaction.set_tag.call_count == 0
 
         _detect_performance_problems(render_blocking_asset_event, sdk_span_mock)
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 4
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 5
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
@@ -617,6 +617,10 @@ class PerformanceDetectionTest(unittest.TestCase):
                 call(
                     "_pi_transaction",
                     "aaaaaaaaaaaaaaaa",
+                ),
+                call(
+                    "_pi_render_blocking_assets_fp",
+                    "6060649d4f8435d88735",
                 ),
                 call(
                     "_pi_render_blocking_assets",


### PR DESCRIPTION
- Use options to control thresholds
- Increase the default FCP ratio from 0.25 to 0.33 for less noise
- return `PerformanceProblem` instead of `PerformanceSpanProblem`, as all new detectors should

Issues still won't be created, but this gets everything else ready to ship after a bit more threshold tuning now that we don't need a deployment.