### PR TITLE
fix(discover-quick-context):Minor improvements.

### DIFF
--- a/static/app/components/discover/quickContextCommitRow.tsx
+++ b/static/app/components/discover/quickContextCommitRow.tsx
@@ -10,22 +10,26 @@ import space from 'sentry/styles/space';
 
 import {CommitRowProps, formatCommitMessage} from '../commitRow';
 import ExternalLink from '../links/externalLink';
+import Tooltip from '../tooltip';
 
 function QuickContextCommitRow({commit}: CommitRowProps) {
   const user = ConfigStore.get('user');
   const isUser = user?.id === commit.author?.id;
   const hasPullRequestURL = commit.pullRequest && commit.pullRequest.externalUrl;
+  const commitMessage = formatCommitMessage(commit.message);
 
   return (
     <StyledPanelItem key={commit.id} data-test-id="quick-context-commit-row">
       <UserAvatar size={24} user={commit.author} />
       <CommitLinks>
         {hasPullRequestURL && commit.message && (
-          <LinkToPullRequest data-test-id="quick-context-commit-row-pr-link">
-            <ExternalLink href={commit.pullRequest?.externalUrl}>
-              {formatCommitMessage(commit.message)}
-            </ExternalLink>
-          </LinkToPullRequest>
+          <Tooltip containerDisplayMode="inline" showOnlyOnOverflow title={commitMessage}>
+            <LinkToPullRequest data-test-id="quick-context-commit-row-pr-link">
+              <ExternalLink href={commit.pullRequest?.externalUrl}>
+                {commitMessage}
+              </ExternalLink>
+            </LinkToPullRequest>
+          </Tooltip>
         )}
         <LinkToCommit
           hasPrTitle={hasPullRequestURL && commit.message}

--- a/static/app/utils/analytics/discoverAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/discoverAnalyticsEvents.tsx
@@ -1,3 +1,4 @@
+import {EventOrGroupType} from 'sentry/types';
 import {ContextType} from 'sentry/views/eventsV2/table/quickContext';
 
 export type DiscoverEventParameters = {
@@ -11,7 +12,7 @@ export type DiscoverEventParameters = {
   'discover_v2.quick_context_header_copy': {clipBoardTitle: string};
   'discover_v2.quick_context_hover_contexts': {
     contextType: ContextType;
-    eventType?: 'error' | 'transaction';
+    eventType?: EventOrGroupType;
   };
   'discover_v2.remove_default': {source: 'homepage' | 'prebuilt-query' | 'saved-query'};
   'discover_v2.saved_query_click': {};

--- a/static/app/views/eventsV2/table/quickContext.spec.tsx
+++ b/static/app/views/eventsV2/table/quickContext.spec.tsx
@@ -1,7 +1,7 @@
 import {browserHistory} from 'react-router';
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import ConfigStore from 'sentry/stores/configStore';
 import {Commit, Repository, User} from 'sentry/types';
@@ -429,10 +429,14 @@ describe('Quick Context', function () {
 
       userEvent.hover(screen.getByText('Text from Child'));
 
-      expect(await screen.findByText(/4/i)).toBeInTheDocument();
-      expect(screen.getByText(/commits by/i)).toBeInTheDocument();
-      expect(screen.getAllByText(/2/i)).toHaveLength(3);
-      expect(screen.getByText(/authors/i)).toBeInTheDocument();
+      const authorsSectionHeader = within(
+        await screen.findByTestId('quick-context-release-author-header')
+      );
+
+      expect(authorsSectionHeader.getByText(/4/i)).toBeInTheDocument();
+      expect(authorsSectionHeader.getByText(/commits by/i)).toBeInTheDocument();
+      expect(authorsSectionHeader.getByText(/2/i)).toBeInTheDocument();
+      expect(authorsSectionHeader.getByText(/authors/i)).toBeInTheDocument();
       expect(screen.getByText(/KN/i)).toBeInTheDocument();
       expect(screen.getByText(/VN/i)).toBeInTheDocument();
     });
@@ -449,9 +453,7 @@ describe('Quick Context', function () {
       userEvent.hover(screen.getByText('Text from Child'));
 
       expect(await screen.findByText(/4/i)).toBeInTheDocument();
-      expect(screen.getByText(/commits by you and/i)).toBeInTheDocument();
-      expect(screen.getAllByText(/1/i)).toHaveLength(3);
-      expect(screen.getByText(/other/i)).toBeInTheDocument();
+      expect(screen.getByText(/commits by you and 1 other/i)).toBeInTheDocument();
       expect(screen.getByText(/KN/i)).toBeInTheDocument();
       expect(screen.getByText(/VN/i)).toBeInTheDocument();
     });

--- a/static/app/views/eventsV2/table/quickContext.spec.tsx
+++ b/static/app/views/eventsV2/table/quickContext.spec.tsx
@@ -232,6 +232,24 @@ describe('Quick Context', function () {
       MockApiClient.clearMockResponses();
     });
 
+    it('Renders issue context header with copy button', async () => {
+      MockApiClient.addMockResponse({
+        url: '/issues/3512441874/',
+        method: 'GET',
+        body: mockedGroup,
+      });
+
+      renderQuickContextContent();
+
+      userEvent.hover(screen.getByText('Text from Child'));
+
+      expect(await screen.findByText(/Issue/i)).toBeInTheDocument();
+      expect(screen.getByText(/SENTRY-VVY/i)).toBeInTheDocument();
+      expect(
+        screen.getByTestId('quick-context-hover-header-copy-icon')
+      ).toBeInTheDocument();
+    });
+
     it('Renders ignored Issue status context when data is loaded', async () => {
       MockApiClient.addMockResponse({
         url: '/issues/3512441874/',

--- a/static/app/views/eventsV2/table/quickContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext.tsx
@@ -92,6 +92,15 @@ function getHoverHeader(
           copyContent={dataRow.release}
         />
       );
+    case ContextType.ISSUE:
+      return (
+        <HoverHeader
+          title={t('Issue')}
+          organization={organization}
+          copyLabel={dataRow.issue}
+          copyContent={dataRow.issue}
+        />
+      );
     case ContextType.EVENT:
       return (
         dataRow.id && (
@@ -176,6 +185,13 @@ function HoverHeader({
 function IssueContext(props: BaseContextProps) {
   const statusTitle = t('Issue Status');
   const {dataRow, organization} = props;
+
+  useEffect(() => {
+    trackAdvancedAnalyticsEvent('discover_v2.quick_context_hover_contexts', {
+      organization,
+      contextType: ContextType.ISSUE,
+    });
+  }, [organization]);
 
   const {
     isLoading: issueLoading,
@@ -262,15 +278,7 @@ function IssueContext(props: BaseContextProps) {
   }
 
   return (
-    <Wrapper
-      onMouseEnter={() => {
-        trackAdvancedAnalyticsEvent('discover_v2.quick_context_hover_contexts', {
-          organization,
-          contextType: ContextType.ISSUE,
-        });
-      }}
-      data-test-id="quick-context-hover-body"
-    >
+    <Wrapper data-test-id="quick-context-hover-body">
       {renderStatus()}
       {renderAssigneeSelector()}
       {renderSuspectCommits()}
@@ -310,6 +318,13 @@ function ReleaseContext(props: BaseContextProps) {
       retry: false,
     }
   );
+
+  useEffect(() => {
+    trackAdvancedAnalyticsEvent('discover_v2.quick_context_hover_contexts', {
+      organization,
+      contextType: ContextType.RELEASE,
+    });
+  }, [organization]);
 
   const getCommitAuthorTitle = () => {
     const user = ConfigStore.get('user');
@@ -417,15 +432,7 @@ function ReleaseContext(props: BaseContextProps) {
   }
 
   return (
-    <Wrapper
-      onMouseEnter={() => {
-        trackAdvancedAnalyticsEvent('discover_v2.quick_context_hover_contexts', {
-          organization,
-          contextType: ContextType.RELEASE,
-        });
-      }}
-      data-test-id="quick-context-hover-body"
-    >
+    <Wrapper data-test-id="quick-context-hover-body">
       {renderReleaseDetails()}
       {renderReleaseAuthors()}
       {renderLastCommit()}
@@ -450,6 +457,16 @@ function EventContext(props: EventContextProps) {
     }
   );
 
+  useEffect(() => {
+    if (data) {
+      trackAdvancedAnalyticsEvent('discover_v2.quick_context_hover_contexts', {
+        organization,
+        contextType: ContextType.EVENT,
+        eventType: data.type,
+      });
+    }
+  }, [data, organization]);
+
   if (isLoading || isError) {
     return <NoContext isLoading={isLoading} />;
   }
@@ -459,16 +476,7 @@ function EventContext(props: EventContextProps) {
     const {start, end} = getTraceTimeRangeFromEvent(data);
     const project = projects?.find(p => p.slug === data.projectID);
     return (
-      <Wrapper
-        onMouseEnter={() => {
-          trackAdvancedAnalyticsEvent('discover_v2.quick_context_hover_contexts', {
-            organization,
-            contextType: ContextType.RELEASE,
-            eventType: 'transaction',
-          });
-        }}
-        data-test-id="quick-context-hover-body"
-      >
+      <Wrapper data-test-id="quick-context-hover-body">
         <EventContextContainer>
           <ContextHeader>
             <Title>
@@ -582,15 +590,7 @@ function EventContext(props: EventContextProps) {
           <ErrorTitleBody>{data.title}</ErrorTitleBody>
         </ErrorTitleContainer>
       )}
-      <StackTraceWrapper
-        onMouseEnter={() => {
-          trackAdvancedAnalyticsEvent('discover_v2.quick_context_hover_contexts', {
-            organization,
-            contextType: ContextType.EVENT,
-            eventType: 'error',
-          });
-        }}
-      >
+      <StackTraceWrapper>
         <StackTracePreviewContent event={data} stacktrace={stackTrace} />
       </StackTraceWrapper>
     </Fragment>

--- a/static/app/views/eventsV2/table/quickContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext.tsx
@@ -377,7 +377,9 @@ function ReleaseContext(props: BaseContextProps) {
     return (
       data && (
         <ReleaseContextContainer data-test-id="quick-context-release-details-container">
-          <ReleaseAuthorsTitle>{getCommitAuthorTitle()}</ReleaseAuthorsTitle>
+          <ReleaseAuthorsTitle data-test-id="quick-context-release-author-header">
+            {getCommitAuthorTitle()}
+          </ReleaseAuthorsTitle>
           <ReleaseAuthorsBody>
             {data.commitCount === 0 ? (
               <IconNot color="gray500" size="md" />


### PR DESCRIPTION
1. Added issue context header with clipboard.
2. Added tooltip for overflowing commit message in issue and release contexts. 
3. Changed hover analytics to trigger whenever contexts load. Previously, the code assumed that users need to hover over body to consume the contexts. 
4. Made release author tests a bit more precise. 