### PR TITLE
fix(alerts): Adjust size of clickable alert link

### DIFF
--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -184,8 +184,6 @@ function RuleListRow({
     },
   };
 
-  const detailsLink = `/organizations/${orgId}/alerts/rules/details/${rule.id}/`;
-
   const ownerId = rule.owner?.split(':')[1];
   const teamActor = ownerId
     ? {type: 'team' as Actor['type'], id: ownerId, name: ''}
@@ -199,7 +197,9 @@ function RuleListRow({
       {rule.name}
     </Link>
   ) : (
-    <TitleLink to={isIssueAlert(rule) ? editLink : detailsLink}>{rule.name}</TitleLink>
+    <Link to={`/organizations/${orgId}/alerts/rules/details/${rule.id}/`}>
+      {rule.name}
+    </Link>
   );
 
   const IssueStatusText: Record<IncidentStatus, string> = {
@@ -407,10 +407,6 @@ function RuleListRow({
     </ErrorBoundary>
   );
 }
-
-const TitleLink = styled(Link)`
-  ${p => p.theme.overflowEllipsis}
-`;
 
 const FlexCenter = styled('div')`
   display: flex;

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -190,17 +190,6 @@ function RuleListRow({
     : null;
 
   const canEdit = ownerId ? userTeams.has(ownerId) : true;
-  const alertLink = isIssueAlert(rule) ? (
-    <Link
-      to={`/organizations/${orgId}/alerts/rules/${rule.projects[0]}/${rule.id}/details/`}
-    >
-      {rule.name}
-    </Link>
-  ) : (
-    <Link to={`/organizations/${orgId}/alerts/rules/details/${rule.id}/`}>
-      {rule.name}
-    </Link>
-  );
 
   const IssueStatusText: Record<IncidentStatus, string> = {
     [IncidentStatus.CRITICAL]: t('Critical'),
@@ -332,7 +321,17 @@ function RuleListRow({
           </Tooltip>
         </FlexCenter>
         <AlertNameAndStatus>
-          <AlertName>{alertLink}</AlertName>
+          <AlertName>
+            <Link
+              to={
+                isIssueAlert(rule)
+                  ? `/organizations/${orgId}/alerts/rules/${rule.projects[0]}/${rule.id}/details/`
+                  : `/organizations/${orgId}/alerts/rules/details/${rule.id}/`
+              }
+            >
+              {rule.name}
+            </Link>
+          </AlertName>
           <AlertIncidentDate>{renderLastIncidentDate()}</AlertIncidentDate>
         </AlertNameAndStatus>
       </AlertNameWrapper>


### PR DESCRIPTION
reduces the size of the clickable area here to just the text
![image](https://user-images.githubusercontent.com/1400464/206546560-3ab6dff3-fff2-4a70-b333-0a7e86da1c7a.png)
