### PR TITLE
ref(discover): removes optional args from decodeColumnOrder and getColumns

### DIFF
--- a/static/app/components/charts/simpleTableChart.tsx
+++ b/static/app/components/charts/simpleTableChart.tsx
@@ -82,8 +82,7 @@ function SimpleTableChart({
 
   const meta = metadata ?? {};
   const columns = decodeColumnOrder(
-    fields.map((field, index) => ({field, alias: fieldAliases[index]})),
-    true
+    fields.map((field, index) => ({field, alias: fieldAliases[index]}))
   );
 
   return (

--- a/static/app/components/modals/widgetViewerModal.tsx
+++ b/static/app/components/modals/widgetViewerModal.tsx
@@ -371,8 +371,7 @@ function WidgetViewerModal(props: Props) {
   let columnOrder = decodeColumnOrder(
     fields.map(field => ({
       field,
-    })),
-    true
+    }))
   );
   const columnSortBy = eventView.getSorts();
   columnOrder = columnOrder.map((column, index) => ({

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -750,8 +750,8 @@ class EventView {
     return this.fields.length;
   }
 
-  getColumns(useFullEquationAsKey?: boolean): TableColumn<React.ReactText>[] {
-    return decodeColumnOrder(this.fields, useFullEquationAsKey);
+  getColumns(): TableColumn<React.ReactText>[] {
+    return decodeColumnOrder(this.fields);
   }
 
   getDays(): number {

--- a/static/app/views/eventsV2/table/tableActions.tsx
+++ b/static/app/views/eventsV2/table/tableActions.tsx
@@ -35,7 +35,7 @@ function handleDownloadAsCsv(title: string, {organization, eventView, tableData}
     eventName: 'Discoverv2: Download CSV',
     organization_id: parseInt(organization.id, 10),
   });
-  downloadAsCsv(tableData, eventView.getColumns(true), title);
+  downloadAsCsv(tableData, eventView.getColumns(), title);
 }
 
 function renderDownloadButton(canEdit: boolean, props: Props) {

--- a/static/app/views/eventsV2/table/tableView.tsx
+++ b/static/app/views/eventsV2/table/tableView.tsx
@@ -581,7 +581,7 @@ function TableView(props: TableViewProps) {
 
   const {isLoading, error, location, tableData, eventView} = props;
 
-  const columnOrder = eventView.getColumns(true);
+  const columnOrder = eventView.getColumns();
   const columnSortBy = eventView.getSorts();
 
   const prependColumnWidths = eventView.hasAggregateField()

--- a/static/app/views/eventsV2/utils.tsx
+++ b/static/app/views/eventsV2/utils.tsx
@@ -64,20 +64,15 @@ const TEMPLATE_TABLE_COLUMN: TableColumn<string> = {
 
 // TODO(mark) these types are coupled to the gridEditable component types and
 // I'd prefer the types to be more general purpose but that will require a second pass.
-export function decodeColumnOrder(
-  fields: Readonly<Field[]>,
-  useFullEquationAsKey?: boolean
-): TableColumn<string>[] {
-  let equations = 0;
+export function decodeColumnOrder(fields: Readonly<Field[]>): TableColumn<string>[] {
   return fields.map((f: Field) => {
     const column: TableColumn<string> = {...TEMPLATE_TABLE_COLUMN};
 
     const col = explodeFieldString(f.field, f.alias);
     const columnName = f.field;
     if (isEquation(f.field)) {
-      column.key = useFullEquationAsKey ? f.field : `equation[${equations}]`;
+      column.key = f.field;
       column.name = getEquation(columnName);
-      equations += 1;
     } else {
       column.key = columnName;
       column.name = columnName;

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -407,7 +407,7 @@ class _Table extends Component<Props, State> {
     const {eventView, organization, location, setError} = this.props;
     const {widths, transaction, transactionThreshold} = this.state;
     const columnOrder = eventView
-      .getColumns(true)
+      .getColumns()
       // remove team_key_transactions from the column order as we'll be rendering it
       // via a prepended column
       .filter(


### PR DESCRIPTION
removes optional useFullEquationAsKey arg from decodeColumnOrder and getColumns the behaviour should always be `true` ie return equation columns with their full name.