### PR TITLE
ref: fix misuse of NoReturn typing

### DIFF
--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -1,5 +1,4 @@
 import time
-from typing import NoReturn
 
 from django.conf import settings
 from packaging.version import Version
@@ -23,7 +22,7 @@ class JavaScriptSdkLoader(BaseView):
     # Do not let an organization load trigger session, breaking Vary header.
     # TODO: This view should probably not be a subclass of BaseView if it doesn't actually use the
     # large amount of organization related support utilities, but that ends up being a large refactor.
-    def determine_active_organization(self, request: Request, organization_slug=None) -> NoReturn:
+    def determine_active_organization(self, request: Request, organization_slug=None) -> None:
         pass
 
     def _get_context(self, key):

--- a/src/sentry/web/frontend/restore_organization.py
+++ b/src/sentry/web/frontend/restore_organization.py
@@ -1,5 +1,4 @@
 import logging
-from typing import NoReturn
 
 from django.contrib import messages
 from django.urls import reverse
@@ -30,7 +29,7 @@ class RestoreOrganizationView(OrganizationView):
     required_scope = "org:admin"
     sudo_required = True
 
-    def determine_active_organization(self, request: Request, organization_slug=None) -> NoReturn:
+    def determine_active_organization(self, request: Request, organization_slug=None) -> None:
         # A simplified version than what comes from the base
         # OrganizationView. We need to grab an organization
         # that is in any state, not just VISIBLE.


### PR DESCRIPTION
`NoReturn` is specifically for functions which either always raise, loop forever, or exec away the current process -- https://youtu.be/-zH0qqDtd4w

(cc @corps just fyi)