### PR TITLE
feat: Enable DS for the Go SDK

### DIFF
--- a/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
+++ b/src/sentry/api/endpoints/organization_dynamic_sampling_sdk_versions.py
@@ -43,6 +43,7 @@ ALLOWED_SDK_NAMES = frozenset(
         "sentry.php",  # PHP
         "sentry.php.laravel",  # Laravel
         "sentry.php.symfony",  # Symfony
+        "sentry.go",  # Go
     )
 )
 # We want sentry.java, sentry.java.spring, sentry.java.android, sentry.java.android.timber,


### PR DESCRIPTION
Go SDK v0.16.0 is still pending release. Will merge once it has been released.