### PR TITLE
fix(perf): Always strip query when rendering `TransactionNameSearchBar`

### DIFF
--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -110,6 +110,17 @@ describe('Performance > Landing > Index', function () {
         ],
       },
     });
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/metrics-compatibility/`,
+      body: [],
+    });
+
+    MockApiClient.addMockResponse({
+      method: 'GET',
+      url: `/organizations/org-slug/metrics-compatibility-sums/`,
+      body: [],
+    });
   });
 
   afterEach(function () {

--- a/static/app/views/performance/landing/index.spec.tsx
+++ b/static/app/views/performance/landing/index.spec.tsx
@@ -3,7 +3,14 @@ import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
 
 import {addMetricsDataMock} from 'sentry-test/performance/addMetricsDataMock';
 import {initializeData} from 'sentry-test/performance/initializePerformanceData';
-import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'sentry-test/reactTestingLibrary';
 
 import TeamStore from 'sentry/stores/teamStore';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
@@ -316,6 +323,21 @@ describe('Performance > Landing > Index', function () {
       );
 
       expect(await screen.findByTestId('transaction-search-bar')).toBeInTheDocument();
+    });
+
+    it('extracts free text from the query', async function () {
+      const data = initializeData({
+        features: [
+          'performance-transaction-name-only-search',
+          'performance-transaction-name-only-search-indexed',
+        ],
+      });
+
+      wrapper = render(<WrappedComponent data={data} />, data.routerContext);
+
+      await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
+      expect(await screen.findByPlaceholderText('Search Transactions')).toHaveValue('');
     });
   });
 });

--- a/static/app/views/performance/landing/index.tsx
+++ b/static/app/views/performance/landing/index.tsx
@@ -244,11 +244,6 @@ export function PerformanceLanding(props: Props) {
                                   {pageFilters}
                                   <MEPConsumer>
                                     {({metricSettingState}) => {
-                                      const searchQuery =
-                                        metricSettingState === MEPState.metricsOnly
-                                          ? getFreeTextFromQuery(derivedQuery)
-                                          : derivedQuery;
-
                                       return (metricSettingState ===
                                         MEPState.metricsOnly &&
                                         shouldShowTransactionNameOnlySearch) ||
@@ -264,14 +259,14 @@ export function PerformanceLanding(props: Props) {
                                               metricSettingState ?? undefined
                                             );
                                           }}
-                                          query={searchQuery}
+                                          query={getFreeTextFromQuery(derivedQuery)}
                                         />
                                       ) : (
                                         <SearchBar
                                           searchSource="performance_landing"
                                           organization={organization}
                                           projectIds={eventView.project}
-                                          query={searchQuery}
+                                          query={derivedQuery}
                                           fields={generateAggregateFields(
                                             organization,
                                             [...eventView.fields, {field: 'tps()'}],


### PR DESCRIPTION
Closes PERF-1853.

The condition for applying `getFreeTextFromQuery` did not match the condition
that toggles between `SearchBar` and `TransactionNameSearchBar`. As a result,
we would sometimes render `TransactionNameSearchBar` with a query in it, which
is incorrect.

Consolidate the logic, always render `TransactionNameSearchBar` with a stripped
query.

