### PR TITLE
fix(alerts): Use mep-rollout-flag metrics backend

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -249,11 +249,6 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
 
         if (
             not features.has(
-                "organizations:metrics-performance-alerts",
-                self.context["organization"],
-                actor=self.context.get("user", None),
-            )
-            and not features.has(
                 "organizations:mep-rollout-flag",
                 self.context["organization"],
                 actor=self.context.get("user", None),

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -175,17 +175,6 @@ class TestAlertRuleSerializer(TestCase):
                 ]
             },
         )
-        with self.feature("organizations:metrics-performance-alerts"):
-            base_params = self.valid_params.copy()
-            base_params["queryType"] = SnubaQuery.Type.PERFORMANCE.value
-            base_params["eventTypes"] = [SnubaQueryEventType.EventType.TRANSACTION.name.lower()]
-            base_params["dataset"] = Dataset.PerformanceMetrics.value
-            base_params["query"] = ""
-            serializer = AlertRuleSerializer(context=self.context, data=base_params)
-            assert serializer.is_valid(), serializer.errors
-            alert_rule = serializer.save()
-            assert alert_rule.snuba_query.type == SnubaQuery.Type.PERFORMANCE.value
-            assert alert_rule.snuba_query.dataset == Dataset.PerformanceMetrics.value
 
         with self.feature("organizations:mep-rollout-flag"):
             base_params = self.valid_params.copy()


### PR DESCRIPTION
Removes use of metrics-performance-alerts
