### PR TITLE
chore(hybrid-cloud): Replace withRouter with withSentryRouter

### DIFF
--- a/static/app/components/asyncComponentSearchInput.tsx
+++ b/static/app/components/asyncComponentSearchInput.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
@@ -8,6 +7,8 @@ import {Client, ResponseMeta} from 'sentry/api';
 import Input from 'sentry/components/input';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type RenderProps = {
   busy: boolean;
@@ -159,4 +160,4 @@ const Form = styled('form')`
   position: relative;
 `;
 
-export default withRouter(AsyncComponentSearchInput);
+export default withSentryRouter(AsyncComponentSearchInput);

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import {Query} from 'history';
 import isEqual from 'lodash/isEqual';
@@ -20,6 +19,8 @@ import parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import {Theme} from 'sentry/utils/theme';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type ReleaseMetaBasic = {
   date: string;
@@ -307,4 +308,4 @@ class ReleaseSeries extends Component<Props, State> {
   }
 }
 
-export default withRouter(withOrganization(withApi(withTheme(ReleaseSeries))));
+export default withSentryRouter(withOrganization(withApi(withTheme(ReleaseSeries))));

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -1,6 +1,5 @@
 import {createRef, Fragment, PureComponent} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import {
   AutoSizer,
   CellMeasurer,
@@ -24,6 +23,8 @@ import {Group, Organization, Project} from 'sentry/types';
 import {Image, ImageStatus} from 'sentry/types/debugImage';
 import {Event} from 'sentry/types/event';
 import {defined} from 'sentry/utils';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import SearchBarAction from '../searchBarAction';
 
@@ -576,7 +577,7 @@ class DebugMetaWithRouter extends PureComponent<Props, State> {
   }
 }
 
-export const DebugMeta = withRouter(DebugMetaWithRouter);
+export const DebugMeta = withSentryRouter(DebugMetaWithRouter);
 
 const StyledPanelTable = styled(PanelTable)<{scrollbarWidth?: number}>`
   overflow: hidden;

--- a/static/app/components/forms/jsonForm.tsx
+++ b/static/app/components/forms/jsonForm.tsx
@@ -1,11 +1,12 @@
 import {Component, Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 import scrollToElement from 'scroll-to-element';
 
 import {defined} from 'sentry/utils';
 import {sanitizeQuerySelector} from 'sentry/utils/sanitizeQuerySelector';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import FormPanel from './formPanel';
 import {Field, FieldObject, JsonFormObject} from './types';
@@ -166,4 +167,4 @@ class JsonForm extends Component<Props, State> {
   }
 }
 
-export default withRouter(JsonForm);
+export default withSentryRouter(JsonForm);

--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -1,6 +1,5 @@
 import {Component, Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import MD5 from 'crypto-js/md5';
 import isEqual from 'lodash/isEqual';
@@ -42,6 +41,8 @@ import {getUtcDateString} from 'sentry/utils/dates';
 import {userDisplayName} from 'sentry/utils/formatters';
 import {isMobilePlatform} from 'sentry/utils/platform';
 import withApi from 'sentry/utils/withApi';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import FeatureBadge from '../featureBadge';
 
@@ -404,6 +405,6 @@ const StyledSidebarSectionTitle = styled(SidebarSection.Title)`
   gap: ${space(1)};
 `;
 
-const GroupSidebar = withApi(withRouter(BaseGroupSidebar));
+const GroupSidebar = withApi(withSentryRouter(BaseGroupSidebar));
 
 export default GroupSidebar;

--- a/static/app/components/integrationExternalMappings.tsx
+++ b/static/app/components/integrationExternalMappings.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import capitalize from 'lodash/capitalize';
 
@@ -25,6 +24,8 @@ import {
   Organization,
 } from 'sentry/types';
 import {getIntegrationIcon, isExternalActorMapping} from 'sentry/utils/integrationUtil';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type CodeOwnersAssociationMappings = {
   [projectSlug: string]: {
@@ -264,7 +265,7 @@ class IntegrationExternalMappings extends AsyncComponent<Props, State> {
   }
 }
 
-export default withRouter(IntegrationExternalMappings);
+export default withSentryRouter(IntegrationExternalMappings);
 
 const AddButton = styled(Button)`
   text-transform: capitalize;

--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory, WithRouterProps} from 'react-router';
 import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import * as qs from 'query-string';
@@ -22,6 +21,8 @@ import {t} from 'sentry/locale';
 import GroupStore from 'sentry/stores/groupStore';
 import {Group} from 'sentry/types';
 import withApi from 'sentry/utils/withApi';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 import {TimePeriodType} from 'sentry/views/alerts/rules/metric/details/constants';
 import {RELATED_ISSUES_BOOLEAN_QUERY_ERROR} from 'sentry/views/alerts/rules/metric/details/relatedIssuesNotAvailable';
 
@@ -312,4 +313,4 @@ class GroupList extends Component<Props, State> {
 
 export {GroupList};
 
-export default withApi(withRouter(GroupList));
+export default withApi(withSentryRouter(GroupList));

--- a/static/app/components/modals/redirectToProject.tsx
+++ b/static/app/components/modals/redirectToProject.tsx
@@ -1,6 +1,5 @@
 import {Component, Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {ModalRenderProps} from 'sentry/actionCreators/modal';
@@ -8,6 +7,8 @@ import Button from 'sentry/components/button';
 import Text from 'sentry/components/text';
 import {t, tct} from 'sentry/locale';
 import recreateRoute from 'sentry/utils/recreateRoute';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type Props = ModalRenderProps &
   WithRouterProps & {
@@ -89,7 +90,7 @@ class RedirectToProjectModal extends Component<Props, State> {
   }
 }
 
-export default withRouter(RedirectToProjectModal);
+export default withSentryRouter(RedirectToProjectModal);
 export {RedirectToProjectModal};
 
 const ButtonWrapper = styled('div')`

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -1,6 +1,5 @@
 import {Component, Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import {logout} from 'sentry/actionCreators/account';
@@ -18,6 +17,8 @@ import ConfigStore from 'sentry/stores/configStore';
 import space from 'sentry/styles/space';
 import {Authenticator} from 'sentry/types';
 import withApi from 'sentry/utils/withApi';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
 type OnTapProps = NonNullable<React.ComponentProps<typeof U2fContainer>['onTap']>;
@@ -314,7 +315,7 @@ class SudoModal extends Component<Props, State> {
   }
 }
 
-export default withRouter(withApi(SudoModal));
+export default withSentryRouter(withApi(SudoModal));
 export {SudoModal};
 
 const StyledTextBlock = styled(TextBlock)`

--- a/static/app/components/search/sources/apiSource.tsx
+++ b/static/app/components/search/sources/apiSource.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
@@ -23,6 +22,8 @@ import {defined} from 'sentry/utils';
 import {createFuzzySearch, Fuse} from 'sentry/utils/fuzzySearch';
 import {singleLineRenderer as markedSingleLine} from 'sentry/utils/marked';
 import withLatestContext from 'sentry/utils/withLatestContext';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import {ChildProps, Result, ResultItem} from './types';
 import {strGetFn} from './utils';
@@ -518,4 +519,4 @@ class ApiSource extends Component<Props, State> {
 }
 
 export {ApiSource};
-export default withLatestContext(withRouter(ApiSource));
+export default withLatestContext(withSentryRouter(ApiSource));

--- a/static/app/components/search/sources/formSource.tsx
+++ b/static/app/components/search/sources/formSource.tsx
@@ -1,11 +1,12 @@
 import {Component} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 
 import {loadSearchMap} from 'sentry/actionCreators/formSearch';
 import FormSearchStore, {FormSearchField} from 'sentry/stores/formSearchStore';
 import {createFuzzySearch, Fuse} from 'sentry/utils/fuzzySearch';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import {ChildProps, Result, ResultItem} from './types';
 import {strGetFn} from './utils';
@@ -111,4 +112,4 @@ class FormSourceContainer extends Component<ContainerProps, ContainerState> {
     return <FormSource searchMap={this.state.searchMap} {...this.props} />;
   }
 }
-export default withRouter(FormSourceContainer);
+export default withSentryRouter(FormSourceContainer);

--- a/static/app/components/search/sources/helpSource.tsx
+++ b/static/app/components/search/sources/helpSource.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import {
   Result as SearchResult,
   SentryGlobalSearch,
@@ -12,6 +11,8 @@ import debounce from 'lodash/debounce';
 import {Organization, Project} from 'sentry/types';
 import parseHtmlMarks from 'sentry/utils/parseHtmlMarks';
 import withLatestContext from 'sentry/utils/withLatestContext';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import {ChildProps, Result, ResultItem} from './types';
 
@@ -138,4 +139,4 @@ function mapSearchResults(results: SearchResult[]) {
 }
 
 export {HelpSource};
-export default withLatestContext(withRouter(HelpSource));
+export default withLatestContext(withSentryRouter(HelpSource));

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1,7 +1,6 @@
 import {Component, createRef, VFC} from 'react';
 import TextareaAutosize from 'react-autosize-textarea';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -46,6 +45,8 @@ import {FieldDefinition, FieldValueType, getFieldDefinition} from 'sentry/utils/
 import getDynamicComponent from 'sentry/utils/getDynamicComponent';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import DropdownMenuControl from '../dropdownMenuControl';
 import {MenuItemProps} from '../dropdownMenuItem';
@@ -1931,7 +1932,7 @@ class SmartSearchBarContainer extends Component<Props, ContainerState> {
   }
 }
 
-export default withApi(withRouter(withOrganization(SmartSearchBarContainer)));
+export default withApi(withSentryRouter(withOrganization(SmartSearchBarContainer)));
 
 export {SmartSearchBar, Props as SmartSearchBarProps};
 

--- a/static/app/views/alerts/rules/issue/details/alertChart.tsx
+++ b/static/app/views/alerts/rules/issue/details/alertChart.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import AsyncComponent from 'sentry/components/asyncComponent';
@@ -14,6 +13,8 @@ import space from 'sentry/styles/space';
 import {Organization, Project} from 'sentry/types';
 import {IssueAlertRule, ProjectAlertRuleStats} from 'sentry/types/alerts';
 import getDynamicText from 'sentry/utils/getDynamicText';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type Props = AsyncComponent['props'] &
   DateTimeObject &
@@ -155,7 +156,7 @@ class AlertChart extends AsyncComponent<Props, State> {
   }
 }
 
-export default withRouter(AlertChart);
+export default withSentryRouter(AlertChart);
 
 const ChartHeader = styled('div')`
   margin-bottom: ${space(3)};

--- a/static/app/views/alerts/rules/metric/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/metric/details/metricChart.tsx
@@ -1,6 +1,5 @@
 import {PureComponent} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import color from 'color';
 import type {LineSeriesOption} from 'echarts';
@@ -45,6 +44,8 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import {MINUTES_THRESHOLD_TO_DISPLAY_SECONDS} from 'sentry/utils/sessions';
 import theme from 'sentry/utils/theme';
 import toArray from 'sentry/utils/toArray';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 import {COMPARISON_DELTA_OPTIONS} from 'sentry/views/alerts/rules/metric/constants';
 import {makeDefaultCta} from 'sentry/views/alerts/rules/metric/metricRulePresets';
 import {
@@ -545,7 +546,7 @@ class MetricChart extends PureComponent<Props, State> {
   }
 }
 
-export default withRouter(MetricChart);
+export default withSentryRouter(MetricChart);
 
 const ChartPanel = styled(Panel)`
   margin-top: ${space(2)};

--- a/static/app/views/dashboardsV2/widgetCard/index.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/index.tsx
@@ -1,7 +1,6 @@
 import React, {Component, Fragment} from 'react';
 import LazyLoad from 'react-lazyload';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import {useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 import {Location} from 'history';
@@ -31,6 +30,8 @@ import {
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
 import withPageFilters from 'sentry/utils/withPageFilters';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import {DRAG_HANDLE_CLASS} from '../dashboard';
 import {DashboardFilters, DisplayType, Widget, WidgetType} from '../types';
@@ -366,7 +367,7 @@ class WidgetCard extends Component<Props, State> {
   }
 }
 
-export default withApi(withOrganization(withPageFilters(withRouter(WidgetCard))));
+export default withApi(withOrganization(withPageFilters(withSentryRouter(WidgetCard))));
 
 const ErrorCard = styled(Placeholder)`
   display: flex;

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
@@ -28,6 +27,8 @@ import withRouteAnalytics, {
 } from 'sentry/utils/routeAnalytics/withRouteAnalytics';
 import useOrganization from 'sentry/utils/useOrganization';
 import withOrganization from 'sentry/utils/withOrganization';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 import AsyncView from 'sentry/views/asyncView';
 
 import MonitorIcon from './monitorIcon';
@@ -208,4 +209,4 @@ const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: 1fr max-content max-content;
 `;
 
-export default withRouteAnalytics(withRouter(withOrganization(Monitors)));
+export default withRouteAnalytics(withSentryRouter(withOrganization(Monitors)));

--- a/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 import xor from 'lodash/xor';
@@ -15,6 +14,8 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {IssueAttachment, Project} from 'sentry/types';
 import {decodeList} from 'sentry/utils/queryString';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 import GroupEventAttachmentsFilter, {
   crashReportTypes,
@@ -236,7 +237,7 @@ class GroupEventAttachments extends AsyncComponent<Props, State> {
   }
 }
 
-export default withRouter(GroupEventAttachments);
+export default withSentryRouter(GroupEventAttachments);
 
 const ScreenshotGrid = styled('div')`
   display: grid;

--- a/static/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/static/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {RouteComponentProps, withRouter, WithRouterProps} from 'react-router';
+import {RouteComponentProps, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -26,6 +25,8 @@ import {Group, Project, SavedQueryVersions, Tag, TagValue} from 'sentry/types';
 import {isUrl, percent} from 'sentry/utils';
 import EventView from 'sentry/utils/discover/eventView';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type RouteParams = {
   groupId: string;
@@ -292,7 +293,7 @@ class GroupTagValues extends AsyncComponent<
   }
 }
 
-export default withRouter(GroupTagValues);
+export default withSentryRouter(GroupTagValues);
 
 function ReplayButton({project, routes, orgId, tagValue}) {
   const replaySlug = `${project?.slug}:${tagValue.value}`;

--- a/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalTeamMappings.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import uniqBy from 'lodash/uniqBy';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -18,6 +17,8 @@ import {
 } from 'sentry/types';
 import {sentryNameToOption} from 'sentry/utils/integrationUtil';
 import withOrganization from 'sentry/utils/withOrganization';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type Props = AsyncComponent['props'] &
   WithRouterProps & {
@@ -206,4 +207,4 @@ class IntegrationExternalTeamMappings extends AsyncComponent<Props, State> {
   }
 }
 
-export default withRouter(withOrganization(IntegrationExternalTeamMappings));
+export default withSentryRouter(withOrganization(IntegrationExternalTeamMappings));

--- a/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
+++ b/static/app/views/organizationIntegrations/integrationExternalUserMappings.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {openModal} from 'sentry/actionCreators/modal';
@@ -18,6 +17,8 @@ import {
 } from 'sentry/types';
 import {sentryNameToOption} from 'sentry/utils/integrationUtil';
 import withOrganization from 'sentry/utils/withOrganization';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 
 type Props = AsyncComponent['props'] &
   WithRouterProps & {
@@ -157,4 +158,4 @@ class IntegrationExternalUserMappings extends AsyncComponent<Props, State> {
   }
 }
 
-export default withRouter(withOrganization(IntegrationExternalUserMappings));
+export default withSentryRouter(withOrganization(IntegrationExternalUserMappings));

--- a/static/app/views/projectInstall/createProject.tsx
+++ b/static/app/views/projectInstall/createProject.tsx
@@ -1,6 +1,5 @@
 import {Component, Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {browserHistory, withRouter, WithRouterProps} from 'react-router';
+import {browserHistory, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {PlatformIcon} from 'platformicons';
@@ -27,6 +26,8 @@ import withRouteAnalytics, {
 import slugify from 'sentry/utils/slugify';
 import withApi from 'sentry/utils/withApi';
 import withOrganization from 'sentry/utils/withOrganization';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 import withTeams from 'sentry/utils/withTeams';
 import IssueAlertOptions from 'sentry/views/projectInstall/issueAlertOptions';
 
@@ -316,7 +317,7 @@ class CreateProject extends Component<Props, State> {
 
 // TODO(davidenwang): change to functional component and replace withTeams with useTeams
 export default withRouteAnalytics(
-  withApi(withRouter(withOrganization(withTeams(CreateProject))))
+  withApi(withSentryRouter(withOrganization(withTeams(CreateProject))))
 );
 export {CreateProject};
 

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -1,6 +1,5 @@
 import {Component} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import {withTheme} from '@emotion/react';
 import round from 'lodash/round';
 
@@ -32,6 +31,8 @@ import {
   MINUTES_THRESHOLD_TO_DISPLAY_SECONDS,
 } from 'sentry/utils/sessions';
 import {Theme} from 'sentry/utils/theme';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 import {displayCrashFreePercent, roundDuration} from 'sentry/views/releases/utils';
 
 import {
@@ -661,4 +662,4 @@ class ReleaseSessionsChart extends Component<Props> {
   }
 }
 
-export default withTheme(withRouter(ReleaseSessionsChart));
+export default withTheme(withSentryRouter(ReleaseSessionsChart));

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {withRouter, WithRouterProps} from 'react-router';
+import {WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 import {QRCodeCanvas} from 'qrcode.react';
 
@@ -27,6 +26,8 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {Authenticator} from 'sentry/types';
 import getPendingInvite from 'sentry/utils/getPendingInvite';
+// eslint-disable-next-line no-restricted-imports
+import withSentryRouter from 'sentry/utils/withSentryRouter';
 import AsyncView from 'sentry/views/asyncView';
 import RemoveConfirm from 'sentry/views/settings/account/accountSecurity/components/removeConfirm';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
@@ -456,4 +457,4 @@ const StyledQRCode = styled(QRCodeCanvas)`
   padding: ${space(2)};
 `;
 
-export default withRouter(AccountSecurityEnroll);
+export default withSentryRouter(AccountSecurityEnroll);


### PR DESCRIPTION
This pull request replaces any and all instances of `withRouter` with `withSentryRouter` that was introduced in https://github.com/getsentry/sentry/pull/41797.

We want to do this to be able to implicitly inject the `orgId` parameter for customer domains.

