### PR TITLE
fix(useVirtualizedTree): one observer is enough

### DIFF
--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -660,37 +660,14 @@ export function useVirtualizedTree<T extends TreeLike>(
     let rafId: number | undefined;
     const resizeObserver = new window.ResizeObserver(elements => {
       rafId = window.requestAnimationFrame(() => {
-        dispatch({
-          type: 'set scroll height',
-          payload: elements[0]?.contentRect?.height ?? 0,
-        });
-      });
-    });
-
-    resizeObserver.observe(props.scrollContainer);
-
-    return () => {
-      if (typeof rafId === 'number') {
-        window.cancelAnimationFrame(rafId);
-      }
-      resizeObserver.disconnect();
-    };
-  }, [props.scrollContainer, props.rowHeight]);
-
-  // Register a resize observer for when the scroll container is resized.
-  // When the container is resized, update the scroll height in our state.
-  // Similarly to handleScroll, we use requestAnimationFrame to avoid overupdating the UI
-  useEffect(() => {
-    if (!props.scrollContainer) {
-      return undefined;
-    }
-    let rafId: number | undefined;
-    const resizeObserver = new window.ResizeObserver(elements => {
-      rafId = window.requestAnimationFrame(() => {
-        dispatch({
-          type: 'set scroll height',
-          payload: elements[0]?.contentRect?.height ?? 0,
-        });
+        // We only care about changes to the height of the scroll container,
+        // if it has not changed then do not update the scroll height.
+        if (elements[0]?.contentRect?.height !== latestStateRef.current.scrollHeight) {
+          dispatch({
+            type: 'set scroll height',
+            payload: elements[0]?.contentRect?.height ?? 0,
+          });
+        }
       });
     });
 


### PR DESCRIPTION
One observer is enough 🤦🏼 + make sure we do not update size if vertical size didn't change 