### PR TITLE
fix(twilio): split on any whitespace between phone numbers

### DIFF
--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import phonenumbers
@@ -47,7 +48,9 @@ def clean_phone(phone):
 #      in theory only cleaned data would make it to the plugin via the form,
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
-    phone_numbers = set(data.split(","))
+    # we use regex below to split the string since we allow any type of whitespace (ex. \n)
+    # around a comma to separate phone numbers
+    phone_numbers = set(re.split(r"\s*,\s*", data))
     stripped_phone_numbers = {num.strip() for num in phone_numbers}
     return stripped_phone_numbers
 

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -22,9 +22,27 @@ class TwilioPluginSMSSplitTest(TestCase):
         actual = split_sms_to(to)
         assert expected == actual
 
+    def test_valid_split_sms_to_with_no_whitespace(self):
+        to = "330-509-3095,(330)-509-3095,+13305093095,4045550144"
+        expected = {"330-509-3095", "(330)-509-3095", "+13305093095", "4045550144"}
+        actual = split_sms_to(to)
+        assert expected == actual
+
     def test_split_sms_to_with_single_number(self):
         to = "555-555-5555"
         expected = {"555-555-5555"}
+        actual = split_sms_to(to)
+        assert expected == actual
+
+    def test_valid_split_sms_to_newline(self):
+        to = "330-509-3095,\n(330)-509-3095\n,+13305093095\n,\n4045550144"
+        expected = {"330-509-3095", "(330)-509-3095", "+13305093095", "4045550144"}
+        actual = split_sms_to(to)
+        assert expected == actual
+
+    def test_valid_split_sms_to_with_extra_newlines(self):
+        to = "330-509-3095\n\n\n\n\n,\n\n\n\n\n\n\n\n\n(330)-509-3095,\n\n\n\n+13305093095,\n\n4045550144"
+        expected = {"330-509-3095", "(330)-509-3095", "+13305093095", "4045550144"}
         actual = split_sms_to(to)
         assert expected == actual
 


### PR DESCRIPTION
Fixes SENTRY-TCG.

We allow users to split phone numbers with any valid whitespace around a comma, not just spaces. I've added additional tests to cover splitting by newline characters.