### PR TITLE
fix(issue-search): properly handle negation logic when searching on Group message

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -548,9 +548,10 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
                             lambda query: Q(type=GroupType.ERROR.value)
                             | _perf_issue_message_condition(query)
                         )
+                        # negation should only apply on the message search icontains, we have to include the
+                        # type filter(type=GroupType.ERROR) check since we don't wanna search on the message
+                        # column when type=GroupType.ERROR - we delegate that to snuba in that case
                         if not message_filter.is_negation
-                        # if we're negating the message search term: '!message:something' we shouldn't apply
-                        # the `type=GroupType.ERROR` check since we'll end up excluding all error issues
                         else QCallbackCondition(lambda query: _perf_issue_message_condition(query))
                     }
                 )

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -39,7 +39,7 @@ from sentry.search.snuba.executors import (
     CdcPostgresSnubaQueryExecutor,
     PostgresSnubaQueryExecutor,
 )
-from sentry.types.issues import GroupType
+from sentry.types.issues import PERFORMANCE_TYPES, GroupType
 from sentry.utils.cursors import Cursor, CursorResult
 
 
@@ -540,18 +540,7 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             if message_filter:
 
                 def _perf_issue_message_condition(query: str) -> Q:
-                    return Q(
-                        type__in=(
-                            GroupType.PERFORMANCE_N_PLUS_ONE.value,
-                            GroupType.PERFORMANCE_SLOW_SPAN.value,
-                            GroupType.PERFORMANCE_SEQUENTIAL_SLOW_SPANS.value,
-                            GroupType.PERFORMANCE_LONG_TASK_SPANS.value,
-                            GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN.value,
-                            GroupType.PERFORMANCE_DUPLICATE_SPANS.value,
-                            GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value,
-                        ),
-                        message__icontains=query,
-                    )
+                    return Q(type__in=PERFORMANCE_TYPES, message__icontains=query)
 
                 queryset_conditions.update(
                     {

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -46,7 +46,7 @@ from sentry.models import Environment, Group, Project
 from sentry.search.events.fields import DateArg
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
 from sentry.search.utils import validate_cdc_search_filters
-from sentry.types.issues import GroupCategory, GroupType
+from sentry.types.issues import PERFORMANCE_TYPES, GroupCategory, GroupType
 from sentry.utils import json, metrics, snuba
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.snuba import SnubaQueryParams, aliased_query_params, bulk_raw_query
@@ -502,17 +502,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                         group_queryset = group_queryset.filter(
                             Q(type=GroupType.ERROR.value)
                             | (
-                                Q(
-                                    type__in=(
-                                        GroupType.PERFORMANCE_N_PLUS_ONE.value,
-                                        GroupType.PERFORMANCE_SLOW_SPAN.value,
-                                        GroupType.PERFORMANCE_SEQUENTIAL_SLOW_SPANS.value,
-                                        GroupType.PERFORMANCE_LONG_TASK_SPANS.value,
-                                        GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN.value,
-                                        GroupType.PERFORMANCE_DUPLICATE_SPANS.value,
-                                        GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value,
-                                    )
-                                )
+                                Q(type__in=PERFORMANCE_TYPES)
                                 and (
                                     ~Q(message__icontains=sf.value.raw_value)
                                     if sf.is_negation

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -501,17 +501,23 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                     if "message" == sf.key.name and isinstance(sf.value.raw_value, str):
                         group_queryset = group_queryset.filter(
                             Q(type=GroupType.ERROR.value)
-                            | Q(
-                                type__in=(
-                                    GroupType.PERFORMANCE_N_PLUS_ONE.value,
-                                    GroupType.PERFORMANCE_SLOW_SPAN.value,
-                                    GroupType.PERFORMANCE_SEQUENTIAL_SLOW_SPANS.value,
-                                    GroupType.PERFORMANCE_LONG_TASK_SPANS.value,
-                                    GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN.value,
-                                    GroupType.PERFORMANCE_DUPLICATE_SPANS.value,
-                                    GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value,
-                                ),
-                                message__icontains=sf.value.raw_value,
+                            | (
+                                Q(
+                                    type__in=(
+                                        GroupType.PERFORMANCE_N_PLUS_ONE.value,
+                                        GroupType.PERFORMANCE_SLOW_SPAN.value,
+                                        GroupType.PERFORMANCE_SEQUENTIAL_SLOW_SPANS.value,
+                                        GroupType.PERFORMANCE_LONG_TASK_SPANS.value,
+                                        GroupType.PERFORMANCE_RENDER_BLOCKING_ASSET_SPAN.value,
+                                        GroupType.PERFORMANCE_DUPLICATE_SPANS.value,
+                                        GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value,
+                                    )
+                                )
+                                and (
+                                    ~Q(message__icontains=sf.value.raw_value)
+                                    if sf.is_negation
+                                    else Q(message__icontains=sf.value.raw_value)
+                                )
                             )
                         )
 

--- a/src/sentry/types/issues.py
+++ b/src/sentry/types/issues.py
@@ -45,6 +45,11 @@ GROUP_TYPE_TO_TEXT = {
 }
 
 
+PERFORMANCE_TYPES = [
+    gt.value for gt, gc in GROUP_TYPE_TO_CATEGORY.items() if gc == GroupCategory.PERFORMANCE
+]
+
+
 def get_category_type_mapping():
     category_type_mapping = defaultdict(list)
 


### PR DESCRIPTION
Searching using the general message term doesn't work properly since we include the predicate condition `type=GroupType.ERROR.value` which gets excluded from the Groups queryset. 

We need to add some special conditional logic to exclude that condition if we're negating the message.