### PR TITLE
fix(ui) Fix more customer domain related links and problems

### DIFF
--- a/static/app/components/issues/compactIssue.tsx
+++ b/static/app/components/issues/compactIssue.tsx
@@ -171,7 +171,6 @@ class CompactIssue extends Component<Props, State> {
         <CompactIssueHeader
           data={issue}
           organization={organization}
-          projectId={issue.project.slug}
           eventId={this.props.eventId}
         />
         {this.props.children}

--- a/static/app/components/issues/compactIssue.tsx
+++ b/static/app/components/issues/compactIssue.tsx
@@ -21,15 +21,14 @@ import withOrganization from 'sentry/utils/withOrganization';
 type HeaderProps = {
   data: BaseGroup;
   organization: Organization;
-  projectId: string;
   eventId?: string;
 };
 
-function CompactIssueHeader({data, organization, projectId, eventId}: HeaderProps) {
+function CompactIssueHeader({data, organization, eventId}: HeaderProps) {
   const basePath = `/organizations/${organization.slug}/issues/`;
 
   const issueLink = eventId
-    ? `/organizations/${organization.slug}/projects/${projectId}/events/${eventId}/?referrer=compact-issue`
+    ? `${basePath}${data.id}/events/${eventId}/?referrer=compact-issue`
     : `${basePath}${data.id}/?referrer=compact-issue`;
 
   const commentColor: keyof Aliases =

--- a/static/app/components/profiling/profileHeader.tsx
+++ b/static/app/components/profiling/profileHeader.tsx
@@ -1,7 +1,6 @@
-import {Link} from 'react-router';
-
 import Button from 'sentry/components/button';
 import * as Layout from 'sentry/components/layouts/thirds';
+import Link from 'sentry/components/links/link';
 import {Breadcrumb} from 'sentry/components/profiling/breadcrumb';
 import {t} from 'sentry/locale';
 import {Event} from 'sentry/types';

--- a/static/app/utils/useApiRequests.tsx
+++ b/static/app/utils/useApiRequests.tsx
@@ -236,7 +236,7 @@ function useApiRequests<T extends Record<string, any>>({
 
   const fetchData = useCallback(
     async (extraState: Partial<State<T>> = {}) => {
-      // Nothing to fetch if enpoints are empty
+      // Nothing to fetch if endpoints are empty
       if (!endpoints.length) {
         setState(prevState => ({
           ...prevState,
@@ -288,7 +288,6 @@ function useApiRequests<T extends Record<string, any>>({
     },
     [api, endpoints, handleError, handleRequestSuccess, location]
   );
-
   const reloadData = useCallback(() => fetchData({isReloading: true}), [fetchData]);
 
   const handleMount = useCallback(async () => {

--- a/static/app/utils/useParams.tsx
+++ b/static/app/utils/useParams.tsx
@@ -1,13 +1,18 @@
+import {useMemo} from 'react';
+
 import {customerDomain, usingCustomerDomain} from 'sentry/constants';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 export function useParams() {
-  const {params} = useRouteContext();
+  const contextParams = useRouteContext().params;
 
-  if (usingCustomerDomain && customerDomain) {
-    // We do not know if the caller of this hook requires orgId, so we populate orgId implicitly.
-    return {...params, orgId: customerDomain};
-  }
-
-  return params;
+  // Memoize params as mutating for customer domains causes other hooks
+  // that depend on `useParams()` to refresh infinitely.
+  return useMemo(() => {
+    if (usingCustomerDomain && customerDomain && contextParams.orgId === undefined) {
+      // We do not know if the caller of this hook requires orgId, so we populate orgId implicitly.
+      return {...contextParams, orgId: customerDomain};
+    }
+    return contextParams;
+  }, [contextParams]);
 }

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -30,6 +30,10 @@ describe('normalizeUrl', function () {
       ['/settings/sentry/teams/peeps/', '/settings/teams/peeps/'],
       ['/settings/account/security/', '/settings/account/security/'],
       ['/settings/account/details/', '/settings/account/details/'],
+      [
+        '/settings/acme/developer-settings/release-bot/',
+        '/settings/developer-settings/release-bot/',
+      ],
       ['/organizations/new', '/organizations/new'],
       ['/organizations/new/', '/organizations/new/'],
       ['/join-request/acme', '/join-request/'],

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -58,16 +58,22 @@ describe('normalizeUrl', function () {
   it('replaces pathname in objects', function () {
     const location = TestStubs.location();
     result = normalizeUrl({pathname: '/settings/acme/'}, location);
-    // @ts-ignore
     expect(result.pathname).toEqual('/settings/organization/');
 
     result = normalizeUrl({pathname: '/settings/sentry/members'}, location);
-    // @ts-ignore
     expect(result.pathname).toEqual('/settings/members');
 
     result = normalizeUrl({pathname: '/organizations/albertos-apples/issues'}, location);
-    // @ts-ignore
     expect(result.pathname).toEqual('/issues');
+
+    result = normalizeUrl(
+      {
+        pathname: '/organizations/sentry/profiling/profile/sentry/abc123/',
+        query: {sorting: 'call order'},
+      },
+      location
+    );
+    expect(result.pathname).toEqual('/profiling/profile/sentry/abc123/');
 
     result = normalizeUrl(
       {
@@ -76,7 +82,6 @@ describe('normalizeUrl', function () {
       },
       location
     );
-    // @ts-ignore
     expect(result.pathname).toEqual('/issues');
   });
 

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -7,7 +7,7 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   // /organizations/slug/section, but not /organizations/new
   [/\/?organizations\/(?!new)[^\/]+\/(.*)/, '/$1'],
   // For /settings/:orgId/ -> /settings/organization/
-  [/\/?settings\/[^\/]+\/?$/, '/settings/organization/'],
+  [/\/settings\/[^\/]+\/?$/, '/settings/organization/'],
   // Move /settings/:orgId/:section -> /settings/:section
   // but not /settings/organization or /settings/projects which is a new URL
   [/\/?settings\/(?!projects)(?!account)[^\/]+\/(.*)/, '/settings/$1'],

--- a/static/app/views/monitors/create.tsx
+++ b/static/app/views/monitors/create.tsx
@@ -1,30 +1,28 @@
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import * as PropTypes from 'prop-types';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import SentryTypes from 'sentry/sentryTypes';
+import {Organization} from 'sentry/types';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 
 import MonitorForm from './monitorForm';
 import {Monitor} from './types';
 
-type Props = AsyncView['props'] & RouteComponentProps<{orgId: string}, {}>;
-
-export default class CreateMonitor extends AsyncView<Props, AsyncView['state']> {
-  static contextTypes = {
-    router: PropTypes.object,
-    organization: SentryTypes.Organization,
+type Props = AsyncView['props'] &
+  RouteComponentProps<{orgId: string}, {}> & {
+    organization: Organization;
   };
 
+class CreateMonitor extends AsyncView<Props, AsyncView['state']> {
   getTitle() {
     return `Monitors - ${this.orgSlug}`;
   }
 
   get orgSlug() {
-    return this.context.organization.slug;
+    return this.props.organization.slug;
   }
 
   onSubmitSuccess = (data: Monitor) => {
@@ -56,6 +54,7 @@ export default class CreateMonitor extends AsyncView<Props, AsyncView['state']> 
     );
   }
 }
+export default withOrganization(CreateMonitor);
 
 const HelpText = styled('p')`
   color: ${p => p.theme.subText};

--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -1,15 +1,15 @@
 import {Fragment} from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import * as PropTypes from 'prop-types';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
 import * as Layout from 'sentry/components/layouts/thirds';
 import PageFilterBar from 'sentry/components/organizations/pageFilterBar';
 import {Panel, PanelHeader} from 'sentry/components/panels';
 import {t} from 'sentry/locale';
-import SentryTypes from 'sentry/sentryTypes';
 import space from 'sentry/styles/space';
+import {Organization} from 'sentry/types';
+import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 
 import MonitorCheckIns from './monitorCheckIns';
@@ -20,20 +20,17 @@ import MonitorOnboarding from './onboarding';
 import {Monitor} from './types';
 
 type Props = AsyncView['props'] &
-  RouteComponentProps<{monitorId: string; orgId: string}, {}>;
+  RouteComponentProps<{monitorId: string; orgId: string}, {}> & {
+    organization: Organization;
+  };
 
 type State = AsyncView['state'] & {
   monitor: Monitor | null;
 };
 
 class MonitorDetails extends AsyncView<Props, State> {
-  static contextTypes = {
-    router: PropTypes.object,
-    organization: SentryTypes.Organization,
-  };
-
   get orgSlug() {
-    return this.context.organization.slug;
+    return this.props.organization.slug;
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
@@ -89,4 +86,4 @@ const StyledPageFilterBar = styled(PageFilterBar)`
   margin-bottom: ${space(2)};
 `;
 
-export default MonitorDetails;
+export default withOrganization(MonitorDetails);

--- a/static/app/views/monitors/edit.tsx
+++ b/static/app/views/monitors/edit.tsx
@@ -1,27 +1,24 @@
 import {browserHistory, RouteComponentProps} from 'react-router';
-import * as PropTypes from 'prop-types';
 
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
-import SentryTypes from 'sentry/sentryTypes';
+import {Organization} from 'sentry/types';
+import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 
 import MonitorForm from './monitorForm';
 import {Monitor} from './types';
 
 type Props = AsyncView['props'] &
-  RouteComponentProps<{monitorId: string; orgId: string}, {}>;
+  RouteComponentProps<{monitorId: string; orgId: string}, {}> & {
+    organization: Organization;
+  };
 
 type State = AsyncView['state'] & {
   monitor: Monitor | null;
 };
 
-export default class EditMonitor extends AsyncView<Props, State> {
-  static contextTypes = {
-    router: PropTypes.object,
-    organization: SentryTypes.Organization,
-  };
-
+class EditMonitor extends AsyncView<Props, State> {
   get orgSlug() {
     return this.context.organization.slug;
   }
@@ -67,3 +64,5 @@ export default class EditMonitor extends AsyncView<Props, State> {
     );
   }
 }
+
+export default withOrganization(EditMonitor);

--- a/static/app/views/monitors/onboarding.tsx
+++ b/static/app/views/monitors/onboarding.tsx
@@ -54,16 +54,16 @@ const MonitorOnboarding = ({monitor}: Props) => {
             </OnboardingText>
             <OnboardingText>
               {t('For reflecting successful execution with optional duration in ms')}
-              <CodeSnippet language="json" hideActionBar>
-                {`curl -X PUT \\\n'${checkInDetailsUrl}' \\\n--header 'Authorization: DSN {DSN}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"status": "ok", "duration": 3000}'`}
-              </CodeSnippet>
             </OnboardingText>
+            <CodeSnippet language="json" hideActionBar>
+              {`curl -X PUT \\\n'${checkInDetailsUrl}' \\\n--header 'Authorization: DSN {DSN}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"status": "ok", "duration": 3000}'`}
+            </CodeSnippet>
             <OnboardingText>
               {t('For reflecting failed execution with optional duration in ms')}
-              <CodeSnippet language="json" hideActionBar>
-                {`curl -X PUT \\\n'${checkInDetailsUrl}' \\\n--header 'Authorization: DSN {DSN}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"status": "error", "duration": 3000}'`}
-              </CodeSnippet>
             </OnboardingText>
+            <CodeSnippet language="json" hideActionBar>
+              {`curl -X PUT \\\n'${checkInDetailsUrl}' \\\n--header 'Authorization: DSN {DSN}' \\\n--header 'Content-Type: application/json' \\\n--data-raw '{"status": "error", "duration": 3000}'`}
+            </CodeSnippet>
           </StyledListItem>
         </List>
       </PanelBody>

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -31,8 +31,10 @@ import {
 import {IconAdd, IconDelete} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {InternalAppApiToken, Scope, SentryApp} from 'sentry/types';
+import {InternalAppApiToken, Organization, Scope, SentryApp} from 'sentry/types';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
+import withOrganization from 'sentry/utils/withOrganization';
 import AsyncView from 'sentry/views/asyncView';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import PermissionsObserver from 'sentry/views/settings/organizationDeveloperSettings/permissionsObserver';
@@ -133,14 +135,16 @@ class SentryAppFormModel extends FormModel {
   }
 }
 
-type Props = RouteComponentProps<{orgId: string; appSlug?: string}, {}>;
+type Props = RouteComponentProps<{orgId: string; appSlug?: string}, {}> & {
+  organization: Organization;
+};
 
 type State = AsyncView['state'] & {
   app: SentryApp | null;
   tokens: InternalAppApiToken[];
 };
 
-export default class SentryApplicationDetails extends AsyncView<Props, State> {
+class SentryApplicationDetails extends AsyncView<Props, State> {
   form = new SentryAppFormModel();
 
   getDefaultState(): State {
@@ -190,7 +194,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
     } else {
       addSuccessMessage(t('%s successfully created.', data.name));
     }
-    browserHistory.push(url);
+    browserHistory.push(normalizeUrl(url));
   };
 
   handleSubmitError = err => {
@@ -378,7 +382,6 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
   };
 
   renderBody() {
-    const {orgId} = this.props.params;
     const {app} = this.state;
     const scopes = (app && [...app.scopes]) || [];
     const events = (app && this.normalize(app.events)) || [];
@@ -403,7 +406,7 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
           apiEndpoint={endpoint}
           allowUndo
           initialData={{
-            organization: orgId,
+            organization: this.props.organization.slug,
             isAlertable: false,
             isInternal: this.isInternal,
             schema: {},
@@ -495,6 +498,8 @@ export default class SentryApplicationDetails extends AsyncView<Props, State> {
     );
   }
 }
+
+export default withOrganization(SentryApplicationDetails);
 
 const StyledPanelItem = styled(PanelItem)`
   display: flex;


### PR DESCRIPTION
* Fix more URLs within profiling.
* Make user-feedback use more direct URLs that actually work with customer domains. The previous project level event path would result in redirect loops.
* Removed redundant properties in CompactIssue to fix user-feedback display problems.
* Fixed monitor onboarding element nesting errors. `pre` elements cannot be inside `p` elements.
* Fixed infinite loops within `useApiRequests()` caused by `useParams()` not having a stable return value. Because of the spread related to customer domains the identity of the object was not consistent causing dependent hooks (like useApiRequests) to spin infinitely. I tried a few different ways to capture this scenario in a test. I ran into multiple issues where `Router` does not like to be re-rendered.
* Remove the usage of `contextTypes` that I added to monitors. I forgot that `contextTypes` was deprecated. I've replaced context usage with our standard HoCs.