### PR TITLE
fix(api): Remove un-used variable team_list

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -98,7 +98,6 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         if request.auth and not request.user.is_authenticated:
             # TODO: remove this, no longer supported probably
             if hasattr(request.auth, "project"):
-                team_list = list(request.auth.project.teams.all())
                 queryset = Project.objects.filter(id=request.auth.project.id)
             elif request.auth.organization is not None:
                 org = request.auth.organization


### PR DESCRIPTION
The variable `team_list` seems to be un-used, especially since the last change to the nearby querysets made here in 2019 https://github.com/getsentry/sentry/pull/15727