### PR TITLE
feat(gh-issue-template): Request identification when filing bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,7 +24,7 @@ body:
     attributes:
       label: Identification
       placeholder: Link to Sentry or org slug or slug id (non-PII)
-      description: If you are using SaaS, in order to speed up investigations - could you please include a link to where you found the issue (if it applies) or your organization slug? If you are concerned with exposing your organization slug (which is included on links to sentry.io) you can share your organization ID which can be found in your client keys (DSN) which follow the format `https://{tag}@o{ORGANISATION_ID}.ingest.sentry.io/{PROJECT_ID}`
+      description: (Optional info) If you are using SaaS, in order to speed up investigations - could you please include a link to where you found the issue (if it applies) or your organization slug? If you are concerned with exposing your organization slug (which is included on links to sentry.io) you can share your organization ID which can be found in your client keys (DSN) which follow the format `https://{tag}@o{ORGANISATION_ID}.ingest.sentry.io/{PROJECT_ID}`
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -19,6 +19,18 @@ body:
       description: If self-hosted, what version are you running?
     validations:
       required: false
+  - type: input
+    id: identification
+    attributes:
+      label: Identification
+      placeholder: 21.7.0 ← should look like this (check the footer)
+      description: If you are using SaaS, in order to speed up investigations - could you please include a link
+      to where you found the issue (if it applies) or your organization slug? If you are concerned with 
+      exposing your organization slug (which is included on links to sentry.io) you can share your
+      organization ID which can be found in your client keys (DSN) which follow the format
+      `https://{tag}@o{ORGANISATION_ID}.ingest.sentry.io/{PROJECT_ID}`
+    validations:
+      required: false
   - type: textarea
     id: repro
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -23,7 +23,7 @@ body:
     id: identification
     attributes:
       label: Identification
-      placeholder: 21.7.0 ← should look like this (check the footer)
+      placeholder: Link to Sentry or org slug or slug id (non-PII)
       description: If you are using SaaS, in order to speed up investigations - could you please include a link to where you found the issue (if it applies) or your organization slug? If you are concerned with exposing your organization slug (which is included on links to sentry.io) you can share your organization ID which can be found in your client keys (DSN) which follow the format `https://{tag}@o{ORGANISATION_ID}.ingest.sentry.io/{PROJECT_ID}`
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -24,11 +24,7 @@ body:
     attributes:
       label: Identification
       placeholder: 21.7.0 ← should look like this (check the footer)
-      description: If you are using SaaS, in order to speed up investigations - could you please include a link
-      to where you found the issue (if it applies) or your organization slug? If you are concerned with 
-      exposing your organization slug (which is included on links to sentry.io) you can share your
-      organization ID which can be found in your client keys (DSN) which follow the format
-      `https://{tag}@o{ORGANISATION_ID}.ingest.sentry.io/{PROJECT_ID}`
+      description: If you are using SaaS, in order to speed up investigations - could you please include a link to where you found the issue (if it applies) or your organization slug? If you are concerned with exposing your organization slug (which is included on links to sentry.io) you can share your organization ID which can be found in your client keys (DSN) which follow the format `https://{tag}@o{ORGANISATION_ID}.ingest.sentry.io/{PROJECT_ID}`
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
A link to Sentry, the org slug or the org id speeds up engineering triaging of issues where checking the issue in Sentry would help.

The org ID is requested in cases where a customer is concerned with divulging their org slug since it may be considered as PII.

This saves an extra step in communications with customers.