### PR TITLE
fix(metrics): Use consume timestamp for metric outcomes

### DIFF
--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import (
     Any,
     Callable,
@@ -114,7 +114,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
         self.__max_batch_size = max_batch_size
         self.__max_batch_time = timedelta(milliseconds=max_batch_time)
         self.__messages_since_last_commit = 0
-        self.__last_commit = datetime.now()
+        self.__last_commit = datetime.now(timezone.utc)
         self.__ready_to_commit: MutableMapping[Partition, Position] = {}
         self.__closed = False
 
@@ -167,7 +167,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
             key_id=None,
             outcome=Outcome.ACCEPTED,
             reason=None,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(timezone.utc),
             event_id=None,
             category=DataCategory.TRANSACTION,
             quantity=quantity,
@@ -184,7 +184,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
             return False
         if self.__messages_since_last_commit >= self.__max_batch_size:
             return True
-        if self.__last_commit + self.__max_batch_time <= datetime.now():
+        if self.__last_commit + self.__max_batch_time <= datetime.now(timezone.utc):
             return True
         return False
 
@@ -192,4 +192,4 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
         self.__commit(self.__ready_to_commit)
         self.__ready_to_commit = {}
         self.__messages_since_last_commit = 0
-        self.__last_commit = datetime.now()
+        self.__last_commit = datetime.now(timezone.utc)

--- a/src/sentry/ingest/billing_metrics_consumer.py
+++ b/src/sentry/ingest/billing_metrics_consumer.py
@@ -167,7 +167,7 @@ class BillingTxCountMetricConsumerStrategy(ProcessingStrategy[KafkaPayload]):
             key_id=None,
             outcome=Outcome.ACCEPTED,
             reason=None,
-            timestamp=datetime.fromtimestamp(payload["timestamp"]),
+            timestamp=datetime.now(),
             event_id=None,
             category=DataCategory.TRANSACTION,
             quantity=quantity,

--- a/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
+++ b/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 from arroyo.backends.kafka import KafkaPayload
@@ -82,7 +82,10 @@ def test_outcomes_consumed(track_outcome):
         encoded = json.dumps(bucket).encode()
         payload = KafkaPayload(key=None, value=encoded, headers=[])
         message = Message(
-            Partition(topic, index=0), generate_kafka_message.counter, payload, datetime.now()
+            Partition(topic, index=0),
+            generate_kafka_message.counter,
+            payload,
+            datetime.now(timezone.utc),
         )
         generate_kafka_message.counter += 1
         return message
@@ -109,7 +112,7 @@ def test_outcomes_consumed(track_outcome):
                     key_id=None,
                     outcome=Outcome.ACCEPTED,
                     reason=None,
-                    timestamp=datetime(1985, 10, 26, 21, 00, 00),
+                    timestamp=datetime(1985, 10, 26, 21, 00, 00, tzinfo=timezone.utc),
                     event_id=None,
                     category=DataCategory.TRANSACTION,
                     quantity=3,

--- a/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
+++ b/tests/sentry/ingest/billing_metrics_consumer/test_billing_metrics_consumer_kafka.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from arroyo.backends.kafka import KafkaPayload
 from arroyo.types import Message, Partition, Topic
+from freezegun import freeze_time
 
 from sentry.constants import DataCategory
 from sentry.ingest.billing_metrics_consumer import (
@@ -15,6 +16,7 @@ from sentry.utils.outcomes import Outcome
 
 
 @mock.patch("sentry.ingest.billing_metrics_consumer.track_outcome")
+@freeze_time("1985-10-26 21:00:00")
 def test_outcomes_consumed(track_outcome):
     # Based on test_ingest_consumer_kafka.py
 
@@ -107,7 +109,7 @@ def test_outcomes_consumed(track_outcome):
                     key_id=None,
                     outcome=Outcome.ACCEPTED,
                     reason=None,
-                    timestamp=datetime(1970, 1, 2, 10, 17, 36),
+                    timestamp=datetime(1985, 10, 26, 21, 00, 00),
                     event_id=None,
                     category=DataCategory.TRANSACTION,
                     quantity=3,


### PR DESCRIPTION
Gets timestamps of outcomes derived from metrics closer to their event-based counterpart. This should reduce a gap of usage numbers between indexed and total transactions when transactions are backdated.

### Details

There are two types of performance traffic that are tracked with separate outcomes:

 - Transaction events flow through the `save_event` task. EventManager uses the `start_time` parameter to track outcomes for indexed transactions. That time is set by Relay during ingest and represents the time at which the event was first recorded at the ingest endpoint. This can be significantly different from the stated transaction timestamp if the transaction is submitted with a delay.
 - Transaction metrics flow through the indexer and the `billing_metrics_consumer`. This consumer uses counts from the `transaction.duration` metric to record outcomes for total transactions. Metric buckets have no received timestamp, since the individual metrics that ended up in a bucket may have been received at different times. The former implementation of this consumer used the stated bucket timestamp to record outcomes, derived from the transaction timestamp. For backdated buckets, this means the outcome is recorded in the past rather than at ingest time.

This difference can create gaps where there are more indexed transactions than total transactions in a given timeframe. Since metrics do not have a `start_time` like events, it's not possible to avoid such a gap entirely. However, the consumer can use the current time to produce the metrics-based outcomes, which will be closer to the ingest time than the bucket timestamp.

Note that this was also fixed in https://github.com/getsentry/sentry/pull/41638 but subsequently reverted.