### PR TITLE
fix(span-tree): Fix SpanBar component instrumentation

### DIFF
--- a/static/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/static/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -10,7 +10,7 @@ import getDisplayName from 'sentry/utils/getDisplayName';
 import {setBodyUserSelect, UserSelectValues} from 'sentry/utils/userselect';
 
 import {DragManagerChildrenProps} from './dragManager';
-import SpanBar from './spanBar';
+import {SpanBar} from './spanBar';
 import {SpansInViewMap, spanTargetHash} from './utils';
 
 export type ScrollbarManagerChildrenProps = {

--- a/static/app/components/events/interfaces/spans/spanBar.tsx
+++ b/static/app/components/events/interfaces/spans/spanBar.tsx
@@ -2,6 +2,7 @@ import 'intersection-observer'; // this is a polyfill
 
 import {Component, createRef, Fragment} from 'react';
 import styled from '@emotion/styled';
+import {withProfiler} from '@sentry/react';
 
 import Count from 'sentry/components/count';
 import {ROW_HEIGHT, SpanBarType} from 'sentry/components/performance/waterfall/constants';
@@ -143,7 +144,7 @@ type SpanBarState = {
   showDetail: boolean;
 };
 
-class SpanBar extends Component<SpanBarProps, SpanBarState> {
+export class SpanBar extends Component<SpanBarProps, SpanBarState> {
   state: SpanBarState = {
     showDetail: false,
   };
@@ -1065,4 +1066,4 @@ const StyledIconWarning = styled(IconWarning)`
 
 const Regroup = styled('span')``;
 
-export default SpanBar;
+export const ProfiledSpanBar = withProfiler(SpanBar);

--- a/static/app/components/events/interfaces/spans/spanTree.tsx
+++ b/static/app/components/events/interfaces/spans/spanTree.tsx
@@ -9,11 +9,10 @@ import {pickBarColor} from 'sentry/components/performance/waterfall/utils';
 import {t, tct} from 'sentry/locale';
 import {Organization} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
-import {CustomerProfiler} from 'sentry/utils/performanceForSentry';
 
 import {DragManagerChildrenProps} from './dragManager';
 import {ScrollbarManagerChildrenProps, withScrollbarManager} from './scrollbarManager';
-import SpanBar from './spanBar';
+import {ProfiledSpanBar} from './spanBar';
 import {SpanDescendantGroupBar} from './spanDescendantGroupBar';
 import SpanSiblingGroupBar from './spanSiblingGroupBar';
 import {
@@ -350,41 +349,38 @@ class SpanTree extends Component<PropType> {
         }
 
         acc.spanTree.push(
-          <CustomerProfiler id="SpanBar" key={key}>
-            <SpanBar
-              organization={organization}
-              event={waterfallModel.event}
-              spanBarColor={spanBarColor}
-              spanBarType={spanBarType}
-              span={span}
-              showSpanTree={!waterfallModel.hiddenSpanSubTrees.has(getSpanID(span))}
-              numOfSpanChildren={numOfSpanChildren}
-              trace={waterfallModel.parsedTrace}
-              generateBounds={generateBounds}
-              toggleSpanTree={this.toggleSpanTree(getSpanID(span))}
-              treeDepth={treeDepth}
-              continuingTreeDepths={continuingTreeDepths}
-              spanNumber={spanNumber}
-              isLast={isLast}
-              isRoot={isRoot}
-              showEmbeddedChildren={payload.showEmbeddedChildren}
-              toggleEmbeddedChildren={payload.toggleEmbeddedChildren}
-              toggleSiblingSpanGroup={toggleSiblingSpanGroup}
-              fetchEmbeddedChildrenState={payload.fetchEmbeddedChildrenState}
-              toggleSpanGroup={toggleSpanGroup}
-              numOfSpans={numOfSpans}
-              groupType={groupType}
-              groupOccurrence={payload.groupOccurrence}
-              isEmbeddedTransactionTimeAdjusted={
-                payload.isEmbeddedTransactionTimeAdjusted
-              }
-              onWheel={onWheel}
-              generateContentSpanBarRef={generateContentSpanBarRef}
-              markSpanOutOfView={markSpanOutOfView}
-              markSpanInView={markSpanInView}
-              storeSpanBar={storeSpanBar}
-            />
-          </CustomerProfiler>
+          <ProfiledSpanBar
+            key={key}
+            organization={organization}
+            event={waterfallModel.event}
+            spanBarColor={spanBarColor}
+            spanBarType={spanBarType}
+            span={span}
+            showSpanTree={!waterfallModel.hiddenSpanSubTrees.has(getSpanID(span))}
+            numOfSpanChildren={numOfSpanChildren}
+            trace={waterfallModel.parsedTrace}
+            generateBounds={generateBounds}
+            toggleSpanTree={this.toggleSpanTree(getSpanID(span))}
+            treeDepth={treeDepth}
+            continuingTreeDepths={continuingTreeDepths}
+            spanNumber={spanNumber}
+            isLast={isLast}
+            isRoot={isRoot}
+            showEmbeddedChildren={payload.showEmbeddedChildren}
+            toggleEmbeddedChildren={payload.toggleEmbeddedChildren}
+            toggleSiblingSpanGroup={toggleSiblingSpanGroup}
+            fetchEmbeddedChildrenState={payload.fetchEmbeddedChildrenState}
+            toggleSpanGroup={toggleSpanGroup}
+            numOfSpans={numOfSpans}
+            groupType={groupType}
+            groupOccurrence={payload.groupOccurrence}
+            isEmbeddedTransactionTimeAdjusted={payload.isEmbeddedTransactionTimeAdjusted}
+            onWheel={onWheel}
+            generateContentSpanBarRef={generateContentSpanBarRef}
+            markSpanOutOfView={markSpanOutOfView}
+            markSpanInView={markSpanInView}
+            storeSpanBar={storeSpanBar}
+          />
         );
 
         // If this is an embedded span tree, we will manually mark these spans as in view.


### PR DESCRIPTION
Previously, I was using the `CustomerProfiler` HoC and wrapping `SpanBar` components with it, within a list. This didn't seem to work, as I was unable to see any render or update spans within the event details page, or any other transactions.