### PR TITLE
chore(perf): Add new param to the widget analytics

### DIFF
--- a/static/app/utils/analytics/performanceAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/performanceAnalyticsEvents.tsx
@@ -50,6 +50,7 @@ export type PerformanceEventParameters = {
     widget_type?: string;
   };
   'performance_views.landingv3.widget.switch': {
+    is_new_menu: boolean;
     from_default?: boolean;
     from_widget?: string;
     to_widget?: string;

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -62,6 +62,7 @@ function trackChartSettingChange(
     from_widget: previousChartSetting,
     to_widget: chartSetting,
     from_default: fromDefault,
+    is_new_menu: organization.features.includes('performance-new-widget-designs'),
   });
 }
 


### PR DESCRIPTION
To differentiate between segments with and without the new widget menu, I'm adding a new `boolean` parameter representing the presence of the new widget design flag.