### PR TITLE
ref(breadcrumbs): Use 14px font size

### DIFF
--- a/static/app/components/breadcrumbs.tsx
+++ b/static/app/components/breadcrumbs.tsx
@@ -139,8 +139,7 @@ const Breadcrumbs = ({crumbs, linkLastItem = false, ...props}: Props) => {
 
 const getBreadcrumbListItemStyles = (p: {theme: Theme}) => css`
   ${p.theme.overflowEllipsis}
-  font-size: ${p.theme.fontSizeLarge};
-  color: ${p.theme.gray300};
+  color: ${p.theme.subText};
   width: auto;
 
   &:last-child {
@@ -176,7 +175,7 @@ const BreadcrumbItem = styled('span')`
 `;
 
 const BreadcrumbDividerIcon = styled(IconChevron)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.subText};
   margin: 0 ${space(1)};
   flex-shrink: 0;
 `;

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -709,7 +709,7 @@ const commonTheme = {
     maxCrumbWidth: '240px',
 
     containerWidth: '1440px',
-    headerHeight: '69px',
+    headerHeight: '61px',
     sidebarWidth: '220px',
   },
 

--- a/static/app/views/alerts/builder/builderBreadCrumbs.tsx
+++ b/static/app/views/alerts/builder/builderBreadCrumbs.tsx
@@ -43,8 +43,7 @@ function BuilderBreadCrumbs({title, alertName, projectSlug, organization}: Props
 }
 
 const StyledBreadcrumbs = styled(Breadcrumbs)`
-  font-size: 18px;
-  margin-bottom: ${space(3)};
+  margin-bottom: ${space(1)};
 `;
 
 export default BuilderBreadCrumbs;

--- a/static/app/views/settings/components/settingsBreadcrumb/crumb.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/crumb.tsx
@@ -6,7 +6,6 @@ const Crumb = styled('div')`
   display: flex;
   align-items: center;
   position: relative;
-  font-size: 18px;
   color: ${p => p.theme.subText};
   padding-right: ${space(1)};
   cursor: pointer;

--- a/static/app/views/settings/components/settingsHeader.tsx
+++ b/static/app/views/settings/components/settingsHeader.tsx
@@ -12,7 +12,7 @@ const SettingsHeader = styled('div')`
   position: sticky;
   top: 0;
   z-index: ${p => p.theme.zIndex.header + HEADER_Z_INDEX_OFFSET};
-  padding: ${space(3)} ${space(4)};
+  padding: ${space(2)} ${space(4)};
   border-bottom: 1px solid ${p => p.theme.border};
   background: ${p => p.theme.background};
   height: ${p => p.theme.settings.headerHeight};


### PR DESCRIPTION
The current breadcrumb font size is `16px` and is a remnant from when our default font size was still `16px` – now it's `14px`.

**Before:**
<img width="668" alt="Screenshot 2022-11-30 at 11 05 19 AM" src="https://user-images.githubusercontent.com/44172267/204886300-3b824c31-869a-488d-85a4-5b1a16f63c57.png">

**After:**
<img width="668" alt="Screenshot 2022-11-30 at 11 05 01 AM" src="https://user-images.githubusercontent.com/44172267/204886242-5f9591e6-bee0-4b0d-861a-ce10648f80ed.png">
