### PR TITLE
fix(profiling): handle unsupported projects

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/proflingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/ProfilingOnboarding/proflingOnboardingSidebar.tsx
@@ -47,7 +47,7 @@ export function ProfilingOnboardingSidebar(props: CommonSidebarProps) {
   );
 
   useEffect(() => {
-    // we'll only ever select an unsupportedProject if they do not have a supported project in their project
+    // we'll only ever select an unsupportedProject if they do not have a supported project in their organization
     if (supportedProjects.length === 0 && unsupportedProjects.length > 0) {
       if (pageFilters.selection.projects[0] === ALL_ACCESS_PROJECTS) {
         setCurrentProject(unsupportedProjects[0]);
@@ -128,20 +128,30 @@ export function ProfilingOnboardingSidebar(props: CommonSidebarProps) {
     <TaskSidebar orientation={orientation} collapsed={collapsed} hidePanel={hidePanel}>
       <TaskSidebarList>
         <Heading>{t('Profile Code')}</Heading>
-        <CompactSelect
-          triggerLabel={
-            <StyledIdBadge
-              project={currentProject}
-              avatarSize={16}
-              hideOverflow
-              disableLink
-            />
-          }
-          onChange={option => setCurrentProject(option.value)}
-          triggerProps={{'aria-label': currentProject?.slug}}
-          options={projectSelectOptions}
-          position="bottom-end"
-        />
+        <div
+          onClick={e => {
+            // we need to stop bubbling the CompactSelect click event
+            // failing to do so will cause the sidebar panel to close
+            // the event.target will be unmounted by the time the panel listener
+            // receives the event and assume the click was outside the panel
+            e.stopPropagation();
+          }}
+        >
+          <CompactSelect
+            triggerLabel={
+              <StyledIdBadge
+                project={currentProject}
+                avatarSize={16}
+                hideOverflow
+                disableLink
+              />
+            }
+            onChange={option => setCurrentProject(option.value)}
+            triggerProps={{'aria-label': currentProject?.slug}}
+            options={projectSelectOptions}
+            position="bottom-end"
+          />
+        </div>
         {currentProject && (
           <OnboardingContent
             currentProject={currentProject}
@@ -193,13 +203,13 @@ function OnboardingContent({
       <Fragment>
         <div>
           {tct(
-            'Fiddlesticks. Profiling isn’t available for your [platform] project yet but we’re definitely still working on it. Stay tuned.',
+            'Fiddlesticks. Profiling isn’t available for your [platform] project yet. Reach out to us on Discord for more information.',
             {platform: currentPlatform?.name || currentProject.slug}
           )}
         </div>
         <div>
-          <Button size="sm" href="https://docs.sentry.io/platforms/" external>
-            {t('Go to Sentry Documentation')}
+          <Button size="sm" href="https://discord.gg/zrMjKA4Vnz" external>
+            {t('Join Discord')}
           </Button>
         </div>
       </Fragment>

--- a/static/app/components/sidebar/sidebarPanel.tsx
+++ b/static/app/components/sidebar/sidebarPanel.tsx
@@ -87,10 +87,20 @@ function SidebarPanel({
   useEffect(() => {
     // Wait one tick to setup the click handler so we don't detect the click
     // that is bubbling up from opening the panel itself
-    window.setTimeout(() => document.addEventListener('click', panelCloseHandler));
+    window.setTimeout(() =>
+      document.addEventListener('click', panelCloseHandler, {
+        // listening on capture ensures we don't incorrectly hide the panel in instances where the target
+        // is unmounted before it bubbles up to this listener
+        capture: true,
+      })
+    );
 
     return function cleanup() {
-      window.setTimeout(() => document.removeEventListener('click', panelCloseHandler));
+      window.setTimeout(() =>
+        document.removeEventListener('click', panelCloseHandler, {
+          capture: true,
+        })
+      );
     };
   }, [panelCloseHandler]);
 

--- a/static/app/components/sidebar/sidebarPanel.tsx
+++ b/static/app/components/sidebar/sidebarPanel.tsx
@@ -87,20 +87,10 @@ function SidebarPanel({
   useEffect(() => {
     // Wait one tick to setup the click handler so we don't detect the click
     // that is bubbling up from opening the panel itself
-    window.setTimeout(() =>
-      document.addEventListener('click', panelCloseHandler, {
-        // listening on capture ensures we don't incorrectly hide the panel in instances where the target
-        // is unmounted before it bubbles up to this listener
-        capture: true,
-      })
-    );
+    window.setTimeout(() => document.addEventListener('click', panelCloseHandler));
 
     return function cleanup() {
-      window.setTimeout(() =>
-        document.removeEventListener('click', panelCloseHandler, {
-          capture: true,
-        })
-      );
+      window.setTimeout(() => document.removeEventListener('click', panelCloseHandler));
     };
   }, [panelCloseHandler]);
 


### PR DESCRIPTION
## Summary
Currently we don't render anything in scenarios where an org only has unsupported projects. 
In these situations we'll select the current/first unsupported project in their org and render the unsupported messaging.

To avoid any "minesweeper" style of UX, we've swapped out the dropdown menu w/ a grouped select control showing supported/unsupported projects. Unsupported projects are disabled. - This was previously used in our onboarding modal.

![image](https://user-images.githubusercontent.com/7349258/206001380-04e24e24-e169-479d-8924-5969fcfc2054.png)
![image](https://user-images.githubusercontent.com/7349258/206001397-e098126d-9e46-4ad9-9b2f-d06af4209b9d.png)
![image](https://user-images.githubusercontent.com/7349258/206001431-5dc3d6c2-9d9c-49e4-b761-3498da61ccdd.png)

