### PR TITLE
feat(integrations): Support generic issue type alerts

### DIFF
--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -105,8 +105,7 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
         problem = get_matched_problem(event)
         return get_span_evidence_value_problem(problem)
 
-    else:
-        return None
+    return None
 
 
 def build_rule_url(rule: Any, group: Group, project: Project) -> str:

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -47,7 +47,7 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
         group = getattr(obj, "group", obj)
         if group.issue_category == GroupCategory.PERFORMANCE:
             title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
-        elif hasattr(obj, "occurrence") and obj.occurrence is not None:
+        elif isinstance(obj, GroupEvent) and obj.occurrence is not None:
             title = obj.occurrence.issue_title
         else:
             event = group.get_latest_event()
@@ -93,7 +93,7 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
     if not event:
         event = group.get_latest_event()
 
-    if hasattr(event, "occurrence") and event.occurrence is not None:
+    if event is not None and event.occurrence is not None:
         if event.occurrence.evidence_display is not None:
             important = event.occurrence.important_evidence_display
             if important:

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -51,7 +51,7 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
             title = obj.occurrence.issue_title
         else:
             event = group.get_latest_event()
-            if event.occurrence is not None:
+            if event is not None and event.occurrence is not None:
                 title = event.occurrence.issue_title
 
     # Explicitly typing to satisfy mypy.

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -51,7 +51,6 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
             title = obj.occurrence.issue_title
         else:
             event = group.get_latest_event()
-            # occurrence doesn't seem to be on the groupevent after being fetched from eventstore
             if event.occurrence is not None:
                 title = event.occurrence.issue_title
 
@@ -91,11 +90,16 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
     ev_metadata = obj.get_event_metadata()
     ev_type = obj.get_event_type()
 
-    if event and hasattr(event, "occurrence"):
-        if event.occurrence.evidence_display is not None:
-            important = event.occurrence.important_evidence_display
-            if important:
-                return important.value
+    if not event:
+        event = group.get_latest_event()
+
+    if hasattr(event, "occurrence"):
+        if event.occurrence is not None:
+            if event.occurrence.evidence_display is not None:
+                important = event.occurrence.important_evidence_display
+                if important:
+                    return important.value
+
     elif ev_type == "error":
         return ev_metadata.get("value") or ev_metadata.get("function")
     elif ev_type == "transaction":

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -35,6 +35,7 @@ def format_actor_option(actor: Team | APIUser) -> Mapping[str, str]:
 def build_attachment_title(obj: Group | GroupEvent) -> str:
     ev_metadata = obj.get_event_metadata()
     ev_type = obj.get_event_type()
+    title = obj.title
 
     if ev_type == "error" and "type" in ev_metadata:
         title = ev_metadata["type"]
@@ -48,6 +49,12 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
             title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
         else:
             title = obj.title
+        elif hasattr(group, "occurrence"):
+            title = group.occurrence.issue_title
+        elif not hasattr(obj, "occurrence"):
+            event = obj.get_latest_event()
+            if event.occurrence is not None:
+                title = event.occurrence.issue_title
 
     # Explicitly typing to satisfy mypy.
     title_str: str = title
@@ -85,7 +92,12 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
     ev_metadata = obj.get_event_metadata()
     ev_type = obj.get_event_type()
 
-    if ev_type == "error":
+    if event and hasattr(event, "occurrence"):
+        if event.occurrence.evidence_display is not None:
+            important = event.occurrence.important_evidence_display
+            if important:
+                return important.value
+    elif ev_type == "error":
         return ev_metadata.get("value") or ev_metadata.get("function")
     elif ev_type == "transaction":
         if not event:

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -93,18 +93,15 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
     if not event:
         event = group.get_latest_event()
 
-    if hasattr(event, "occurrence"):
-        if event.occurrence is not None:
-            if event.occurrence.evidence_display is not None:
-                important = event.occurrence.important_evidence_display
-                if important:
-                    return important.value
+    if hasattr(event, "occurrence") and event.occurrence is not None:
+        if event.occurrence.evidence_display is not None:
+            important = event.occurrence.important_evidence_display
+            if important:
+                return important.value
 
     elif ev_type == "error":
         return ev_metadata.get("value") or ev_metadata.get("function")
     elif ev_type == "transaction":
-        if not event:
-            event = group.get_latest_event()
         problem = get_matched_problem(event)
         return get_span_evidence_value_problem(problem)
 

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -94,10 +94,9 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
         event = group.get_latest_event()
 
     if event is not None and event.occurrence is not None:
-        if event.occurrence.evidence_display is not None:
-            important = event.occurrence.important_evidence_display
-            if important:
-                return important.value
+        important = event.occurrence.important_evidence_display
+        if important:
+            return important.value
 
     elif ev_type == "error":
         return ev_metadata.get("value") or ev_metadata.get("function")

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -47,14 +47,14 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
         group = getattr(obj, "group", obj)
         if group.issue_category == GroupCategory.PERFORMANCE:
             title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
-        else:
-            title = obj.title
         elif hasattr(group, "occurrence"):
             title = group.occurrence.issue_title
         elif not hasattr(obj, "occurrence"):
             event = obj.get_latest_event()
             if event.occurrence is not None:
                 title = event.occurrence.issue_title
+            else:
+                title = obj.title
 
     # Explicitly typing to satisfy mypy.
     title_str: str = title

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -47,7 +47,7 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
         group = getattr(obj, "group", obj)
         if group.issue_category == GroupCategory.PERFORMANCE:
             title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
-        elif hasattr(obj, "occurrence"):
+        elif hasattr(obj, "occurrence") and obj.occurrence is not None:
             title = obj.occurrence.issue_title
         else:
             event = group.get_latest_event()

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -47,14 +47,13 @@ def build_attachment_title(obj: Group | GroupEvent) -> str:
         group = getattr(obj, "group", obj)
         if group.issue_category == GroupCategory.PERFORMANCE:
             title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
-        elif hasattr(group, "occurrence"):
-            title = group.occurrence.issue_title
-        elif not hasattr(obj, "occurrence"):
-            event = obj.get_latest_event()
+        elif hasattr(obj, "occurrence"):
+            title = obj.occurrence.issue_title
+        else:
+            event = group.get_latest_event()
+            # occurrence doesn't seem to be on the groupevent after being fetched from eventstore
             if event.occurrence is not None:
                 title = event.occurrence.issue_title
-            else:
-                title = obj.title
 
     # Explicitly typing to satisfy mypy.
     title_str: str = title

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -93,7 +93,7 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
     if not event:
         event = group.get_latest_event()
 
-    if event is not None and hasattr(event, "occurrence") and event.occurrence is not None:
+    if event and getattr(event, "occurrence", None) is not None:
         important = event.occurrence.important_evidence_display
         if important:
             return important.value

--- a/src/sentry/integrations/message_builder.py
+++ b/src/sentry/integrations/message_builder.py
@@ -93,7 +93,7 @@ def build_attachment_text(group: Group, event: GroupEvent | None = None) -> Any 
     if not event:
         event = group.get_latest_event()
 
-    if event is not None and event.occurrence is not None:
+    if event is not None and hasattr(event, "occurrence") and event.occurrence is not None:
         important = event.occurrence.important_evidence_display
         if important:
             return important.value

--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import Any, Mapping, MutableMapping, Sequence
 
-from sentry.eventstore.models import Event
+from sentry.eventstore.models import Event, GroupEvent
 from sentry.integrations.message_builder import AbstractMessageBuilder
 from sentry.integrations.slack.message_builder import LEVEL_TO_COLOR, SlackBody
 from sentry.models import Group
@@ -36,13 +36,16 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
         """Abstract `build` method that all inheritors must implement."""
         raise NotImplementedError
 
-    def build_fallback_text(self, obj: Group | Event, project_slug: str) -> str:
+    def build_fallback_text(self, obj: Group | Event | GroupEvent, project_slug: str) -> str:
         """Fallback text is used in the message preview popup."""
         title = obj.title
         group = getattr(obj, "group", obj)
 
         if group.issue_category == GroupCategory.PERFORMANCE:
             title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
+
+        elif hasattr(obj, "occurrence") and obj.occurrence is not None:
+            title = obj.occurrence.issue_title
 
         return f"[{project_slug}] {title}"
 

--- a/src/sentry/integrations/slack/message_builder/base/base.py
+++ b/src/sentry/integrations/slack/message_builder/base/base.py
@@ -44,7 +44,7 @@ class SlackMessageBuilder(AbstractMessageBuilder, ABC):
         if group.issue_category == GroupCategory.PERFORMANCE:
             title = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
 
-        elif hasattr(obj, "occurrence") and obj.occurrence is not None:
+        elif isinstance(obj, GroupEvent) and obj.occurrence is not None:
             title = obj.occurrence.issue_title
 
         return f"[{project_slug}] {title}"

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -225,7 +225,7 @@ def get_color(
             return "info"
     if event_for_tags:
         color: str | None = event_for_tags.get_tag("level")
-        if event_for_tags.occurrence is not None and hasattr(event_for_tags.occurrence, "level"):
+        if event_for_tags.occurrence is not None:
             color = event_for_tags.occurrence.level
         if color and color in LEVEL_TO_COLOR.keys():
             return color

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -225,7 +225,11 @@ def get_color(
             return "info"
     if event_for_tags:
         color: str | None = event_for_tags.get_tag("level")
-        if event_for_tags.occurrence is not None and hasattr(event_for_tags.occurrence, "level"):
+        if (
+            hasattr(event_for_tags, "occurrence")
+            and event_for_tags.occurrence is not None
+            and hasattr(event_for_tags.occurrence, "level")
+        ):
             color = event_for_tags.occurrence.level
         if color and color in LEVEL_TO_COLOR.keys():
             return color

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -225,6 +225,8 @@ def get_color(
             return "info"
     if event_for_tags:
         color: str | None = event_for_tags.get_tag("level")
+        if event_for_tags.occurrence is not None and hasattr(event_for_tags.occurrence, "level"):
+            color = event_for_tags.occurrence.level
         if color and color in LEVEL_TO_COLOR.keys():
             return color
     if group.issue_category == GroupCategory.PERFORMANCE:

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -225,11 +225,7 @@ def get_color(
             return "info"
     if event_for_tags:
         color: str | None = event_for_tags.get_tag("level")
-        if (
-            hasattr(event_for_tags, "occurrence")
-            and event_for_tags.occurrence is not None
-            and hasattr(event_for_tags.occurrence, "level")
-        ):
+        if event_for_tags.occurrence is not None and hasattr(event_for_tags.occurrence, "level"):
             color = event_for_tags.occurrence.level
         if color and color in LEVEL_TO_COLOR.keys():
             return color

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -225,7 +225,11 @@ def get_color(
             return "info"
     if event_for_tags:
         color: str | None = event_for_tags.get_tag("level")
-        if hasattr(event_for_tags, "occurrence") and event_for_tags.occurrence is not None:
+        if (
+            hasattr(event_for_tags, "occurrence")
+            and event_for_tags.occurrence is not None
+            and event_for_tags.occurrence.level is not None
+        ):
             color = event_for_tags.occurrence.level
         if color and color in LEVEL_TO_COLOR.keys():
             return color

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -225,7 +225,7 @@ def get_color(
             return "info"
     if event_for_tags:
         color: str | None = event_for_tags.get_tag("level")
-        if event_for_tags.occurrence is not None:
+        if hasattr(event_for_tags, "occurrence") and event_for_tags.occurrence is not None:
             color = event_for_tags.occurrence.level
         if color and color in LEVEL_TO_COLOR.keys():
             return color

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -118,7 +118,7 @@ class IssueOccurrence:
             ],
             GroupType(data["type"]),
             cast(datetime, parse_timestamp(data["detection_time"])),
-            data["level"],
+            data.get("level"),
         )
 
     @property

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -77,6 +77,7 @@ class IssueOccurrence:
     evidence_display: Sequence[IssueEvidence]
     type: GroupType
     detection_time: datetime
+    level: Optional[str] = None
 
     def __post_init__(self) -> None:
         if not is_aware(self.detection_time):
@@ -96,6 +97,7 @@ class IssueOccurrence:
             "evidence_display": [evidence.to_dict() for evidence in self.evidence_display],
             "type": self.type.value,
             "detection_time": self.detection_time.timestamp(),
+            "level": self.level,
         }
 
     @classmethod
@@ -115,6 +117,7 @@ class IssueOccurrence:
             ],
             GroupType(data["type"]),
             cast(datetime, parse_timestamp(data["detection_time"])),
+            data["level"],
         )
 
     @property

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -29,7 +29,7 @@ class IssueOccurrenceData(TypedDict):
     evidence_display: Sequence[IssueEvidenceData]
     type: int
     detection_time: float
-    level: str
+    level: Optional[str]
 
 
 @dataclass(frozen=True)

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -29,6 +29,7 @@ class IssueOccurrenceData(TypedDict):
     evidence_display: Sequence[IssueEvidenceData]
     type: int
     detection_time: float
+    level: str
 
 
 @dataclass(frozen=True)

--- a/src/sentry/testutils/helpers/notifications.py
+++ b/src/sentry/testutils/helpers/notifications.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import uuid
+from datetime import datetime
 from typing import Any, Iterable, Mapping
 
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.models import Team, User
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.services.hybrid_cloud.user import APIUser
 from sentry.types.integrations import ExternalProviders
+from sentry.types.issues import GroupType
+from sentry.utils.dates import ensure_aware
 
 
 class DummyNotification(BaseNotification):
@@ -63,3 +68,21 @@ class DummyNotificationWithMoreFields(DummyNotification):
         from sentry.integrations.message_builder import get_title_link
 
         return get_title_link(self.group, None, False, True, self)
+
+
+TEST_ISSUE_OCCURRENCE = IssueOccurrence(
+    uuid.uuid4().hex,
+    uuid.uuid4().hex,
+    ["some-fingerprint"],
+    "something bad happened",
+    "it was bad",
+    "1234",
+    {"Test": 123},
+    [
+        IssueEvidence("Attention", "Very important information!!!", True),
+        IssueEvidence("Evidence 2", "Not important", False),
+        IssueEvidence("Evidence 3", "Nobody cares about this", False),
+    ],
+    GroupType.PROFILE_BLOCKED_THREAD,
+    ensure_aware(datetime.now()),
+)

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -15,6 +15,24 @@ from sentry.types.integrations import ExternalProviders
 from sentry.types.issues import GroupType
 from sentry.utils.dates import ensure_aware
 
+# TODO put this in a shared spot to be reused for mocks
+my_occurrence = IssueOccurrence(
+    uuid.uuid4().hex,
+    uuid.uuid4().hex,
+    ["some-fingerprint"],
+    "something bad happened",
+    "it was bad",
+    "1234",
+    {"Test": 123},
+    [
+        IssueEvidence("Attention", "Very important information!!!", True),
+        IssueEvidence("Evidence 2", "Not important", False),
+        IssueEvidence("Evidence 3", "Nobody cares about this", False),
+    ],
+    GroupType.PROFILE_BLOCKED_THREAD,
+    ensure_aware(datetime.now()),
+)
+
 
 class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
     @responses.activate
@@ -152,42 +170,25 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         )
 
     @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=my_occurrence,
+        new_callable=mock.PropertyMock,
+    )
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
-    def test_assignment_generic_issue(self, mock_func):
+    def test_assignment_generic_issue(self, mock_func, occurrence):
         """
         Test that a Slack message is sent with the expected payload when a generic issue type is assigned
         """
-
         event = self.store_event(
             data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
         )
         event = event.for_group(event.groups[0])
-        occurrence = IssueOccurrence(
-            uuid.uuid4().hex,
-            uuid.uuid4().hex,
-            ["some-fingerprint"],
-            "something bad happened",
-            "it was bad",
-            "1234",
-            {"Test": 123},
-            [
-                IssueEvidence("Attention", "Very important information!!!", True),
-                IssueEvidence("Evidence 2", "Not important", False),
-                IssueEvidence("Evidence 3", "Nobody cares about this", False),
-            ],
-            GroupType.PROFILE_BLOCKED_THREAD,
-            ensure_aware(datetime.now()),
-        )
-        occurrence.save()
-        event.occurrence = occurrence
-
-        event.group.type = GroupType.PROFILE_BLOCKED_THREAD
-        group = event.group
 
         notification = AssignedActivityNotification(
             Activity(
                 project=self.project,
-                group=group,
+                group=event.group,
                 user=self.user,
                 type=ActivityType.ASSIGNED,
                 data={"assignee": self.user.id},
@@ -197,7 +198,8 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             notification.send()
         attachment, text = get_attachment()
         assert text == f"Issue assigned to {self.name} by themselves"
-        assert attachment["title"] == occurrence.issue_title
+        assert attachment["title"] == my_occurrence.issue_title
+        assert attachment["text"] == my_occurrence.evidence_display[0].value
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user|Notification Settings>"

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -159,7 +159,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         """
 
         event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
+            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
         )
         event = event.for_group(event.groups[0])
         occurrence = IssueOccurrence(
@@ -197,7 +197,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
             notification.send()
         attachment, text = get_attachment()
         assert text == f"Issue assigned to {self.name} by themselves"
-        assert attachment["title"] == "Blocked Thread"
+        assert attachment["title"] == occurrence.issue_title
         assert (
             attachment["footer"]
             == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=assigned_activity-slack-user|Notification Settings>"

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -30,6 +30,7 @@ from sentry.ownership.grammar import dump_schema
 from sentry.plugins.base import Notification
 from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.testutils.silo import region_silo_test
 from sentry.types.integrations import ExternalProviders
@@ -38,20 +39,14 @@ from sentry.utils import json
 
 @region_silo_test
 class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, PerformanceIssueTestCase):
-    @responses.activate
-    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
-    def test_issue_alert_user(self, mock_func):
-        """Test that issue alerts are sent to a Slack user."""
-
-        event = self.store_event(
-            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
-        )
+    def setUp(self):
+        super().setUp()
         action_data = {
             "id": "sentry.mail.actions.NotifyEmailAction",
             "targetType": "Member",
             "targetIdentifier": str(self.user.id),
         }
-        rule = Rule.objects.create(
+        self.rule = Rule.objects.create(
             project=self.project,
             label="ja rule",
             data={
@@ -60,8 +55,17 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
             },
         )
 
+    @responses.activate
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_issue_alert_user(self, mock_func):
+        """Test that issue alerts are sent to a Slack user."""
+
+        event = self.store_event(
+            data={"message": "Hello world", "level": "error"}, project_id=self.project.id
+        )
+
         notification = AlertRuleNotification(
-            Notification(event=event, rule=rule), ActionTargetType.MEMBER, self.user.id
+            Notification(event=event, rule=self.rule), ActionTargetType.MEMBER, self.user.id
         )
 
         with self.tasks():
@@ -82,22 +86,8 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
 
         event = self.create_performance_issue()
 
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "Member",
-            "targetIdentifier": str(self.user.id),
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
-
         notification = AlertRuleNotification(
-            Notification(event=event, rule=rule), ActionTargetType.MEMBER, self.user.id
+            Notification(event=event, rule=self.rule), ActionTargetType.MEMBER, self.user.id
         )
         with self.feature("organizations:performance-issues"), self.tasks():
             notification.send()
@@ -114,6 +104,34 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         )
 
     @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_generic_issue_alert_user(self, mock_func, occurrence):
+        """Test that generic issue alerts are sent to a Slack user."""
+        event = self.store_event(
+            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
+        )
+        event = event.for_group(event.groups[0])
+
+        notification = AlertRuleNotification(
+            Notification(event=event, rule=self.rule), ActionTargetType.MEMBER, self.user.id
+        )
+        with self.tasks():
+            notification.send()
+
+        attachment, text = get_attachment()
+        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
+        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/alerts/?referrer=issue_alert-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
     @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_disabled_org_integration_for_user(self, mock_func):
 
@@ -124,22 +142,9 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         event = self.store_event(
             data={"message": "Hello world", "level": "error"}, project_id=self.project.id
         )
-        action_data = {
-            "id": "sentry.mail.actions.NotifyEmailAction",
-            "targetType": "Member",
-            "targetIdentifier": str(self.user.id),
-        }
-        rule = Rule.objects.create(
-            project=self.project,
-            label="ja rule",
-            data={
-                "match": "all",
-                "actions": [action_data],
-            },
-        )
 
         notification = AlertRuleNotification(
-            Notification(event=event, rule=rule), ActionTargetType.MEMBER, self.user.id
+            Notification(event=event, rule=self.rule), ActionTargetType.MEMBER, self.user.id
         )
 
         with self.tasks():

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -5,6 +5,7 @@ import responses
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import NoteActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
@@ -72,4 +73,40 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         assert (
             attachment["footer"]
             == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_note_generic_issue(self, mock_func, occurrence):
+        """
+        Test that a Slack message is sent with the expected payload when a comment is made on a generic issue type
+        """
+        event = self.store_event(
+            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
+        )
+        event = event.for_group(event.groups[0])
+        notification = NoteActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.NOTE,
+                data={"text": "text", "mentions": []},
+            )
+        )
+        with self.tasks():
+            notification.send()
+
+        attachment, text = get_attachment()
+        assert text == f"New comment by {self.name}"
+        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
+        assert attachment["text"] == notification.activity.data["text"]
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=note_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -5,6 +5,7 @@ import responses
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import RegressionActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
@@ -66,4 +67,40 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         assert (
             attachment["footer"]
             == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_regression_generic_issue(self, mock_func, occurrence):
+        """
+        Test that a Slack message is sent with the expected payload when a generic issue type regresses
+        """
+        event = self.store_event(
+            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
+        )
+        event = event.for_group(event.groups[0])
+        notification = RegressionActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.SET_REGRESSION,
+                data={},
+            )
+        )
+        with self.tasks():
+            notification.send()
+
+        attachment, text = get_attachment()
+        assert text == "Issue marked as regression"
+        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
+        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -5,6 +5,7 @@ import responses
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import ResolvedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
@@ -70,4 +71,43 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert (
             attachment["footer"]
             == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_resolved_generic_issue(self, mock_func, occurrence):
+        """
+        Test that a Slack message is sent with the expected payload when a generic issue type is resolved
+        """
+        event = self.store_event(
+            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
+        )
+        event = event.for_group(event.groups[0])
+        notification = ResolvedActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.SET_RESOLVED,
+                data={"assignee": ""},
+            )
+        )
+        with self.tasks():
+            notification.send()
+
+        attachment, text = get_attachment()
+        assert (
+            text
+            == f"{self.name} marked <http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=activity_notification|{self.project.slug.upper()}-{event.group.short_id}> as resolved"
+        )
+        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
+        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -5,6 +5,7 @@ import responses
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import ResolvedInReleaseActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
@@ -68,4 +69,41 @@ class SlackResolvedInReleaseNotificationTest(
         assert (
             attachment["footer"]
             == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_resolved_in_release_generic_issue(self, mock_func, occurrence):
+        """
+        Test that a Slack message is sent with the expected payload when a generic issue type is resolved in a release
+        """
+        event = self.store_event(
+            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
+        )
+        event = event.for_group(event.groups[0])
+        notification = ResolvedInReleaseActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.SET_RESOLVED_IN_RELEASE,
+                data={"version": "meow"},
+            )
+        )
+        with self.tasks():
+            notification.send()
+
+        attachment, text = get_attachment()
+        release_name = notification.activity.data["version"]
+        assert text == f"Issue marked as resolved in {release_name} by {self.name}"
+        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
+        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=resolved_in_release_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -5,6 +5,7 @@ import responses
 from sentry.models import Activity
 from sentry.notifications.notifications.activity import UnassignedActivityNotification
 from sentry.testutils.cases import PerformanceIssueTestCase, SlackActivityNotificationTest
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.testutils.helpers.slack import get_attachment, send_notification
 from sentry.types.activity import ActivityType
 
@@ -65,4 +66,40 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         assert (
             attachment["footer"]
             == f"{self.project.slug} | production | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user|Notification Settings>"
+        )
+
+    @responses.activate
+    @mock.patch(
+        "sentry.eventstore.models.GroupEvent.occurrence",
+        return_value=TEST_ISSUE_OCCURRENCE,
+        new_callable=mock.PropertyMock,
+    )
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
+    def test_unassignment_generic_issue(self, mock_func, occurrence):
+        """
+        Test that a Slack message is sent with the expected payload when a generic issue type is unassigned
+        """
+        event = self.store_event(
+            data={"message": "Hellboy's world", "level": "error"}, project_id=self.project.id
+        )
+        event = event.for_group(event.groups[0])
+        notification = UnassignedActivityNotification(
+            Activity(
+                project=self.project,
+                group=event.group,
+                user=self.user,
+                type=ActivityType.ASSIGNED,
+                data={"assignee": ""},
+            )
+        )
+        with self.tasks():
+            notification.send()
+
+        attachment, text = get_attachment()
+        assert text == f"Issue unassigned by {self.name}"
+        assert attachment["title"] == TEST_ISSUE_OCCURRENCE.issue_title
+        assert attachment["text"] == TEST_ISSUE_OCCURRENCE.evidence_display[0].value
+        assert (
+            attachment["footer"]
+            == f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=unassigned_activity-slack-user|Notification Settings>"
         )

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -199,6 +199,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase):
         assert attachments["title"] == occurrence.issue_title
         assert attachments["text"] == occurrence.evidence_display[0].value
         assert attachments["fallback"] == f"[{self.project.slug}] {occurrence.issue_title}"
+        assert attachments["color"] == "#E03E2F"  # red for error level
 
     def test_build_error_issue_fallback_text(self):
         event = self.store_event(data={}, project_id=self.project.id)
@@ -215,6 +216,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase):
             == "db - SELECT `books_author`.`id`, `books_author`.`name` FROM `books_author` WHERE `books_author`.`id` = %s LIMIT 21"
         )
         assert attachments["fallback"] == f"[{self.project.slug}] N+1 Query"
+        assert attachments["color"] == "#2788CE"  # blue for info level
 
     def test_build_performance_issue_color_no_event_passed(self):
         """This test doesn't pass an event to the SlackIssuesMessageBuilder to mimic what

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -187,6 +187,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase):
             ],
             GroupType.PROFILE_BLOCKED_THREAD,
             ensure_aware(datetime.now()),
+            "info",  # add a level value of info
         )
         # TODO use Dan's OccurrenceTestMixin once merged
         occurrence.save()
@@ -199,7 +200,7 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase):
         assert attachments["title"] == occurrence.issue_title
         assert attachments["text"] == occurrence.evidence_display[0].value
         assert attachments["fallback"] == f"[{self.project.slug}] {occurrence.issue_title}"
-        assert attachments["color"] == "#E03E2F"  # red for error level
+        assert attachments["color"] == "#2788CE"  # blue for info level
 
     def test_build_error_issue_fallback_text(self):
         event = self.store_event(data={}, project_id=self.project.id)

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -34,6 +34,7 @@ class OccurrenceTestMixin:
             ],
             "type": GroupType.PROFILE_BLOCKED_THREAD,
             "detection_time": datetime.now().timestamp(),
+            "level": "warning",
         }
         kwargs.update(overrides)  # type: ignore
         return kwargs


### PR DESCRIPTION
Add support for issue alerting integrations that use the message builder (Slack and MSTeams) for generic issue types.


Preview text for Slack alert:
<img width="350" alt="Screen Shot 2022-12-08 at 4 07 16 PM" src="https://user-images.githubusercontent.com/29959063/206593405-7a206d88-a31a-4e85-8c15-1f7534733ca7.png">

Slack generic issue alert shows the `occurrence.issue_title` and the "important" evidence value
<img width="395" alt="Screen Shot 2022-12-08 at 4 11 20 PM" src="https://user-images.githubusercontent.com/29959063/206593408-6942d74d-4238-4df9-bfee-601ce2bc1098.png">

MSTeams generic issue alert shows the `occurrence.issue_title` and the "important" evidence value
<img width="654" alt="Screen Shot 2022-12-08 at 4 13 45 PM" src="https://user-images.githubusercontent.com/29959063/206593410-2773746a-16b3-4652-ba2c-a7d5fdc76992.png">


Fixes #42047