### PR TITLE
feat(metrics): Add abnormal_mechanism tag & values to indexer

### DIFF
--- a/src/sentry/sentry_metrics/indexer/strings.py
+++ b/src/sentry/sentry_metrics/indexer/strings.py
@@ -115,6 +115,9 @@ SHARED_TAG_STRINGS = {
     "good": PREFIX + 233,
     "bad": PREFIX + 234,
     "meh": PREFIX + 235,
+    "abnormal_mechanism": PREFIX + 236,  # release health
+    "anr_foreground": PREFIX + 237,  # release health
+    "anr_background": PREFIX + 238,  # release health
     # GENERAL/MISC (don't have a category)
     "": PREFIX + 1000,
 }


### PR DESCRIPTION
Add `abnormal_mechanism`, `anr_foreground` and `anr_background`
values to string indexer to optimize querying the new tags that
are going to be extracted.