### PR TITLE
feat(analytics): Find out how many repositories don't exist in GitHub

### DIFF
--- a/src/sentry/analytics/events/integration_failed_to_fetch_commit_context.py
+++ b/src/sentry/analytics/events/integration_failed_to_fetch_commit_context.py
@@ -1,0 +1,16 @@
+from sentry import analytics
+
+
+class IntegrationsFailedToFetchCommitContext(analytics.Event):
+    type = "integrations.failed_to_fetch_commit_context"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("code_mapping_id"),
+        analytics.Attribute("provider", type=str),
+        analytics.Attribute("error_message", type=str),
+    )
+
+
+analytics.register(IntegrationsFailedToFetchCommitContext)

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -378,12 +378,7 @@ class GitHubClientMixin(ApiClient):  # type: ignore
             path="/graphql",
             data={"query": query},
         )
-        sentry_sdk.add_breadcrumb(
-            category="sentry.integrations.client.github",
-            message="get_blame_for_file query results",
-            level="info",
-            data=contents,
-        )
+
         try:
             results: Sequence[Mapping[str, Any]] = (
                 contents.get("data", {})
@@ -395,7 +390,11 @@ class GitHubClientMixin(ApiClient):  # type: ignore
             )
             return results
         except AttributeError as e:
+            if contents.get("data", {}).get("repository", {}).get("ref", {}) is None:
+                raise ApiError("Repository does not exist in GitHub.")
+
             sentry_sdk.capture_exception(e)
+
             return []
 
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -193,7 +193,10 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
         lineno = event_frame.get("lineno", 0)
         if not lineno:
             return None
-        blame_range = self.get_blame_for_file(repo, filepath, ref, lineno)
+        try:
+            blame_range = self.get_blame_for_file(repo, filepath, ref, lineno)
+        except ApiError as e:
+            raise e
 
         try:
             commit = max(

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, Mapping, Sequence
 from urllib.parse import quote
 
-import sentry_sdk
 from django.urls import reverse
 
 from sentry.integrations.client import ApiClient
@@ -329,10 +328,5 @@ class GitLabApiClient(ApiClient):
         contents = self.get(
             request_path, params={"ref": ref, "range[start]": lineno, "range[end]": lineno}
         )
-        sentry_sdk.add_breadcrumb(
-            category="sentry.integrations.client.gitlab",
-            message="get_blame_for_file query results",
-            level="info",
-            data=contents,
-        )
+
         return contents

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -153,7 +153,10 @@ class GitlabIntegration(
         lineno = event_frame.get("lineno", 0)
         if not lineno:
             return None
-        blame_range = self.get_blame_for_file(repo, filepath, ref, lineno)
+        try:
+            blame_range = self.get_blame_for_file(repo, filepath, ref, lineno)
+        except ApiError as e:
+            raise e
 
         try:
             commit = max(

--- a/src/sentry/integrations/utils/commit_context.py
+++ b/src/sentry/integrations/utils/commit_context.py
@@ -1,7 +1,9 @@
 from typing import Any, Mapping, Sequence
 
+from sentry import analytics
 from sentry.models.integrations.repository_project_path_config import RepositoryProjectPathConfig
 from sentry.ownership.grammar import get_source_code_path_from_stacktrace_path
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils.committers import get_stacktrace_path_from_event_frame
 
 
@@ -37,9 +39,20 @@ def find_commit_context_for_event(
         install = integration.get_installation(
             code_mapping.organization_integration.organization_id
         )
-        commit_context = install.get_commit_context(
-            code_mapping.repository, src_path, code_mapping.default_branch, frame
-        )
+        try:
+            commit_context = install.get_commit_context(
+                code_mapping.repository, src_path, code_mapping.default_branch, frame
+            )
+        except ApiError as e:
+            commit_context = None
+            analytics.record(
+                "integrations.failed_to_fetch_commit_context",
+                organization_id=code_mapping.organization_integration.organization_id,
+                project_id=code_mapping.project.id,
+                code_mapping_id=code_mapping.id,
+                provider=integration.provider,
+                error_message=e.text,
+            )
 
         logger.info(
             "find_commit_context_for_event.integration_fetch",


### PR DESCRIPTION
## Objective:
I noticed a bunch of similar AttributeErrors from GitHub's GraphQL query results where the `repository` returns None.
This means that the repository that was added in Sentry and is in a code mapping, does not exist in GitHub. This implies that the code mapping is invalid and the repository record in Sentry should be deleted.

So I created an analytics event to group those errors that we can query the impact.

Also removed the custom sentry breadcrumbs. These ended up not useful bc of the server side scrubbing.