### PR TITLE
fix(notification-test): msteams notification fix

### DIFF
--- a/src/sentry/api/endpoints/project_rule_actions.py
+++ b/src/sentry/api/endpoints/project_rule_actions.py
@@ -50,7 +50,7 @@ class ProjectRuleActionsEndpoint(ProjectEndpoint):
                 "frequency": 30,
             }
         )
-        rule = Rule(project=project, data=data)
+        rule = Rule(id=-1, project=project, data=data)
 
         test_event = create_sample_event(
             project, platform=project.platform, default="javascript", tagged=True


### PR DESCRIPTION
Set a dummy id for the dummy rule created. By default it was `None`, which isn't valid json so the req failed. Should fix [SENTRY-WTC](https://sentry.io/organizations/sentry/issues/3789793515/?project=1&query=is%3Aunresolved+assigned%3Ame&referrer=issue-stream&statsPeriod=14d)