### PR TITLE
fix(stacktrace-link): Use the correct value for tagging in_app

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -79,9 +79,11 @@ def set_top_tags(
         )
         scope.set_tag("stacktrace_link.platform", ctx["platform"])
         scope.set_tag("stacktrace_link.code_mappings", has_code_mappings)
+        scope.set_tag("stacktrace_link.file", ctx["file"])
+        scope.set_tag("stacktrace_link.abs_path", ctx["abs_path"])
         if ctx["platform"] == "python":
             # This allows detecting a file that belongs to Python's 3rd party modules
-            scope.set_tag("stacktrace_link.in_app", "site-packages" not in str(ctx["file"]))
+            scope.set_tag("stacktrace_link.in_app", "site-packages" not in str(ctx["abs_path"]))
     except Exception:
         # If errors arises we can still proceed
         logger.exception("We failed to set a tag.")


### PR DESCRIPTION
For instance, absPath: `/payments/lib/slack_client.py` vs file: `lib/slack_client.py`

It will also be nice to catch the values as tags since `stack.*` never work.