### PR TITLE
fix(logging): Prepend 'sentry' to logger names

### DIFF
--- a/src/sentry/api/endpoints/internal/beacon.py
+++ b/src/sentry/api/endpoints/internal/beacon.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint, pending_silo_endpoint
 from sentry.tasks.beacon import send_beacon_metric
 
-logger = logging.getLogger("beacon")
+logger = logging.getLogger(__name__)
 
 # These is an arbitrarily picked limit for both the # of batched metrics supported,
 # as well as the size of the dict for each metric

--- a/src/sentry/release_health/tasks.py
+++ b/src/sentry/release_health/tasks.py
@@ -23,7 +23,7 @@ from sentry.utils import metrics
 CHUNK_SIZE = 1000
 MAX_SECONDS = 60
 
-logger = logging.getLogger("tasks.releasemonitor")
+logger = logging.getLogger("sentry.tasks.releasemonitor")
 
 
 @instrumented_task(

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -301,7 +301,7 @@ class EventFrequencyPercentForm(EventFrequencyForm):
 class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
     id = "sentry.rules.conditions.event_frequency.EventFrequencyPercentCondition"
     label = "The issue affects more than {value} percent of sessions in {interval}"
-    logger = logging.getLogger("rules.event_frequency")
+    logger = logging.getLogger("sentry.rules.event_frequency")
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.intervals = percent_intervals

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -17,7 +17,7 @@ from sentry.utils import json
 
 BEACON_URL = "https://sentry.io/remote/beacon/"
 
-logger = logging.getLogger("beacon")
+logger = logging.getLogger(__name__)
 
 
 def get_install_id():

--- a/src/sentry/tasks/commit_context.py
+++ b/src/sentry/tasks/commit_context.py
@@ -20,7 +20,7 @@ from sentry.utils.sdk import set_current_event_project
 PREFERRED_GROUP_OWNERS = 1
 PREFERRED_GROUP_OWNER_AGE = timedelta(days=7)
 
-logger = logging.getLogger("sentry.tasks.commit_context")
+logger = logging.getLogger(__name__)
 
 
 @instrumented_task(

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -16,7 +16,7 @@ PREFERRED_GROUP_OWNERS = 2
 PREFERRED_GROUP_OWNER_AGE = timedelta(days=7)
 MIN_COMMIT_SCORE = 2
 
-logger = logging.getLogger("tasks.groupowner")
+logger = logging.getLogger(__name__)
 
 
 def _process_suspect_commits(

--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -17,7 +17,7 @@ from django.conf import settings
 
 from sentry.utils import kafka_config
 
-logger = logging.getLogger("batching-kafka-consumer")
+logger = logging.getLogger("sentry.batching-kafka-consumer")
 
 DEFAULT_QUEUED_MAX_MESSAGE_KBYTES = 50000
 DEFAULT_QUEUED_MIN_MESSAGES = 10000


### PR DESCRIPTION
Based on our logging configuration we need to prepend the logger name with `sentry`. https://github.com/getsentry/sentry/blob/master/src/sentry/conf/server.py#L864

We can use `__name__` to automatically get the module name