### PR TITLE
feat(domains) Add utility methods to unblock email updates

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import datetime
 import logging
+import re
 from datetime import timedelta
-from typing import Any, Literal, overload
+from typing import Any, List, Literal, Tuple, overload
 from urllib.parse import urlparse
 
 from django.utils import timezone
@@ -237,3 +238,28 @@ def generate_region_url() -> str:
     if not region_url_template or not region:
         return options.get("system.url-prefix")  # type: ignore[no-any-return]
     return region_url_template.replace("{region}", region)
+
+
+_path_patterns: List[Tuple[re.Pattern, str]] = [
+    # /organizations/slug/section, but not /organizations/new
+    (re.compile(r"\/?organizations\/(?!new)[^\/]+\/(.*)"), r"/\1"),
+    # For /settings/:orgId/ -> /settings/organization/
+    (re.compile(r"\/settings\/(?!account)[^\/]+\/?$"), "/settings/organization/"),
+    # Move /settings/:orgId/:section -> /settings/:section
+    # but not /settings/organization or /settings/projects which is a new URL
+    (re.compile(r"\/?settings\/(?!projects)(?!account)[^\/]+\/(.*)"), r"/settings/\1"),
+    (re.compile(r"\/?join-request\/[^\/]+\/?.*"), r"/join-request/"),
+    (re.compile(r"\/?onboarding\/[^\/]+\/(.*)"), r"/onboarding/\1"),
+    (re.compile(r"\/?[^\/]+\/([^\/]+)\/getting-started\/(.*)"), r"/getting-started/\1/\2"),
+]
+
+
+def customer_domain_path(path: str) -> str:
+    """
+    Server side companion to path normalizations found in withDomainRequired
+    """
+    for pattern, replacement in _path_patterns:
+        updated = pattern.sub(replacement, path)
+        if updated != path:
+            return updated
+    return path

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -240,7 +240,7 @@ def generate_region_url() -> str:
     return region_url_template.replace("{region}", region)
 
 
-_path_patterns: List[Tuple[re.Pattern, str]] = [
+_path_patterns: List[Tuple[re.Pattern[str], str]] = [
     # /organizations/slug/section, but not /organizations/new
     (re.compile(r"\/?organizations\/(?!new)[^\/]+\/(.*)"), r"/\1"),
     # For /settings/:orgId/ -> /settings/organization/

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 from enum import IntEnum
-from typing import FrozenSet, Sequence
+from typing import FrozenSet, Optional, Sequence
 
 from django.conf import settings
 from django.db import IntegrityError, models, router, transaction
@@ -33,7 +33,7 @@ from sentry.locks import locks
 from sentry.models.organizationmember import OrganizationMember
 from sentry.roles.manager import Role
 from sentry.services.hybrid_cloud.user import APIUser, user_service
-from sentry.utils.http import absolute_uri, is_using_customer_domain
+from sentry.utils.http import is_using_customer_domain
 from sentry.utils.retries import TimedRetryPolicy
 from sentry.utils.snowflake import SnowflakeIdMixin
 
@@ -470,12 +470,13 @@ class Organization(Model, SnowflakeIdMixin):
         from sentry.utils.email import MessageBuilder
 
         owners = self.get_owners()
+        url = self.absolute_url(reverse("sentry-restore-organization", args=[self.slug]))
 
         context = {
             "organization": self,
             "audit_log_entry": audit_log_entry,
             "eta": timezone.now() + timedelta(seconds=countdown),
-            "url": absolute_uri(reverse("sentry-restore-organization", args=[self.slug])),
+            "url": url,
         }
 
         MessageBuilder(
@@ -513,7 +514,10 @@ class Organization(Model, SnowflakeIdMixin):
             )
 
     @staticmethod
-    def get_url_viewname():
+    def get_url_viewname() -> str:
+        """
+        Get the default view name for an organization taking customer-domains into account.
+        """
         request = env.request
         if request and is_using_customer_domain(request):
             return "issues"
@@ -521,10 +525,55 @@ class Organization(Model, SnowflakeIdMixin):
 
     @staticmethod
     def get_url(slug: str) -> str:
+        """
+        Get a relative URL to the organization's issue list with `slug`
+        """
         try:
             return reverse(Organization.get_url_viewname(), args=[slug])
         except NoReverseMatch:
             return reverse(Organization.get_url_viewname())
+
+    __has_customer_domain: Optional[bool] = None
+
+    def _has_customer_domain(self) -> bool:
+        """
+        Check if the current organization is using or has access to customer domains.
+        """
+        if self.__has_customer_domain is not None:
+            return self.__has_customer_domain
+
+        request = env.request
+        if request and is_using_customer_domain(request):
+            self.__has_customer_domain = True
+            return True
+
+        self.__has_customer_domain = features.has("organizations:customer-domains", self)
+
+        return self.__has_customer_domain
+
+    def absolute_url(
+        self, path: str, query: Optional[str] = None, fragment: Optional[str] = None
+    ) -> str:
+        """
+        Get an absolute URL to `path` for this organization.
+
+        This method takes customer-domains into account and will update the path when
+        customer-domains are active.
+        """
+        # Avoid cycles.
+        from sentry.api.utils import customer_domain_path, generate_organization_url
+        from sentry.utils.http import absolute_uri
+
+        url_base = None
+        if self._has_customer_domain():
+            path = customer_domain_path(path)
+            url_base = generate_organization_url(self.slug)
+        uri = absolute_uri(path, url_prefix=url_base)
+        if query:
+            uri = f"{uri}?{query}"
+        if fragment:
+            uri = f"{uri}#{fragment}"
+        return uri
 
     def get_scopes(self, role: Role) -> FrozenSet[str]:
         if role.priority > 0:

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -3,6 +3,7 @@ import {Location, LocationDescriptor} from 'history';
 import trimEnd from 'lodash/trimEnd';
 import trimStart from 'lodash/trimStart';
 
+// If you change this also update the patterns in sentry.api.utils
 const NORMALIZE_PATTERNS: Array<[pattern: RegExp, replacement: string]> = [
   // /organizations/slug/section, but not /organizations/new
   [/\/?organizations\/(?!new)[^\/]+\/(.*)/, '/$1'],

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -5,7 +5,12 @@ import pytest
 from django.utils import timezone
 from freezegun import freeze_time
 
-from sentry.api.utils import MAX_STATS_PERIOD, InvalidParams, get_date_range_from_params
+from sentry.api.utils import (
+    MAX_STATS_PERIOD,
+    InvalidParams,
+    customer_domain_path,
+    get_date_range_from_params,
+)
 
 
 class GetDateRangeFromParamsTest(unittest.TestCase):
@@ -72,6 +77,46 @@ class GetDateRangeFromParamsTest(unittest.TestCase):
 
     @freeze_time("2018-12-11 03:21:34")
     def test_relative_date_range_incomplete(self):
-
         with pytest.raises(InvalidParams):
             start, end = get_date_range_from_params({"timeframeStart": "14d"})
+
+
+def test_customer_domain_path():
+    scenarios = [
+        # Input, expected
+        ["/settings/", "/settings/"],
+        # Organization settings views.
+        ["/settings/acme/", "/settings/organization/"],
+        ["/settings/organization", "/settings/organization/"],
+        ["/settings/sentry/members/", "/settings/members/"],
+        ["/settings/sentry/members/3/", "/settings/members/3/"],
+        ["/settings/sentry/teams/peeps/", "/settings/teams/peeps/"],
+        ["/settings/sentry/billing/receipts/", "/settings/billing/receipts/"],
+        [
+            "/settings/acme/developer-settings/release-bot/",
+            "/settings/developer-settings/release-bot/",
+        ],
+        # Account settings should stay the same
+        ["/settings/account/", "/settings/account/"],
+        ["/settings/account/security/", "/settings/account/security/"],
+        ["/settings/account/details/", "/settings/account/details/"],
+        ["/join-request/acme", "/join-request/"],
+        ["/join-request/acme/", "/join-request/"],
+        ["/onboarding/acme/", "/onboarding/"],
+        ["/onboarding/acme/project/", "/onboarding/project/"],
+        ["/organizations/new/", "/organizations/new/"],
+        ["/organizations/albertos-apples/issues/", "/issues/"],
+        ["/organizations/albertos-apples/issues/?_q=all#hash", "/issues/?_q=all#hash"],
+        ["/acme/project-slug/getting-started/", "/getting-started/project-slug/"],
+        [
+            "/acme/project-slug/getting-started/python",
+            "/getting-started/project-slug/python",
+        ],
+        ["/settings/projects/python/filters/", "/settings/projects/python/filters/"],
+        [
+            "/settings/projects/python/filters/discarded/",
+            "/settings/projects/python/filters/discarded/",
+        ],
+    ]
+    for input_path, expected in scenarios:
+        assert expected == customer_domain_path(input_path)


### PR DESCRIPTION
We need to update all the links embedded in emails to reflect customer domains. I didn't want to add conditional branching to all the emails, so instead I've added a few more utility methods to `Organization` so that help generate absolute URLs for an organization.

In order to generate URLs correctly for customer-domains I needed to port the URL replacement logic we use in the frontend to the server as well.