### PR TITLE
chore: Update user feedback path in acceptance test

### DIFF
--- a/tests/acceptance/test_project_user_feedback.py
+++ b/tests/acceptance/test_project_user_feedback.py
@@ -15,7 +15,7 @@ class ProjectUserFeedbackTest(AcceptanceTestCase):
         )
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
-        self.path = f"/{self.org.slug}/{self.project.slug}/user-feedback/"
+        self.path = f"/organizations/{self.org.slug}/user-feedback/?project=${self.project.id}"
         self.project.update(first_event=timezone.now())
 
     def test(self):


### PR DESCRIPTION
Before I can remove pre-Sentry 10 legacy React routes in https://github.com/getsentry/sentry/pull/42103, there is an acceptance test that makes use of a legacy route that will need to be updated. 

I've updated that path here.