### PR TITLE
ref(perf-issues): Remove admin controls for Extended N+1 DB Query detector

### DIFF
--- a/static/app/views/admin/adminSettings.tsx
+++ b/static/app/views/admin/adminSettings.tsx
@@ -24,7 +24,6 @@ const optionsAvailable = [
   'performance.issues.all.post-process-group-early-adopter-rollout',
   'performance.issues.all.post-process-group-ga-rollout',
   'performance.issues.n_plus_one_db.problem-creation',
-  'performance.issues.n_plus_one_db_ext.problem-creation',
   'performance.issues.n_plus_one_db.count_threshold',
   'performance.issues.n_plus_one_db.duration_threshold',
 ];
@@ -112,7 +111,6 @@ export default class AdminSettings extends AsyncView<{}, State> {
             <Panel>
               <PanelHeader>Performance Issues - Detectors</PanelHeader>
               {fields['performance.issues.n_plus_one_db.problem-creation']}
-              {fields['performance.issues.n_plus_one_db_ext.problem-creation']}
               {fields['performance.issues.n_plus_one_db.count_threshold']}
               {fields['performance.issues.n_plus_one_db.duration_threshold']}
             </Panel>

--- a/static/app/views/admin/options.tsx
+++ b/static/app/views/admin/options.tsx
@@ -143,14 +143,6 @@ const performanceOptionDefinitions: Field[] = [
     ...HIGH_THROUGHPUT_RATE_OPTION,
   },
   {
-    key: 'performance.issues.n_plus_one_db_ext.problem-creation',
-    label: t('N+1 (DB) (Extended) creation rate'),
-    help: t(
-      'Controls the rate at which performance issues are created specifically for N+1 detection (extended). Value of 0 will disable creation, a value of 1.0 fully enables it.'
-    ),
-    ...HIGH_THROUGHPUT_RATE_OPTION,
-  },
-  {
     key: 'performance.issues.n_plus_one_db.count_threshold',
     label: t('N+1 (DB) count threshold'),
     help: t(


### PR DESCRIPTION
The Extended detector was used to experiment with changes to the N+1 DB Query detector that have now all shipped. It is currently only duplicating the work and metrics of the N+1 detector. Remove the admin controls for changing the detection rate. The option and the detector as a whole will be removed in a followup PR.