### PR TITLE
chore(team-roles): Delete organization.role type

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -67,10 +67,6 @@ export interface Organization extends OrganizationSummary {
   teamRoleList: TeamRole[];
   trustedRelays: Relay[];
   orgRole?: string;
-  /**
-   * @deprecated use orgRole instead
-   */
-  role?: string;
 }
 
 export type Team = {


### PR DESCRIPTION
Requires https://github.com/getsentry/getsentry/pull/9027

This removes `organization.role` type since it is now deprecated. 

