### PR TITLE
feat(replays): Improve search/empty table consistency in Replay Details page

### DIFF
--- a/docs-ui/stories/views/emptyStateWarning.stories.js
+++ b/docs-ui/stories/views/emptyStateWarning.stories.js
@@ -1,4 +1,8 @@
+import {action} from '@storybook/addon-actions';
+
+import Button from 'sentry/components/button';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
+import {IconClose} from 'sentry/icons';
 
 export default {
   title: 'Views/Empty States/Empty State Warning',
@@ -8,6 +12,19 @@ export default {
 export const Default = () => (
   <EmptyStateWarning data="https://example.org/foo/bar/">
     <p>There are no events found!</p>
+  </EmptyStateWarning>
+);
+
+export const WithInnerButton = () => (
+  <EmptyStateWarning data="https://example.org/foo/bar/">
+    <p>There are no events found!</p>
+    <Button
+      size="sm"
+      icon={<IconClose color="gray500" size="md" isCircled />}
+      onClick={action('click')}
+    >
+      Clear filters
+    </Button>
   </EmptyStateWarning>
 );
 

--- a/static/app/components/emptyStateWarning.tsx
+++ b/static/app/components/emptyStateWarning.tsx
@@ -44,7 +44,7 @@ const EmptyStreamWrapper = styled('div')`
     }
   }
 
-  svg {
+  > svg {
     fill: ${p => p.theme.gray200};
     margin-bottom: ${space(2)};
   }

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -45,14 +45,14 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
           onChange={selected => setLogLevel(selected.map(_ => _.value))}
           size="sm"
           value={logLevel}
-          isDisabled={!breadcrumbs}
+          isDisabled={!breadcrumbs || !breadcrumbs.length}
         />
         <SearchBar
           onChange={setSearchTerm}
           placeholder={t('Search Logs')}
           size="sm"
           query={searchTerm}
-          disabled={!breadcrumbs}
+          disabled={!breadcrumbs || !breadcrumbs.length}
         />
       </ConsoleFilters>
       <ConsoleMessageContainer ref={containerRef}>

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -49,7 +49,7 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
         />
         <SearchBar
           onChange={setSearchTerm}
-          placeholder={t('Search Logs')}
+          placeholder={t('Search Console Logs')}
           size="sm"
           query={searchTerm}
           disabled={!breadcrumbs || !breadcrumbs.length}
@@ -126,7 +126,7 @@ function ConsoleContent({
   if (breadcrumbs.length === 0) {
     return (
       <StyledEmptyStateWarning>
-        <p>{t('No logs recorded')}</p>
+        <p>{t('No console logs recorded')}</p>
       </StyledEmptyStateWarning>
     );
   }

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 
+import Button from 'sentry/components/button';
 import CompactSelect from 'sentry/components/compactSelect';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import {Panel} from 'sentry/components/panels';
@@ -8,6 +9,7 @@ import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import SearchBar from 'sentry/components/searchBar';
+import {IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
@@ -47,7 +49,7 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
         />
         <SearchBar
           onChange={setSearchTerm}
-          placeholder={t('Search console logs...')}
+          placeholder={t('Search Logs')}
           size="sm"
           query={searchTerm}
           disabled={!breadcrumbs}
@@ -58,6 +60,7 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
           <ConsoleContent
             breadcrumbs={breadcrumbs}
             items={items}
+            setSearchTerm={setSearchTerm}
             startTimestampMs={startTimestampMs}
           />
         ) : (
@@ -71,10 +74,16 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
 type ContentProps = {
   breadcrumbs: Extract<Crumb, BreadcrumbTypeDefault>[];
   items: Extract<Crumb, BreadcrumbTypeDefault>[];
+  setSearchTerm: (term: string) => void;
   startTimestampMs: number;
 };
 
-function ConsoleContent({items, breadcrumbs, startTimestampMs}: ContentProps) {
+function ConsoleContent({
+  items,
+  breadcrumbs,
+  setSearchTerm,
+  startTimestampMs,
+}: ContentProps) {
   const {currentHoverTime, currentTime} = useReplayContext();
 
   const currentUserAction = getPrevReplayEvent({
@@ -116,16 +125,23 @@ function ConsoleContent({items, breadcrumbs, startTimestampMs}: ContentProps) {
 
   if (breadcrumbs.length === 0) {
     return (
-      <EmptyStateWarning withIcon={false} small>
-        {t('No console messages recorded')}
-      </EmptyStateWarning>
+      <StyledEmptyStateWarning>
+        <p>{t('No logs recorded')}</p>
+      </StyledEmptyStateWarning>
     );
   }
   if (items.length === 0) {
     return (
-      <EmptyStateWarning withIcon small>
-        {t('No results found')}
-      </EmptyStateWarning>
+      <StyledEmptyStateWarning>
+        <p>{t('No results found')}</p>
+        <Button
+          icon={<IconClose color="gray500" size="sm" isCircled />}
+          onClick={() => setSearchTerm('')}
+          size="md"
+        >
+          {t('Clear filters')}
+        </Button>
+      </StyledEmptyStateWarning>
     );
   }
   return (
@@ -150,6 +166,15 @@ function ConsoleContent({items, breadcrumbs, startTimestampMs}: ContentProps) {
     </ConsoleTable>
   );
 }
+
+const StyledEmptyStateWarning = styled(EmptyStateWarning)`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
 
 const ConsoleContainer = styled(FluidHeight)`
   height: 100%;

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-virtualized';
 import styled from '@emotion/styled';
 
+import Button from 'sentry/components/button';
 import CompactSelect from 'sentry/components/compactSelect';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
@@ -18,6 +19,7 @@ import PlayerRelativeTime from 'sentry/components/replays/playerRelativeTime';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import SearchBar from 'sentry/components/searchBar';
+import {IconClose} from 'sentry/icons';
 import {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -136,7 +138,7 @@ function DomMutations({replay}: Props) {
         <SearchBar
           size="sm"
           onChange={setSearchTerm}
-          placeholder={t('Search DOM')}
+          placeholder={t('Search DOM Events')}
           query={searchTerm}
           disabled={!replay}
         />
@@ -157,13 +159,20 @@ function DomMutations({replay}: Props) {
                 rowCount={items.length}
                 noRowsRenderer={() =>
                   actions.length === 0 ? (
-                    <EmptyStateWarning withIcon={false} small>
-                      {t('No related DOM events recorded')}
-                    </EmptyStateWarning>
+                    <StyledEmptyStateWarning>
+                      <p>{t('No DOM events recorded')}</p>
+                    </StyledEmptyStateWarning>
                   ) : (
-                    <EmptyStateWarning withIcon small>
-                      {t('No results found')}
-                    </EmptyStateWarning>
+                    <StyledEmptyStateWarning>
+                      <p>{t('No results found')}</p>
+                      <Button
+                        icon={<IconClose color="gray500" size="sm" isCircled />}
+                        onClick={() => setSearchTerm('')}
+                        size="md"
+                      >
+                        {t('Clear filters')}
+                      </Button>
+                    </StyledEmptyStateWarning>
                   )
                 }
                 rowHeight={cache.rowHeight}
@@ -186,6 +195,15 @@ const MutationFilters = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.small}) {
     margin-top: ${space(1)};
   }
+`;
+
+const StyledEmptyStateWarning = styled(EmptyStateWarning)`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 `;
 
 const MutationContainer = styled(FluidHeight)`

--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -133,14 +133,14 @@ function DomMutations({replay}: Props) {
           size="sm"
           onChange={selected => setType(selected.map(_ => _.value))}
           value={filteredTypes}
-          isDisabled={!replay}
+          isDisabled={!replay || !actions.length}
         />
         <SearchBar
           size="sm"
           onChange={setSearchTerm}
           placeholder={t('Search DOM Events')}
           query={searchTerm}
-          disabled={!replay}
+          disabled={!replay || !actions.length}
         />
       </MutationFilters>
       <MutationList>

--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -89,7 +89,7 @@ function IssueList({projectId, replayId}: Props) {
     <ReplayCountContext.Provider value={counts}>
       <StyledPanelTable
         isEmpty={state.issues.length === 0}
-        emptyMessage={t('No related Issues found.')}
+        emptyMessage={t('No Issues are related')}
         isLoading={state.fetching}
         headers={
           isScreenLarge ? columns : columns.filter(column => column !== t('Graph'))

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-virtualized';
 import styled from '@emotion/styled';
 
+import Button from 'sentry/components/button';
 import CompactSelect from 'sentry/components/compactSelect';
 import DateTime from 'sentry/components/dateTime';
 import EmptyStateWarning from 'sentry/components/emptyStateWarning';
@@ -17,7 +18,7 @@ import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs, showPlayerTime} from 'sentry/components/replays/utils';
 import SearchBar from 'sentry/components/searchBar';
 import Tooltip from 'sentry/components/tooltip';
-import {IconArrow} from 'sentry/icons';
+import {IconArrow, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
@@ -316,7 +317,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
         <SearchBar
           size="sm"
           onChange={setSearchTerm}
-          placeholder={t('Search Network...')}
+          placeholder={t('Search Network Requests')}
           query={searchTerm}
           disabled={!networkSpans}
         />
@@ -360,13 +361,20 @@ function NetworkList({replayRecord, networkSpans}: Props) {
                 }}
                 noContentRenderer={() =>
                   networkSpans.length === 0 ? (
-                    <EmptyStateWarning withIcon={false} small>
-                      {t('No related network requests recorded')}
-                    </EmptyStateWarning>
+                    <StyledEmptyStateWarning>
+                      <p>{t('No network requests recorded')}</p>
+                    </StyledEmptyStateWarning>
                   ) : (
-                    <EmptyStateWarning withIcon small>
-                      {t('No results found')}
-                    </EmptyStateWarning>
+                    <StyledEmptyStateWarning>
+                      <p>{t('No results found')}</p>
+                      <Button
+                        icon={<IconClose color="gray500" size="sm" isCircled />}
+                        onClick={() => setSearchTerm('')}
+                        size="md"
+                      >
+                        {t('Clear filters')}
+                      </Button>
+                    </StyledEmptyStateWarning>
                   )
                 }
               />
@@ -379,6 +387,15 @@ function NetworkList({replayRecord, networkSpans}: Props) {
     </NetworkContainer>
   );
 }
+
+const StyledEmptyStateWarning = styled(EmptyStateWarning)`
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
 
 const NetworkContainer = styled(FluidHeight)`
   height: 100%;

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -299,7 +299,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
           size="sm"
           onChange={selected => setStatus(selected.map(_ => _.value))}
           value={selectedStatus}
-          isDisabled={!networkSpans}
+          isDisabled={!networkSpans || !networkSpans.length}
         />
         <CompactSelect
           triggerProps={{prefix: t('Type')}}
@@ -312,14 +312,14 @@ function NetworkList({replayRecord, networkSpans}: Props) {
           size="sm"
           onChange={selected => setType(selected.map(_ => _.value))}
           value={selectedType}
-          isDisabled={!networkSpans}
+          isDisabled={!networkSpans || !networkSpans.length}
         />
         <SearchBar
           size="sm"
           onChange={setSearchTerm}
           placeholder={t('Search Network Requests')}
           query={searchTerm}
-          disabled={!networkSpans}
+          disabled={!networkSpans || !networkSpans.length}
         />
       </NetworkFilters>
 


### PR DESCRIPTION
We've got a pattern for "no results found [btn: clear filters]" happening inside the Replay Details page now, based on these figma designs: https://www.figma.com/file/QKNOhvnIlqoTZxCUyTIDFz/Specs%3A-Details-Empty-States?node-id=101%3A5582&t=I7MFokTvfgb0qSUz-0

So i updated storybook to showcase it:

<img width="856" alt="SCR-20221205-e0a" src="https://user-images.githubusercontent.com/187460/205710005-079fb63a-2858-4602-9423-29c4cece0682.png">


In app all the pages are looking the same now when they have no data, of if there is 
The in-app pages all look the same now under two cases:
 
1. No records exist, nothing to find.
  - Search Textbox is disabled
  
  <img width="654" alt="SCR-20221205-dwe" src="https://user-images.githubusercontent.com/187460/205712207-be4e7f8e-fab8-4dbf-87e9-08b48efe344d.png">

2. Nothing matches the text Search that was entered
  - Using the dropdown does not create this situation, because the dropdowns are only populated with valid values

  <img width="653" alt="SCR-20221205-dwi" src="https://user-images.githubusercontent.com/187460/205712256-93c87516-bba9-44a6-90e6-60c264b53bbe.png">


Fixes #41732