### PR TITLE
chore(hybrid-cloud): Add test to check that ApiOrganization works for feature.has

### DIFF
--- a/tests/sentry/testutils/helpers/test_features.py
+++ b/tests/sentry/testutils/helpers/test_features.py
@@ -1,4 +1,5 @@
 from sentry import features
+from sentry.services.hybrid_cloud.organization import ApiOrganization, organization_service
 from sentry.testutils import TestCase
 from sentry.testutils.helpers import with_feature
 
@@ -13,3 +14,25 @@ class TestTestUtilsFeatureHelper(TestCase):
     @with_feature("organizations:global-views")
     def test_with_feature(self):
         assert features.has("organizations:global-views", self.org)
+
+    def test_feature_with_api_organization(self):
+
+        with self.feature({"organizations:customer-domains": False}):
+            org_context = organization_service.get_organization_by_slug(
+                slug=self.org.slug, only_visible=False, user_id=None
+            )
+            assert org_context
+            assert org_context.organization
+            assert isinstance(org_context.organization, ApiOrganization)
+
+            assert features.has("organizations:customer-domains", org_context.organization) is False
+
+        with self.feature({"organizations:customer-domains": True}):
+            org_context = organization_service.get_organization_by_slug(
+                slug=self.org.slug, only_visible=False, user_id=None
+            )
+            assert org_context
+            assert org_context.organization
+            assert isinstance(org_context.organization, ApiOrganization)
+
+            assert features.has("organizations:customer-domains", org_context.organization)


### PR DESCRIPTION
We are beginning to make use of the organization service, and injecting them into `feature.has()` in some places (for example in https://github.com/getsentry/sentry/pull/41592).

The pattern will be something like:

```python
org_context = organization_service.get_organization_by_slug(
    slug=org_slug, only_visible=False, user_id=user
)

if features.has("organizations:feature-name", org_context.organization):
    pass
```

Here, `org_context.organization` is not an instance of `Organization`, but is instead an instance of `ApiOrganization`. 

This will be a new pattern of checking for organization features, and I've added a test to ensure it works.