### PR TITLE
perf(replays): Lazy/Defer loading all the main tabs of the Replay Details page

### DIFF
--- a/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
+++ b/static/app/utils/replays/hooks/useExtractedCrumbHtml.tsx
@@ -25,7 +25,7 @@ export type Extraction = {
 };
 
 type HookOpts = {
-  replay: ReplayReader;
+  replay: null | ReplayReader;
 };
 
 const requestIdleCallback =
@@ -47,6 +47,9 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
   const [breadcrumbRefs, setBreadcrumbReferences] = useState<Extraction[]>([]);
 
   useEffect(() => {
+    if (!replay) {
+      return;
+    }
     requestIdleCallback(
       () => {
         let isMounted = true;
@@ -68,7 +71,7 @@ function useExtractedCrumbHtml({replay}: HookOpts) {
           .getRawCrumbs()
           .filter(crumb => crumb.data && 'nodeId' in crumb.data);
 
-        const rrwebEvents = replay.getRRWebEvents();
+        const rrwebEvents = replay.getRRWebEvents() || [];
 
         // Grab the last event, but skip the synthetic `replay-end` event that the
         // ReplayerReader added. RRWeb will skip that event when it comes time to render

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -30,7 +30,7 @@ import {getDomMutationsTypes} from 'sentry/views/replays/detail/domMutations/uti
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 
 type Props = {
-  replay: ReplayReader;
+  replay: null | ReplayReader;
 };
 
 // The cache is used to measure the height of each row
@@ -40,7 +40,7 @@ const cache = new CellMeasurerCache({
 });
 
 function DomMutations({replay}: Props) {
-  const startTimestampMs = replay.getReplay().startedAt.getTime();
+  const startTimestampMs = replay?.getReplay()?.startedAt?.getTime() || 0;
   const {currentTime} = useReplayContext();
   const {isLoading, actions} = useExtractedCrumbHtml({replay});
   let listRef: ReactVirtualizedList | null = null;
@@ -131,18 +131,21 @@ function DomMutations({replay}: Props) {
           size="sm"
           onChange={selected => setType(selected.map(_ => _.value))}
           value={filteredTypes}
+          isDisabled={!replay}
         />
         <SearchBar
           size="sm"
           onChange={setSearchTerm}
           placeholder={t('Search DOM')}
           query={searchTerm}
+          disabled={!replay}
         />
       </MutationFilters>
-      {isLoading ? (
-        <Placeholder height="200px" />
-      ) : (
-        <MutationList>
+
+      <MutationList>
+        {isLoading ? (
+          <Placeholder height="100%" />
+        ) : (
           <AutoSizer>
             {({width, height}) => (
               <ReactVirtualizedList
@@ -170,8 +173,8 @@ function DomMutations({replay}: Props) {
               />
             )}
           </AutoSizer>
-        </MutationList>
-      )}
+        )}
+      </MutationList>
     </MutationContainer>
   );
 }


### PR DESCRIPTION
Not sure if this is a perf win.

In dev I saw some components getting imorted and setup before they are rendered, and it took some js time. Need to do proper benchmarks to know.