### PR TITLE
bug(replays): Fix conditions for showing the Configure Session Replay CTA inside Issue Details

### DIFF
--- a/static/app/views/replays/replays.tsx
+++ b/static/app/views/replays/replays.tsx
@@ -55,8 +55,7 @@ function Replays({location}: Props) {
     organization,
   });
 
-  const {enabled: shouldShowOnboardingPanel, activateSidebar} =
-    useReplayOnboardingSidebarPanel();
+  const {hasSentOneReplay, activateSidebar} = useReplayOnboardingSidebarPanel();
 
   return (
     <Fragment>
@@ -70,19 +69,7 @@ function Replays({location}: Props) {
       <PageFiltersContainer>
         <StyledPageContent>
           <ReplaysFilters />
-          {shouldShowOnboardingPanel ? (
-            <ReplayOnboardingPanel>
-              <Button onClick={activateSidebar} priority="primary">
-                {t('Get Started')}
-              </Button>
-              <Button
-                href="https://github.com/getsentry/sentry-replay/blob/main/README.md"
-                external
-              >
-                {t('See Readme')}
-              </Button>
-            </ReplayOnboardingPanel>
-          ) : (
+          {hasSentOneReplay ? (
             <Fragment>
               <ReplayTable
                 isFetching={isFetching}
@@ -101,6 +88,18 @@ function Replays({location}: Props) {
                 }}
               />
             </Fragment>
+          ) : (
+            <ReplayOnboardingPanel>
+              <Button onClick={activateSidebar} priority="primary">
+                {t('Get Started')}
+              </Button>
+              <Button
+                href="https://github.com/getsentry/sentry-replay/blob/main/README.md"
+                external
+              >
+                {t('See Readme')}
+              </Button>
+            </ReplayOnboardingPanel>
           )}
         </StyledPageContent>
       </PageFiltersContainer>


### PR DESCRIPTION
The Configure Session Replay panel was appearing too often, specifically on Issues that are not supported by replay, like Python, iOS and all the rest!

<img width="655" alt="Screen Shot 2022-12-06 at 18 13 26" src="https://user-images.githubusercontent.com/187460/206033051-84e7074b-2888-4fd2-b3d2-947f998b61b0.png">


So we've added a check that the platform is indeed JS

Also, i renamed a bunch of vars to make it easier understand what the check is really doing. And added a test case.