### PR TITLE
logging(weekly-email): adds logging for key errors

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -764,6 +764,13 @@ def render_template_context(ctx, user):
         def all_key_errors():
             for project_ctx in user_projects:
                 for group, group_history, count in project_ctx.key_errors:
+                    # TODO(Steve): Remove debug logging for Sentry
+                    if ctx.organization.slug == "sentry":
+                        logger.info(
+                            "render_template_context.key_error: %s",
+                            group,
+                            extra={"group_id": group.id, "user_id": user.id},
+                        )
                     yield {
                         "count": count,
                         "group": group,


### PR DESCRIPTION
We are having problems where key errors are not showing up in weekly emails. However, when we do a test run in the admin UI the email looks fine so I'm adding some debugging just for the Sentry org