### PR TITLE
fix(project options): Store feedback:branding options correctly

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -166,25 +166,26 @@ def get_features_for_projects(
 
 
 def format_options(attrs: defaultdict(dict)):
+    options = attrs["options"]
     return {
         "sentry:csp_ignored_sources_defaults": bool(
-            attrs["options"].get("sentry:csp_ignored_sources_defaults", True)
+            options.get("sentry:csp_ignored_sources_defaults", True)
         ),
         "sentry:csp_ignored_sources": "\n".join(
-            attrs["options"].get("sentry:csp_ignored_sources", []) or []
+            options.get("sentry:csp_ignored_sources", []) or []
         ),
-        "sentry:reprocessing_active": bool(attrs.get("sentry:reprocessing_active", False)),
-        "sentry:performance_issue_creation_rate": attrs["options"].get(
+        "sentry:reprocessing_active": bool(options.get("sentry:reprocessing_active", False)),
+        "sentry:performance_issue_creation_rate": options.get(
             "sentry:performance_issue_creation_rate"
         ),
-        "filters:blacklisted_ips": "\n".join(attrs["options"].get("sentry:blacklisted_ips", [])),
+        "filters:blacklisted_ips": "\n".join(options.get("sentry:blacklisted_ips", [])),
         f"filters:{FilterTypes.RELEASES}": "\n".join(
-            attrs["options"].get(f"sentry:{FilterTypes.RELEASES}", [])
+            options.get(f"sentry:{FilterTypes.RELEASES}", [])
         ),
         f"filters:{FilterTypes.ERROR_MESSAGES}": "\n".join(
-            attrs["options"].get(f"sentry:{FilterTypes.ERROR_MESSAGES}", [])
+            options.get(f"sentry:{FilterTypes.ERROR_MESSAGES}", [])
         ),
-        "feedback:branding": attrs["options"].get("feedback:branding", "1") == "1",
+        "feedback:branding": options.get("feedback:branding", "1") == "1",
     }
 
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -184,7 +184,7 @@ def format_options(attrs: defaultdict(dict)):
         f"filters:{FilterTypes.ERROR_MESSAGES}": "\n".join(
             attrs["options"].get(f"sentry:{FilterTypes.ERROR_MESSAGES}", [])
         ),
-        "feedback:branding": attrs.get("feedback:branding", "1") == "1",
+        "feedback:branding": attrs["options"].get("feedback:branding", "1") == "1",
     }
 
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -474,6 +474,7 @@ class ProjectUpdateTest(APITestCase):
             "sentry:token": "*",
             "sentry:token_header": "*",
             "sentry:verify_ssl": False,
+            "feedback:branding": False,
         }
         with self.feature("projects:custom-inbound-filters"):
             self.get_success_response(self.org_slug, self.proj_slug, options=options)
@@ -556,6 +557,10 @@ class ProjectUpdateTest(APITestCase):
             organization=project.organization, event=audit_log.get_event_id("PROJECT_EDIT")
         ).exists()
         assert project.get_option("sentry:verify_ssl", False) == options["sentry:verify_ssl"]
+        assert AuditLogEntry.objects.filter(
+            organization=project.organization, event=audit_log.get_event_id("PROJECT_EDIT")
+        ).exists()
+        assert project.get_option("feedback:branding") == "0"
         assert AuditLogEntry.objects.filter(
             organization=project.organization, event=audit_log.get_event_id("PROJECT_EDIT")
         ).exists()


### PR DESCRIPTION
Toggling off the user feedback branding option wasn't actually doing anything - when the user refreshed the screen it was back to "on". This PR fixes that by grabbing the option correctly - before it was always falling back to the default value and setting it to True. 