### PR TITLE
feat(perf-issues): N+1 API Calls detector improvements I

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -980,7 +980,9 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         span_a_start: int = span_a.get("start_timestamp", 0) or 0
         span_b_start: int = span_b.get("start_timestamp", 0) or 0
 
-        return abs(span_a_start - span_b_start) < self.settings["concurrency_threshold"]
+        return timedelta(seconds=abs(span_a_start - span_b_start)) < timedelta(
+            milliseconds=self.settings["concurrency_threshold"]
+        )
 
     def _spans_are_similar(self, span_a: Span, span_b: Span) -> bool:
         return (

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -921,6 +921,9 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         if not description:
             return
 
+        if description[:3].upper() != "GET":
+            return
+
         if op not in self.settings.get("allowed_span_ops", []):
             return
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -921,7 +921,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         if not description:
             return
 
-        if description[:3].upper() != "GET":
+        if description.strip()[:3].upper() != "GET":
             return
 
         if op not in self.settings.get("allowed_span_ops", []):


### PR DESCRIPTION
First round of improvements after the first audit.

- Only examine `GET` requests, that's the most useful
- Fix bug in concurrency calculations
