### PR TITLE
feat(mobile-exp): Tag distribution removes the expand button and adds more tags

### DIFF
--- a/static/app/components/group/tagFacets/index.spec.tsx
+++ b/static/app/components/group/tagFacets/index.spec.tsx
@@ -1,17 +1,14 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {
-  MOBILE_TAGS,
-  MOBILE_TAGS_FORMATTER,
-  TagFacets,
-} from 'sentry/components/group/tagFacets';
+import {MOBILE_TAGS_FORMATTER, TagFacets} from 'sentry/components/group/tagFacets';
 import {Event} from 'sentry/types/event';
 
 const {organization} = initializeOrg();
 describe('Tag Facets', function () {
   let tagsMock;
   const project = TestStubs.Project();
+  const tags = ['os', 'device', 'release'];
 
   beforeEach(function () {
     tagsMock = MockApiClient.addMockResponse({
@@ -99,7 +96,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           style="bars"
         />,
         {
@@ -120,7 +117,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           style="bars"
         />,
         {
@@ -161,7 +158,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           event={{tags: [{key: 'os', value: 'Android 12'}]} as Event}
           style="bars"
         />,
@@ -187,7 +184,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="bars"
         />,
@@ -210,7 +207,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="bars"
         />,
@@ -230,7 +227,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="bars"
         />,
@@ -270,7 +267,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="bars"
         />,
@@ -324,7 +321,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="bars"
         />,
@@ -361,7 +358,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           style="breakdowns"
         />,
         {
@@ -382,7 +379,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           style="breakdowns"
         />,
         {
@@ -425,7 +422,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           event={{tags: [{key: 'os', value: 'Android 12'}]} as Event}
           style="breakdowns"
         />,
@@ -451,7 +448,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="breakdowns"
         />,
@@ -474,7 +471,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="breakdowns"
         />,
@@ -494,7 +491,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="breakdowns"
         />,
@@ -518,7 +515,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="breakdowns"
         />,
@@ -553,7 +550,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="breakdowns"
         />,
@@ -607,7 +604,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           tagFormatter={MOBILE_TAGS_FORMATTER}
           style="breakdowns"
         />,
@@ -644,7 +641,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           style="distributions"
           tagFormatter={MOBILE_TAGS_FORMATTER}
         />,
@@ -666,7 +663,7 @@ describe('Tag Facets', function () {
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           style="distributions"
           tagFormatter={MOBILE_TAGS_FORMATTER}
         />,
@@ -688,36 +685,13 @@ describe('Tag Facets', function () {
       expect(screen.getByText('100%')).toBeInTheDocument();
     });
 
-    it('displays tag breakdown when expand button is clicked', async function () {
-      render(
-        <TagFacets
-          environments={[]}
-          groupId="1"
-          project={project}
-          tagKeys={MOBILE_TAGS}
-          style="distributions"
-        />,
-        {
-          organization,
-        }
-      );
-      await waitFor(() => {
-        expect(tagsMock).toHaveBeenCalled();
-      });
-      expect(screen.queryByText('iOS 16.0')).not.toBeInTheDocument();
-      expect(screen.queryByText('33%')).not.toBeInTheDocument();
-      userEvent.click(screen.getByLabelText('expand-os'));
-      expect(screen.getByText('iOS 16.0')).toBeInTheDocument();
-      expect(screen.getByText('33%')).toBeInTheDocument();
-    });
-
     it('displays tag breakdown when hovering over segments', async function () {
       render(
         <TagFacets
           environments={[]}
           groupId="1"
           project={project}
-          tagKeys={MOBILE_TAGS}
+          tagKeys={tags}
           style="distributions"
           tagFormatter={MOBILE_TAGS_FORMATTER}
         />,

--- a/static/app/components/group/tagFacets/index.tsx
+++ b/static/app/components/group/tagFacets/index.tsx
@@ -6,7 +6,14 @@ import TagFacetsBreakdowns from './tagFacetsBreakdowns';
 import TagFacetsDistributions from './tagFacetsDistributions';
 import {TagFacetsProps} from './tagFacetsTypes';
 
-export const MOBILE_TAGS = ['os', 'device', 'release'];
+export const MOBILE_TAGS = [
+  'device',
+  'environment',
+  'os',
+  'release',
+  'browser',
+  'transaction',
+];
 
 export function MOBILE_TAGS_FORMATTER(tagsData: Record<string, TagWithTopValues>) {
   // For "release" tag keys, format the release tag value to be more readable (ie removing version prefix)

--- a/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
+++ b/static/app/components/group/tagFacets/tagFacetsDistributionMeter.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
@@ -6,7 +5,6 @@ import {TagSegment} from 'sentry/actionCreators/events';
 import Link from 'sentry/components/links/link';
 import {SegmentValue} from 'sentry/components/tagDistributionMeter';
 import Tooltip from 'sentry/components/tooltip';
-import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {percent} from 'sentry/utils';
@@ -28,8 +26,6 @@ function TagFacetsDistributionMeter({
   totalValues,
   onTagClick,
 }: Props) {
-  const [expanded, setExpanded] = useState<boolean>(false);
-
   function renderTitle() {
     if (!Array.isArray(segments) || segments.length <= 0) {
       return (
@@ -45,14 +41,6 @@ function TagFacetsDistributionMeter({
         <TitleDescription>
           <Label>{segments[0].name || t('n/a')}</Label>
         </TitleDescription>
-        <StyledChevron
-          direction={expanded ? 'up' : 'down'}
-          size="md"
-          onClick={() => {
-            setExpanded(!expanded);
-          }}
-          aria-label={`expand-${title}`}
-        />
       </Title>
     );
   }
@@ -142,7 +130,7 @@ function TagFacetsDistributionMeter({
   return (
     <TagSummary>
       {renderTitle()}
-      {expanded ? renderLegend() : renderSegments()}
+      {renderSegments()}
     </TagSummary>
   );
 }
@@ -182,7 +170,6 @@ const TitleDescription = styled('div')`
 
 const Label = styled('div')`
   ${p => p.theme.overflowEllipsis};
-  max-width: 150px;
 `;
 
 const OtherSegment = styled('span')<{color: string}>`
@@ -208,10 +195,6 @@ const Segment = styled(Link, {shouldForwardProp: isPropValid})<{color: string}>`
   text-align: right;
   font-size: ${p => p.theme.fontSizeExtraSmall};
   padding: 1px ${space(0.5)} 0 0;
-`;
-
-const StyledChevron = styled(IconChevron)`
-  margin: -${space(0.5)} 0 0 ${space(0.5)};
 `;
 
 const LegendGrid = styled('div')`


### PR DESCRIPTION
Adds some more tags and removes the expand button
![image](https://user-images.githubusercontent.com/83961295/204018909-25cdd087-4075-4167-bfb5-09939be3e688.png)