### PR TITLE
feat: Add useRouter and replace useRouteContext with other hooks

### DIFF
--- a/static/app/components/createAlertButton.tsx
+++ b/static/app/components/createAlertButton.tsx
@@ -14,7 +14,7 @@ import {t, tct} from 'sentry/locale';
 import type {Organization, Project} from 'sentry/types';
 import type EventView from 'sentry/utils/discover/eventView';
 import useApi from 'sentry/utils/useApi';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 import {
   AlertType,
   AlertWizardAlertNames,
@@ -126,7 +126,7 @@ const CreateAlertButton = ({
   onEnter,
   ...buttonProps
 }: CreateAlertButtonProps) => {
-  const {router} = useRouteContext();
+  const router = useRouter();
   const api = useApi();
   const createAlertUrl = (providedProj: string): string => {
     const params = new URLSearchParams();

--- a/static/app/components/datePageFilter.tsx
+++ b/static/app/components/datePageFilter.tsx
@@ -17,7 +17,7 @@ import {
 } from 'sentry/utils/dates';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 type Props = Omit<
   React.ComponentProps<typeof TimeRangeSelector>,
@@ -30,7 +30,7 @@ type Props = Omit<
 };
 
 function DatePageFilter({resetParamsOnChange, disabled, ...props}: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
   const {selection, desyncedFilters} = usePageFilters();
   const organization = useOrganization();
   const {start, end, period, utc} = selection.datetime;

--- a/static/app/components/environmentPageFilter.tsx
+++ b/static/app/components/environmentPageFilter.tsx
@@ -13,7 +13,7 @@ import {trimSlug} from 'sentry/utils/trimSlug';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 type EnvironmentSelectorProps = React.ComponentProps<typeof EnvironmentSelector>;
 
@@ -39,7 +39,7 @@ function EnvironmentPageFilter({
   maxTitleLength = 20,
   size = 'md',
 }: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
 
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const organization = useOrganization();

--- a/static/app/components/events/meta/annotatedText/index.tsx
+++ b/static/app/components/events/meta/annotatedText/index.tsx
@@ -1,6 +1,6 @@
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import useProjects from 'sentry/utils/useProjects';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 import {AnnotatedTextErrors} from './annotatedTextErrors';
 import {AnnotatedTextValue} from './annotatedTextValue';
@@ -13,8 +13,8 @@ type Props = {
 
 export function AnnotatedText({value, meta, className, ...props}: Props) {
   const organization = useOrganization();
-  const routerContext = useRouteContext();
-  const projectId = routerContext.location.query.project;
+  const location = useLocation();
+  const projectId = location.query.project;
   const {projects} = useProjects();
   const currentProject = projects.find(project => project.id === projectId);
 

--- a/static/app/components/links/listLink.tsx
+++ b/static/app/components/links/listLink.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import {LocationDescriptor} from 'history';
 import * as qs from 'query-string';
 
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 type LinkProps = Omit<React.ComponentProps<typeof RouterLink>, 'to'>;
@@ -38,7 +38,7 @@ function ListLink({
   disabled = false,
   ...props
 }: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
   const queryData = query ? qs.parse(query) : undefined;
   const targetLocation = typeof to === 'string' ? {pathname: to, query: queryData} : to;
   const target = normalizeUrl(targetLocation);

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -48,7 +48,7 @@ import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhan
 import {decodeInteger, decodeList, decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 import withPageFilters from 'sentry/utils/withPageFilters';
 import {DisplayType, Widget, WidgetType} from 'sentry/views/dashboardsV2/types';
 import {
@@ -169,7 +169,7 @@ function WidgetViewerModal(props: Props) {
     seriesResultsType,
   } = props;
   const location = useLocation();
-  const {router} = useRouteContext();
+  const router = useRouter();
   const shouldShowSlider = organization.features.includes('widget-viewer-modal-minimap');
   // Get widget zoom from location
   // We use the start and end query params for just the initial state

--- a/static/app/components/organizations/environmentSelector.tsx
+++ b/static/app/components/organizations/environmentSelector.tsx
@@ -20,7 +20,7 @@ import {Organization, Project} from 'sentry/types';
 import {analytics} from 'sentry/utils/analytics';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import theme from 'sentry/utils/theme';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 type Props = {
   customDropdownButton: (config: {
@@ -65,7 +65,7 @@ function EnvironmentSelector({
   customLoadingIndicator,
   disabled,
 }: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
   const [selectedEnvs, setSelectedEnvs] = useState(value);
   const hasChanges = !isEqual(selectedEnvs, value);
 

--- a/static/app/components/organizations/pageFilters/container.tsx
+++ b/static/app/components/organizations/pageFilters/container.tsx
@@ -12,9 +12,10 @@ import {
 import DesyncedFilterAlert from 'sentry/components/organizations/pageFilters/desyncedFiltersAlert';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {PageContent} from 'sentry/styles/organization';
+import {useLocation} from 'sentry/utils/useLocation';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import {getDatetimeFromState, getStateFromQuery} from './parse';
@@ -57,7 +58,8 @@ function Container({skipLoadLastUsed, children, ...props}: Props) {
     desyncedAlertMessage,
     hideDesyncRevertButton,
   } = props;
-  const {location, router} = useRouteContext();
+  const router = useRouter();
+  const location = useLocation();
 
   const {isReady} = usePageFilters();
 

--- a/static/app/components/organizations/projectSelector/index.tsx
+++ b/static/app/components/organizations/projectSelector/index.tsx
@@ -14,7 +14,7 @@ import {Organization, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
 import theme from 'sentry/utils/theme';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import ProjectSelectorFooter from './footer';
 import SelectorItem from './selectorItem';
@@ -82,7 +82,7 @@ function ProjectSelector({
   value,
   disabled,
 }: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
   // Used to determine if we should show the 'apply' changes button
   const [hasChanges, setHasChanges] = useState(false);
 

--- a/static/app/components/projectPageFilter.tsx
+++ b/static/app/components/projectPageFilter.tsx
@@ -20,7 +20,7 @@ import {trimSlug} from 'sentry/utils/trimSlug';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 type ProjectSelectorProps = React.ComponentProps<typeof ProjectSelector>;
 
@@ -85,7 +85,7 @@ function ProjectPageFilter({
   disabled,
   ...otherProps
 }: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
 
   const [currentSelectedProjects, setCurrentSelectedProjects] = useState<number[] | null>(
     null

--- a/static/app/components/replays/deleteButton.tsx
+++ b/static/app/components/replays/deleteButton.tsx
@@ -6,11 +6,13 @@ import Confirm from 'sentry/components/confirm';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import useApi from 'sentry/utils/useApi';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import {useParams} from 'sentry/utils/useParams';
+import useRouter from 'sentry/utils/useRouter';
 
 function DeleteButton() {
   const api = useApi();
-  const {params, router} = useRouteContext();
+  const router = useRouter();
+  const params = useParams();
 
   const orgSlug = params.orgId;
   const [projectSlug, replayId] = params.replaySlug.split(':');

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -15,7 +15,7 @@ import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAna
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 import replaceRouterParams from 'sentry/utils/replaceRouterParams';
 import {useParams} from 'sentry/utils/useParams';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {Result} from './sources/types';
 import List from './list';
@@ -82,7 +82,7 @@ function Search({
   searchOptions,
   sources,
 }: SearchProps): React.ReactElement {
-  const {router} = useRouteContext();
+  const router = useRouter();
 
   const params = useParams<{orgId: string}>();
   useEffect(() => {

--- a/static/app/components/sidebar/sidebarItem.tsx
+++ b/static/app/components/sidebar/sidebarItem.tsx
@@ -11,7 +11,7 @@ import {Organization} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import localStorage from 'sentry/utils/localStorage';
 import {Theme} from 'sentry/utils/theme';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {SidebarOrientation} from './types';
 
@@ -102,7 +102,7 @@ const SidebarItem = ({
   onClick,
   ...props
 }: Props) => {
-  const {router} = useRouteContext();
+  const router = useRouter();
   // label might be wrapped in a guideAnchor
   let labelString = label;
   if (isValidElement(label)) {

--- a/static/app/utils/useRouter.spec.tsx
+++ b/static/app/utils/useRouter.spec.tsx
@@ -1,0 +1,60 @@
+import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
+
+import {render} from 'sentry-test/reactTestingLibrary';
+
+import useRouter from 'sentry/utils/useRouter';
+import {RouteContext} from 'sentry/views/routeContext';
+
+describe('useRouter', () => {
+  it('returns the current router object', function () {
+    let expectedRouter;
+    let actualRouter;
+    function HomePage() {
+      actualRouter = useRouter();
+      return null;
+    }
+
+    const memoryHistory = createMemoryHistory();
+    memoryHistory.push('/');
+
+    render(
+      <Router
+        history={memoryHistory}
+        render={props => {
+          expectedRouter = props.router;
+          return (
+            <RouteContext.Provider value={props}>
+              <RouterContext {...props} />
+            </RouteContext.Provider>
+          );
+        }}
+      >
+        <Route path="/" component={HomePage} />
+      </Router>
+    );
+    expect(actualRouter).toEqual(expectedRouter);
+  });
+
+  it('throws error when called outside of routes provider', function () {
+    // Error is expected, do not fail when calling console.error
+    jest.spyOn(console, 'error').mockImplementation();
+    const memoryHistory = createMemoryHistory();
+    memoryHistory.push('/');
+
+    expect(() =>
+      render(
+        <RouteContext.Provider value={null}>
+          <Router history={memoryHistory}>
+            <Route
+              path="/"
+              component={() => {
+                useRouter();
+                return null;
+              }}
+            />
+          </Router>
+        </RouteContext.Provider>
+      )
+    ).toThrow(/useRouteContext called outside of routes provider/);
+  });
+});

--- a/static/app/utils/useRouter.tsx
+++ b/static/app/utils/useRouter.tsx
@@ -1,0 +1,8 @@
+import {useRouteContext} from 'sentry/utils/useRouteContext';
+
+function useRouter() {
+  const route = useRouteContext();
+  return route.router;
+}
+
+export default useRouter;

--- a/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboardsV2/widgetCard/widgetCardChartContainer.tsx
@@ -12,7 +12,7 @@ import {EChartEventHandler, Series} from 'sentry/types/echarts';
 import {TableDataWithTitle} from 'sentry/utils/discover/discoverQuery';
 import {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {DashboardFilters, Widget, WidgetType} from '../types';
 
@@ -73,7 +73,7 @@ export function WidgetCardChartContainer({
   chartZoomOptions,
 }: Props) {
   const location = useLocation();
-  const {router} = useRouteContext();
+  const router = useRouter();
   if (widget.widgetType === WidgetType.ISSUE) {
     return (
       <IssueWidgetQueries

--- a/static/app/views/eventsV2/table/quickContext.spec.tsx
+++ b/static/app/views/eventsV2/table/quickContext.spec.tsx
@@ -148,6 +148,7 @@ describe('Quick Context', function () {
     afterEach(() => {
       queryClient.clear();
       MockApiClient.clearMockResponses();
+      mockUseLocation.mockReset();
     });
 
     it('Renders child', async () => {
@@ -658,7 +659,7 @@ describe('Quick Context', function () {
         ],
       } as EventError;
 
-      mockUseLocation.mockReturnValueOnce(
+      mockUseLocation.mockReturnValue(
         TestStubs.location({
           query: {
             field: ['issue', 'transaction.duration'],
@@ -671,8 +672,11 @@ describe('Quick Context', function () {
         body: makeEvent(errorEvent),
       });
 
-      delete defaultRow.title;
-      renderQuickContextContent(defaultRow, ContextType.EVENT);
+      const dataRow = {
+        ...defaultRow,
+      };
+      delete dataRow.title;
+      renderQuickContextContent(dataRow, ContextType.EVENT);
 
       userEvent.hover(screen.getByText('Text from Child'));
 

--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -13,7 +13,7 @@ import {
   tooltipFormatter,
 } from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 type Props = {
   data: Series[];
@@ -76,7 +76,7 @@ function Chart({
   chartColors,
   isLineChart,
 }: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
   const theme = useTheme();
 
   if (!data || data.length <= 0) {

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -30,8 +30,8 @@ import SidebarPanelStore from 'sentry/stores/sidebarPanelStore';
 import {Organization, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import useApi from 'sentry/utils/useApi';
+import {useLocation} from 'sentry/utils/useLocation';
 import useProjects from 'sentry/utils/useProjects';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
 
 const performanceSetupUrl =
   'https://docs.sentry.io/performance-monitoring/getting-started/';
@@ -99,9 +99,8 @@ type Props = {
 
 function Onboarding({organization, project}: Props) {
   const api = useApi();
-
   const {projects} = useProjects();
-  const {location} = useRouteContext();
+  const location = useLocation();
 
   const {projectsForOnboarding} = filterProjects(projects);
 

--- a/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
+++ b/static/app/views/performance/transactionSummary/transactionAnomalies/anomalyChart.tsx
@@ -8,7 +8,7 @@ import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 type Props = {
   data: Series[];
@@ -19,7 +19,7 @@ type Props = {
 };
 
 export function AnomalyChart(props: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
   const location = useLocation();
   const {data, statsPeriod, height, start: propsStart, end: propsEnd} = props;
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/durationChart/index.tsx
@@ -13,7 +13,7 @@ import {OrganizationSummary} from 'sentry/types';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {ViewProps} from '../../../types';
 import {
@@ -54,7 +54,7 @@ function DurationChart({
   start: propsStart,
   end: propsEnd,
 }: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
   const location = useLocation();
   const api = useApi();
   const theme = useTheme();

--- a/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/sidebarCharts.tsx
@@ -33,7 +33,7 @@ import AnomaliesQuery from 'sentry/utils/performance/anomalies/anomaliesQuery';
 import {decodeScalar} from 'sentry/utils/queryString';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
 
 import {
@@ -81,7 +81,7 @@ function SidebarCharts({
   transactionName,
 }: Props) {
   const location = useLocation();
-  const {router} = useRouteContext();
+  const router = useRouter();
   const useAggregateAlias = !organization.features.includes(
     'performance-frontend-use-events-endpoint'
   );
@@ -243,8 +243,7 @@ function SidebarChartsContainer({
   transactionName,
 }: ContainerProps) {
   const location = useLocation();
-  const {router} = useRouteContext();
-
+  const router = useRouter();
   const api = useApi();
   const theme = useTheme();
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -13,7 +13,7 @@ import {OrganizationSummary} from 'sentry/types';
 import {getUtcToLocalDateObject} from 'sentry/utils/dates';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {TrendFunctionField} from '../../../trends/types';
 import {generateTrendFunctionAsString} from '../../../trends/utils';
@@ -42,7 +42,7 @@ function TrendChart({
   start: propsStart,
   end: propsEnd,
 }: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
   const location = useLocation();
   const api = useApi();
   const theme = useTheme();

--- a/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/vitalsChart/index.tsx
@@ -15,7 +15,7 @@ import {getAggregateArg, getMeasurementSlug} from 'sentry/utils/discover/fields'
 import {WebVital} from 'sentry/utils/fields';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {ViewProps} from '../../../types';
 
@@ -39,7 +39,7 @@ function VitalsChart({
   end: propsEnd,
 }: Props) {
   const location = useLocation();
-  const {router} = useRouteContext();
+  const router = useRouter();
   const api = useApi();
   const theme = useTheme();
 

--- a/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
+++ b/static/app/views/performance/transactionSummary/transactionSpans/spanDetails/exclusiveTimeTimeSeries.tsx
@@ -23,7 +23,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import {SpanSlug} from 'sentry/utils/performance/suspectSpans/types';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {getExclusiveTimeDisplayedValue} from '../utils';
 
@@ -36,7 +36,7 @@ type Props = {
 
 export default function ExclusiveTimeTimeSeries(props: Props) {
   const location = useLocation();
-  const {router} = useRouteContext();
+  const router = useRouter();
   const {organization, eventView, spanSlug, withoutZerofill} = props;
 
   const api = useApi();

--- a/static/app/views/performance/trends/chart.tsx
+++ b/static/app/views/performance/trends/chart.tsx
@@ -25,7 +25,7 @@ import getDynamicText from 'sentry/utils/getDynamicText';
 import {decodeList} from 'sentry/utils/queryString';
 import {Theme} from 'sentry/utils/theme';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {ViewProps} from '../types';
 
@@ -244,7 +244,7 @@ export function Chart({
   project,
 }: Props) {
   const location = useLocation();
-  const {router} = useRouteContext();
+  const router = useRouter();
   const theme = useTheme();
 
   const handleLegendSelectChanged = legendChange => {

--- a/static/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChart.tsx
@@ -21,7 +21,7 @@ import {WebVital} from 'sentry/utils/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {replaceSeriesName, transformEventStatsSmoothed} from '../trends/utils';
 import {ViewProps} from '../types';
@@ -53,7 +53,7 @@ function VitalChart({
   interval,
 }: Props) {
   const location = useLocation();
-  const {router} = useRouteContext();
+  const router = useRouter();
   const api = useApi();
   const theme = useTheme();
 

--- a/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
+++ b/static/app/views/performance/vitalDetail/vitalChartMetrics.tsx
@@ -18,7 +18,7 @@ import {Series} from 'sentry/types/echarts';
 import {WebVital} from 'sentry/utils/fields';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {replaceSeriesName, transformEventStatsSmoothed} from '../trends/utils';
 import {ViewProps} from '../types';
@@ -50,7 +50,7 @@ function VitalChartMetrics({
   vital,
 }: Props) {
   const location = useLocation();
-  const {router} = useRouteContext();
+  const router = useRouter();
   const theme = useTheme();
 
   const {utc, legend, vitalPoor, markLines, chartOptions} = getVitalChartDefinitions({

--- a/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
+++ b/static/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
@@ -6,7 +6,7 @@ import FeatureTourModal from 'sentry/components/modals/featureTourModal';
 import {t} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import {trackAnalyticsEvent} from 'sentry/utils/analytics';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 import {PERFORMANCE_TOUR_STEPS} from 'sentry/views/performance/onboarding';
 
 const DOCS_URL = 'https://docs.sentry.io/performance-monitoring/getting-started/';
@@ -16,7 +16,7 @@ type Props = {
 };
 
 function MissingPerformanceButtons({organization}: Props) {
-  const {router} = useRouteContext();
+  const router = useRouter();
 
   function handleTourAdvance(step: number, duration: number) {
     trackAnalyticsEvent({

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -21,7 +21,7 @@ import {aggregateOutputType} from 'sentry/utils/discover/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 import withOrganization from 'sentry/utils/withOrganization';
 import {getTermHelp, PERFORMANCE_TERM} from 'sentry/views/performance/data';
 
@@ -57,7 +57,7 @@ function ReleaseEventsChart({
   utc,
 }: Props) {
   const location = useLocation();
-  const {router, location: _location} = useRouteContext();
+  const router = useRouter();
   const api = useApi();
   const theme = useTheme();
 

--- a/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -23,7 +23,7 @@ import {
 import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
 import {getAdoptionSeries, getCount, getCountAtIndex} from 'sentry/utils/sessions';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 
 import {
   ADOPTION_STAGE_LABELS,
@@ -62,7 +62,7 @@ function ReleaseAdoption({
   errored,
 }: Props) {
   const location = useLocation();
-  const {router} = useRouteContext();
+  const router = useRouter();
   const theme = useTheme();
 
   const hasUsers = !!getCount(releaseSessions?.groups, SessionFieldWithOperation.USERS);

--- a/static/app/views/replays/detail/replayMetaData.tsx
+++ b/static/app/views/replays/detail/replayMetaData.tsx
@@ -10,8 +10,9 @@ import TimeSince from 'sentry/components/timeSince';
 import {IconCalendar, IconClock} from 'sentry/icons';
 import {tn} from 'sentry/locale';
 import space from 'sentry/styles/space';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useParams} from 'sentry/utils/useParams';
 import useProjects from 'sentry/utils/useProjects';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 type Props = {
@@ -19,10 +20,8 @@ type Props = {
 };
 
 function ReplayMetaData({replayRecord}: Props) {
-  const {
-    location: {pathname, query},
-    params: {replaySlug},
-  } = useRouteContext();
+  const {pathname, query} = useLocation();
+  const {replaySlug} = useParams();
   const {projects} = useProjects();
   const [slug] = replaySlug.split(':');
 

--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -21,11 +21,11 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {DEFAULT_SORT, REPLAY_LIST_FIELDS} from 'sentry/utils/replays/fetchReplayList';
 import useReplayList from 'sentry/utils/replays/hooks/useReplayList';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useLocation} from 'sentry/utils/useLocation';
 import useMedia from 'sentry/utils/useMedia';
 import useOrganization from 'sentry/utils/useOrganization';
 import usePageFilters from 'sentry/utils/usePageFilters';
 import useProjects from 'sentry/utils/useProjects';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
 import ReplaysFilters from 'sentry/views/replays/filters';
 import ReplayOnboardingPanel from 'sentry/views/replays/list/replayOnboardingPanel';
 import ReplayTable from 'sentry/views/replays/replayTable';
@@ -59,7 +59,7 @@ function useShouldShowOnboardingPanel() {
 }
 
 function useReplayOnboardingSidebarPanel() {
-  const {location} = useRouteContext();
+  const location = useLocation();
   const enabled = useShouldShowOnboardingPanel();
 
   useEffect(() => {

--- a/static/app/views/settings/components/dataScrubbing/index.tsx
+++ b/static/app/views/settings/components/dataScrubbing/index.tsx
@@ -14,7 +14,7 @@ import {Organization, Project} from 'sentry/types';
 import {defined} from 'sentry/utils';
 import useApi from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import {useParams} from 'sentry/utils/useParams';
 
 import Add from './modals/add';
 import Edit from './modals/edit';
@@ -49,7 +49,7 @@ export function DataScrubbing({
   const api = useApi();
   const [rules, setRules] = useState<Rule[]>([]);
   const navigate = useNavigate();
-  const routeContext = useRouteContext();
+  const params = useParams();
 
   const successfullySaved = useCallback(
     (response: {relayPiiConfig: string}, successMessage: string) => {
@@ -70,8 +70,8 @@ export function DataScrubbing({
 
   useEffect(() => {
     if (
-      !defined(routeContext.params.scrubbingId) ||
-      !rules.some(rule => String(rule.id) === routeContext.params.scrubbingId)
+      !defined(params.scrubbingId) ||
+      !rules.some(rule => String(rule.id) === params.scrubbingId)
     ) {
       return;
     }
@@ -80,7 +80,7 @@ export function DataScrubbing({
       modalProps => (
         <Edit
           {...modalProps}
-          rule={rules[routeContext.params.scrubbingId]}
+          rule={rules[params.scrubbingId]}
           projectId={project?.id}
           savedRules={rules}
           api={api}
@@ -97,7 +97,7 @@ export function DataScrubbing({
       {onClose: handleCloseModal}
     );
   }, [
-    routeContext.params.scrubbingId,
+    params.scrubbingId,
     rules,
     project?.id,
     api,

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -42,7 +42,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import useOrganization from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import usePrevious from 'sentry/utils/usePrevious';
-import {useRouteContext} from 'sentry/utils/useRouteContext';
+import useRouter from 'sentry/utils/useRouter';
 import SettingsPageHeader from 'sentry/views/settings/components/settingsPageHeader';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 import PermissionAlert from 'sentry/views/settings/organization/permissionAlert';
@@ -90,8 +90,7 @@ export function ServerSideSampling({project}: Props) {
   const previousRules = usePrevious(currentRules);
   const navigate = useNavigate();
   const params = useParams();
-  const routeContext = useRouteContext();
-  const router = routeContext.router;
+  const router = useRouter();
 
   const samplingProjectSettingsPath = `/settings/${organization.slug}/projects/${project.slug}/dynamic-sampling/`;
 


### PR DESCRIPTION
After discussing with @NisanthanNanthakumar offline, we should generally discourage and limit the usage of the `useRouteContext` hook. Thus, this pull request introduces the `useRouter` hook, and replaces any and all applicable usage of `useRouteContext` with the `useRouter`, `useLocation`, and/or `useParam` hooks.

If and when the upgrade to React Router v6 occurs, we'll flesh out the `useRouter` hook implementation. Something similar to https://usehooks.com/useRouter/.

This is clean up from my replacement of the `withRouter` HoC with the `useRouteContext` hook in some React components.