### PR TITLE
feat(mobile-exp): adds some tracking for project and performance pages

### DIFF
--- a/static/app/views/performance/content.tsx
+++ b/static/app/views/performance/content.tsx
@@ -25,6 +25,7 @@ import usePrevious from 'sentry/utils/usePrevious';
 import useProjects from 'sentry/utils/useProjects';
 import withPageFilters from 'sentry/utils/withPageFilters';
 
+import {getLandingDisplayFromParam} from './landing/utils';
 import {DEFAULT_STATS_PERIOD, generatePerformanceEventView} from './data';
 import {PerformanceLanding} from './landing';
 import {
@@ -97,6 +98,7 @@ function PerformanceContent({selection, location, demoMode, router}: Props) {
   useRouteAnalyticsParams({
     project_platforms: getSelectedProjectPlatforms(location, projects),
     show_onboarding: onboardingProject !== undefined,
+    tab: getLandingDisplayFromParam(location)?.field,
   });
 
   useEffect(() => {

--- a/static/app/views/projectDetail/index.tsx
+++ b/static/app/views/projectDetail/index.tsx
@@ -16,7 +16,7 @@ function ProjectDetailContainer(
     project
       ? {
           project_id: project.id,
-          project_platforms: project.platform,
+          project_platform: project.platform,
         }
       : {}
   );

--- a/static/app/views/projectDetail/index.tsx
+++ b/static/app/views/projectDetail/index.tsx
@@ -1,3 +1,5 @@
+import useRouteAnalyticsParams from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
+import useProjects from 'sentry/utils/useProjects';
 import withOrganization from 'sentry/utils/withOrganization';
 
 import ProjectDetail from './projectDetail';
@@ -8,6 +10,16 @@ function ProjectDetailContainer(
     'projects' | 'loadingProjects' | 'selection'
   >
 ) {
+  const {projects} = useProjects();
+  const project = projects.find(p => p.slug === props.params.projectId);
+  useRouteAnalyticsParams(
+    project
+      ? {
+          project_id: project.id,
+          project_platforms: project.platform,
+        }
+      : {}
+  );
   return <ProjectDetail {...props} />;
 }
 


### PR DESCRIPTION
Track project and platform on project detail page and track tab for performance landing page. For use in tracking mobile usage.