### PR TITLE
feat(scim): idp flag ui permissions changes

### DIFF
--- a/fixtures/js-stubs/member.js
+++ b/fixtures/js-stubs/member.js
@@ -13,6 +13,8 @@ export function Member(params = {}) {
     expired: false,
     flags: {
       'sso:linked': false,
+      'idp:provisioned': false,
+      'idp:role-restricted': false,
     },
     user: User(),
     inviteStatus: 'approved',

--- a/fixtures/js-stubs/members.js
+++ b/fixtures/js-stubs/members.js
@@ -14,6 +14,8 @@ export function Members(params = []) {
       pending: true,
       flags: {
         'sso:linked': false,
+        'idp:provisioned': false,
+        'idp:role-restricted': false,
       },
       user: null,
     },
@@ -28,6 +30,8 @@ export function Members(params = []) {
       pending: false,
       flags: {
         'sso:linked': true,
+        'idp:provisioned': false,
+        'idp:role-restricted': false,
       },
       user: {
         id: '3',
@@ -48,6 +52,8 @@ export function Members(params = []) {
       pending: false,
       flags: {
         'sso:linked': true,
+        'idp:provisioned': false,
+        'idp:role-restricted': false,
       },
       user: {
         id: '4',

--- a/fixtures/js-stubs/team.js
+++ b/fixtures/js-stubs/team.js
@@ -5,6 +5,9 @@ export function Team(params = {}) {
     name: 'Team Name',
     isMember: true,
     memberCount: 0,
+    flags: {
+      'idp:provisioned': false,
+    },
     ...params,
   };
 }

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -79,8 +79,8 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             "pending": obj.is_pending,
             "expired": obj.token_expired,
             "flags": {
-                "idp:provisioned": True,
-                "idp:role-restricted": False,
+                "idp:provisioned": bool(getattr(obj.flags, "idp:provisioned")),
+                "idp:role-restricted": bool(getattr(obj.flags, "idp:role-restricted")),
                 "sso:linked": bool(getattr(obj.flags, "sso:linked")),
                 "sso:invalid": bool(getattr(obj.flags, "sso:invalid")),
                 "member-limit:restricted": bool(getattr(obj.flags, "member-limit:restricted")),

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -79,8 +79,8 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             "pending": obj.is_pending,
             "expired": obj.token_expired,
             "flags": {
-                "idp:provisioned": bool(getattr(obj.flags, "idp:provisioned")),
-                "idp:role-restricted": bool(getattr(obj.flags, "idp:role-restricted")),
+                "idp:provisioned": True,
+                "idp:role-restricted": False,
                 "sso:linked": bool(getattr(obj.flags, "sso:linked")),
                 "sso:invalid": bool(getattr(obj.flags, "sso:invalid")),
                 "member-limit:restricted": bool(getattr(obj.flags, "member-limit:restricted")),

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -77,6 +77,7 @@ export type Team = {
   externalTeams: ExternalTeam[];
   hasAccess: boolean;
   id: string;
+  idpProvisioned: boolean;
   isMember: boolean;
   isPending: boolean;
   memberCount: number;

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -111,6 +111,8 @@ export interface Member {
   email: string;
   expired: boolean;
   flags: {
+    'idp:provisioned': boolean;
+    'idp:role-restricted': boolean;
     'member-limit:restricted': boolean;
     'sso:invalid': boolean;
     'sso:linked': boolean;

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -75,9 +75,11 @@ export interface Organization extends OrganizationSummary {
 export type Team = {
   avatar: Avatar;
   externalTeams: ExternalTeam[];
+  flags: {
+    'idp:provisioned': boolean;
+  };
   hasAccess: boolean;
   id: string;
-  idpProvisioned: boolean;
   isMember: boolean;
   isPending: boolean;
   memberCount: number;

--- a/static/app/views/settings/components/teamSelect.tsx
+++ b/static/app/views/settings/components/teamSelect.tsx
@@ -21,15 +21,15 @@ import useTeams from 'sentry/utils/useTeams';
 
 type Props = {
   /**
-   * Should button be disabled
-   */
-  disabled: boolean;
-  /**
    * Is this component for a project
    * and should adding a team be disabled based
    * on whether the team is idpProvisioned
    */
-  isProject: boolean;
+  addingTeamToProject: boolean;
+  /**
+   * Should button be disabled
+   */
+  disabled: boolean;
   /**
    * callback when teams are added
    */
@@ -60,7 +60,7 @@ type Props = {
 
 function TeamSelect({
   disabled,
-  isProject,
+  addingTeamToProject,
   selectedTeams,
   menuHeader,
   organization,
@@ -106,9 +106,9 @@ function TeamSelect({
       index,
       value: team.slug,
       searchKey: team.slug,
-      disabled: !isProject && team.idpProvisioned,
+      disabled: !addingTeamToProject && team.idpProvisioned,
       label: () => {
-        if (isProject || !team.idpProvisioned) {
+        if (addingTeamToProject || !team.idpProvisioned) {
           return <DropdownTeamBadge avatarSize={18} team={team} />;
         }
         return (

--- a/static/app/views/settings/components/teamSelect.tsx
+++ b/static/app/views/settings/components/teamSelect.tsx
@@ -11,6 +11,7 @@ import {TeamBadge} from 'sentry/components/idBadge/teamBadge';
 import Link from 'sentry/components/links/link';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'sentry/components/panels';
+import Tooltip from 'sentry/components/tooltip';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconSubtract} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -92,18 +93,25 @@ function TeamSelect({
   };
 
   // Only show options that aren't selected in the dropdown
-  // and that aren't idp-provisioned
   const options = teams
-    .filter(
-      team =>
-        !selectedTeams.some(selectedTeam => selectedTeam.slug === team.slug) &&
-        !team.idpProvisioned
-    )
+    .filter(team => !selectedTeams.some(selectedTeam => selectedTeam.slug === team.slug))
     .map((team, index) => ({
       index,
       value: team.slug,
       searchKey: team.slug,
-      label: <DropdownTeamBadge avatarSize={18} team={team} />,
+      disabled: !team.idpProvisioned,
+      label: () => {
+        if (!team.idpProvisioned) {
+          return <DropdownTeamBadge avatarSize={18} team={team} />;
+        }
+        return (
+          <Tooltip
+            title={`Membership to this team is managed through your organization's identity provider.`}
+          >
+            <DropdownTeamBadgeDisabled avatarSize={18} team={team} />
+          </Tooltip>
+        );
+      },
     }));
 
   return (
@@ -182,6 +190,13 @@ const DropdownTeamBadge = styled(TeamBadge)`
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeMedium};
   text-transform: none;
+`;
+
+const DropdownTeamBadgeDisabled = styled(TeamBadge)`
+  font-weight: normal;
+  font-size: ${p => p.theme.fontSizeMedium};
+  text-transform: none;
+  filter: grayscale(1);
 `;
 
 const TeamPanelItem = styled(PanelItem)`

--- a/static/app/views/settings/components/teamSelect.tsx
+++ b/static/app/views/settings/components/teamSelect.tsx
@@ -25,6 +25,12 @@ type Props = {
    */
   disabled: boolean;
   /**
+   * Is this component for a project
+   * and should adding a team be disabled based
+   * on whether the team is idpProvisioned
+   */
+  isProject: boolean;
+  /**
    * callback when teams are added
    */
   onAddTeam: (team: Team) => void;
@@ -54,6 +60,7 @@ type Props = {
 
 function TeamSelect({
   disabled,
+  isProject,
   selectedTeams,
   menuHeader,
   organization,
@@ -99,9 +106,9 @@ function TeamSelect({
       index,
       value: team.slug,
       searchKey: team.slug,
-      disabled: team.idpProvisioned,
+      disabled: !isProject && team.idpProvisioned,
       label: () => {
-        if (!team.idpProvisioned) {
+        if (isProject || !team.idpProvisioned) {
           return <DropdownTeamBadge avatarSize={18} team={team} />;
         }
         return (

--- a/static/app/views/settings/components/teamSelect.tsx
+++ b/static/app/views/settings/components/teamSelect.tsx
@@ -99,7 +99,7 @@ function TeamSelect({
       index,
       value: team.slug,
       searchKey: team.slug,
-      disabled: !team.idpProvisioned,
+      disabled: team.idpProvisioned,
       label: () => {
         if (!team.idpProvisioned) {
           return <DropdownTeamBadge avatarSize={18} team={team} />;

--- a/static/app/views/settings/components/teamSelect.tsx
+++ b/static/app/views/settings/components/teamSelect.tsx
@@ -92,8 +92,13 @@ function TeamSelect({
   };
 
   // Only show options that aren't selected in the dropdown
+  // and that aren't idp-provisioned
   const options = teams
-    .filter(team => !selectedTeams.some(selectedTeam => selectedTeam.slug === team.slug))
+    .filter(
+      team =>
+        !selectedTeams.some(selectedTeam => selectedTeam.slug === team.slug) &&
+        !team.idpProvisioned
+    )
     .map((team, index) => ({
       index,
       value: team.slug,
@@ -153,9 +158,18 @@ const TeamRow = ({orgId, team, onRemove, disabled, confirmMessage}: TeamRowProps
       message={confirmMessage}
       bypass={!confirmMessage}
       onConfirm={() => onRemove(team.slug)}
-      disabled={disabled}
+      disabled={disabled || team.idpProvisioned}
     >
-      <Button size="xs" icon={<IconSubtract isCircled size="xs" />} disabled={disabled}>
+      <Button
+        size="xs"
+        icon={<IconSubtract isCircled size="xs" />}
+        disabled={disabled || team.idpProvisioned}
+        title={
+          team.idpProvisioned
+            ? t('You cannot leave this team as it has been idp-provisioned.')
+            : undefined
+        }
+      >
         {t('Remove')}
       </Button>
     </Confirm>

--- a/static/app/views/settings/components/teamSelect.tsx
+++ b/static/app/views/settings/components/teamSelect.tsx
@@ -110,7 +110,9 @@ function TeamSelect({
         if (enforceIdpProvisioned && team.flags['idp:provisioned']) {
           return (
             <Tooltip
-              title={`Membership to this team is managed through your organization's identity provider.`}
+              title={t(
+                "Membership to this team is managed through your organization's identity provider."
+              )}
             >
               <DropdownTeamBadgeDisabled avatarSize={18} team={team} />
             </Tooltip>

--- a/static/app/views/settings/components/teamSelect.tsx
+++ b/static/app/views/settings/components/teamSelect.tsx
@@ -166,7 +166,9 @@ const TeamRow = ({orgId, team, onRemove, disabled, confirmMessage}: TeamRowProps
         disabled={disabled || team.idpProvisioned}
         title={
           team.idpProvisioned
-            ? t('You cannot leave this team as it has been idp-provisioned.')
+            ? t(
+                "Membership to this team is managed through your organization's identity provider."
+              )
             : undefined
         }
       >

--- a/static/app/views/settings/components/teamSelect.tsx
+++ b/static/app/views/settings/components/teamSelect.tsx
@@ -106,9 +106,8 @@ function TeamSelect({
       index,
       value: team.slug,
       searchKey: team.slug,
-      disabled: enforceIdpProvisioned && team.idpProvisioned,
       label: () => {
-        if (enforceIdpProvisioned && team.idpProvisioned) {
+        if (enforceIdpProvisioned && team.flags['idp:provisioned']) {
           return (
             <Tooltip
               title={`Membership to this team is managed through your organization's identity provider.`}
@@ -119,6 +118,7 @@ function TeamSelect({
         }
         return <DropdownTeamBadge avatarSize={18} team={team} />;
       },
+      disabled: enforceIdpProvisioned && team.flags['idp:provisioned'],
     }));
 
   return (
@@ -181,14 +181,14 @@ const TeamRow = ({
       message={confirmMessage}
       bypass={!confirmMessage}
       onConfirm={() => onRemove(team.slug)}
-      disabled={disabled || (enforceIdpProvisioned && team.idpProvisioned)}
+      disabled={disabled || (enforceIdpProvisioned && team.flags['idp:provisioned'])}
     >
       <Button
         size="xs"
         icon={<IconSubtract isCircled size="xs" />}
-        disabled={disabled || (enforceIdpProvisioned && team.idpProvisioned)}
+        disabled={disabled || (enforceIdpProvisioned && team.flags['idp:provisioned'])}
         title={
-          enforceIdpProvisioned && team.idpProvisioned
+          enforceIdpProvisioned && team.flags['idp:provisioned']
             ? t(
                 "Membership to this team is managed through your organization's identity provider."
               )

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -23,8 +23,8 @@ const Label = styled('label')`
 type Props = {
   disabled: boolean;
   enforceAllowed: boolean;
+  enforceIdpRestricted: boolean;
   enforceRetired: boolean;
-  idpRoleRestricted: boolean;
   isCurrentUser: boolean;
   roleList: OrgRole[];
   roleSelected: string;
@@ -39,25 +39,23 @@ class OrganizationRoleSelect extends Component<Props> {
       enforceAllowed,
       isCurrentUser,
       roleList,
-      idpRoleRestricted,
+      enforceIdpRestricted,
       roleSelected,
       setSelected,
     } = this.props;
-
-    const panelAlertText = () => {
-      if (isCurrentUser) {
-        return "Your organization-level role is managed through your organization's identity provider.";
-      }
-      return "This member's organization-level role is managed through your organization's identity provider.";
-    };
 
     return (
       <Panel>
         <PanelHeader>
           <div>{t('Organization Role')} </div>
         </PanelHeader>
-        {idpRoleRestricted && (
-          <PanelAlert>{tct('[text]', {text: panelAlertText()})}</PanelAlert>
+        {enforceIdpRestricted && (
+          <PanelAlert>
+            {tct(
+              "[person] organization-level role is managed through your organization's identity provider.",
+              {person: isCurrentUser ? 'Your' : "This member's"}
+            )}
+          </PanelAlert>
         )}
 
         <PanelBody>
@@ -66,7 +64,10 @@ class OrganizationRoleSelect extends Component<Props> {
 
             const isRetired = enforceRetired && roleRetired;
             const isDisabled =
-              disabled || isRetired || (enforceAllowed && !allowed) || idpRoleRestricted;
+              disabled ||
+              isRetired ||
+              (enforceAllowed && !allowed) ||
+              enforceIdpRestricted;
 
             return (
               <PanelItem

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -44,7 +44,7 @@ class OrganizationRoleSelect extends Component<Props> {
       setSelected,
     } = this.props;
 
-    const tooltipText = () => {
+    const panelAlertText = () => {
       if (isCurrentUser) {
         return "Your organization-level role is managed through your organization's identity provider.";
       }
@@ -57,7 +57,7 @@ class OrganizationRoleSelect extends Component<Props> {
           <div>{t('Organization Role')} </div>
         </PanelHeader>
         {idpRoleRestricted && (
-          <PanelAlert>{tct('[text]', {text: tooltipText()})}</PanelAlert>
+          <PanelAlert>{tct('[text]', {text: panelAlertText()})}</PanelAlert>
         )}
 
         <PanelBody>

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -47,7 +47,7 @@ class OrganizationRoleSelect extends Component<Props> {
     return (
       <Panel>
         <PanelHeader>
-          <div>{t('Organization Role')} </div>
+          <div>{t('Organization Role')}</div>
         </PanelHeader>
         {enforceIdpRoleRestricted && (
           <PanelAlert>

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -23,7 +23,7 @@ const Label = styled('label')`
 type Props = {
   disabled: boolean;
   enforceAllowed: boolean;
-  enforceIdpRestricted: boolean;
+  enforceIdpRoleRestricted: boolean;
   enforceRetired: boolean;
   isCurrentUser: boolean;
   roleList: OrgRole[];
@@ -39,7 +39,7 @@ class OrganizationRoleSelect extends Component<Props> {
       enforceAllowed,
       isCurrentUser,
       roleList,
-      enforceIdpRestricted,
+      enforceIdpRoleRestricted,
       roleSelected,
       setSelected,
     } = this.props;
@@ -49,7 +49,7 @@ class OrganizationRoleSelect extends Component<Props> {
         <PanelHeader>
           <div>{t('Organization Role')} </div>
         </PanelHeader>
-        {enforceIdpRestricted && (
+        {enforceIdpRoleRestricted && (
           <PanelAlert>
             {tct(
               "[person] organization-level role is managed through your organization's identity provider.",
@@ -67,7 +67,7 @@ class OrganizationRoleSelect extends Component<Props> {
               disabled ||
               isRetired ||
               (enforceAllowed && !allowed) ||
-              enforceIdpRestricted;
+              enforceIdpRoleRestricted;
 
             return (
               <PanelItem

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -1,10 +1,15 @@
 import {Component} from 'react';
 import styled from '@emotion/styled';
 
-import {Panel, PanelBody, PanelHeader, PanelItem} from 'sentry/components/panels';
-import QuestionTooltip from 'sentry/components/questionTooltip';
+import {
+  Panel,
+  PanelAlert,
+  PanelBody,
+  PanelHeader,
+  PanelItem,
+} from 'sentry/components/panels';
 import Radio from 'sentry/components/radio';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {OrgRole} from 'sentry/types';
 import TextBlock from 'sentry/views/settings/components/text/textBlock';
 
@@ -19,6 +24,7 @@ type Props = {
   disabled: boolean;
   enforceAllowed: boolean;
   enforceRetired: boolean;
+  idpRoleRestricted: boolean;
   isCurrentUser: boolean;
   roleList: OrgRole[];
   roleSelected: string;
@@ -33,32 +39,34 @@ class OrganizationRoleSelect extends Component<Props> {
       enforceAllowed,
       isCurrentUser,
       roleList,
+      idpRoleRestricted,
       roleSelected,
       setSelected,
     } = this.props;
 
+    const tooltipText = () => {
+      if (isCurrentUser) {
+        return "Your organization-level role is managed through your organization's identity provider.";
+      }
+      return "This member's organization-level role is managed through your organization's identity provider.";
+    };
+
     return (
       <Panel>
         <PanelHeader>
-          <div>
-            {t('Organization Role')}{' '}
-            <QuestionTooltip
-              title={
-                isCurrentUser
-                  ? "Your organization-level role is managed through your organization's identity provider."
-                  : "This member's organization-level role is managed through your organization's identity provider."
-              }
-              size="xs"
-            />
-          </div>
+          <div>{t('Organization Role')} </div>
         </PanelHeader>
+        {idpRoleRestricted && (
+          <PanelAlert>{tct('[text]', {text: tooltipText()})}</PanelAlert>
+        )}
 
         <PanelBody>
           {roleList.map(role => {
             const {desc, name, id, allowed, isRetired: roleRetired} = role;
 
             const isRetired = enforceRetired && roleRetired;
-            const isDisabled = disabled || isRetired || (enforceAllowed && !allowed);
+            const isDisabled =
+              disabled || isRetired || (enforceAllowed && !allowed) || idpRoleRestricted;
 
             return (
               <PanelItem

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -2,6 +2,7 @@ import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'sentry/components/panels';
+import QuestionTooltip from 'sentry/components/questionTooltip';
 import Radio from 'sentry/components/radio';
 import {t} from 'sentry/locale';
 import {OrgRole} from 'sentry/types';
@@ -36,7 +37,15 @@ class OrganizationRoleSelect extends Component<Props> {
 
     return (
       <Panel>
-        <PanelHeader>{t('Organization Role')}</PanelHeader>
+        <PanelHeader>
+          <div>
+            {t('Organization Role')}{' '}
+            <QuestionTooltip
+              title="You cannot change the organization role because it has been idp-provisioned."
+              size="xs"
+            />
+          </div>
+        </PanelHeader>
 
         <PanelBody>
           {roleList.map(role => {

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -19,6 +19,7 @@ type Props = {
   disabled: boolean;
   enforceAllowed: boolean;
   enforceRetired: boolean;
+  isCurrentUser: boolean;
   roleList: OrgRole[];
   roleSelected: string;
   setSelected: (id: string) => void;
@@ -30,6 +31,7 @@ class OrganizationRoleSelect extends Component<Props> {
       disabled,
       enforceRetired,
       enforceAllowed,
+      isCurrentUser,
       roleList,
       roleSelected,
       setSelected,
@@ -41,7 +43,11 @@ class OrganizationRoleSelect extends Component<Props> {
           <div>
             {t('Organization Role')}{' '}
             <QuestionTooltip
-              title="You cannot change the organization role because it has been idp-provisioned."
+              title={
+                isCurrentUser
+                  ? "Your organization-level role is managed through your organization's identity provider."
+                  : "This member's organization-level role is managed through your organization's identity provider."
+              }
               size="xs"
             />
           </div>

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -148,6 +148,27 @@ describe('OrganizationMemberDetail', function () {
         })
       );
     });
+
+    it('cannot change roles if member is idp-provisioned', function () {
+      const roleRestrictedMember = TestStubs.Member({
+        roles: TestStubs.OrgRoleList(),
+        dateCreated: new Date(),
+        teams: [team.slug],
+        flags: {
+          'idp:role-restricted': true,
+        },
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/members/${member.id}/`,
+        body: roleRestrictedMember,
+      });
+      render(<OrganizationMemberDetail params={{memberId: roleRestrictedMember.id}} />, {
+        context: routerContext,
+      });
+
+      const radios = screen.getAllByRole('radio');
+      expect(radios.at(0)).toHaveAttribute('readonly');
+    });
   });
 
   describe('Cannot Edit', function () {

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -16,13 +16,19 @@ jest.mock('sentry/actionCreators/members', () => ({
 describe('OrganizationMemberDetail', function () {
   let organization;
   let routerContext;
-  const team = TestStubs.Team();
+  const team = TestStubs.Team({
+    flags: {
+      'idp:provisioned': false,
+    },
+  });
   const idpTeam = TestStubs.Team({
     id: '4',
     slug: 'idp-member-team',
     name: 'Idp Member Team',
     isMember: true,
-    idpProvisioned: true,
+    flags: {
+      'idp:provisioned': true,
+    },
   });
   const teams = [
     team,
@@ -31,13 +37,16 @@ describe('OrganizationMemberDetail', function () {
       slug: 'new-team',
       name: 'New Team',
       isMember: false,
+      flags: {'idp:provisioned': false},
     }),
     TestStubs.Team({
       id: '3',
       slug: 'idp-team',
       name: 'Idp Team',
       isMember: false,
-      idpProvisioned: true,
+      flags: {
+        'idp:provisioned': true,
+      },
     }),
     idpTeam,
   ];

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -182,13 +182,18 @@ describe('OrganizationMemberDetail', function () {
       );
     });
 
-    it('cannot join idp-provisioned team', function () {
+    it('cannot join idp-provisioned team', async function () {
       render(<OrganizationMemberDetail params={{memberId: member.id}} />, {
         context: routerContext,
       });
 
       userEvent.click(screen.getByText('Add Team'));
-      expect(screen.queryByText('#idp-team')).not.toBeInTheDocument();
+      userEvent.hover(screen.queryByText('#idp-team'));
+      expect(
+        await screen.findByText(
+          "Membership to this team is managed through your organization's identity provider."
+        )
+      ).toBeInTheDocument();
     });
 
     it('cannot change roles if member is idp-provisioned', function () {

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -16,11 +16,7 @@ jest.mock('sentry/actionCreators/members', () => ({
 describe('OrganizationMemberDetail', function () {
   let organization;
   let routerContext;
-  const team = TestStubs.Team({
-    flags: {
-      'idp:provisioned': false,
-    },
-  });
+  const team = TestStubs.Team();
   const idpTeam = TestStubs.Team({
     id: '4',
     slug: 'idp-member-team',
@@ -37,7 +33,6 @@ describe('OrganizationMemberDetail', function () {
       slug: 'new-team',
       name: 'New Team',
       isMember: false,
-      flags: {'idp:provisioned': false},
     }),
     TestStubs.Team({
       id: '3',

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -152,7 +152,6 @@ describe('OrganizationMemberDetail', function () {
         context: routerContext,
       });
 
-      // Remove our one team
       expect(screen.getByRole('button', {name: 'Remove'})).toBeDisabled();
     });
 
@@ -188,11 +187,7 @@ describe('OrganizationMemberDetail', function () {
         context: routerContext,
       });
 
-      // Select new team to join
-      // Open the dropdown
       userEvent.click(screen.getByText('Add Team'));
-
-      // Save Member
       expect(screen.queryByText('#idp-team')).not.toBeInTheDocument();
     });
 

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -357,9 +357,9 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
 
         <OrganizationRoleSelect
           enforceAllowed={false}
+          enforceIdpRoleRestricted={member.flags['idp:role-restricted']}
           enforceRetired={hasTeamRoles}
           isCurrentUser={isCurrentUser}
-          enforceIdpRoleRestricted={member.flags['idp:role-restricted']}
           disabled={!canEdit}
           roleList={member.roles}
           roleSelected={member.role}

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -359,7 +359,7 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
           enforceAllowed={false}
           enforceRetired={hasTeamRoles}
           isCurrentUser={isCurrentUser}
-          idpRoleRestricted={member.flags['idp:role-restricted']}
+          enforceIdpRestricted={member.flags['idp:role-restricted']}
           disabled={!canEdit}
           roleList={member.roles}
           roleSelected={member.role}
@@ -375,7 +375,7 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
               onAddTeam={this.handleAddTeam}
               onRemoveTeam={this.handleRemoveTeam}
               loadingTeams={!initiallyLoaded}
-              addingTeamToProject={false}
+              enforceIdpProvisioned
             />
           )}
         </Teams>

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -359,7 +359,8 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
           enforceAllowed={false}
           enforceRetired={hasTeamRoles}
           isCurrentUser={isCurrentUser}
-          disabled={!canEdit || member.flags['idp:role-restricted']}
+          idpRoleRestricted={member.flags['idp:role-restricted']}
+          disabled={!canEdit}
           roleList={member.roles}
           roleSelected={member.role}
           setSelected={slug => this.setState({member: {...member, role: slug}})}
@@ -374,7 +375,7 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
               onAddTeam={this.handleAddTeam}
               onRemoveTeam={this.handleRemoveTeam}
               loadingTeams={!initiallyLoaded}
-              isProject={false}
+              addingTeamToProject={false}
             />
           )}
         </Teams>

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -374,6 +374,7 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
               onAddTeam={this.handleAddTeam}
               onRemoveTeam={this.handleRemoveTeam}
               loadingTeams={!initiallyLoaded}
+              isProject={false}
             />
           )}
         </Teams>

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -359,7 +359,7 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
           enforceAllowed={false}
           enforceRetired={hasTeamRoles}
           isCurrentUser={isCurrentUser}
-          enforceIdpRestricted={member.flags['idp:role-restricted']}
+          enforceIdpRoleRestricted={member.flags['idp:role-restricted']}
           disabled={!canEdit}
           roleList={member.roles}
           roleSelected={member.role}

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -21,6 +21,7 @@ import {Panel, PanelBody, PanelHeader, PanelItem} from 'sentry/components/panels
 import TextCopyInput from 'sentry/components/textCopyInput';
 import Tooltip from 'sentry/components/tooltip';
 import {t, tct} from 'sentry/locale';
+import configStore from 'sentry/stores/configStore';
 import space from 'sentry/styles/space';
 import {Member, Organization, Team} from 'sentry/types';
 import isMemberDisabledFromLimit from 'sentry/utils/isMemberDisabledFromLimit';
@@ -251,6 +252,8 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
     const {email, expired, pending} = member;
     const canResend = !expired;
     const showAuth = !pending;
+    const currentUser = configStore.get('user');
+    const isCurrentUser = currentUser.email === email;
 
     return (
       <Fragment>
@@ -355,6 +358,7 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
         <OrganizationRoleSelect
           enforceAllowed={false}
           enforceRetired={hasTeamRoles}
+          isCurrentUser={isCurrentUser}
           disabled={!canEdit || member.flags['idp:role-restricted']}
           roleList={member.roles}
           roleSelected={member.role}

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -369,13 +369,13 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
         <Teams slugs={member.teams}>
           {({teams, initiallyLoaded}) => (
             <TeamSelect
+              enforceIdpProvisioned
               organization={organization}
               selectedTeams={teams}
               disabled={!canEdit}
               onAddTeam={this.handleAddTeam}
               onRemoveTeam={this.handleRemoveTeam}
               loadingTeams={!initiallyLoaded}
-              enforceIdpProvisioned
             />
           )}
         </Teams>

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -355,7 +355,7 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
         <OrganizationRoleSelect
           enforceAllowed={false}
           enforceRetired={hasTeamRoles}
-          disabled={!canEdit}
+          disabled={!canEdit || member.flags['idp:role-restricted']}
           roleList={member.roles}
           roleSelected={member.role}
           setSelected={slug => this.setState({member: {...member, role: slug}})}

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.jsx
@@ -12,6 +12,8 @@ describe('OrganizationMemberRow', function () {
     pending: false,
     flags: {
       'sso:linked': false,
+      'idp:provisioned': false,
+      'idp:role-restricted': false,
     },
     user: {
       id: '',
@@ -23,6 +25,10 @@ describe('OrganizationMemberRow', function () {
   const currentUser = {
     id: '2',
     email: 'currentUser@email.com',
+    flags: {
+      'idp:provisioned': false,
+      'idp:role-restricted': false,
+    },
   };
 
   const defaultProps = {
@@ -225,6 +231,34 @@ describe('OrganizationMemberRow', function () {
     });
   });
 
+  describe('IDP flags permissions', function () {
+    member.flags['idp:provisioned'] = true;
+    it('current user cannot leave if idp:provisioned', function () {
+      const props = {
+        ...defaultProps,
+        member: {
+          ...member,
+          email: 'currentUser@email.com',
+        },
+      };
+
+      render(
+        <OrganizationMemberRow
+          {...props}
+          memberCanLeave={!member.flags['idp:provisioned']}
+        />
+      );
+
+      expect(leaveButton()).toBeDisabled();
+    });
+
+    it('cannot remove member if member is idp:provisioned', function () {
+      render(<OrganizationMemberRow {...defaultProps} />);
+
+      expect(removeButton()).toBeDisabled();
+    });
+  });
+
   describe('Not Current User', function () {
     const props = {
       ...defaultProps,
@@ -237,12 +271,16 @@ describe('OrganizationMemberRow', function () {
     });
 
     it('has Remove disabled button when `canRemoveMembers` is false', function () {
+      member.flags['idp:provisioned'] = false;
+
       render(<OrganizationMemberRow {...props} />);
 
       expect(removeButton()).toBeDisabled();
     });
 
     it('has Remove button when `canRemoveMembers` is true', function () {
+      member.flags['idp:provisioned'] = false;
+
       render(<OrganizationMemberRow {...props} canRemoveMembers />);
 
       expect(removeButton()).toBeEnabled();

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.spec.jsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.spec.jsx
@@ -12,8 +12,6 @@ describe('OrganizationMemberRow', function () {
     pending: false,
     flags: {
       'sso:linked': false,
-      'idp:provisioned': false,
-      'idp:role-restricted': false,
     },
     user: {
       id: '',
@@ -25,10 +23,6 @@ describe('OrganizationMemberRow', function () {
   const currentUser = {
     id: '2',
     email: 'currentUser@email.com',
-    flags: {
-      'idp:provisioned': false,
-      'idp:role-restricted': false,
-    },
   };
 
   const defaultProps = {

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -224,7 +224,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
               </Button>
             )}
 
-            {showLeaveButton && !memberCanLeave && flags['idp:provisioned'] && (
+            {showLeaveButton && !memberCanLeave && isIdpProvisioned && (
               <Button
                 size="sm"
                 icon={<IconClose size="xs" />}

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -230,7 +230,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                 icon={<IconClose size="xs" />}
                 disabled
                 title={t(
-                  "Your organization-level role is managed through your organization's identity provider."
+                  "Membership to this organization is managed through your organization's identity provider."
                 )}
               >
                 {t('Leave')}

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -106,12 +106,12 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
     const {id, flags, email, name, pending, user} = member;
 
     // if member is not the only owner, they can leave
+    const isIdpProvisioned = flags['idp:provisioned'];
     const needsSso = !flags['sso:linked'] && requireLink;
     const isCurrentUser = currentUser.email === email;
     const showRemoveButton = !isCurrentUser;
     const showLeaveButton = isCurrentUser;
-    const canRemoveMember =
-      canRemoveMembers && !isCurrentUser && !flags['idp:provisioned'];
+    const canRemoveMember = canRemoveMembers && !isCurrentUser && !isIdpProvisioned;
     // member has a `user` property if they are registered with sentry
     // i.e. has accepted an invite to join org
     const has2fa = user && user.has2fa;
@@ -211,7 +211,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
               </Confirm>
             )}
 
-            {showLeaveButton && !memberCanLeave && !flags['idp:provisioned'] && (
+            {showLeaveButton && !memberCanLeave && !isIdpProvisioned && (
               <Button
                 size="sm"
                 icon={<IconClose size="xs" />}
@@ -230,7 +230,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                 icon={<IconClose size="xs" />}
                 disabled
                 title={t(
-                  'You cannot leave this organization as your role has been idp-provisioned.'
+                  "Your organization-level role is managed through your organization's identity provider."
                 )}
               >
                 {t('Leave')}

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -110,7 +110,8 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
     const isCurrentUser = currentUser.email === email;
     const showRemoveButton = !isCurrentUser;
     const showLeaveButton = isCurrentUser;
-    const canRemoveMember = canRemoveMembers && !isCurrentUser;
+    const canRemoveMember =
+      canRemoveMembers && !isCurrentUser && !flags['idp:provisioned'];
     // member has a `user` property if they are registered with sentry
     // i.e. has accepted an invite to join org
     const has2fa = user && user.has2fa;
@@ -210,13 +211,26 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
               </Confirm>
             )}
 
-            {showLeaveButton && !memberCanLeave && (
+            {showLeaveButton && !memberCanLeave && !flags['idp:provisioned'] && (
               <Button
                 size="sm"
                 icon={<IconClose size="xs" />}
                 disabled
                 title={t(
                   'You cannot leave this organization as you are the only organization owner.'
+                )}
+              >
+                {t('Leave')}
+              </Button>
+            )}
+
+            {showLeaveButton && !memberCanLeave && flags['idp:provisioned'] && (
+              <Button
+                size="sm"
+                icon={<IconClose size="xs" />}
+                disabled
+                title={t(
+                  'You cannot leave this organization as your role has been idp-provisioned.'
                 )}
               >
                 {t('Leave')}

--- a/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberRow.tsx
@@ -230,7 +230,7 @@ export default class OrganizationMemberRow extends PureComponent<Props, State> {
                 icon={<IconClose size="xs" />}
                 disabled
                 title={t(
-                  "Membership to this organization is managed through your organization's identity provider."
+                  "This user is managed through your organization's identity provider."
                 )}
               >
                 {t('Leave')}

--- a/static/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -330,7 +330,7 @@ class OrganizationMembersList extends AsyncView<Props, State> {
                 organization={organization}
                 member={member}
                 status={this.state.invited[member.id]}
-                memberCanLeave={!isOnlyOwner}
+                memberCanLeave={!isOnlyOwner && !member.flags['idp:provisioned']}
                 currentUser={currentUser}
                 canRemoveMembers={canRemove}
                 canAddMembers={canAddMembers}

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -180,7 +180,7 @@ class AllTeamsRow extends Component<Props, State> {
   render() {
     const {team, openMembership, organization} = this.props;
     const urlPrefix = `/settings/${organization.slug}/teams/`;
-    const buttonHelpText = team.idpProvisioned
+    const buttonHelpText = team.flags['idp:provisioned']
       ? t(
           "Membership to this team is managed through your organization's identity provider."
         )
@@ -197,6 +197,8 @@ class AllTeamsRow extends Component<Props, State> {
     // You can only view team details if you have access to team -- this should account
     // for your role + org open membership
     const canViewTeam = team.hasAccess;
+
+    const idpProvisioned = team.flags['idp:provisioned'];
 
     return (
       <TeamPanelItem>
@@ -219,7 +221,7 @@ class AllTeamsRow extends Component<Props, State> {
             <Button
               size="sm"
               onClick={this.handleLeaveTeam}
-              disabled={team.idpProvisioned}
+              disabled={idpProvisioned}
               title={buttonHelpText}
             >
               {t('Leave Team')}
@@ -238,7 +240,7 @@ class AllTeamsRow extends Component<Props, State> {
             <Button
               size="sm"
               onClick={this.handleJoinTeam}
-              disabled={team.idpProvisioned}
+              disabled={idpProvisioned}
               title={buttonHelpText}
             >
               {t('Join Team')}
@@ -247,7 +249,7 @@ class AllTeamsRow extends Component<Props, State> {
             <Button
               size="sm"
               onClick={this.handleRequestAccess}
-              disabled={team.idpProvisioned}
+              disabled={idpProvisioned}
               title={buttonHelpText}
             >
               {t('Request Access')}

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -217,7 +217,9 @@ class AllTeamsRow extends Component<Props, State> {
               disabled={team.idpProvisioned}
               title={
                 team.idpProvisioned
-                  ? t('You cannot leave this team as it has been idp-provisioned.')
+                  ? t(
+                      "Membership to this team is managed through your organization's identity provider."
+                    )
                   : undefined
               }
             >

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -211,7 +211,16 @@ class AllTeamsRow extends Component<Props, State> {
               ...
             </Button>
           ) : team.isMember ? (
-            <Button size="sm" onClick={this.handleLeaveTeam}>
+            <Button
+              size="sm"
+              onClick={this.handleLeaveTeam}
+              disabled={team.idpProvisioned}
+              title={
+                team.idpProvisioned
+                  ? t('You cannot leave this team as it has been idp-provisioned.')
+                  : undefined
+              }
+            >
               {t('Leave Team')}
             </Button>
           ) : team.isPending ? (
@@ -225,11 +234,31 @@ class AllTeamsRow extends Component<Props, State> {
               {t('Request Pending')}
             </Button>
           ) : openMembership ? (
-            <Button size="sm" onClick={this.handleJoinTeam}>
+            <Button
+              size="sm"
+              onClick={this.handleJoinTeam}
+              disabled={team.idpProvisioned}
+              title={
+                team.idpProvisioned
+                  ? t('You cannot join this team as it has been idp-provisioned.')
+                  : undefined
+              }
+            >
               {t('Join Team')}
             </Button>
           ) : (
-            <Button size="sm" onClick={this.handleRequestAccess}>
+            <Button
+              size="sm"
+              onClick={this.handleRequestAccess}
+              disabled={team.idpProvisioned}
+              title={
+                team.idpProvisioned
+                  ? t(
+                      'You cannot request to join this team as it has been idp-provisioned.'
+                    )
+                  : undefined
+              }
+            >
               {t('Request Access')}
             </Button>
           )}

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -180,6 +180,11 @@ class AllTeamsRow extends Component<Props, State> {
   render() {
     const {team, openMembership, organization} = this.props;
     const urlPrefix = `/settings/${organization.slug}/teams/`;
+    const buttonHelpText = team.idpProvisioned
+      ? t(
+          "Membership to this team is managed through your organization's identity provider."
+        )
+      : undefined;
 
     const display = (
       <IdBadge
@@ -215,13 +220,7 @@ class AllTeamsRow extends Component<Props, State> {
               size="sm"
               onClick={this.handleLeaveTeam}
               disabled={team.idpProvisioned}
-              title={
-                team.idpProvisioned
-                  ? t(
-                      "Membership to this team is managed through your organization's identity provider."
-                    )
-                  : undefined
-              }
+              title={buttonHelpText}
             >
               {t('Leave Team')}
             </Button>
@@ -240,11 +239,7 @@ class AllTeamsRow extends Component<Props, State> {
               size="sm"
               onClick={this.handleJoinTeam}
               disabled={team.idpProvisioned}
-              title={
-                team.idpProvisioned
-                  ? t('You cannot join this team as it has been idp-provisioned.')
-                  : undefined
-              }
+              title={buttonHelpText}
             >
               {t('Join Team')}
             </Button>
@@ -253,13 +248,7 @@ class AllTeamsRow extends Component<Props, State> {
               size="sm"
               onClick={this.handleRequestAccess}
               disabled={team.idpProvisioned}
-              title={
-                team.idpProvisioned
-                  ? t(
-                      'You cannot request to join this team as it has been idp-provisioned.'
-                    )
-                  : undefined
-              }
+              title={buttonHelpText}
             >
               {t('Request Access')}
             </Button>

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.jsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.jsx
@@ -81,6 +81,24 @@ describe('OrganizationTeams', function () {
 
       expect(getOrgMock).toHaveBeenCalledTimes(1);
     });
+
+    it('cannot leave idp-provisioned team', function () {
+      const mockTeams = [TestStubs.Team({idpProvisioned: true, isMember: true})];
+      act(() => void TeamStore.loadInitialData(mockTeams, false, null));
+      createWrapper();
+
+      expect(screen.getByRole('button', {name: 'Leave Team'})).toBeDisabled();
+    });
+
+    it('cannot join idp-provisioned team', function () {
+      const mockTeams = [TestStubs.Team({idpProvisioned: true, isMember: false})];
+      act(() => void TeamStore.loadInitialData(mockTeams, false, null));
+      createWrapper({
+        access: new Set([]),
+      });
+
+      expect(screen.getByRole('button', {name: 'Join Team'})).toBeDisabled();
+    });
   });
 
   describe('Closed Membership', function () {
@@ -122,6 +140,26 @@ describe('OrganizationTeams', function () {
       });
 
       expect(screen.getByLabelText('Leave Team')).toBeInTheDocument();
+    });
+
+    it('cannot request to join idp-provisioned team', function () {
+      const mockTeams = [TestStubs.Team({idpProvisioned: true, isMember: false})];
+      act(() => void TeamStore.loadInitialData(mockTeams, false, null));
+      createWrapper({
+        access: new Set([]),
+      });
+
+      expect(screen.getByRole('button', {name: 'Request Access'})).toBeDisabled();
+    });
+
+    it('cannot leave idp-provisioned team', function () {
+      const mockTeams = [TestStubs.Team({idpProvisioned: true, isMember: true})];
+      act(() => void TeamStore.loadInitialData(mockTeams, false, null));
+      createWrapper({
+        access: new Set([]),
+      });
+
+      expect(screen.getByRole('button', {name: 'Leave Team'})).toBeDisabled();
     });
   });
 

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.jsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.jsx
@@ -51,7 +51,6 @@ describe('OrganizationTeams', function () {
     it('can join team and have link to details', function () {
       const mockTeams = [
         TestStubs.Team({
-          flags: {'idp:provisioned': false},
           hasAccess: true,
           isMember: false,
         }),
@@ -68,7 +67,6 @@ describe('OrganizationTeams', function () {
 
     it('reloads projects after joining a team', async function () {
       const team = TestStubs.Team({
-        flags: {'idp:provisioned': false},
         hasAccess: true,
         isMember: false,
       });
@@ -138,7 +136,6 @@ describe('OrganizationTeams', function () {
     it('can request access to team and does not have link to details', function () {
       const mockTeams = [
         TestStubs.Team({
-          flags: {'idp:provisioned': false},
           hasAccess: false,
           isMember: false,
         }),
@@ -155,7 +152,6 @@ describe('OrganizationTeams', function () {
     it('can leave team when you are a member', function () {
       const mockTeams = [
         TestStubs.Team({
-          flags: {'idp:provisioned': false},
           hasAccess: true,
           isMember: true,
         }),

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.jsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.jsx
@@ -49,7 +49,13 @@ describe('OrganizationTeams', function () {
     });
 
     it('can join team and have link to details', function () {
-      const mockTeams = [TestStubs.Team({hasAccess: true, isMember: false})];
+      const mockTeams = [
+        TestStubs.Team({
+          flags: {'idp:provisioned': false},
+          hasAccess: true,
+          isMember: false,
+        }),
+      ];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper({
         access: new Set([]),
@@ -61,7 +67,11 @@ describe('OrganizationTeams', function () {
     });
 
     it('reloads projects after joining a team', async function () {
-      const team = TestStubs.Team({hasAccess: true, isMember: false});
+      const team = TestStubs.Team({
+        flags: {'idp:provisioned': false},
+        hasAccess: true,
+        isMember: false,
+      });
       const getOrgMock = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/',
         body: TestStubs.Organization(),
@@ -83,7 +93,9 @@ describe('OrganizationTeams', function () {
     });
 
     it('cannot leave idp-provisioned team', function () {
-      const mockTeams = [TestStubs.Team({idpProvisioned: true, isMember: true})];
+      const mockTeams = [
+        TestStubs.Team({flags: {'idp:provisioned': true}, isMember: true}),
+      ];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper();
 
@@ -91,7 +103,9 @@ describe('OrganizationTeams', function () {
     });
 
     it('cannot join idp-provisioned team', function () {
-      const mockTeams = [TestStubs.Team({idpProvisioned: true, isMember: false})];
+      const mockTeams = [
+        TestStubs.Team({flags: {'idp:provisioned': true}, isMember: false}),
+      ];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper({
         access: new Set([]),
@@ -122,7 +136,13 @@ describe('OrganizationTeams', function () {
       );
 
     it('can request access to team and does not have link to details', function () {
-      const mockTeams = [TestStubs.Team({hasAccess: false, isMember: false})];
+      const mockTeams = [
+        TestStubs.Team({
+          flags: {'idp:provisioned': false},
+          hasAccess: false,
+          isMember: false,
+        }),
+      ];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper({access: new Set([])});
 
@@ -133,7 +153,13 @@ describe('OrganizationTeams', function () {
     });
 
     it('can leave team when you are a member', function () {
-      const mockTeams = [TestStubs.Team({hasAccess: true, isMember: true})];
+      const mockTeams = [
+        TestStubs.Team({
+          flags: {'idp:provisioned': false},
+          hasAccess: true,
+          isMember: true,
+        }),
+      ];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper({
         access: new Set([]),
@@ -143,7 +169,9 @@ describe('OrganizationTeams', function () {
     });
 
     it('cannot request to join idp-provisioned team', function () {
-      const mockTeams = [TestStubs.Team({idpProvisioned: true, isMember: false})];
+      const mockTeams = [
+        TestStubs.Team({flags: {'idp:provisioned': true}, isMember: false}),
+      ];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper({
         access: new Set([]),
@@ -153,7 +181,9 @@ describe('OrganizationTeams', function () {
     });
 
     it('cannot leave idp-provisioned team', function () {
-      const mockTeams = [TestStubs.Team({idpProvisioned: true, isMember: true})];
+      const mockTeams = [
+        TestStubs.Team({flags: {'idp:provisioned': true}, isMember: true}),
+      ];
       act(() => void TeamStore.loadInitialData(mockTeams, false, null));
       createWrapper({
         access: new Set([]),

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
@@ -18,7 +18,9 @@ describe('TeamMembers', function () {
 
   const organization = TestStubs.Organization();
   const team = TestStubs.Team({
-    idpProvisioned: false,
+    flags: {
+      'idp:provisioned': false,
+    },
   });
   const members = TestStubs.Members();
   const member = TestStubs.Member({
@@ -274,9 +276,11 @@ describe('TeamMembers', function () {
     expect(contributors).toHaveLength(2);
   });
 
-  it('cannot add or remove members if team is idpProvisioned', function () {
+  it('cannot add or remove members if team is idp:provisioned', function () {
     const team2 = TestStubs.Team({
-      idpProvisioned: true,
+      flags: {
+        'idp:provisioned': true,
+      },
     });
 
     const me = TestStubs.Member({

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
@@ -276,7 +276,7 @@ describe('TeamMembers', function () {
     expect(contributors).toHaveLength(2);
   });
 
-  it('cannot add members if team is idp:provisioned', function () {
+  it('cannot add or remove members if team is idp:provisioned', function () {
     const team2 = TestStubs.Team({
       flags: {
         'idp:provisioned': true,
@@ -318,6 +318,7 @@ describe('TeamMembers', function () {
 
     waitFor(() => {
       expect(screen.findByRole('button', {name: 'Add Member'})).toBeDisabled();
+      expect(screen.findByRole('button', {name: 'Remove'})).toBeDisabled();
     });
   });
 });

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
@@ -17,11 +17,7 @@ describe('TeamMembers', function () {
   let createMock;
 
   const organization = TestStubs.Organization();
-  const team = TestStubs.Team({
-    flags: {
-      'idp:provisioned': false,
-    },
-  });
+  const team = TestStubs.Team();
   const members = TestStubs.Members();
   const member = TestStubs.Member({
     id: '9',
@@ -56,7 +52,11 @@ describe('TeamMembers', function () {
   it('can add member to team with open membership', async function () {
     const org = TestStubs.Organization({access: [], openMembership: true});
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />
+      <TeamMembers
+        params={{orgId: org.slug, teamId: team.slug}}
+        organization={org}
+        team={team}
+      />
     );
 
     userEvent.click((await screen.findAllByRole('button', {name: 'Add Member'}))[0]);
@@ -68,7 +68,11 @@ describe('TeamMembers', function () {
   it('can add member to team with team:admin permission', async function () {
     const org = TestStubs.Organization({access: ['team:admin'], openMembership: false});
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />
+      <TeamMembers
+        params={{orgId: org.slug, teamId: team.slug}}
+        organization={org}
+        team={team}
+      />
     );
 
     userEvent.click((await screen.findAllByRole('button', {name: 'Add Member'}))[0]);
@@ -80,7 +84,11 @@ describe('TeamMembers', function () {
   it('can add member to team with org:write permission', async function () {
     const org = TestStubs.Organization({access: ['org:write'], openMembership: false});
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />
+      <TeamMembers
+        params={{orgId: org.slug, teamId: team.slug}}
+        organization={org}
+        team={team}
+      />
     );
 
     userEvent.click((await screen.findAllByRole('button', {name: 'Add Member'}))[0]);
@@ -92,7 +100,11 @@ describe('TeamMembers', function () {
   it('can request access to add member to team without permission', async function () {
     const org = TestStubs.Organization({access: [], openMembership: false});
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />
+      <TeamMembers
+        params={{orgId: org.slug, teamId: team.slug}}
+        organization={org}
+        team={team}
+      />
     );
 
     userEvent.click((await screen.findAllByRole('button', {name: 'Add Member'}))[0]);
@@ -109,7 +121,11 @@ describe('TeamMembers', function () {
       }),
     });
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      <TeamMembers
+        params={{orgId: org.slug, teamId: team.slug}}
+        organization={org}
+        team={team}
+      />,
       {context: routerContext}
     );
 
@@ -127,7 +143,11 @@ describe('TeamMembers', function () {
       }),
     });
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      <TeamMembers
+        params={{orgId: org.slug, teamId: team.slug}}
+        organization={org}
+        team={team}
+      />,
       {context: routerContext}
     );
 
@@ -142,7 +162,11 @@ describe('TeamMembers', function () {
       organization: TestStubs.Organization({access: [], openMembership: true}),
     });
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      <TeamMembers
+        params={{orgId: org.slug, teamId: team.slug}}
+        organization={org}
+        team={team}
+      />,
       {context: routerContext}
     );
 
@@ -157,7 +181,11 @@ describe('TeamMembers', function () {
       organization: TestStubs.Organization({access: [], openMembership: false}),
     });
     render(
-      <TeamMembers params={{orgId: org.slug, teamId: team.slug}} organization={org} />,
+      <TeamMembers
+        params={{orgId: org.slug, teamId: team.slug}}
+        organization={org}
+        team={team}
+      />,
       {context: routerContext}
     );
 
@@ -176,6 +204,7 @@ describe('TeamMembers', function () {
       <TeamMembers
         params={{orgId: organization.slug, teamId: team.slug}}
         organization={organization}
+        team={team}
       />
     );
 
@@ -208,6 +237,7 @@ describe('TeamMembers', function () {
       <TeamMembers
         params={{orgId: organization.slug, teamId: team.slug}}
         organization={organizationMember}
+        team={team}
       />
     );
 
@@ -241,6 +271,7 @@ describe('TeamMembers', function () {
       <TeamMembers
         params={{orgId: organization.slug, teamId: team.slug}}
         organization={organization}
+        team={team}
       />
     );
 
@@ -268,6 +299,7 @@ describe('TeamMembers', function () {
       <TeamMembers
         params={{orgId: orgWithTeamRoles.slug, teamId: team.slug}}
         organization={orgWithTeamRoles}
+        team={team}
       />
     );
     const admins = screen.queryAllByText('Team Admin');
@@ -313,6 +345,7 @@ describe('TeamMembers', function () {
       <TeamMembers
         params={{orgId: organization.slug, teamId: team2.slug}}
         organization={organization}
+        team={team2}
       />
     );
 

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
@@ -18,9 +18,7 @@ describe('TeamMembers', function () {
 
   const organization = TestStubs.Organization();
   const team = TestStubs.Team({
-    flags: {
-      'idp:provisioned': false,
-    },
+    idpProvisioned: false,
   });
   const members = TestStubs.Members();
   const member = TestStubs.Member({
@@ -276,11 +274,9 @@ describe('TeamMembers', function () {
     expect(contributors).toHaveLength(2);
   });
 
-  it('cannot add or remove members if team is idp:provisioned', function () {
+  it('cannot add or remove members if team is idpProvisioned', function () {
     const team2 = TestStubs.Team({
-      flags: {
-        'idp:provisioned': true,
-      },
+      idpProvisioned: true,
     });
 
     const me = TestStubs.Member({

--- a/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.spec.jsx
@@ -17,7 +17,11 @@ describe('TeamMembers', function () {
   let createMock;
 
   const organization = TestStubs.Organization();
-  const team = TestStubs.Team();
+  const team = TestStubs.Team({
+    flags: {
+      'idp:provisioned': false,
+    },
+  });
   const members = TestStubs.Members();
   const member = TestStubs.Member({
     id: '9',
@@ -36,6 +40,11 @@ describe('TeamMembers', function () {
       url: `/teams/${organization.slug}/${team.slug}/members/`,
       method: 'GET',
       body: members,
+    });
+    Client.addMockResponse({
+      url: `/teams/${organization.slug}/${team.slug}/`,
+      method: 'GET',
+      body: team,
     });
 
     createMock = Client.addMockResponse({
@@ -267,7 +276,13 @@ describe('TeamMembers', function () {
     expect(contributors).toHaveLength(2);
   });
 
-  it('cannot add members if idp:provisioned', function () {
+  it('cannot add members if team is idp:provisioned', function () {
+    const team2 = TestStubs.Team({
+      flags: {
+        'idp:provisioned': true,
+      },
+    });
+
     const me = TestStubs.Member({
       id: '123',
       email: 'foo@example.com',
@@ -277,15 +292,26 @@ describe('TeamMembers', function () {
       },
     });
 
+    Client.clearMockResponses();
     Client.addMockResponse({
       url: `/organizations/${organization.slug}/members/`,
       method: 'GET',
       body: [...members, me],
     });
+    Client.addMockResponse({
+      url: `/teams/${organization.slug}/${team2.slug}/members/`,
+      method: 'GET',
+      body: members,
+    });
+    Client.addMockResponse({
+      url: `/teams/${organization.slug}/${team.slug}/`,
+      method: 'GET',
+      body: team2,
+    });
 
     render(
       <TeamMembers
-        params={{orgId: organization.slug, teamId: team.slug}}
+        params={{orgId: organization.slug, teamId: team2.slug}}
         organization={organization}
       />
     );

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -264,14 +264,14 @@ class TeamMembers extends AsyncView<Props, State> {
         onChange={this.handleMemberFilterChange}
         busy={this.state.dropdownBusy}
         onClose={() => this.debouncedFetchMembersRequest('')}
-        disabled={team?.idpProvisioned}
+        disabled={team?.flags['idp:provisioned']}
       >
         {({isOpen}) => (
           <DropdownButton
             isOpen={isOpen}
             size="xs"
             data-test-id="add-member"
-            disabled={team?.idpProvisioned}
+            disabled={team?.flags['idp:provisioned']}
           >
             {t('Add Member')}
           </DropdownButton>

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -22,7 +22,6 @@ import Pagination from 'sentry/components/pagination';
 import {Panel, PanelHeader} from 'sentry/components/panels';
 import {IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import TeamStore from 'sentry/stores/teamStore';
 import space from 'sentry/styles/space';
 import {Config, Member, Organization, Team, TeamMember} from 'sentry/types';
 import withApi from 'sentry/utils/withApi';
@@ -40,6 +39,7 @@ type Props = {
   api: Client;
   config: Config;
   organization: Organization;
+  team: Team;
 } & RouteComponentProps<RouteParams, {}>;
 
 type State = {
@@ -66,14 +66,6 @@ class TeamMembers extends AsyncView<Props, State> {
   componentDidMount() {
     // Initialize "add member" dropdown with data
     this.fetchMembersRequest('');
-
-    const {teamId} = this.props.params;
-    const team = TeamStore.getBySlug(teamId);
-    if (team) {
-      this.setState({
-        team,
-      });
-    }
   }
 
   debouncedFetchMembersRequest = debounce(
@@ -219,8 +211,8 @@ class TeamMembers extends AsyncView<Props, State> {
   };
 
   renderDropdown(hasWriteAccess: boolean) {
-    const {organization, params} = this.props;
-    const {orgMembers, team} = this.state;
+    const {organization, params, team} = this.props;
+    const {orgMembers} = this.state;
     const existingMembers = new Set(this.state.teamMembers.map(member => member.id));
 
     // members can add other members to a team if the `Open Membership` setting is enabled

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -22,6 +22,7 @@ import Pagination from 'sentry/components/pagination';
 import {Panel, PanelHeader} from 'sentry/components/panels';
 import {IconUser} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import ConfigStore from 'sentry/stores/configStore';
 import space from 'sentry/styles/space';
 import {Config, Member, Organization, TeamMember} from 'sentry/types';
 import withApi from 'sentry/utils/withApi';
@@ -212,6 +213,7 @@ class TeamMembers extends AsyncView<Props, State> {
     const {organization, params} = this.props;
     const {orgMembers} = this.state;
     const existingMembers = new Set(this.state.teamMembers.map(member => member.id));
+    const currentUser = ConfigStore.get('user');
 
     // members can add other members to a team if the `Open Membership` setting is enabled
     // otherwise, `org:write` or `team:admin` permissions are required
@@ -230,6 +232,10 @@ class TeamMembers extends AsyncView<Props, State> {
           </StyledUserListElement>
         ),
       }));
+
+    const currentMember = (orgMembers || []).find(member => () => {
+      return member.id === currentUser.id;
+    });
 
     const menuHeader = (
       <StyledMembersLabel>
@@ -263,9 +269,15 @@ class TeamMembers extends AsyncView<Props, State> {
         onChange={this.handleMemberFilterChange}
         busy={this.state.dropdownBusy}
         onClose={() => this.debouncedFetchMembersRequest('')}
+        disabled={currentMember?.flags['idp:provisioned']}
       >
         {({isOpen}) => (
-          <DropdownButton isOpen={isOpen} size="xs" data-test-id="add-member">
+          <DropdownButton
+            isOpen={isOpen}
+            size="xs"
+            data-test-id="add-member"
+            disabled={currentMember?.flags['idp:provisioned']}
+          >
             {t('Add Member')}
           </DropdownButton>
         )}

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -47,7 +47,6 @@ type State = {
   error: boolean;
   loading: boolean;
   orgMembers: Member[];
-  team: Team;
   teamMembers: TeamMember[];
 } & AsyncView['state'];
 
@@ -265,14 +264,14 @@ class TeamMembers extends AsyncView<Props, State> {
         onChange={this.handleMemberFilterChange}
         busy={this.state.dropdownBusy}
         onClose={() => this.debouncedFetchMembersRequest('')}
-        disabled={team?.idpProvisioned}
+        disabled={team.idpProvisioned}
       >
         {({isOpen}) => (
           <DropdownButton
             isOpen={isOpen}
             size="xs"
             data-test-id="add-member"
-            disabled={team?.idpProvisioned}
+            disabled={team.idpProvisioned}
           >
             {t('Add Member')}
           </DropdownButton>

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -264,14 +264,14 @@ class TeamMembers extends AsyncView<Props, State> {
         onChange={this.handleMemberFilterChange}
         busy={this.state.dropdownBusy}
         onClose={() => this.debouncedFetchMembersRequest('')}
-        disabled={team?.flags['idp:provisioned']}
+        disabled={team.flags['idp:provisioned']}
       >
         {({isOpen}) => (
           <DropdownButton
             isOpen={isOpen}
             size="xs"
             data-test-id="add-member"
-            disabled={team?.flags['idp:provisioned']}
+            disabled={team.flags['idp:provisioned']}
           >
             {t('Add Member')}
           </DropdownButton>

--- a/static/app/views/settings/organizationTeams/teamMembers.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembers.tsx
@@ -264,14 +264,14 @@ class TeamMembers extends AsyncView<Props, State> {
         onChange={this.handleMemberFilterChange}
         busy={this.state.dropdownBusy}
         onClose={() => this.debouncedFetchMembersRequest('')}
-        disabled={team.idpProvisioned}
+        disabled={team?.idpProvisioned}
       >
         {({isOpen}) => (
           <DropdownButton
             isOpen={isOpen}
             size="xs"
             data-test-id="add-member"
-            disabled={team.idpProvisioned}
+            disabled={team?.idpProvisioned}
           >
             {t('Add Member')}
           </DropdownButton>

--- a/static/app/views/settings/organizationTeams/teamMembersRow.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembersRow.tsx
@@ -119,7 +119,9 @@ const RemoveButton = (props: {
         icon={<IconSubtract size="xs" isCircled />}
         onClick={onClick}
         aria-label={t('Remove')}
-        title={t('You cannot remove this member as their role has been idp-provisioned.')}
+        title={t(
+          "Membership to this team is managed through your organization's identity provider."
+        )}
       >
         {t('Remove')}
       </Button>

--- a/static/app/views/settings/organizationTeams/teamMembersRow.tsx
+++ b/static/app/views/settings/organizationTeams/teamMembersRow.tsx
@@ -111,6 +111,21 @@ const RemoveButton = (props: {
     return null;
   }
 
+  if (member.flags['idp:provisioned']) {
+    return (
+      <Button
+        size="xs"
+        disabled
+        icon={<IconSubtract size="xs" isCircled />}
+        onClick={onClick}
+        aria-label={t('Remove')}
+        title={t('You cannot remove this member as their role has been idp-provisioned.')}
+      >
+        {t('Remove')}
+      </Button>
+    );
+  }
+
   return (
     <Button
       size="xs"

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -154,7 +154,7 @@ class ProjectTeams extends AsyncView<Props, State> {
           menuHeader={menuHeader}
           confirmLastTeamRemoveMessage={confirmRemove}
           disabled={!hasAccess}
-          isProject
+          addingTeamToProject
         />
       </div>
     );

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -154,7 +154,7 @@ class ProjectTeams extends AsyncView<Props, State> {
           menuHeader={menuHeader}
           confirmLastTeamRemoveMessage={confirmRemove}
           disabled={!hasAccess}
-          addingTeamToProject
+          enforceIdpProvisioned={false}
         />
       </div>
     );

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -154,6 +154,7 @@ class ProjectTeams extends AsyncView<Props, State> {
           menuHeader={menuHeader}
           confirmLastTeamRemoveMessage={confirmRemove}
           disabled={!hasAccess}
+          isProject
         />
       </div>
     );


### PR DESCRIPTION
Cannot remove a member from the org if they are `idp:provisioned` and cannot leave the org if you are `idp:provisioned`
https://user-images.githubusercontent.com/70817427/210852591-4abf1b69-15a0-402b-9a5e-135f894a285d.mov


Cannot change your or a member's role if you/they are `idp:role-restricted`
https://user-images.githubusercontent.com/70817427/210882081-1d67c719-e4d3-4d7c-81cb-989cd97c3dd2.mov


Cannot join or leave a team if the team is `idpProvisioned` (the same component is used for adding a team to a project -- you *can* add a team to a project even if the team is `idpProvisioned`
https://user-images.githubusercontent.com/70817427/210882015-3cae148c-9f50-4af7-882d-af96afff2c55.mov





Addresses ER-1289

[ER-1289]: https://getsentry.atlassian.net/browse/ER-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ