### PR TITLE
fix(replay): Move setBufferTime into useEffect

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -491,9 +491,11 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
       ? [true, buffer.target]
       : [false, currentPlayerTime];
 
-  if (!isBuffering && buffer.target !== -1) {
-    setBufferTime({target: -1, previous: -1});
-  }
+  useEffect(() => {
+    if (!isBuffering && buffer.target !== -1) {
+      setBufferTime({target: -1, previous: -1});
+    }
+  }, [isBuffering, buffer.target]);
 
   return (
     <ReplayPlayerContext.Provider


### PR DESCRIPTION
State setters from `useState` shouldn't be called within render functions. I've moved `setBufferTime` into a `useEffect` hook to respect how state setters should be used.