### PR TITLE
feat(profiling): optimize gl draws

### DIFF
--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -241,14 +241,17 @@ function FlamegraphZoomView({
   }, [dispatch, lastInteraction, previousInteraction, flamegraphView]);
 
   useEffect(() => {
+    flamegraphRenderer?.setSearchResults(flamegraphSearch.results);
+  }, [flamegraphRenderer, flamegraphSearch.results]);
+
+  useEffect(() => {
     if (!flamegraphCanvas || !flamegraphView || !flamegraphRenderer) {
       return undefined;
     }
 
     const drawRectangles = () => {
       flamegraphRenderer.draw(
-        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace),
-        flamegraphState.search.results
+        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
       );
     };
 
@@ -258,13 +261,7 @@ function FlamegraphZoomView({
     return () => {
       scheduler.unregisterBeforeFrameCallback(drawRectangles);
     };
-  }, [
-    flamegraphCanvas,
-    flamegraphRenderer,
-    flamegraphState.search.results,
-    scheduler,
-    flamegraphView,
-  ]);
+  }, [flamegraphCanvas, flamegraphRenderer, scheduler, flamegraphView]);
 
   useEffect(() => {
     if (!flamegraphCanvas || !flamegraphView || !textRenderer || !gridRenderer) {

--- a/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraphZoomViewMinimap.tsx
@@ -89,8 +89,7 @@ function FlamegraphZoomViewMinimap({
 
     const drawRectangles = () => {
       flamegraphMiniMapRenderer.draw(
-        flamegraphMiniMapView.fromConfigSpace(flamegraphMiniMapCanvas.physicalSpace),
-        new Map()
+        flamegraphMiniMapView.fromConfigSpace(flamegraphMiniMapCanvas.physicalSpace)
       );
     };
 

--- a/static/app/utils/profiling/differentialFlamegraph.tsx
+++ b/static/app/utils/profiling/differentialFlamegraph.tsx
@@ -3,7 +3,9 @@ import {relativeChange} from './units/units';
 import {Flamegraph} from './flamegraph';
 import {FlamegraphFrame} from './flamegraphFrame';
 
-function countFrameOccurences(frames: FlamegraphFrame[]): Map<string, number> {
+function countFrameOccurences(
+  frames: ReadonlyArray<FlamegraphFrame>
+): Map<string, number> {
   const counts = new Map<string, number>();
 
   for (const frame of frames) {

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -13,7 +13,7 @@ import {Frame} from './frame';
 // keeping an intermediary stack so as to resemble the execution of the program.
 export class Flamegraph {
   profile: Profile;
-  frames: FlamegraphFrame[] = [];
+  frames: ReadonlyArray<FlamegraphFrame> = [];
   profileIndex: number;
 
   inverted?: boolean = false;

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
@@ -16,6 +16,8 @@ import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 
+import {getFlamegraphFrameSearchId} from '../flamegraphFrame';
+
 const originalDpr = window.devicePixelRatio;
 
 describe('flamegraphRenderer', () => {
@@ -51,7 +53,9 @@ describe('flamegraphRenderer', () => {
         vec2.fromValues(0, 0)
       );
 
-      expect(renderer.colors).toEqual([1, 0, 0, 1]);
+      expect(JSON.stringify(renderer.colors)).toEqual(
+        JSON.stringify(new Float32Array([1, 0, 0, 1]))
+      );
     });
   });
 
@@ -74,13 +78,25 @@ describe('flamegraphRenderer', () => {
     // To draw a rect, we need to draw 2 triangles, each with 3 vertices
     // First triangle:  top left -> top right -> bottom left
     // Second triangle: bottom left -> top right -> bottom right
-    expect(renderer.positions.slice(0, 2)).toEqual([rect.left, rect.top]);
-    expect(renderer.positions.slice(2, 4)).toEqual([rect.right, rect.top]);
-    expect(renderer.positions.slice(4, 6)).toEqual([rect.left, rect.bottom]);
+    expect(JSON.stringify(renderer.positions.slice(0, 2))).toEqual(
+      JSON.stringify(new Float32Array([rect.left, rect.top]))
+    );
+    expect(JSON.stringify(renderer.positions.slice(2, 4))).toEqual(
+      JSON.stringify(new Float32Array([rect.right, rect.top]))
+    );
+    expect(JSON.stringify(renderer.positions.slice(4, 6))).toEqual(
+      JSON.stringify(new Float32Array([rect.left, rect.bottom]))
+    );
 
-    expect(renderer.positions.slice(6, 8)).toEqual([rect.left, rect.bottom]);
-    expect(renderer.positions.slice(8, 10)).toEqual([rect.right, rect.top]);
-    expect(renderer.positions.slice(10, 12)).toEqual([rect.right, rect.bottom]);
+    expect(JSON.stringify(renderer.positions.slice(6, 8))).toEqual(
+      JSON.stringify(new Float32Array([rect.left, rect.bottom]))
+    );
+    expect(JSON.stringify(renderer.positions.slice(8, 10))).toEqual(
+      JSON.stringify(new Float32Array([rect.right, rect.top]))
+    );
+    expect(JSON.stringify(renderer.positions.slice(10, 12))).toEqual(
+      JSON.stringify(new Float32Array([rect.right, rect.bottom]))
+    );
   });
 
   it('inits shaders', () => {
@@ -176,7 +192,7 @@ describe('flamegraphRenderer', () => {
   });
 
   describe('draw', () => {
-    it('sets uniform1f for search results', () => {
+    it('sets search results buffer', () => {
       const context = makeContextMock();
       const canvas = makeCanvasMock({
         getContext: jest.fn().mockReturnValue(context),
@@ -213,8 +229,6 @@ describe('flamegraphRenderer', () => {
       );
 
       const results: FlamegraphSearch['results'] = new Map();
-      // @ts-ignore we just need a partial frame
-      results.set('f00', {});
 
       const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
       const flamegraphView = new FlamegraphView({
@@ -224,12 +238,16 @@ describe('flamegraphRenderer', () => {
       });
       const renderer = new FlamegraphRenderer(canvas, flamegraph, theme);
 
-      renderer.draw(
-        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace),
-        results
+      // @ts-ignore we only need a partial frame mock
+      results.set(getFlamegraphFrameSearchId(flamegraph.frames[0]), {});
+      renderer.setSearchResults(results);
+
+      expect(JSON.stringify(renderer.searchResults.slice(0, 6))).toEqual(
+        JSON.stringify(new Float32Array([1, 1, 1, 1, 1, 1]))
       );
-      expect(context.uniform1i).toHaveBeenCalledTimes(3);
-      expect(context.drawArrays).toHaveBeenCalledTimes(2);
+
+      renderer.draw(flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace));
+      expect(context.drawArrays).toHaveBeenCalledTimes(1);
     });
 
     it('draws all frames', () => {
@@ -276,11 +294,8 @@ describe('flamegraphRenderer', () => {
       });
       const renderer = new FlamegraphRenderer(canvas, flamegraph, theme);
 
-      renderer.draw(
-        flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace),
-        new Map()
-      );
-      expect(context.drawArrays).toHaveBeenCalledTimes(2);
+      renderer.draw(flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace));
+      expect(context.drawArrays).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -27,9 +27,10 @@ class FlamegraphRenderer {
   roots: ReadonlyArray<FlamegraphFrame> = [];
 
   // Vertex and color buffer
-  positions: Array<number> = [];
-  bounds: Array<number> = [];
-  colors: Array<number> = [];
+  positions: Float32Array = new Float32Array();
+  bounds: Float32Array = new Float32Array();
+  colors: Float32Array = new Float32Array();
+  searchResults: Float32Array = new Float32Array();
 
   colorMap: Map<string | number, number[]> = new Map();
 
@@ -38,23 +39,23 @@ class FlamegraphRenderer {
   attributes: {
     a_bounds: number | null;
     a_color: number | null;
+    a_is_search_result: number | null;
     a_position: number | null;
   } = {
     a_position: null,
     a_color: null,
     a_bounds: null,
+    a_is_search_result: null,
   };
 
   uniforms: {
     u_border_width: WebGLUniformLocation | null;
     u_draw_border: WebGLUniformLocation | null;
-    u_is_search_result: WebGLUniformLocation | null;
     u_model: WebGLUniformLocation | null;
     u_projection: WebGLUniformLocation | null;
   } = {
     u_border_width: null,
     u_draw_border: null,
-    u_is_search_result: null,
     u_model: null,
     u_projection: null,
   };
@@ -81,7 +82,7 @@ class FlamegraphRenderer {
     const VERTICES = 6;
     const COLOR_COMPONENTS = 4;
 
-    this.colors = new Array(VERTICES * COLOR_COMPONENTS);
+    this.colors = new Float32Array(VERTICES * COLOR_COMPONENTS);
     this.frames = [...this.flamegraph.frames];
     this.roots = [...this.flamegraph.root.children];
 
@@ -93,7 +94,7 @@ class FlamegraphRenderer {
     );
 
     this.colorMap = colorMap;
-    this.colors = colorBuffer;
+    this.colors = new Float32Array(colorBuffer);
 
     this.initCanvasContext();
     this.initVertices();
@@ -101,16 +102,17 @@ class FlamegraphRenderer {
   }
 
   initVertices(): void {
-    const POSITIONS_PER_PASS = 2;
-    const BOUNDS_PER_PASS = 4;
+    const POSITIONS = 2;
+    const BOUNDS = 4;
     const VERTICES = 6;
 
-    this.bounds = new Array(VERTICES * BOUNDS_PER_PASS * this.frames.length);
-    this.positions = new Array(VERTICES * POSITIONS_PER_PASS * this.frames.length);
+    const FRAME_COUNT = this.frames.length;
 
-    const length = this.frames.length;
+    this.bounds = new Float32Array(VERTICES * BOUNDS * FRAME_COUNT);
+    this.positions = new Float32Array(VERTICES * POSITIONS * FRAME_COUNT);
+    this.searchResults = new Float32Array(FRAME_COUNT * VERTICES);
 
-    for (let index = 0; index < length; index++) {
+    for (let index = 0; index < FRAME_COUNT; index++) {
       const frame = this.frames[index];
 
       const x1 = frame.start;
@@ -137,10 +139,10 @@ class FlamegraphRenderer {
 
       // @TODO check if we can pack bounds across vertex calls,
       // we are allocating 6x the amount of memory here
-      const boundsOffset = index * VERTICES * BOUNDS_PER_PASS;
+      const boundsOffset = index * VERTICES * BOUNDS;
 
       for (let i = 0; i < VERTICES; i++) {
-        const offset = boundsOffset + i * BOUNDS_PER_PASS;
+        const offset = boundsOffset + i * BOUNDS;
 
         this.bounds[offset] = x1;
         this.bounds[offset + 1] = y1;
@@ -176,10 +178,18 @@ class FlamegraphRenderer {
       throw new Error('Uninitialized WebGL context');
     }
 
-    // @ts-ignore
-    this.uniforms = {};
-    // @ts-ignore
-    this.attributes = {};
+    this.uniforms = {
+      u_border_width: null,
+      u_draw_border: null,
+      u_model: null,
+      u_projection: null,
+    };
+    this.attributes = {
+      a_bounds: null,
+      a_color: null,
+      a_is_search_result: null,
+      a_position: null,
+    };
 
     const vertexShader = createShader(this.gl, this.gl.VERTEX_SHADER, vertex());
 
@@ -194,10 +204,6 @@ class FlamegraphRenderer {
 
     const uProjectionMatrix = this.gl.getUniformLocation(this.program, 'u_projection');
     const uModelMatrix = this.gl.getUniformLocation(this.program, 'u_model');
-    const uIsSearchResult = this.gl.getUniformLocation(
-      this.program,
-      'u_is_search_result'
-    );
     const uBorderWidth = this.gl.getUniformLocation(this.program, 'u_border_width');
     const uDrawBorder = this.gl.getUniformLocation(this.program, 'u_draw_border');
 
@@ -206,9 +212,6 @@ class FlamegraphRenderer {
     }
     if (!uModelMatrix) {
       throw new Error('Could not locate u_model in shader');
-    }
-    if (!uIsSearchResult) {
-      throw new Error('Could not locate u_is_search_result in shader');
     }
     if (!uBorderWidth) {
       throw new Error('Could not locate u_border_width in shader');
@@ -219,9 +222,39 @@ class FlamegraphRenderer {
 
     this.uniforms.u_projection = uProjectionMatrix;
     this.uniforms.u_model = uModelMatrix;
-    this.uniforms.u_is_search_result = uIsSearchResult;
     this.uniforms.u_border_width = uBorderWidth;
     this.uniforms.u_draw_border = uDrawBorder;
+
+    {
+      const aIsSearchResult = this.gl.getAttribLocation(
+        this.program,
+        'a_is_search_result'
+      );
+
+      if (aIsSearchResult === -1) {
+        throw new Error('Could not locate a_is_search_result in shader');
+      }
+
+      // attributes get data from buffers
+      this.attributes.a_is_search_result = aIsSearchResult;
+
+      // Init color buffer
+      const searchResultsBuffer = this.gl.createBuffer();
+
+      // Bind it to ARRAY_BUFFER (think of it as ARRAY_BUFFER = searchResultsBuffer)
+      this.gl.bindBuffer(this.gl.ARRAY_BUFFER, searchResultsBuffer);
+      this.gl.bufferData(this.gl.ARRAY_BUFFER, this.searchResults, this.gl.DYNAMIC_DRAW);
+
+      const size = 1;
+      const type = this.gl.FLOAT;
+      const normalize = false;
+      const stride = 0;
+      const offset = 0;
+
+      this.gl.vertexAttribPointer(aIsSearchResult, size, type, normalize, stride, offset);
+      // Point to attribute location
+      this.gl.enableVertexAttribArray(aIsSearchResult);
+    }
 
     {
       const aColorAttributeLocation = this.gl.getAttribLocation(this.program, 'a_color');
@@ -238,11 +271,7 @@ class FlamegraphRenderer {
 
       // Bind it to ARRAY_BUFFER (think of it as ARRAY_BUFFER = colorBuffer)
       this.gl.bindBuffer(this.gl.ARRAY_BUFFER, colorBuffer);
-      this.gl.bufferData(
-        this.gl.ARRAY_BUFFER,
-        new Float32Array(this.colors),
-        this.gl.STATIC_DRAW
-      );
+      this.gl.bufferData(this.gl.ARRAY_BUFFER, this.colors, this.gl.STATIC_DRAW);
 
       const size = 4;
       const type = this.gl.FLOAT;
@@ -261,6 +290,7 @@ class FlamegraphRenderer {
       // Point to attribute location
       this.gl.enableVertexAttribArray(aColorAttributeLocation);
     }
+
     {
       // look up where the vertex data needs to go.
       const aPositionAttributeLocation = this.gl.getAttribLocation(
@@ -280,11 +310,8 @@ class FlamegraphRenderer {
 
       // Bind it to ARRAY_BUFFER (think of it as ARRAY_BUFFER = positionBuffer)
       this.gl.bindBuffer(this.gl.ARRAY_BUFFER, positionBuffer);
-      this.gl.bufferData(
-        this.gl.ARRAY_BUFFER,
-        new Float32Array(this.positions),
-        this.gl.STATIC_DRAW
-      );
+      this.gl.bufferData(this.gl.ARRAY_BUFFER, this.positions, this.gl.STATIC_DRAW);
+
       const size = 2;
       const type = this.gl.FLOAT;
       const normalize = false;
@@ -322,11 +349,8 @@ class FlamegraphRenderer {
 
       // Bind it to ARRAY_BUFFER (think of it as ARRAY_BUFFER = boundsBuffer)
       this.gl.bindBuffer(this.gl.ARRAY_BUFFER, boundsBuffer);
-      this.gl.bufferData(
-        this.gl.ARRAY_BUFFER,
-        new Float32Array(this.bounds),
-        this.gl.STATIC_DRAW
-      );
+      this.gl.bufferData(this.gl.ARRAY_BUFFER, this.bounds, this.gl.STATIC_DRAW);
+
       const size = 4;
       const type = this.gl.FLOAT;
       const normalize = false;
@@ -390,10 +414,46 @@ class FlamegraphRenderer {
     return hoveredNode;
   }
 
-  draw(
-    configViewToPhysicalSpace: mat3,
-    searchResults: FlamegraphSearch['results']
-  ): void {
+  setSearchResults(searchResults: FlamegraphSearch['results']) {
+    const matchedFrame = new Float32Array(6).fill(1);
+    const unMatchedFrame = new Float32Array(6).fill(0);
+
+    for (let i = 0; i < this.frames.length; i++) {
+      this.searchResults.set(
+        searchResults.has(getFlamegraphFrameSearchId(this.frames[i]))
+          ? matchedFrame
+          : unMatchedFrame,
+        i * 6
+      );
+    }
+
+    if (!this.program || !this.gl) {
+      return;
+    }
+
+    const aIsSearchResult = this.gl.getAttribLocation(this.program, 'a_is_search_result');
+    // attributes get data from buffers
+    this.attributes.a_is_search_result = aIsSearchResult;
+
+    // Init color buffer
+    const searchResultsBuffer = this.gl.createBuffer();
+
+    // Bind it to ARRAY_BUFFER (think of it as ARRAY_BUFFER = searchResultsBuffer)
+    this.gl.bindBuffer(this.gl.ARRAY_BUFFER, searchResultsBuffer);
+    this.gl.bufferData(this.gl.ARRAY_BUFFER, this.searchResults, this.gl.DYNAMIC_DRAW);
+
+    const size = 1;
+    const type = this.gl.FLOAT;
+    const normalize = false;
+    const stride = 0;
+    const offset = 0;
+
+    this.gl.vertexAttribPointer(aIsSearchResult, size, type, normalize, stride, offset);
+    // Point to attribute location
+    this.gl.enableVertexAttribArray(aIsSearchResult);
+  }
+
+  draw(configViewToPhysicalSpace: mat3): void {
     if (!this.gl) {
       throw new Error('Uninitialized WebGL context');
     }
@@ -402,7 +462,7 @@ class FlamegraphRenderer {
     this.gl.clear(this.gl.COLOR_BUFFER_BIT);
 
     // We have no frames to draw
-    if (!this.positions.length) {
+    if (!this.positions.length || !this.program) {
       return;
     }
 
@@ -436,29 +496,7 @@ class FlamegraphRenderer {
     );
 
     const VERTICES = 6;
-
-    const length = this.frames.length;
-    let frame: FlamegraphFrame | null;
-
-    // This is an optimization to avoid setting uniform1i for each draw call when user is not searching
-    if (searchResults.size > 0) {
-      for (let i = 0; i < length; i++) {
-        frame = this.frames[i];
-        const vertexOffset = i * VERTICES;
-        this.gl.uniform1i(
-          this.uniforms.u_is_search_result,
-          searchResults.has(getFlamegraphFrameSearchId(frame)) ? 1 : 0
-        );
-        this.gl.drawArrays(this.gl.TRIANGLES, vertexOffset, VERTICES);
-      }
-    } else {
-      this.gl.uniform1i(this.uniforms.u_is_search_result, 0);
-      for (let i = 0; i < length; i++) {
-        const vertexOffset = i * VERTICES;
-
-        this.gl.drawArrays(this.gl.TRIANGLES, vertexOffset, VERTICES);
-      }
-    }
+    this.gl.drawArrays(this.gl.TRIANGLES, 0, this.frames.length * VERTICES);
   }
 }
 

--- a/static/app/utils/profiling/renderers/shaders.tsx
+++ b/static/app/utils/profiling/renderers/shaders.tsx
@@ -4,13 +4,15 @@ export const vertex = () => `
 attribute vec2 a_position;
 attribute vec4 a_color;
 attribute vec4 a_bounds;
+attribute float a_is_search_result;
 
 uniform mat3 u_model;
 uniform mat3 u_projection;
 
-varying lowp vec4 v_color;
+varying vec4 v_color;
 varying vec2 v_pos;
 varying vec4 v_bounds;
+varying float v_is_search_result;
 
 void main() {
   vec2 scaled = (u_model * vec3(a_position.xy, 1)).xy;
@@ -21,21 +23,20 @@ void main() {
   v_color = a_color;
   v_pos = a_position.xy;
   v_bounds = a_bounds;
+  v_is_search_result = a_is_search_result;
 }
 `;
 
 export const fragment = (theme: FlamegraphTheme) => `
-// fragment shaders don't have a default precision so we need
-// to pick one. mediump is a good default
 precision mediump float;
 
-uniform bool u_is_search_result;
 uniform vec2 u_border_width;
 uniform bool u_draw_border;
 
-varying lowp vec4 v_color;
+varying vec4 v_color;
 varying vec4 v_bounds;
 varying vec2 v_pos;
+varying float v_is_search_result;
 
 void main() {
   float minX = v_bounds.x + u_border_width.x;
@@ -46,7 +47,7 @@ void main() {
 
   float width = maxX - minX;
 
-  if (u_is_search_result) {
+  if (v_is_search_result == 1.0) {
     gl_FragColor = ${theme.COLORS.SEARCH_RESULT_FRAME_COLOR};
   } else if (u_draw_border) {
     if(width <= u_border_width.x) {


### PR DESCRIPTION
We were previously doing a draw call for each frame from JS which means that as profiles grew in number of frames, iterating over the large number of frames was sufficient to not be able to render a chart at 60FPS anymore.

We can improve that by pre-uploading the buffer data and performing draw calls on the GPU only.
One inconvenience that we hit with that is that we cannot pre-upload the search results buffer to the GPU as it changes when users search. To mitigate that, we need a method that sets the appropriate buffer values when new search results are available. I have tried inlining it inside the draw call, but we have the same problem of expensive iterations which can still cause frame drops. Having a separate method also allows us to only set the buffer once and only when new search results are available.