### PR TITLE
feat(hybrid-cloud): Add withSentryRouter

### DIFF
--- a/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
@@ -21,6 +21,7 @@ import {
 } from 'sentry/utils/dates';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {Theme} from 'sentry/utils/theme';
+// eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 const getTimeStringFromDate = (date: Date) => moment(date).local().format('HH:mm');

--- a/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
@@ -1,7 +1,6 @@
 import {Component} from 'react';
 import type {Range} from 'react-date-range';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import moment from 'moment';
@@ -22,6 +21,7 @@ import {
 } from 'sentry/utils/dates';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import {Theme} from 'sentry/utils/theme';
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 const getTimeStringFromDate = (date: Date) => moment(date).local().format('HH:mm');
 
@@ -219,7 +219,7 @@ class BaseDateRange extends Component<Props, State> {
   }
 }
 
-const DateRange = styled(withTheme(withRouter(BaseDateRange)))`
+const DateRange = styled(withTheme(withSentryRouter(BaseDateRange)))`
   display: flex;
   flex-direction: column;
   border-left: 1px solid ${p => p.theme.border};

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -32,6 +32,7 @@ import {
 } from 'sentry/utils/dates';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+// eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import SelectorItems from './selectorItems';

--- a/static/app/components/organizations/timeRangeSelector/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/index.tsx
@@ -1,6 +1,6 @@
 import {PureComponent} from 'react';
 // eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import {ClassNames} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -32,6 +32,7 @@ import {
 } from 'sentry/utils/dates';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import SelectorItems from './selectorItems';
 import {getRelativeSummary, timeRangeAutoCompleteFilter} from './utils';
@@ -593,6 +594,6 @@ const StyledPinButton = styled(PageFilterPinButton)`
   margin: 0 ${space(1)};
 `;
 
-export default withRouter(TimeRangeSelector);
+export default withSentryRouter(TimeRangeSelector);
 
 export {TimeRangeRoot};

--- a/static/app/utils/withSentryRouter.spec.tsx
+++ b/static/app/utils/withSentryRouter.spec.tsx
@@ -3,6 +3,7 @@ import {WithRouterProps} from 'react-router';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
+// eslint-disable-next-line no-restricted-imports
 import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 const mockUsingCustomerDomain = jest.fn();

--- a/static/app/utils/withSentryRouter.spec.tsx
+++ b/static/app/utils/withSentryRouter.spec.tsx
@@ -1,0 +1,82 @@
+import {WithRouterProps} from 'react-router';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import withSentryRouter from 'sentry/utils/withSentryRouter';
+
+const mockUsingCustomerDomain = jest.fn();
+const mockCustomerDomain = jest.fn();
+
+jest.mock('sentry/constants', () => {
+  const sentryConstant = jest.requireActual('sentry/constants');
+  return {
+    ...sentryConstant,
+
+    get usingCustomerDomain() {
+      return mockUsingCustomerDomain();
+    },
+
+    get customerDomain() {
+      return mockCustomerDomain();
+    },
+  };
+});
+
+describe('withSentryRouter', function () {
+  type Props = WithRouterProps<{orgId: string}>;
+  const MyComponent = (props: Props) => {
+    const {params} = props;
+    return <div>Org slug: {params.orgId ?? 'no org slug'}</div>;
+  };
+
+  it('injects orgId when a customer domain is being used', function () {
+    mockUsingCustomerDomain.mockReturnValue(true);
+    mockCustomerDomain.mockReturnValue('albertos-apples');
+
+    const organization = TestStubs.Organization({
+      slug: 'albertos-apples',
+      features: [],
+    });
+
+    const {routerContext} = initializeOrg({
+      ...initializeOrg(),
+      organization,
+    });
+
+    const WrappedComponent = withSentryRouter(MyComponent);
+    render(<WrappedComponent />, {
+      context: routerContext,
+    });
+
+    expect(screen.getByText('Org slug: albertos-apples')).toBeInTheDocument();
+  });
+
+  it('does not inject orgId when a customer domain is not being used', function () {
+    mockUsingCustomerDomain.mockReturnValue(false);
+    mockCustomerDomain.mockReturnValue(undefined);
+
+    const organization = TestStubs.Organization({
+      slug: 'albertos-apples',
+      features: [],
+    });
+
+    const params = {
+      orgId: 'something-else',
+    };
+    const {routerContext} = initializeOrg({
+      ...initializeOrg(),
+      organization,
+      router: {
+        params,
+      },
+    });
+
+    const WrappedComponent = withSentryRouter(MyComponent);
+    render(<WrappedComponent />, {
+      context: routerContext,
+    });
+
+    expect(screen.getByText('Org slug: something-else')).toBeInTheDocument();
+  });
+});

--- a/static/app/utils/withSentryRouter.tsx
+++ b/static/app/utils/withSentryRouter.tsx
@@ -1,0 +1,28 @@
+// eslint-disable-next-line no-restricted-imports
+import {withRouter, WithRouterProps} from 'react-router';
+
+import {customerDomain, usingCustomerDomain} from 'sentry/constants';
+
+/**
+ * withSentryRouter is a higher-order component (HOC) that wraps withRouter, and implicitly injects the current customer
+ * domain as the orgId parameter. This only happens if a customer domain is currently being used.
+ *
+ * Since withRouter() is discouraged from being used on new React components, we would use withSentryRouter() on
+ * pre-existing React components.
+ */
+function withSentryRouter<P extends WithRouterProps>(
+  WrappedComponent: React.ComponentType<P>
+) {
+  function WithSentryRouterWrapper(props: P) {
+    const {params} = props;
+    if (usingCustomerDomain) {
+      const newParams = {...params, orgId: customerDomain};
+      return <WrappedComponent {...props} params={newParams} />;
+    }
+
+    return <WrappedComponent {...props} />;
+  }
+  return withRouter(WithSentryRouterWrapper);
+}
+
+export default withSentryRouter;


### PR DESCRIPTION
This pull request adds the `withSentryRouter()` higher order component that wraps `withRouter`, and implicitly injects the current customer domain as the `orgId` parameter. This only happens if a customer domain is currently being used.

The motivation for the existence of this higher order component is that we're now using React routes with the `orgId` parameter omitted.
 
Since `withRouter()` is discouraged from being used on new React components, we would use `withSentryRouter()` on
pre-existing React components.

I've applied `withSentryRouter()` to the time range components to showcase the conversion.

I've done some work in refactoring out `withRouter()` in favour of hooks. For instance, https://github.com/getsentry/sentry/pull/41786.