### PR TITLE
test(perf-issues): Walk entire directory tree when loading performance issue fixtures

### DIFF
--- a/src/sentry/testutils/performance_issues/event_generators.py
+++ b/src/sentry/testutils/performance_issues/event_generators.py
@@ -25,6 +25,7 @@ for (dirpath, dirnames, filenames) in os.walk(_fixture_path):
 
         with open(filepath) as f:
             event = json.load(f)
+            event["project"] = PROJECT_ID
 
         EVENTS[full_event_name] = event
 

--- a/src/sentry/testutils/performance_issues/event_generators.py
+++ b/src/sentry/testutils/performance_issues/event_generators.py
@@ -10,16 +10,23 @@ _fixture_path = get_fixture_path("events", "performance_problems")
 EVENTS = {}
 PROJECT_ID = 1
 
-for filename in os.listdir(_fixture_path):
-    if not filename.endswith(".json"):
-        continue
+for (dirpath, dirnames, filenames) in os.walk(_fixture_path):
 
-    [event_name, _extension] = filename.split(".")
+    for filename in filenames:
+        [name, extension] = filename.split(".")
 
-    with open(os.path.join(_fixture_path, filename)) as f:
-        event = json.load(f)
-        event["project"] = PROJECT_ID
-        EVENTS[event_name] = event
+        if not extension == "json":
+            continue
+
+        filepath = os.path.join(dirpath, filename)
+        relative_path = os.path.relpath(filepath, _fixture_path)
+
+        [full_event_name, _] = relative_path.split(".")
+
+        with open(filepath) as f:
+            event = json.load(f)
+
+        EVENTS[full_event_name] = event
 
 
 # Duration is in ms


### PR DESCRIPTION
When generating the `EVENTS` lookup for fixtures, walk the entire tree of fixture files, not just whatever is in the root. Ensures that files in `fixtures/events/performance_problems/n-plus-one-api-calls/` make into `EVENTS`.
