### PR TITLE
ref(sampling): Remove dynamic sampling dead line from tsc config -  [TET-605]

### DIFF
--- a/config/tsconfig.build.json
+++ b/config/tsconfig.build.json
@@ -7,7 +7,6 @@
     "../tests/js",
     "../fixtures/js-stubs",
     "../static/app/**/*.spec.*",
-    "../static/app/**/*.benchmark.ts",
-    "../static/app/views/settings/project/server-side-sampling/testUtils.tsx"
+    "../static/app/**/*.benchmark.ts"
   ]
 }


### PR DESCRIPTION
the file path `../static/app/views/settings/project/server-side-sampling/testUtils.tsx` is invalid as it no longer exists (see https://github.com/getsentry/sentry/pull/42000/files#diff-63b4916cc3944f2a11330cdc3089f75fc492de21bf7dadbada4b650b68d329df), so I am removing it from the tsconfig. 