### PR TITLE
fix(derived_code_mappings): Use default refresh period

### DIFF
--- a/src/sentry/tasks/derive_code_mappings.py
+++ b/src/sentry/tasks/derive_code_mappings.py
@@ -70,7 +70,7 @@ def derive_code_mappings(
 
     try:
         with lock.acquire():
-            trees = installation.get_trees_for_org(3600 * 3)
+            trees = installation.get_trees_for_org()
     except UnableToAcquireLock as error:
         extra["error"] = error
         logger.warning("derive_code_mappings.getting_lock_failed", extra=extra)


### PR DESCRIPTION
I added the 3 hours refresh period in order to find bugs quickly under the dry run. This brings it back to its original value.