### PR TITLE
feat(alert-preview): show last triggered in preview

### DIFF
--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -7,15 +7,21 @@ import space from 'sentry/styles/space';
 type Props = {
   withChart: boolean;
   narrowGroups?: boolean;
+  showLastTriggered?: boolean;
 };
 
-const GroupListHeader = ({withChart = true, narrowGroups = false}: Props) => (
+const GroupListHeader = ({
+  withChart = true,
+  narrowGroups = false,
+  showLastTriggered = false,
+}: Props) => (
   <PanelHeader disablePadding>
     <IssueWrapper>{t('Issue')}</IssueWrapper>
     {withChart && <ChartWrapper narrowGroups={narrowGroups}>{t('Graph')}</ChartWrapper>}
     <EventUserWrapper>{t('events')}</EventUserWrapper>
     <EventUserWrapper>{t('users')}</EventUserWrapper>
     <AssigneeWrapper narrowGroups={narrowGroups}>{t('Assignee')}</AssigneeWrapper>
+    {showLastTriggered && <EventUserWrapper>{t('last triggered')}</EventUserWrapper>}
   </PanelHeader>
 );
 

--- a/static/app/components/issues/groupListHeader.tsx
+++ b/static/app/components/issues/groupListHeader.tsx
@@ -21,7 +21,7 @@ const GroupListHeader = ({
     <EventUserWrapper>{t('events')}</EventUserWrapper>
     <EventUserWrapper>{t('users')}</EventUserWrapper>
     <AssigneeWrapper narrowGroups={narrowGroups}>{t('Assignee')}</AssigneeWrapper>
-    {showLastTriggered && <EventUserWrapper>{t('last triggered')}</EventUserWrapper>}
+    {showLastTriggered && <EventUserWrapper>{t('Last Triggered')}</EventUserWrapper>}
   </PanelHeader>
 );
 

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -422,28 +422,12 @@ function BaseGroupRow({
   const lastTriggered = !defined(lastTriggeredDate) ? (
     <Placeholder height="18px" />
   ) : (
-    <DeprecatedDropdownMenu isNestedDropdown>
-      {({isOpen, getRootProps, getActorProps}) => {
-        const topLevelCx = classNames('dropdown', {'anchor-middle': true, open: isOpen});
-
-        return (
-          <GuideAnchor target="dynamic_counts" disabled={!hasGuideAnchor}>
-            <span {...getRootProps({className: topLevelCx})}>
-              <span {...getActorProps({})}>
-                <div className="dropdown-actor-title">
-                  <TimeSince
-                    tooltipTitle={t('Last Triggered')}
-                    date={lastTriggeredDate}
-                    suffix={t('ago')}
-                    shorten
-                  />
-                </div>
-              </span>
-            </span>
-          </GuideAnchor>
-        );
-      }}
-    </DeprecatedDropdownMenu>
+    <TimeSince
+      tooltipTitle={t('Last Triggered')}
+      date={lastTriggeredDate}
+      suffix={t('ago')}
+      shorten
+    />
   );
 
   const issueStreamAnchor = isDemoWalkthrough() ? (

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -64,6 +64,7 @@ type Props = {
   query?: string;
   queryFilterDescription?: string;
   showInboxTime?: boolean;
+  showLastTriggered?: boolean;
   source?: string;
   statsPeriod?: string;
   useFilteredStats?: boolean;
@@ -89,6 +90,7 @@ function BaseGroupRow({
   useFilteredStats = false,
   useTintRow = true,
   narrowGroups = false,
+  showLastTriggered = false,
 }: Props) {
   const groups = useLegacyStore(GroupStore);
   const group = groups.find(item => item.id === id) as Group;
@@ -298,6 +300,8 @@ function BaseGroupRow({
   const secondaryCount = group.filtered ? group.count : undefined;
   const primaryUserCount = group.filtered ? group.filtered.userCount : group.userCount;
   const secondaryUserCount = group.filtered ? group.userCount : undefined;
+  // preview stats
+  const lastTriggeredDate = group.lastTriggered;
 
   const showSecondaryPoints = Boolean(
     withChart && group && group.filtered && statsPeriod && useFilteredStats
@@ -415,6 +419,33 @@ function BaseGroupRow({
     </DeprecatedDropdownMenu>
   );
 
+  const lastTriggered = !defined(lastTriggeredDate) ? (
+    <Placeholder height="18px" />
+  ) : (
+    <DeprecatedDropdownMenu isNestedDropdown>
+      {({isOpen, getRootProps, getActorProps}) => {
+        const topLevelCx = classNames('dropdown', {'anchor-middle': true, open: isOpen});
+
+        return (
+          <GuideAnchor target="dynamic_counts" disabled={!hasGuideAnchor}>
+            <span {...getRootProps({className: topLevelCx})}>
+              <span {...getActorProps({})}>
+                <div className="dropdown-actor-title">
+                  <TimeSince
+                    tooltipTitle={t('Last Triggered')}
+                    date={lastTriggeredDate}
+                    suffix={t('ago')}
+                    shorten
+                  />
+                </div>
+              </span>
+            </span>
+          </GuideAnchor>
+        );
+      }}
+    </DeprecatedDropdownMenu>
+  );
+
   const issueStreamAnchor = isDemoWalkthrough() ? (
     <GuideAnchor target="issue_stream" disabled={!DemoWalkthroughStore.get('issue')} />
   ) : (
@@ -482,6 +513,7 @@ function BaseGroupRow({
               onAssign={trackAssign}
             />
           </AssigneeWrapper>
+          {showLastTriggered && <EventCountsWrapper>{lastTriggered}</EventCountsWrapper>}
         </Fragment>
       )}
     </Wrapper>

--- a/static/app/components/tooltip.tsx
+++ b/static/app/components/tooltip.tsx
@@ -12,11 +12,11 @@ import {useHoverOverlay, UseHoverOverlayProps} from 'sentry/utils/useHoverOverla
 import {AcceptanceTestTooltip} from './acceptanceTestTooltip';
 
 export interface InternalTooltipProps extends UseHoverOverlayProps {
-  children: React.ReactNode;
   /**
    * The content to show in the tooltip popover
    */
   title: React.ReactNode;
+  children?: React.ReactNode;
   /**
    * Disable the tooltip display entirely
    */

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -430,6 +430,7 @@ interface GroupFiltered {
 export interface GroupStats extends GroupFiltered {
   filtered: GroupFiltered | null;
   id: string;
+  // for issue alert previews, the last time a group triggered a rule
   lastTriggered?: string;
   lifetime?: GroupFiltered;
   sessionCount?: string | null;

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -430,6 +430,7 @@ interface GroupFiltered {
 export interface GroupStats extends GroupFiltered {
   filtered: GroupFiltered | null;
   id: string;
+  lastTriggered?: string;
   lifetime?: GroupFiltered;
   sessionCount?: string | null;
 }

--- a/static/app/views/alerts/create.spec.jsx
+++ b/static/app/views/alerts/create.spec.jsx
@@ -464,6 +464,10 @@ describe('ProjectAlertsCreate', function () {
     });
     it('valid preview table', async () => {
       const groups = TestStubs.Groups();
+      const date = new Date();
+      for (let i = 0; i < groups.length; i++) {
+        groups[i].lastTriggered = date;
+      }
       const mock = MockApiClient.addMockResponse({
         url: '/projects/org-slug/project-slug/rules/preview',
         method: 'POST',
@@ -490,13 +494,12 @@ describe('ProjectAlertsCreate', function () {
         );
       });
       expect(
-        screen.getByText(
-          "issues would have triggered this rule in the past 14 days approximately. If you're looking to reduce noise then make sure to"
-        )
+        screen.getByText('issues would have triggered this rule in the past 14 days')
       ).toBeInTheDocument();
       for (const group of groups) {
         expect(screen.getByText(group.shortId)).toBeInTheDocument();
       }
+      expect(screen.getAllByText('3mo ago')[0]).toBeInTheDocument();
 
       await selectEvent.select(screen.getByText('Add optional trigger...'), [
         'A new issue is created',

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -35,6 +35,7 @@ import LoadingMask from 'sentry/components/loadingMask';
 import {CursorHandler} from 'sentry/components/pagination';
 import {Panel, PanelBody} from 'sentry/components/panels';
 import TeamSelector from 'sentry/components/teamSelector';
+import Tooltip from 'sentry/components/tooltip';
 import {ALL_ENVIRONMENTS_KEY} from 'sentry/constants';
 import {IconChevron} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
@@ -937,9 +938,17 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       );
     }
     return tct(
-      "[issueCount] issues would have triggered this rule in the past 14 days approximately. If you're looking to reduce noise then make sure to [link:read the docs].",
+      "[issueCount] issues would have triggered this rule in the past 14 days [approximately]. If you're looking to reduce noise then make sure to [link:read the docs].",
       {
         issueCount,
+        approximately: (
+          <Tooltip
+            title="Previews that include issue frequency conditions are approximated"
+            showUnderline
+          >
+            approximately
+          </Tooltip>
+        ),
         link: <a href={SENTRY_ISSUE_ALERT_DOCS_URL} />,
       }
     );

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -938,16 +938,14 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       );
     }
     return tct(
-      "[issueCount] issues would have triggered this rule in the past 14 days [approximately]. If you're looking to reduce noise then make sure to [link:read the docs].",
+      "[issueCount] issues would have triggered this rule in the past 14 days [approximately:approximately]. If you're looking to reduce noise then make sure to [link:read the docs].",
       {
         issueCount,
         approximately: (
           <Tooltip
-            title="Previews that include issue frequency conditions are approximated"
+            title={t('Previews that include issue frequency conditions are approximated')}
             showUnderline
-          >
-            approximately
-          </Tooltip>
+          />
         ),
         link: <a href={SENTRY_ISSUE_ALERT_DOCS_URL} />,
       }

--- a/static/app/views/alerts/rules/issue/previewTable.tsx
+++ b/static/app/views/alerts/rules/issue/previewTable.tsx
@@ -67,6 +67,7 @@ const PreviewTable = ({
           useFilteredStats
           withChart={false}
           canSelect={false}
+          showLastTriggered
         />
       );
     });
@@ -97,7 +98,7 @@ const PreviewTable = ({
   return (
     <IssuesReplayCountProvider groupIds={previewGroups || []}>
       <Panel>
-        <GroupListHeader withChart={false} />
+        <GroupListHeader withChart={false} showLastTriggered />
         <PanelBody>{renderBody()}</PanelBody>
       </Panel>
       {renderPagination()}


### PR DESCRIPTION
Display a column for last triggered in preview table.

![Screen Shot 2022-12-06 at 12 45 27 PM](https://user-images.githubusercontent.com/39287272/206022489-a4f4d95f-d83d-443a-abfb-5203e00deef3.jpg)

Also adds a tooltip describing which previews are approximate.

![Screen Shot 2022-12-06 at 1 06 35 PM](https://user-images.githubusercontent.com/39287272/206022927-06685680-61d7-4d78-b79c-ce06aac9a9e0.jpg)
