### PR TITLE
feat(perf-issues): Add issue type to latest

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -12,7 +12,12 @@ from sentry.eventstore.models import Event, GroupEvent
 from sentry.models import EventAttachment, EventError, GroupHash, Release, User, UserReport
 from sentry.sdk_updates import SdkSetupState, get_suggested_updates
 from sentry.search.utils import convert_user_tag_to_query
-from sentry.types.issues import GROUP_CATEGORY_TO_TYPES, GroupCategory
+from sentry.types.issues import (
+    GROUP_CATEGORY_TO_TYPES,
+    GROUP_TYPE_TO_TEXT,
+    GroupCategory,
+    GroupType,
+)
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.performance_issues.performance_detection import EventPerformanceProblem
 from sentry.utils.safe import get_path
@@ -350,9 +355,13 @@ class DetailedEventSerializer(EventSerializer):
         result["release"] = self._get_release_info(user, obj)
         result["userReport"] = self._get_user_report(user, obj)
         result["sdkUpdates"] = self._get_sdk_updates(obj)
-        result["perfProblem"] = convert_dict_key_case(
-            attrs.get("perf_problem"), snake_to_camel_case
-        )
+        perf_problem = attrs.get("perf_problem")
+        result["perfProblem"] = convert_dict_key_case(perf_problem, snake_to_camel_case)
+        issue_type = perf_problem.get("type")
+        if issue_type in [type.value for type in GroupType]:
+            result["issueType"] = GROUP_TYPE_TO_TEXT.get(GroupType(issue_type), "Issue")
+        else:
+            result["issueType"] = "Issue"
         return result
 
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -348,20 +348,26 @@ class DetailedEventSerializer(EventSerializer):
     def _get_sdk_updates(self, obj):
         return list(get_suggested_updates(SdkSetupState.from_event_json(obj.data)))
 
-    def serialize(self, obj, attrs, user):
+    def _get_perf_problem(self, attrs):
         from sentry.api.serializers.rest_framework import convert_dict_key_case, snake_to_camel_case
 
+        perf_problem = attrs.get("perf_problem")
+        if perf_problem is None:
+            return None
+        converted_problem = convert_dict_key_case(perf_problem, snake_to_camel_case)
+        issue_type = perf_problem.get("type")
+        if issue_type in [type.value for type in GroupType]:
+            converted_problem["issueType"] = GROUP_TYPE_TO_TEXT.get(GroupType(issue_type), "Issue")
+        else:
+            converted_problem["issueType"] = "Issue"
+        return converted_problem
+
+    def serialize(self, obj, attrs, user):
         result = super().serialize(obj, attrs, user)
         result["release"] = self._get_release_info(user, obj)
         result["userReport"] = self._get_user_report(user, obj)
         result["sdkUpdates"] = self._get_sdk_updates(obj)
-        perf_problem = attrs.get("perf_problem")
-        result["perfProblem"] = convert_dict_key_case(perf_problem, snake_to_camel_case)
-        issue_type = perf_problem.get("type")
-        if issue_type in [type.value for type in GroupType]:
-            result["issueType"] = GROUP_TYPE_TO_TEXT.get(GroupType(issue_type), "Issue")
-        else:
-            result["issueType"] = "Issue"
+        result["perfProblem"] = self._get_perf_problem(attrs)
         return result
 
 

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -416,6 +416,7 @@ class DetailedEventSerializerTest(TestCase):
             ],
             "op": "db",
             "parentSpanIds": ["8dd7a5869a4f4583"],
+            "issueType": "N+1 Query",
             "type": 1006,
         }
 


### PR DESCRIPTION
- this adds the issue type to the latest event endpoint too so that it can be used to determine how we want to display the span evidence preview