### PR TITLE
bug(replays): Use `/issue-replay-count/` endpoint so we get accurate counts in the Issues>Replay list and tab.

### DIFF
--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -74,8 +74,8 @@ describe('useReplaysCount', () => {
   });
 
   it('should query for groupIds', async () => {
-    const countRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
+    const replayCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issue-replay-count/`,
       method: 'GET',
       body: {data: []},
     });
@@ -89,12 +89,13 @@ describe('useReplaysCount', () => {
     });
 
     expect(result.current).toEqual({});
-    expect(countRequest).toHaveBeenCalledWith(
-      '/organizations/org-slug/events/',
-      getExpectedReqestParams({
-        field: ['count_unique(replayId)', 'issue.id'],
-        project,
-        query: `!replayId:"" issue.id:[${mockGroupIds.join(',')}]`,
+    expect(replayCountRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/issue-replay-count/',
+      expect.objectContaining({
+        query: {
+          query: `issue.id:[${mockGroupIds.join(',')}]`,
+          statsPeriod: '14d',
+        },
       })
     );
 
@@ -102,16 +103,12 @@ describe('useReplaysCount', () => {
   });
 
   it('should return the count of each groupId, or zero if not included in the response', async () => {
-    const countRequest = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
+    const replayCountRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issue-replay-count/`,
       method: 'GET',
       body: {
-        data: [
-          {
-            'count_unique(replayId)': 42,
-            'issue.id': 123,
-          },
-        ],
+        123: 42,
+        456: 0,
       },
     });
 
@@ -124,7 +121,7 @@ describe('useReplaysCount', () => {
     });
 
     expect(result.current).toEqual({});
-    expect(countRequest).toHaveBeenCalled();
+    expect(replayCountRequest).toHaveBeenCalled();
 
     await waitForNextUpdate();
 

--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -77,7 +77,7 @@ describe('useReplaysCount', () => {
     const replayCountRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issue-replay-count/`,
       method: 'GET',
-      body: {data: []},
+      body: {},
     });
 
     const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {

--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -108,7 +108,6 @@ describe('useReplaysCount', () => {
       method: 'GET',
       body: {
         123: 42,
-        456: 0,
       },
     });
 

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -25,13 +25,12 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
   const [replayCounts, setReplayCounts] = useState<CountState>({});
 
   const zeroCounts = useMemo(() => {
-    const ids = toArray(groupIds || []);
     const names = toArray(transactionNames || []);
-    return [...ids, ...names].reduce<CountState>((record, key) => {
+    return names.reduce<CountState>((record, key) => {
       record[key] = 0;
       return record;
     }, {});
-  }, [groupIds, transactionNames]);
+  }, [transactionNames]);
 
   const query = useMemo(() => {
     if (groupIds === undefined && transactionNames === undefined) {

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -33,7 +33,7 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
     }, {});
   }, [groupIds, transactionNames]);
 
-  const [condition, fieldName] = useMemo(() => {
+  const query = useMemo(() => {
     if (groupIds === undefined && transactionNames === undefined) {
       throw new Error('Missing groupId or transactionName in useReplaysCount()');
     }
@@ -43,15 +43,20 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
       );
     }
     if (groupIds && groupIds.length) {
-      return [`issue.id:[${toArray(groupIds).join(',')}]`, 'issue.id'];
+      return {
+        field: 'issue.id' as const,
+        conditions: `issue.id:[${toArray(groupIds).join(',')}]`,
+      };
     }
     if (transactionNames && transactionNames.length) {
-      return [
-        `event.type:transaction transaction:[${toArray(transactionNames).join(',')}]`,
-        'transaction',
-      ];
+      return {
+        field: 'transaction' as const,
+        conditions: `event.type:transaction transaction:[${toArray(transactionNames).join(
+          ','
+        )}]`,
+      };
     }
-    return [null, null];
+    return null;
   }, [groupIds, transactionNames]);
 
   const eventView = useMemo(
@@ -60,35 +65,49 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
         id: '',
         name: `Errors within replay`,
         version: 2,
-        fields: ['count_unique(replayId)', String(fieldName)],
-        query: `!replayId:"" ${condition}`,
+        fields: ['count_unique(replayId)', String(query?.field)],
+        query: `!replayId:"" ${query?.conditions}`,
         projects: [Number(project?.id)],
       }),
-    [project?.id, condition, fieldName]
+    [project?.id, query]
   );
 
   const fetchReplayCount = useCallback(async () => {
     try {
-      if (!condition || !fieldName) {
+      if (!query) {
         return;
       }
-      const [data] = await doDiscoverQuery<TableData>(
-        api,
-        `/organizations/${organization.slug}/events/`,
-        eventView.getEventsAPIPayload({query: {}} as Location<any>)
-      );
 
-      const counts = data.data.reduce((obj, record) => {
-        const key = record[fieldName] as string;
-        const val = record['count_unique(replayId)'] as number;
-        obj[key] = val;
-        return obj;
-      }, zeroCounts);
-      setReplayCounts(counts);
+      if (query.field === 'issue.id') {
+        const response = await api.requestPromise(
+          `/organizations/${organization.slug}/issue-replay-count/`,
+          {
+            query: {
+              query: query.conditions,
+              statsPeriod: '14d',
+            },
+          }
+        );
+        setReplayCounts(response);
+      } else {
+        const [data] = await doDiscoverQuery<TableData>(
+          api,
+          `/organizations/${organization.slug}/events/`,
+          eventView.getEventsAPIPayload({query: {}} as Location<any>)
+        );
+
+        const counts = data.data.reduce((obj, record) => {
+          const key = record[query.field] as string;
+          const val = record['count_unique(replayId)'] as number;
+          obj[key] = val;
+          return obj;
+        }, zeroCounts);
+        setReplayCounts(counts);
+      }
     } catch (err) {
       Sentry.captureException(err);
     }
-  }, [api, organization.slug, condition, fieldName, zeroCounts, eventView]);
+  }, [api, organization.slug, query, zeroCounts, eventView]);
 
   useEffect(() => {
     const hasSessionReplay =

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -25,12 +25,13 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
   const [replayCounts, setReplayCounts] = useState<CountState>({});
 
   const zeroCounts = useMemo(() => {
+    const ids = toArray(groupIds || []);
     const names = toArray(transactionNames || []);
-    return names.reduce<CountState>((record, key) => {
+    return [...ids, ...names].reduce<CountState>((record, key) => {
       record[key] = 0;
       return record;
     }, {});
-  }, [transactionNames]);
+  }, [groupIds, transactionNames]);
 
   const query = useMemo(() => {
     if (groupIds === undefined && transactionNames === undefined) {
@@ -87,7 +88,7 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
             },
           }
         );
-        setReplayCounts(response);
+        setReplayCounts({...zeroCounts, ...response});
       } else {
         const [data] = await doDiscoverQuery<TableData>(
           api,


### PR DESCRIPTION
Fixes #42160