### PR TITLE
ref(replays): Refactor Replay Timeline to have fewer DOM nodes as crumbs/duration increases

### DIFF
--- a/static/app/components/replays/breadcrumbs/gridlines.tsx
+++ b/static/app/components/replays/breadcrumbs/gridlines.tsx
@@ -43,17 +43,23 @@ export function MajorGridlines({durationMs, minWidth = 50, width}: Props) {
   const {timespan, cols, remaining} = countColumns(durationMs, width, minWidth);
 
   return (
-    <Gridlines cols={cols} lineStyle="solid" remaining={remaining}>
+    <FullHeightGridLines cols={cols} lineStyle="solid" remaining={remaining}>
       {i => <Label>{formatTime((i + 1) * timespan)}</Label>}
-    </Gridlines>
+    </FullHeightGridLines>
   );
 }
 
 export function MinorGridlines({durationMs, minWidth = 20, width}: Props) {
   const {cols, remaining} = countColumns(durationMs, width, minWidth);
 
-  return <Gridlines cols={cols} lineStyle="dotted" remaining={remaining} />;
+  return <FullHeightGridLines cols={cols} lineStyle="dotted" remaining={remaining} />;
 }
+
+const FullHeightGridLines = styled(Gridlines)`
+  height: 100%;
+  width: 100%;
+  place-items: stretch;
+`;
 
 const Label = styled('small')`
   font-variant-numeric: tabular-nums;

--- a/static/app/components/replays/breadcrumbs/replayTimeline.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimeline.tsx
@@ -53,7 +53,7 @@ function ReplayTimeline({}: Props) {
                   startTimestampMs={startTimestampMs}
                 />
               </UnderTimestamp>
-              <UnderTimestamp paddingTop="0">
+              <UnderTimestamp paddingTop="26px">
                 <ReplayTimelineEvents
                   crumbs={userCrumbs}
                   durationMs={durationMs}

--- a/static/app/components/replays/breadcrumbs/timeline.tsx
+++ b/static/app/components/replays/breadcrumbs/timeline.tsx
@@ -16,13 +16,9 @@ export const Columns = styled('ul')<{remainder: number; totalColumns: number}>`
   margin: 0;
   padding: 0;
 
-  height: 100%;
-  width: 100%;
-
   /* Layout of the lines */
   display: grid;
   grid-template-columns: repeat(${p => p.totalColumns}, 1fr) ${p => p.remainder}fr;
-  place-items: stretch;
 `;
 
 // Export an empty component which so that callsites can correctly nest nodes:


### PR DESCRIPTION
With all the refactoring, it looks almost exactly the same as before (testing in Chrome and Safari):

|  | img |
| --- | --- |
| Before | <img width="1313" alt="before" src="https://user-images.githubusercontent.com/187460/204681613-148d2f19-e251-471f-a275-48aea6e5e3ca.png"> |
| After | <img width="1316" alt="after" src="https://user-images.githubusercontent.com/187460/204681615-95a22ebc-85e8-4c6c-b3d8-c3419ac02cbc.png"> |

^ this is showing all the css changes and radial gradient background.

Then there's a change on top of all that:
```typescript
  const markerWidth = crumbs.length < 200 ? 4 : crumbs.length < 500 ? 6 : 10;
```

This change is a first pass at reducing the number of event nodes (so the dropdown behind each circle has more things inside it).

This that enabled the Timeline for that same replay changes to this:

|  | img |
| --- | --- |
| 4px margin | <img width="1316" alt="after" src="https://user-images.githubusercontent.com/187460/204681615-95a22ebc-85e8-4c6c-b3d8-c3419ac02cbc.png"> |
| dynamic margin | <img width="1314" alt="SCR-20221129-nod" src="https://user-images.githubusercontent.com/187460/204682177-38d729f9-d3f3-443c-9969-17043cf4c5c5.png"> |

Notice how the circles overlap a lot less. I'm not sure this is the final ratio we should be using, we could tweak the numbers and/or use the total duration as an input as well.


References [41792](https://github.com/getsentry/sentry/issues/41792)