### PR TITLE
feat(alert-preview): user frequency and interval comparison

### DIFF
--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, Mapping, Sequence, Tuple
+from typing import Any, Dict, Mapping, Tuple
 
 from django import forms
 from django.core.cache import cache
@@ -159,7 +159,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
 
         return result > value
 
-    def get_preview_aggregate(self):
+    def get_preview_aggregate(self) -> Tuple[str, str]:
         raise NotImplementedError
 
     def query(self, event: GroupEvent, start: datetime, end: datetime, environment_id: str) -> int:
@@ -238,7 +238,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         )
         return sums[event.group_id]
 
-    def get_preview_aggregate(self):
+    def get_preview_aggregate(self) -> Tuple[str, str]:
         return "count", "roundedTime"
 
 
@@ -260,7 +260,7 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
         )
         return totals[event.group_id]
 
-    def get_preview_aggregate(self):
+    def get_preview_aggregate(self) -> Tuple[str, str]:
         return "uniq", "user"
 
 
@@ -381,7 +381,7 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
         return 0
 
     def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: Sequence[Dict[str, Any]]
+        self, activity: ConditionActivity, buckets: Dict[datetime, int]
     ) -> bool:
         raise NotImplementedError
 

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -394,4 +394,8 @@ def bucket_count(start: datetime, end: datetime, buckets: Dict[datetime, int]) -
 
 
 def percent_increase(result: int, comparison_result: int) -> int:
-    return int(max(0, ((result / comparison_result) * 100) - 100)) if comparison_result > 0 else 0
+    return (
+        int(max(0, ((result - comparison_result) / comparison_result * 100)))
+        if comparison_result > 0
+        else 0
+    )

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, Mapping, Tuple
+from typing import Any, Dict, Mapping, Tuple, Sequence
 
 from django import forms
 from django.core.cache import cache
@@ -133,6 +133,33 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
     def passes_activity_frequency(
         self, activity: ConditionActivity, buckets: Dict[datetime, int]
     ) -> bool:
+        interval, value = self._get_options()
+        if not (interval and value is not None):
+            return False
+        interval_delta = self.intervals[interval][1]
+        comparison_type = self.get_option("comparisonType", COMPARISON_TYPE_COUNT)
+
+        # extrapolate if interval less than bucket size
+        # if comparing percent increase, both intervals will be increased, so do not extrapolate value
+        if interval_delta < FREQUENCY_CONDITION_BUCKET_SIZE:
+            if comparison_type != COMPARISON_TYPE_PERCENT:
+                value *= int(FREQUENCY_CONDITION_BUCKET_SIZE / interval_delta)
+            interval_delta = FREQUENCY_CONDITION_BUCKET_SIZE
+
+        result = bucket_count(activity.timestamp - interval_delta, activity.timestamp, buckets)
+
+        if comparison_type == COMPARISON_TYPE_PERCENT:
+            comparison_interval = comparison_intervals[self.get_option("comparisonInterval")][1]
+            comparison_end = activity.timestamp - comparison_interval
+
+            comparison_result = bucket_count(
+                comparison_end - interval_delta, comparison_end, buckets
+            )
+            result = percent_increase(result, comparison_result)
+
+        return result > value
+
+    def get_preview_aggregate(self):
         raise NotImplementedError
 
     def query(self, event: GroupEvent, start: datetime, end: datetime, environment_id: str) -> int:
@@ -172,11 +199,7 @@ class BaseEventFrequencyCondition(EventCondition, abc.ABC):
                 comparison_result = self.query(
                     event, comparison_end - duration, comparison_end, environment_id=environment_id
                 )
-                result = (
-                    int(max(0, ((result / comparison_result) * 100) - 100))
-                    if comparison_result > 0
-                    else 0
-                )
+                result = percent_increase(result, comparison_result)
 
         return result
 
@@ -215,24 +238,8 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         )
         return sums[event.group_id]
 
-    def passes_activity_frequency(
-        self, activity: ConditionActivity, buckets: Dict[datetime, int]
-    ) -> bool:
-        interval, value = self._get_options()
-        if not (interval and value is not None):
-            return False
-        interval_delta = self.intervals[interval][1]
-
-        # extrapolate if interval less than bucket size
-        if interval_delta < FREQUENCY_CONDITION_BUCKET_SIZE:
-            value *= int(FREQUENCY_CONDITION_BUCKET_SIZE / interval_delta)
-            interval_delta = FREQUENCY_CONDITION_BUCKET_SIZE
-
-        end = round_to_five_minute(activity.timestamp)
-        start = round_to_five_minute(end - interval_delta)
-        count = buckets.get(end, 0) - buckets.get(start, 0)
-
-        return count > value
+    def get_preview_aggregate(self):
+        return "count", "roundedTime"
 
 
 class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
@@ -252,6 +259,9 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
             jitter_value=event.group_id,
         )
         return totals[event.group_id]
+
+    def get_preview_aggregate(self):
+        return "uniq", "user"
 
 
 percent_intervals = {
@@ -369,3 +379,19 @@ class EventFrequencyPercentCondition(BaseEventFrequencyCondition):
             return percent
 
         return 0
+
+    def passes_activity_frequency(
+        self, activity: ConditionActivity, buckets: Sequence[Dict[str, Any]]
+    ) -> bool:
+        raise NotImplementedError
+
+
+def bucket_count(start: datetime, end: datetime, buckets: Dict[datetime, int]) -> int:
+    rounded_end = round_to_five_minute(end)
+    rounded_start = round_to_five_minute(start)
+    count = buckets.get(rounded_end, 0) - buckets.get(rounded_start, 0)
+    return count
+
+
+def percent_increase(result: int, comparison_result: int) -> int:
+    return int(max(0, ((result / comparison_result) * 100) - 100)) if comparison_result > 0 else 0

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, Mapping, Tuple, Sequence
+from typing import Any, Dict, Mapping, Sequence, Tuple
 
 from django import forms
 from django.core.cache import cache

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -398,6 +398,7 @@ def apply_frequency_conditions(
     if condition_match == "all":
         for group, activities in group_activity.items():
             init_activities_from_freq_cond = False
+            passes = [True] * len(activities)
             for conditions in condition_types.values():
                 # reuse frequency buckets for conditions of the same type
                 try:
@@ -429,7 +430,9 @@ def apply_frequency_conditions(
                         except NotImplementedError:
                             raise PreviewException
 
-                passes = [True] * len(activities)
+                    # recreate passes array
+                    passes = [True] * len(activities)
+
                 for condition in conditions[1:] if skip_first else conditions:
                     for i, activity in enumerate(activities):
                         try:
@@ -440,11 +443,9 @@ def apply_frequency_conditions(
                         except NotImplementedError:
                             raise PreviewException
 
-                filtered_activity[group] = [
-                    activities[i] for i in range(len(activities)) if passes[i]
-                ]
+            filtered_activity[group] = [activities[i] for i in range(len(activities)) if passes[i]]
 
-            return filtered_activity
+        return filtered_activity
     elif condition_match == "any":
         # Find buckets that pass at least one condition, and create condition activity from it
         for group, activities in group_activity.items():

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -217,7 +217,7 @@ def get_top_groups(
     Filters the activity to contain only groups that have the most events (out of the given groups) in the past 2 weeks.
     If no groups are provided because there are no issue state change conditions, returns the top groups overall.
 
-    Since frequency conditions require one snuba query per groups, we need to limit the number groups we process.
+    Since frequency conditions require snuba query(s), we need to limit the number groups we process.
     """
     if has_issue_state_condition:
         datasets = {dataset_map.get(group) for group in condition_activity.keys()}
@@ -387,68 +387,92 @@ def apply_frequency_conditions(
     """
     Applies frequency conditions to issue state activity.
     """
-    # TODO: separate the conditions so we can reuse queries for conditions of the same class
-    conditions = []
+    condition_types = defaultdict(list)
     for condition_data in frequency_conditions:
         condition_cls = rules.get(condition_data["id"])
         if condition_cls is None:
             raise PreviewException
-        conditions.append(condition_cls(project, data=condition_data))
+        condition_types[condition_data["id"]].append(condition_cls(project, data=condition_data))
 
+    filtered_activity = defaultdict(list)
     if condition_match == "all":
-        filtered_activity = {}
         for group, activities in group_activity.items():
-            # TODO: only EventFrequencyCondition is supported right now, so we can reuse the same query
-            buckets = get_frequency_buckets(
-                project, start, end, group, dataset_map.get(group, None)
-            )
-            if not has_issue_state_condition:
-                # If there are no issue state change conditions, then we won't have any initial activities to base our
-                # frequency condition queries off of. Instead, we take the first frequency condition and create the
-                # initial activities from that
-                for bucket_time in buckets.keys():
-                    activity = ConditionActivity(
+            init_activities_from_freq_cond = False
+            for conditions in condition_types.values():
+                # reuse frequency buckets for conditions of the same type
+                try:
+                    buckets = get_frequency_buckets(
+                        project,
+                        start,
+                        end,
                         group,
-                        ConditionActivityType.FREQUENCY_CONDITION,
-                        bucket_time,
+                        dataset_map[group],
+                        conditions[0].get_preview_aggregate(),
                     )
-                    try:
-                        if conditions[0].passes_activity_frequency(activity, buckets):
-                            activities.append(activity)
-                    except NotImplementedError:
-                        raise PreviewException
+                except NotImplementedError:
+                    raise PreviewException
+                skip_first = False
+                if not has_issue_state_condition and not init_activities_from_freq_cond:
+                    # If there are no issue state change conditions, then we won't have any initial activities
+                    # to base our frequency condition queries off of. Instead, we take the first frequency condition and
+                    # create the initial activities from that
+                    init_activities_from_freq_cond = skip_first = True
+                    for bucket_time in buckets.keys():
+                        activity = ConditionActivity(
+                            group,
+                            ConditionActivityType.FREQUENCY_CONDITION,
+                            bucket_time,
+                        )
+                        try:
+                            if conditions[0].passes_activity_frequency(activity, buckets):
+                                activities.append(activity)
+                        except NotImplementedError:
+                            raise PreviewException
 
-            passes = [True] * len(activities)
-            for condition in conditions if has_issue_state_condition else conditions[1:]:
-                for i, activity in enumerate(activities):
-                    try:
-                        if passes[i] and not condition.passes_activity_frequency(activity, buckets):
-                            passes[i] = False
-                    except NotImplementedError:
-                        raise PreviewException
+                passes = [True] * len(activities)
+                for condition in conditions[1:] if skip_first else conditions:
+                    for i, activity in enumerate(activities):
+                        try:
+                            if passes[i] and not condition.passes_activity_frequency(
+                                activity, buckets
+                            ):
+                                passes[i] = False
+                        except NotImplementedError:
+                            raise PreviewException
 
-            filtered_activity[group] = [activities[i] for i in range(len(activities)) if passes[i]]
+                filtered_activity[group] = [
+                    activities[i] for i in range(len(activities)) if passes[i]
+                ]
 
-        return filtered_activity
+            return filtered_activity
     elif condition_match == "any":
         # Find buckets that pass at least one condition, and create condition activity from it
         for group, activities in group_activity.items():
             pass_buckets = set()
-            buckets = get_frequency_buckets(
-                project, start, end, group, dataset_map.get(group, None)
-            )
-            for condition in conditions:
-                for bucket_time in buckets.keys():
-                    activity = ConditionActivity(
+            for conditions in condition_types.values():
+                try:
+                    buckets = get_frequency_buckets(
+                        project,
+                        start,
+                        end,
                         group,
-                        ConditionActivityType.FREQUENCY_CONDITION,
-                        bucket_time,
+                        dataset_map[group],
+                        conditions[0].get_preview_aggregate(),
                     )
-                    try:
-                        if condition.passes_activity_frequency(activity, buckets):
-                            pass_buckets.add(activity.timestamp)
-                    except NotImplementedError:
-                        raise PreviewException
+                except NotImplementedError:
+                    raise PreviewException
+                for condition in conditions:
+                    for bucket_time in buckets.keys():
+                        activity = ConditionActivity(
+                            group,
+                            ConditionActivityType.FREQUENCY_CONDITION,
+                            bucket_time,
+                        )
+                        try:
+                            if condition.passes_activity_frequency(activity, buckets):
+                                pass_buckets.add(activity.timestamp)
+                        except NotImplementedError:
+                            raise PreviewException
 
             for bucket in pass_buckets:
                 activities.append(
@@ -467,6 +491,7 @@ def get_frequency_buckets(
     end: datetime,
     group_id: int,
     dataset: Dataset,
+    aggregate: Tuple[str, str],
 ) -> Dict[datetime, int]:
     """
     Puts the events of a group into buckets, and returns the bucket counts.
@@ -474,7 +499,6 @@ def get_frequency_buckets(
     if dataset not in UPDATE_KWARGS_FOR_GROUP:
         return {}
 
-    # TODO: support counting of other fields (# of unique users, ...)
     kwargs = UPDATE_KWARGS_FOR_GROUP[dataset](
         group_id,
         {
@@ -484,7 +508,7 @@ def get_frequency_buckets(
             "filter_keys": {"project_id": [project.id]},
             "aggregations": [
                 ("toStartOfFiveMinute", "timestamp", "roundedTime"),
-                ("count", "roundedTime", "bucketCount"),
+                (*aggregate, "bucketCount"),
             ],
             "orderby": ["-roundedTime"],
             "groupby": ["roundedTime"],

--- a/src/sentry/types/condition_activity.py
+++ b/src/sentry/types/condition_activity.py
@@ -18,7 +18,7 @@ class ConditionActivityType(Enum):
 
 @dataclass
 class ConditionActivity:
-    group_id: str
+    group_id: int
     type: ConditionActivityType
     timestamp: datetime
     data: Dict[str, Any] = field(default_factory=dict)

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -709,6 +709,33 @@ class FrequencyConditionTest(TestCase, SnubaTestCase):
         result = preview(self.project, conditions, [], *MATCH_ARGS)
         assert group not in result
 
+    def tests_multiple_freq_cond_types(self):
+        prev_hour = timezone.now() - timedelta(hours=1)
+        group = self.store_event(
+            project_id=self.project.id,
+            data={"timestamp": iso_format(prev_hour), "user": {"id": self.user.id}},
+        ).group
+
+        conditions = [
+            {
+                "id": "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
+                "value": 0,
+                "interval": "5m",
+            },
+            {
+                "id": "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyCondition",
+                "value": 0,
+                "interval": "5m",
+            },
+        ]
+
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
+        assert group in result
+
+        conditions[1]["value"] = 1
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
+        assert group not in result
+
 
 @freeze_time()
 @region_silo_test


### PR DESCRIPTION
Adds support for user frequency conditions (`Number of users affected by an issue is...`) and comparison intervals (`{value}% higher in {interval} compared to {comparisonInterval} ago`).