### PR TITLE
ref(issue-details-page-analytics): Add has_minified_stack_trace property - [TET-562]

### DIFF
--- a/static/app/components/events/interfaces/exceptionV2.tsx
+++ b/static/app/components/events/interfaces/exceptionV2.tsx
@@ -25,7 +25,7 @@ function Exception({
   hasHierarchicalGrouping,
   groupingCurrentLevel,
 }: Props) {
-  const eventHasThreads = !!event.entries.some(entry => entry.type === 'threads');
+  const eventHasThreads = !!event.entries.some(entry => entry.type === EntryType.THREADS);
 
   /* in case there are threads in the event data, we don't render the
    exception block.  Instead the exception is contained within the

--- a/static/app/components/events/interfaces/threads/threadSelector/findBestThread.tsx
+++ b/static/app/components/events/interfaces/threads/threadSelector/findBestThread.tsx
@@ -1,6 +1,6 @@
 import {Thread} from 'sentry/types';
 
-function findBestThread(threads: Array<Thread>) {
+function findBestThread(threads: Thread[]) {
   // search the entire threads list for a crashed thread with stack trace
   return (
     threads.find(thread => thread.crashed) ||

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -208,7 +208,7 @@ function hasTrace(event: Event) {
 function eventHasSourceMaps(event: Event) {
   return event.entries?.some(entry => {
     return (
-      (entry.type === EntryType.EXCEPTION || entry.type === EntryType.THREADS) &&
+      entry.type === EntryType.EXCEPTION &&
       entry.data.values?.some(value => !!value.rawStacktrace && !!value.stacktrace)
     );
   });
@@ -220,7 +220,7 @@ function eventHasSourceMaps(event: Event) {
 function eventHasMinifiedStackTrace(event: Event) {
   return event.entries?.some(entry => {
     return (
-      (entry.type === EntryType.EXCEPTION || entry.type === EntryType.THREADS) &&
+      entry.type === EntryType.EXCEPTION &&
       entry.data.values?.some(value => !!value.rawStacktrace)
     );
   });


### PR DESCRIPTION
This PR adds the new property `has_minified_stack_trace` to the analytic's event `Issue Details: Viewed` so we can track if the viewed issue details contain minified stack trace. This will give us metrics that help us figure out how we can better inform users that they can get better stack traces if they configure source maps