### PR TITLE
fix(alerts): Use only mep-rollout-flag for metrics dataset

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -436,9 +436,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
     const eventOmitTags =
       dataset === 'events' ? [...measurementTags, ...transactionTags] : [];
 
-    const hasMetricDataset =
-      organization.features.includes('metrics-performance-alerts') ||
-      organization.features.includes('mep-rollout-flag');
+    const hasMetricDataset = organization.features.includes('mep-rollout-flag');
 
     return (
       <Fragment>

--- a/static/app/views/alerts/rules/metric/ruleForm.spec.jsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.spec.jsx
@@ -126,11 +126,7 @@ describe('Incident Rules Form', () => {
     });
 
     it('creates a rule with generic_metrics dataset', async () => {
-      organization.features = [
-        ...organization.features,
-        'metrics-performance-alerts',
-        'mep-rollout-flag',
-      ];
+      organization.features = [...organization.features, 'mep-rollout-flag'];
       const rule = TestStubs.MetricRule();
       createWrapper({
         rule: {

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -555,9 +555,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       }
       transaction.setData('actions', sanitizedTriggers);
 
-      const hasMetricDataset =
-        organization.features.includes('metrics-performance-alerts') ||
-        organization.features.includes('mep-rollout-flag');
+      const hasMetricDataset = organization.features.includes('mep-rollout-flag');
 
       this.setState({loading: true});
       const [data, , resp] = await addOrUpdateRule(
@@ -710,10 +708,11 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
   handleMEPAlertDataset = (data: EventsStats | MultiSeriesEventsStats | null) => {
     const {isMetricsData} = data ?? {};
+    const {organization} = this.props;
 
     if (
       isMetricsData === undefined ||
-      !this.props.organization.features.includes('metrics-performance-alerts')
+      !organization.features.includes('mep-rollout-flag')
     ) {
       return;
     }

--- a/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
+++ b/static/app/views/alerts/rules/metric/utils/getMetricDatasetQueryExtras.tsx
@@ -17,9 +17,7 @@ export function getMetricDatasetQueryExtras({
   organization: Organization;
   location?: Location;
 }) {
-  const hasMetricDataset =
-    organization.features.includes('metrics-performance-alerts') ||
-    organization.features.includes('mep-rollout-flag');
+  const hasMetricDataset = organization.features.includes('mep-rollout-flag');
   const disableMetricDataset =
     decodeScalar(location?.query?.disableMetricDataset) === 'true';
 


### PR DESCRIPTION
Switch the frontend to using only the mep-rollout-flag instead of both flags

will need to merge the backend pr first https://github.com/getsentry/sentry/pull/42111
