### PR TITLE
fix(hybrid-cloud): Bulletproof React page view to handle unresolved url_names

### DIFF
--- a/src/sentry/web/frontend/react_page.py
+++ b/src/sentry/web/frontend/react_page.py
@@ -57,11 +57,13 @@ class ReactMixin:
         get_csrf_token(request)
 
         url_name = request.resolver_match.url_name
+        url_is_non_customer_domain = (
+            any(fnmatch(url_name, p) for p in NON_CUSTOMER_DOMAIN_URL_NAMES) if url_name else False
+        )
+
         # If a customer domain is being used, and if a non-customer domain url_name is encountered, we redirect the user
         # to sentryUrl.
-        if is_using_customer_domain(request) and any(
-            fnmatch(url_name, p) for p in NON_CUSTOMER_DOMAIN_URL_NAMES
-        ):
+        if is_using_customer_domain(request) and url_is_non_customer_domain:
             redirect_url = options.get("system.url-prefix")
             qs = query_string(request)
             redirect_url = f"{redirect_url}{request.path}{qs}"

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -194,3 +194,12 @@ class ReactPageViewTest(TestCase):
 
                 assert response.status_code == 302
                 assert response["Location"] == f"http://testserver{path}"
+
+    def test_handles_unknown_url_name(self):
+        user = self.create_user("bar@example.com")
+        org = self.create_organization(owner=user)
+        self.login_as(user)
+
+        response = self.client.get(f"/settings/{org.slug}/projects/albertos-apples/keys/")
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "sentry/base-react.html")


### PR DESCRIPTION
There may be paths that Django is unable to resolve to a `url_name`, but a page may exist for that path/route for in the frontend app. Here I'm bulletproofing the React page view to handle unresolved url_names.

Fixes SENTRY-WTT