### PR TITLE
ref(hybrid-cloud): Add org_setup_complete signal

### DIFF
--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -23,7 +23,7 @@ from sentry.models import (
     ProjectPlatform,
 )
 from sentry.search.utils import tokenize_query
-from sentry.signals import terms_accepted
+from sentry.signals import setup_subscription, terms_accepted
 
 
 class OrganizationSerializer(BaseOrganizationSerializer):
@@ -212,6 +212,10 @@ class OrganizationIndexEndpoint(Endpoint):
                         OrganizationMemberTeam.objects.create(
                             team=team, organizationmember=om, is_active=True
                         )
+
+                    setup_subscription.send_robust(
+                        instance=org, user=request.user, sender=self.__class__
+                    )
 
                     self.create_audit_entry(
                         request=request,

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -23,7 +23,7 @@ from sentry.models import (
     ProjectPlatform,
 )
 from sentry.search.utils import tokenize_query
-from sentry.signals import setup_subscription, terms_accepted
+from sentry.signals import org_setup_complete, terms_accepted
 
 
 class OrganizationSerializer(BaseOrganizationSerializer):
@@ -213,7 +213,7 @@ class OrganizationIndexEndpoint(Endpoint):
                             team=team, organizationmember=om, is_active=True
                         )
 
-                    setup_subscription.send_robust(
+                    org_setup_complete.send_robust(
                         instance=org, user=request.user, sender=self.__class__
                     )
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -100,6 +100,7 @@ class BetterSignal(Signal):
 buffer_incr_complete = BetterSignal(providing_args=["model", "columns", "extra", "result"])
 pending_delete = BetterSignal(providing_args=["instance", "actor"])
 event_processed = BetterSignal(providing_args=["project", "event"])
+setup_subscription = BetterSignal(providing_args=["organization", "user"])
 
 # This signal should eventually be removed as we should not send
 # transactions through post processing

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -100,7 +100,8 @@ class BetterSignal(Signal):
 buffer_incr_complete = BetterSignal(providing_args=["model", "columns", "extra", "result"])
 pending_delete = BetterSignal(providing_args=["instance", "actor"])
 event_processed = BetterSignal(providing_args=["project", "event"])
-setup_subscription = BetterSignal(providing_args=["organization", "user"])
+# When the organization and initial member have been created
+org_setup_complete = BetterSignal(providing_args=["organization", "user"])
 
 # This signal should eventually be removed as we should not send
 # transactions through post processing


### PR DESCRIPTION
Adds a `org_setup_complete` signal after an organization and member are created in the `OrganizationIndexEndpoint`. Currently, subscriptions are setup in a post_save signal on the AuditLogEntry model. This won't work for hybrid cloud since AuditLogEntry and Subscription are located in different silos. It's also unexpected for subscriptions to rely on audit log creation.