### PR TITLE
ref(plugin): split 'to' phone numbers without regex in Twilio plugin

### DIFF
--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -48,7 +48,7 @@ def clean_phone(phone):
 #      in theory only cleaned data would make it to the plugin via the form,
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
-    return set(filter(bool, re.split(r"\s*,\s*|\s+", data)))
+    return set(filter(bool, re.split(r"\s*,\s*", data)))
 
 
 class TwilioConfigurationForm(forms.Form):

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from typing import Any
 
 import phonenumbers
@@ -48,7 +47,9 @@ def clean_phone(phone):
 #      in theory only cleaned data would make it to the plugin via the form,
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
-    return set(filter(bool, re.split(r"\s*,\s*", data)))
+    phone_numbers = set(data.split(","))
+    stripped_phone_numbers = {num.strip() for num in phone_numbers}
+    return stripped_phone_numbers
 
 
 class TwilioConfigurationForm(forms.Form):

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -6,7 +6,27 @@ from exam import fixture
 from sentry.models import Rule
 from sentry.plugins.base import Notification
 from sentry.testutils import PluginTestCase, TestCase
-from sentry_plugins.twilio.plugin import TwilioConfigurationForm, TwilioPlugin
+from sentry_plugins.twilio.plugin import TwilioConfigurationForm, TwilioPlugin, split_sms_to
+
+
+class TwilioPluginSMSSplitTest(TestCase):
+    def test_valid_split_sms_to(self):
+        to = "330-509-3095, (330)-509-3095, +13305093095, 4045550144"
+        expected = {"330-509-3095", "(330)-509-3095", "+13305093095", "4045550144"}
+        actual = split_sms_to(to)
+        assert expected == actual
+
+    def test_valid_split_sms_to_with_extra_spaces(self):
+        to = "330-509-3095       ,            (330)-509-3095,     +13305093095,    4045550144"
+        expected = {"330-509-3095", "(330)-509-3095", "+13305093095", "4045550144"}
+        actual = split_sms_to(to)
+        assert expected == actual
+
+    def test_split_sms_to_with_single_number(self):
+        to = "555-555-5555"
+        expected = {"555-555-5555"}
+        actual = split_sms_to(to)
+        assert expected == actual
 
 
 class TwilioConfigurationFormTest(TestCase):


### PR DESCRIPTION
Removes the use of `re.split` for Python's standard string split. The
previous regex was potentially vulnerable to a ReDOS by passing in a string with
multiple spaces in a row after the comma. See [here](https://github.com/getsentry/sentry/security/code-scanning/98) for more details.

Using Python's string split combined with `strip()` to remove any whitespace
avoids this problem and maintains expected functionality.

Added test coverage for the phone number splitting.