### PR TITLE
ref(profiling): drop node profile

### DIFF
--- a/static/app/types/profiling.d.ts
+++ b/static/app/types/profiling.d.ts
@@ -95,10 +95,6 @@ declare namespace Profiling {
     type: 'sampled';
   }
 
-  interface NodeProfile extends Profiling.SampledProfile {
-    frames: Profiling.FrameInfo[];
-  }
-
   type Event = {at: number; frame: number; type: 'O' | 'C'};
 
   type Span = {

--- a/static/app/utils/profiling/guards/profile.tsx
+++ b/static/app/utils/profiling/guards/profile.tsx
@@ -8,10 +8,6 @@ export function isSchema(input: any): input is Profiling.Schema {
   );
 }
 
-export function isNodeProfile(profile: any): profile is [Profiling.NodeProfile, {}] {
-  return Array.isArray(profile) && profile.length === 2 && isSampledProfile(profile[0]);
-}
-
 export function isEventedProfile(profile: any): profile is Profiling.EventedProfile {
   return 'type' in profile && profile.type === 'evented';
 }

--- a/static/app/utils/profiling/profile/importProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/importProfile.spec.tsx
@@ -92,22 +92,6 @@ describe('importProfile', () => {
     const imported = importProfile(typescriptProfile, '');
     expect(imported.profiles[0]).toBeInstanceOf(ChromeTraceProfile);
   });
-  it('imports a nodejs profile', () => {
-    const nodeProfile: Profiling.NodeProfile = {
-      name: 'profile',
-      startValue: 0,
-      endValue: 1000,
-      threadID: 0,
-      unit: 'milliseconds',
-      type: 'sampled',
-      weights: [],
-      samples: [],
-      frames: [],
-    };
-
-    const imported = importProfile([nodeProfile, {}], '');
-    expect(imported.profiles[0]).toBeInstanceOf(SampledProfile);
-  });
   it('imports JS self profile from schema', () => {
     const jsSelfProfile: JSSelfProfiling.Trace = {
       resources: ['app.js', 'vendor.js'],

--- a/static/app/utils/profiling/profile/importProfile.tsx
+++ b/static/app/utils/profiling/profile/importProfile.tsx
@@ -6,7 +6,6 @@ import {
   isChromeTraceObjectFormat,
   isEventedProfile,
   isJSProfile,
-  isNodeProfile,
   isSampledProfile,
   isSchema,
   isSentrySampledProfile,
@@ -43,8 +42,7 @@ export function importProfile(
     | Profiling.Schema
     | JSSelfProfiling.Trace
     | ChromeTrace.ProfileType
-    | Profiling.SentrySampledProfile
-    | [Profiling.NodeProfile, {}], // this is hack so that we distinguish between typescript and node profiles
+    | Profiling.SentrySampledProfile,
   traceID: string
 ): ProfileGroup {
   const transaction = Sentry.startTransaction({
@@ -53,15 +51,6 @@ export function importProfile(
   });
 
   try {
-    if (isNodeProfile(input)) {
-      // In some cases, the SDK may return transaction as undefined and we dont want to throw there.
-      if (transaction) {
-        transaction.setTag('profile.type', 'nodejs');
-      }
-
-      return importNodeProfile(input[0], traceID, {transaction});
-    }
-
     if (isJSProfile(input)) {
       // In some cases, the SDK may return transaction as undefined and we dont want to throw there.
       if (transaction) {
@@ -245,23 +234,6 @@ function importSchema(
     profiles: input.profiles.map(profile =>
       importSingleProfile(profile, frameIndex, options)
     ),
-  };
-}
-
-function importNodeProfile(
-  input: Profiling.NodeProfile,
-  traceID: string,
-  options: ImportOptions
-): ProfileGroup {
-  const frameIndex = createFrameIndex('web', input.frames);
-
-  return {
-    traceID,
-    transactionID: null,
-    name: input.name,
-    activeProfileIndex: 0,
-    metadata: {},
-    profiles: [importSingleProfile(input, frameIndex, options)],
   };
 }
 


### PR DESCRIPTION
This was used to import typescript compiler profiles - we removed that part of the code and we no longer need the types or the import code