### PR TITLE
feat(issue-platform): Allow issue occurrence information to be passed via eventstream

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2511,7 +2511,7 @@ KAFKA_INGEST_REPLAY_EVENTS = "ingest-replay-events"
 KAFKA_INGEST_REPLAYS_RECORDINGS = "ingest-replay-recordings"
 KAFKA_INGEST_OCCURRENCES = "ingest-occurrences"
 KAFKA_REGION_TO_CONTROL = "region-to-control"
-KAFKA_EVENTSTREAM_ISSUE_PLATFORM = "eventstream-issue-platform"
+KAFKA_EVENTSTREAM_GENERIC = "generic-events"
 
 # topic for testing multiple indexer backends in parallel
 # in production. So far just testing backends for the perf data,
@@ -2562,7 +2562,7 @@ KAFKA_TOPICS = {
     KAFKA_SNUBA_GENERICS_METRICS_CS: {"cluster": "default"},
     # Region to Control Silo messaging - eg UserIp and AuditLog
     KAFKA_REGION_TO_CONTROL: {"cluster": "default"},
-    KAFKA_EVENTSTREAM_ISSUE_PLATFORM: {"cluster": "default"},
+    KAFKA_EVENTSTREAM_GENERIC: {"cluster": "default"},
 }
 
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2511,6 +2511,7 @@ KAFKA_INGEST_REPLAY_EVENTS = "ingest-replay-events"
 KAFKA_INGEST_REPLAYS_RECORDINGS = "ingest-replay-recordings"
 KAFKA_INGEST_OCCURRENCES = "ingest-occurrences"
 KAFKA_REGION_TO_CONTROL = "region-to-control"
+KAFKA_EVENTSTREAM_ISSUE_PLATFORM = "eventstream-issue-platform"
 
 # topic for testing multiple indexer backends in parallel
 # in production. So far just testing backends for the perf data,
@@ -2561,6 +2562,7 @@ KAFKA_TOPICS = {
     KAFKA_SNUBA_GENERICS_METRICS_CS: {"cluster": "default"},
     # Region to Control Silo messaging - eg UserIp and AuditLog
     KAFKA_REGION_TO_CONTROL: {"cluster": "default"},
+    KAFKA_EVENTSTREAM_ISSUE_PLATFORM: {"cluster": "default"},
 }
 
 

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -201,7 +201,7 @@ class EventStream(Service):
 
     def run_post_process_forwarder(
         self,
-        entity: Union[Literal["errors"], Literal["transactions"], Literal["issue_platform"]],
+        entity: Union[Literal["errors"], Literal["transactions"], Literal["search_issues"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -53,7 +53,7 @@ class EventStreamEventType(Enum):
 
     Error = "error"  # error, default, various security errors
     Transaction = "transaction"  # transactions
-    IssuePlatform = "issue_platform"  # events ingested via the issue platform
+    Generic = "generic"  # generic events ingested via the issue platform
 
 
 class EventStream(Service):
@@ -110,7 +110,7 @@ class EventStream(Service):
         event_type = self._get_event_type(event)
         if event_type == EventStreamEventType.Transaction:
             return "post_process_transactions"
-        elif event_type == EventStreamEventType.IssuePlatform:
+        elif event_type == EventStreamEventType.Generic:
             return "post_process_issue_platform"
         else:
             return "post_process_errors"
@@ -221,7 +221,7 @@ class EventStream(Service):
         if getattr(event, "occurrence", None):
             # For now, all events with an associated occurrence are specific to the issue platform.
             # When/if we move errors and transactions onto the platform, this might change.
-            return EventStreamEventType.IssuePlatform
+            return EventStreamEventType.Generic
         if event.get_event_type() == "transaction":
             return EventStreamEventType.Transaction
         return EventStreamEventType.Error

--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -2,18 +2,22 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
     Collection,
     Literal,
     Mapping,
+    MutableMapping,
     Optional,
     Sequence,
     TypedDict,
     Union,
+    cast,
 )
 
+from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.tasks.post_process import post_process_group
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.services import Service
@@ -22,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    from sentry.eventstore.models import Event
+    from sentry.eventstore.models import Event, GroupEvent
 
 
 class ForwarderNotRequired(NotImplementedError):
@@ -42,6 +46,16 @@ class GroupState(TypedDict):
 GroupStates = Sequence[GroupState]
 
 
+class EventStreamEventType(Enum):
+    """
+    We have 3 broad categories of event types that we care about in eventstream.
+    """
+
+    Error = "error"  # error, default, various security errors
+    Transaction = "transaction"  # transactions
+    IssuePlatform = "issue_platform"  # events ingested via the issue platform
+
+
 class EventStream(Service):
     __all__ = (
         "insert",
@@ -58,6 +72,7 @@ class EventStream(Service):
         "exclude_groups",
         "requires_post_process_forwarder",
         "run_post_process_forwarder",
+        "_get_event_type",
     )
 
     def _dispatch_post_process_group_task(
@@ -92,14 +107,26 @@ class EventStream(Service):
             )
 
     def _get_queue_for_post_process(self, event: Event) -> str:
-        if event.get_event_type() == "transaction":
+        event_type = self._get_event_type(event)
+        if event_type == EventStreamEventType.Transaction:
             return "post_process_transactions"
+        elif event_type == EventStreamEventType.IssuePlatform:
+            return "post_process_issue_platform"
         else:
             return "post_process_errors"
 
+    def _get_occurrence_data(self, event: Event | GroupEvent) -> MutableMapping[str, Any]:
+        occurrence = cast(Optional[IssueOccurrence], getattr(event, "occurrence", None))
+        occurrence_data: MutableMapping[str, Any] = {}
+        if occurrence:
+            occurrence_data = cast(MutableMapping[str, Any], occurrence.to_dict())
+            del occurrence_data["evidence_data"]
+            del occurrence_data["evidence_display"]
+        return occurrence_data
+
     def insert(
         self,
-        event: Event,
+        event: Event | GroupEvent,
         is_new: bool,
         is_regression: bool,
         is_new_group_environment: bool,
@@ -174,7 +201,7 @@ class EventStream(Service):
 
     def run_post_process_forwarder(
         self,
-        entity: Union[Literal["errors"], Literal["transactions"]],
+        entity: Union[Literal["errors"], Literal["transactions"], Literal["issue_platform"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,
@@ -188,3 +215,13 @@ class EventStream(Service):
     ) -> None:
         assert not self.requires_post_process_forwarder()
         raise ForwarderNotRequired
+
+    @staticmethod
+    def _get_event_type(event: Event | GroupEvent) -> EventStreamEventType:
+        if getattr(event, "occurrence", None):
+            # For now, all events with an associated occurrence are specific to the issue platform.
+            # When/if we move errors and transactions onto the platform, this might change.
+            return EventStreamEventType.IssuePlatform
+        if event.get_event_type() == "transaction":
+            return EventStreamEventType.Transaction
+        return EventStreamEventType.Error

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -37,7 +37,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
     def __init__(self, **options: Any) -> None:
         self.topic = settings.KAFKA_EVENTS
         self.transactions_topic = settings.KAFKA_TRANSACTIONS
-        self.issue_platform_topic = settings.KAFKA_EVENTSTREAM_ISSUE_PLATFORM
+        self.issue_platform_topic = settings.KAFKA_EVENTSTREAM_GENERIC
         self.assign_transaction_partitions_randomly = True
         self.__producers = {}
 

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -131,7 +131,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
     ):
         event_type = self._get_event_type(event)
 
-        if event_type == EventStreamEventType.IssuePlatform:
+        if event_type == EventStreamEventType.Generic:
             assign_partitions_randomly = True
         elif (
             event_type == EventStreamEventType.Transaction
@@ -176,7 +176,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
         if event_type == EventStreamEventType.Transaction:
             topic = self.get_transactions_topic(project_id)
-        elif event_type == EventStreamEventType.IssuePlatform:
+        elif event_type == EventStreamEventType.Generic:
             topic = self.issue_platform_topic
         else:
             topic = self.topic

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -297,7 +297,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def run_consumer(
         self,
-        entity: Union[Literal["errors"], Literal["transactions"], Literal["issue_platform"]],
+        entity: Union[Literal["errors"], Literal["transactions"], Literal["search_issues"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,
@@ -356,7 +356,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def run_post_process_forwarder(
         self,
-        entity: Union[Literal["errors"], Literal["transactions"], Literal["issue_platform"]],
+        entity: Union[Literal["errors"], Literal["transactions"], Literal["search_issues"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,

--- a/src/sentry/eventstream/kafka/backend.py
+++ b/src/sentry/eventstream/kafka/backend.py
@@ -12,7 +12,7 @@ from confluent_kafka import Producer
 from django.conf import settings
 
 from sentry import options
-from sentry.eventstream.base import GroupStates
+from sentry.eventstream.base import EventStreamEventType, GroupStates
 from sentry.eventstream.kafka.consumer import SynchronizedConsumer
 from sentry.eventstream.kafka.consumer_strategy import PostProcessForwarderStrategyFactory
 from sentry.eventstream.kafka.postprocessworker import (
@@ -37,6 +37,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
     def __init__(self, **options: Any) -> None:
         self.topic = settings.KAFKA_EVENTS
         self.transactions_topic = settings.KAFKA_TRANSACTIONS
+        self.issue_platform_topic = settings.KAFKA_EVENTSTREAM_ISSUE_PLATFORM
         self.assign_transaction_partitions_randomly = True
         self.__producers = {}
 
@@ -128,14 +129,19 @@ class KafkaEventStream(SnubaProtocolEventStream):
         group_states: Optional[GroupStates] = None,
         **kwargs,
     ):
-        message_type = "transaction" if self._is_transaction_event(event) else "error"
+        event_type = self._get_event_type(event)
 
-        if message_type == "transaction" and self.assign_transaction_partitions_randomly:
+        if event_type == EventStreamEventType.IssuePlatform:
+            assign_partitions_randomly = True
+        elif (
+            event_type == EventStreamEventType.Transaction
+            and self.assign_transaction_partitions_randomly
+        ):
             assign_partitions_randomly = True
         else:
             assign_partitions_randomly = killswitch_matches_context(
                 "kafka.send-project-events-to-random-partitions",
-                {"project_id": event.project_id, "message_type": message_type},
+                {"project_id": event.project_id, "message_type": event_type.value},
             )
 
         if assign_partitions_randomly:
@@ -161,15 +167,17 @@ class KafkaEventStream(SnubaProtocolEventStream):
         asynchronous: bool = True,
         headers: Optional[MutableMapping[str, str]] = None,
         skip_semantic_partitioning: bool = False,
-        is_transaction_event: bool = False,
+        event_type: EventStreamEventType = EventStreamEventType.Error,
     ) -> None:
         if headers is None:
             headers = {}
         headers["operation"] = _type
         headers["version"] = str(self.EVENT_PROTOCOL_VERSION)
 
-        if is_transaction_event:
+        if event_type == EventStreamEventType.Transaction:
             topic = self.get_transactions_topic(project_id)
+        elif event_type == EventStreamEventType.IssuePlatform:
+            topic = self.issue_platform_topic
         else:
             topic = self.topic
 
@@ -289,7 +297,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def run_consumer(
         self,
-        entity: Union[Literal["errors"], Literal["transactions"]],
+        entity: Union[Literal["errors"], Literal["transactions"], Literal["issue_platform"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,
@@ -307,6 +315,8 @@ class KafkaEventStream(SnubaProtocolEventStream):
             default_topic = self.transactions_topic
         elif entity == PostProcessForwarderType.ERRORS:
             default_topic = self.topic
+        elif entity == PostProcessForwarderType.ISSUE_PLATFORM:
+            default_topic = self.issue_platform_topic
         else:
             raise ValueError("Invalid entity")
 
@@ -346,7 +356,7 @@ class KafkaEventStream(SnubaProtocolEventStream):
 
     def run_post_process_forwarder(
         self,
-        entity: Union[Literal["errors"], Literal["transactions"]],
+        entity: Union[Literal["errors"], Literal["transactions"], Literal["issue_platform"]],
         consumer_group: str,
         topic: Optional[str],
         commit_log_topic: str,

--- a/src/sentry/eventstream/kafka/postprocessworker.py
+++ b/src/sentry/eventstream/kafka/postprocessworker.py
@@ -31,6 +31,7 @@ _MESSAGES_METRIC = "eventstream.messages"
 class PostProcessForwarderType(str, Enum):
     ERRORS = "errors"
     TRANSACTIONS = "transactions"
+    ISSUE_PLATFORM = "issue_platform"
 
 
 @contextmanager
@@ -71,6 +72,7 @@ def _record_metrics(partition: int, task_kwargs: Mapping[str, Any]) -> None:
     """
     global __metrics
     global __last_flush
+    # TODO: Fix this, it's already broken for transactions with groups
     event_type = "transactions" if task_kwargs["group_id"] is None else "errors"
     __metrics[(partition, event_type)] += 1
 

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -400,7 +400,7 @@ class SnubaEventStream(SnubaProtocolEventStream):
         entity = "events"
         if event_type == EventStreamEventType.Transaction:
             entity = "transactions"
-        if event_type == EventStreamEventType.IssuePlatform:
+        if event_type == EventStreamEventType.Generic:
             entity = "search_issues"
         try:
             resp = snuba._snuba_pool.urlopen(

--- a/src/sentry/snuba/dataset.py
+++ b/src/sentry/snuba/dataset.py
@@ -14,6 +14,7 @@ class Dataset(Enum):
     PerformanceMetrics = "generic_metrics"
     Replays = "replays"
     Profiles = "profiles"
+    IssuePlatform = "search_issues"
 
 
 @unique
@@ -27,3 +28,4 @@ class EntityKey(Enum):
     MetricsDistributions = "metrics_distributions"
     GenericMetricsDistributions = "generic_metrics_distributions"
     GenericMetricsSets = "generic_metrics_sets"
+    IssuePlatform = "search_issues"

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -202,6 +202,8 @@ def pytest_configure(config):
     # If a request hits the wrong silo, replace the 404 response with an error state
     settings.FAIL_ON_UNAVAILABLE_API_CALL = True
 
+    settings.SENTRY_USE_ISSUE_OCCURRENCE = True
+
     # django mail uses socket.getfqdn which doesn't play nice if our
     # networking isn't stable
     patcher = mock.patch("socket.getfqdn", return_value="localhost")

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -532,6 +532,7 @@ def _prepare_query_params(query_params):
         Dataset.Sessions,
         Dataset.Transactions,
         Dataset.Replays,
+        Dataset.IssuePlatform,
     ]:
         (organization_id, params_to_update) = get_query_params_to_update_for_projects(
             query_params, with_org=query_params.dataset == Dataset.Sessions

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -57,8 +57,8 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         if event_type == EventStreamEventType.Transaction:
             assert produce_kwargs["topic"] == settings.KAFKA_TRANSACTIONS
             assert produce_kwargs["key"] is None
-        elif event_type == EventStreamEventType.IssuePlatform:
-            assert produce_kwargs["topic"] == settings.KAFKA_EVENTSTREAM_ISSUE_PLATFORM
+        elif event_type == EventStreamEventType.Generic:
+            assert produce_kwargs["topic"] == settings.KAFKA_EVENTSTREAM_GENERIC
             assert produce_kwargs["key"] is None
         else:
             assert produce_kwargs["topic"] == settings.KAFKA_EVENTS
@@ -236,7 +236,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
         produce_args, produce_kwargs = list(producer.produce.call_args)
 
         version, type_, payload1, payload2 = json.loads(produce_kwargs["value"])
-        assert produce_kwargs["topic"] == settings.KAFKA_EVENTSTREAM_ISSUE_PLATFORM
+        assert produce_kwargs["topic"] == settings.KAFKA_EVENTSTREAM_GENERIC
         assert produce_kwargs["key"] is None
         assert version == 2
         assert type_ == "insert"

--- a/tests/sentry/eventstream/test_eventstream.py
+++ b/tests/sentry/eventstream/test_eventstream.py
@@ -6,16 +6,18 @@ from unittest.mock import Mock, patch
 from django.conf import settings
 
 from sentry.event_manager import EventManager
+from sentry.eventstream.base import EventStreamEventType
 from sentry.eventstream.kafka import KafkaEventStream
 from sentry.eventstream.snuba import SnubaEventStream
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.silo import region_silo_test
 from sentry.utils import json, snuba
 from sentry.utils.samples import load_data
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 @region_silo_test
-class SnubaEventStreamTest(TestCase, SnubaTestCase):
+class SnubaEventStreamTest(TestCase, SnubaTestCase, OccurrenceTestMixin):
     def setUp(self):
         super().setUp()
 
@@ -43,7 +45,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
 
     def __produce_event(self, *insert_args, **insert_kwargs):
 
-        is_transaction_event = insert_kwargs["event"].get_event_type() == "transaction"
+        event_type = self.kafka_eventstream._get_event_type(insert_kwargs["event"])
 
         # pass arguments on to Kafka EventManager
         self.kafka_eventstream.insert(*insert_args, **insert_kwargs)
@@ -52,8 +54,11 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
 
         produce_args, produce_kwargs = list(producer.produce.call_args)
         assert not produce_args
-        if is_transaction_event:
+        if event_type == EventStreamEventType.Transaction:
             assert produce_kwargs["topic"] == settings.KAFKA_TRANSACTIONS
+            assert produce_kwargs["key"] is None
+        elif event_type == EventStreamEventType.IssuePlatform:
+            assert produce_kwargs["topic"] == settings.KAFKA_EVENTSTREAM_ISSUE_PLATFORM
             assert produce_kwargs["key"] is None
         else:
             assert produce_kwargs["topic"] == settings.KAFKA_EVENTS
@@ -70,7 +75,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
             self.project.id,
             "insert",
             (payload1, payload2),
-            is_transaction_event=is_transaction_event,
+            event_type=event_type,
         )
 
     def __produce_payload(self, *insert_args, **insert_kwargs):
@@ -202,9 +207,57 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
         self.kafka_eventstream.insert(*insert_args, **insert_kwargs)
         assert not self.producer_mock.produce.called
         logger.error.assert_called_with(
-            "`GroupEvent` passed to `EventStream.insert`. Only `Event` is allowed here.",
+            "`GroupEvent` passed to `EventStream.insert`. `GroupEvent` may only be passed when "
+            "associated with an `IssueOccurrence`",
             exc_info=True,
         )
+
+    @patch("sentry.eventstream.insert", autospec=True)
+    def test_groupevent_occurrence_passed(self, mock_eventstream_insert):
+        event = self.__build_transaction_event()
+        event.group_id = self.group.id
+        group_event = event.for_group(self.group)
+        group_event.occurrence = self.build_occurrence()
+
+        insert_args = ()
+        insert_kwargs = {
+            "event": group_event,
+            "is_new_group_environment": True,
+            "is_new": True,
+            "is_regression": False,
+            "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "skip_consume": False,
+            "received_timestamp": event.data["received"],
+        }
+        # TODO: Use this once we have a dataset in snuba
+        # self.__produce_event(*insert_args, **insert_kwargs)
+        self.kafka_eventstream.insert(*insert_args, **insert_kwargs)
+        producer = self.producer_mock
+        produce_args, produce_kwargs = list(producer.produce.call_args)
+
+        version, type_, payload1, payload2 = json.loads(produce_kwargs["value"])
+        assert produce_kwargs["topic"] == settings.KAFKA_EVENTSTREAM_ISSUE_PLATFORM
+        assert produce_kwargs["key"] is None
+        assert version == 2
+        assert type_ == "insert"
+        occurrence_data = group_event.occurrence.to_dict()
+        del occurrence_data["evidence_data"]
+        del occurrence_data["evidence_display"]
+        assert payload1["occurrence_data"] == occurrence_data
+        assert payload1["group_id"] == self.group.id
+
+        # TODO: Query this data and make sure it's present once we have a corresponding dataset in
+        # snuba
+        # result = snuba.raw_query(
+        #     dataset=snuba.Dataset.IssuePlatform,
+        #     start=now - timedelta(days=1),
+        #     end=now + timedelta(days=1),
+        #     selected_columns=["event_id", "group_id", "occurrence_id"],
+        #     groupby=None,
+        #     filter_keys={"project_id": [self.project.id], "event_id": [event.event_id]},
+        # )
+        # assert len(result["data"]) == 1
+        # assert result["data"][0]["group_ids"] == [self.group.id]
 
     @patch("sentry.eventstream.insert", autospec=True)
     def test_error_queue(self, mock_eventstream_insert):
@@ -260,3 +313,31 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
 
         assert ("queue", b"post_process_transactions") in headers
         assert body["queue"] == "post_process_transactions"
+
+    @patch("sentry.eventstream.insert", autospec=True)
+    def test_issue_platform_queue(self, mock_eventstream_insert):
+        event = self.__build_transaction_event()
+        event.group_id = None
+        event.groups = [self.group]
+        group_event = event.for_group(self.group)
+        group_event.occurrence = self.build_occurrence()
+
+        insert_args = ()
+        group_state = {
+            "is_new_group_environment": True,
+            "is_new": True,
+            "is_regression": False,
+        }
+        insert_kwargs = {
+            "event": group_event,
+            **group_state,
+            "primary_hash": "acbd18db4cc2f85cedef654fccc4a4d8",
+            "skip_consume": False,
+            "received_timestamp": event.data["received"],
+            "group_states": [{"id": event.groups[0].id, **group_state}],
+        }
+
+        headers, body = self.__produce_payload(*insert_args, **insert_kwargs)
+
+        assert ("queue", b"post_process_issue_platform") in headers
+        assert body["queue"] == "post_process_issue_platform"


### PR DESCRIPTION
We'll include this data in the `occurrence_data` key for any events that have an `IssueOccurrence` passed along with them in eventstream. 
This will be backwards compatible, since existing consumers can ignore the new key.
