### PR TITLE
fix(team-roles): Swap organization.role to organization.orgRole

### DIFF
--- a/static/app/components/acl/demoModeGate.tsx
+++ b/static/app/components/acl/demoModeGate.tsx
@@ -24,7 +24,7 @@ type Props = {
 function DemoModeGate(props: Props) {
   const {organization, children, demoComponent = null} = props;
 
-  if (organization?.role === 'member' && ConfigStore.get('demoMode')) {
+  if (organization?.orgRole === 'member' && ConfigStore.get('demoMode')) {
     if (typeof demoComponent === 'function') {
       return demoComponent({children});
     }

--- a/static/app/components/acl/role.spec.tsx
+++ b/static/app/components/acl/role.spec.tsx
@@ -7,7 +7,7 @@ import ConfigStore from 'sentry/stores/configStore';
 
 describe('Role', function () {
   const organization = TestStubs.Organization({
-    role: 'admin',
+    orgRole: 'admin',
     orgRoleList: [
       {
         id: 'member',

--- a/static/app/components/acl/role.tsx
+++ b/static/app/components/acl/role.tsx
@@ -27,12 +27,12 @@ function checkUserRole(user: User, organization: Organization, role: RoleProps['
 
   const roleIds = organization.orgRoleList.map(r => r.id);
 
-  if (!roleIds.includes(role) || !roleIds.includes(organization.role ?? '')) {
+  if (!roleIds.includes(role) || !roleIds.includes(organization.orgRole ?? '')) {
     return false;
   }
 
   const requiredIndex = roleIds.indexOf(role);
-  const currentIndex = roleIds.indexOf(organization.role ?? '');
+  const currentIndex = roleIds.indexOf(organization.orgRole ?? '');
   return currentIndex >= requiredIndex;
 }
 

--- a/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/index.spec.tsx
@@ -113,7 +113,7 @@ describe('EventTagsAndScreenshot', function () {
 
   const {organization, project, router} = initializeOrg({
     organization: {
-      role: 'member',
+      orgRole: 'member',
       attachmentsRole: 'member',
       orgRoleList: [
         {

--- a/static/app/components/organizations/projectSelector/footer.tsx
+++ b/static/app/components/organizations/projectSelector/footer.tsx
@@ -46,7 +46,8 @@ const ProjectSelectorFooter = ({
   }
 
   // see if we should show "All Projects" or "My Projects" if disableMultipleProjectSelection isn't true
-  const hasGlobalRole = organization.role === 'owner' || organization.role === 'manager';
+  const hasGlobalRole =
+    organization.orgRole === 'owner' || organization.orgRole === 'manager';
   const hasOpenMembership = organization.features.includes('open-membership');
   const allSelected = selected && selected.has(ALL_ACCESS_PROJECTS);
 

--- a/static/app/components/organizations/projectSelector/index.spec.jsx
+++ b/static/app/components/organizations/projectSelector/index.spec.jsx
@@ -372,7 +372,7 @@ describe('ProjectSelector', function () {
       <ProjectSelector
         {...props}
         nonMemberProjects={[anotherProject]}
-        organization={{...mockOrg, role: 'owner'}}
+        organization={{...mockOrg, orgRole: 'owner'}}
         onApplyChange={mockOnApplyChange}
       />,
       {context: routerContext}
@@ -392,7 +392,7 @@ describe('ProjectSelector', function () {
       <ProjectSelector
         {...props}
         nonMemberProjects={[anotherProject]}
-        organization={{...mockOrg, role: 'manager'}}
+        organization={{...mockOrg, orgRole: 'manager'}}
         onApplyChange={mockOnApplyChange}
       />,
       {context: routerContext}
@@ -432,7 +432,7 @@ describe('ProjectSelector', function () {
       <ProjectSelector
         {...props}
         nonMemberProjects={[anotherProject]}
-        organization={{...mockOrg, role: 'manager'}}
+        organization={{...mockOrg, orgRole: 'manager'}}
         onApplyChange={mockOnApplyChange}
       />,
       {context: routerContext}

--- a/static/app/components/sidebar/sidebarDropdown/index.spec.jsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.spec.jsx
@@ -6,7 +6,7 @@ import ConfigStore from 'sentry/stores/configStore';
 function renderDropdown(props) {
   const user = ConfigStore.get('user');
   const config = ConfigStore.get('config');
-  const organization = TestStubs.Organization({role: 'member'});
+  const organization = TestStubs.Organization({orgRole: 'member'});
   const routerContext = TestStubs.routerContext([
     {
       organization,


### PR DESCRIPTION
Since `organization.role` is deprecated, I've changed any and all instances of it to be `organization.orgRole`.