### PR TITLE
ref(alert-preview): preview strategies

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -5,13 +5,10 @@ from django import forms
 from sentry.eventstore.models import GroupEvent
 from sentry.rules import MATCH_CHOICES, EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
+from sentry.rules.history.preview_strategy import DATASET_TO_COLUMN_NAME, get_dataset_columns
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
-from sentry.types.condition_activity import (
-    DATASET_TO_COLUMN_NAME,
-    ConditionActivity,
-    get_dataset_columns,
-)
+from sentry.types.condition_activity import ConditionActivity
 
 # Maps attributes to snuba columns
 ATTR_CHOICES = {

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -9,9 +9,10 @@ from sentry.eventstore.models import GroupEvent
 from sentry.rules import LEVEL_MATCH_CHOICES as MATCH_CHOICES
 from sentry.rules import EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
+from sentry.rules.history.preview_strategy import get_dataset_columns
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
-from sentry.types.condition_activity import ConditionActivity, get_dataset_columns
+from sentry.types.condition_activity import ConditionActivity
 
 key: Callable[[Tuple[int, str]], int] = lambda x: x[0]
 LEVEL_CHOICES = {f"{k}": v for k, v in sorted(LOG_LEVELS.items(), key=key, reverse=True)}

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -8,9 +8,10 @@ from sentry import tagstore
 from sentry.eventstore.models import GroupEvent
 from sentry.rules import MATCH_CHOICES, EventState, MatchType
 from sentry.rules.conditions.base import EventCondition
+from sentry.rules.history.preview_strategy import get_dataset_columns
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.events import Columns
-from sentry.types.condition_activity import ConditionActivity, get_dataset_columns
+from sentry.types.condition_activity import ConditionActivity
 
 
 class TaggedEventForm(forms.Form):  # type: ignore

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -11,8 +11,8 @@ from sentry.models import Group, Project
 from sentry.rules import RuleBase, rules
 from sentry.rules.history.preview_strategy import (
     GROUP_CATEGORY_TO_DATASET,
-    GROUP_STRATEGIES,
-    GROUPS_STRATEGIES,
+    UPDATE_KWARGS_FOR_GROUP,
+    UPDATE_KWARGS_FOR_GROUPS,
 )
 from sentry.rules.processor import get_match_function
 from sentry.snuba.dataset import Dataset
@@ -216,10 +216,10 @@ def get_top_groups(
     # queries each dataset for top x groups and then gets top x overall
     query_params = []
     for dataset in datasets:
-        if dataset not in GROUPS_STRATEGIES:
+        if dataset not in UPDATE_KWARGS_FOR_GROUPS:
             continue
 
-        kwargs = GROUPS_STRATEGIES[dataset](
+        kwargs = UPDATE_KWARGS_FOR_GROUPS[dataset](
             group_ids,
             {
                 "dataset": dataset,
@@ -297,12 +297,12 @@ def get_events(
     for dataset, ids in group_ids.items():
         if (
             dataset not in columns
-            or dataset not in GROUP_STRATEGIES
+            or dataset not in UPDATE_KWARGS_FOR_GROUP
             or dataset == Dataset.Transactions
         ):
             # transaction query cannot be made until https://getsentry.atlassian.net/browse/SNS-1891 is fixed
             continue
-        kwargs = GROUPS_STRATEGIES[dataset](
+        kwargs = UPDATE_KWARGS_FOR_GROUPS[dataset](
             ids,
             {
                 "dataset": dataset,
@@ -412,11 +412,11 @@ def get_frequency_buckets(
     """
     Puts the events of a group into buckets, and returns the bucket counts.
     """
-    if dataset not in GROUP_STRATEGIES:
+    if dataset not in UPDATE_KWARGS_FOR_GROUP:
         return []
 
     # TODO: support counting of other fields (# of unique users, ...)
-    kwargs = GROUP_STRATEGIES[dataset](
+    kwargs = UPDATE_KWARGS_FOR_GROUP[dataset](
         group_id,
         {
             "dataset": dataset,

--- a/src/sentry/rules/history/preview_strategy.py
+++ b/src/sentry/rules/history/preview_strategy.py
@@ -40,19 +40,18 @@ def get_dataset_columns(columns: Sequence[Column]) -> Dict[Dataset, Sequence[str
     return dataset_columns
 
 
-def _events_kwargs(group_ids: Sequence[int]) -> Dict[str, Any]:
-    return {"conditions": [("group_id", "IN", group_ids)]}
+def _events_kwargs(group_ids: Sequence[int], kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    kwargs["conditions"] = [("group_id", "IN", group_ids)]
+    return kwargs
 
 
-def _transactions_kwargs(group_ids: Sequence[int]) -> Dict[str, Any]:
-    return {
-        "having": [("group_id", "IN", group_ids)],
-        "conditions": [[["hasAny", ["group_ids", ["array", group_ids]]], "=", 1]],
-        "aggregations": [
-            ("arrayJoin", ["group_ids"], "group_id"),
-            ("count", "group_id", "groupCount"),
-        ],
-    }
+def _transactions_kwargs(group_ids: Sequence[int], kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    kwargs["having"] = [("group_id", "IN", group_ids)]
+    kwargs["conditions"] = [[["hasAny", ["group_ids", ["array", group_ids]]], "=", 1]]
+    if "aggregations" not in kwargs:
+        kwargs["aggregations"] = []
+    kwargs["aggregations"].append(("arrayJoin", ["group_ids"], "group_id"))
+    return kwargs
 
 
 """
@@ -65,12 +64,14 @@ GROUPS_STRATEGIES = {
 }
 
 
-def _event_kwargs(group_id: int) -> Dict[str, Any]:
-    return {"conditions": [("group_id", "=", group_id)]}
+def _event_kwargs(group_id: int, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    kwargs["conditions"] = [("group_id", "=", group_id)]
+    return kwargs
 
 
-def _transaction_kwargs(group_id: int) -> Dict[str, Any]:
-    return {"conditions": [[["has", ["group_ids", group_id]], "=", 1]]}
+def _transaction_kwargs(group_id: int, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    kwargs["conditions"] = [[["has", ["group_ids", group_id]], "=", 1]]
+    return kwargs
 
 
 """

--- a/src/sentry/rules/history/preview_strategy.py
+++ b/src/sentry/rules/history/preview_strategy.py
@@ -1,0 +1,79 @@
+from typing import Any, Dict, Sequence
+
+from sentry.snuba.dataset import Dataset
+from sentry.snuba.events import Column
+from sentry.types.issues import GroupCategory
+
+"""
+Issue category specific components to computing a preview for a set of rules.
+
+To add support for a new issue category/dataset:
+    1. Add mapping from GroupCategory to Dataset
+    2. Add mapping from Dataset to snuba column name
+        a. The column name should be a field in sentry.snuba.events.Column
+    3. Add category-specific query params for GROUPS_STRATEGIES and GROUP_STRATEGIES
+"""
+
+# Maps group category to dataset
+GROUP_CATEGORY_TO_DATASET: Dict[GroupCategory, Dataset] = {
+    GroupCategory.ERROR: Dataset.Events,
+    GroupCategory.PERFORMANCE: Dataset.Transactions,
+}
+
+# Maps datasets to snuba column name
+DATASET_TO_COLUMN_NAME: Dict[Dataset, str] = {
+    Dataset.Events: "event_name",
+    Dataset.Transactions: "transaction_name",
+}
+
+
+# Given a list of Column Enum objects, return their actual column name in each dataset that is supported
+def get_dataset_columns(columns: Sequence[Column]) -> Dict[Dataset, Sequence[str]]:
+    dataset_columns: Dict[Dataset, Sequence[str]] = {}
+    for dataset, column_name in DATASET_TO_COLUMN_NAME.items():
+        dataset_columns[dataset] = [
+            getattr(column.value, column_name)
+            for column in columns
+            if getattr(column.value, column_name) is not None
+        ]
+
+    return dataset_columns
+
+
+def _events_kwargs(group_ids: Sequence[int]) -> Dict[str, Any]:
+    return {"conditions": [("group_id", "IN", group_ids)]}
+
+
+def _transactions_kwargs(group_ids: Sequence[int]) -> Dict[str, Any]:
+    return {
+        "having": [("group_id", "IN", group_ids)],
+        "conditions": [[["hasAny", ["group_ids", ["array", group_ids]]], "=", 1]],
+        "aggregations": [("arrayJoin", ["group_ids"], "group_id")],
+    }
+
+
+"""
+Returns the rows that contain the group id.
+If there's a many-to-many relationship, the group id column should be arrayjoined
+"""
+GROUPS_STRATEGIES = {
+    Dataset.Events: _events_kwargs,
+    Dataset.Transactions: _transactions_kwargs,
+}
+
+
+def _event_kwargs(group_id: int) -> Dict[str, Any]:
+    return {"conditions": [("group_id", "=", group_id)]}
+
+
+def _transaction_kwargs(group_id: int) -> Dict[str, Any]:
+    return {"conditions": [[["has", ["group_ids", group_id]], "=", 1]]}
+
+
+"""
+Returns the rows that reference the group id without arrayjoining.
+"""
+GROUP_STRATEGIES = {
+    Dataset.Events: _event_kwargs,
+    Dataset.Transactions: _transaction_kwargs,
+}

--- a/src/sentry/rules/history/preview_strategy.py
+++ b/src/sentry/rules/history/preview_strategy.py
@@ -48,7 +48,10 @@ def _transactions_kwargs(group_ids: Sequence[int]) -> Dict[str, Any]:
     return {
         "having": [("group_id", "IN", group_ids)],
         "conditions": [[["hasAny", ["group_ids", ["array", group_ids]]], "=", 1]],
-        "aggregations": [("arrayJoin", ["group_ids"], "group_id")],
+        "aggregations": [
+            ("arrayJoin", ["group_ids"], "group_id"),
+            ("count", "group_id", "groupCount"),
+        ],
     }
 
 

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Dict, Sequence
-
-from sentry.snuba.dataset import Dataset
-from sentry.snuba.events import Column
+from typing import Any, Dict
 
 FREQUENCY_CONDITION_BUCKET_SIZE = timedelta(minutes=5)
 
@@ -23,25 +20,3 @@ class ConditionActivity:
     type: ConditionActivityType
     timestamp: datetime
     data: Dict[str, Any] = field(default_factory=dict)
-
-
-# Map of supported datasets for preview
-DATASET_TO_COLUMN_NAME = {
-    Dataset.Events: "event_name",
-    Dataset.Transactions: "transaction_name",
-}
-
-
-def get_dataset_columns(columns: Sequence[Column]) -> Dict[Dataset, Sequence[str]]:
-    """
-    Given a list of Column Enum objects, return their actual column name in each dataset that is supported
-    """
-    dataset_columns = {}
-    for dataset, column_name in DATASET_TO_COLUMN_NAME.items():
-        dataset_columns[dataset] = [
-            getattr(column.value, column_name)
-            for column in columns
-            if getattr(column.value, column_name) is not None
-        ]
-
-    return dataset_columns


### PR DESCRIPTION
Tried to pull all the category-specific stuff into `preview_strategy.py`. There are two types of snuba queries that are different depending on the dataset:
1. `GROUPS_STRATEGY` given a list of ids, checks if a row contains at least one of the ids and arrayjoin
2. `GROUP_STRATEGY` given a single id, return rows that contain the id

Could use a better name for these strategies.