### PR TITLE
fix(twilio): allow phone numbers to split with either a comma or any whitespace

### DIFF
--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -48,9 +48,9 @@ def clean_phone(phone):
 #      in theory only cleaned data would make it to the plugin via the form,
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
-    # we use regex below to split the string since we allow any type of whitespace (ex. \n)
-    # around a comma to separate phone numbers
-    phone_numbers = set(re.split(r"\s*,\s*", data))
+    # we use regex below to split the string since we allow any whitespace, comma, or combination of the two
+    # as a delimeter
+    phone_numbers = set(re.split(r"[,\s]+", data))
     stripped_phone_numbers = {num.strip() for num in phone_numbers}
     return stripped_phone_numbers
 

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -22,6 +22,12 @@ class TwilioPluginSMSSplitTest(TestCase):
         actual = split_sms_to(to)
         assert expected == actual
 
+    def test_valid_split_sms_to_with_just_spaces(self):
+        to = "330-509-3095 (330)-509-3095 +13305093095 4045550144"
+        expected = {"330-509-3095", "(330)-509-3095", "+13305093095", "4045550144"}
+        actual = split_sms_to(to)
+        assert expected == actual
+
     def test_valid_split_sms_to_with_no_whitespace(self):
         to = "330-509-3095,(330)-509-3095,+13305093095,4045550144"
         expected = {"330-509-3095", "(330)-509-3095", "+13305093095", "4045550144"}
@@ -36,6 +42,12 @@ class TwilioPluginSMSSplitTest(TestCase):
 
     def test_valid_split_sms_to_newline(self):
         to = "330-509-3095,\n(330)-509-3095\n,+13305093095\n,\n4045550144"
+        expected = {"330-509-3095", "(330)-509-3095", "+13305093095", "4045550144"}
+        actual = split_sms_to(to)
+        assert expected == actual
+
+    def test_valid_split_sms_to_with_just_newlines(self):
+        to = "330-509-3095\n(330)-509-3095\n+13305093095\n\n4045550144"
         expected = {"330-509-3095", "(330)-509-3095", "+13305093095", "4045550144"}
         actual = split_sms_to(to)
         assert expected == actual


### PR DESCRIPTION
Fixes SENTRY-TCG.

Continuation of #42002. I missed that we also allow users in practice to delimit the phone numbers with whitespace exclusively (no commas). This new regex allows for either a comma or whitespace [while limiting the vulnerability to a potential ReDOS.](https://github.com/getsentry/sentry/pull/41983)

I've also added more tests to prevent future regressions.