### PR TITLE
chore(hybrid-cloud): Convert SpanDetail to function component

### DIFF
--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import map from 'lodash/map';
 import omit from 'lodash/omit';
 
-import {Client} from 'sentry/api';
 import Alert from 'sentry/components/alert';
 import Button from 'sentry/components/button';
 import Clipboard from 'sentry/components/clipboard';
@@ -40,7 +39,6 @@ import {generateEventSlug} from 'sentry/utils/discover/urls';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {QuickTraceEvent, TraceError} from 'sentry/utils/performance/quickTrace/types';
 import {useLocation} from 'sentry/utils/useLocation';
-import withApi from 'sentry/utils/withApi';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
@@ -68,7 +66,6 @@ type TransactionResult = {
 };
 
 type Props = {
-  api: Client;
   childTransactions: QuickTraceEvent[] | null;
   event: Readonly<EventTransaction>;
   isRoot: boolean;
@@ -651,4 +648,4 @@ const ButtonContainer = styled('div')`
   padding: 8px 10px;
 `;
 
-export default withApi(SpanDetail);
+export default SpanDetail;

--- a/static/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/static/app/components/events/interfaces/spans/spanDetail.tsx
@@ -1,6 +1,4 @@
-import {Component, Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import map from 'lodash/map';
 import omit from 'lodash/omit';
@@ -41,6 +39,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {generateEventSlug} from 'sentry/utils/discover/urls';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {QuickTraceEvent, TraceError} from 'sentry/utils/performance/quickTrace/types';
+import {useLocation} from 'sentry/utils/useLocation';
 import withApi from 'sentry/utils/withApi';
 import {spanDetailsRouteWithQuery} from 'sentry/views/performance/transactionSummary/transactionSpans/spanDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
@@ -68,7 +67,7 @@ type TransactionResult = {
   transaction: string;
 };
 
-type Props = WithRouterProps & {
+type Props = {
   api: Client;
   childTransactions: QuickTraceEvent[] | null;
   event: Readonly<EventTransaction>;
@@ -80,17 +79,14 @@ type Props = WithRouterProps & {
   trace: Readonly<ParsedTraceType>;
 };
 
-type State = {
-  errorsOpened: boolean;
-};
+function SpanDetail(props: Props) {
+  const [errorsOpened, setErrorsOpened] = useState(false);
+  const location = useLocation();
 
-class SpanDetail extends Component<Props, State> {
-  state: State = {
-    errorsOpened: false,
-  };
+  useEffect(() => {
+    // Run on mount.
 
-  componentDidMount() {
-    const {span, organization, event} = this.props;
+    const {span, organization, event} = props;
     if ('type' in span) {
       return;
     }
@@ -100,10 +96,11 @@ class SpanDetail extends Component<Props, State> {
       operation: span.op ?? 'undefined',
       project_platform: event.platform ?? 'undefined',
     });
-  }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  renderTraversalButton(): React.ReactNode {
-    if (!this.props.childTransactions) {
+  function renderTraversalButton(): React.ReactNode {
+    if (!props.childTransactions) {
       // TODO: Amend size to use theme when we eventually refactor LoadingIndicator
       // 12px is consistent with theme.iconSizes['xs'] but theme returns a string.
       return (
@@ -113,16 +110,16 @@ class SpanDetail extends Component<Props, State> {
       );
     }
 
-    if (this.props.childTransactions.length <= 0) {
+    if (props.childTransactions.length <= 0) {
       return null;
     }
 
-    const {span, trace, event, organization} = this.props;
+    const {span, trace, event, organization} = props;
 
     assert(!isGapSpan(span));
 
-    if (this.props.childTransactions.length === 1) {
-      // Note: This is rendered by this.renderSpanChild() as a dedicated row
+    if (props.childTransactions.length === 1) {
+      // Note: This is rendered by renderSpanChild() as a dedicated row
       return null;
     }
 
@@ -164,8 +161,8 @@ class SpanDetail extends Component<Props, State> {
     );
   }
 
-  renderSpanChild(): React.ReactNode {
-    const {childTransactions, organization, location} = this.props;
+  function renderSpanChild(): React.ReactNode {
+    const {childTransactions, organization} = props;
 
     if (!childTransactions || childTransactions.length !== 1) {
       return null;
@@ -222,8 +219,8 @@ class SpanDetail extends Component<Props, State> {
     );
   }
 
-  renderTraceButton() {
-    const {span, organization, event} = this.props;
+  function renderTraceButton() {
+    const {span, organization, event} = props;
 
     if (isGapSpan(span)) {
       return null;
@@ -236,8 +233,8 @@ class SpanDetail extends Component<Props, State> {
     );
   }
 
-  renderViewSimilarSpansButton() {
-    const {span, organization, location, event} = this.props;
+  function renderViewSimilarSpansButton() {
+    const {span, organization, event} = props;
 
     if (isGapSpan(span) || !span.op || !span.hash) {
       return null;
@@ -260,8 +257,8 @@ class SpanDetail extends Component<Props, State> {
     );
   }
 
-  renderOrphanSpanMessage() {
-    const {span} = this.props;
+  function renderOrphanSpanMessage() {
+    const {span} = props;
 
     if (!isOrphanSpan(span)) {
       return null;
@@ -276,13 +273,12 @@ class SpanDetail extends Component<Props, State> {
     );
   }
 
-  toggleErrors = () => {
-    this.setState(({errorsOpened}) => ({errorsOpened: !errorsOpened}));
-  };
+  function toggleErrors() {
+    setErrorsOpened(prevErrorsOpened => !prevErrorsOpened);
+  }
 
-  renderSpanErrorMessage() {
-    const {span, organization, relatedErrors} = this.props;
-    const {errorsOpened} = this.state;
+  function renderSpanErrorMessage() {
+    const {span, organization, relatedErrors} = props;
 
     if (!relatedErrors || relatedErrors.length <= 0 || isGapSpan(span)) {
       return null;
@@ -315,7 +311,7 @@ class SpanDetail extends Component<Props, State> {
           ))}
         </ErrorMessageContent>
         {relatedErrors.length > DEFAULT_ERRORS_VISIBLE && (
-          <ErrorToggle size="xs" onClick={this.toggleErrors}>
+          <ErrorToggle size="xs" onClick={toggleErrors}>
             {errorsOpened ? t('Show less') : t('Show more')}
           </ErrorToggle>
         )}
@@ -323,7 +319,7 @@ class SpanDetail extends Component<Props, State> {
     );
   }
 
-  partitionSizes(data) {
+  function partitionSizes(data) {
     const sizeKeys = SIZE_DATA_KEYS.reduce((keys, key) => {
       if (data.hasOwnProperty(key)) {
         keys[key] = data[key];
@@ -340,8 +336,8 @@ class SpanDetail extends Component<Props, State> {
     };
   }
 
-  renderSpanDetails() {
-    const {span, event, location, organization, scrollToHash} = this.props;
+  function renderSpanDetails() {
+    const {span, event, organization, scrollToHash} = props;
 
     if (isGapSpan(span)) {
       return (
@@ -367,7 +363,7 @@ class SpanDetail extends Component<Props, State> {
       return !rawSpanKeys.has(key as any);
     });
 
-    const {sizeKeys, nonSizeKeys} = this.partitionSizes(span?.data ?? {});
+    const {sizeKeys, nonSizeKeys} = partitionSizes(span?.data ?? {});
 
     const allZeroSizes = SIZE_DATA_KEYS.map(key => sizeKeys[key]).every(
       value => value === 0
@@ -375,8 +371,8 @@ class SpanDetail extends Component<Props, State> {
 
     return (
       <Fragment>
-        {this.renderOrphanSpanMessage()}
-        {this.renderSpanErrorMessage()}
+        {renderOrphanSpanMessage()}
+        {renderSpanErrorMessage()}
         <SpanDetails>
           <table className="table key-value">
             <tbody>
@@ -405,16 +401,16 @@ class SpanDetail extends Component<Props, State> {
                     </SpanIdTitle>
                   )
                 }
-                extra={this.renderTraversalButton()}
+                extra={renderTraversalButton()}
               >
                 {span.span_id}
               </Row>
               <Row title="Parent Span ID">{span.parent_span_id || ''}</Row>
-              {this.renderSpanChild()}
-              <Row title="Trace ID" extra={this.renderTraceButton()}>
+              {renderSpanChild()}
+              <Row title="Trace ID" extra={renderTraceButton()}>
                 {span.trace_id}
               </Row>
-              <Row title="Description" extra={this.renderViewSimilarSpansButton()}>
+              <Row title="Description" extra={renderViewSimilarSpansButton()}>
                 {span?.description ?? ''}
               </Row>
               <Row title="Status">{span.status || ''}</Row>
@@ -493,19 +489,17 @@ class SpanDetail extends Component<Props, State> {
     );
   }
 
-  render() {
-    return (
-      <SpanDetailContainer
-        data-component="span-detail"
-        onClick={event => {
-          // prevent toggling the span detail
-          event.stopPropagation();
-        }}
-      >
-        {this.renderSpanDetails()}
-      </SpanDetailContainer>
-    );
-  }
+  return (
+    <SpanDetailContainer
+      data-component="span-detail"
+      onClick={event => {
+        // prevent toggling the span detail
+        event.stopPropagation();
+      }}
+    >
+      {renderSpanDetails()}
+    </SpanDetailContainer>
+  );
 }
 
 const StyledDiscoverButton = styled(DiscoverButton)`
@@ -657,4 +651,4 @@ const ButtonContainer = styled('div')`
   padding: 8px 10px;
 `;
 
-export default withApi(withRouter(SpanDetail));
+export default withApi(SpanDetail);


### PR DESCRIPTION
This converts the `SpanDetail` component from a class component to a function component such that we forgo the higher order components in favour of their hook counter parts. 

The motivation is to refactor out `withRouter()` as in https://github.com/getsentry/sentry/pull/41786.