### PR TITLE
fix(issues): Fix prompt stacktrace link query

### DIFF
--- a/static/app/actionCreators/prompts.tsx
+++ b/static/app/actionCreators/prompts.tsx
@@ -1,5 +1,5 @@
 import type {Client} from 'sentry/api';
-import {useQuery} from 'sentry/utils/queryClient';
+import {QueryKey, useQuery} from 'sentry/utils/queryClient';
 
 type PromptsUpdateParams = {
   /**
@@ -92,9 +92,9 @@ export const makePromptsCheckQueryKey = ({
   feature,
   organizationId,
   projectId,
-}: PromptCheckParams): [string, Record<string, string | undefined>] => [
+}: PromptCheckParams): QueryKey => [
   '/prompts-activity/',
-  {feature, organizationId, projectId},
+  {query: {feature, organizationId, projectId}},
 ];
 
 /**

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -60,6 +60,12 @@ describe('StacktraceLink', function () {
       })
     );
     expect(promptActivity).toHaveBeenCalledTimes(1);
+    expect(promptActivity).toHaveBeenCalledWith(
+      '/prompts-activity/',
+      expect.objectContaining({
+        query: {feature: 'stacktrace_link', organizationId: '3', projectId: '2'},
+      })
+    );
     expect(analyticsSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.spec.tsx
@@ -63,7 +63,11 @@ describe('StacktraceLink', function () {
     expect(promptActivity).toHaveBeenCalledWith(
       '/prompts-activity/',
       expect.objectContaining({
-        query: {feature: 'stacktrace_link', organizationId: '3', projectId: '2'},
+        query: {
+          feature: 'stacktrace_link',
+          organizationId: org.id,
+          projectId: project.id,
+        },
       })
     );
     expect(analyticsSpy).toHaveBeenCalledTimes(1);

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -8,7 +8,7 @@ type QueryKeyEndpointOptions = {
   query?: Record<string, any>;
 };
 
-type QueryKey =
+export type QueryKey =
   | readonly [url: string]
   | readonly [url: string, options: QueryKeyEndpointOptions];
 


### PR DESCRIPTION
I messed up the query, also exports the type so that requests don't have to use `as const` to use it