### PR TITLE
fix(team-roles): Swap organization.role to organization.orgRole

### DIFF
--- a/static/app/components/acl/demoModeGate.tsx
+++ b/static/app/components/acl/demoModeGate.tsx
@@ -24,7 +24,7 @@ type Props = {
 function DemoModeGate(props: Props) {
   const {organization, children, demoComponent = null} = props;
 
-  if (organization?.role === 'member' && ConfigStore.get('demoMode')) {
+  if (organization?.orgRole === 'member' && ConfigStore.get('demoMode')) {
     if (typeof demoComponent === 'function') {
       return demoComponent({children});
     }

--- a/static/app/components/acl/role.tsx
+++ b/static/app/components/acl/role.tsx
@@ -27,12 +27,12 @@ function checkUserRole(user: User, organization: Organization, role: RoleProps['
 
   const roleIds = organization.orgRoleList.map(r => r.id);
 
-  if (!roleIds.includes(role) || !roleIds.includes(organization.role ?? '')) {
+  if (!roleIds.includes(role) || !roleIds.includes(organization.orgRole ?? '')) {
     return false;
   }
 
   const requiredIndex = roleIds.indexOf(role);
-  const currentIndex = roleIds.indexOf(organization.role ?? '');
+  const currentIndex = roleIds.indexOf(organization.orgRole ?? '');
   return currentIndex >= requiredIndex;
 }
 

--- a/static/app/components/organizations/projectSelector/footer.tsx
+++ b/static/app/components/organizations/projectSelector/footer.tsx
@@ -46,7 +46,8 @@ const ProjectSelectorFooter = ({
   }
 
   // see if we should show "All Projects" or "My Projects" if disableMultipleProjectSelection isn't true
-  const hasGlobalRole = organization.role === 'owner' || organization.role === 'manager';
+  const hasGlobalRole =
+    organization.orgRole === 'owner' || organization.orgRole === 'manager';
   const hasOpenMembership = organization.features.includes('open-membership');
   const allSelected = selected && selected.has(ALL_ACCESS_PROJECTS);
 


### PR DESCRIPTION
Since `organization.role` is deprecated, I've changed any and all instances of it to be `organization.orgRole`.