### PR TITLE
fix(issue-alert): Do not sort array of numbers alphabetically

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1474,9 +1474,7 @@ export const findIncompatibleRules = (
       if (firstSeenError || regressionReappearedError) {
         const indices = [firstSeen, regression, reappeared, eventFrequency, userFrequency]
           .filter(idx => idx !== -1)
-          .sort(function (a, b) {
-            return a - b;
-          });
+          .sort((a, b) => a - b);
         return {conditionIndices: indices, filterIndices: null};
       }
     }

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1474,7 +1474,9 @@ export const findIncompatibleRules = (
       if (firstSeenError || regressionReappearedError) {
         const indices = [firstSeen, regression, reappeared, eventFrequency, userFrequency]
           .filter(idx => idx !== -1)
-          .sort();
+          .sort(function (a, b) {
+            return a - b;
+          });
         return {conditionIndices: indices, filterIndices: null};
       }
     }


### PR DESCRIPTION
Regression from https://github.com/getsentry/sentry/pull/41423.

Sorting an array of numbers will be done **_alphabetically_** if a comparator function is not provided.

See:

- https://stackoverflow.com/questions/1063007/how-to-sort-an-array-of-integers-correctly
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description