### PR TITLE
fix(replays): fix multiple of same issue in one replay edge case

### DIFF
--- a/src/sentry/replays/endpoints/organization_issue_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_issue_replay_count.py
@@ -72,11 +72,11 @@ def _query_discover_for_replay_ids(
         dataset=Dataset.Discover,
         params=params,
         snuba_params=snuba_params,
-        selected_columns=["group_array(100,replayId)", "issue.id"],
+        selected_columns=["group_uniq_array(100,replayId)", "issue.id"],
         query=request.GET.get("query"),
         limit=25,
         offset=0,
-        functions_acl=["group_array"],
+        functions_acl=["group_uniq_array"],
     )
     _validate_params(builder)
 
@@ -85,7 +85,7 @@ def _query_discover_for_replay_ids(
     replay_id_to_issue_map = defaultdict(list)
 
     for row in discover_results["data"]:
-        for replay_id in row["group_array_100_replayId"]:
+        for replay_id in row["group_uniq_array_100_replayId"]:
             replay_id_to_issue_map[replay_id].append(row["issue.id"])
 
     return replay_id_to_issue_map

--- a/src/sentry/search/events/datasets/discover.py
+++ b/src/sentry/search/events/datasets/discover.py
@@ -267,10 +267,10 @@ class DiscoverDatasetConfig(DatasetConfig):
                     default_result_type="percentage",
                 ),
                 SnQLFunction(
-                    "group_array",
+                    "group_uniq_array",
                     required_args=[NumberRange("max_size", 0, 101), ColumnTagArg("column")],
                     snql_aggregate=lambda args, alias: CurriedFunction(
-                        "groupArray",
+                        "groupUniqArray",
                         [int(args["max_size"])],
                         [args["column"]],
                         alias,

--- a/tests/sentry/replays/test_organization_issue_replay_count.py
+++ b/tests/sentry/replays/test_organization_issue_replay_count.py
@@ -143,6 +143,47 @@ class OrganizationIssueReplayCountEndpoint(APITestCase, SnubaTestCase, ReplaysSn
         assert response.status_code == 200, response.content
         assert response.data == expected
 
+    def test_one_replay_same_issue_twice(self):
+        event_id_a = "a" * 32
+        event_id_b = "b" * 32
+        replay1_id = uuid.uuid4().hex
+
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay1_id,
+            )
+        )
+        event_a = self.store_event(
+            data={
+                "event_id": event_id_a,
+                "timestamp": iso_format(self.min_ago),
+                "tags": {"replayId": replay1_id},
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        event_b = self.store_event(
+            data={
+                "event_id": event_id_b,
+                "timestamp": iso_format(self.min_ago),
+                "tags": {"replayId": replay1_id},
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+
+        query = {"query": f"issue.id:[{event_a.group.id}, {event_b.group.id}]"}
+        with self.feature(self.features):
+            response = self.client.get(self.url, query, format="json")
+
+        expected = {
+            event_a.group.id: 1,
+        }
+        assert response.status_code == 200, response.content
+        assert response.data == expected
+
     def test_max_50(self):
         replay_ids = [uuid.uuid4().hex for _ in range(100)]
         for replay_id in replay_ids:


### PR DESCRIPTION
### Problem
- if error A happens twice in the same replay, it will result in an incorrect count because we don't ensure that our replayIds are unique, so when we append to the list, we'll increment twice.

### Solution
- use `GroupUniqArray` instead of `GroupArray`
- added test case that covers this.