### PR TITLE
ref(hybrid-cloud): use organization_slug in AcceptOrganizationInvite API

### DIFF
--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -41,6 +41,8 @@ class AcceptOrganizationInvite(Endpoint):
         if organization_slug:
             if organization_slug != organization.slug:
                 return self.respond_invalid()
+        else:
+            organization_slug = organization.slug
 
         if (
             not helper.member_pending
@@ -81,7 +83,7 @@ class AcceptOrganizationInvite(Endpoint):
             # When SSO is required do *not* set a next_url to return to accept
             # invite. The invite will be accepted after SSO is completed.
             url = (
-                reverse("sentry-accept-invite", args=[member_id, token])
+                reverse("sentry-accept-invite", args=[organization_slug, member_id, token])
                 if not auth_provider
                 else "/"
             )

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -83,7 +83,7 @@ class AcceptOrganizationInvite(Endpoint):
             # When SSO is required do *not* set a next_url to return to accept
             # invite. The invite will be accepted after SSO is completed.
             url = (
-                reverse("sentry-accept-invite", args=[organization_slug, member_id, token])
+                reverse("sentry-accept-invite", args=[member_id, token])
                 if not auth_provider
                 else "/"
             )

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -36,7 +36,7 @@ class AcceptOrganizationInvite(Endpoint):
             return self.respond_invalid()
 
         organization_member = helper.om
-        organization = organization_member.organization
+        organization = helper.organization
 
         if organization_slug:
             if organization_slug != organization.slug:
@@ -133,8 +133,7 @@ class AcceptOrganizationInvite(Endpoint):
         else:
             response = Response(status=status.HTTP_204_NO_CONTENT)
 
-        organization_member = helper.om
-        organization = organization_member.organization
+        organization = helper.organization
 
         if organization_slug:
             if organization_slug != organization.slug:

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.request import Request
@@ -25,7 +27,9 @@ class AcceptOrganizationInvite(Endpoint):
     def get_helper(self, request: Request, member_id: int, token: str) -> ApiInviteHelper:
         return ApiInviteHelper(request=request, member_id=member_id, instance=self, token=token)
 
-    def get(self, request: Request, member_id: int, token: str) -> Response:
+    def get(
+        self, request: Request, member_id: int, token: str, organization_slug: Optional[str] = None
+    ) -> Response:
         try:
             helper = self.get_helper(request, member_id, token)
         except OrganizationMember.DoesNotExist:
@@ -33,6 +37,10 @@ class AcceptOrganizationInvite(Endpoint):
 
         organization_member = helper.om
         organization = organization_member.organization
+
+        if organization_slug:
+            if organization_slug != organization.slug:
+                return self.respond_invalid()
 
         if (
             not helper.member_pending
@@ -102,7 +110,9 @@ class AcceptOrganizationInvite(Endpoint):
 
         return response
 
-    def post(self, request: Request, member_id: int, token: str) -> Response:
+    def post(
+        self, request: Request, member_id: int, token: str, organization_slug: Optional[str] = None
+    ) -> Response:
         try:
             helper = self.get_helper(request, member_id, token)
         except OrganizationMember.DoesNotExist:
@@ -120,6 +130,13 @@ class AcceptOrganizationInvite(Endpoint):
             )
         else:
             response = Response(status=status.HTTP_204_NO_CONTENT)
+
+        organization_member = helper.om
+        organization = organization_member.organization
+
+        if organization_slug:
+            if organization_slug != organization.slug:
+                return self.respond_invalid()
 
         helper.accept_invite()
         remove_invite_details_from_session(request)

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -110,7 +110,7 @@ class ApiInviteHelper:
         self.instance = instance
         self.logger = logger
         self.om = self.organization_member
-        self.organization: self.om.organization
+        self.organization = self.om.organization
 
     def handle_success(self) -> None:
         member_joined.send_robust(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -660,9 +660,14 @@ urlpatterns = [
     ),
     # Organization invite
     url(
-        r"^accept-invite/(?P<member_id>[^\/]+)/(?P<token>[^\/]+)/$",
+        r"^accept-invite/(?P<organization_slug>[^\/]+)/(?P<member_id>[^\/]+)/(?P<token>[^\/]+)/$",
         AcceptOrganizationInvite.as_view(),
         name="sentry-api-0-accept-organization-invite",
+    ),
+    url(
+        r"^accept-invite/(?P<member_id>[^\/]+)/(?P<token>[^\/]+)/$",
+        AcceptOrganizationInvite.as_view(),
+        name="sentry-api-0-accept-organization-invite-orgless",
     ),
     # Monitors
     url(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -662,12 +662,12 @@ urlpatterns = [
     url(
         r"^accept-invite/(?P<organization_slug>[^\/]+)/(?P<member_id>[^\/]+)/(?P<token>[^\/]+)/$",
         AcceptOrganizationInvite.as_view(),
-        name="sentry-api-0-accept-organization-invite",
+        name="sentry-api-0-accept-organization-invite-with-org",
     ),
     url(
         r"^accept-invite/(?P<member_id>[^\/]+)/(?P<token>[^\/]+)/$",
         AcceptOrganizationInvite.as_view(),
-        name="sentry-api-0-accept-organization-invite-orgless",
+        name="sentry-api-0-accept-organization-invite",
     ),
     # Monitors
     url(

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -239,6 +239,7 @@ class OrganizationMember(Model):
     def generate_token(self):
         return uuid4().hex + uuid4().hex
 
+    # TODO: does this need to be updated?
     def get_invite_link(self):
         if not self.is_pending or not self.invite_approved:
             return None

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -246,7 +246,6 @@ class OrganizationMember(Model):
             reverse(
                 "sentry-accept-invite",
                 kwargs={
-                    "organization_slug": self.organization.slug,
                     "member_id": self.id,
                     "token": self.token or self.legacy_token,
                 },

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -239,14 +239,17 @@ class OrganizationMember(Model):
     def generate_token(self):
         return uuid4().hex + uuid4().hex
 
-    # TODO: does this need to be updated?
     def get_invite_link(self):
         if not self.is_pending or not self.invite_approved:
             return None
         return absolute_uri(
             reverse(
                 "sentry-accept-invite",
-                kwargs={"member_id": self.id, "token": self.token or self.legacy_token},
+                kwargs={
+                    "organization_slug": self.organization.slug,
+                    "member_id": self.id,
+                    "token": self.token or self.legacy_token,
+                },
             )
         )
 

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -599,7 +599,7 @@ def invitation(request):
             "url": absolute_uri(
                 reverse(
                     "sentry-accept-invite",
-                    kwargs={"organization_slug": org.slug, "member_id": om.id, "token": om.token},
+                    kwargs={"member_id": om.id, "token": om.token},
                 )
             ),
         },

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -597,7 +597,10 @@ def invitation(request):
             "email": "foo@example.com",
             "organization": org,
             "url": absolute_uri(
-                reverse("sentry-accept-invite", kwargs={"member_id": om.id, "token": om.token})
+                reverse(
+                    "sentry-accept-invite",
+                    kwargs={"organization_slug": org.slug, "member_id": om.id, "token": om.token},
+                )
             ),
         },
     ).render(request)

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -355,7 +355,7 @@ urlpatterns += [
         r"^accept/(?P<member_id>\d+)/(?P<token>\w+)/$",
         GenericReactPageView.as_view(auth_required=False),
         name="sentry-accept-invite",
-    ),
+    ),  # TODO: does this need to be converted as well?
     # User settings use generic_react_page_view, while any view acting on
     # behalf of an organization should use react_page_view
     url(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -352,10 +352,10 @@ urlpatterns += [
     url(r"^out/$", OutView.as_view()),
     url(r"^accept-transfer/$", react_page_view, name="sentry-accept-project-transfer"),
     url(
-        r"^accept/(?P<member_id>\d+)/(?P<token>\w+)/$",
+        r"^accept/(?P<organization_slug>[^/]+)/(?P<member_id>\d+)/(?P<token>\w+)/$",
         GenericReactPageView.as_view(auth_required=False),
         name="sentry-accept-invite",
-    ),  # TODO: does this need to be converted as well?
+    ),
     # User settings use generic_react_page_view, while any view acting on
     # behalf of an organization should use react_page_view
     url(

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -352,9 +352,14 @@ urlpatterns += [
     url(r"^out/$", OutView.as_view()),
     url(r"^accept-transfer/$", react_page_view, name="sentry-accept-project-transfer"),
     url(
-        r"^accept/(?P<organization_slug>[^/]+)/(?P<member_id>\d+)/(?P<token>\w+)/$",
+        r"^accept/(?P<member_id>\d+)/(?P<token>\w+)/$",
         GenericReactPageView.as_view(auth_required=False),
         name="sentry-accept-invite",
+    ),
+    url(
+        r"^accept/(?P<organization_slug>[^/]+)/(?P<member_id>\d+)/(?P<token>\w+)/$",
+        GenericReactPageView.as_view(auth_required=False),
+        name="sentry-accept-invite-with-org",
     ),
     # User settings use generic_react_page_view, while any view acting on
     # behalf of an organization should use react_page_view

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -14,13 +14,35 @@ from sentry.models import (
     OrganizationMember,
 )
 from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
 
 
+@region_silo_test
 class AcceptInviteTest(TestCase):
     def setUp(self):
         super().setUp()
         self.organization = self.create_organization(owner=self.create_user("foo@example.com"))
         self.user = self.create_user("bar@example.com")
+
+    def _get_paths(self, args):
+        return (
+            reverse("sentry-api-0-accept-organization-invite-orgless", args=args),
+            reverse(
+                "sentry-api-0-accept-organization-invite",
+                args=[self.organization.slug] + args,
+            ),
+        )
+
+    def _get_urls(self):
+        return (
+            "sentry-api-0-accept-organization-invite-orgless",
+            "sentry-api-0-accept-organization-invite",
+        )
+
+    def _get_path(self, url, args):
+        if url == self._get_urls()[0]:
+            return reverse(url, args=args)
+        return reverse(url, args=[self.organization.slug] + args)
 
     def _require_2fa_for_organization(self):
         self.organization.update(flags=F("flags").bitor(Organization.flags.require_2fa))
@@ -36,31 +58,32 @@ class AcceptInviteTest(TestCase):
         assert session_invite_token is None
         assert session_invite_member_id is None
 
-    def _enroll_user_in_2fa(self):
+    def _enroll_user_in_2fa(self, user):
         interface = TotpInterface()
-        interface.enroll(self.user)
-        assert Authenticator.objects.user_has_2fa(self.user)
+        interface.enroll(user)
+        assert Authenticator.objects.user_has_2fa(user)
 
     def test_invalid_member_id(self):
-        resp = self.client.get(reverse("sentry-api-0-accept-organization-invite", args=[1, 2]))
-        assert resp.status_code == 400
+        for path in self._get_paths([1, 2]):
+            resp = self.client.get(path)
+            assert resp.status_code == 400
 
     def test_invalid_token(self):
         om = OrganizationMember.objects.create(
             email="newuser@example.com", token="abc", organization=self.organization
         )
-        resp = self.client.get(reverse("sentry-api-0-accept-organization-invite", args=[om.id, 2]))
-        assert resp.status_code == 400
+        for path in self._get_paths([om.id, 2]):
+            resp = self.client.get(path)
+            assert resp.status_code == 400
 
     def test_invite_not_pending(self):
         user = self.create_user(email="test@gmail.com")
         om = OrganizationMember.objects.create(
             email="newuser@example.com", token="abc", organization=self.organization, user=user
         )
-        resp = self.client.get(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 400
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.get(path)
+            assert resp.status_code == 400
 
     def test_invite_unapproved(self):
         om = OrganizationMember.objects.create(
@@ -69,20 +92,18 @@ class AcceptInviteTest(TestCase):
             organization=self.organization,
             invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
         )
-        resp = self.client.get(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 400
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.get(path)
+            assert resp.status_code == 400
 
     def test_needs_authentication(self):
         om = OrganizationMember.objects.create(
             email="newuser@example.com", token="abc", organization=self.organization
         )
-        resp = self.client.get(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 200
-        assert resp.data["needsAuthentication"]
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+            assert resp.data["needsAuthentication"]
 
     def test_not_needs_authentication(self):
         self.login_as(self.user)
@@ -90,11 +111,10 @@ class AcceptInviteTest(TestCase):
         om = OrganizationMember.objects.create(
             email="newuser@example.com", token="abc", organization=self.organization
         )
-        resp = self.client.get(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 200
-        assert not resp.data["needsAuthentication"]
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+            assert not resp.data["needsAuthentication"]
 
     def test_user_needs_2fa(self):
         self._require_2fa_for_organization()
@@ -105,30 +125,29 @@ class AcceptInviteTest(TestCase):
         om = OrganizationMember.objects.create(
             email="newuser@example.com", token="abc", organization=self.organization
         )
-        resp = self.client.get(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 200
-        assert resp.data["needs2fa"]
 
-        self._assert_pending_invite_details_in_session(om)
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+            assert resp.data["needs2fa"]
+
+            self._assert_pending_invite_details_in_session(om)
 
     def test_user_has_2fa(self):
         self._require_2fa_for_organization()
-        self._enroll_user_in_2fa()
+        self._enroll_user_in_2fa(self.user)
 
         self.login_as(self.user)
 
         om = OrganizationMember.objects.create(
             email="newuser@example.com", token="abc", organization=self.organization
         )
-        resp = self.client.get(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 200
-        assert not resp.data["needs2fa"]
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+            assert not resp.data["needs2fa"]
 
-        self._assert_pending_invite_details_not_in_session(resp)
+            self._assert_pending_invite_details_not_in_session(resp)
 
     def test_user_can_use_sso(self):
         AuthProvider.objects.create(organization=self.organization, provider="google")
@@ -137,37 +156,42 @@ class AcceptInviteTest(TestCase):
         om = OrganizationMember.objects.create(
             email="newuser@example.com", token="abc", organization=self.organization
         )
-        resp = self.client.get(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 200
-        assert resp.data["needsSso"]
-        assert resp.data["hasAuthProvider"]
-        assert resp.data["ssoProvider"] == "Google"
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+            assert resp.data["needsSso"]
+            assert resp.data["hasAuthProvider"]
+            assert resp.data["ssoProvider"] == "Google"
 
     def test_can_accept_while_authenticated(self):
-        self.login_as(self.user)
+        urls = self._get_urls()
+        user = self.create_user("boo@example.com")
+        users = [self.user, user]
 
-        om = OrganizationMember.objects.create(
-            email="newuser@example.com", role="member", token="abc", organization=self.organization
-        )
-        resp = self.client.post(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 204
+        for i, url in enumerate(urls):
+            self.login_as(users[i])
+            om = OrganizationMember.objects.create(
+                email="newuser" + str(i) + "@example.com",
+                role="member",
+                token="abc",
+                organization=self.organization,
+            )
+            path = self._get_path(url, [om.id, om.token])
+            resp = self.client.post(path)
+            assert resp.status_code == 204
 
-        om = OrganizationMember.objects.get(id=om.id)
-        assert om.email is None
-        assert om.user == self.user
+            om = OrganizationMember.objects.get(id=om.id)
+            assert om.email is None
+            assert om.user == users[i]
 
-        ale = AuditLogEntry.objects.get(
-            organization=self.organization, event=audit_log.get_event_id("MEMBER_ACCEPT")
-        )
+            ale = AuditLogEntry.objects.filter(
+                organization=self.organization, event=audit_log.get_event_id("MEMBER_ACCEPT")
+            ).order_by("-datetime")[0]
 
-        assert ale.actor == self.user
-        assert ale.target_object == om.id
-        assert ale.target_user == self.user
-        assert ale.data
+            assert ale.actor == users[i]
+            assert ale.target_object == om.id
+            assert ale.target_user == users[i]
+            assert ale.data
 
     def test_cannot_accept_expired(self):
         self.login_as(self.user)
@@ -178,14 +202,14 @@ class AcceptInviteTest(TestCase):
         OrganizationMember.objects.filter(id=om.id).update(
             token_expires_at=om.token_expires_at - timedelta(days=31)
         )
-        resp = self.client.post(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 400
 
-        om = OrganizationMember.objects.get(id=om.id)
-        assert om.is_pending, "should not have been accepted"
-        assert om.token, "should not have been accepted"
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.post(path)
+            assert resp.status_code == 400
+
+            om = OrganizationMember.objects.get(id=om.id)
+            assert om.is_pending, "should not have been accepted"
+            assert om.token, "should not have been accepted"
 
     def test_cannot_accept_unapproved_invite(self):
         self.login_as(self.user)
@@ -197,10 +221,9 @@ class AcceptInviteTest(TestCase):
             organization=self.organization,
             invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
         )
-        resp = self.client.post(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 400
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.post(path)
+            assert resp.status_code == 400
 
         om = OrganizationMember.objects.get(id=om.id)
         assert not om.invite_approved
@@ -208,61 +231,74 @@ class AcceptInviteTest(TestCase):
         assert om.token
 
     def test_member_already_exists(self):
-        self.login_as(self.user)
+        urls = self._get_urls()
+        user = self.create_user("boo@example.com")
+        users = [self.user, user]
 
-        om = OrganizationMember.objects.create(
-            email="newuser@example.com", role="member", token="abc", organization=self.organization
-        )
-        resp = self.client.post(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 204
+        for i, url in enumerate(urls):
+            self.login_as(users[i])
 
-        om = OrganizationMember.objects.get(id=om.id)
-        assert om.email is None
-        assert om.user == self.user
+            om = OrganizationMember.objects.create(
+                email="newuser" + str(i) + "@example.com",
+                role="member",
+                token="abc",
+                organization=self.organization,
+            )
+            path = self._get_path(url, [om.id, om.token])
+            resp = self.client.post(path)
+            assert resp.status_code == 204
 
-        om2 = OrganizationMember.objects.create(
-            email="newuser1@example.com",
-            role="member",
-            token="abcd",
-            organization=self.organization,
-        )
-        resp = self.client.post(
-            reverse("sentry-api-0-accept-organization-invite", args=[om2.id, om2.token])
-        )
-        assert resp.status_code == 400
-        assert not OrganizationMember.objects.filter(id=om2.id).exists()
+            om = OrganizationMember.objects.get(id=om.id)
+            assert om.email is None
+            assert om.user == users[i]
+
+            om2 = OrganizationMember.objects.create(
+                email="newuser3@example.com",
+                role="member",
+                token="abcd",
+                organization=self.organization,
+            )
+            path = self._get_path(url, [om2.id, om2.token])
+            resp = self.client.post(path)
+            assert resp.status_code == 400
+            assert not OrganizationMember.objects.filter(id=om2.id).exists()
 
     def test_can_accept_when_user_has_2fa(self):
-        self._require_2fa_for_organization()
-        self._enroll_user_in_2fa()
+        urls = self._get_urls()
+        user = self.create_user("boo@example.com")
+        users = [self.user, user]
 
-        self.login_as(self.user)
+        for i, url in enumerate(urls):
+            self._require_2fa_for_organization()
+            self._enroll_user_in_2fa(users[i])
 
-        om = OrganizationMember.objects.create(
-            email="newuser@example.com", role="member", token="abc", organization=self.organization
-        )
+            self.login_as(users[i])
 
-        resp = self.client.post(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 204
+            om = OrganizationMember.objects.create(
+                email="newuser" + str(i) + "@example.com",
+                role="member",
+                token="abc",
+                organization=self.organization,
+            )
 
-        self._assert_pending_invite_details_not_in_session(resp)
+            path = self._get_path(url, [om.id, om.token])
+            resp = self.client.post(path)
+            assert resp.status_code == 204
 
-        om = OrganizationMember.objects.get(id=om.id)
-        assert om.email is None
-        assert om.user == self.user
+            self._assert_pending_invite_details_not_in_session(resp)
 
-        ale = AuditLogEntry.objects.get(
-            organization=self.organization, event=audit_log.get_event_id("MEMBER_ACCEPT")
-        )
+            om = OrganizationMember.objects.get(id=om.id)
+            assert om.email is None
+            assert om.user == users[i]
 
-        assert ale.actor == self.user
-        assert ale.target_object == om.id
-        assert ale.target_user == self.user
-        assert ale.data
+            ale = AuditLogEntry.objects.filter(
+                organization=self.organization, event=audit_log.get_event_id("MEMBER_ACCEPT")
+            ).order_by("-datetime")[0]
+
+            assert ale.actor == users[i]
+            assert ale.target_object == om.id
+            assert ale.target_user == users[i]
+            assert ale.data
 
     def test_cannot_accept_when_user_needs_2fa(self):
         self._require_2fa_for_organization()
@@ -273,30 +309,52 @@ class AcceptInviteTest(TestCase):
         om = OrganizationMember.objects.create(
             email="newuser@example.com", role="member", token="abc", organization=self.organization
         )
-        resp = self.client.post(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 400
+        for path in self._get_paths([om.id, om.token]):
+            resp = self.client.post(path)
+            assert resp.status_code == 400
 
     def test_2fa_cookie_deleted_after_accept(self):
-        self._require_2fa_for_organization()
-        self.assertFalse(Authenticator.objects.user_has_2fa(self.user))
+        urls = self._get_urls()
+        user = self.create_user("boo@example.com")
+        users = [self.user, user]
 
+        for i, url in enumerate(urls):
+            self._require_2fa_for_organization()
+            self.assertFalse(Authenticator.objects.user_has_2fa(users[i]))
+
+            self.login_as(users[i])
+
+            om = OrganizationMember.objects.create(
+                email="newuser" + str(i) + "@example.com",
+                role="member",
+                token="abc",
+                organization=self.organization,
+            )
+            path = self._get_path(url, [om.id, om.token])
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+            self._assert_pending_invite_details_in_session(om)
+
+            self._enroll_user_in_2fa(users[i])
+            resp = self.client.post(path)
+            assert resp.status_code == 204
+
+            self._assert_pending_invite_details_not_in_session(resp)
+
+    def test_mismatched_org_slug(self):
         self.login_as(self.user)
 
         om = OrganizationMember.objects.create(
-            email="newuser@example.com", role="member", token="abc", organization=self.organization
+            email="newuser@example.com",
+            role="member",
+            token="abc",
+            organization=self.organization,
         )
-        resp = self.client.get(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 200
-        self._assert_pending_invite_details_in_session(om)
 
-        self._enroll_user_in_2fa()
-        resp = self.client.post(
-            reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-        )
-        assert resp.status_code == 204
+        path = reverse("sentry-api-0-accept-organization-invite", args=["asdf", om.id, om.token])
 
-        self._assert_pending_invite_details_not_in_session(resp)
+        resp = self.client.get(path)
+        assert resp.status_code == 400
+
+        resp = self.client.post(path)
+        assert resp.status_code == 400

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -26,17 +26,17 @@ class AcceptInviteTest(TestCase):
 
     def _get_paths(self, args):
         return (
-            reverse("sentry-api-0-accept-organization-invite-orgless", args=args),
+            reverse("sentry-api-0-accept-organization-invite", args=args),
             reverse(
-                "sentry-api-0-accept-organization-invite",
+                "sentry-api-0-accept-organization-invite-with-org",
                 args=[self.organization.slug] + args,
             ),
         )
 
     def _get_urls(self):
         return (
-            "sentry-api-0-accept-organization-invite-orgless",
             "sentry-api-0-accept-organization-invite",
+            "sentry-api-0-accept-organization-invite-with-org",
         )
 
     def _get_path(self, url, args):
@@ -351,7 +351,9 @@ class AcceptInviteTest(TestCase):
             organization=self.organization,
         )
 
-        path = reverse("sentry-api-0-accept-organization-invite", args=["asdf", om.id, om.token])
+        path = reverse(
+            "sentry-api-0-accept-organization-invite-with-org", args=["asdf", om.id, om.token]
+        )
 
         resp = self.client.get(path)
         assert resp.status_code == 400


### PR DESCRIPTION
Not yet region stable.

Immediately changing the invite link to include the org slug causes the `test_accept_organization_invite` acceptance tests to fail, so I will look more into it and address it in a follow up PR.

For HC-511