### PR TITLE
feat(profiling): computeConfigView w/ highlightFrames

### DIFF
--- a/static/app/components/profiling/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph.tsx
@@ -33,7 +33,7 @@ import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {
-  computeConfigViewWithStategy,
+  computeConfigViewWithStrategy,
   formatColorForFrame,
   Rect,
   watchForResize,
@@ -168,7 +168,7 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
         // was specified, this should be used as the initial view.
         defined(zoomIntoFrame)
       ) {
-        const newConfigView = computeConfigViewWithStategy(
+        const newConfigView = computeConfigViewWithStrategy(
           'min',
           newView.configView,
           new Rect(
@@ -222,7 +222,7 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
     };
 
     const onZoomIntoFrame = (frame: FlamegraphFrame, strategy: 'min' | 'exact') => {
-      const newConfigView = computeConfigViewWithStategy(
+      const newConfigView = computeConfigViewWithStrategy(
         strategy,
         flamegraphView.configView,
         new Rect(frame.start, frame.depth, frame.end - frame.start, 1)

--- a/static/app/utils/profiling/gl/utils.spec.tsx
+++ b/static/app/utils/profiling/gl/utils.spec.tsx
@@ -2,7 +2,7 @@ import Fuse from 'fuse.js';
 import {mat3, vec2} from 'gl-matrix';
 
 import {
-  computeConfigViewWithStategy,
+  computeConfigViewWithStrategy,
   computeHighlightedBounds,
   createProgram,
   createShader,
@@ -480,13 +480,13 @@ describe('computeHighlightedBounds', () => {
   });
 });
 
-describe('computeConfigViewWithStategy', () => {
+describe('computeConfigViewWithStrategy', () => {
   it('exact (preserves view height)', () => {
     const view = new Rect(0, 0, 1, 1);
     const frame = new Rect(0, 0, 0.5, 0.5);
 
     expect(
-      computeConfigViewWithStategy('exact', view, frame).equals(new Rect(0, 0, 0.5, 1))
+      computeConfigViewWithStrategy('exact', view, frame).equals(new Rect(0, 0, 0.5, 1))
     ).toBe(true);
   });
 
@@ -495,7 +495,7 @@ describe('computeConfigViewWithStategy', () => {
     const frame = new Rect(2, 2, 5, 1);
 
     expect(
-      computeConfigViewWithStategy('min', view, frame).equals(new Rect(2, 2, 5, 1))
+      computeConfigViewWithStrategy('min', view, frame).equals(new Rect(2, 2, 5, 1))
     ).toBe(true);
   });
 
@@ -504,7 +504,7 @@ describe('computeConfigViewWithStategy', () => {
     const frame = new Rect(1, 0, 1, 1);
 
     expect(
-      computeConfigViewWithStategy('min', view, frame).equals(new Rect(1, 0, 10, 1))
+      computeConfigViewWithStrategy('min', view, frame).equals(new Rect(1, 0, 10, 1))
     ).toBe(true);
   });
 
@@ -513,7 +513,7 @@ describe('computeConfigViewWithStategy', () => {
     const frame = new Rect(4, 0, 2, 1);
 
     expect(
-      computeConfigViewWithStategy('min', view, frame).equals(new Rect(4, 0, 10, 1))
+      computeConfigViewWithStrategy('min', view, frame).equals(new Rect(4, 0, 10, 1))
     ).toBe(true);
   });
 
@@ -522,7 +522,7 @@ describe('computeConfigViewWithStategy', () => {
     const frame = new Rect(9, 0, 5, 1);
 
     expect(
-      computeConfigViewWithStategy('min', view, frame).equals(new Rect(4, 0, 10, 1))
+      computeConfigViewWithStrategy('min', view, frame).equals(new Rect(4, 0, 10, 1))
     ).toBe(true);
   });
 
@@ -531,7 +531,7 @@ describe('computeConfigViewWithStategy', () => {
     const frame = new Rect(12, 0, 5, 1);
 
     expect(
-      computeConfigViewWithStategy('min', view, frame).equals(new Rect(7, 0, 10, 1))
+      computeConfigViewWithStrategy('min', view, frame).equals(new Rect(7, 0, 10, 1))
     ).toBe(true);
   });
 
@@ -540,7 +540,7 @@ describe('computeConfigViewWithStategy', () => {
     const frame = new Rect(0, 0, 10, 1);
 
     expect(
-      computeConfigViewWithStategy('min', view, frame).equals(new Rect(0, 0, 10, 1))
+      computeConfigViewWithStrategy('min', view, frame).equals(new Rect(0, 0, 10, 1))
     ).toBe(true);
   });
 
@@ -549,7 +549,7 @@ describe('computeConfigViewWithStategy', () => {
     const frame = new Rect(0, 2, 10, 1);
 
     expect(
-      computeConfigViewWithStategy('min', view, frame).equals(new Rect(0, 2, 10, 1))
+      computeConfigViewWithStrategy('min', view, frame).equals(new Rect(0, 2, 10, 1))
     ).toBe(true);
   });
 });

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -636,7 +636,7 @@ export function computeHighlightedBounds(
 // we will only move the viewport to the right until the frame is in view. Exact strategy
 // means we will zoom into the frame by moving the viewport to the exact location of the frame
 // and setting the width of the view to that of the frame.
-export function computeConfigViewWithStategy(
+export function computeConfigViewWithStrategy(
   strategy: 'min' | 'exact',
   view: Rect,
   frame: Rect


### PR DESCRIPTION
## Summary
This PR ensures we properly adjust the flamegraphView to the highlighted frames.

Closes https://github.com/getsentry/team-profiling/issues/63

https://user-images.githubusercontent.com/7349258/204899640-cdbe6162-3cb7-4f4b-9090-9dca5a4d0630.mov


