### PR TITLE
feat(alert-preview): add inbox reason to preview

### DIFF
--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -72,8 +72,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
 
         inbox_details = get_inbox_details([Group(id=int(g["id"])) for g in response.data])
         for group in response.data:
-            if int(group["id"]) in inbox_details:
-                group["inbox"] = inbox_details[int(group["id"])]
+            group["inbox"] = inbox_details.get(int(group["id"]))
 
         response["Endpoint"] = data["endpoint"]
         return response

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -8,7 +8,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.rule import RulePreviewSerializer
-from sentry.models import Group, get_inbox_details
+from sentry.models import get_inbox_details_from_ids
 from sentry.rules.history.preview import preview
 from sentry.web.decorators import transaction_start
 
@@ -70,7 +70,7 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
             count_hits=True,
         )
 
-        inbox_details = get_inbox_details([Group(id=int(g["id"])) for g in response.data])
+        inbox_details = get_inbox_details_from_ids([int(g["id"]) for g in response.data])
         for group in response.data:
             group["inbox"] = inbox_details.get(int(group["id"]))
 

--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -8,6 +8,7 @@ from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.rule import RulePreviewSerializer
+from sentry.models import Group, get_inbox_details
 from sentry.rules.history.preview import preview
 from sentry.web.decorators import transaction_start
 
@@ -68,5 +69,11 @@ class ProjectRulePreviewEndpoint(ProjectEndpoint):
             on_results=lambda x: serialize(x, request.user),
             count_hits=True,
         )
+
+        inbox_details = get_inbox_details([Group(id=int(g["id"])) for g in response.data])
+        for group in response.data:
+            if int(group["id"]) in inbox_details:
+                group["inbox"] = inbox_details[int(group["id"])]
+
         response["Endpoint"] = data["endpoint"]
         return response

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -122,10 +122,7 @@ def remove_group_from_inbox(group, action=None, user=None, referrer=None):
 
 
 def get_inbox_details(group_list):
-    return get_inbox_details_from_ids([g.id for g in group_list])
-
-
-def get_inbox_details_from_ids(group_ids):
+    group_ids = [g.id for g in group_list]
     group_inboxes = GroupInbox.objects.filter(group__in=group_ids)
     inbox_stats = {
         gi.group_id: {

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -122,7 +122,10 @@ def remove_group_from_inbox(group, action=None, user=None, referrer=None):
 
 
 def get_inbox_details(group_list):
-    group_ids = [g.id for g in group_list]
+    return get_inbox_details_from_ids([g.id for g in group_list])
+
+
+def get_inbox_details_from_ids(group_ids):
     group_inboxes = GroupInbox.objects.filter(group__in=group_ids)
     inbox_stats = {
         gi.group_id: {


### PR DESCRIPTION
Attaches inbox reason to each group to display in preview table. No changes needed on frontend.

![Screen Shot 2022-12-05 at 10 15 18 AM](https://user-images.githubusercontent.com/39287272/205711512-1e7ca936-5369-42e6-8b7d-ccd8d056e2d2.jpg)
^ "New issue" 