### PR TITLE
Fix: `list` object has no attribute `get`

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -140,7 +140,7 @@ class EventAttributeCondition(EventCondition):
                 contexts = event.data["contexts"]
                 response = contexts.get("response")
                 if response is None:
-                    response = []
+                    response = {}
                 return [response.get(path[1])]
 
             return []


### PR DESCRIPTION
https://sentry.io/organizations/sentry/issues/3683869023/?project=1&query=is%3Aunresolved

Bug introduced by https://github.com/getsentry/sentry/pull/39913 when `status_code` is used but there's no `response` object within the `contexts`.




<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
