### PR TITLE
feat(discover-quick-context): Switched to transaction.status from http.status_code for context actions

### DIFF
--- a/static/app/views/eventsV2/table/quickContext/eventContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext/eventContext.tsx
@@ -73,10 +73,6 @@ function EventContext(props: EventContextProps) {
       2,
       true
     );
-    const httpStatusTag = data.tags.find(
-      tagObject => tagObject.key === 'http.status_code'
-    );
-    const httpStatusValue = httpStatusTag ? httpStatusTag.value : '';
     return (
       <Wrapper data-test-id="quick-context-hover-body">
         <EventContextContainer>
@@ -98,36 +94,43 @@ function EventContext(props: EventContextProps) {
         </EventContextContainer>
         {location && (
           <EventContextContainer>
-            <ContextHeader>
-              <ContextTitle>{t('Status')}</ContextTitle>
-              {location && eventView && (
-                <ActionDropDown
-                  dataRow={dataRow}
-                  contextValueType={ContextValueType.STRING}
-                  location={location}
-                  eventView={eventView}
-                  organization={organization}
-                  queryKey="http.status_code"
-                  value={httpStatusValue}
-                />
-              )}
-            </ContextHeader>
-            <EventContextBody>
-              <ContextRow>
-                <TraceMetaQuery
-                  location={location}
-                  orgSlug={organization.slug}
-                  traceId={traceId}
-                  start={start}
-                  end={end}
-                >
-                  {metaResults => getStatusBodyText(project, data, metaResults?.meta)}
-                </TraceMetaQuery>
-                <HttpStatusWrapper>
-                  (<HttpStatus event={data} />)
-                </HttpStatusWrapper>
-              </ContextRow>
-            </EventContextBody>
+            <TraceMetaQuery
+              location={location}
+              orgSlug={organization.slug}
+              traceId={traceId}
+              start={start}
+              end={end}
+            >
+              {metaResults => {
+                const status = getStatusBodyText(project, data, metaResults?.meta);
+                return (
+                  <Fragment>
+                    <ContextHeader>
+                      <ContextTitle>{t('Status')}</ContextTitle>
+                      {location && eventView && (
+                        <ActionDropDown
+                          dataRow={dataRow}
+                          contextValueType={ContextValueType.STRING}
+                          location={location}
+                          eventView={eventView}
+                          organization={organization}
+                          queryKey="transaction.status"
+                          value={status}
+                        />
+                      )}
+                    </ContextHeader>
+                    <EventContextBody>
+                      <ContextRow>
+                        {status}
+                        <HttpStatusWrapper>
+                          (<HttpStatus event={data} />)
+                        </HttpStatusWrapper>
+                      </ContextRow>
+                    </EventContextBody>
+                  </Fragment>
+                );
+              }}
+            </TraceMetaQuery>
           </EventContextContainer>
         )}
       </Wrapper>


### PR DESCRIPTION
1. Status in the event details page represents the transaction.status field. It's confusing to be adding status.code as a column/filter from the menu in the setting below:
<img width="330" alt="Screen Shot 2022-12-09 at 11 50 48 AM" src="https://user-images.githubusercontent.com/60121741/206751607-ff75d62d-b8dd-448f-817a-6371620a4bd0.png">

<img width="430" alt="Screen Shot 2022-12-09 at 11 49 08 AM" src="https://user-images.githubusercontent.com/60121741/206751339-29a9b75f-79a1-45eb-b4c3-0b7a035485ae.png">
2. Should add `transaction.status:not_found` to filter and not `http.status_code:404`
