### PR TITLE
feat(domains) Make slug updates work with customer domains

### DIFF
--- a/static/app/utils/useResolveRoute.tsx
+++ b/static/app/utils/useResolveRoute.tsx
@@ -5,6 +5,7 @@ import {OrganizationSummary} from 'sentry/types';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import shouldUseLegacyRoute from './shouldUseLegacyRoute';
+import {normalizeUrl} from './withDomainRequired';
 
 /**
  * If organization is passed, then a URL with the route will be returned with the customer domain prefix attached if the
@@ -19,7 +20,7 @@ function useResolveRoute(route: string, organization?: OrganizationSummary) {
 
   if (!organization) {
     if (hasCustomerDomain) {
-      return `${sentryUrl}${route}`;
+      return `${sentryUrl}${normalizeUrl(route)}`;
     }
     return route;
   }
@@ -36,7 +37,7 @@ function useResolveRoute(route: string, organization?: OrganizationSummary) {
     }
     return route;
   }
-  return `${organizationUrl}${route}`;
+  return `${organizationUrl}${normalizeUrl(route)}`;
 }
 
 export default useResolveRoute;

--- a/static/app/views/acceptOrganizationInvite.spec.jsx
+++ b/static/app/views/acceptOrganizationInvite.spec.jsx
@@ -167,15 +167,10 @@ describe('AcceptOrganizationInvite', function () {
 
     expect(screen.getByTestId('existing-member')).toBeInTheDocument();
 
-    const {replace} = window.location;
-    window.location.replace = jest.fn();
-
     userEvent.click(screen.getByTestId('existing-member-link'));
 
     expect(logout).toHaveBeenCalled();
     await waitFor(() => expect(window.location.replace).toHaveBeenCalled());
-
-    window.location.replace = replace;
   });
 
   it('shows right options for logged in user and optional SSO', function () {
@@ -209,16 +204,10 @@ describe('AcceptOrganizationInvite', function () {
     render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
 
     expect(screen.getByTestId('existing-member')).toBeInTheDocument();
-
-    const {replace} = window.location;
-    window.location.replace = jest.fn();
-
     userEvent.click(screen.getByTestId('existing-member-link'));
 
     expect(logout).toHaveBeenCalled();
     await waitFor(() => expect(window.location.replace).toHaveBeenCalled());
-
-    window.location.replace = replace;
   });
 
   it('shows 2fa warning', function () {

--- a/static/app/views/app/index.spec.jsx
+++ b/static/app/views/app/index.spec.jsx
@@ -3,8 +3,6 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import ConfigStore from 'sentry/stores/configStore';
 import App from 'sentry/views/app';
 
-const originalLocation = window.location;
-
 describe('App', function () {
   beforeEach(function () {
     MockApiClient.addMockResponse({
@@ -28,17 +26,10 @@ describe('App', function () {
       url: '/internal/options/?query=is:required',
       body: TestStubs.InstallWizard(),
     });
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: {
-        replace: jest.fn(),
-      },
-    });
   });
 
   afterEach(function () {
     jest.resetAllMocks();
-    window.location = originalLocation;
   });
 
   it('renders', function () {

--- a/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.spec.tsx
@@ -61,7 +61,7 @@ describe('OrganizationGeneralSettings', function () {
     const mock = MockApiClient.addMockResponse({
       url: ENDPOINT,
       method: 'PUT',
-      body: organization,
+      body: {...organization, slug: 'new-slug'},
     });
 
     userEvent.clear(screen.getByRole('textbox', {name: /slug/i}));

--- a/static/app/views/settings/organizationGeneralSettings/index.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/index.tsx
@@ -66,17 +66,20 @@ function OrganizationGeneralSettings(props: Props) {
 
   const handleSaveForm: React.ComponentProps<
     typeof OrganizationSettingsForm
-  >['onSave'] = (prevData: Organization, data: Partial<Organization>) => {
-    if (data.slug && data.slug !== prevData.slug) {
-      changeOrganizationSlug(
-        prevData,
-        data as Partial<Organization> & Pick<Organization, 'slug'>
-      );
-      browserHistory.replace(`/settings/${data.slug}/`);
+  >['onSave'] = (prevData: Organization, updated: Organization) => {
+    if (updated.slug && updated.slug !== prevData.slug) {
+      changeOrganizationSlug(prevData, updated);
+
+      if (updated.features.includes('customer-domains')) {
+        const {organizationUrl} = updated.links;
+        window.location.replace(`${organizationUrl}/settings/organization/`);
+      } else {
+        browserHistory.replace(`/settings/${updated.slug}/`);
+      }
     } else {
       // This will update OrganizationStore (as well as OrganizationsStore
       // which is slightly incorrect because it has summaries vs a detailed org)
-      updateOrganization(data);
+      updateOrganization(updated);
     }
   };
 

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.jsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.spec.jsx
@@ -24,6 +24,7 @@ describe('OrganizationSettingsForm', function () {
     putMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,
       method: 'PUT',
+      body: organization,
     });
 
     render(
@@ -91,6 +92,7 @@ describe('OrganizationSettingsForm', function () {
     putMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/`,
       method: 'PUT',
+      body: organization,
     });
 
     render(

--- a/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
+++ b/static/app/views/settings/organizationGeneralSettings/organizationSettingsForm.tsx
@@ -15,7 +15,7 @@ type Props = {
   access: Set<Scope>;
   initialData: Organization;
   location: Location;
-  onSave: (previous: Organization, updated: Record<string, any>) => void;
+  onSave: (previous: Organization, updated: Organization) => void;
   organization: Organization;
 } & RouteComponentProps<{orgId: string}, {}>;
 
@@ -50,10 +50,10 @@ class OrganizationSettingsForm extends AsyncComponent<Props, State> {
         saveOnBlur
         allowUndo
         initialData={initialData}
-        onSubmitSuccess={(_resp, model) => {
+        onSubmitSuccess={(updated, _model) => {
           // Special case for slug, need to forward to new slug
           if (typeof onSave === 'function') {
-            onSave(initialData, model.initialData);
+            onSave(initialData, updated);
           }
         }}
         onSubmitError={() => addErrorMessage('Unable to save change')}

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -261,7 +261,7 @@ window.scrollTo = jest.fn();
 // We need to re-define `window.location`, otherwise we can't spyOn certain
 // methods as `window.location` is read-only
 Object.defineProperty(window, 'location', {
-  value: {...window.location, assign: jest.fn(), reload: jest.fn()},
+  value: {...window.location, assign: jest.fn(), reload: jest.fn(), replace: jest.fn()},
   configurable: true,
   writable: true,
 });


### PR DESCRIPTION
When an org switches their slug & has subdomains enabled we need to redirect them to their new domain. Unfortunately `browserHistory` is unable to change history to a new domain so we need to use `.replace` on window.location.

I've added a global mock for `window.location.replace` as we had it defined in a few places and also have already mocked out several other methods on `window.location`.