### PR TITLE
chore(hybrid-cloud): Replace withRouter with hooks part 3

### DIFF
--- a/static/app/components/events/interfaces/spans/index.tsx
+++ b/static/app/components/events/interfaces/spans/index.tsx
@@ -1,6 +1,4 @@
 import {useMemo} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 import {Observer} from 'mobx-react';
@@ -17,6 +15,7 @@ import {objectIsEmpty} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {QuickTraceContext} from 'sentry/utils/performance/quickTrace/quickTraceContext';
 import {TraceError} from 'sentry/utils/performance/quickTrace/types';
+import {useLocation} from 'sentry/utils/useLocation';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import * as AnchorLinkManager from './anchorLinkManager';
@@ -31,7 +30,7 @@ type Props = {
   event: EventTransaction;
   organization: Organization;
   affectedSpanIds?: string[];
-} & WithRouterProps;
+};
 
 function TraceErrorAlerts({
   isLoading,
@@ -85,7 +84,8 @@ function TraceErrorAlerts({
   );
 }
 
-function SpansInterface({event, affectedSpanIds, organization, location}: Props) {
+function SpansInterface({event, affectedSpanIds, organization}: Props) {
+  const location = useLocation();
   const parsedTrace = useMemo(() => parseTrace(event), [event]);
 
   const waterfallModel = useMemo(
@@ -192,4 +192,4 @@ const ErrorLabel = styled('div')`
   margin-bottom: ${space(1)};
 `;
 
-export default withRouter(withOrganization(SpansInterface));
+export default withOrganization(SpansInterface);

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -47,7 +47,6 @@ import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metr
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {decodeInteger, decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
-import {useParams} from 'sentry/utils/useParams';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
@@ -168,8 +167,7 @@ function WidgetViewerModal(props: Props) {
     pageLinks: defaultPageLinks,
     seriesResultsType,
   } = props;
-  const {location, router, routes} = useRouteContext();
-  const params = useParams();
+  const {location, router} = useRouteContext();
   const shouldShowSlider = organization.features.includes('widget-viewer-modal-minimap');
   // Get widget zoom from location
   // We use the start and end query params for just the initial state
@@ -832,9 +830,6 @@ function WidgetViewerModal(props: Props) {
             ) : (
               <MemoizedWidgetCardChartContainer
                 location={location}
-                router={router}
-                routes={routes}
-                params={params}
                 api={api}
                 organization={organization}
                 selection={modalChartSelection.current}

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -168,7 +168,8 @@ function WidgetViewerModal(props: Props) {
     pageLinks: defaultPageLinks,
     seriesResultsType,
   } = props;
-  const {location, router} = useRouteContext();
+  const location = useLocation();
+  const {router} = useRouteContext();
   const shouldShowSlider = organization.features.includes('widget-viewer-modal-minimap');
   // Get widget zoom from location
   // We use the start and end query params for just the initial state

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -47,6 +47,7 @@ import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metr
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {decodeInteger, decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';

--- a/static/app/components/version.tsx
+++ b/static/app/components/version.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -12,6 +10,7 @@ import space from 'sentry/styles/space';
 import {Organization} from 'sentry/types';
 import {formatVersion} from 'sentry/utils/formatters';
 import theme from 'sentry/utils/theme';
+import {useLocation} from 'sentry/utils/useLocation';
 import withOrganization from 'sentry/utils/withOrganization';
 
 type Props = {
@@ -61,8 +60,8 @@ const Version = ({
   projectId,
   truncate,
   className,
-  location,
-}: WithRouterProps & Props) => {
+}: Props) => {
+  const location = useLocation();
   const versionToDisplay = formatVersion(version, withPackage);
 
   let releaseDetailProjectId: null | undefined | string | string[];
@@ -187,8 +186,4 @@ const TooltipClipboardIconWrapper = styled('span')`
   }
 `;
 
-type PropsWithoutOrg = Omit<Props, 'organization'>;
-
-export default withOrganization(
-  withRouter(Version)
-) as React.ComponentClass<PropsWithoutOrg>;
+export default withOrganization(Version);

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -230,6 +230,7 @@ class WidgetCard extends Component<Props, State> {
       noDashboardsMEPProvider,
       dashboardFilters,
       isWidgetInvalid,
+      location,
     } = this.props;
 
     if (widget.displayType === DisplayType.TOP_N) {
@@ -289,6 +290,7 @@ class WidgetCard extends Component<Props, State> {
                 </Fragment>
               ) : noLazyLoad ? (
                 <WidgetCardChartContainer
+                  location={location}
                   api={api}
                   organization={organization}
                   selection={selection}
@@ -303,6 +305,7 @@ class WidgetCard extends Component<Props, State> {
               ) : (
                 <LazyLoad once resize height={200}>
                   <WidgetCardChartContainer
+                    location={location}
                     api={api}
                     organization={organization}
                     selection={selection}

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -1,6 +1,4 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import type {DataZoomComponentOption} from 'echarts';
 import {LegendComponentOption} from 'echarts';
@@ -12,6 +10,7 @@ import {Organization, PageFilters} from 'sentry/types';
 import {EChartEventHandler, Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {AggregationOutputType} from 'sentry/utils/discover/fields';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {DashboardFilters, Widget, WidgetType} from '../types';
 
@@ -21,7 +20,7 @@ import IssueWidgetQueries from './issueWidgetQueries';
 import ReleaseWidgetQueries from './releaseWidgetQueries';
 import WidgetQueries from './widgetQueries';
 
-type Props = WithRouterProps & {
+type Props = {
   api: Client;
   organization: Organization;
   selection: PageFilters;
@@ -52,8 +51,6 @@ type Props = WithRouterProps & {
 };
 
 export function WidgetCardChartContainer({
-  location,
-  router,
   api,
   organization,
   selection,
@@ -72,6 +69,7 @@ export function WidgetCardChartContainer({
   noPadding,
   chartZoomOptions,
 }: Props) {
+  const {location, router} = useRouteContext();
   if (widget.widgetType === WidgetType.ISSUE) {
     return (
       <IssueWidgetQueries
@@ -198,7 +196,7 @@ export function WidgetCardChartContainer({
   );
 }
 
-export default withRouter(WidgetCardChartContainer);
+export default WidgetCardChartContainer;
 
 const StyledTransparentLoadingMask = styled(props => (
   <TransparentLoadingMask {...props} maskBackgroundColor="transparent" />

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import type {DataZoomComponentOption} from 'echarts';
 import {LegendComponentOption} from 'echarts';
+import {Location} from 'history';
 
 import {Client} from 'sentry/api';
 import TransparentLoadingMask from 'sentry/components/charts/transparentLoadingMask';
@@ -22,6 +23,7 @@ import WidgetQueries from './widgetQueries';
 
 type Props = {
   api: Client;
+  location: Location;
   organization: Organization;
   selection: PageFilters;
   widget: Widget;

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -11,6 +11,7 @@ import {Organization, PageFilters} from 'sentry/types';
 import {EChartEventHandler, Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {AggregationOutputType} from 'sentry/utils/discover/fields';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {DashboardFilters, Widget, WidgetType} from '../types';

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -72,7 +72,8 @@ export function WidgetCardChartContainer({
   noPadding,
   chartZoomOptions,
 }: Props) {
-  const {location, router} = useRouteContext();
+  const location = useLocation();
+  const {router} = useRouteContext();
   if (widget.widgetType === WidgetType.ISSUE) {
     return (
       <IssueWidgetQueries

--- a/static/app/views/issueList/filters.tsx
+++ b/static/app/views/issueList/filters.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import DatePageFilter from 'sentry/components/datePageFilter';
@@ -12,10 +10,11 @@ import {
 } from 'sentry/components/smartSearchBar/actions';
 import space from 'sentry/styles/space';
 import {Organization, SavedSearch} from 'sentry/types';
+import {useLocation} from 'sentry/utils/useLocation';
 
 import IssueListSearchBar from './searchBar';
 
-interface Props extends WithRouterProps {
+interface Props {
   onSearch: (query: string) => void;
   organization: Organization;
   query: string;
@@ -23,14 +22,9 @@ interface Props extends WithRouterProps {
   sort: string;
 }
 
-function IssueListFilters({
-  organization,
-  savedSearch,
-  query,
-  sort,
-  onSearch,
-  location,
-}: Props) {
+function IssueListFilters({organization, savedSearch, query, sort, onSearch}: Props) {
+  const location = useLocation();
+
   const pinnedSearch = savedSearch?.isPinned ? savedSearch : undefined;
 
   return (
@@ -86,4 +80,4 @@ const StyledIssueListSearchBar = styled(IssueListSearchBar)`
   }
 `;
 
-export default withRouter(IssueListFilters);
+export default IssueListFilters;

--- a/static/app/views/issueList/issueListSetAsDefault.tsx
+++ b/static/app/views/issueList/issueListSetAsDefault.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import isNil from 'lodash/isNil';
 
 import Button from 'sentry/components/button';
@@ -8,10 +7,11 @@ import {IconBookmark} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {Organization, SavedSearch, SavedSearchType} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
+import {useLocation} from 'sentry/utils/useLocation';
 import {usePinSearch} from 'sentry/views/issueList/mutations/usePinSearch';
 import {useUnpinSearch} from 'sentry/views/issueList/mutations/useUnpinSearch';
 
-interface IssueListSetAsDefaultProps extends WithRouterProps {
+interface IssueListSetAsDefaultProps {
   organization: Organization;
   query: string;
   savedSearch: SavedSearch | null;
@@ -19,12 +19,13 @@ interface IssueListSetAsDefaultProps extends WithRouterProps {
 }
 
 const IssueListSetAsDefault = ({
-  location,
   organization,
   savedSearch,
   sort,
   query,
 }: IssueListSetAsDefaultProps) => {
+  const location = useLocation();
+
   const pinnedSearch = savedSearch?.isPinned ? savedSearch : undefined;
   const pinnedSearchActive = !isNil(pinnedSearch);
 
@@ -88,4 +89,4 @@ const IssueListSetAsDefault = ({
   );
 };
 
-export default withRouter(IssueListSetAsDefault);
+export default IssueListSetAsDefault;

--- a/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachmentsFilter.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 import xor from 'lodash/xor';
@@ -10,6 +8,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Project} from 'sentry/types';
 import {isMobilePlatform} from 'sentry/utils/platform';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 const crashReportTypes = ['event.minidump', 'event.applecrashreport'];
@@ -17,11 +16,11 @@ const SCREENSHOT_TYPE = 'event.screenshot';
 
 type Props = {
   project: Project;
-} & WithRouterProps;
+};
 
 const GroupEventAttachmentsFilter = (props: Props) => {
   const {project} = props;
-  const {query, pathname} = props.location;
+  const {query, pathname} = useLocation();
   const {types} = query;
   const allAttachmentsQuery = omit(query, 'types');
   const onlyCrashReportsQuery = {
@@ -77,4 +76,4 @@ const FilterWrapper = styled('div')`
 `;
 
 export {crashReportTypes, SCREENSHOT_TYPE};
-export default withRouter(GroupEventAttachmentsFilter);
+export default GroupEventAttachmentsFilter;

--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -1,4 +1,3 @@
-import {InjectedRouter} from 'react-router';
 import {useTheme} from '@emotion/react';
 import max from 'lodash/max';
 import min from 'lodash/min';
@@ -14,12 +13,12 @@ import {
   tooltipFormatter,
 } from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 type Props = {
   data: Series[];
   end: DateString;
   loading: boolean;
-  router: InjectedRouter;
   start: DateString;
   statsPeriod: string | null | undefined;
   utc: boolean;
@@ -64,7 +63,6 @@ function computeAxisMax(data: Series[]) {
 function Chart({
   data,
   previousData,
-  router,
   statsPeriod,
   start,
   end,
@@ -78,6 +76,7 @@ function Chart({
   chartColors,
   isLineChart,
 }: Props) {
+  const {router} = useRouteContext();
   const theme = useTheme();
 
   if (!data || data.length <= 0) {

--- a/static/app/views/performance/charts/index.tsx
+++ b/static/app/views/performance/charts/index.tsx
@@ -43,7 +43,7 @@ class Container extends Component<Props> {
   }
 
   render() {
-    const {api, organization, location, eventView, router} = this.props;
+    const {api, organization, location, eventView} = this.props;
 
     // construct request parameters for fetching chart data
     const globalSelection = eventView.getPageFilters();
@@ -115,7 +115,6 @@ class Container extends Component<Props> {
                       <Chart
                         data={results}
                         loading={loading || reloading}
-                        router={router}
                         statsPeriod={globalSelection.datetime.period}
                         start={start}
                         end={end}

--- a/static/app/views/performance/landing/chart/durationChart.tsx
+++ b/static/app/views/performance/landing/chart/durationChart.tsx
@@ -40,8 +40,7 @@ function DurationChart({
   backupField,
   usingBackupAxis,
 }: Props) {
-  const {location} = useRouteContext();
-
+  const location = useLocation();
   const api = useApi();
 
   // construct request parameters for fetching chart data

--- a/static/app/views/performance/landing/chart/durationChart.tsx
+++ b/static/app/views/performance/landing/chart/durationChart.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import ErrorPanel from 'sentry/components/charts/errorPanel';
@@ -17,6 +15,7 @@ import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useApi from 'sentry/utils/useApi';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import Chart from '../../charts/chart';
 import {DoubleHeaderContainer} from '../../styles';
@@ -30,19 +29,19 @@ type Props = {
   titleTooltip: string;
   usingBackupAxis: boolean;
   backupField?: string;
-} & WithRouterProps;
+};
 
 function DurationChart({
   organization,
   eventView,
-  location,
-  router,
   field,
   title,
   titleTooltip,
   backupField,
   usingBackupAxis,
 }: Props) {
+  const {location, router} = useRouteContext();
+
   const api = useApi();
 
   // construct request parameters for fetching chart data
@@ -165,4 +164,4 @@ const MaskContainer = styled('div')`
   position: relative;
 `;
 
-export default withRouter(DurationChart);
+export default DurationChart;

--- a/static/app/views/performance/landing/chart/durationChart.tsx
+++ b/static/app/views/performance/landing/chart/durationChart.tsx
@@ -40,7 +40,7 @@ function DurationChart({
   backupField,
   usingBackupAxis,
 }: Props) {
-  const {location, router} = useRouteContext();
+  const {location} = useRouteContext();
 
   const api = useApi();
 
@@ -131,7 +131,6 @@ function DurationChart({
                         height={250}
                         data={series}
                         loading={loading || reloading}
-                        router={router}
                         statsPeriod={globalSelection.datetime.period}
                         start={start}
                         end={end}

--- a/static/app/views/performance/landing/chart/durationChart.tsx
+++ b/static/app/views/performance/landing/chart/durationChart.tsx
@@ -15,7 +15,7 @@ import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import EventView from 'sentry/utils/discover/eventView';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useApi from 'sentry/utils/useApi';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import {useLocation} from 'sentry/utils/useLocation';
 
 import Chart from '../../charts/chart';
 import {DoubleHeaderContainer} from '../../styles';

--- a/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
+++ b/static/app/views/performance/landing/widgets/components/performanceWidget.tsx
@@ -1,6 +1,4 @@
 import {Fragment, useCallback, useRef, useState} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter} from 'react-router';
 import styled from '@emotion/styled';
 
 import ErrorPanel from 'sentry/components/charts/errorPanel';
@@ -80,7 +78,7 @@ export function GenericPerformanceWidget<T extends WidgetDataConstraint>(
           queries={queries}
           api={api}
         />
-        <_DataDisplay<T> {...props} {...widgetProps} totalHeight={totalHeight} />
+        <DataDisplay<T> {...props} {...widgetProps} totalHeight={totalHeight} />
       </MEPDataProvider>
     </Fragment>
   );
@@ -96,7 +94,7 @@ function trackDataComponentClicks(
   });
 }
 
-function _DataDisplay<T extends WidgetDataConstraint>(
+export function DataDisplay<T extends WidgetDataConstraint>(
   props: GenericPerformanceWidgetProps<T> & WidgetDataProps<T> & {totalHeight: number}
 ) {
   const {Visualizations, chartHeight, totalHeight, containerType, EmptyComponent} = props;
@@ -158,8 +156,6 @@ function _DataDisplay<T extends WidgetDataConstraint>(
     </Container>
   );
 }
-
-export const DataDisplay = withRouter(_DataDisplay);
 
 const DefaultErrorComponent = (props: {height: number}) => {
   return (

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -32,7 +32,6 @@ export type PerformanceWidgetProps = {
   chartSetting: PerformanceWidgetSetting;
   eventView: EventView;
   fields: string[];
-  location: Location;
 
   organization: Organization;
   title: string;
@@ -129,7 +128,6 @@ export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
   eventView: EventView;
 
   fields: string[];
-  location: Location;
   organization: Organization;
 
   // Header;

--- a/static/app/views/performance/landing/widgets/types.tsx
+++ b/static/app/views/performance/landing/widgets/types.tsx
@@ -128,6 +128,7 @@ export type GenericPerformanceWidgetProps<T extends WidgetDataConstraint> = {
   eventView: EventView;
 
   fields: string[];
+  location: Location;
   organization: Organization;
 
   // Header;

--- a/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/histogramWidget.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {t} from 'sentry/locale';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import HistogramQuery from 'sentry/utils/performance/histogram/histogramQuery';
+import {useLocation} from 'sentry/utils/useLocation';
 import {Chart as HistogramChart} from 'sentry/views/performance/landing/chart/histogramChart';
 
 import {GenericPerformanceWidget} from '../components/performanceWidget';
@@ -16,8 +17,9 @@ type AreaDataType = {
 };
 
 export function HistogramWidget(props: PerformanceWidgetProps) {
+  const location = useLocation();
   const mepSetting = useMEPSettingContext();
-  const {ContainerActions, location} = props;
+  const {ContainerActions} = props;
   const globalSelection = props.eventView.getPageFilters();
 
   const Queries = useMemo(() => {
@@ -28,7 +30,7 @@ export function HistogramWidget(props: PerformanceWidgetProps) {
           <HistogramQuery
             {...provided}
             eventView={provided.eventView}
-            location={props.location}
+            location={location}
             numBuckets={20}
             dataFilter="exclude_outliers"
             queryExtras={getMEPQueryParams(mepSetting)}
@@ -37,13 +39,15 @@ export function HistogramWidget(props: PerformanceWidgetProps) {
         transform: transformHistogramQuery,
       },
     };
-  }, [props.chartSetting, mepSetting.memoizationKey]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.chartSetting, mepSetting.memoizationKey, location]);
 
   const onFilterChange = () => {};
 
   return (
     <GenericPerformanceWidget<AreaDataType>
       {...props}
+      location={location}
       Subtitle={() => (
         <Subtitle>
           {globalSelection.datetime.period

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -1,6 +1,4 @@
 import {Fragment, useMemo, useState} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter} from 'react-router';
 import pick from 'lodash/pick';
 
 import _EventsRequest from 'sentry/components/charts/eventsRequest';
@@ -18,6 +16,7 @@ import {
 } from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import withApi from 'sentry/utils/withApi';
 import _DurationChart from 'sentry/views/performance/charts/chart';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
@@ -61,6 +60,7 @@ const framesList = [
 ];
 
 export function LineChartListWidget(props: PerformanceWidgetProps) {
+  const location = useLocation();
   const mepSetting = useMEPSettingContext();
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
   const {ContainerActions, organization} = props;
@@ -125,7 +125,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
           <DiscoverQuery
             {...provided}
             eventView={eventView}
-            location={props.location}
+            location={location}
             limit={3}
             cursor="0:0:1"
             noPagination
@@ -274,7 +274,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                 const transactionTarget = isUnparameterizedRow
                   ? createUnnamedTransactionsDiscoverTarget({
                       organization,
-                      location: props.location,
+                      location,
                     })
                   : transactionSummaryRouteWithQuery({
                       orgSlug: props.organization.slug,
@@ -315,7 +315,10 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                           <ListClose
                             setSelectListIndex={setSelectListIndex}
                             onClick={() =>
-                              excludeTransaction(listItem.transaction, props)
+                              excludeTransaction(listItem.transaction, {
+                                eventView: props.eventView,
+                                location,
+                              })
                             }
                           />
                         )}
@@ -336,7 +339,10 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                           <ListClose
                             setSelectListIndex={setSelectListIndex}
                             onClick={() =>
-                              excludeTransaction(listItem.transaction, props)
+                              excludeTransaction(listItem.transaction, {
+                                eventView: props.eventView,
+                                location,
+                              })
                             }
                           />
                         )}
@@ -356,7 +362,10 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                             <ListClose
                               setSelectListIndex={setSelectListIndex}
                               onClick={() =>
-                                excludeTransaction(listItem.transaction, props)
+                                excludeTransaction(listItem.transaction, {
+                                  eventView: props.eventView,
+                                  location,
+                                })
                               }
                             />
                           )}
@@ -373,7 +382,10 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
                           <ListClose
                             setSelectListIndex={setSelectListIndex}
                             onClick={() =>
-                              excludeTransaction(listItem.transaction, props)
+                              excludeTransaction(listItem.transaction, {
+                                eventView: props.eventView,
+                                location,
+                              })
                             }
                           />
                         )}
@@ -392,4 +404,4 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
 }
 
 const EventsRequest = withApi(_EventsRequest);
-const DurationChart = withRouter(_DurationChart);
+const DurationChart = _DurationChart;

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -18,7 +18,7 @@ import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import withApi from 'sentry/utils/withApi';
-import _DurationChart from 'sentry/views/performance/charts/chart';
+import DurationChart from 'sentry/views/performance/charts/chart';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 import {
   createUnnamedTransactionsDiscoverTarget,
@@ -405,4 +405,3 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
 }
 
 const EventsRequest = withApi(_EventsRequest);
-const DurationChart = _DurationChart;

--- a/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/lineChartListWidget.tsx
@@ -222,6 +222,7 @@ export function LineChartListWidget(props: PerformanceWidgetProps) {
   return (
     <GenericPerformanceWidget<DataType>
       {...props}
+      location={location}
       Subtitle={() => <Subtitle>{t('Suggested transactions')}</Subtitle>}
       HeaderActions={provided => (
         <ContainerActions isLoading={provided.widgetData.list?.isLoading} />

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -116,6 +116,7 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
   return (
     <GenericPerformanceWidget<DataType>
       {...props}
+      location={location}
       Subtitle={() => (
         <Subtitle>
           {globalSelection.datetime.period

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -16,7 +16,7 @@ import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnh
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {useLocation} from 'sentry/utils/useLocation';
 import withApi from 'sentry/utils/withApi';
-import _DurationChart from 'sentry/views/performance/charts/chart';
+import DurationChart from 'sentry/views/performance/charts/chart';
 
 import {GenericPerformanceWidget} from '../components/performanceWidget';
 import {transformDiscoverToSingleValue} from '../transforms/transformDiscoverToSingleValue';
@@ -167,7 +167,6 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
 }
 
 const EventsRequest = withApi(_EventsRequest);
-export const DurationChart = _DurationChart;
 export const Subtitle = styled('span')`
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/singleFieldAreaWidget.tsx
@@ -1,6 +1,4 @@
 import {Fragment, useMemo} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter} from 'react-router';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
@@ -16,6 +14,7 @@ import {
 } from 'sentry/utils/performance/contexts/genericQueryBatcher';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import {usePageError} from 'sentry/utils/performance/contexts/pageError';
+import {useLocation} from 'sentry/utils/useLocation';
 import withApi from 'sentry/utils/withApi';
 import _DurationChart from 'sentry/views/performance/charts/chart';
 
@@ -31,6 +30,7 @@ type DataType = {
 };
 
 export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
+  const location = useLocation();
   const {ContainerActions} = props;
   const globalSelection = props.eventView.getPageFilters();
   const pageError = usePageError();
@@ -94,7 +94,7 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
                 {...provided}
                 queryBatching={queryBatching}
                 eventView={eventView}
-                location={props.location}
+                location={location}
                 queryExtras={getMEPQueryParams(mepSetting)}
                 useEvents
               />
@@ -166,7 +166,7 @@ export function SingleFieldAreaWidget(props: PerformanceWidgetProps) {
 }
 
 const EventsRequest = withApi(_EventsRequest);
-export const DurationChart = withRouter(_DurationChart);
+export const DurationChart = _DurationChart;
 export const Subtitle = styled('span')`
   color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeMedium};

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -97,6 +97,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
   return (
     <GenericPerformanceWidget<DataType>
       {...rest}
+      location={location}
       Subtitle={() => <Subtitle>{t('Trending Transactions')}</Subtitle>}
       HeaderActions={provided => {
         return (

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -6,6 +6,7 @@ import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import TrendsDiscoverQuery from 'sentry/utils/performance/trends/trendsDiscoverQuery';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
 import withProjects from 'sentry/utils/withProjects';
 import {CompareDurations} from 'sentry/views/performance/trends/changedTransactions';
@@ -37,12 +38,12 @@ type DataType = {
 const fields = [{field: 'transaction'}, {field: 'project'}];
 
 export function TrendsWidget(props: PerformanceWidgetProps) {
+  const location = useLocation();
   const {projects} = useProjects();
 
   const {
     eventView: _eventView,
     ContainerActions,
-    location,
     organization,
     withStaticFilters,
   } = props;
@@ -75,7 +76,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
         <TrendsDiscoverQuery
           {...provided}
           eventView={provided.eventView}
-          location={props.location}
+          location={location}
           trendChangeType={trendChangeType}
           trendFunctionField={trendFunctionField}
           limit={3}
@@ -156,7 +157,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
 
                 const trendsTarget = trendsTargetRoute({
                   organization: props.organization,
-                  location: props.location,
+                  location,
                   initialConditions,
                   additionalQuery: {
                     trendFunction: trendFunctionField,
@@ -174,7 +175,12 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
                     {!withStaticFilters && (
                       <ListClose
                         setSelectListIndex={setSelectListIndex}
-                        onClick={() => excludeTransaction(listItem.transaction, props)}
+                        onClick={() =>
+                          excludeTransaction(listItem.transaction, {
+                            eventView: props.eventView,
+                            location,
+                          })
+                        }
                       />
                     )}
                   </Fragment>

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -1,6 +1,4 @@
 import {Fragment, useMemo, useState} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter} from 'react-router';
 
 import Button from 'sentry/components/button';
 import Truncate from 'sentry/components/truncate';
@@ -192,4 +190,4 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
   );
 }
 
-const TrendsChart = withRouter(withProjects(Chart));
+const TrendsChart = withProjects(Chart);

--- a/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/vitalWidget.tsx
@@ -20,6 +20,7 @@ import {usePageError} from 'sentry/utils/performance/contexts/pageError';
 import {VitalData} from 'sentry/utils/performance/vitals/vitalsCardsDiscoverQuery';
 import {decodeList} from 'sentry/utils/queryString';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import withApi from 'sentry/utils/withApi';
 import {
   createUnnamedTransactionsDiscoverTarget,
@@ -94,8 +95,9 @@ export function transformFieldsWithStops(props: {
 }
 
 export function VitalWidget(props: PerformanceWidgetProps) {
+  const location = useLocation();
   const mepSetting = useMEPSettingContext();
-  const {ContainerActions, eventView, organization, location} = props;
+  const {ContainerActions, eventView, organization} = props;
   const useEvents = organization.features.includes(
     'performance-frontend-use-events-endpoint'
   );
@@ -139,7 +141,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
             <DiscoverQuery
               {...provided}
               eventView={_eventView}
-              location={props.location}
+              location={location}
               limit={4}
               cursor="0:0:1"
               noPagination
@@ -210,6 +212,7 @@ export function VitalWidget(props: PerformanceWidgetProps) {
   return (
     <GenericPerformanceWidget<DataType>
       {...props}
+      location={location}
       Subtitle={provided => {
         const listItem = provided.widgetData.list?.data[selectedListIndex];
 
@@ -337,7 +340,12 @@ export function VitalWidget(props: PerformanceWidgetProps) {
                     {!props.withStaticFilters && (
                       <ListClose
                         setSelectListIndex={setSelectListIndex}
-                        onClick={() => excludeTransaction(listItem.transaction, props)}
+                        onClick={() =>
+                          excludeTransaction(listItem.transaction, {
+                            eventView: props.eventView,
+                            location,
+                          })
+                        }
                       />
                     )}
                   </Fragment>

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
@@ -1,7 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {InjectedRouter, withRouter} from 'react-router';
-import {Location} from 'history';
-
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import {LineChart, LineChartProps} from 'sentry/components/charts/lineChart';
 import {normalizeDateTimeParams} from 'sentry/components/organizations/pageFilters/parse';
@@ -11,27 +7,19 @@ import {Series} from 'sentry/types/echarts';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 type Props = {
   data: Series[];
   end: DateString;
-  location: Location;
-  router: InjectedRouter;
   start: DateString;
   statsPeriod: string | undefined;
   height?: number;
 };
 
-const _AnomalyChart = (props: Props) => {
-  const {
-    data,
-    location,
-    statsPeriod,
-    height,
-    router,
-    start: propsStart,
-    end: propsEnd,
-  } = props;
+export function AnomalyChart(props: Props) {
+  const {location, router} = useRouteContext();
+  const {data, statsPeriod, height, start: propsStart, end: propsEnd} = props;
 
   const start = propsStart ? getUtcToLocalDateObject(propsStart) : null;
   const end = propsEnd ? getUtcToLocalDateObject(propsEnd) : null;
@@ -74,6 +62,4 @@ const _AnomalyChart = (props: Props) => {
       )}
     </ChartZoom>
   );
-};
-
-export const AnomalyChart = withRouter(_AnomalyChart);
+}

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
@@ -7,6 +7,7 @@ import {Series} from 'sentry/types/echarts';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 type Props = {

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
@@ -19,7 +19,8 @@ type Props = {
 };
 
 export function AnomalyChart(props: Props) {
-  const {location, router} = useRouteContext();
+  const {router} = useRouteContext();
+  const location = useLocation();
   const {data, statsPeriod, height, start: propsStart, end: propsEnd} = props;
 
   const start = propsStart ? getUtcToLocalDateObject(propsStart) : null;

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
@@ -54,7 +54,8 @@ function DurationChart({
   start: propsStart,
   end: propsEnd,
 }: Props) {
-  const {location, router} = useRouteContext();
+  const {router} = useRouteContext();
+  const location = useLocation();
   const api = useApi();
   const theme = useTheme();
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
@@ -1,8 +1,7 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
-import {Location, Query} from 'history';
+import {Query} from 'history';
 
 import EventsRequest from 'sentry/components/charts/eventsRequest';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
@@ -13,6 +12,7 @@ import {t, tct} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import useApi from 'sentry/utils/useApi';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {ViewProps} from '../../../types';
 import {
@@ -22,14 +22,12 @@ import {
 
 import Content from './content';
 
-type Props = WithRouterProps &
-  ViewProps & {
-    currentFilter: SpanOperationBreakdownFilter;
-    location: Location;
-    organization: OrganizationSummary;
-    queryExtra: Query;
-    withoutZerofill: boolean;
-  };
+type Props = ViewProps & {
+  currentFilter: SpanOperationBreakdownFilter;
+  organization: OrganizationSummary;
+  queryExtra: Query;
+  withoutZerofill: boolean;
+};
 
 enum DurationFunctionField {
   P50 = 'p50',
@@ -46,17 +44,16 @@ enum DurationFunctionField {
 function DurationChart({
   project,
   environment,
-  location,
   organization,
   query,
   statsPeriod,
-  router,
   queryExtra,
   currentFilter,
   withoutZerofill,
   start: propsStart,
   end: propsEnd,
 }: Props) {
+  const {location, router} = useRouteContext();
   const api = useApi();
   const theme = useTheme();
 
@@ -161,4 +158,4 @@ function DurationChart({
   );
 }
 
-export default withRouter(DurationChart);
+export default DurationChart;

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
@@ -12,6 +12,7 @@ import {t, tct} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {ViewProps} from '../../../types';

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -32,6 +32,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import AnomaliesQuery from 'sentry/utils/performance/anomalies/anomaliesQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -80,7 +80,8 @@ function SidebarCharts({
   eventView,
   transactionName,
 }: Props) {
-  const {location, router} = useRouteContext();
+  const location = useLocation();
+  const {router} = useRouteContext();
   const useAggregateAlias = !organization.features.includes(
     'performance-frontend-use-events-endpoint'
   );

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -242,7 +242,8 @@ function SidebarChartsContainer({
   totals,
   transactionName,
 }: ContainerProps) {
-  const {location, router} = useRouteContext();
+  const location = useLocation();
+  const {router} = useRouteContext();
 
   const api = useApi();
   const theme = useTheme();

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -1,9 +1,7 @@
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, InjectedRouter, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import color from 'color';
-import {Location} from 'history';
 
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import MarkPoint from 'sentry/components/charts/components/markPoint';
@@ -34,6 +32,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import AnomaliesQuery from 'sentry/utils/performance/anomalies/anomaliesQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
 
 import {
@@ -42,11 +41,10 @@ import {
   anomalyToColor,
 } from '../transactionAnomalies/utils';
 
-type ContainerProps = WithRouterProps & {
+type ContainerProps = {
   error: QueryError | null;
   eventView: EventView;
   isLoading: boolean;
-  location: Location;
   organization: Organization;
   totals: Record<string, number> | null;
   transactionName: string;
@@ -61,8 +59,6 @@ type Props = Pick<ContainerProps, 'organization' | 'isLoading' | 'error' | 'tota
     series: LineChartProps['series'];
   };
   eventView: EventView;
-  location: Location;
-  router: InjectedRouter;
   transactionName: string;
   utc: boolean;
   end?: Date;
@@ -78,13 +74,12 @@ function SidebarCharts({
   start,
   end,
   utc,
-  router,
   statsPeriod,
   chartData,
   eventView,
-  location,
   transactionName,
 }: Props) {
+  const {location, router} = useRouteContext();
   const useAggregateAlias = !organization.features.includes(
     'performance-frontend-use-events-endpoint'
   );
@@ -238,15 +233,15 @@ function SidebarCharts({
 }
 
 function SidebarChartsContainer({
-  location,
   eventView,
   organization,
-  router,
   isLoading,
   error,
   totals,
   transactionName,
 }: ContainerProps) {
+  const {location, router} = useRouteContext();
+
   const api = useApi();
   const theme = useTheme();
 
@@ -403,7 +398,6 @@ function SidebarChartsContainer({
           <SidebarCharts
             {...contentCommonProps}
             transactionName={transactionName}
-            location={location}
             eventView={eventView}
             chartData={{series, errored, loading, reloading, chartOptions}}
           />
@@ -450,4 +444,4 @@ const ChartValue = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
 `;
 
-export default withRouter(SidebarChartsContainer);
+export default SidebarChartsContainer;

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -1,8 +1,7 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
-import {Location, Query} from 'history';
+import {Query} from 'history';
 
 import EventsRequest from 'sentry/components/charts/eventsRequest';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
@@ -13,6 +12,7 @@ import {t} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import useApi from 'sentry/utils/useApi';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {TrendFunctionField} from '../../../trends/types';
 import {generateTrendFunctionAsString} from '../../../trends/utils';
@@ -20,24 +20,20 @@ import {ViewProps} from '../../../types';
 
 import Content from './content';
 
-type Props = WithRouterProps &
-  ViewProps & {
-    location: Location;
-    organization: OrganizationSummary;
-    queryExtra: Query;
-    trendFunction: TrendFunctionField;
-    trendParameter: string;
-    withoutZerofill: boolean;
-  };
+type Props = ViewProps & {
+  organization: OrganizationSummary;
+  queryExtra: Query;
+  trendFunction: TrendFunctionField;
+  trendParameter: string;
+  withoutZerofill: boolean;
+};
 
 function TrendChart({
   project,
   environment,
-  location,
   organization,
   query,
   statsPeriod,
-  router,
   trendFunction,
   trendParameter,
   queryExtra,
@@ -45,6 +41,7 @@ function TrendChart({
   start: propsStart,
   end: propsEnd,
 }: Props) {
+  const {location, router} = useRouteContext();
   const api = useApi();
   const theme = useTheme();
 
@@ -146,4 +143,4 @@ function TrendChart({
   );
 }
 
-export default withRouter(TrendChart);
+export default TrendChart;

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -42,7 +42,8 @@ function TrendChart({
   start: propsStart,
   end: propsEnd,
 }: Props) {
-  const {location, router} = useRouteContext();
+  const {router} = useRouteContext();
+  const location = useLocation();
   const api = useApi();
   const theme = useTheme();
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -12,6 +12,7 @@ import {t} from 'sentry/locale';
 import {OrganizationSummary} from 'sentry/types';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {TrendFunctionField} from '../../../trends/types';

--- a/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
@@ -1,7 +1,5 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
-import {Location, Query} from 'history';
+import {Query} from 'history';
 
 import EventsRequest from 'sentry/components/charts/eventsRequest';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
@@ -14,18 +12,17 @@ import {Series} from 'sentry/types/echarts';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
 import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
 import {DurationChart} from 'sentry/views/performance/landing/widgets/widgets/singleFieldAreaWidget';
 import {ViewProps} from 'sentry/views/performance/types';
 
-type Props = WithRouterProps &
-  ViewProps & {
-    location: Location;
-    organization: OrganizationSummary;
-    queryExtra: Query;
-    withoutZerofill: boolean;
-  };
+type Props = ViewProps & {
+  organization: OrganizationSummary;
+  queryExtra: Query;
+  withoutZerofill: boolean;
+};
 
 /**
  * Fetch and render an area chart that shows user misery over a period
@@ -33,7 +30,6 @@ type Props = WithRouterProps &
 function UserMiseryChart({
   project,
   environment,
-  location,
   organization,
   query,
   statsPeriod,
@@ -41,6 +37,7 @@ function UserMiseryChart({
   start: propsStart,
   end: propsEnd,
 }: Props) {
+  const location = useLocation();
   const api = useApi();
   const mepContext = useMEPSettingContext();
 
@@ -112,4 +109,4 @@ function UserMiseryChart({
   );
 }
 
-export default withRouter(UserMiseryChart);
+export default UserMiseryChart;

--- a/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/userMiseryChart/index.tsx
@@ -13,9 +13,9 @@ import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {useMEPSettingContext} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
+import DurationChart from 'sentry/views/performance/charts/chart';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
 import {getMEPQueryParams} from 'sentry/views/performance/landing/widgets/utils';
-import {DurationChart} from 'sentry/views/performance/landing/widgets/widgets/singleFieldAreaWidget';
 import {ViewProps} from 'sentry/views/performance/types';
 
 type Props = ViewProps & {

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
@@ -14,6 +14,7 @@ import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {getAggregateArg, getMeasurementSlug} from 'sentry/utils/discover/fields';
 import {WebVital} from 'sentry/utils/fields';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {ViewProps} from '../../../types';

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
@@ -38,7 +38,8 @@ function VitalsChart({
   start: propsStart,
   end: propsEnd,
 }: Props) {
-  const {location, router} = useRouteContext();
+  const location = useLocation();
+  const {router} = useRouteContext();
   const api = useApi();
   const theme = useTheme();
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
@@ -1,8 +1,7 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
-import {Location, Query} from 'history';
+import {Query} from 'history';
 
 import EventsRequest from 'sentry/components/charts/eventsRequest';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
@@ -15,32 +14,30 @@ import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {getAggregateArg, getMeasurementSlug} from 'sentry/utils/discover/fields';
 import {WebVital} from 'sentry/utils/fields';
 import useApi from 'sentry/utils/useApi';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {ViewProps} from '../../../types';
 
 import Content from './content';
 
-type Props = WithRouterProps &
-  ViewProps & {
-    location: Location;
-    organization: OrganizationSummary;
-    queryExtra: Query;
-    withoutZerofill: boolean;
-  };
+type Props = ViewProps & {
+  organization: OrganizationSummary;
+  queryExtra: Query;
+  withoutZerofill: boolean;
+};
 
 function VitalsChart({
   project,
   environment,
-  location,
   organization,
   query,
   statsPeriod,
-  router,
   queryExtra,
   withoutZerofill,
   start: propsStart,
   end: propsEnd,
 }: Props) {
+  const {location, router} = useRouteContext();
   const api = useApi();
   const theme = useTheme();
 
@@ -154,4 +151,4 @@ function VitalsChart({
   );
 }
 
-export default withRouter(VitalsChart);
+export default VitalsChart;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/chart.tsx
@@ -1,6 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
-import {Location} from 'history';
+import {browserHistory} from 'react-router';
 
 import Feature from 'sentry/components/acl/feature';
 import OptionSelector from 'sentry/components/charts/optionSelector';
@@ -20,13 +18,13 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import EventView from 'sentry/utils/discover/eventView';
 import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 
 import ExclusiveTimeHistogram from './exclusiveTimeHistogram';
 import ExclusiveTimeTimeSeries from './exclusiveTimeTimeSeries';
 
-type Props = WithRouterProps & {
+type Props = {
   eventView: EventView;
-  location: Location;
   organization: Organization;
   spanSlug: SpanSlug;
   totalCount?: number;
@@ -38,9 +36,9 @@ enum DisplayModes {
 }
 
 function Chart(props: Props) {
-  const {location} = props;
+  const location = useLocation();
 
-  const display = decodeScalar(props.location.query.display, DisplayModes.TIMESERIES);
+  const display = decodeScalar(location.query.display, DisplayModes.TIMESERIES);
 
   function generateDisplayOptions() {
     return [
@@ -101,4 +99,4 @@ function Chart(props: Props) {
   );
 }
 
-export default withRouter(Chart);
+export default Chart;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeHistogram.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeHistogram.tsx
@@ -1,7 +1,5 @@
 import {Fragment} from 'react';
-import {WithRouterProps} from 'react-router';
 import {useTheme} from '@emotion/react';
-import {Location} from 'history';
 
 import {BarChart} from 'sentry/components/charts/barChart';
 import BarChartZoom from 'sentry/components/charts/barChartZoom';
@@ -27,21 +25,22 @@ import {
 } from 'sentry/utils/performance/histogram/utils';
 import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocation} from 'sentry/utils/useLocation';
 
 import {ZoomKeys} from './utils';
 
 const NUM_BUCKETS = 50;
 const PRECISION = 0;
 
-type Props = WithRouterProps & {
+type Props = {
   eventView: EventView;
-  location: Location;
   organization: Organization;
   spanSlug: SpanSlug;
 };
 
 export default function ExclusiveTimeHistogram(props: Props) {
-  const {location, organization, eventView, spanSlug} = props;
+  const {organization, eventView, spanSlug} = props;
+  const location = useLocation();
 
   const start = decodeScalar(location.query[ZoomKeys.MIN]);
   const end = decodeScalar(location.query[ZoomKeys.MAX]);
@@ -95,7 +94,6 @@ export default function ExclusiveTimeHistogram(props: Props) {
                     isLoading={isLoading}
                     isErrored={!!error}
                     chartData={histogram}
-                    location={location}
                     spanSlug={spanSlug}
                   />
                 )}
@@ -112,7 +110,6 @@ type ChartProps = {
   chartData: HistogramData | null;
   isErrored: boolean;
   isLoading: boolean;
-  location: Location;
   spanSlug: SpanSlug;
   zoomProps: any;
   disableChartPadding?: boolean;

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
@@ -22,6 +22,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {getExclusiveTimeDisplayedValue} from '../utils';

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
@@ -35,7 +35,8 @@ type Props = {
 };
 
 export default function ExclusiveTimeTimeSeries(props: Props) {
-  const {location, router} = useRouteContext();
+  const location = useLocation();
+  const {router} = useRouteContext();
   const {organization, eventView, spanSlug, withoutZerofill} = props;
 
   const api = useApi();

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
@@ -1,7 +1,6 @@
 import {Fragment} from 'react';
-import {browserHistory, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
-import {Location} from 'history';
 
 import ChartZoom from 'sentry/components/charts/chartZoom';
 import ErrorPanel from 'sentry/components/charts/errorPanel';
@@ -23,19 +22,20 @@ import EventView from 'sentry/utils/discover/eventView';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import useApi from 'sentry/utils/useApi';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {getExclusiveTimeDisplayedValue} from '../utils';
 
-type Props = WithRouterProps & {
+type Props = {
   eventView: EventView;
-  location: Location;
   organization: Organization;
   spanSlug: SpanSlug;
   withoutZerofill: boolean;
 };
 
 export default function ExclusiveTimeTimeSeries(props: Props) {
-  const {location, router, organization, eventView, spanSlug, withoutZerofill} = props;
+  const {location, router} = useRouteContext();
+  const {organization, eventView, spanSlug, withoutZerofill} = props;
 
   const api = useApi();
   const theme = useTheme();

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -243,7 +243,8 @@ export function Chart({
   projects,
   project,
 }: Props) {
-  const {location, router} = useRouteContext();
+  const location = useLocation();
+  const {router} = useRouteContext();
   const theme = useTheme();
 
   const handleLegendSelectChanged = legendChange => {

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
 import type {LegendComponentOption} from 'echarts';
 
@@ -25,6 +24,7 @@ import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {decodeList} from 'sentry/utils/queryString';
 import {Theme} from 'sentry/utils/theme';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {ViewProps} from '../types';
 
@@ -43,21 +43,19 @@ import {
   trendToColor,
 } from './utils';
 
-type Props = WithRouterProps &
-  ViewProps & {
-    isLoading: boolean;
-    location: Location;
-    organization: OrganizationSummary;
-    projects: Project[];
-    statsData: TrendsStats;
-    trendChangeType: TrendChangeType;
-    disableLegend?: boolean;
-    disableXAxis?: boolean;
-    grid?: LineChartProps['grid'];
-    height?: number;
-    transaction?: NormalizedTrendsTransaction;
-    trendFunctionField?: TrendFunctionField;
-  };
+type Props = ViewProps & {
+  isLoading: boolean;
+  organization: OrganizationSummary;
+  projects: Project[];
+  statsData: TrendsStats;
+  trendChangeType: TrendChangeType;
+  disableLegend?: boolean;
+  disableXAxis?: boolean;
+  grid?: LineChartProps['grid'];
+  height?: number;
+  transaction?: NormalizedTrendsTransaction;
+  trendFunctionField?: TrendFunctionField;
+};
 
 function transformEventStats(data: EventsStatsData, seriesName?: string): Series[] {
   return [
@@ -230,12 +228,10 @@ function getIntervalLine(
 
 export function Chart({
   trendChangeType,
-  router,
   statsPeriod,
   transaction,
   statsData,
   isLoading,
-  location,
   start: propsStart,
   end: propsEnd,
   trendFunctionField,
@@ -246,6 +242,7 @@ export function Chart({
   projects,
   project,
 }: Props) {
+  const {location, router} = useRouteContext();
   const theme = useTheme();
 
   const handleLegendSelectChanged = legendChange => {
@@ -402,4 +399,4 @@ export function Chart({
   );
 }
 
-export default withRouter(Chart);
+export default Chart;

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -24,6 +24,7 @@ import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {decodeList} from 'sentry/utils/queryString';
 import {Theme} from 'sentry/utils/theme';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {ViewProps} from '../types';

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -20,6 +20,7 @@ import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {WebVital} from 'sentry/utils/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {replaceSeriesName, transformEventStatsSmoothed} from '../trends/utils';

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
 
 import ChartZoom from 'sentry/components/charts/chartZoom';
@@ -21,6 +20,7 @@ import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {WebVital} from 'sentry/utils/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useApi from 'sentry/utils/useApi';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {replaceSeriesName, transformEventStatsSmoothed} from '../trends/utils';
 import {ViewProps} from '../types';
@@ -34,26 +34,24 @@ import {
   vitalStateColors,
 } from './utils';
 
-type Props = WithRouterProps &
-  Omit<ViewProps, 'start' | 'end'> & {
-    end: DateString | null;
-    interval: string;
-    organization: OrganizationSummary;
-    start: DateString | null;
-  };
+type Props = Omit<ViewProps, 'start' | 'end'> & {
+  end: DateString | null;
+  interval: string;
+  organization: OrganizationSummary;
+  start: DateString | null;
+};
 
 function VitalChart({
   project,
   environment,
-  location,
   organization,
   query,
   statsPeriod,
-  router,
   start,
   end,
   interval,
 }: Props) {
+  const {location, router} = useRouteContext();
   const api = useApi();
   const theme = useTheme();
 
@@ -182,7 +180,7 @@ function VitalChart({
   );
 }
 
-export default withRouter(VitalChart);
+export default VitalChart;
 
 export type _VitalChartProps = {
   field: string;

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -52,7 +52,8 @@ function VitalChart({
   end,
   interval,
 }: Props) {
-  const {location, router} = useRouteContext();
+  const location = useLocation();
+  const {router} = useRouteContext();
   const api = useApi();
   const theme = useTheme();
 

--- a/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
@@ -49,7 +49,8 @@ function VitalChartMetrics({
   field,
   vital,
 }: Props) {
-  const {location, router} = useRouteContext();
+  const location = useLocation();
+  const {router} = useRouteContext();
   const theme = useTheme();
 
   const {utc, legend, vitalPoor, markLines, chartOptions} = getVitalChartDefinitions({

--- a/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory} from 'react-router';
 import {useTheme} from '@emotion/react';
 import moment from 'moment';
 
@@ -18,23 +17,23 @@ import {DateString, MetricsApiResponse} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {WebVital} from 'sentry/utils/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {replaceSeriesName, transformEventStatsSmoothed} from '../trends/utils';
 import {ViewProps} from '../types';
 
 import {getMaxOfSeries, getVitalChartDefinitions, getVitalChartTitle} from './utils';
 
-type Props = WithRouterProps &
-  Omit<ViewProps, 'query' | 'start' | 'end'> & {
-    end: DateString | null;
-    errored: boolean;
-    field: string;
-    loading: boolean;
-    reloading: boolean;
-    response: MetricsApiResponse | null;
-    start: DateString | null;
-    vital: WebVital;
-  };
+type Props = Omit<ViewProps, 'query' | 'start' | 'end'> & {
+  end: DateString | null;
+  errored: boolean;
+  field: string;
+  loading: boolean;
+  reloading: boolean;
+  response: MetricsApiResponse | null;
+  start: DateString | null;
+  vital: WebVital;
+};
 
 function VitalChartMetrics({
   reloading,
@@ -48,9 +47,8 @@ function VitalChartMetrics({
   environment,
   field,
   vital,
-  router,
-  location,
 }: Props) {
+  const {location, router} = useRouteContext();
   const theme = useTheme();
 
   const {utc, legend, vitalPoor, markLines, chartOptions} = getVitalChartDefinitions({
@@ -163,4 +161,4 @@ function VitalChartMetrics({
   );
 }
 
-export default withRouter(VitalChartMetrics);
+export default VitalChartMetrics;

--- a/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
@@ -17,6 +17,7 @@ import {DateString, MetricsApiResponse} from 'sentry/types';
 import {Series} from 'sentry/types/echarts';
 import {WebVital} from 'sentry/utils/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {replaceSeriesName, transformEventStatsSmoothed} from '../trends/utils';

--- a/static/app/views/permissionDenied.tsx
+++ b/static/app/views/permissionDenied.tsx
@@ -1,6 +1,4 @@
-import {Component} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {useEffect} from 'react';
 import * as Sentry from '@sentry/react';
 
 import ExternalLink from 'sentry/components/links/externalLink';
@@ -10,20 +8,21 @@ import {t, tct} from 'sentry/locale';
 import {PageContent} from 'sentry/styles/organization';
 import {Organization, Project} from 'sentry/types';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+import {useRoutes} from 'sentry/utils/useRoutes';
 import withOrganization from 'sentry/utils/withOrganization';
 import withProject from 'sentry/utils/withProject';
 
 const ERROR_NAME = 'Permission Denied';
 
-type Props = WithRouterProps & {
+type Props = {
   organization: Organization;
   project?: Project;
 };
 
-class PermissionDenied extends Component<Props> {
-  componentDidMount() {
-    const {organization, project, routes} = this.props;
-
+function PermissionDenied(props: Props) {
+  const {organization, project} = props;
+  const routes = useRoutes();
+  useEffect(() => {
     const route = getRouteStringFromRoutes(routes);
     Sentry.withScope(scope => {
       scope.setFingerprint([ERROR_NAME, route]);
@@ -33,27 +32,26 @@ class PermissionDenied extends Component<Props> {
       scope.setExtra('projectFeatures', (project && project.features) || []);
       Sentry.captureException(new Error(`${ERROR_NAME}${route ? ` : ${route}` : ''}`));
     });
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  render() {
-    return (
-      <SentryDocumentTitle title={t('Permission Denied')}>
-        <PageContent>
-          <LoadingError
-            message={tct(
-              `Your role does not have the necessary permissions to access this
-               resource, please read more about [link:organizational roles]`,
-              {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/product/accounts/membership/" />
-                ),
-              }
-            )}
-          />
-        </PageContent>
-      </SentryDocumentTitle>
-    );
-  }
+  return (
+    <SentryDocumentTitle title={t('Permission Denied')}>
+      <PageContent>
+        <LoadingError
+          message={tct(
+            `Your role does not have the necessary permissions to access this
+             resource, please read more about [link:organizational roles]`,
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/accounts/membership/" />
+              ),
+            }
+          )}
+        />
+      </PageContent>
+    </SentryDocumentTitle>
+  );
 }
 
-export default withRouter(withOrganization(withProject(PermissionDenied)));
+export default withOrganization(withProject(PermissionDenied));

--- a/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
@@ -1,6 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
-
 import {navigateTo} from 'sentry/actionCreators/navigation';
 import Feature from 'sentry/components/acl/feature';
 import Button from 'sentry/components/button';
@@ -9,15 +6,18 @@ import FeatureTourModal from 'sentry/components/modals/featureTourModal';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 import {PERFORMANCE_TOUR_STEPS} from 'sentry/views/performance/onboarding';
 
 const DOCS_URL = 'https://docs.sentry.io/performance-monitoring/getting-started/';
 
 type Props = {
   organization: Organization;
-} & WithRouterProps;
+};
 
-function MissingPerformanceButtons({organization, router}: Props) {
+function MissingPerformanceButtons({organization}: Props) {
+  const {router} = useRouteContext();
+
   function handleTourAdvance(step: number, duration: number) {
     trackAnalyticsEvent({
       eventKey: 'project_detail.performance_tour.advance',
@@ -78,4 +78,4 @@ function MissingPerformanceButtons({organization, router}: Props) {
   );
 }
 
-export default withRouter(MissingPerformanceButtons);
+export default MissingPerformanceButtons;

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -55,8 +55,8 @@ function ReleaseEventsChart({
   end,
   utc,
 }: Props) {
-  const {location, router} = useRouteContext();
-
+  const location = useLocation();
+  const {router, location: _location} = useRouteContext();
   const api = useApi();
   const theme = useTheme();
 

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -16,6 +16,7 @@ import {
   ReleaseWithHealth,
 } from 'sentry/types';
 import {tooltipFormatter} from 'sentry/utils/discover/charts';
+import EventView from 'sentry/utils/discover/eventView';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
@@ -133,8 +134,9 @@ function ReleaseEventsChart({
     }
   }
 
-  const projects = location.query.project;
-  const environments = location.query.environment;
+  const eventView = EventView.fromSavedQueryOrLocation(undefined, location);
+  const projects = eventView.project as number[];
+  const environments = eventView.environment as string[];
   const markLines = generateReleaseMarkLines(release, project, theme, location);
 
   return (

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -1,6 +1,4 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {useTheme} from '@emotion/react';
 import type {ToolboxComponentOption} from 'echarts';
 
@@ -21,6 +19,7 @@ import {tooltipFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 import withOrganization from 'sentry/utils/withOrganization';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
 
@@ -30,7 +29,7 @@ import {
   releaseMarkLinesLabels,
 } from '../../utils';
 
-type Props = WithRouterProps & {
+type Props = {
   chartType: ReleaseComparisonChartType;
   diff: React.ReactNode;
   organization: Organization;
@@ -50,13 +49,13 @@ function ReleaseEventsChart({
   value,
   diff,
   organization,
-  router,
   period,
   start,
   end,
   utc,
-  location,
 }: Props) {
+  const {location, router} = useRouteContext();
+
   const api = useApi();
   const theme = useTheme();
 
@@ -234,4 +233,4 @@ function ReleaseEventsChart({
   );
 }
 
-export default withOrganization(withRouter(ReleaseEventsChart));
+export default withOrganization(ReleaseEventsChart);

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -19,6 +19,7 @@ import {tooltipFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 import withOrganization from 'sentry/utils/withOrganization';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -22,6 +22,7 @@ import {
 } from 'sentry/types';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {getAdoptionSeries, getCount, getCountAtIndex} from 'sentry/utils/sessions';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -61,8 +61,8 @@ function ReleaseAdoption({
   reloading,
   errored,
 }: Props) {
-  const {location, router} = useRouteContext();
-
+  const location = useLocation();
+  const {router} = useRouteContext();
   const theme = useTheme();
 
   const hasUsers = !!getCount(releaseSessions?.groups, SessionFieldWithOperation.USERS);

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -24,6 +22,7 @@ import {
 } from 'sentry/types';
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {getAdoptionSeries, getCount, getCountAtIndex} from 'sentry/utils/sessions';
+import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {
   ADOPTION_STAGE_LABELS,
@@ -49,7 +48,7 @@ type Props = {
   release: ReleaseWithHealth;
   releaseSessions: SessionApiResponse | null;
   reloading: boolean;
-} & WithRouterProps;
+};
 
 function ReleaseAdoption({
   release,
@@ -60,9 +59,9 @@ function ReleaseAdoption({
   loading,
   reloading,
   errored,
-  router,
-  location,
 }: Props) {
+  const {location, router} = useRouteContext();
+
   const theme = useTheme();
 
   const hasUsers = !!getCount(releaseSessions?.groups, SessionFieldWithOperation.USERS);
@@ -357,4 +356,4 @@ const RelativeBox = styled('div')`
   position: relative;
 `;
 
-export default withRouter(ReleaseAdoption);
+export default ReleaseAdoption;

--- a/static/app/views/routeError.tsx
+++ b/static/app/views/routeError.tsx
@@ -1,6 +1,4 @@
 import {useEffect} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
@@ -13,9 +11,10 @@ import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import space from 'sentry/styles/space';
 import {Project} from 'sentry/types';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+import {useRoutes} from 'sentry/utils/useRoutes';
 import withProject from 'sentry/utils/withProject';
 
-type Props = WithRouterProps & {
+type Props = {
   /**
    * Disable logging to Sentry
    */
@@ -28,7 +27,8 @@ type Props = WithRouterProps & {
   project?: Project;
 };
 
-function RouteError({error, disableLogSentry, disableReport, project, routes}: Props) {
+function RouteError({error, disableLogSentry, disableReport, project}: Props) {
+  const routes = useRoutes();
   const {organization} = useLegacyStore(OrganizationStore);
 
   useEffect(() => {
@@ -133,4 +133,4 @@ const Heading = styled('h1')`
   margin-bottom: ${space(1)};
 `;
 
-export default withRouter(withProject(RouteError));
+export default withProject(RouteError);


### PR DESCRIPTION

This pull request is a continuation of https://github.com/getsentry/sentry/pull/41741 to replace `withRouter()` with hooks for function components.

My motivation for replacing `withRouter()` with hooks in this pull request is to make use of my patch of `useParams()` in https://github.com/getsentry/sentry/pull/41611.

I'm refactoring towards implicitly injecting org slugs in the customer domain world (i.e. `orgslug.sentry.io`)