### PR TITLE
fix(open-source): Check membership before issue routing logic

### DIFF
--- a/.github/workflows/issue-routing-helper.yml
+++ b/.github/workflows/issue-routing-helper.yml
@@ -18,11 +18,34 @@ jobs:
       &&
       !contains(github.event.issue.labels.*.name, 'Status: In Progress')
     steps:
+      - name: "Check Membership of issue creator"
+        id: "check_membership"
+        env:
+          issue_number: ${{ github.event.issue.number }}
+        run: |
+          author_association=$(gh api "repos/$GH_REPO/issues/$issue_number" -q .author_association)
+          echo "membership=$author_association" >> $GITHUB_OUTPUT
       - name: "Ensure a single 'Team: *' label with 'Status: Untriaged'"
+        env:
+          team_label: ${{ github.event.label.name }}
+          issue_number: ${{ github.event.issue.number }}
+          membership: ${{ steps.check_membership.outputs.membership }}
+        if: >-
+          env.membership != 'OWNER'
+          &&
+          env.membership != 'MEMBER'
         run: |
           labels_to_remove=$(gh api --paginate "/repos/$GH_REPO/labels" -q '[.[].name | select((startswith("Team: ") or startswith("Status: ")) and . != "${{ github.event.label.name }}" and . != "Status: Untriaged")] | join(",")')
           gh issue edit ${{ github.event.issue.number }} --remove-label "$labels_to_remove" --add-label '${{ github.event.label.name }},Status: Untriaged'
       - name: "Mention/ping assigned team for triage"
+        env:
+          team_label: ${{ github.event.label.name }}
+          issue_number: ${{ github.event.issue.number }}
+          membership: ${{ steps.check_membership.outputs.membership }}
+        if: >-
+          env.membership != 'OWNER'
+          &&
+          env.membership != 'MEMBER'
         run: |
           # Get team label mention name:
           team_label='${{ github.event.label.name }}'


### PR DESCRIPTION
This PR adds a check for issue creator membership before introducing any routing logic.