### PR TITLE
fix(profiling): fix search matching

### DIFF
--- a/static/app/components/profiling/flamegraphSearch.spec.tsx
+++ b/static/app/components/profiling/flamegraphSearch.spec.tsx
@@ -1,0 +1,44 @@
+import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
+
+import {searchFzf, searchRegExp} from './flamegraphSearch';
+
+const f = (name: string) => {
+  return {
+    frame: {
+      name,
+    },
+  } as FlamegraphFrame;
+};
+
+describe('fzf', () => {
+  it('matches only first occurence', () => {
+    expect(searchFzf(f('foofoo'), new Map(), 'foo')).toMatchObject({
+      start: 0,
+      end: 3,
+      matches: [[0, 3]],
+    });
+  });
+
+  it('prefers matches at start', () => {
+    expect(searchFzf(f('f'), new Map(), 'f').score).toBeGreaterThan(
+      searchFzf(f('of'), new Map(), 'f').score
+    );
+  });
+
+  it('penalizes gaps', () => {
+    expect(searchFzf(f('f oo'), new Map(), 'foo').score).toBeLessThan(
+      searchFzf(f('foo'), new Map(), 'foo').score
+    );
+  });
+
+  it('narrows down indices on backtracking', () => {
+    // https://github.com/junegunn/fzf/blob/f81feb1e69e5cb75797d50817752ddfe4933cd68/src/algo/algo.go#L13
+    expect(searchFzf(f('a_____b___abc__'), new Map(), 'abc').matches).toEqual([[10, 13]]);
+  });
+});
+
+describe('regexp', () => {
+  it('finds all matches', () => {
+    expect(searchRegExp(f('foofoo'), new Map(), 'foo', 'g')).toEqual([0, 3]);
+  });
+});

--- a/static/app/utils/profiling/validators/regExp.tsx
+++ b/static/app/utils/profiling/validators/regExp.tsx
@@ -1,13 +1,5 @@
-const REG_EXP = /(.*)\/([dgimsuy])/;
+const REG_EXP = /^\/(.*)\/([dgimsuy])?/;
 
 export const parseRegExp = (string: string): RegExpMatchArray | null => {
   return string.match(REG_EXP);
-};
-
-export const isRegExpString = (string?: string): boolean => {
-  if (!string?.trim().length) {
-    return false;
-  }
-
-  return REG_EXP.test(string);
 };


### PR DESCRIPTION
Fix for https://github.com/getsentry/team-profiling/issues/118

I went ahead and added some very basic tests for fzf and slightly modified the regexp required input so that it has to start with a forward slash and I actually made flags optional.

<img width="1292" alt="CleanShot 2022-12-05 at 11 48 34@2x" src="https://user-images.githubusercontent.com/9317857/205695171-074168b1-e152-4c4d-bb90-c4f531153694.png">
