### PR TITLE
fix(team-roles): Swap organization.role to organization.orgRole

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -66,10 +66,6 @@ export interface Organization extends OrganizationSummary {
   teamRoleList: TeamRole[];
   trustedRelays: Relay[];
   orgRole?: string;
-  /**
-   * @deprecated use orgRole instead
-   */
-  role?: string;
 }
 
 export type Team = {


### PR DESCRIPTION
Requires https://github.com/getsentry/getsentry/pull/9025

This removes `organization.role` type since it is now deprecated. 

