### PR TITLE
fix(discover-quick-context): Removed GroupStore and assigneeSelector usage.

### DIFF
--- a/static/app/components/group/assignedTo.tsx
+++ b/static/app/components/group/assignedTo.tsx
@@ -26,6 +26,19 @@ interface AssignedToProps {
   onAssign?: AssigneeSelectorDropdownProps['onAssign'];
 }
 
+export function getAssignedToDisplayName(group: Group, assignedTo?: Actor) {
+  if (assignedTo?.type === 'team') {
+    const team = TeamStore.getById(group.assignedTo.id);
+    return `#${team?.slug ?? group.assignedTo.name}`;
+  }
+  if (assignedTo?.type === 'user') {
+    const user = MemberListStore.getById(assignedTo.id);
+    return user?.name ?? group.assignedTo.name;
+  }
+
+  return group.assignedTo?.name ?? t('No-one');
+}
+
 function AssignedTo({group, projectId, disableDropdown = false}: AssignedToProps) {
   const organization = useOrganization();
   const api = useApi();
@@ -33,19 +46,6 @@ function AssignedTo({group, projectId, disableDropdown = false}: AssignedToProps
     // TODO: We should check if this is already loaded
     fetchOrgMembers(api, organization.slug, [projectId]);
   }, [api, organization.slug, projectId]);
-
-  function getAssignedToDisplayName(assignedTo?: Actor) {
-    if (assignedTo?.type === 'team') {
-      const team = TeamStore.getById(group.assignedTo.id);
-      return `#${team?.slug ?? group.assignedTo.name}`;
-    }
-    if (assignedTo?.type === 'user') {
-      const user = MemberListStore.getById(assignedTo.id);
-      return user?.name ?? group.assignedTo.name;
-    }
-
-    return group.assignedTo?.name ?? t('No-one');
-  }
 
   return (
     <SidebarSection.Wrap>
@@ -69,7 +69,7 @@ function AssignedTo({group, projectId, disableDropdown = false}: AssignedToProps
                     <IconUser size="md" />
                   </IconWrapper>
                 )}
-                <ActorName>{getAssignedToDisplayName(assignedTo)}</ActorName>
+                <ActorName>{getAssignedToDisplayName(group, assignedTo)}</ActorName>
               </ActorWrapper>
               {!disableDropdown && (
                 <IconChevron

--- a/static/app/views/eventsV2/table/quickContext.spec.tsx
+++ b/static/app/views/eventsV2/table/quickContext.spec.tsx
@@ -100,7 +100,13 @@ const mockedReleaseWithHealth = TestStubs.Release({
   authors: [mockedUser1, mockedUser2],
 });
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
 
 const renderQuickContextContent = (
   dataRow: EventData = defaultRow,

--- a/static/app/views/eventsV2/table/quickContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext.tsx
@@ -3,12 +3,13 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import AvatarList from 'sentry/components/avatar/avatarList';
 import Clipboard from 'sentry/components/clipboard';
 import {QuickContextCommitRow} from 'sentry/components/discover/quickContextCommitRow';
 import EventCause from 'sentry/components/events/eventCause';
 import {CauseHeader, DataSection} from 'sentry/components/events/styles';
-import AssignedTo from 'sentry/components/group/assignedTo';
+import {getAssignedToDisplayName} from 'sentry/components/group/assignedTo';
 import {
   getStacktrace,
   StackTracePreviewContent,
@@ -17,13 +18,20 @@ import {Body, Hovercard} from 'sentry/components/hovercard';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels';
 import * as SidebarSection from 'sentry/components/sidebarSection';
+import {IconWrapper} from 'sentry/components/sidebarSection';
 import TimeSince from 'sentry/components/timeSince';
 import Tooltip from 'sentry/components/tooltip';
 import Version from 'sentry/components/version';
-import {IconAdd, IconCheckmark, IconCopy, IconMute, IconNot} from 'sentry/icons';
+import {
+  IconAdd,
+  IconCheckmark,
+  IconCopy,
+  IconMute,
+  IconNot,
+  IconUser,
+} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
-import GroupStore from 'sentry/stores/groupStore';
 import space from 'sentry/styles/space';
 import {Event, Group, Organization, Project, ReleaseWithHealth, User} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
@@ -208,11 +216,7 @@ function IssueContext(props: BaseContextProps) {
       },
     ],
     {
-      onSuccess: group => {
-        GroupStore.add([group]);
-      },
       staleTime: fiveMinutesInMs,
-      retry: false,
     }
   );
 
@@ -251,11 +255,26 @@ function IssueContext(props: BaseContextProps) {
       </IssueContextContainer>
     );
 
-  const renderAssigneeSelector = () =>
+  const renderAssignee = () =>
     issue && (
-      <IssueContextContainer data-test-id="quick-context-assigned-to-container">
-        <AssignedTo disableDropdown group={issue} projectId={issue.project.id} />
-      </IssueContextContainer>
+      <AssignedToContainer data-test-id="quick-context-assigned-to-container">
+        <ContextHeader>{t('Assigned To')}</ContextHeader>
+        <AssignedToBody>
+          {issue.assignedTo ? (
+            <ActorAvatar
+              data-test-id="assigned-avatar"
+              actor={issue.assignedTo}
+              hasTooltip={false}
+              size={24}
+            />
+          ) : (
+            <IconWrapper>
+              <IconUser size="md" />
+            </IconWrapper>
+          )}
+          {getAssignedToDisplayName(issue, issue.assignedTo)}
+        </AssignedToBody>
+      </AssignedToContainer>
     );
 
   const renderSuspectCommits = () =>
@@ -280,7 +299,7 @@ function IssueContext(props: BaseContextProps) {
   return (
     <Wrapper data-test-id="quick-context-hover-body">
       {renderStatus()}
-      {renderAssigneeSelector()}
+      {renderAssignee()}
       {renderSuspectCommits()}
     </Wrapper>
   );
@@ -619,7 +638,6 @@ export function QuickContextHoverWrapper(props: ContextProps) {
 
   useEffect(() => {
     return () => {
-      GroupStore.reset();
       queryClient.clear();
     };
   }, [queryClient]);
@@ -678,7 +696,7 @@ const IssueContextContainer = styled(ContextContainer)`
     padding: 0;
   }
 
-  ${CauseHeader}, ${SidebarSection.Title} {
+  ${CauseHeader} {
     margin-top: ${space(2)};
   }
 
@@ -696,6 +714,10 @@ const ContextHeader = styled('h6')`
   justify-content: space-between;
   align-items: center;
   margin: 0;
+`;
+
+const AssignedToContainer = styled(IssueContextContainer)`
+  margin-top: ${space(2)};
 `;
 
 const ContextBody = styled('div')`
@@ -732,6 +754,10 @@ const EventContextBody = styled(ContextBody)`
 const StatusText = styled('span')`
   margin-left: ${space(1)};
   text-transform: capitalize;
+`;
+
+const AssignedToBody = styled(ContextBody)`
+  gap: ${space(1)};
 `;
 
 const Wrapper = styled('div')`


### PR DESCRIPTION
1. We no longer need AssigneeSelector since the 'Assigned To' context is now readonly.
2. Should no longer see requests to /users endpoint, after the first time it has been hovered. 