### PR TITLE
fix(metric_alerts): If session dataset is passed when creating a metric alert, coerce it to metrics

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -194,15 +194,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 "Must send 1 or 2 triggers - A critical trigger, and an optional warning trigger"
             )
 
-        dataset = data["dataset"]
-        # If metric based crash rate alerts are enabled, coerce sessions over
-        if dataset == Dataset.Sessions and features.has(
-            "organizations:alert-crash-free-metrics",
-            self.context["organization"],
-            actor=self.context.get("user", None),
-        ):
-            data["dataset"] = Dataset.Metrics
-
         if query_type == SnubaQuery.Type.CRASH_RATE:
             data["event_types"] = []
         event_types = data.get("event_types")
@@ -239,6 +230,14 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
     def _validate_query(self, data):
         dataset = data.setdefault("dataset", Dataset.Events)
+        # If metric based crash rate alerts are enabled, coerce sessions over
+        if dataset == Dataset.Sessions and features.has(
+            "organizations:alert-crash-free-metrics",
+            self.context["organization"],
+            actor=self.context.get("user", None),
+        ):
+            dataset = data["dataset"] = Dataset.Metrics
+
         query_type = data.setdefault("query_type", query_datasets_to_type[dataset])
 
         valid_datasets = QUERY_TYPE_VALID_DATASETS[query_type]

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -194,6 +194,15 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                 "Must send 1 or 2 triggers - A critical trigger, and an optional warning trigger"
             )
 
+        dataset = data["dataset"]
+        # If metric based crash rate alerts are enabled, coerce sessions over
+        if dataset == Dataset.Sessions and features.has(
+            "organizations:alert-crash-free-metrics",
+            self.context["organization"],
+            actor=self.context.get("user", None),
+        ):
+            data["dataset"] = Dataset.Metrics
+
         if query_type == SnubaQuery.Type.CRASH_RATE:
             data["event_types"] = []
         event_types = data.get("event_types")


### PR DESCRIPTION
If we have the `organizations:alert-crash-free-metrics` flag enabled then coerce the dataset to be
metrics. We already did this at a lower level, but we need to do it here as well to make sure that
the validation query is run on the right dataset