### PR TITLE
fix(profiling): Limit RabbitMQ queue size

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -3,7 +3,7 @@
 beautifulsoup4>=4.7.1
 boto3>=1.22.12
 botocore>=1.25.12
-celery>=4.4.7
+celery[brotli]>=4.4.7
 click>=8.0.4
 confluent-kafka>=1.9.2
 croniter>=0.3.37

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -676,7 +676,13 @@ CELERY_QUEUES = [
     ),
     Queue("unmerge", routing_key="unmerge"),
     Queue("update", routing_key="update"),
-    Queue("profiles.process", routing_key="profiles.process"),
+    Queue(
+        "profiles.process",
+        routing_key="profiles.process",
+        queue_arguments={
+            "x-max-length-bytes": 34359738368,  # 32GiB
+        },
+    ),
     Queue("get_suspect_resolutions", routing_key="get_suspect_resolutions"),
     Queue("get_suspect_resolutions_releases", routing_key="get_suspect_resolutions_releases"),
     Queue("replays.ingest_replay", routing_key="replays.ingest_replay"),

--- a/src/sentry/profiles/consumer.py
+++ b/src/sentry/profiles/consumer.py
@@ -43,7 +43,7 @@ class ProfilesConsumer(AbstractBatchWorker):  # type: ignore
     ) -> None:
         for message in messages:
             key_id, profile = message
-            process_profile.s(profile=profile, key_id=key_id).apply_async()
+            process_profile.s(profile=profile, key_id=key_id).apply_async(compression="brotli")
 
     def shutdown(self) -> None:
         pass


### PR DESCRIPTION
In order to avoid putting at risk the RabbitMQ servers, we'd like to limit the amount of data the profiles worker can push to the queue. This will limit the queue to a maximum of 32GiB and will drop incoming profiles by default.