### PR TITLE
feat(serializers): Fault-tolerant serialization

### DIFF
--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -93,7 +93,7 @@ class Serializer:
         """See documentation for `serialize`."""
         if obj is None:
             return None
-        return self.serialize(obj, attrs, user, **kwargs)
+        return self._serialize(obj, attrs, user, **kwargs)
 
     def get_attrs(self, item_list: List[Any], user: Any, **kwargs: Any) -> MutableMapping[Any, Any]:
         """
@@ -105,6 +105,15 @@ class Serializer:
         :returns A mapping of items from the `item_list` to an Object.
         """
         return {}
+
+    def _serialize(
+        self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
+    ) -> MutableMapping[str, JSONData]:
+        try:
+            return self.serialize(obj, attrs, user, **kwargs)
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+            return None
 
     def serialize(
         self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -108,7 +108,7 @@ class Serializer:
 
     def _serialize(
         self, obj: Any, attrs: Mapping[Any, Any], user: Any, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
+    ) -> Optional[MutableMapping[str, JSONData]]:
         try:
             return self.serialize(obj, attrs, user, **kwargs)
         except Exception as e:

--- a/tests/sentry/api/serializers/test_base.py
+++ b/tests/sentry/api/serializers/test_base.py
@@ -16,6 +16,22 @@ class VariadicSerializer(Serializer):
         return {"kw": kw}
 
 
+class FailingChildSerializer(Serializer):
+    def serialize(self, obj, attrs, user, **kwargs):
+        raise Exception
+
+
+class ParentSerializer(Serializer):
+    def get_attrs(self, item_list, user, **kwargs):
+        return {item: {"child_data": Foo()} for item in item_list}
+
+    def serialize(self, obj, attrs, user, **kwargs):
+        return {
+            "parent": "something",
+            "child": serialize(attrs["child_data"], serializer=FailingChildSerializer()),
+        }
+
+
 class BaseSerializerTest(TestCase):
     def test_serialize(self):
         assert serialize([]) == []
@@ -53,3 +69,10 @@ class BaseSerializerTest(TestCase):
         user = self.create_user()
         result = serialize(foo, user, VariadicSerializer(), kw="keyword")
         assert result["kw"] == "keyword"
+
+    def test_child_serializer_failure(self):
+        foo = Foo()
+
+        result = serialize(foo, serializer=ParentSerializer())
+        assert result["parent"] == "something"
+        assert result["child"] is None


### PR DESCRIPTION
## Objective:

We should not let failing child serializers make the root serializer return an error.

Serializers should have an error boundary that returns None and let the root serializer succeed.