### PR TITLE
fix(ui) Use normalized URL in ListLink

### DIFF
--- a/static/app/components/links/listLink.tsx
+++ b/static/app/components/links/listLink.tsx
@@ -50,7 +50,7 @@ function ListLink({
       className={classNames({[activeClassName]: active}, className)}
       disabled={disabled}
     >
-      <RouterLink {...props} onlyActiveOnIndex={index} to={disabled ? '' : to}>
+      <RouterLink {...props} onlyActiveOnIndex={index} to={disabled ? '' : target}>
         {children}
       </RouterLink>
     </StyledLi>

--- a/static/app/utils/withDomainRequired.spec.tsx
+++ b/static/app/utils/withDomainRequired.spec.tsx
@@ -30,6 +30,7 @@ describe('normalizeUrl', function () {
       ['/settings/sentry/teams/peeps/', '/settings/teams/peeps/'],
       ['/settings/account/security/', '/settings/account/security/'],
       ['/settings/account/details/', '/settings/account/details/'],
+      ['/settings/sentry/billing/receipts/', '/settings/billing/receipts/'],
       [
         '/settings/acme/developer-settings/release-bot/',
         '/settings/developer-settings/release-bot/',


### PR DESCRIPTION
I forgot to pass the normalized link into the wrapped RouterLink. This fixes broken links in the subscription tab bar.