### PR TITLE
feat(alert-preview): last triggered

### DIFF
--- a/src/sentry/api/endpoints/project_rule_preview.py
+++ b/src/sentry/api/endpoints/project_rule_preview.py
@@ -92,5 +92,5 @@ class PreviewSerializer(GroupSerializer):
         result = super().serialize(obj, attrs, user, **kwargs)
         group_id = int(result["id"])
         result["inbox"] = kwargs["inbox_details"].get(group_id)
-        result["lastTriggered"] = kwargs["group_fires"][group_id][-1]
+        result["lastTriggered"] = kwargs["group_fires"][group_id]
         return result

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1021,7 +1021,7 @@ SENTRY_FEATURES = {
     # Enable issue alert incompatible rule check
     "organizations:issue-alert-incompatible-rules": False,
     # Enable issue alert previews
-    "organizations:issue-alert-preview": False,
+    "organizations:issue-alert-preview": True,
     # Enable issue alert test notifications
     "organizations:issue-alert-test-notifications": False,
     # Whether to allow issue only search on the issue list

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1021,7 +1021,7 @@ SENTRY_FEATURES = {
     # Enable issue alert incompatible rule check
     "organizations:issue-alert-incompatible-rules": False,
     # Enable issue alert previews
-    "organizations:issue-alert-preview": True,
+    "organizations:issue-alert-preview": False,
     # Enable issue alert test notifications
     "organizations:issue-alert-test-notifications": False,
     # Whether to allow issue only search on the issue list

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -49,7 +49,7 @@ def preview(
     filter_match: str,
     frequency_minutes: int,
     end: datetime | None = None,
-) -> Dict[int, List[datetime]] | None:
+) -> Dict[int, datetime] | None:
     """
     Returns groups that would have triggered the given conditions and filters in the past 2 weeks
     """
@@ -184,11 +184,12 @@ def get_fired_groups(
     start: datetime,
     frequency: timedelta,
     event_map: Dict[str, Any],
-) -> Dict[int, List[datetime]]:
+) -> Dict[int, datetime]:
     """
-    Applies filter objects to the condition activity, returns the group ids of activities that pass the filters
+    Applies filter objects to the condition activity.
+    Returns the group ids of activities that pass the filters and the last fire of each group
     """
-    group_fires = defaultdict(list)
+    group_fires = {}
     for group, activities in group_activity.items():
         last_fire = start - frequency
         for event in activities:
@@ -197,7 +198,7 @@ def get_fired_groups(
             except NotImplementedError:
                 raise PreviewException
             if last_fire <= event.timestamp - frequency and filter_func(passes):
-                group_fires[group].append(event.timestamp)
+                group_fires[group] = event.timestamp
                 last_fire = event.timestamp
 
     return group_fires

--- a/src/sentry/rules/history/preview.py
+++ b/src/sentry/rules/history/preview.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Dict, List, Sequence, Tuple
 
 from django.utils import timezone
 
-from sentry.db.models import BaseQuerySet
 from sentry.models import Group, Project
 from sentry.rules import RuleBase, rules
 from sentry.rules.history.preview_strategy import (
@@ -50,7 +49,7 @@ def preview(
     filter_match: str,
     frequency_minutes: int,
     end: datetime | None = None,
-) -> BaseQuerySet | None:
+) -> Dict[int, List[datetime]] | None:
     """
     Returns groups that would have triggered the given conditions and filters in the past 2 weeks
     """
@@ -62,7 +61,7 @@ def preview(
 
     # all the issue state conditions are mutually exclusive
     if len(issue_state_conditions) > 1 and condition_match == "all":
-        return Group.objects.none()
+        return {}
 
     if end is None:
         end = timezone.now()
@@ -98,11 +97,11 @@ def preview(
             )
 
         frequency = timedelta(minutes=frequency_minutes)
-        group_ids = get_fired_groups(
+        group_fires = get_fired_groups(
             group_activity, filter_objects, filter_func, start, frequency, event_map
         )
 
-        return Group.objects.filter(id__in=group_ids)
+        return group_fires
     except PreviewException:
         return None
 
@@ -185,11 +184,11 @@ def get_fired_groups(
     start: datetime,
     frequency: timedelta,
     event_map: Dict[str, Any],
-) -> Sequence[int]:
+) -> Dict[int, List[datetime]]:
     """
     Applies filter objects to the condition activity, returns the group ids of activities that pass the filters
     """
-    group_ids = set()
+    group_fires = defaultdict(list)
     for group, activities in group_activity.items():
         last_fire = start - frequency
         for event in activities:
@@ -198,11 +197,10 @@ def get_fired_groups(
             except NotImplementedError:
                 raise PreviewException
             if last_fire <= event.timestamp - frequency and filter_func(passes):
-                # XXX: we could break after adding the group, but we may potentially want the times of fires later
-                group_ids.add(group)
+                group_fires[group].append(event.timestamp)
                 last_fire = event.timestamp
 
-    return list(group_ids)
+    return group_fires
 
 
 def get_top_groups(

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -466,10 +466,10 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
         conditions = [{"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"}]
 
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert result[self.group.id] == [prev_two_hour, prev_hour]
+        assert result[self.group.id] == prev_hour
 
         result = preview(self.project, conditions, [], "all", "all", 180)
-        assert result[self.group.id] == [prev_two_hour]
+        assert result[self.group.id] == prev_two_hour
 
 
 @freeze_time()

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -71,7 +71,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
     def _test_preview(self, condition, expected):
         conditions = [{"id": condition}]
         result = preview(self.project, conditions, [], "all", "all", 60)
-        assert result.count() == expected
+        assert len(result) == expected
 
     def test_first_seen(self):
         hours = self._set_up_first_seen()
@@ -124,8 +124,8 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
                 older.append(group)
 
         result = preview(self.project, conditions, filters, *MATCH_ARGS)
-        assert all(g in result for g in newer)
-        assert all(g not in result for g in older)
+        assert all(g.id in result for g in newer)
+        assert all(g.id not in result for g in older)
 
     def test_occurrences(self):
         hours = get_hours(PREVIEW_TIME_RANGE)
@@ -157,9 +157,9 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
 
         result = preview(self.project, conditions, filters, *MATCH_ARGS)
         for i in range(threshold + 1):
-            assert groups[i] not in result
+            assert groups[i].id not in result
         for i in range(threshold + 1, hours):
-            assert groups[i] in result
+            assert groups[i].id in result
 
     def test_issue_category(self):
         hours = get_hours(PREVIEW_TIME_RANGE)
@@ -190,8 +190,8 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
             }
         ]
         result = preview(self.project, conditions, filters, *MATCH_ARGS)
-        assert all(group in result for group in errors)
-        assert all(group not in result for group in n_plus_one)
+        assert all(group.id in result for group in errors)
+        assert all(group.id not in result for group in n_plus_one)
 
     def test_level(self):
         event = self._set_up_event({"tags": {"level": "error"}})
@@ -199,16 +199,16 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
         conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
         filters = [{"id": "sentry.rules.filters.level.LevelFilter", "level": "40", "match": "eq"}]
         results = preview(self.project, conditions, filters, *MATCH_ARGS)
-        assert event.group in results
+        assert event.group.id in results
 
         filters[0]["match"] = "gte"
         filters[0]["level"] = "50"
         results = preview(self.project, conditions, filters, *MATCH_ARGS)
-        assert event.group not in results
+        assert event.group.id not in results
 
         filters[0]["match"] = "lte"
         results = preview(self.project, conditions, filters, *MATCH_ARGS)
-        assert event.group in results
+        assert event.group.id in results
 
     def test_tagged(self):
         event = self._set_up_event({"tags": {"foo": "bar"}})
@@ -223,11 +223,11 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
         ]
 
         results = preview(self.project, conditions, filters, *MATCH_ARGS)
-        assert event.group in results
+        assert event.group.id in results
 
         filters[0]["value"] = "baz"
         results = preview(self.project, conditions, filters, *MATCH_ARGS)
-        assert event.group not in results
+        assert event.group.id not in results
 
     def test_event_attribute(self):
         event = self._set_up_event({"message": "hello world"})
@@ -242,11 +242,11 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
         ]
 
         results = preview(self.project, conditions, filters, *MATCH_ARGS)
-        assert event.group in results
+        assert event.group.id in results
 
         filters[0]["value"] = "goodbye world"
         results = preview(self.project, conditions, filters, *MATCH_ARGS)
-        assert event.group not in results
+        assert event.group.id not in results
 
     def test_unsupported_conditions(self):
         self._set_up_first_seen()
@@ -315,8 +315,8 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
         ]
         result = preview(self.project, conditions, [], "any", "all", 0)
         # result should only contain groups of `self.project`
-        assert all(g in result for g in groups[0])
-        assert all(g not in result for g in groups[1])
+        assert all(g.id in result for g in groups[0])
+        assert all(g.id not in result for g in groups[1])
 
     def test_out_of_time_range(self):
         out_of_range = timezone.now() - PREVIEW_TIME_RANGE - timedelta(hours=1)
@@ -341,7 +341,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
             {"id": "sentry.rules.conditions.reappeared_event.ReappearedEventCondition"},
         ]
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert result.count() == 0
+        assert not result
 
     def test_transactions(self):
         prev_hour = timezone.now() - timedelta(hours=1)
@@ -375,11 +375,11 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
             }
         ]
         result = preview(self.project, conditions, filters, "all", "all", 0)
-        assert perf_issue in result
+        assert perf_issue.id in result
 
         filters[0]["value"] = "baz"
         result = preview(self.project, conditions, filters, "all", "all", 0)
-        assert perf_issue not in result
+        assert perf_issue.id not in result
 
         filters = [
             {
@@ -390,11 +390,11 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
             }
         ]
         result = preview(self.project, conditions, filters, "all", "all", 0)
-        assert perf_issue in result
+        assert perf_issue.id in result
 
         filters[0]["value"] = "wrong message"
         result = preview(self.project, conditions, filters, "all", "all", 0)
-        assert perf_issue not in result
+        assert perf_issue.id not in result
         # this can be tested when SNS-1891 is fixed
         """
         conditions = [{"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}]
@@ -405,7 +405,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
             "value": "bar",
         }]
         result = preview(self.project, conditions, filters, "all", "all", 0)
-        assert perf_issue in result
+        assert perf_issue.id in result
         """
 
     def test_errors_transactions_together(self):
@@ -450,7 +450,26 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase):
             }
         ]
         result = preview(self.project, conditions, filters, "any", "all", 0)
-        assert issue in result and perf_issue in result
+        assert issue.id in result and perf_issue.id in result
+
+    def test_triggered_times(self):
+        prev_hour = timezone.now() - timedelta(hours=1)
+        prev_two_hour = timezone.now() - timedelta(hours=2)
+        for time in (prev_hour, prev_two_hour):
+            Activity.objects.create(
+                project=self.project,
+                group=self.group,
+                type=ActivityType.SET_REGRESSION.value,
+                datetime=time,
+            )
+
+        conditions = [{"id": "sentry.rules.conditions.regression_event.RegressionEventCondition"}]
+
+        result = preview(self.project, conditions, [], *MATCH_ARGS)
+        assert result[self.group.id] == [prev_two_hour, prev_hour]
+
+        result = preview(self.project, conditions, [], "all", "all", 180)
+        assert result[self.group.id] == [prev_two_hour]
 
 
 @freeze_time()
@@ -536,15 +555,15 @@ class FrequencyConditionTest(TestCase, SnubaTestCase):
             },
         ]
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group in result
+        assert group.id in result
 
         conditions[1]["value"] = 5
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group not in result
+        assert group.id not in result
 
         conditions[1]["interval"] = "1d"
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group in result
+        assert group.id in result
 
     def test_transaction(self):
         prev_hour = timezone.now() - timedelta(hours=1)
@@ -577,11 +596,11 @@ class FrequencyConditionTest(TestCase, SnubaTestCase):
         ]
 
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group in result
+        assert group.id in result
 
         conditions[1]["value"] = 1
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group not in result
+        assert group.id not in result
 
     def test_no_activity_event_filter(self):
         conditions = [
@@ -611,11 +630,11 @@ class FrequencyConditionTest(TestCase, SnubaTestCase):
             }
         ]
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group in result
+        assert group.id in result
 
         conditions[0]["value"] = 5
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group not in result
+        assert group.id not in result
 
     def test_frequency_conditions(self):
         prev_hour = timezone.now() - timedelta(hours=1)
@@ -640,14 +659,14 @@ class FrequencyConditionTest(TestCase, SnubaTestCase):
             },
         ]
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group in result
+        assert group.id in result
 
         conditions[0]["value"] = 5
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group not in result
+        assert group.id not in result
 
         result = preview(self.project, conditions, [], "any", "all", 0)
-        assert group in result
+        assert group.id in result
 
     def test_interval_comparison(self):
         prev_hour = timezone.now() - timedelta(hours=1)
@@ -667,11 +686,11 @@ class FrequencyConditionTest(TestCase, SnubaTestCase):
             },
         ]
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group in result
+        assert group.id in result
 
         conditions[0]["value"] = 100
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group not in result
+        assert group.id not in result
 
         conditions.append(
             {
@@ -683,7 +702,7 @@ class FrequencyConditionTest(TestCase, SnubaTestCase):
             }
         )
         result = preview(self.project, conditions, [], "any", "all", 0)
-        assert group in result
+        assert group.id in result
 
     def test_unique_user(self):
         prev_hour = timezone.now() - timedelta(hours=1)
@@ -703,11 +722,11 @@ class FrequencyConditionTest(TestCase, SnubaTestCase):
         ]
 
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group in result
+        assert group.id in result
 
         conditions[0]["value"] = 3
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group not in result
+        assert group.id not in result
 
     def tests_multiple_freq_cond_types(self):
         prev_hour = timezone.now() - timedelta(hours=1)
@@ -730,11 +749,11 @@ class FrequencyConditionTest(TestCase, SnubaTestCase):
         ]
 
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group in result
+        assert group.id in result
 
         conditions[1]["value"] = 1
         result = preview(self.project, conditions, [], *MATCH_ARGS)
-        assert group not in result
+        assert group.id not in result
 
 
 @freeze_time()


### PR DESCRIPTION
Attaches `last_triggered` to group info. `preview` now returns a mapping of group_ids to triggers, updated tests to reflect that.