### PR TITLE
feat(perf-issues): N+1 API Calls detector improvements III

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -962,6 +962,14 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
             self.spans = [span]
 
     @classmethod
+    def is_event_eligible(cls, event):
+        trace_op = event.get("contexts", {}).get("trace", {}).get("op")
+        if trace_op and trace_op not in ["navigation", "pageload", "ui.load", "ui.action"]:
+            return False
+
+        return True
+
+    @classmethod
     def is_span_eligible(cls, span: Span) -> bool:
         span_id = span.get("span_id", None)
         op = span.get("op", None)

--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -987,7 +987,12 @@ class NPlusOneAPICallsDetector(PerformanceDetector):
 
         # Ignore anything that looks like an asset
         data = span.get("data") or {}
-        parsed_url = urlparse(data.get("url") or "")
+        url = data.get("url") or ""
+        if type(url) is dict:
+            url = url.get("pathname") or ""
+
+        parsed_url = urlparse(str(url))
+
         _pathname, extension = os.path.splitext(parsed_url.path)
         if extension and extension in [".js", ".css"]:
             return False

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -85,7 +85,7 @@ class NPlusOneAPICallsDetectorTest(unittest.TestCase):
         },
     ],
 )
-def test_accepts_valid_spans(span):
+def test_allows_eligible_spans(span):
     assert NPlusOneAPICallsDetector.is_span_eligible(span)
 
 
@@ -109,7 +109,7 @@ def test_accepts_valid_spans(span):
         },
     ],
 )
-def test_rejects_invalid_spans(span):
+def test_rejects_ineligible_spans(span):
     assert not NPlusOneAPICallsDetector.is_span_eligible(span)
 
 

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -111,3 +111,21 @@ def test_accepts_valid_spans(span):
 )
 def test_rejects_invalid_spans(span):
     assert not NPlusOneAPICallsDetector.is_span_eligible(span)
+
+
+@pytest.mark.parametrize(
+    "event",
+    [EVENTS["n-plus-one-api-calls/not-n-plus-one-api-calls"]],
+)
+def test_allows_eligible_events(event):
+    assert NPlusOneAPICallsDetector.is_event_eligible(event)
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"contexts": {"trace": {"op": "task"}}},
+    ],
+)
+def test_rejects_ineligible_events(event):
+    assert not NPlusOneAPICallsDetector.is_event_eligible(event)

--- a/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
+++ b/tests/sentry/utils/performance_issues/test_n_plus_one_api_calls_detector.py
@@ -83,6 +83,26 @@ class NPlusOneAPICallsDetectorTest(unittest.TestCase):
             "hash": "b",
             "description": "GET http://service.io/resource",
         },
+        {
+            "span_id": "a",
+            "op": "http.client",
+            "description": "GET http://service.io/resource",
+            "hash": "a",
+            "data": {
+                "url": "/resource",
+            },
+        },
+        {
+            "span_id": "a",
+            "op": "http.client",
+            "description": "GET http://service.io/resource",
+            "hash": "a",
+            "data": {
+                "url": {
+                    "pathname": "/resource",
+                }
+            },
+        },
     ],
 )
 def test_allows_eligible_spans(span):


### PR DESCRIPTION
Closes PERF-1850 for real.

- Reject backend transactions
- Improve handling of URL data, sometimes its a `dict`!
- Rename misleading test
