### PR TITLE
fix(global-search): Remove scroll logic on mouse hover and keep open after focus is lost

### DIFF
--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -161,6 +161,7 @@ function Search({
       defaultHighlightedIndex={0}
       onSelect={handleSelectItem}
       closeOnSelect={closeOnSelect ?? true}
+      isOpen
     >
       {({getInputProps, isOpen, inputValue, ...autocompleteProps}) => {
         const searchQuery = inputValue.toLowerCase().trim();

--- a/static/app/components/search/searchResultWrapper.tsx
+++ b/static/app/components/search/searchResultWrapper.tsx
@@ -1,17 +1,7 @@
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
-interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  highlighted?: boolean;
-}
-
-function scrollIntoView(element: HTMLDivElement) {
-  element?.scrollIntoView?.({block: 'nearest'});
-}
-
-const SearchResultWrapper = styled(({highlighted, ...props}: Props) => (
-  <div {...props} ref={highlighted ? scrollIntoView : undefined} />
-))`
+const SearchResultWrapper = styled('div')<{highlighted?: boolean}>`
   cursor: pointer;
   display: block;
   color: ${p => p.theme.textColor};


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry/issues/41935

- Fixes jittery scrolling in the global search. This logic is no longer necessary because Autocomplete does this on keyboard events.
- Keeps the search open at all times, even after focus is lost. Since it's a full page component, there shouldn't be a reason we need to ever close it