### PR TITLE
bug(replays): Fix Timeline placeholder height so it matches the rendered component

### DIFF
--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -28,7 +28,7 @@ function ReplayTimeline({}: Props) {
   const {replay} = useReplayContext();
 
   if (!replay) {
-    return <Placeholder height="48px" bottomGutter={2} />;
+    return <Placeholder height="54px" bottomGutter={2} />;
   }
 
   const durationMs = replay.getDurationMs();


### PR DESCRIPTION
Before it was a little short, causing the Url bar and tabs to be misaligned. 

See a zoomed-in split-screen comparison of the loading vs loaded page: 
<img width="340" alt="SCR-20221128-t78" src="https://user-images.githubusercontent.com/187460/204443249-a0f76cf5-7204-440b-985e-8879bf390c73.png">


After things are all lining up:
<img width="349" alt="SCR-20221128-t7r" src="https://user-images.githubusercontent.com/187460/204443276-ce08be8e-1b31-49ed-93a7-5e83f574c2b9.png">

References #[41792](https://github.com/getsentry/sentry/issues/41792)