### PR TITLE
feat(perf-issues): Slow db span detection only on queries starting with `SELECT`

### DIFF
--- a/fixtures/events/performance_problems/n-plus-one-in-django-index-view.json
+++ b/fixtures/events/performance_problems/n-plus-one-in-django-index-view.json
@@ -13,7 +13,7 @@
       "status": "ok",
       "type": "trace"
     }
-},
+  },
   "spans": [
     {
       "timestamp": 1661957873.995433,
@@ -168,7 +168,7 @@
       "same_process_as_parent": true
     },
     {
-      "timestamp": 1661957871.418989,
+      "timestamp": 1661959871.418989,
       "start_timestamp": 1661957871.249481,
       "exclusive_time": 169.507981,
       "description": "\n                SELECT VERSION(),\n                       @@sql_mode,\n                       @@default_storage_engine,\n                       @@sql_auto_is_null,\n                       @@lower_case_table_names,\n                       CONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC') IS NOT NULL\n            ",

--- a/fixtures/events/performance_problems/solved-n-plus-one-in-django-index-view.json
+++ b/fixtures/events/performance_problems/solved-n-plus-one-in-django-index-view.json
@@ -157,7 +157,7 @@
       "same_process_as_parent": true
     },
     {
-      "timestamp": 1661957972.078148,
+      "timestamp": 1761957972.078148,
       "start_timestamp": 1661957971.911963,
       "exclusive_time": 166.184903,
       "description": "\n                SELECT VERSION(),\n                       @@sql_mode,\n                       @@default_storage_engine,\n                       @@sql_auto_is_null,\n                       @@lower_case_table_names,\n                       CONVERT_TZ('2001-01-01 01:00:00', 'UTC', 'UTC') IS NOT NULL\n            ",

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -634,11 +634,12 @@ class SlowSpanDetector(PerformanceDetector):
         if not fingerprint:
             return
 
-        description = span.get("description")
-        if not description:
+        query = span.get("description", None)
+        if not query:
             return
 
-        if not description.startswith("SELECT"):
+        query.strip()
+        if not query.startswith("SELECT"):
             return
 
         if span_duration >= timedelta(

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -634,6 +634,13 @@ class SlowSpanDetector(PerformanceDetector):
         if not fingerprint:
             return
 
+        description = span.get("description")
+        if not description:
+            return
+
+        if not description.startswith("SELECT"):
+            return
+
         if span_duration >= timedelta(
             milliseconds=duration_threshold
         ) and not self.stored_problems.get(fingerprint, False):

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -638,7 +638,7 @@ class SlowSpanDetector(PerformanceDetector):
         if not query:
             return
 
-        query.strip()
+        query = query.strip()
         if not query.startswith("SELECT"):
             return
 

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -634,12 +634,12 @@ class SlowSpanDetector(PerformanceDetector):
         if not fingerprint:
             return
 
-        query = span.get("description", None)
-        if not query:
+        description = span.get("description", None)
+        if not description:
             return
 
-        query = query.strip()
-        if not query.startswith("SELECT"):
+        description = description.strip()
+        if description.strip()[:6].upper() != "SELECT":
             return
 
         if span_duration >= timedelta(

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -721,12 +721,12 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         _detect_performance_problems(n_plus_one_event, sdk_span_mock)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 6
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 5
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
                     "_pi_all_issue_count",
-                    3,
+                    2,
                 ),
                 call(
                     "_pi_sdk_name",
@@ -740,7 +740,6 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_duplicates",
                     "86d2ede57bbf48d4",
                 ),
-                call("_pi_slow_span", "82428e8ef4c5a539"),
                 call(
                     "_pi_sequential",
                     "8e554c84cdc9731e",

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -640,7 +640,7 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 9
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 10
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
@@ -659,6 +659,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_duplicates",
                     "86d2ede57bbf48d4",
                 ),
+                call("_pi_slow_span", "b33db57efd994615"),
                 call(
                     "_pi_sequential",
                     "b409e78a092e642f",

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -686,12 +686,12 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         _detect_performance_problems(n_plus_one_event, sdk_span_mock)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 6
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 5
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
                     "_pi_all_issue_count",
-                    3,
+                    2,
                 ),
                 call(
                     "_pi_sdk_name",
@@ -705,7 +705,6 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_duplicates",
                     "86d2ede57bbf48d4",
                 ),
-                call("_pi_slow_span", "82428e8ef4c5a539"),
                 call(
                     "_pi_sequential",
                     "b409e78a092e642f",

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -640,7 +640,7 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         perf_problems = _detect_performance_problems(n_plus_one_event, sdk_span_mock)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 10
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 9
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
@@ -659,7 +659,6 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_duplicates",
                     "86d2ede57bbf48d4",
                 ),
-                call("_pi_slow_span", "82428e8ef4c5a539"),
                 call(
                     "_pi_sequential",
                     "b409e78a092e642f",

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -915,7 +915,7 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "",
                 ),
                 call("_pi_transaction", "4e7c82a05f514c93b6101d255ca14f89"),
-                call("_pi_slow_span", "9f31e1ee4ef94970"),
+                call("_pi_slow_span", "a05754d3fde2db29"),
             ]
         )
 

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -756,12 +756,12 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         _detect_performance_problems(n_plus_one_event, sdk_span_mock)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 6
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 5
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
                 call(
                     "_pi_all_issue_count",
-                    3,
+                    2,
                 ),
                 call(
                     "_pi_sdk_name",
@@ -775,7 +775,6 @@ class PerformanceDetectionTest(unittest.TestCase):
                     "_pi_duplicates",
                     "86d2ede57bbf48d4",
                 ),
-                call("_pi_slow_span", "82428e8ef4c5a539"),
                 call(
                     "_pi_sequential",
                     "8e554c84cdc9731e",

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -880,15 +880,14 @@ class PerformanceDetectionTest(unittest.TestCase):
 
         _detect_performance_problems(query_waterfall_event, sdk_span_mock)
 
-        assert sdk_span_mock.containing_transaction.set_tag.call_count == 6
+        assert sdk_span_mock.containing_transaction.set_tag.call_count == 5
         sdk_span_mock.containing_transaction.set_tag.assert_has_calls(
             [
-                call("_pi_all_issue_count", 2),
+                call("_pi_all_issue_count", 1),
                 call("_pi_sdk_name", ""),
                 call("_pi_transaction", "ba9cf0e72b8c42439a6490be90d9733e"),
                 call("_pi_consecutive_db_fp", "1-GroupType.PERFORMANCE_CONSECUTIVE_DB_OP"),
                 call("_pi_consecutive_db", "abca1c35669c11f2"),
-                call("_pi_slow_span", "870ada8266466319"),
             ]
         )
 


### PR DESCRIPTION
Changes the slow db span detector to only look at queries that start with `SELECT` and updates the tests to reflect this change. 