### PR TITLE
feat(alert-preview): keep track of preview endpoint

### DIFF
--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -467,7 +467,7 @@ describe('ProjectAlertsCreate', function () {
       const mock = MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/rules/preview',
         method: 'POST',
-        body: groups,
+        body: {data: groups, endpoint: 'endpoint'},
         headers: {
           'X-Hits': groups.length,
         },
@@ -483,6 +483,7 @@ describe('ProjectAlertsCreate', function () {
               filterMatch: 'all',
               filters: [],
               frequency: 60 * 24,
+              endpoint: null,
             },
           })
         );
@@ -495,6 +496,20 @@ describe('ProjectAlertsCreate', function () {
       for (const group of groups) {
         expect(screen.getByText(group.shortId)).toBeInTheDocument();
       }
+
+      await selectEvent.select(screen.getByText('Add optional trigger...'), [
+        'A new issue is created',
+      ]);
+      await waitFor(() => {
+        expect(mock).toHaveBeenLastCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            data: expect.objectContaining({
+              endpoint: 'endpoint',
+            }),
+          })
+        );
+      });
     });
 
     it('invalid preview alert', async () => {
@@ -514,7 +529,7 @@ describe('ProjectAlertsCreate', function () {
       const mock = MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/rules/preview',
         method: 'POST',
-        body: [],
+        body: {data: [], endpoint: 'endpoint'},
         headers: {
           'X-Hits': 0,
         },

--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -467,9 +467,10 @@ describe('ProjectAlertsCreate', function () {
       const mock = MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/rules/preview',
         method: 'POST',
-        body: {data: groups, endpoint: 'endpoint'},
+        body: groups,
         headers: {
           'X-Hits': groups.length,
+          Endpoint: 'endpoint',
         },
       });
       createWrapper({organization});
@@ -529,9 +530,10 @@ describe('ProjectAlertsCreate', function () {
       const mock = MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/rules/preview',
         method: 'POST',
-        body: {data: [], endpoint: 'endpoint'},
+        body: [],
         headers: {
           'X-Hits': 0,
+          Endpoint: 'endpoint',
         },
       });
       createWrapper({organization});

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -396,19 +396,20 @@ class IssueRuleEditor extends AsyncView<Props, State> {
         },
       })
       .then(([data, _, resp]) => {
-        GroupStore.add(data.data);
+        GroupStore.add(data);
 
         const pageLinks = resp?.getResponseHeader('Link');
         const hits = resp?.getResponseHeader('X-Hits');
+        const endpoint = resp?.getResponseHeader('Endpoint');
         const issueCount =
           typeof hits !== 'undefined' && hits ? parseInt(hits, 10) || 0 : 0;
         this.setState({
-          previewGroups: data.data.map(g => g.id),
+          previewGroups: data.map(g => g.id),
           previewError: false,
           pageLinks: pageLinks ?? '',
           issueCount,
           loadingPreview: false,
-          previewEndpoint: data.endpoint,
+          previewEndpoint: endpoint ?? null,
         });
       })
       .catch(_ => {


### PR DESCRIPTION
Frontend change to go with [this](https://github.com/getsentry/sentry/pull/41858). Preview endpoint also returns the endpoint of the window, and should be passed back for the next calls to preview.