### PR TITLE
feat(issue-alert): use prefix sum for calculating bucket sums

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, Mapping, Sequence, Tuple
+from typing import Any, Dict, Mapping, Tuple
 
 from django import forms
 from django.core.cache import cache
@@ -131,7 +131,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
         return current_value > value
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: Sequence[Dict[str, Any]]
+        self, activity: ConditionActivity, buckets: Dict[datetime, int]
     ) -> bool:
         raise NotImplementedError
 
@@ -216,7 +216,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         return sums[event.group_id]
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: Sequence[Dict[str, Any]]
+        self, activity: ConditionActivity, buckets: Dict[datetime, int]
     ) -> bool:
         interval, value = self._get_options()
         if not (interval and value is not None):
@@ -230,7 +230,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
 
         end = round_to_five_minute(activity.timestamp)
         start = round_to_five_minute(end - interval_delta)
-        count = buckets[end] - buckets.get(start, 0)
+        count = buckets.get(end, 0) - buckets.get(start, 0)
 
         return count > value
 

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -21,6 +21,7 @@ from sentry.types.condition_activity import (
     FREQUENCY_CONDITION_BUCKET_SIZE,
     ConditionActivity,
     ConditionActivityType,
+    round_to_five_minute,
 )
 from sentry.types.issues import GROUP_TYPE_TO_CATEGORY, GroupType
 from sentry.utils.snuba import SnubaQueryParams, bulk_raw_query, parse_snuba_datetime, raw_query
@@ -405,11 +406,11 @@ def apply_frequency_conditions(
                 # If there are no issue state change conditions, then we won't have any initial activities to base our
                 # frequency condition queries off of. Instead, we take the first frequency condition and create the
                 # initial activities from that
-                for bucket in buckets:
+                for bucket_time in buckets.keys():
                     activity = ConditionActivity(
                         group,
                         ConditionActivityType.FREQUENCY_CONDITION,
-                        bucket["roundedTime"] + FREQUENCY_CONDITION_BUCKET_SIZE,
+                        bucket_time,
                     )
                     try:
                         if conditions[0].passes_activity_frequency(activity, buckets):
@@ -437,11 +438,11 @@ def apply_frequency_conditions(
                 project, start, end, group, dataset_map.get(group, None)
             )
             for condition in conditions:
-                for bucket in buckets:
+                for bucket_time in buckets.keys():
                     activity = ConditionActivity(
                         group,
                         ConditionActivityType.FREQUENCY_CONDITION,
-                        bucket["roundedTime"] + FREQUENCY_CONDITION_BUCKET_SIZE,
+                        bucket_time,
                     )
                     try:
                         if condition.passes_activity_frequency(activity, buckets):
@@ -485,20 +486,32 @@ def get_frequency_buckets(
                 ("toStartOfFiveMinute", "timestamp", "roundedTime"),
                 ("count", "roundedTime", "bucketCount"),
             ],
-            "orderby": ["roundedTime"],
+            "orderby": ["-roundedTime"],
             "groupby": ["roundedTime"],
             "selected_columns": ["roundedTime", "bucketCount"],
             "limit": PREVIEW_TIME_RANGE // FREQUENCY_CONDITION_BUCKET_SIZE + 1,  # at most ~4k
         },
     )
-
     bucket_counts: Sequence[Dict[str, Any]] = raw_query(
         **kwargs, use_cache=True, referrer="preview.get_frequency_buckets"
     ).get("data", [])
 
     for bucket in bucket_counts:
         bucket["roundedTime"] = parse_snuba_datetime(bucket["roundedTime"])
-    return bucket_counts
+
+    rounded_time = round_to_five_minute(start)
+    rounded_end = round_to_five_minute(end)
+    cumulative_sum = 0
+    buckets = {}
+    # the query result only contains buckets that have a positive count
+    # here we fill in the empty buckets and accumulate the sum
+    while rounded_time <= rounded_end:
+        if bucket_counts and bucket_counts[-1]["roundedTime"] == rounded_time:
+            cumulative_sum += bucket_counts.pop()["bucketCount"]
+        buckets[rounded_time] = cumulative_sum
+        rounded_time += FREQUENCY_CONDITION_BUCKET_SIZE
+
+    return buckets
 
 
 class PreviewException(Exception):

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -467,12 +467,12 @@ def get_frequency_buckets(
     end: datetime,
     group_id: int,
     dataset: Dataset,
-) -> Sequence[Dict[str, Any]]:
+) -> Dict[datetime, int]:
     """
     Puts the events of a group into buckets, and returns the bucket counts.
     """
     if dataset not in UPDATE_KWARGS_FOR_GROUP:
-        return []
+        return {}
 
     # TODO: support counting of other fields (# of unique users, ...)
     kwargs = UPDATE_KWARGS_FOR_GROUP[dataset](
@@ -492,7 +492,7 @@ def get_frequency_buckets(
             "limit": PREVIEW_TIME_RANGE // FREQUENCY_CONDITION_BUCKET_SIZE + 1,  # at most ~4k
         },
     )
-    bucket_counts: Sequence[Dict[str, Any]] = raw_query(
+    bucket_counts = raw_query(
         **kwargs, use_cache=True, referrer="preview.get_frequency_buckets"
     ).get("data", [])
 

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -22,3 +22,9 @@ class ConditionActivity:
     type: ConditionActivityType
     timestamp: datetime
     data: Dict[str, Any] = field(default_factory=dict)
+
+
+def round_to_five_minute(time: datetime) -> datetime:
+    return time - timedelta(
+        minutes=time.minute % 5, seconds=time.second, microseconds=time.microsecond
+    )


### PR DESCRIPTION
Iterating over all the buckets in `passes_activity_frequency` is to slow, instead we use prefix sums to quickly query range sums.