### PR TITLE
fix(hybrid-cloud): Do not redirect to customer domain for non-customer domain paths

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -69,7 +69,7 @@ class ReactMixin:
             redirect_url = f"{redirect_url}{request.path}{qs}"
             return HttpResponseRedirect(redirect_url)
 
-        if request.subdomain is None:
+        if request.subdomain is None and not url_is_non_customer_domain:
             matched_url = resolve(request.path)
             if "organization_slug" in matched_url.kwargs:
                 org_slug = matched_url.kwargs["organization_slug"]

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -166,7 +166,10 @@ class ReactPageViewTest(TestCase):
             url_name_is_non_customer_domain = any(
                 fnmatch(url_name, p) for p in NON_CUSTOMER_DOMAIN_URL_NAMES
             )
-            assert url_name_is_non_customer_domain
+            assert (
+                url_name_is_non_customer_domain, 
+                "precondition missing. org-create should be non-customer-domain"
+            )
 
             # Induce last active org.
             assert "activeorg" not in self.client.session

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -183,7 +183,7 @@ class ReactPageViewTest(TestCase):
             assert response.status_code == 200
             assert self.client.session["activeorg"]
 
-            # No redirect if customer domain if path is not meant to be accessed in customer domain context.
+            # No redirect to customer domain if path is not meant to be accessed in customer domain context.
             # There should be no redirect to the last active org.
             response = self.client.get(
                 reverse(url_name),

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -155,7 +155,7 @@ class ReactPageViewTest(TestCase):
             assert response.status_code == 200
             assert response.redirect_chain == [(f"http://{org.slug}.testserver/issues/", 302)]
 
-    def test_doest_notredirect_to_customer_domain_for_unsupported_paths(self):
+    def test_does_not_redirect_to_customer_domain_for_unsupported_paths(self):
         user = self.create_user("bar@example.com")
         org = self.create_organization(owner=user)
         self.login_as(user)

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -167,9 +167,8 @@ class ReactPageViewTest(TestCase):
                 fnmatch(url_name, p) for p in NON_CUSTOMER_DOMAIN_URL_NAMES
             )
             assert (
-                url_name_is_non_customer_domain,
-                "precondition missing. org-create should be non-customer-domain",
-            )
+                url_name_is_non_customer_domain
+            ), "precondition missing. org-create should be non-customer-domain"
 
             # Induce last active org.
             assert "activeorg" not in self.client.session

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -155,6 +155,40 @@ class ReactPageViewTest(TestCase):
             assert response.status_code == 200
             assert response.redirect_chain == [(f"http://{org.slug}.testserver/issues/", 302)]
 
+    def test_doest_notredirect_to_customer_domain_for_unsupported_paths(self):
+        user = self.create_user("bar@example.com")
+        org = self.create_organization(owner=user)
+        self.login_as(user)
+
+        with self.feature({"organizations:customer-domains": True}):
+
+            url_name = "sentry-organization-create"
+            url_name_is_non_customer_domain = any(
+                fnmatch(url_name, p) for p in NON_CUSTOMER_DOMAIN_URL_NAMES
+            )
+            assert url_name_is_non_customer_domain
+
+            # Induce last active org.
+            assert "activeorg" not in self.client.session
+            response = self.client.get(
+                reverse(
+                    "sentry-organization-issue-list",
+                    args=[org.slug],
+                ),
+                HTTP_HOST=f"{org.slug}.testserver",
+            )
+            assert response.status_code == 200
+            assert self.client.session["activeorg"]
+
+            # No redirect if customer domain if path is not meant to be accessed in customer domain context.
+            # There should be no redirect to the last active org.
+            response = self.client.get(
+                reverse(url_name),
+                follow=True,
+            )
+            assert response.status_code == 200
+            assert response.redirect_chain == []
+
     def test_non_customer_domain_url_names(self):
         user = self.create_user("bar@example.com")
         org = self.create_organization(owner=user)

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -167,8 +167,8 @@ class ReactPageViewTest(TestCase):
                 fnmatch(url_name, p) for p in NON_CUSTOMER_DOMAIN_URL_NAMES
             )
             assert (
-                url_name_is_non_customer_domain, 
-                "precondition missing. org-create should be non-customer-domain"
+                url_name_is_non_customer_domain,
+                "precondition missing. org-create should be non-customer-domain",
             )
 
             # Induce last active org.


### PR DESCRIPTION
If a last active org exists in the user's session, then a redirect loop could occur if they try to access `orgslug.sentry.io/organizations/new/`.

This pull request addresses this by not redirecting to `orgslug.sentry.io` for any Django routes not meant to be accessed in a customer domain world.