### PR TITLE
ref(onboarding-analytics): Add has_minified_stack_trace and url properties to analytics code - [TET-562]

### DIFF
--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -9,8 +9,8 @@ class FirstEventSentEvent(analytics.Event):
         analytics.Attribute("user_id"),
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id"),
-        analytics.Attribute("url"),
         analytics.Attribute("platform", required=False),
+        analytics.Attribute("url", required=False),
         analytics.Attribute("has_minified_stack_trace", required=False),
     )
 

--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -19,9 +19,11 @@ class FirstEventSentEvent(analytics.Event):
 class FirstEventSentEventForProject(FirstEventSentEvent):
     type = "first_event_for_project.sent"
 
+
 # first error with minified stack trace for a project
 class FirstEventSentEventWithMinifiedStackTraceForProject(FirstEventSentEvent):
     type = "first_event_with_minified_stack_trace_for_project.sent"
+
 
 analytics.register(FirstEventSentEvent)
 analytics.register(FirstEventSentEventForProject)

--- a/src/sentry/analytics/events/first_event_sent.py
+++ b/src/sentry/analytics/events/first_event_sent.py
@@ -1,7 +1,7 @@
 from sentry import analytics
 
 
-# first error for that organization
+# first error for an organization
 class FirstEventSentEvent(analytics.Event):
     type = "first_event.sent"
 
@@ -9,14 +9,20 @@ class FirstEventSentEvent(analytics.Event):
         analytics.Attribute("user_id"),
         analytics.Attribute("organization_id"),
         analytics.Attribute("project_id"),
+        analytics.Attribute("url"),
         analytics.Attribute("platform", required=False),
+        analytics.Attribute("has_minified_stack_trace", required=False),
     )
 
 
-# first error for that project
+# first error for a project
 class FirstEventSentEventForProject(FirstEventSentEvent):
     type = "first_event_for_project.sent"
 
+# first error with minified stack trace for a project
+class FirstEventSentEventWithMinifiedStackTraceForProject(FirstEventSentEvent):
+    type = "first_event_with_minified_stack_trace_for_project.sent"
 
 analytics.register(FirstEventSentEvent)
 analytics.register(FirstEventSentEventForProject)
+analytics.register(FirstEventSentEventWithMinifiedStackTraceForProject)

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -145,9 +145,9 @@ def record_first_event(project, event, **kwargs):
         return
 
     # Check for the event url
-    for tag in event.tags:
-        if tag[0] == "url":
-            url = tag[1]
+    for key, value in event.tags:
+        if key == "url":
+            url = value
             break
 
     # Check if an event contains a minified stack trace

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -145,13 +145,10 @@ def record_first_event(project, event, **kwargs):
         return
 
     # Check for the event url
-    url = event.data.request.get("url")
-
-    if not url:
-        for tag in event.tags:
-            if tag.key == "url":
-                url = tag.value
-                break
+    for tag in event.tags:
+        if tag.key == "url":
+            url = tag.value
+            break
 
     # Check if an event contains a minified stack trace
     has_minified_stack_trace = False

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -145,7 +145,7 @@ def record_first_event(project, event, **kwargs):
         return
 
     # Check for the event url
-    url = event.data.get("request").url
+    url = event.data.request.get("url")
 
     if not url:
         for tag in event.tags:

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -144,18 +144,16 @@ def record_first_event(project, event, **kwargs):
         )
         return
 
-
     # Check if an event contains a minified stack trace
     has_minified_stack_trace = False
 
     values = get_path(event.data, "exception", "values", filter=True)
 
     if values:
-            for value in values:
-              if 'raw_stacktrace' in value:
+        for value in values:
+            if "raw_stacktrace" in value:
                 has_minified_stack_trace = True
                 break
-
 
     if has_minified_stack_trace:
         analytics.record(
@@ -186,7 +184,6 @@ def record_first_event(project, event, **kwargs):
             organization_id=project.organization_id,
             project_id=project.id,
             platform=event.platform,
-            url=event.request.url,
         )
         return
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -144,6 +144,8 @@ def record_first_event(project, event, **kwargs):
         )
         return
 
+    url = None
+
     # Check for the event url
     for key, value in event.tags:
         if key == "url":

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -146,8 +146,8 @@ def record_first_event(project, event, **kwargs):
 
     # Check for the event url
     for tag in event.tags:
-        if tag.key == "url":
-            url = tag.value
+        if tag[0] == "url":
+            url = tag[1]
             break
 
     # Check if an event contains a minified stack trace

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -144,6 +144,15 @@ def record_first_event(project, event, **kwargs):
         )
         return
 
+    # Check for the event url
+    url = event.data.get("request").url
+
+    if not url:
+        for tag in event.tags:
+            if tag.key == "url":
+                url = tag.value
+                break
+
     # Check if an event contains a minified stack trace
     has_minified_stack_trace = False
 
@@ -162,7 +171,7 @@ def record_first_event(project, event, **kwargs):
             organization_id=project.organization_id,
             project_id=project.id,
             platform=event.platform,
-            url=event.request.url,
+            url=url,
         )
 
     # this event fires once per project
@@ -172,7 +181,7 @@ def record_first_event(project, event, **kwargs):
         organization_id=project.organization_id,
         project_id=project.id,
         platform=event.platform,
-        url=event.request.url,
+        url=url,
         has_minified_stack_trace=has_minified_stack_trace,
     )
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -156,11 +156,11 @@ def record_first_event(project, event, **kwargs):
     # Check if an event contains a minified stack trace
     has_minified_stack_trace = False
 
-    values = get_path(event.data, "exception", "values", filter=True)
+    exception_values = get_path(event.data, "exception", "values", filter=True)
 
-    if values:
-        for value in values:
-            if "raw_stacktrace" in value:
+    if exception_values:
+        for exception_value in exception_values:
+            if "raw_stacktrace" in exception_value:
                 has_minified_stack_trace = True
                 break
 

--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -3,7 +3,6 @@ import logging
 from django.db import IntegrityError, transaction
 from django.db.models import F, Q
 from django.utils import timezone
-from sentry.utils.safe import get_path
 
 from sentry import analytics
 from sentry.models import (
@@ -33,6 +32,7 @@ from sentry.signals import (
     transaction_processed,
 )
 from sentry.utils.javascript import has_sourcemap
+from sentry.utils.safe import get_path
 
 
 def try_mark_onboarding_complete(organization_id):


### PR DESCRIPTION
This PR adds the new properties `has_minified_stack_trace` and `URL` to the analytic's events `first_event.sent` and `first_event_for_project.sent` so we can get metrics which will help us improve the onboarding experience for our users.

The new analytics property `first_event_with_minified_stack_trace_for_project.sent` was also created so we can separate track first events already with a minified stack trace.
