### PR TITLE
feat(hybrid-cloud): Add customer domain support for org creation flow

### DIFF
--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -18,14 +18,34 @@ const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
 
 type LocationTarget = ((location: Location) => LocationDescriptor) | LocationDescriptor;
 
+type NormalizeUrlOptions = {
+  forceCustomerDomain: boolean;
+};
+
 /**
  * Normalize a URL for customer domains based on the current route state
  */
-export function normalizeUrl(path: string): string;
-export function normalizeUrl(path: LocationDescriptor): LocationDescriptor;
-export function normalizeUrl(path: LocationTarget, location?: Location): LocationTarget;
-export function normalizeUrl(path: LocationTarget, location?: Location): LocationTarget {
-  if (!window.__initialData?.customerDomain) {
+export function normalizeUrl(path: string, options?: NormalizeUrlOptions): string;
+export function normalizeUrl(
+  path: LocationDescriptor,
+  options?: NormalizeUrlOptions
+): LocationDescriptor;
+export function normalizeUrl(
+  path: LocationTarget,
+  location?: Location,
+  options?: NormalizeUrlOptions
+): LocationTarget;
+export function normalizeUrl(
+  path: LocationTarget,
+  location?: Location | NormalizeUrlOptions,
+  options?: NormalizeUrlOptions
+): LocationTarget {
+  if (location && 'forceCustomerDomain' in location) {
+    options = location;
+    location = undefined;
+  }
+
+  if (!options?.forceCustomerDomain && !window.__initialData?.customerDomain) {
     return path;
   }
 

--- a/static/app/views/organizationCreate.spec.tsx
+++ b/static/app/views/organizationCreate.spec.tsx
@@ -5,8 +5,8 @@ import OrganizationCreate from 'sentry/views/organizationCreate';
 
 describe('OrganizationCreate', function () {
   beforeEach(() => {
-    ConfigStore.get('termsUrl', null);
-    ConfigStore.get('privacyUrl', null);
+    ConfigStore.get('termsUrl');
+    ConfigStore.get('privacyUrl');
   });
 
   afterEach(() => {

--- a/static/app/views/organizationCreate.spec.tsx
+++ b/static/app/views/organizationCreate.spec.tsx
@@ -11,6 +11,7 @@ describe('OrganizationCreate', function () {
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
+    jest.resetAllMocks();
   });
 
   it('renders without terms', function () {
@@ -29,6 +30,7 @@ describe('OrganizationCreate', function () {
     const orgCreateMock = MockApiClient.addMockResponse({
       url: '/organizations/',
       method: 'POST',
+      body: TestStubs.Organization(),
     });
     ConfigStore.set('termsUrl', 'https://example.com/terms');
     ConfigStore.set('privacyUrl', 'https://example.com/privacy');
@@ -48,6 +50,43 @@ describe('OrganizationCreate', function () {
       expect.objectContaining({
         data: {agreeTerms: true, defaultTeam: true, name: 'Good Burger'},
       })
+    );
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
+      '/organizations/org-slug/projects/new/'
+    );
+  });
+
+  it('creates a new org with customer domain feature', function () {
+    const orgCreateMock = MockApiClient.addMockResponse({
+      url: '/organizations/',
+      method: 'POST',
+      body: TestStubs.Organization({
+        features: ['customer-domains'],
+      }),
+    });
+    ConfigStore.set('termsUrl', 'https://example.com/terms');
+    ConfigStore.set('privacyUrl', 'https://example.com/privacy');
+    render(<OrganizationCreate />);
+    expect(screen.getByText('Create a New Organization')).toBeInTheDocument();
+
+    userEvent.paste(screen.getByPlaceholderText('e.g. My Company'), 'Good Burger');
+    userEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'I agree to the Terms of Service and the Privacy Policy',
+      })
+    );
+    userEvent.click(screen.getByText('Create Organization'));
+
+    expect(orgCreateMock).toHaveBeenCalledWith(
+      '/organizations/',
+      expect.objectContaining({
+        data: {agreeTerms: true, defaultTeam: true, name: 'Good Burger'},
+      })
+    );
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
+      'https://org-slug.sentry.io/projects/new/'
     );
   });
 });

--- a/static/app/views/organizationCreate.tsx
+++ b/static/app/views/organizationCreate.tsx
@@ -3,6 +3,8 @@ import NarrowLayout from 'sentry/components/narrowLayout';
 import SentryDocumentTitle from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import ConfigStore from 'sentry/stores/configStore';
+import {OrganizationSummary} from 'sentry/types';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 function OrganizationCreate() {
   const termsUrl = ConfigStore.get('termsUrl');
@@ -24,10 +26,18 @@ function OrganizationCreate() {
           submitLabel={t('Create Organization')}
           apiEndpoint="/organizations/"
           apiMethod="POST"
-          onSubmitSuccess={data => {
+          onSubmitSuccess={(createdOrg: OrganizationSummary) => {
+            const hasCustomerDomain = createdOrg?.features.includes('customer-domains');
+            let nextUrl = normalizeUrl(
+              `/organizations/${createdOrg.slug}/projects/new/`,
+              {forceCustomerDomain: hasCustomerDomain}
+            );
+            if (hasCustomerDomain) {
+              nextUrl = `${createdOrg.links.organizationUrl}${nextUrl}`;
+            }
             // redirect to project creation *(BYPASS REACT ROUTER AND FORCE PAGE REFRESH TO GRAB CSRF TOKEN)*
             // browserHistory.pushState(null, `/organizations/${data.slug}/projects/new/`);
-            window.location.href = `/organizations/${data.slug}/projects/new/`;
+            window.location.assign(nextUrl);
           }}
           requireChanges
         >


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry/pull/42113.

This adds customer domain support for the org creation flow. 

After creating a new organization, the user would be redirected to the organization's customer domain URL if the customer domain feature is enabled for that organization.

In addition, I've added `{forceCustomerDomain: true}` option to the `normalizeUrl()` utility function.