### PR TITLE
fix(metrics): Add missing `spans.ui` span op

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -227,6 +227,7 @@ METRICS_MAP = {
     "spans.db": "d:transactions/breakdowns.span_ops.ops.db@millisecond",
     "spans.http": "d:transactions/breakdowns.span_ops.ops.http@millisecond",
     "spans.resource": "d:transactions/breakdowns.span_ops.ops.resource@millisecond",
+    "spans.ui": "d:transactions/breakdowns.span_ops.ops.ui@millisecond",
     "transaction.duration": "d:transactions/duration@millisecond",
     "user": "s:transactions/user@none",
 }


### PR DESCRIPTION
`spans.ui` was missing in metrics constants and, because of that, requests with `spans.ui` field were failing. This PR fixes that.

Fixes PERF-1854
