### PR TITLE
ref(replays): Use <NoRowRenderer> in all the replay details tabs

### DIFF
--- a/static/app/views/replays/detail/domMutations/index.tsx
+++ b/static/app/views/replays/detail/domMutations/index.tsx
@@ -7,15 +7,12 @@ import {
 } from 'react-virtualized';
 import styled from '@emotion/styled';
 
-import Button from 'sentry/components/button';
-import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import BreadcrumbIcon from 'sentry/components/events/interfaces/breadcrumbs/breadcrumb/type/icon';
 import HTMLCode from 'sentry/components/htmlCode';
 import Placeholder from 'sentry/components/placeholder';
 import {getDetails} from 'sentry/components/replays/breadcrumbs/utils';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
-import {IconClose} from 'sentry/icons';
 import {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -26,6 +23,7 @@ import type ReplayReader from 'sentry/utils/replays/replayReader';
 import DomFilters from 'sentry/views/replays/detail/domMutations/domFilters';
 import useDomFilters from 'sentry/views/replays/detail/domMutations/useDomFilters';
 import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
+import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 import useVirtualizedList from 'sentry/views/replays/detail/useVirtualizedList';
 
@@ -40,6 +38,7 @@ function DomMutations({replay}: Props) {
 
   const filterProps = useDomFilters({actions: actions || []});
   const {items, setSearchTerm} = filterProps;
+  const clearSearchTerm = () => setSearchTerm('');
 
   const currentDomMutation = getPrevReplayEvent({
     items: items.map(mutation => mutation.crumb),
@@ -124,24 +123,14 @@ function DomMutations({replay}: Props) {
                 height={height}
                 overscanRowCount={5}
                 rowCount={items.length}
-                noRowsRenderer={() =>
-                  actions.length === 0 ? (
-                    <StyledEmptyStateWarning>
-                      <p>{t('No DOM events recorded')}</p>
-                    </StyledEmptyStateWarning>
-                  ) : (
-                    <StyledEmptyStateWarning>
-                      <p>{t('No results found')}</p>
-                      <Button
-                        icon={<IconClose color="gray500" size="sm" isCircled />}
-                        onClick={() => setSearchTerm('')}
-                        size="md"
-                      >
-                        {t('Clear filters')}
-                      </Button>
-                    </StyledEmptyStateWarning>
-                  )
-                }
+                noRowsRenderer={() => (
+                  <NoRowRenderer
+                    unfilteredItems={actions}
+                    clearSearchTerm={clearSearchTerm}
+                  >
+                    {t('No DOM events recorded')}
+                  </NoRowRenderer>
+                )}
                 rowHeight={cache.rowHeight}
                 rowRenderer={renderRow}
                 width={width}
@@ -153,15 +142,6 @@ function DomMutations({replay}: Props) {
     </MutationContainer>
   );
 }
-
-const StyledEmptyStateWarning = styled(EmptyStateWarning)`
-  height: 100%;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-`;
 
 const MutationContainer = styled(FluidHeight)`
   height: 100%;

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -8,14 +8,12 @@ import {
 } from 'react-virtualized';
 import styled from '@emotion/styled';
 
-import Button from 'sentry/components/button';
-import EmptyStateWarning from 'sentry/components/emptyStateWarning';
 import FileSize from 'sentry/components/fileSize';
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import Tooltip from 'sentry/components/tooltip';
-import {IconArrow, IconClose} from 'sentry/icons';
+import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
@@ -24,6 +22,7 @@ import FluidHeight from 'sentry/views/replays/detail/layout/fluidHeight';
 import NetworkFilters from 'sentry/views/replays/detail/network/networkFilters';
 import useNetworkFilters from 'sentry/views/replays/detail/network/useNetworkFilters';
 import {ISortConfig, sortNetwork} from 'sentry/views/replays/detail/network/utils';
+import NoRowRenderer from 'sentry/views/replays/detail/noRowRenderer';
 import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 import type {NetworkSpan, ReplayRecord} from 'sentry/views/replays/types';
 
@@ -55,6 +54,7 @@ function NetworkList({replayRecord, networkSpans}: Props) {
 
   const filterProps = useNetworkFilters({networkSpans: networkSpans || []});
   const {items, searchTerm, setSearchTerm} = filterProps;
+  const clearSearchTerm = () => setSearchTerm('');
 
   const networkData = useMemo(() => sortNetwork(items, sortConfig), [items, sortConfig]);
 
@@ -312,24 +312,14 @@ function NetworkList({replayRecord, networkSpans}: Props) {
                     setScrollBarWidth(0);
                   }
                 }}
-                noContentRenderer={() =>
-                  networkSpans.length === 0 ? (
-                    <StyledEmptyStateWarning>
-                      <p>{t('No network requests recorded')}</p>
-                    </StyledEmptyStateWarning>
-                  ) : (
-                    <StyledEmptyStateWarning>
-                      <p>{t('No results found')}</p>
-                      <Button
-                        icon={<IconClose color="gray500" size="sm" isCircled />}
-                        onClick={() => setSearchTerm('')}
-                        size="md"
-                      >
-                        {t('Clear filters')}
-                      </Button>
-                    </StyledEmptyStateWarning>
-                  )
-                }
+                noContentRenderer={() => (
+                  <NoRowRenderer
+                    unfilteredItems={networkSpans}
+                    clearSearchTerm={clearSearchTerm}
+                  >
+                    {t('No network requests recorded')}
+                  </NoRowRenderer>
+                )}
               />
             )}
           </AutoSizer>
@@ -340,15 +330,6 @@ function NetworkList({replayRecord, networkSpans}: Props) {
     </NetworkContainer>
   );
 }
-
-const StyledEmptyStateWarning = styled(EmptyStateWarning)`
-  height: 100%;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-`;
 
 const NetworkContainer = styled(FluidHeight)`
   height: 100%;


### PR DESCRIPTION
Re-use the component instead of all the imports all the time.

IDK why i didn't do this to start with, when we last touched this stuff.