### PR TITLE
feat(_admin): Sentry Options readonly endpoint

### DIFF
--- a/src/sentry/options/__init__.py
+++ b/src/sentry/options/__init__.py
@@ -1,6 +1,7 @@
 from .manager import (  # NOQA
     DEFAULT_FLAGS,
     FLAG_ALLOW_EMPTY,
+    FLAG_CREDENTIAL,
     FLAG_IMMUTABLE,
     FLAG_NOSTORE,
     FLAG_PRIORITIZE_DISK,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -7,6 +7,7 @@ from sentry.options import (
     FLAG_REQUIRED,
     register,
 )
+from sentry.options.manager import FLAG_CREDENTIAL
 from sentry.utils.types import Any, Bool, Dict, Int, Sequence, String
 
 # Cache
@@ -21,7 +22,7 @@ register("system.databases", type=Dict, flags=FLAG_NOSTORE)
 # register('system.debug', default=False, flags=FLAG_NOSTORE)
 register("system.rate-limit", default=0, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register("system.event-retention-days", default=0, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
-register("system.secret-key", flags=FLAG_NOSTORE)
+register("system.secret-key", flags=FLAG_CREDENTIAL | FLAG_NOSTORE)
 # Absolute URL to the sentry root directory. Should not include a trailing slash.
 register("system.url-prefix", ttl=60, grace=3600, flags=FLAG_REQUIRED | FLAG_PRIORITIZE_DISK)
 register("system.internal-url-prefix", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
@@ -97,7 +98,9 @@ register(
 
 # SMS
 register("sms.twilio-account", default="", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
-register("sms.twilio-token", default="", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
+register(
+    "sms.twilio-token", default="", flags=FLAG_CREDENTIAL | FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK
+)
 register("sms.twilio-number", default="", flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK)
 register(
     "sms.disallow-new-enrollment",
@@ -187,26 +190,26 @@ register(
 register("analytics.backend", default="noop", flags=FLAG_NOSTORE)
 register("analytics.options", default={}, flags=FLAG_NOSTORE)
 
-register("cloudflare.secret-key", default="")
+register("cloudflare.secret-key", default="", flags=FLAG_CREDENTIAL)
 
 # Slack Integration
 register("slack.client-id", flags=FLAG_PRIORITIZE_DISK)
-register("slack.client-secret", flags=FLAG_PRIORITIZE_DISK)
+register("slack.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 # signing-secret is preferred, but need to keep verification-token for apps that use it
-register("slack.verification-token", flags=FLAG_PRIORITIZE_DISK)
-register("slack.signing-secret", flags=FLAG_PRIORITIZE_DISK)
+register("slack.verification-token", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
+register("slack.signing-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
 # GitHub Integration
 register("github-app.id", default=0)
 register("github-app.name", default="")
-register("github-app.webhook-secret", default="")
-register("github-app.private-key", default="")
+register("github-app.webhook-secret", default="", flags=FLAG_CREDENTIAL)
+register("github-app.private-key", default="", flags=FLAG_CREDENTIAL)
 register("github-app.client-id", flags=FLAG_PRIORITIZE_DISK)
-register("github-app.client-secret", flags=FLAG_PRIORITIZE_DISK)
+register("github-app.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
 # GitHub Auth
 register("github-login.client-id", default="", flags=FLAG_PRIORITIZE_DISK)
-register("github-login.client-secret", default="", flags=FLAG_PRIORITIZE_DISK)
+register("github-login.client-secret", default="", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register(
     "github-login.require-verified-email", type=Bool, default=False, flags=FLAG_PRIORITIZE_DISK
 )
@@ -217,27 +220,27 @@ register("github-login.organization", flags=FLAG_PRIORITIZE_DISK)
 
 # VSTS Integration
 register("vsts.client-id", flags=FLAG_PRIORITIZE_DISK)
-register("vsts.client-secret", flags=FLAG_PRIORITIZE_DISK)
+register("vsts.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 # VSTS Integration - with limited scopes
 register("vsts-limited.client-id", flags=FLAG_PRIORITIZE_DISK)
-register("vsts-limited.client-secret", flags=FLAG_PRIORITIZE_DISK)
+register("vsts-limited.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 
 # PagerDuty Integration
 register("pagerduty.app-id", default="")
 
 # Vercel Integration
 register("vercel.client-id", flags=FLAG_PRIORITIZE_DISK)
-register("vercel.client-secret", flags=FLAG_PRIORITIZE_DISK)
+register("vercel.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("vercel.integration-slug", default="sentry")
 
 # MsTeams Integration
 register("msteams.client-id", flags=FLAG_PRIORITIZE_DISK)
-register("msteams.client-secret", flags=FLAG_PRIORITIZE_DISK)
+register("msteams.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("msteams.app-id")
 
 # AWS Lambda Integration
 register("aws-lambda.access-key-id", flags=FLAG_PRIORITIZE_DISK)
-register("aws-lambda.secret-access-key", flags=FLAG_PRIORITIZE_DISK)
+register("aws-lambda.secret-access-key", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)
 register("aws-lambda.cloudformation-url")
 register("aws-lambda.account-number", default="943013980633")
 register("aws-lambda.node.layer-name", default="SentryNodeServerlessSDK")

--- a/src/sentry/options/manager.py
+++ b/src/sentry/options/manager.py
@@ -32,6 +32,8 @@ FLAG_REQUIRED = 1 << 4
 FLAG_PRIORITIZE_DISK = 1 << 5
 # If the value is allowed to be empty to be considered valid
 FLAG_ALLOW_EMPTY = 1 << 6
+# Values that are credentials should not show up in web UI.
+FLAG_CREDENTIAL = 1 << 7
 
 # How long will a cache key exist in local memory before being evicted
 DEFAULT_KEY_TTL = 10

--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -20,6 +20,12 @@ class SystemOptionsTest(APITestCase):
         assert "system.url-prefix" in response.data
         assert "system.admin-email" in response.data
 
+    def test_redacted_secret(self):
+        self.login_as(user=self.user, superuser=True)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert response.data["github-login.client-secret"]["value"] == "[redacted]"
+
     def test_bad_query(self):
         self.login_as(user=self.user, superuser=True)
         response = self.client.get(self.url, {"query": "nonsense"})


### PR DESCRIPTION
### Overview
- Currently, anyone authenticated as a superuser can view all live prod options - including all tokens and secrets!
     - I can confirm I was able to view all of our prod options
- As part of self-serving sentry options, we want to expose production options as view only to the _admin UI
- This means tokens/secrets should be redacted

### Changes
- Changed the default functionality of the internal options endpoint to redact secrets
- Introduced new Flag `FLAG_CREDENTIAL` which should be used to flag any token/secret option