### PR TITLE
feat(hybrid-cloud): Redirect for non-customer domain url paths

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -16,7 +16,7 @@ from sentry.web.frontend.base import BaseView, OrganizationView
 from sentry.web.helpers import render_to_response
 
 # url names that should only be accessible from a non-customer domain hostname.
-NON_CUSTOMER_DOMAIN_URL_NAMES = ["sentry-organization-create"]
+NON_CUSTOMER_DOMAIN_URL_NAMES = ["sentry-organization-create", "sentry-admin-overview"]
 
 
 def resolve_redirect_url(request, org_slug, user_id=None):

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -579,7 +579,11 @@ urlpatterns += [
         r"^organizations/",
         include(
             [
-                url(r"^new/$", generic_react_page_view),
+                url(
+                    r"^new/$",
+                    generic_react_page_view,
+                    name="sentry-organization-create",
+                ),
                 url(
                     r"^(?P<organization_slug>[\w_-]+)/$",
                     react_page_view,

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -406,7 +406,7 @@ urlpatterns += [
                 url(
                     r"^account/api/auth-tokens/new-token/$",
                     generic_react_page_view,
-                    name="sentry-api-new-auth-token",
+                    name="sentry-account-api-new-auth-token",
                 ),
                 url(r"^account/api/", generic_react_page_view, name="sentry-api"),
                 url(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -317,7 +317,9 @@ urlpatterns += [
                 ),
                 url(
                     r"^remove/$",
-                    RedirectView.as_view(pattern_name="sentry-remove-account", permanent=False),
+                    RedirectView.as_view(
+                        pattern_name="sentry-account-close-account", permanent=False
+                    ),
                 ),
                 url(r"^settings/social/", include("social_auth.urls")),
                 url(r"^", generic_react_page_view),
@@ -417,7 +419,7 @@ urlpatterns += [
                 url(
                     r"^account/close-account/$",
                     generic_react_page_view,
-                    name="sentry-remove-account",
+                    name="sentry-account-close-account",
                 ),
                 url(r"^account/", generic_react_page_view),
                 url(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -250,9 +250,7 @@ urlpatterns += [
                 ),
                 url(
                     r"^settings/appearance/$",
-                    RedirectView.as_view(
-                        pattern_name="sentry-account-settings-appearance", permanent=False
-                    ),
+                    RedirectView.as_view(pattern_name="sentry-account-settings", permanent=False),
                 ),
                 url(
                     r"^settings/identities/$",
@@ -365,11 +363,6 @@ urlpatterns += [
         include(
             [
                 url(r"^account/$", generic_react_page_view, name="sentry-account-settings"),
-                url(
-                    r"^account/$",
-                    generic_react_page_view,
-                    name="sentry-account-settings-appearance",
-                ),
                 url(
                     r"^account/authorizations/$",
                     generic_react_page_view,

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -414,7 +414,7 @@ urlpatterns += [
                     generic_react_page_view,
                     name="sentry-account-close-account",
                 ),
-                url(r"^account/", generic_react_page_view),
+                url(r"^account/", generic_react_page_view, name="sentry-account-settings-generic"),
                 url(
                     r"^organization/",
                     react_page_view,

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -342,7 +342,7 @@ urlpatterns += [
     url(r"^api/$", RedirectView.as_view(pattern_name="sentry-api", permanent=False)),
     url(
         r"^api/applications/$",
-        RedirectView.as_view(pattern_name="sentry-api-applications", permanent=False),
+        RedirectView.as_view(pattern_name="sentry-account-api-applications", permanent=False),
     ),
     url(
         r"^api/new-token/$",
@@ -401,7 +401,7 @@ urlpatterns += [
                 url(
                     r"^account/api/applications/$",
                     generic_react_page_view,
-                    name="sentry-api-applications",
+                    name="sentry-account-api-applications",
                 ),
                 url(
                     r"^account/api/auth-tokens/new-token/$",

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -438,7 +438,7 @@ class AuthLoginCustomerDomainTest(TestCase):
         resp = self.client.post(
             self.path,
             {"username": self.user.username, "password": "admin", "op": "login"},
-            HTTP_HOST="albertos-apples.testserver",
+            SERVER_NAME="albertos-apples.testserver",
             follow=True,
         )
         assert resp.status_code == 200
@@ -542,7 +542,7 @@ class AuthLoginCustomerDomainTest(TestCase):
             resp = self.client.post(
                 self.path,
                 {"username": user.username, "password": "admin", "op": "login"},
-                HTTP_HOST="albertos-apples.testserver",
+                SERVER_NAME="albertos-apples.testserver",
                 follow=True,
             )
 


### PR DESCRIPTION
There are url paths that should not be accessible within a customer domain context (i.e. `orgslug.sentry.io`).

One example would be when a user creates a new organization (`/organizations/new/`). So if `orgslug.sentry.io/organizations/new/` is accessed, we redirect the user to `sentry.io/organizations/new/`.