### PR TITLE
fix(profiling): drop tid if we have name

### DIFF
--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -33,7 +33,7 @@ function ThreadMenuSelector({
 
     sortedProfiles.forEach(profile => {
       const option = {
-        label: profile.name ? `${profile.name}` : `tid(${profile.threadId})`,
+        label: profile.name ? profile.name : `tid(${profile.threadId})`,
         value: profile.threadId,
         details: (
           <ThreadLabelDetails

--- a/static/app/components/profiling/threadSelector.tsx
+++ b/static/app/components/profiling/threadSelector.tsx
@@ -33,9 +33,7 @@ function ThreadMenuSelector({
 
     sortedProfiles.forEach(profile => {
       const option = {
-        label: profile.name
-          ? `tid (${profile.threadId}): ${profile.name}`
-          : `tid (${profile.threadId})`,
+        label: profile.name ? `${profile.name}` : `tid(${profile.threadId})`,
         value: profile.threadId,
         details: (
           <ThreadLabelDetails


### PR DESCRIPTION
Drop tid if we have a thread name

Fix for https://github.com/getsentry/team-profiling/issues/99

https://user-images.githubusercontent.com/9317857/205734470-ae7c368d-8bc0-4095-9dd4-6ae9a26c7a52.mp4

