### PR TITLE
fix(discover): Added coalesce for http.status_code

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -34,6 +34,7 @@ MEASUREMENTS_FRAMES_FROZEN_RATE = "measurements.frames_frozen_rate"
 MEASUREMENTS_STALL_PERCENTAGE = "measurements.stall_percentage"
 TRACE_PARENT_SPAN_CONTEXT = "trace.parent_span_id"
 TRACE_PARENT_SPAN_ALIAS = "trace.parent_span"
+HTTP_STATUS_CODE_ALIAS = "http.status_code"
 
 
 class ThresholdDict(TypedDict):

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -134,6 +134,7 @@ class DiscoverDatasetConfig(DatasetConfig):
             MEASUREMENTS_FRAMES_SLOW_RATE: self._resolve_measurements_frames_slow_rate,
             MEASUREMENTS_FRAMES_FROZEN_RATE: self._resolve_measurements_frames_frozen_rate,
             MEASUREMENTS_STALL_PERCENTAGE: self._resolve_measurements_stall_percentage,
+            "http.status_code": self._resolve_http_status_code,
         }
 
     @property
@@ -1027,6 +1028,16 @@ class DiscoverDatasetConfig(DatasetConfig):
         columns = ["user.email", "user.username", "user.id", "user.ip"]
         return Function(
             "coalesce", [self.builder.column(column) for column in columns], USER_DISPLAY_ALIAS
+        )
+
+    def _resolve_http_status_code(self, _: str) -> SelectType:
+        return Function(
+            "coalesce",
+            [
+                Function("nullif", [self.builder.column("http.status_code"), ""]),
+                self.builder.column("tags[http.status_code]"),
+            ],
+            "http.status_code",
         )
 
     @cached_property  # type: ignore

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -24,6 +24,7 @@ from sentry.search.events.constants import (
     ERROR_HANDLED_ALIAS,
     ERROR_UNHANDLED_ALIAS,
     FUNCTION_ALIASES,
+    HTTP_STATUS_CODE_ALIAS,
     ISSUE_ALIAS,
     ISSUE_ID_ALIAS,
     MAX_QUERYABLE_TRANSACTION_THRESHOLDS,
@@ -134,7 +135,7 @@ class DiscoverDatasetConfig(DatasetConfig):
             MEASUREMENTS_FRAMES_SLOW_RATE: self._resolve_measurements_frames_slow_rate,
             MEASUREMENTS_FRAMES_FROZEN_RATE: self._resolve_measurements_frames_frozen_rate,
             MEASUREMENTS_STALL_PERCENTAGE: self._resolve_measurements_stall_percentage,
-            "http.status_code": self._resolve_http_status_code,
+            HTTP_STATUS_CODE_ALIAS: self._resolve_http_status_code,
         }
 
     @property
@@ -1037,7 +1038,7 @@ class DiscoverDatasetConfig(DatasetConfig):
                 Function("nullif", [self.builder.column("http.status_code"), ""]),
                 self.builder.column("tags[http.status_code]"),
             ],
-            "http.status_code",
+            HTTP_STATUS_CODE_ALIAS,
         )
 
     @cached_property  # type: ignore

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -5563,3 +5563,70 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         assert len(data) == 1
         assert data[0]["device"] == "iPhone14,3"
         assert data[0]["readable"] == "iPhone 13 Pro Max"
+
+    def test_http_status_code(self):
+        project1 = self.create_project()
+        project2 = self.create_project()
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "transaction": "/example",
+                "message": "how to make fast",
+                "timestamp": self.ten_mins_ago_iso,
+                "user": {"email": "cathy@example.com"},
+                "tags": {"http.status_code": "200"},
+            },
+            project_id=project1.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "transaction": "/example",
+                "message": "how to make fast",
+                "timestamp": self.ten_mins_ago_iso,
+                "user": {"username": "catherine"},
+                "contexts": {"response": {"status_code": 400}},
+            },
+            project_id=project2.id,
+        )
+
+        features = {"organizations:discover-basic": True, "organizations:global-views": True}
+        query = {
+            "field": ["event.type", "http.status_code"],
+            "query": "",
+            "statsPeriod": "24h",
+        }
+        response = self.do_request(query, features=features)
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 2
+        result = {r["http.status_code"] for r in data}
+        assert result == {"200", "400"}
+
+    def test_http_status_code_context_priority(self):
+        project1 = self.create_project()
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "transaction": "/example",
+                "message": "how to make fast",
+                "timestamp": self.ten_mins_ago_iso,
+                "user": {"email": "cathy@example.com"},
+                "tags": {"http.status_code": "200"},
+                "contexts": {"response": {"status_code": 400}},
+            },
+            project_id=project1.id,
+        )
+
+        features = {"organizations:discover-basic": True, "organizations:global-views": True}
+        query = {
+            "field": ["event.type", "http.status_code"],
+            "query": "",
+            "statsPeriod": "24h",
+        }
+        response = self.do_request(query, features=features)
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+        assert len(data) == 1
+        result = {r["http.status_code"] for r in data}
+        assert result == {"400"}

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -5573,7 +5573,6 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
                 "transaction": "/example",
                 "message": "how to make fast",
                 "timestamp": self.ten_mins_ago_iso,
-                "user": {"email": "cathy@example.com"},
                 "tags": {"http.status_code": "200"},
             },
             project_id=project1.id,
@@ -5584,7 +5583,6 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
                 "transaction": "/example",
                 "message": "how to make fast",
                 "timestamp": self.ten_mins_ago_iso,
-                "user": {"username": "catherine"},
                 "contexts": {"response": {"status_code": 400}},
             },
             project_id=project2.id,
@@ -5611,7 +5609,6 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
                 "transaction": "/example",
                 "message": "how to make fast",
                 "timestamp": self.ten_mins_ago_iso,
-                "user": {"email": "cathy@example.com"},
                 "tags": {"http.status_code": "200"},
                 "contexts": {"response": {"status_code": 400}},
             },
@@ -5628,5 +5625,4 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
-        result = {r["http.status_code"] for r in data}
-        assert result == {"400"}
+        assert data[0]["http.status_code"] == "400"


### PR DESCRIPTION
Http status code exists both as a field and tag in discover. 
1. Added coalesce, prioritizing field.
2. Added tests. 