### PR TITLE
feat(issue_platform): Create a function to support saving an issue occurrence and related data

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
+
+
+def save_issue_occurrence(
+    occurrence_data: IssueOccurrenceData, event_data: Optional[dict[str, Any]] = None
+) -> None:
+    event_id = occurrence_data.get("event_id")
+    if event_id is None:
+        if event_data is None:
+            raise ValueError("At least one of `event_id` or `event_data` must be passed")
+
+        occurrence_data["event_id"] = event_data["id"]
+
+    # Convert occurrence data to `IssueOccurrence`
+    occurrence = IssueOccurrence.from_dict(occurrence_data)
+    occurrence.save()
+
+    if event_data:
+        # TODO: Save event via EventManager
+        pass
+
+    # TODO: Create/update issue
+    # TODO: Write occurrence and event eventstream

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from sentry.eventstore.models import Event
 from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
 
 
-def save_issue_occurrence(
-    occurrence_data: IssueOccurrenceData, event: Optional[Event] = None
-) -> None:
+def save_issue_occurrence(occurrence_data: IssueOccurrenceData, event: Event) -> None:
     # Convert occurrence data to `IssueOccurrence`
     occurrence = IssueOccurrence.from_dict(occurrence_data)
+    if occurrence.event_id != event.event_id:
+        raise ValueError("IssueOccurrence must have the same event_id as the passed Event")
     occurrence.save()
 
     # TODO: Create/update issue

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -4,7 +4,7 @@ from sentry.eventstore.models import Event
 from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
 
 
-def save_issue_occurrence(occurrence_data: IssueOccurrenceData, event: Event) -> None:
+def save_issue_occurrence(occurrence_data: IssueOccurrenceData, event: Event) -> IssueOccurrence:
     # Convert occurrence data to `IssueOccurrence`
     occurrence = IssueOccurrence.from_dict(occurrence_data)
     if occurrence.event_id != event.event_id:
@@ -13,3 +13,4 @@ def save_issue_occurrence(occurrence_data: IssueOccurrenceData, event: Event) ->
 
     # TODO: Create/update issue
     # TODO: Write occurrence and event eventstream
+    return occurrence

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -1,27 +1,17 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Optional
 
+from sentry.eventstore.models import Event
 from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
 
 
 def save_issue_occurrence(
-    occurrence_data: IssueOccurrenceData, event_data: Optional[dict[str, Any]] = None
+    occurrence_data: IssueOccurrenceData, event: Optional[Event] = None
 ) -> None:
-    event_id = occurrence_data.get("event_id")
-    if event_id is None:
-        if event_data is None:
-            raise ValueError("At least one of `event_id` or `event_data` must be passed")
-
-        occurrence_data["event_id"] = event_data["id"]
-
     # Convert occurrence data to `IssueOccurrence`
     occurrence = IssueOccurrence.from_dict(occurrence_data)
     occurrence.save()
-
-    if event_data:
-        # TODO: Save event via EventManager
-        pass
 
     # TODO: Create/update issue
     # TODO: Write occurrence and event eventstream

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -9,7 +9,9 @@ def save_issue_occurrence(occurrence_data: IssueOccurrenceData, event: Event) ->
     occurrence = IssueOccurrence.from_dict(occurrence_data)
     if occurrence.event_id != event.event_id:
         raise ValueError("IssueOccurrence must have the same event_id as the passed Event")
-    occurrence.save()
+    # Note: For now we trust the project id passed along with the event. Later on we should make
+    # sure that this is somehow validated.
+    occurrence.save(event.project_id)
 
     # TODO: Create/update issue
     # TODO: Write occurrence and event eventstream

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -20,7 +20,7 @@ class IssueEvidenceData(TypedDict):
 
 class IssueOccurrenceData(TypedDict):
     id: str
-    event_id: Optional[str]
+    event_id: str
     fingerprint: Sequence[str]
     issue_title: str
     subtitle: str
@@ -103,7 +103,7 @@ class IssueOccurrence:
         return cls(
             data["id"],
             # We'll always have an event id when loading an issue occurrence
-            data["event_id"],  # type: ignore
+            data["event_id"],
             data["fingerprint"],
             data["issue_title"],
             data["subtitle"],

--- a/src/sentry/issues/issue_occurrence.py
+++ b/src/sentry/issues/issue_occurrence.py
@@ -136,21 +136,17 @@ class IssueOccurrence:
     def __hash__(self) -> int:
         return hash(self.id)
 
-    @property
-    def storage_identifier(self) -> str:
-        return self.build_storage_identifier(self.id)
-
     @classmethod
-    def build_storage_identifier(cls, id_: str) -> str:
-        identifier = hashlib.md5(f"{id_}".encode()).hexdigest()
+    def build_storage_identifier(cls, id_: str, project_id: int) -> str:
+        identifier = hashlib.md5(f"{id_}::{project_id}".encode()).hexdigest()
         return f"i-o:{identifier}"
 
-    def save(self) -> None:
-        nodestore.set(self.storage_identifier, self.to_dict())
+    def save(self, project_id: int) -> None:
+        nodestore.set(self.build_storage_identifier(self.id, project_id), self.to_dict())
 
     @classmethod
-    def fetch(cls, id_: str) -> Optional[IssueOccurrence]:
-        results = nodestore.get(cls.build_storage_identifier(id_))
+    def fetch(cls, id_: str, project_id: int) -> Optional[IssueOccurrence]:
+        results = nodestore.get(cls.build_storage_identifier(id_, project_id))
         if results:
             return IssueOccurrence.from_dict(results)
         return None

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from django.utils.functional import cached_property
 
+from sentry.eventstore.models import Event
 from sentry.incidents.models import IncidentActivityType
 from sentry.models import (
     Activity,
@@ -227,7 +228,7 @@ class Fixtures:
     def create_useremail(self, *args, **kwargs):
         return Factories.create_useremail(*args, **kwargs)
 
-    def store_event(self, *args, **kwargs):
+    def store_event(self, *args, **kwargs) -> Event:
         return Factories.store_event(*args, **kwargs)
 
     def create_group(self, project=None, *args, **kwargs):

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -1,0 +1,24 @@
+from sentry.issues.ingest import save_issue_occurrence
+from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
+from tests.sentry.issues.utils import OccurrenceTestMixin
+
+
+@region_silo_test
+class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignore
+    def test(self) -> None:
+        # TODO: We should make this a platform event once we have one
+        event = self.store_event(data={}, project_id=self.project.id)
+        occurrence = self.build_occurrence(event_id=event.event_id)
+        self.assert_occurrences_identical(
+            occurrence, save_issue_occurrence(occurrence.to_dict(), event)
+        )
+
+    def test_different_ids(self) -> None:
+        # TODO: We should make this a platform event once we have one
+        event = self.store_event(data={}, project_id=self.project.id)
+        occurrence = self.build_occurrence()
+        with self.assertRaisesMessage(
+            ValueError, "IssueOccurrence must have the same event_id as the passed Event"
+        ):
+            save_issue_occurrence(occurrence.to_dict(), event)

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -1,7 +1,7 @@
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
-from tests.sentry.issues.utils import OccurrenceTestMixin
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 @region_silo_test

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -17,8 +17,8 @@ class IssueOccurenceSerializeTest(OccurrenceTestMixin, TestCase):  # type: ignor
 class IssueOccurenceSaveAndFetchTest(OccurrenceTestMixin, TestCase):  # type: ignore
     def test(self) -> None:
         occurrence = self.build_occurrence()
-        occurrence.save()
-        fetched_occurrence = IssueOccurrence.fetch(occurrence.id)
+        occurrence.save(self.project.id)
+        fetched_occurrence = IssueOccurrence.fetch(occurrence.id, self.project.id)
         assert fetched_occurrence is not None
         self.assert_occurrences_identical(occurrence, fetched_occurrence)
 

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -1,49 +1,11 @@
-import uuid
-from datetime import datetime
-from typing import Any
-
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
-from sentry.types.issues import GroupType
-from sentry.utils.dates import ensure_aware
-
-
-class BaseIssueOccurrenceTest:
-    def assert_occurrences_identical(self, o1: IssueOccurrence, o2: IssueOccurrence) -> None:
-        assert o1.id == o2.id
-        assert o1.event_id == o2.event_id
-        assert o1.fingerprint == o2.fingerprint
-        assert o1.issue_title == o2.issue_title
-        assert o1.subtitle == o2.subtitle
-        assert o1.resource_id == o2.resource_id
-        assert o1.evidence_data == o2.evidence_data
-        assert o1.evidence_display == o2.evidence_display
-        assert o1.type == o2.type
-        assert o1.detection_time == o2.detection_time
-
-    def build_occurrence(self, **overrides: Any) -> IssueOccurrence:
-        kwargs = {
-            "id": uuid.uuid4().hex,
-            "event_id": uuid.uuid4().hex,
-            "fingerprint": ["some-fingerprint"],
-            "issue_title": "something bad happened",
-            "subtitle": "it was bad",
-            "resource_id": "1234",
-            "evidence_data": {"Test": 123},
-            "evidence_display": [
-                IssueEvidence("hi", "bye", True),
-                IssueEvidence("what", "where", False),
-            ],
-            "type": GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
-            "detection_time": ensure_aware(datetime.now()),
-        }
-        kwargs.update(overrides)
-        return IssueOccurrence(**kwargs)
+from tests.sentry.issues.utils import OccurrenceTestMixin
 
 
 @region_silo_test
-class IssueOccurenceSerializeTest(BaseIssueOccurrenceTest, TestCase):  # type: ignore
+class IssueOccurenceSerializeTest(OccurrenceTestMixin, TestCase):  # type: ignore
     def test(self) -> None:
         occurrence = self.build_occurrence()
         self.assert_occurrences_identical(
@@ -52,7 +14,7 @@ class IssueOccurenceSerializeTest(BaseIssueOccurrenceTest, TestCase):  # type: i
 
 
 @region_silo_test
-class IssueOccurenceSaveAndFetchTest(BaseIssueOccurrenceTest, TestCase):  # type: ignore
+class IssueOccurenceSaveAndFetchTest(OccurrenceTestMixin, TestCase):  # type: ignore
     def test(self) -> None:
         occurrence = self.build_occurrence()
         occurrence.save()
@@ -62,7 +24,7 @@ class IssueOccurenceSaveAndFetchTest(BaseIssueOccurrenceTest, TestCase):  # type
 
 
 @region_silo_test
-class IssueOccurrenceEvidenceDisplayPrimaryTest(BaseIssueOccurrenceTest, TestCase):  # type: ignore
+class IssueOccurrenceEvidenceDisplayPrimaryTest(OccurrenceTestMixin, TestCase):  # type: ignore
     def test(self) -> None:
         important_evidence = IssueEvidence("Hello", "Hi", True)
         occurrence = self.build_occurrence(evidence_display=[important_evidence])

--- a/tests/sentry/issues/test_issue_occurrence.py
+++ b/tests/sentry/issues/test_issue_occurrence.py
@@ -1,7 +1,7 @@
 from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.testutils import TestCase
 from sentry.testutils.silo import region_silo_test
-from tests.sentry.issues.utils import OccurrenceTestMixin
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 @region_silo_test

--- a/tests/sentry/issues/test_utils.py
+++ b/tests/sentry/issues/test_utils.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
+from sentry.types.issues import GroupType
+from sentry.utils.dates import ensure_aware
+
+
+class OccurrenceTestMixin:
+    def assert_occurrences_identical(self, o1: IssueOccurrence, o2: IssueOccurrence) -> None:
+        assert o1.id == o2.id
+        assert o1.event_id == o2.event_id
+        assert o1.fingerprint == o2.fingerprint
+        assert o1.issue_title == o2.issue_title
+        assert o1.subtitle == o2.subtitle
+        assert o1.resource_id == o2.resource_id
+        assert o1.evidence_data == o2.evidence_data
+        assert o1.evidence_display == o2.evidence_display
+        assert o1.type == o2.type
+        assert o1.detection_time == o2.detection_time
+
+    def build_occurrence(self, **overrides: Any) -> IssueOccurrence:
+        kwargs = {
+            "id": uuid.uuid4().hex,
+            "event_id": uuid.uuid4().hex,
+            "fingerprint": ["some-fingerprint"],
+            "issue_title": "something bad happened",
+            "subtitle": "it was bad",
+            "resource_id": "1234",
+            "evidence_data": {"Test": 123},
+            "evidence_display": [
+                IssueEvidence("hi", "bye", True),
+                IssueEvidence("what", "where", False),
+            ],
+            "type": GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES,
+            "detection_time": ensure_aware(datetime.now()),
+        }
+        kwargs.update(overrides)
+        return IssueOccurrence(**kwargs)

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -304,7 +304,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             GroupType.PROFILE_BLOCKED_THREAD,
             ensure_aware(datetime.now()),
         )
-        occurrence.save()
+        occurrence.save(self.project.id)
         event.occurrence = occurrence
 
         event.group.type = GroupType.PROFILE_BLOCKED_THREAD
@@ -351,7 +351,7 @@ class MailAdapterNotifyTest(BaseMailAdapterTest):
             GroupType.PROFILE_BLOCKED_THREAD,
             ensure_aware(datetime.now()),
         )
-        occurrence.save()
+        occurrence.save(self.project.id)
         event.occurrence = occurrence
 
         event.group.type = GroupType.PROFILE_BLOCKED_THREAD


### PR DESCRIPTION
This introduces a function for saving an `IssueOccurrence` based on `IssueOccurrenceData`, as well as an related event data. In future prs it will also handle creating/updating the related issue and passing this information to eventstream.
