### PR TITLE
fix(weekly-email): fix id tag and remove debug logging

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -349,11 +349,6 @@ def project_key_errors(ctx, project):
         # Set project_ctx.key_errors to be an array of (group_id, count) for now.
         # We will query the group history later on in `fetch_key_error_groups`, batched in a per-organization basis
         ctx.projects[project.id].key_errors = [(e["group_id"], e["count()"]) for e in key_errors]
-        if ctx.organization.slug == "sentry":
-            logger.info(
-                "project_key_errors.results",
-                extra={"project_id": project.id, "num_key_errors": len(key_errors)},
-            )
 
 
 # Organization pass. Depends on project_key_errors.
@@ -769,13 +764,6 @@ def render_template_context(ctx, user):
         def all_key_errors():
             for project_ctx in user_projects:
                 for group, group_history, count in project_ctx.key_errors:
-                    # TODO(Steve): Remove debug logging for Sentry
-                    if ctx.organization.slug == "sentry":
-                        logger.info(
-                            "render_template_context.key_error: %s",
-                            group,
-                            extra={"group_id": group.id, "user_id": user.id},
-                        )
                     yield {
                         "count": count,
                         "group": group,

--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -346,7 +346,7 @@
   </div>
   {% endif %}
   {%if key_performance_issues|length > 0 %}
-  <div id="key-errors">
+  <div id="key-performance-issues">
     <h4>Most frequent performance issues</h4>
     {% for a in key_performance_issues %}
     <div style="display: flex; flex-direction: row; margin-bottom: 8px; align-items: flex-start;">


### PR DESCRIPTION
I think the reason the key errors section wasn't showing up was we had a duplicate ID tag