### PR TITLE
fix(perf-issues): Actually enable MN+1 in dry run mode

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -360,6 +360,7 @@ def _detect_performance_problems(data: Event, sdk_span: Any) -> List[Performance
         ),
         DetectorType.FILE_IO_MAIN_THREAD: FileIOMainThreadDetector(detection_settings, data),
         DetectorType.N_PLUS_ONE_API_CALLS: NPlusOneAPICallsDetector(detection_settings, data),
+        DetectorType.M_N_PLUS_ONE_DB: MNPlusOneDBSpanDetector(detection_settings, data),
     }
 
     for _, detector in detectors.items():


### PR DESCRIPTION
Missed adding the detector to the detectors hash in https://github.com/getsentry/sentry/pull/41968.