### PR TITLE
fix(auth) Redirect to customer domain on login more often

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -119,7 +119,6 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "integrations",
         "jobs",
         "legal",
-        "legal",
         "login",
         "logout",
         "manage",

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -214,6 +214,9 @@ class OrganizationMixin:
         if self.active_organization:
             current_org_slug = self.active_organization.organization.slug
             url = Organization.get_url(current_org_slug)
+            if using_customer_domain:
+                url_prefix = generate_organization_url(request.subdomain)
+                url = absolute_uri(url, url_prefix=url_prefix)
         elif not features.has("organizations:create"):
             return self.respond("sentry/no-organization-access.html", status=403)
         else:

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -443,7 +443,7 @@ class AuthLoginCustomerDomainTest(TestCase):
         )
         assert resp.status_code == 200
         assert resp.redirect_chain == [
-            (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
+            ("http://albertos-apples.testserver/auth/login/", 302),
             ("http://testserver/organizations/new/", 302),
         ]
 
@@ -460,8 +460,8 @@ class AuthLoginCustomerDomainTest(TestCase):
         )
         assert resp.status_code == 200
         assert resp.redirect_chain == [
-            (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
-            ("/issues/", 302),
+            ("http://albertos-apples.testserver/auth/login/", 302),
+            ("http://albertos-apples.testserver/issues/", 302),
         ]
 
     def test_login_valid_credentials_invalid_customer_domain(self):
@@ -481,9 +481,9 @@ class AuthLoginCustomerDomainTest(TestCase):
 
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (f"http://invalid.testserver{reverse('sentry-login')}", 302),
+                ("http://invalid.testserver/auth/login/", 302),
                 ("http://albertos-apples.testserver/auth/login/", 302),
-                ("/issues/", 302),
+                ("http://albertos-apples.testserver/issues/", 302),
             ]
 
     def test_login_valid_credentials_non_staff(self):
@@ -504,8 +504,8 @@ class AuthLoginCustomerDomainTest(TestCase):
             )
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
-                ("/issues/", 302),
+                ("http://albertos-apples.testserver/auth/login/", 302),
+                ("http://albertos-apples.testserver/issues/", 302),
             ]
 
     def test_login_valid_credentials_not_a_member(self):
@@ -548,6 +548,6 @@ class AuthLoginCustomerDomainTest(TestCase):
 
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
+                ("http://albertos-apples.testserver/auth/login/", 302),
                 ("http://testserver/organizations/new/", 302),
             ]


### PR DESCRIPTION
We weren't redirecting to customer domains when the user came from `sentry.io/auth/login/` as the GET request after login that forwards the user to the `/issues` was missing a subdomain which results in the final redirect also missing a subdomain.