### PR TITLE
feat(profiling): extract package from path

### DIFF
--- a/static/app/utils/profiling/frame.spec.tsx
+++ b/static/app/utils/profiling/frame.spec.tsx
@@ -17,4 +17,48 @@ describe('Frame', () => {
       ).toBe(true);
     });
   });
+  describe('pulls package from path for web|node platforms', () => {
+    it('file in node modules', () => {
+      expect(
+        new Frame(
+          {
+            key: 0,
+            name: 'Foo',
+            path: '/usr/code/node_modules/file.js',
+            line: undefined,
+            column: undefined,
+          },
+          'node'
+        ).image
+      ).toBe(undefined);
+    });
+    it('scoped module', () => {
+      expect(
+        new Frame(
+          {
+            key: 0,
+            name: 'Foo',
+            path: '/usr/code/node_modules/@sentry/profiling-node/file.js',
+            line: undefined,
+            column: undefined,
+          },
+          'node'
+        ).image
+      ).toBe('@sentry/profiling-node');
+    });
+    it('module', () => {
+      expect(
+        new Frame(
+          {
+            key: 0,
+            name: 'Foo',
+            path: '/usr/code/node_modules/sentry/profiling-node/file.js',
+            line: undefined,
+            column: undefined,
+          },
+          'node'
+        ).image
+      ).toBe('sentry');
+    });
+  });
 });

--- a/static/app/utils/profiling/frame.tsx
+++ b/static/app/utils/profiling/frame.tsx
@@ -62,10 +62,12 @@ export class Frame extends WeightedNode {
       }
 
       // Doing this on the frontend while we figure out how to do this on the backend/client properly
-      if (this.image === undefined && this.path) {
+      // @TODO Our old node.js incorrectly sends file instead of path (fixed in SDK, but not all SDK's are upgraded :rip:)
+      const pathOrFile = this.path || this.file;
+      if (this.image === undefined && pathOrFile) {
         const match =
           /node_modules\/(?<maybeScopeOrPackage>.*)\/(?<maybeFileOrPackage>.*)\//.exec(
-            this.path
+            pathOrFile
           );
         if (match?.groups) {
           const {maybeScopeOrPackage, maybeFileOrPackage} = match.groups;

--- a/static/app/utils/profiling/frame.tsx
+++ b/static/app/utils/profiling/frame.tsx
@@ -60,6 +60,23 @@ export class Frame extends WeightedNode {
       if (this.line === undefined && this.column === undefined) {
         this.name += ` ${t('[native code]')}`;
       }
+
+      // Doing this on the frontend while we figure out how to do this on the backend/client properly
+      if (this.image === undefined && this.path) {
+        const match =
+          /node_modules\/(?<maybeScopeOrPackage>.*)\/(?<maybeFileOrPackage>.*)\//.exec(
+            this.path
+          );
+        if (match?.groups) {
+          const {maybeScopeOrPackage, maybeFileOrPackage} = match.groups;
+
+          if (maybeScopeOrPackage.startsWith('@')) {
+            this.image = `${maybeScopeOrPackage}/${maybeFileOrPackage}`;
+          } else {
+            this.image = match.groups.maybeScopeOrPackage;
+          }
+        }
+      }
     }
 
     if (!this.name) {


### PR DESCRIPTION
Attempts to extract package from path by checking for node_modules prefix - this allows us to visualize flamecharts via the package field. This is a best effort case for now and is probably not the right place to do this, ideally this could be done by the backend using similar detection (codemappings could also expose a setting for custom /package/ dir which would make this feature more bulletproof cc @armenzg). Doing it in the SDK as a pre-processing step probably an expensive step we'd want to avoid (would need some benchmarks to confirm)

Before:
<img width="1302" alt="CleanShot 2022-12-05 at 17 10 16@2x" src="https://user-images.githubusercontent.com/9317857/205753150-71cd3ded-cb34-45b3-a20e-482f4eabd7f2.png">

After
<img width="1512" alt="CleanShot 2022-12-05 at 17 06 16@2x" src="https://user-images.githubusercontent.com/9317857/205753040-6674bd3c-ea49-441b-a4c3-f7e2e6060f3f.png">
