### PR TITLE
fix(widget-builder): Handles undefined access for orderby

### DIFF
--- a/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/static/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -193,7 +193,12 @@ export function normalizeQueries({
             widgetType: widgetType ?? WidgetType.DISCOVER,
             columns: queries[0].columns,
             aggregates: queries[0].aggregates,
-          })[0].value);
+          })[0]?.value);
+
+    if (!orderBy) {
+      query.orderby = '';
+      return query;
+    }
 
     // A widget should be descending if:
     // - There is no orderby, so we're defaulting to desc


### PR DESCRIPTION
There are some cases where generateOrderOptions returns an empty array. Since our assumption is that there are values, indexing into this array returns undefined and causes the page to error when accessing `.value`.

This PR handles the undefined access and clears the orderby to prevent breaking the page for users.

Fixes JAVASCRIPT-28Q4