### PR TITLE
fix(createuser): Fix email prompt return

### DIFF
--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -15,7 +15,7 @@ def _get_email():
     rv = click.prompt("Email")
     field = _get_field("email")
     try:
-        return field.clean(rv, None)
+        return [ field.clean(rv, None) ]
     except ValidationError as e:
         raise click.ClickException("; ".join(e.messages))
 

--- a/src/sentry/runner/commands/createuser.py
+++ b/src/sentry/runner/commands/createuser.py
@@ -15,7 +15,7 @@ def _get_email():
     rv = click.prompt("Email")
     field = _get_field("email")
     try:
-        return [ field.clean(rv, None) ]
+        return [field.clean(rv, None)]
     except ValidationError as e:
         raise click.ClickException("; ".join(e.messages))
 


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/41834 introduced multiple email arg support but missed that prompting for an email needs to return a 1 item list instead of a string.