### PR TITLE
feat(alert-preview): pass endpoint to api

### DIFF
--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -6,7 +6,6 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
-from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.rule import RulePreviewSerializer
 from sentry.rules.history.preview import preview
@@ -38,7 +37,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
         if not features.has(
             "organizations:issue-alert-preview", project.organization, actor=request.user
         ):
-            return ResourceDoesNotExist
+            return Response(status=404)
         serializer = RulePreviewSerializer(
             context={"project": project, "organization": project.organization}, data=request.data
         )

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -46,7 +46,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
             raise ValidationError
 
         data = serializer.validated_data
-        if data["endpoint"] is None:
+        if data.get("endpoint") is None:
             data["endpoint"] = timezone.now()
         results = preview(
             project,

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -68,8 +68,5 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
             on_results=lambda x: serialize(x, request.user),
             count_hits=True,
         )
-        response.data = {
-            "data": response.data,
-            "endpoint": data["endpoint"],
-        }
+        response["Endpoint"] = data["endpoint"]
         return response

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -119,6 +119,10 @@ class RuleSetSerializer(serializers.Serializer):
         return attrs
 
 
+class RulePreviewSerializer(RuleSetSerializer):
+    endpoint = serializers.DateTimeField(required=False, allow_null=True)
+
+
 class RuleActionSerializer(serializers.Serializer):
     actions = ListField(child=RuleNodeField(type="action/event"), required=False)
 

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -47,13 +47,11 @@ def preview(
     condition_match: str,
     filter_match: str,
     frequency_minutes: int,
+    end: datetime | None = None,
 ) -> BaseQuerySet | None:
     """
     Returns groups that would have triggered the given conditions and filters in the past 2 weeks
     """
-    end = timezone.now()
-    start = end - PREVIEW_TIME_RANGE
-
     issue_state_conditions, frequency_conditions = categorize_conditions(conditions)
 
     # must have at least one issue state condition to filter activity
@@ -64,6 +62,9 @@ def preview(
     elif len(issue_state_conditions) > 1 and condition_match == "all":
         return Group.objects.none()
 
+    if end is None:
+        end = timezone.now()
+    start = end - PREVIEW_TIME_RANGE
     try:
         group_activity = get_issue_state_activity(project, issue_state_conditions, start, end)
         filter_objects, filter_func, event_columns = get_filters(project, filters, filter_match)

--- a/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from dateutil.parser import parse as parse_datetime
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -35,10 +36,9 @@ class ProjectRulePreviewEndpointTest(APITestCase):
                 actionMatch="any",
                 filterMatch="all",
                 frequency=10,
-                endpoint=None,
             )
-        assert len(resp.data["data"]) == 1
-        assert resp.data["data"][0]["id"] == str(group.id)
+        assert len(resp.data) == 1
+        assert resp.data[0]["id"] == str(group.id)
 
     def test_invalid_conditions(self):
         conditions = [
@@ -55,7 +55,6 @@ class ProjectRulePreviewEndpointTest(APITestCase):
                     actionMatch="any",
                     filterMatch="all",
                     frequency=10,
-                    endpoint=None,
                 )
                 assert resp.status_code == 400
 
@@ -72,7 +71,6 @@ class ProjectRulePreviewEndpointTest(APITestCase):
                 actionMatch="any",
                 filterMatch="all",
                 frequency=10,
-                endpoint=None,
             )
         assert resp.status_code == 400
 
@@ -92,9 +90,9 @@ class ProjectRulePreviewEndpointTest(APITestCase):
                     endpoint=None,
                 )
 
-            tz = resp.data["endpoint"].tzinfo
-            endpoint = frozen_time.time_to_freeze.replace(tzinfo=tz)
-            assert resp.data["endpoint"] == endpoint
+            result = parse_datetime(resp["endpoint"])
+            endpoint = frozen_time.time_to_freeze.replace(tzinfo=result.tzinfo)
+            assert result == endpoint
             frozen_time.tick(1)
 
             with self.feature(self.features):
@@ -111,4 +109,4 @@ class ProjectRulePreviewEndpointTest(APITestCase):
                     endpoint=endpoint,
                 )
 
-            assert resp.data["endpoint"] == endpoint
+            assert parse_datetime(resp["endpoint"]) == endpoint

--- a/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_preview.py
@@ -69,7 +69,7 @@ class ProjectRulePreviewEndpointTest(APITestCase):
 
     def test_endpoint(self):
         with freeze_time(timezone.now()) as frozen_time:
-            resp = self.get_response(
+            resp = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
                 conditions=[
@@ -79,7 +79,7 @@ class ProjectRulePreviewEndpointTest(APITestCase):
                 actionMatch="any",
                 filterMatch="all",
                 frequency=10,
-                endpoint="invalid endpoint",
+                endpoint=None,
             )
 
             tz = resp.data["endpoint"].tzinfo
@@ -87,7 +87,7 @@ class ProjectRulePreviewEndpointTest(APITestCase):
             assert resp.data["endpoint"] == endpoint
             frozen_time.tick(1)
 
-            resp = self.get_response(
+            resp = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
                 conditions=[

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -12,7 +12,7 @@ from sentry.rules.history.preview import (
     preview,
 )
 from sentry.snuba.dataset import Dataset
-from sentry.testutils import TestCase
+from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.types.activity import ActivityType
@@ -29,8 +29,9 @@ def get_hours(time: timedelta) -> int:
 
 @freeze_time()
 @region_silo_test
-class ProjectRulePreviewTest(TestCase):
+class ProjectRulePreviewTest(TestCase, SnubaTestCase):
     def setUp(self):
+        super().setUp()
         self.transaction_data = load_data(
             "transaction",
             fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
@@ -445,8 +446,9 @@ class ProjectRulePreviewTest(TestCase):
 
 @freeze_time()
 @region_silo_test
-class FrequencyConditionTest(TestCase):
+class FrequencyConditionTest(TestCase, SnubaTestCase):
     def setUp(self):
+        super().setUp()
         self.transaction_data = load_data(
             "transaction",
             fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
@@ -572,7 +574,7 @@ class FrequencyConditionTest(TestCase):
 
 @freeze_time()
 @region_silo_test
-class GetEventsTest(TestCase):
+class GetEventsTest(TestCase, SnubaTestCase):
     def test_get_first_seen(self):
         prev_hour = timezone.now() - timedelta(hours=1)
         two_hours = timezone.now() - timedelta(hours=2)


### PR DESCRIPTION
Returns the preview window endpoint so that it can be kept in the frontend session and declared for subsequent preview calls.

Right now, the endpoint of the preview window is determined with `timezone.now()` whenever the endpoint is hit, which means all requests will have different endpoint. So, no two snuba queries will have the same start/end. Instead if we use the same endpoint for queries in a session, we can take advantage of caching, since there are identical snuba queries that are performed for many combinations of conditions.

Also, these queries will further benefit from caching because even though we are displaying one page of the results at a time, we still need to do the entire computation for each request. This means the same whole process is performed if the user is simply switching the pages.