### PR TITLE
feat(workflow): Replace suggested assignee spinner

### DIFF
--- a/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedAssignees.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import ActorAvatar from 'sentry/components/avatar/actorAvatar';
 import Button from 'sentry/components/button';
 import SuggestedOwnerHovercard from 'sentry/components/group/suggestedOwnerHovercard';
+import Placeholder from 'sentry/components/placeholder';
 import * as SidebarSection from 'sentry/components/sidebarSection';
 import {IconCheckmark} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -24,6 +25,7 @@ type Props = {
   onAssign: (actor: Actor) => void;
   organization: Organization;
   owners: Array<Owner>;
+  loading?: boolean;
   projectId?: string;
 };
 
@@ -32,6 +34,7 @@ const SuggestedAssignees = ({
   owners,
   projectId,
   organization,
+  loading,
   onAssign,
 }: Props) => {
   const handleAssign = useCallback(
@@ -48,6 +51,21 @@ const SuggestedAssignees = ({
     },
     [onAssign, group.id, group.issueCategory, projectId, organization]
   );
+
+  if (loading) {
+    return (
+      <SidebarSection.Wrap>
+        <SidebarSection.Title>{t('Suggested Assignees')}</SidebarSection.Title>
+        <SidebarSection.Content>
+          <Placeholder />
+        </SidebarSection.Content>
+      </SidebarSection.Wrap>
+    );
+  }
+
+  if (!owners.length) {
+    return null;
+  }
 
   return (
     <SidebarSection.Wrap>

--- a/static/app/components/group/suggestedOwners/suggestedOwners.spec.jsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.spec.jsx
@@ -162,4 +162,27 @@ describe('SuggestedOwners', function () {
     expect(await screen.findByText('Suspect Release')).toBeInTheDocument();
     expect(screen.getByText('last committed')).toBeInTheDocument();
   });
+
+  it('hides when there are no suggestions', async () => {
+    Client.addMockResponse({
+      url: `${endpoint}/committers/`,
+      body: {
+        committers: [],
+      },
+    });
+    Client.addMockResponse({
+      url: `${endpoint}/owners/`,
+      body: {owners: [], rules: []},
+    });
+    const {container} = render(
+      <SuggestedOwners project={project} group={group} event={event} />,
+      {
+        organization,
+      }
+    );
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
 });

--- a/static/app/components/group/suggestedOwners/suggestedOwners.tsx
+++ b/static/app/components/group/suggestedOwners/suggestedOwners.tsx
@@ -28,8 +28,8 @@ type Props = {
 } & AsyncComponent['props'];
 
 type State = {
-  codeowners: CodeOwner[];
-  eventOwners: {owners: Array<Actor>; rules: Rules};
+  codeowners: CodeOwner[] | null;
+  eventOwners: {owners: Array<Actor>; rules: Rules} | null;
 } & AsyncComponent['state'];
 
 class SuggestedOwners extends AsyncComponent<Props, State> {
@@ -108,8 +108,8 @@ class SuggestedOwners extends AsyncComponent<Props, State> {
       source: 'suspectCommit',
     }));
 
-    this.state.eventOwners.owners.forEach(owner => {
-      const matchingRule = findMatchedRules(this.state.eventOwners.rules || [], owner);
+    this.state.eventOwners?.owners.forEach(owner => {
+      const matchingRule = findMatchedRules(this.state.eventOwners?.rules || [], owner);
       const normalizedOwner: OwnerList[0] = {
         actor: owner,
         rules: matchingRule,
@@ -162,19 +162,25 @@ class SuggestedOwners extends AsyncComponent<Props, State> {
     }
   };
 
+  renderLoading() {
+    return this.renderBody();
+  }
+
   renderBody() {
     const {organization, group} = this.props;
+    const {loading} = this.state;
     const owners = this.getOwnerList();
 
-    return owners.length > 0 ? (
+    return (
       <SuggestedAssignees
         group={group}
         organization={organization}
         owners={owners}
         projectId={group.project.id}
         onAssign={this.handleAssign}
+        loading={loading}
       />
-    ) : null;
+    );
   }
 }
 


### PR DESCRIPTION
Use a smaller placeholder instead of the large spinner

before
![image](https://user-images.githubusercontent.com/1400464/205787060-be4f83aa-7fed-426c-81eb-9c900bc46957.png)


after - you can only kinda see the light grey placeholder
![image](https://user-images.githubusercontent.com/1400464/205786669-3adc2f29-48f5-436c-8756-1099a670e2e1.png)


fixes https://getsentry.atlassian.net/browse/WOR-2223