### PR TITLE
feat(perf-issues): Allow disqualifying events from issue detection

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -936,7 +936,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
         self.spans: list[Span] = []
 
     def visit_span(self, span: Span) -> None:
-        if not NPlusOneAPICallsDetector.is_span_valid(span):
+        if not NPlusOneAPICallsDetector.is_span_eligible(span):
             return
 
         op = span.get("op", None)
@@ -962,7 +962,7 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
             self.spans = [span]
 
     @classmethod
-    def is_span_valid(cls, span: Span) -> bool:
+    def is_span_eligible(cls, span: Span) -> bool:
         span_id = span.get("span_id", None)
         op = span.get("op", None)
         hash = span.get("hash", None)

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -389,6 +389,9 @@ def _detect_performance_problems(data: Event, sdk_span: Any) -> List[Performance
 
 
 def run_detector_on_data(detector, data):
+    if not detector.is_event_eligible(data):
+        return
+
     spans = data.get("spans", [])
     for span in spans:
         detector.visit_span(span)
@@ -545,6 +548,10 @@ class PerformanceDetector(ABC):
     @abstractmethod
     def stored_problems(self) -> PerformanceProblemsMap:
         raise NotImplementedError
+
+    @classmethod
+    def is_event_eligible(cls, event):
+        return True
 
 
 class DuplicateSpanDetector(PerformanceDetector):

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -86,7 +86,7 @@ class NPlusOneAPICallsDetectorTest(unittest.TestCase):
     ],
 )
 def test_accepts_valid_spans(span):
-    assert NPlusOneAPICallsDetector.is_span_valid(span)
+    assert NPlusOneAPICallsDetector.is_span_eligible(span)
 
 
 @pytest.mark.parametrize(
@@ -110,4 +110,4 @@ def test_accepts_valid_spans(span):
     ],
 )
 def test_rejects_invalid_spans(span):
-    assert not NPlusOneAPICallsDetector.is_span_valid(span)
+    assert not NPlusOneAPICallsDetector.is_span_eligible(span)


### PR DESCRIPTION
It's useful to be able to fully skip an event from running detection. e.g., we don't want to run N+1 API Calls detection on backend transactions. Right now there's no mechanism for this, since the detectors are passed every single span, and we need to check the _event_ data (like the trace `"op"`).

Adds a class method to check if an event is eligible for the current detector. Check that method when running detection. Renames a philosophically similar method to match
