### PR TITLE
fix(profiling): drop default focus border

### DIFF
--- a/static/app/components/profiling/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraphZoomView.tsx
@@ -828,6 +828,10 @@ const Canvas = styled('canvas')`
   height: 100%;
   user-select: none;
   position: absolute;
+
+  &:focus {
+    outline: none;
+  }
 `;
 
 // loosely based spreadsheet navigation


### PR DESCRIPTION
The `:focus` state which occured when clicking the chart caused a tiny blue border all around the canvas.