### PR TITLE
bug(replays): Fix an null value issue with 0ms replays

### DIFF
--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -72,7 +72,9 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
     ...apiResponse,
     ...(apiResponse.startedAt ? {startedAt: new Date(apiResponse.startedAt)} : {}),
     ...(apiResponse.finishedAt ? {finishedAt: new Date(apiResponse.finishedAt)} : {}),
-    ...(apiResponse.duration ? {duration: duration(apiResponse.duration * 1000)} : {}),
+    ...(apiResponse.duration !== undefined
+      ? {duration: duration(apiResponse.duration * 1000)}
+      : {}),
     tags,
   };
 }


### PR DESCRIPTION
`duration` can be zero, which is falsy, which means we unset it. Which is bad.

Fixes #41840