### PR TITLE
fix(dropdownMenu): Only show scrollbar when needed

### DIFF
--- a/static/app/components/dropdownMenu.tsx
+++ b/static/app/components/dropdownMenu.tsx
@@ -225,7 +225,7 @@ const MenuWrap = styled('ul')<{hasTitle: boolean}>`
   padding: ${space(0.5)} 0;
   font-size: ${p => p.theme.fontSizeMedium};
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
 
   ${p => p.hasTitle && `padding-top: calc(${space(0.5)} + 1px);`}
 


### PR DESCRIPTION
If the OS has been configured to always show scrollbars, then the user will see a scroll gutter in dropdown menus regardless of whether the menu is scrollable or not. This PR fixes that – scroll gutters will now only appear if there is overflow.

**Before:**
<img width="131" alt="Screenshot 2022-12-07 at 9 57 35 AM" src="https://user-images.githubusercontent.com/44172267/206259730-def57320-12b8-4635-ab8a-687aaa766bac.png">
**After:**
<img width="131" alt="Screenshot 2022-12-07 at 9 57 48 AM" src="https://user-images.githubusercontent.com/44172267/206259771-dbace324-df96-4c1b-ac9a-650655cfd43b.png">
