### PR TITLE
feat(discover-homepage): Default feature flag to True

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -975,7 +975,7 @@ SENTRY_FEATURES = {
     # Enables events endpoint usage on discover and dashboards frontend
     "organizations:discover-frontend-use-events-endpoint": True,
     # Enable using All Events as the landing page for Discover
-    "organizations:discover-query-builder-as-landing-page": False,
+    "organizations:discover-query-builder-as-landing-page": True,
     # Enables events endpoint usage on performance frontend
     "organizations:performance-frontend-use-events-endpoint": True,
     # Enables events endpoint rate limit

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -48,6 +48,7 @@ class OrganizationSerializerTest(TestCase):
             "dashboards-top-level-filter",
             "discover-basic",
             "discover-query",
+            "discover-query-builder-as-landing-page",
             "event-attachments",
             "integrations-alert-rule",
             "integrations-chat-unfurl",


### PR DESCRIPTION
This feature has been GA'd for a while now. Defaulting the feature flag to True for self hosted releases