### PR TITLE
feat(profiling): place gc stack frames on top of previous stack

### DIFF
--- a/static/app/utils/profiling/profile/sampledProfile.spec.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.spec.tsx
@@ -169,4 +169,76 @@ describe('SampledProfile', () => {
 
     expect(profile.minFrameDuration).toBe(0.5);
   });
+
+  it('places garbace collector calls on top of previous stack for node', () => {
+    const trace: Profiling.SampledProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      threadID: 0,
+      type: 'sampled',
+      weights: [1, 3],
+      samples: [
+        [0, 1],
+        [0, 2],
+      ],
+    };
+
+    const profile = SampledProfile.FromProfile(
+      trace,
+      createFrameIndex('node', [
+        {name: 'f0'},
+        {name: 'f1'},
+        {name: '(garbage collector)'},
+      ])
+    );
+
+    // GC gets places on top of the previous stack and the weight is updated
+    expect(profile.appendOrderTree.children[0].children[0].frame.name).toBe(
+      'f1 [native code]'
+    );
+    // The total weight of the previous top is now the weight of the GC call + the weight of the previous top
+    expect(profile.appendOrderTree.children[0].children[0].frame.totalWeight).toBe(4);
+    expect(profile.appendOrderTree.children[0].children[0].children[0].frame.name).toBe(
+      '(garbage collector) [native code]'
+    );
+    // The self weight of the GC call is only the weight of the GC call
+    expect(
+      profile.appendOrderTree.children[0].children[0].children[0].frame.selfWeight
+    ).toBe(3);
+  });
+
+  it('merges consecutive garbage collector calls on top of previous stack for node', () => {
+    const trace: Profiling.SampledProfile = {
+      name: 'profile',
+      startValue: 0,
+      endValue: 1000,
+      unit: 'milliseconds',
+      threadID: 0,
+      type: 'sampled',
+      weights: [1, 2, 2, 2],
+      samples: [
+        [0, 1],
+        [0, 2],
+        [0, 2],
+        [0, 2],
+      ],
+    };
+
+    const profile = SampledProfile.FromProfile(
+      trace,
+      createFrameIndex('node', [
+        {name: 'f0'},
+        {name: 'f1'},
+        {name: '(garbage collector)'},
+      ])
+    );
+
+    // There are no other children than the GC call meaning merge happened
+    expect(profile.appendOrderTree.children[0].children[0].children[1]).toBe(undefined);
+    expect(
+      profile.appendOrderTree.children[0].children[0].children[0].frame.selfWeight
+    ).toBe(6);
+  });
 });

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -43,6 +43,11 @@ export class SampledProfile extends Profile {
 
       if (
         i > 0 &&
+        // We check for size <= 2 because we have so far only seen node profiles
+        // where GC is either marked as the root node or is directly under the root node.
+        // There is a good chance that this logic will at some point live on the backend
+        // and when that happens, we do not want to enter this case as the GC will already
+        // be placed at the top of the previous stack and the new stack length will be > 2
         resolvedStack.length <= 2 &&
         resolvedStack[resolvedStack.length - 1]?.name ===
           '(garbage collector) [native code]'
@@ -61,6 +66,11 @@ export class SampledProfile extends Profile {
         // Now collect all weights of all the consecutive gc frames and skip the samples
         while (
           sampledProfile.samples[i + 1] &&
+          // We check for size <= 2 because we have so far only seen node profiles
+          // where GC is either marked as the root node or is directly under the root node.
+          // There is a good chance that this logic will at some point live on the backend
+          // and when that happens, we do not want to enter this case as the GC will already
+          // be placed at the top of the previous stack and the new stack length will be > 2
           sampledProfile.samples[i + 1].length <= 2 &&
           frameIndex[
             sampledProfile.samples[i + 1][sampledProfile.samples[i + 1].length - 1]

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -43,6 +43,7 @@ export class SampledProfile extends Profile {
 
       if (
         i > 0 &&
+        resolvedStack.length <= 2 &&
         resolvedStack[resolvedStack.length - 1]?.name ===
           '(garbage collector) [native code]'
       ) {
@@ -60,6 +61,7 @@ export class SampledProfile extends Profile {
         // Now collect all weights of all the consecutive gc frames and skip the samples
         while (
           sampledProfile.samples[i + 1] &&
+          sampledProfile.samples[i + 1].length <= 2 &&
           frameIndex[
             sampledProfile.samples[i + 1][sampledProfile.samples[i + 1].length - 1]
           ]?.name === '(garbage collector) [native code]'


### PR DESCRIPTION
This PR improves the flamechart UI for Node profiles.There is a slight annoyance with how GC is reported by the CPU profiler where it is not placed on top of any stacks, but is marked as just a frame (often) without any root. This means that a function which triggers many GC events (array resizing for example) ends up being reported as many individual stacks because GC stacks have no common root with the previous stack so we cannot merge any frames.

It seems that chrome devtools handles this by placing GC calls on top of the previous stack so that any common frames can still be merged.

Devtools example
<img width="586" alt="CleanShot 2022-12-05 at 16 59 01@2x" src="https://user-images.githubusercontent.com/9317857/205980419-681432b0-cdcd-4c6b-a635-15ec24a6d2cb.png">

Previous behavior with many small stacks being broken up by GC calls
![CleanShot 2022-12-06 at 12 01 47@2x](https://user-images.githubusercontent.com/9317857/205980500-7242c7cb-37f2-4f18-bc31-f41f3ae779e3.png)

New behavior with GC placed on top of previous stack
<img width="1134" alt="CleanShot 2022-12-06 at 12 26 37@2x" src="https://user-images.githubusercontent.com/9317857/205980584-f7b8c187-02f4-422a-a38a-e1609174ee97.png">
