### PR TITLE
ref(dynamic-sampling): Remove server-side-sampling invalid paths from the file - [TET-605]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -370,13 +370,8 @@ yarn.lock           @getsentry/owners-js-deps
 /tests/sentry/api/endpoints/test_organization_dynamic_sampling_sdk_versions.py           @getsentry/telemetry-experience
 /tests/sentry/snuba/metrics/                                                             @getsentry/telemetry-experience
 /tests/snuba/api/endpoints/test_organization_sessions.py                                 @getsentry/telemetry-experience
-/tests/acceptance/test_project_settings_sampling.py                                      @getsentry/telemetry-experience
 
-/static/app/views/settings/project/server-side-sampling/                                 @getsentry/telemetry-experience
 /static/app/views/settings/project/dynamicSampling/                                      @getsentry/telemetry-experience
-/static/app/stores/serverSideSamplingStore.tsx                                           @getsentry/telemetry-experience
-/static/app/stores/serverSideSamplingStore.spec.tsx                                      @getsentry/telemetry-experience
-/static/app/actionCreators/serverSideSampling.tsx                                        @getsentry/telemetry-experience
 /static/app/views/performance/landing/dynamicSamplingMetricsAccuracyAlert.tsx            @getsentry/telemetry-experience
 /static/app/views/performance/landing/dynamicSamplingMetricsAccuracy.spec.tsx            @getsentry/telemetry-experience
 /static/app/utils/metrics/                                                               @getsentry/telemetry-experience


### PR DESCRIPTION
The `server-side-sampling` code was recently removed https://github.com/getsentry/sentry/pull/42000, so I am removing the no longer existing paths from the github code owners file 