### PR TITLE
fix[orgstats] include -1 in project_ids list

### DIFF
--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -2,6 +2,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {act, cleanup, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import OrganizationStore from 'sentry/stores/organizationStore';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
@@ -110,7 +111,7 @@ describe('OrganizationStats', function () {
         statsPeriod: DEFAULT_STATS_PERIOD,
         interval: '1h',
         groupBy: ['category', 'outcome'],
-        project: [],
+        project: [-1],
         field: ['sum(quantity)'],
       },
       UsageStatsPerMin: {
@@ -123,7 +124,7 @@ describe('OrganizationStats', function () {
         statsPeriod: DEFAULT_STATS_PERIOD,
         interval: '1h',
         groupBy: ['outcome', 'project'],
-        project: [],
+        project: [-1],
         field: ['sum(quantity)'],
         category: 'error',
       },
@@ -244,7 +245,8 @@ describe('OrganizationStats', function () {
       if (query?.statsPeriod === '5m') {
         return;
       }
-      expect(query.project).toEqual(defaultSelection.projects);
+      expect(query.project).toEqual([ALL_ACCESS_PROJECTS]);
+      expect(defaultSelection.projects).toEqual([]);
     });
   });
 

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -149,7 +149,7 @@ export class OrganizationStats extends Component<Props> {
 
   // Project selection from GlobalSelectionHeader
   get projectIds(): number[] {
-    return this.hasProjectStats ? this.props.selection.projects : [];
+    return this.hasProjectStats ? [-1, ...this.props.selection.projects] : [-1];
   }
 
   /**

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -26,6 +26,7 @@ import {
   DEFAULT_RELATIVE_PERIODS,
   DEFAULT_STATS_PERIOD,
 } from 'sentry/constants';
+import {ALL_ACCESS_PROJECTS} from 'sentry/constants/pageFilters';
 import {t, tct} from 'sentry/locale';
 import {PageHeader} from 'sentry/styles/organization';
 import space from 'sentry/styles/space';
@@ -151,8 +152,8 @@ export class OrganizationStats extends Component<Props> {
   get projectIds(): number[] {
     const selection_projects = this.props.selection.projects.length
       ? this.props.selection.projects
-      : [-1];
-    return this.hasProjectStats ? selection_projects : [-1];
+      : [ALL_ACCESS_PROJECTS];
+    return this.hasProjectStats ? selection_projects : [ALL_ACCESS_PROJECTS];
   }
 
   /**

--- a/static/app/views/organizationStats/index.tsx
+++ b/static/app/views/organizationStats/index.tsx
@@ -149,7 +149,10 @@ export class OrganizationStats extends Component<Props> {
 
   // Project selection from GlobalSelectionHeader
   get projectIds(): number[] {
-    return this.hasProjectStats ? [-1, ...this.props.selection.projects] : [-1];
+    const selection_projects = this.props.selection.projects.length
+      ? this.props.selection.projects
+      : [-1];
+    return this.hasProjectStats ? selection_projects : [-1];
   }
 
   /**


### PR DESCRIPTION
Orgstats v2 requests are not sending projects unless `hasProjectStats` is set.

This update ensures we're able to query all projects



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
