### PR TITLE
feat(replays): Replay list page should have a default filter for duration > 5seconds

### DIFF
--- a/static/app/utils/replays/hooks/useReplayList.tsx
+++ b/static/app/utils/replays/hooks/useReplayList.tsx
@@ -20,7 +20,6 @@ function useReplayList({eventView, organization}: Options): Result {
   const api = useApi();
   const location = useLocation<ReplayListLocationQuery>();
   const querySearchRef = useRef<string>();
-  const controllerRef = useRef<AbortController | null>(null);
 
   const [data, setData] = useState<State>({
     fetchError: undefined,
@@ -51,21 +50,16 @@ function useReplayList({eventView, organization}: Options): Result {
 
   useEffect(() => {
     if (!querySearchRef.current || querySearchRef.current !== location.search) {
-      controllerRef.current = new AbortController();
+      const controller = new AbortController();
       querySearchRef.current = location.search;
 
-      loadReplays(controllerRef.current.signal);
-    }
-  }, [loadReplays, location.search]);
-
-  useEffect(() => {
-    const controller = controllerRef?.current;
-    return () => {
-      if (controller) {
+      loadReplays(controller.signal);
+      return () => {
         controller.abort();
-      }
-    };
-  }, []);
+      };
+    }
+    return () => {};
+  }, [loadReplays, location.search]);
 
   return data;
 }

--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -72,7 +72,9 @@ export function mapResponseToReplayRecord(apiResponse: any): ReplayRecord {
     ...apiResponse,
     ...(apiResponse.startedAt ? {startedAt: new Date(apiResponse.startedAt)} : {}),
     ...(apiResponse.finishedAt ? {finishedAt: new Date(apiResponse.finishedAt)} : {}),
-    ...(apiResponse.duration ? {duration: duration(apiResponse.duration * 1000)} : {}),
+    ...(apiResponse.duration !== undefined
+      ? {duration: duration(apiResponse.duration * 1000)}
+      : {}),
     tags,
   };
 }

--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -13,7 +13,7 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import ReplaySearchBar from 'sentry/views/replays/replaySearchBar';
 
-const DEFAULT_QUERY = 'duration:>5';
+const DEFAULT_QUERY = 'duration:>=5';
 
 function ReplaysFilters() {
   const {selection} = usePageFilters();

--- a/static/app/views/replays/filters.tsx
+++ b/static/app/views/replays/filters.tsx
@@ -1,3 +1,4 @@
+import {useEffect, useRef} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 
@@ -12,12 +13,29 @@ import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import ReplaySearchBar from 'sentry/views/replays/replaySearchBar';
 
+const DEFAULT_QUERY = 'duration:>5';
+
 function ReplaysFilters() {
   const {selection} = usePageFilters();
   const location = useLocation();
   const organization = useOrganization();
+  const didMount = useRef(false);
 
   const {pathname, query} = location;
+
+  useEffect(() => {
+    if (!didMount.current && !query?.query) {
+      browserHistory.push({
+        pathname,
+        query: {
+          ...query,
+          cursor: undefined,
+          query: DEFAULT_QUERY,
+        },
+      });
+    }
+    didMount.current = true;
+  }, [pathname, query]);
 
   return (
     <FilterContainer>
@@ -29,7 +47,7 @@ function ReplaysFilters() {
       <ReplaySearchBar
         organization={organization}
         pageFilters={selection}
-        defaultQuery={decodeScalar(location.query?.query, '')}
+        defaultQuery={decodeScalar(query?.query ?? DEFAULT_QUERY, '')}
         onSearch={searchQuery => {
           browserHistory.push({
             pathname,


### PR DESCRIPTION
**Test Plan:** 

Load the replays index page
- Notice that the query gets added to the URL and also the Input box by default
- notice that two api requests get sent out.
  - The first request is cancelled in the browser, so the data is never saved into any `useState`

Remove the query from the input box
- notice the URL is updated in the browser, new results are shown

Make another custom query, example: `user.email:*@sentry.io`
- notice the url is updated, new results are shown

Copy+Paste that current url into a new window
- notice that only one query is made on pageload.

**Note**
`useReplayList` is also used to populate the the Issues>Replays list tab. I tested that it still loads data and only makes one request as before. This page still depends on #41720 though.