### PR TITLE
feat(perf-issues): N+1 API Calls detector improvements V

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -333,7 +333,7 @@ def get_detection_settings(project_id: Optional[str] = None) -> Dict[DetectorTyp
             }
         ],
         DetectorType.N_PLUS_ONE_API_CALLS: {
-            "duration_threshold": 5,  # ms
+            "duration_threshold": 50,  # ms
             "concurrency_threshold": 5,  # ms
             "count": 10,
             "allowed_span_ops": ["http.client"],


### PR DESCRIPTION
Increase the duration threshold to 50ms. Short spans usually indicate a very optimized call, or perhaps a local request. Ignoring these cleans up the output a lot.
