### PR TITLE
fix(auth) Redirect to customer domain on login more often

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -135,7 +135,6 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "invoices",
         "jobs",
         "legal",
-        "legal",
         "login",
         "logout",
         "mail",

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -208,6 +208,9 @@ class OrganizationMixin:
         if self.active_organization:
             current_org_slug = self.active_organization.organization.slug
             url = Organization.get_url(current_org_slug)
+            if using_customer_domain:
+                url_prefix = generate_organization_url(request.subdomain)
+                url = absolute_uri(url, url_prefix=url_prefix)
         elif not features.has("organizations:create"):
             return self.respond("sentry/no-organization-access.html", status=403)
         else:

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -12,6 +12,7 @@ from sentry import newsletter, options
 from sentry.auth.authenticators import RecoveryCodeInterface, TotpInterface
 from sentry.models import OrganizationMember, User
 from sentry.testutils import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 from sentry.utils.client_state import get_client_state_key, get_redis_client
@@ -110,6 +111,23 @@ class AuthLoginTest(TestCase):
                 (reverse("sentry-login"), 302),
                 ("/organizations/baz/issues/", 302),
             ]
+
+    @with_feature("organizations:customer-domains")
+    def test_login_valid_credentials_with_org_and_customer_domains(self):
+        org = self.create_organization(owner=self.user)
+        # load it once for test cookie
+        self.client.get(self.path)
+
+        resp = self.client.post(
+            self.path,
+            {"username": self.user.username, "password": "admin", "op": "login"},
+            follow=True,
+        )
+        assert resp.status_code == 200
+        assert resp.redirect_chain == [
+            (f"http://{org.slug}.testserver/auth/login/", 302),
+            (f"http://{org.slug}.testserver/issues/", 302),
+        ]
 
     def test_registration_disabled(self):
         options.set("auth.allow-registration", True)
@@ -425,7 +443,7 @@ class AuthLoginCustomerDomainTest(TestCase):
         )
         assert resp.status_code == 200
         assert resp.redirect_chain == [
-            (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
+            ("http://albertos-apples.testserver/auth/login/", 302),
             ("http://testserver/organizations/new/", 302),
         ]
 
@@ -442,8 +460,8 @@ class AuthLoginCustomerDomainTest(TestCase):
         )
         assert resp.status_code == 200
         assert resp.redirect_chain == [
-            (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
-            ("/issues/", 302),
+            ("http://albertos-apples.testserver/auth/login/", 302),
+            ("http://albertos-apples.testserver/issues/", 302),
         ]
 
     def test_login_valid_credentials_invalid_customer_domain(self):
@@ -463,9 +481,9 @@ class AuthLoginCustomerDomainTest(TestCase):
 
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (f"http://invalid.testserver{reverse('sentry-login')}", 302),
+                ("http://invalid.testserver/auth/login/", 302),
                 ("http://albertos-apples.testserver/auth/login/", 302),
-                ("/issues/", 302),
+                ("http://albertos-apples.testserver/issues/", 302),
             ]
 
     def test_login_valid_credentials_non_staff(self):
@@ -486,8 +504,8 @@ class AuthLoginCustomerDomainTest(TestCase):
             )
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
-                ("/issues/", 302),
+                ("http://albertos-apples.testserver/auth/login/", 302),
+                ("http://albertos-apples.testserver/issues/", 302),
             ]
 
     def test_login_valid_credentials_not_a_member(self):
@@ -530,6 +548,6 @@ class AuthLoginCustomerDomainTest(TestCase):
 
             assert resp.status_code == 200
             assert resp.redirect_chain == [
-                (f"http://albertos-apples.testserver{reverse('sentry-login')}", 302),
+                ("http://albertos-apples.testserver/auth/login/", 302),
                 ("http://testserver/organizations/new/", 302),
             ]


### PR DESCRIPTION
We weren't redirecting to customer domains when the user came from sentry.io/auth/login/ as the GET request after login that forwards the user to the /issues was missing a subdomain which results in the final redirect also missing a subdomain.

Revert "Revert "fix(auth) Redirect to customer domain on login more often (#41795)""

This reverts commit 81722a367c1f41036b4fc8a3732c7ac4cf49b223