### PR TITLE
chore(hybrid-cloud): use organization_slug in relay register APIs

### DIFF
--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -6,7 +8,7 @@ from sentry_relay import create_register_challenge, is_version_supported
 
 from sentry import options
 from sentry.api.authentication import is_internal_relay, is_static_relay, relay_from_id
-from sentry.api.base import Endpoint, pending_silo_endpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
 from sentry.api.serializers import serialize
 from sentry.relay.utils import get_header_relay_id, get_header_relay_signature
@@ -17,9 +19,10 @@ from . import RelayIdSerializer
 
 class RelayRegisterChallengeSerializer(RelayIdSerializer):
     public_key = serializers.CharField(max_length=64, required=True)
+    organization_slug = serializers.CharField(required=False)
 
 
-@pending_silo_endpoint
+@region_silo_endpoint
 class RelayRegisterChallengeEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
@@ -27,7 +30,7 @@ class RelayRegisterChallengeEndpoint(Endpoint):
     enforce_rate_limit = True
     rate_limits = RELAY_AUTH_RATE_LIMITS
 
-    def post(self, request: Request) -> Response:
+    def post(self, request: Request, organization_slug: Optional[str]) -> Response:
         """
         Requests to Register a Relay
         ````````````````````````````

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -17,7 +17,6 @@ from . import RelayIdSerializer
 
 class RelayRegisterChallengeSerializer(RelayIdSerializer):
     public_key = serializers.CharField(max_length=64, required=True)
-    organization_slug = serializers.CharField(required=False)
 
 
 @region_silo_endpoint

--- a/src/sentry/api/endpoints/relay/register_challenge.py
+++ b/src/sentry/api/endpoints/relay/register_challenge.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.conf import settings
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -30,7 +28,7 @@ class RelayRegisterChallengeEndpoint(Endpoint):
     enforce_rate_limit = True
     rate_limits = RELAY_AUTH_RATE_LIMITS
 
-    def post(self, request: Request, organization_slug: Optional[str]) -> Response:
+    def post(self, request: Request, organization_slug: str = None) -> Response:
         """
         Requests to Register a Relay
         ````````````````````````````

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.utils import timezone
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -6,7 +8,7 @@ from sentry_relay import UnpackErrorSignatureExpired, validate_register_response
 
 from sentry import options
 from sentry.api.authentication import is_internal_relay, relay_from_id
-from sentry.api.base import Endpoint, pending_silo_endpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.endpoints.relay.constants import RELAY_AUTH_RATE_LIMITS
 from sentry.api.serializers import serialize
 from sentry.models import Relay, RelayUsage
@@ -20,7 +22,7 @@ class RelayRegisterResponseSerializer(RelayIdSerializer):
     token = serializers.CharField(required=True)
 
 
-@pending_silo_endpoint
+@region_silo_endpoint
 class RelayRegisterResponseEndpoint(Endpoint):
     authentication_classes = ()
     permission_classes = ()
@@ -28,7 +30,7 @@ class RelayRegisterResponseEndpoint(Endpoint):
     enforce_rate_limit = True
     rate_limits = RELAY_AUTH_RATE_LIMITS
 
-    def post(self, request: Request) -> Response:
+    def post(self, request: Request, organization_slug: Optional[str]) -> Response:
         """
         Registers a Relay
         `````````````````

--- a/src/sentry/api/endpoints/relay/register_response.py
+++ b/src/sentry/api/endpoints/relay/register_response.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.utils import timezone
 from rest_framework import serializers, status
 from rest_framework.request import Request
@@ -30,7 +28,7 @@ class RelayRegisterResponseEndpoint(Endpoint):
     enforce_rate_limit = True
     rate_limits = RELAY_AUTH_RATE_LIMITS
 
-    def post(self, request: Request, organization_slug: Optional[str]) -> Response:
+    def post(self, request: Request, organization_slug: str = None) -> Response:
         """
         Registers a Relay
         `````````````````

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -568,14 +568,24 @@ urlpatterns = [
             [
                 url(r"^$", RelayIndexEndpoint.as_view(), name="sentry-api-0-relays-index"),
                 url(
-                    r"^register/challenge/$",
+                    r"^(?P<organization_slug>[^\/]+)/register/challenge/$",
                     RelayRegisterChallengeEndpoint.as_view(),
                     name="sentry-api-0-relay-register-challenge",
                 ),
                 url(
-                    r"^register/response/$",
+                    r"^register/challenge/$",
+                    RelayRegisterChallengeEndpoint.as_view(),
+                    name="sentry-api-0-relay-register-challenge-orgless",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/register/response/$",
                     RelayRegisterResponseEndpoint.as_view(),
                     name="sentry-api-0-relay-register-response",
+                ),
+                url(
+                    r"^register/response/$",
+                    RelayRegisterResponseEndpoint.as_view(),
+                    name="sentry-api-0-relay-register-response-orgless",
                 ),
                 url(
                     r"^projectconfigs/$",

--- a/src/sentry/models/relay.py
+++ b/src/sentry/models/relay.py
@@ -3,10 +3,10 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from sentry_relay import PublicKey
 
-from sentry.db.models import Model, control_silo_with_replication_model
+from sentry.db.models import Model, region_silo_only_model
 
 
-@control_silo_with_replication_model
+@region_silo_only_model
 class RelayUsage(Model):
     __include_in_export__ = True
 
@@ -22,7 +22,7 @@ class RelayUsage(Model):
         db_table = "sentry_relayusage"
 
 
-@control_silo_with_replication_model
+@region_silo_only_model
 class Relay(Model):
     __include_in_export__ = True
 

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -11,7 +11,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 
 
-@region_silo_test(stable=True)
+@region_silo_test
 class RelayRegisterTest(APITestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -11,7 +11,7 @@ from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 
 
-@region_silo_test
+@region_silo_test(stable=True)
 class RelayRegisterTest(APITestCase):
     def setUp(self):
         super().setUp()

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -7,9 +7,11 @@ from sentry_relay import generate_key_pair
 
 from sentry.models import Relay, RelayUsage
 from sentry.testutils import APITestCase
+from sentry.testutils.silo import region_silo_test
 from sentry.utils import json
 
 
+@region_silo_test(stable=True)
 class RelayRegisterTest(APITestCase):
     def setUp(self):
         super().setUp()
@@ -22,7 +24,7 @@ class RelayRegisterTest(APITestCase):
         self.private_key = self.key_pair[0]
         self.relay_id = str(uuid4())
 
-        self.path = reverse("sentry-api-0-relay-register-challenge")
+        self.path = reverse("sentry-api-0-relay-register-challenge", args=[self.organization.slug])
 
     def add_internal_key(self, public_key):
         if public_key not in settings.SENTRY_RELAY_WHITELIST_PK:
@@ -57,7 +59,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = private_key.pack(data)
 
         resp = self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=relay_id,
@@ -183,7 +185,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = self.private_key.pack(result)
 
         resp = self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,
@@ -214,7 +216,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = self.private_key.pack(result)
 
         self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,
@@ -258,7 +260,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = self.private_key.pack(result)
 
         self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,
@@ -272,7 +274,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = keys[0].pack(data)
 
         resp = self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,
@@ -313,7 +315,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = keys[0].pack(data)
 
         resp = self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,
@@ -341,7 +343,7 @@ class RelayRegisterTest(APITestCase):
         _, signature = self.private_key.pack(result)
 
         resp = self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data="a",
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,
@@ -371,7 +373,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = self.private_key.pack(result)
 
         resp = self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,
@@ -399,7 +401,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = self.private_key.pack(result)
 
         resp = self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,
@@ -426,7 +428,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = self.private_key.pack(result)
 
         resp = self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=str(uuid4()),
@@ -466,7 +468,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = self.private_key.pack(result)
 
         self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,
@@ -478,7 +480,7 @@ class RelayRegisterTest(APITestCase):
         raw_json, signature = self.private_key.pack(data)
 
         resp = self.client.post(
-            reverse("sentry-api-0-relay-register-response"),
+            reverse("sentry-api-0-relay-register-response", args=[self.organization.slug]),
             data=raw_json,
             content_type="application/json",
             HTTP_X_SENTRY_RELAY_ID=self.relay_id,


### PR DESCRIPTION
Adds `organization_slug` to the urls for RelayRegisterChallengeEndpoint and RelayRegisterResponseEndpoint since they should be region silo endpoints and (later) OrganizationEndpoints. Also retains the original urls, which will later be removed.

Completely changing the API to an OrganizationEndpoint causes a 404 from Relay because Relay is POSTing to `/api/0/relays/register/challenge/` and not `/api/0/relays/<org_slug>/register/challenge/`

Addresses HC-507