### PR TITLE
fix(discover): fixes discover chart not rendering when the page filter contains a project selection

### DIFF
--- a/static/app/views/eventsV2/results.tsx
+++ b/static/app/views/eventsV2/results.tsx
@@ -156,7 +156,7 @@ export class Results extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
-    const {api, location, organization, selection} = this.props;
+    const {location, organization, selection} = this.props;
     const {eventView, confirmedQuery, savedQuery} = this.state;
 
     this.checkEventView();
@@ -166,16 +166,14 @@ export class Results extends Component<Props, State> {
     const prevYAxisArray = getYAxis(prevProps.location, eventView, prevState.savedQuery);
 
     if (
-      prevQuery.field.length !== 0 &&
-      (!isAPIPayloadSimilar(currentQuery, prevQuery) ||
-        this.hasChartParametersChanged(
-          prevState.eventView,
-          eventView,
-          prevYAxisArray,
-          yAxisArray
-        ))
+      !isAPIPayloadSimilar(currentQuery, prevQuery) ||
+      this.hasChartParametersChanged(
+        prevState.eventView,
+        eventView,
+        prevYAxisArray,
+        yAxisArray
+      )
     ) {
-      api.clear();
       this.canLoadEvents();
     }
     if (


### PR DESCRIPTION
Selecting a project or having all projects selected in the page filter causes discover to cancel the events-stats request on first render.

Removed the api.clear call in results.tsx since it was causing requests to erroneously be cancelled. This call was already redundant since eventsRequest already handles calling api.clear whenever query parameters change