### PR TITLE
fix(ecosystem): Add missing integration requester info

### DIFF
--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -65,6 +65,8 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
     def get_context(self) -> MutableMapping[str, Any]:
         return {
             **self.get_base_context(),
+            "requester_name": self.requester.get_display_name(),
+            "organization_name": self.organization.name,
             "integration_link": self.integration_link,
             "integration_name": self.provider_name,
             "message": self.message,

--- a/src/sentry/templates/sentry/debug/mail/preview.html
+++ b/src/sentry/templates/sentry/debug/mail/preview.html
@@ -45,6 +45,7 @@
         <option value="mail/access-approved/">Access Approved</option>
         <option value="mail/invitation/">Membership Invite</option>
         <option value="mail/invite-request/">Invite Request</option>
+        <option value="mail/integration-request/">Integration Request</option>
         <option value="mail/join-request/">Join Request</option>
       </optgroup>
       <optgroup label="Reports">

--- a/src/sentry/web/debug_urls.py
+++ b/src/sentry/web/debug_urls.py
@@ -33,6 +33,9 @@ from sentry.web.frontend.debug.debug_oauth_authorize import (
 from sentry.web.frontend.debug.debug_onboarding_continuation_email import (
     DebugOrganizationOnboardingContinuationEmail,
 )
+from sentry.web.frontend.debug.debug_organization_integration_request import (
+    DebugOrganizationIntegrationRequestEmailView,
+)
 from sentry.web.frontend.debug.debug_organization_invite_request import (
     DebugOrganizationInviteRequestEmailView,
 )
@@ -105,6 +108,9 @@ urlpatterns = [
     ),
     url(r"^debug/mail/join-request/$", DebugOrganizationJoinRequestEmailView.as_view()),
     url(r"^debug/mail/invite-request/$", DebugOrganizationInviteRequestEmailView.as_view()),
+    url(
+        r"^debug/mail/integration-request/$", DebugOrganizationIntegrationRequestEmailView.as_view()
+    ),
     url(r"^debug/mail/access-approved/$", sentry.web.frontend.debug.mail.access_approved),
     url(r"^debug/mail/invitation/$", sentry.web.frontend.debug.mail.invitation),
     url(r"^debug/mail/invalid-identity/$", DebugInvalidIdentityEmailView.as_view()),

--- a/src/sentry/web/frontend/debug/debug_organization_integration_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_integration_request.py
@@ -1,0 +1,30 @@
+from django.views.generic import View
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.models import Organization, OrganizationMember, User
+from sentry.notifications.notifications.organization_request.integration_request import (
+    IntegrationRequestNotification,
+)
+
+from .mail import render_preview_email_for_notification
+
+
+class DebugOrganizationIntegrationRequestEmailView(View):
+    def get(self, request: Request) -> Response:
+        org = Organization(id=1, slug="default", name="Default")
+        requester = User(name="Rick Swan")
+        recipient = User(name="James Bond")
+        recipient_member = OrganizationMember(user=recipient, organization=org)
+
+        notification = IntegrationRequestNotification(
+            org,
+            requester,
+            provider_type="first_party",
+            provider_slug="slack",
+            provider_name="Slack",
+        )
+
+        # hack to avoid a query
+        notification.role_based_recipient_strategy.set_member_in_cache(recipient_member)
+        return render_preview_email_for_notification(notification, recipient)

--- a/tests/sentry/notifications/notifications/organization_request/test_integration_request.py
+++ b/tests/sentry/notifications/notifications/organization_request/test_integration_request.py
@@ -1,0 +1,26 @@
+from sentry.notifications.notifications.organization_request.integration_request import (
+    IntegrationRequestNotification,
+)
+from sentry.testutils.cases import TestCase
+
+
+class AssignedNotificationAPITest(TestCase):
+    def test_sends_integration_request(self):
+        owner = self.create_user("owner@example.com")
+        org = self.create_organization(owner=owner)
+        requester = self.create_user()
+        self.create_member(user=requester, organization=org)
+
+        message = "hello"
+        notification = IntegrationRequestNotification(
+            org,
+            requester,
+            provider_type="first_party",
+            provider_slug="slack",
+            provider_name="Slack",
+            message=message,
+        )
+        context = notification.get_context()
+        context["requester_name"] = requester.get_display_name()
+        context["organization_name"] = org.name
+        context["message"] = message


### PR DESCRIPTION
- Adds the org slug and requester name to the integration request email
- Adds a debug page for this email

![Screenshot 2022-12-08 at 3 32 18 PM](https://user-images.githubusercontent.com/1400464/206588934-bfb3ca31-8cdb-47c4-b3ba-d62544a9a414.png)

WOR-2405