### PR TITLE
fix(hybrid-cloud): get_organizations does not query related data.

### DIFF
--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -36,7 +36,7 @@ from sentry.models import (
     UserPermission,
     UserRoleUser,
 )
-from sentry.services.hybrid_cloud.organization import ApiOrganization, organization_service
+from sentry.services.hybrid_cloud.organization import ApiOrganizationSummary, organization_service
 from sentry.utils.avatar import get_gravatar_url
 
 
@@ -209,7 +209,7 @@ class UserSerializer(Serializer):  # type: ignore
                 only_visible=False,
                 organization_ids=list(organization_ids),
             )
-            orgs_by_id: Mapping[int, ApiOrganization] = {
+            orgs_by_id: Mapping[int, ApiOrganizationSummary] = {
                 o.id: o for o in auth_identity_organizations
             }
 

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -30,16 +30,18 @@ class OrganizationService(InterfaceWithLifecycle):
         scope: Optional[str],
         only_visible: bool,
         organization_ids: Optional[List[int]] = None,
-    ) -> List["ApiOrganization"]:
+    ) -> List["ApiOrganizationSummary"]:
         """
         When user_id is set, returns all organizations associated with that user id given
         a scope and visibility requirement.  When user_id is not set, but organization_ids is, provides the
         set of organizations matching those ids, ignore scope and user_id.
 
         When only_visible set, the organization object is only returned if it's status is Visible, otherwise any
-        organization will be returned. NOTE: related resources, including membership, projects, and teams, will
-        ALWAYS filter by status=VISIBLE.  To pull projects or teams that are not visible, use a different service
-        endpoint.
+        organization will be returned.
+
+        Because this endpoint fetches not from region silos, but the control silo organization membership table,
+        only a subset of all organization metadata is available.  Spanning out and querying multiple organizations
+        for their full metadata is greatly discouraged for performance reasons.
         """
         pass
 
@@ -177,6 +179,10 @@ class ApiOrganizationFlags:
 
 @dataclass
 class ApiOrganizationSummary:
+    """
+    The subset of organization metadata available from the control silo specifically.
+    """
+
     slug: str = ""
     id: int = -1
     name: str = ""

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -26,6 +26,7 @@ from sentry.models.avatars.base import AvatarBase
 from sentry.models.user import User
 from sentry.services.hybrid_cloud.organization import (
     ApiOrganization,
+    ApiOrganizationSummary,
     ApiUserOrganizationContext,
     organization_service,
 )
@@ -84,12 +85,8 @@ class OrganizationMixin:
             if not is_implicit:
                 self.active_organization = None
                 return
-            active_organization = ApiUserOrganizationContext(
-                user_id=request.user.id,
-                organization=backup_organization,
-                member=organization_service.check_membership_by_id(
-                    organization_id=backup_organization.id, user_id=request.user.id
-                ),
+            active_organization = organization_service.get_organization_by_id(
+                id=backup_organization.id, user_id=request.user.id
             )
 
         if active_organization and active_organization.member:
@@ -99,11 +96,11 @@ class OrganizationMixin:
 
     def _lookup_organizations(
         self, is_implicit: bool, organization_slug: str | None, request: Request
-    ) -> tuple[ApiUserOrganizationContext | None, ApiOrganization | None]:
+    ) -> tuple[ApiUserOrganizationContext | None, ApiOrganizationSummary | None]:
         active_organization: ApiUserOrganizationContext | None = self._try_superuser_org_lookup(
             organization_slug, request
         )
-        backup_organization: ApiOrganization | None = None
+        backup_organization: ApiOrganizationSummary | None = None
         if active_organization is None:
             organizations = organization_service.get_organizations(
                 user_id=request.user.id, scope=None, only_visible=True
@@ -121,11 +118,11 @@ class OrganizationMixin:
         self,
         is_implicit: bool,
         organization_slug: str,
-        organizations: list[ApiOrganization],
+        organizations: list[ApiOrganizationSummary],
         request: Request,
     ) -> ApiUserOrganizationContext | None:
         try:
-            backup_org: ApiOrganization | None = next(
+            backup_org: ApiOrganizationSummary | None = next(
                 o for o in organizations if o.slug == organization_slug
             )
         except StopIteration:
@@ -137,11 +134,8 @@ class OrganizationMixin:
             backup_org = None
 
         if backup_org is not None:
-            membership = organization_service.check_membership_by_id(
-                organization_id=backup_org.id, user_id=request.user.id
-            )
-            return ApiUserOrganizationContext(
-                user_id=request.user.id, organization=backup_org, member=membership
+            return organization_service.get_organization_by_id(
+                id=backup_org.id, user_id=request.user.id
             )
         return None
 


### PR DESCRIPTION
I introduced get_organizations into the user serializer recently in my continued attempts to enable more silo tests and convert code to hybrid cloud compatibility by ensuring that organization objects (which exist in the region silo) can be serialized into metadata from the user serializer (in the control silo).   The `get_organizations` service stub represents a future silo RPC interaction to fulfill this need.

However, the existing `get_organizations` call was being used primarily for `authentication` purposes, and required doing a large lookup for a user's teams and other related data.  Doing this across many users in the user serializer therefore introduced  large performance pain.

In reality, `get_organizations` should likely not be querying and serializing related data.  From the user serializer perspective, the need is only on minor metadata such as the `slug` and `name`.  From auth and access, only the final id of "some" organization is needed, and once it is determined that the teams data will be required, a separate, full query can be made.

This should greatly improve the performance of both call sites.