### PR TITLE
fix(replays): Fix error count color

### DIFF
--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -129,6 +129,10 @@ const ErrorTag = styled(Tag)<{level: 'fatal' | 'default'}>`
     background: ${p => p.theme.level[p.level]};
     border-color: ${p => p.theme.level[p.level]};
     padding: 0 ${space(0.75)};
+
+    span {
+      color: ${p => p.theme.buttonCountActive} !important;
+    }
   }
 `;
 


### PR DESCRIPTION
This got messed up in #41728

We need the white color override still.

| **AFTER** | No Error | Has Error |
| --- | --- | --- |
| Light | <img width="372" alt="SCR-20221129-c27" src="https://user-images.githubusercontent.com/187460/204589546-fd82f54c-cb5d-488e-b0c3-19fa81eee9b8.png"> | <img width="374" alt="SCR-20221129-c2b" src="https://user-images.githubusercontent.com/187460/204589543-6daf8987-e3be-4ba0-ae22-e45d8f4d6e91.png"> |
| Dark | <img width="385" alt="SCR-20221129-c2m" src="https://user-images.githubusercontent.com/187460/204589551-6c681e54-dff2-4b1c-b62b-423f70172e98.png"> | <img width="374" alt="SCR-20221129-c2p" src="https://user-images.githubusercontent.com/187460/204589541-d3dc1281-e32a-4892-93cd-3441834de1f4.png"> |


**Before (only poor color for the has-error case):**

| **Before** | No Error | Has Error |
| --- | --- | --- |
| Light | _same as above_ | <img width="375" alt="SCR-20221129-c3g" src="https://user-images.githubusercontent.com/187460/204589806-a8db4dd4-71dd-4f4e-978b-0f89af4f7db8.png"> |
| Dark | _same as above_ | <img width="379" alt="SCR-20221129-c39" src="https://user-images.githubusercontent.com/187460/204589800-a30b5264-f071-4b73-9a16-a522f1e49e61.png"> |
