### PR TITLE
feat(sampling): Remove LA docs links

### DIFF
--- a/static/app/views/settings/project/server-side-sampling/samplingPromo.tsx
+++ b/static/app/views/settings/project/server-side-sampling/samplingPromo.tsx
@@ -7,15 +7,13 @@ import ButtonBar from 'sentry/components/buttonBar';
 import OnboardingPanel from 'sentry/components/onboardingPanel';
 import {t} from 'sentry/locale';
 
-import {SERVER_SIDE_SAMPLING_DOC_LINK} from './utils';
-
 type Props = {
   hasAccess: boolean;
   onGetStarted: () => void;
   onReadDocs: () => void;
 };
 
-export function SamplingPromo({onGetStarted, onReadDocs, hasAccess}: Props) {
+export function SamplingPromo({onGetStarted, hasAccess}: Props) {
   return (
     <OnboardingPanel image={<img src={onboardingServerSideSampling} />}>
       <h3>{t('Sample for relevancy')}</h3>
@@ -27,9 +25,6 @@ export function SamplingPromo({onGetStarted, onReadDocs, hasAccess}: Props) {
       <ButtonList gap={1}>
         <Button priority="primary" onClick={onGetStarted} disabled={!hasAccess}>
           {t('Start Setup')}
-        </Button>
-        <Button href={SERVER_SIDE_SAMPLING_DOC_LINK} onClick={onReadDocs} external>
-          {t('Read Docs')}
         </Button>
       </ButtonList>
     </OnboardingPanel>

--- a/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
+++ b/static/app/views/settings/project/server-side-sampling/serverSideSampling.tsx
@@ -19,11 +19,10 @@ import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import FeatureBadge from 'sentry/components/featureBadge';
 import HookOrDefault from 'sentry/components/hookOrDefault';
-import ExternalLink from 'sentry/components/links/externalLink';
 import {Panel, PanelFooter, PanelHeader} from 'sentry/components/panels';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {IconAdd} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import {ServerSideSamplingStore} from 'sentry/stores/serverSideSamplingStore';
 import space from 'sentry/styles/space';
@@ -69,7 +68,7 @@ import {SamplingProjectIncompatibleAlert} from './samplingProjectIncompatibleAle
 import {SamplingPromo} from './samplingPromo';
 import {SamplingSDKClientRateChangeAlert} from './samplingSDKClientRateChangeAlert';
 import {SamplingSDKUpgradesAlert} from './samplingSDKUpgradesAlert';
-import {isUniformRule, SERVER_SIDE_SAMPLING_DOC_LINK} from './utils';
+import {isUniformRule} from './utils';
 
 const LimitedAvailabilityProgramEndingAlert = HookOrDefault({
   hookName: 'component:dynamic-sampling-limited-availability-program-ending',
@@ -501,14 +500,8 @@ export function ServerSideSampling({project}: Props) {
           action={<SamplingFeedback />}
         />
         <TextBlock>
-          {tct(
-            'Improve the accuracy of your [performanceMetrics: performance metrics] and [targetTransactions: target those transactions] which are most valuable for your organization. Server-side rules are applied immediately, without having to re-deploy your app.',
-            {
-              performanceMetrics: (
-                <ExternalLink href="https://docs.sentry.io/product/performance/dsla-metrics/#metrics-and-sampling" />
-              ),
-              targetTransactions: <ExternalLink href={SERVER_SIDE_SAMPLING_DOC_LINK} />,
-            }
+          {t(
+            'Improve the accuracy of your performance metrics and target those transactions which are most valuable for your organization. Server-side rules are applied immediately, without having to re-deploy your app.'
           )}
         </TextBlock>
         <PermissionAlert
@@ -647,13 +640,6 @@ export function ServerSideSampling({project}: Props) {
             />
             <RulesPanelFooter>
               <ButtonBar gap={1}>
-                <Button
-                  href={SERVER_SIDE_SAMPLING_DOC_LINK}
-                  onClick={handleReadDocs}
-                  external
-                >
-                  {t('Read Docs')}
-                </Button>
                 <GuideAnchor
                   target="add_conditional_rule"
                   disabled={!uniformRule?.active || !hasAccess || rules.length !== 1}


### PR DESCRIPTION
These docs will likely be removed before we kill this UI, so removing all the references on landing page so that we don't get broken links.