### PR TITLE
ref: ban exam.before / exam.around

### DIFF
--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -61,7 +61,7 @@ from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
-from exam import Exam, before, fixture
+from exam import Exam, fixture
 from pkg_resources import iter_entry_points
 from rest_framework import status
 from rest_framework.test import APITestCase as BaseAPITestCase
@@ -173,7 +173,7 @@ class BaseTestCase(Fixtures, Exam):
         assert resp.status_code == 302
         assert resp["Location"].startswith("http://testserver" + reverse("sentry-login"))
 
-    @before
+    @pytest.fixture(autouse=True)
     def setup_dummy_auth_provider(self):
         auth.register("dummy", DummyProvider)
         self.addCleanup(auth.unregister, "dummy", DummyProvider)

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 from django.conf import settings
 from django.core.cache.backends.locmem import LocMemCache
-from exam import around, fixture
+from exam import fixture
 
 from sentry.models import Option
 from sentry.options.manager import (
@@ -32,7 +32,7 @@ class OptionsManagerTest(TestCase):
     def manager(self):
         return OptionsManager(store=self.store)
 
-    @around
+    @pytest.fixture(autouse=True)
     def register(self):
         default_options = settings.SENTRY_DEFAULT_OPTIONS.copy()
         settings.SENTRY_DEFAULT_OPTIONS = {}

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -4,7 +4,7 @@ from uuid import uuid1
 import pytest
 from django.conf import settings
 from django.core.cache.backends.locmem import LocMemCache
-from exam import before, fixture
+from exam import fixture
 
 from sentry.models import Option
 from sentry.options.store import OptionsStore
@@ -22,7 +22,7 @@ class OptionsStoreTest(TestCase):
     def key(self):
         return self.make_key()
 
-    @before
+    @pytest.fixture(autouse=True)
     def flush_local_cache(self):
         self.store.flush_local_cache()
 

--- a/tests/sentry/rules/actions/test_notify_event_sentry_app.py
+++ b/tests/sentry/rules/actions/test_notify_event_sentry_app.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import pytest
-from exam import before
 from rest_framework import serializers
 
 from sentry.rules.actions.sentry_apps import NotifyEventSentryAppAction
@@ -21,7 +20,7 @@ class NotifyEventSentryAppActionTest(RuleTestCase):
         {"name": "summary", "value": "circle triangle square"},
     ]
 
-    @before
+    @pytest.fixture(autouse=True)
     def create_schema(self):
         self.schema = {"elements": [self.create_alert_rule_action_schema()]}
 

--- a/tests/sentry/web/frontend/test_account_identity.py
+++ b/tests/sentry/web/frontend/test_account_identity.py
@@ -1,6 +1,6 @@
+import pytest
 from django.urls import reverse
 from django.utils.encoding import force_bytes
-from exam import before
 
 from sentry import identity
 from sentry.identity.providers.dummy import DummyProvider
@@ -11,7 +11,7 @@ from sentry.testutils.silo import control_silo_test
 
 @control_silo_test
 class AccountIdentityTest(TestCase):
-    @before
+    @pytest.fixture(autouse=True)
     def setup_dummy_identity_provider(self):
         identity.register(DummyProvider)
         self.addCleanup(identity.unregister, DummyProvider)

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -1,15 +1,16 @@
 from unittest import mock
 from unittest.mock import patch
 
+import pytest
 from django.conf import settings
 from django.urls import reverse
-from exam import before, fixture
+from exam import fixture
 
 from sentry.testutils import TestCase
 
 
 class JavaScriptSdkLoaderTest(TestCase):
-    @before
+    @pytest.fixture(autouse=True)
     def set_settings(self):
         settings.JS_SDK_LOADER_SDK_VERSION = "0.5.2"
         settings.JS_SDK_LOADER_DEFAULT_SDK_URL = (

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -99,3 +99,15 @@ from exam import patcher
     assert errors == [
         "t.py:1:0: S006 use unittest.mock instead of exam.patcher",
     ]
+
+
+def test_S007():
+    S006_py = """\
+from exam import before
+from exam import around
+"""
+    errors = _run(S006_py)
+    assert errors == [
+        "t.py:1:0: S007 use pytest.fixture(autouse=True) instead of exam.before / exam.around",
+        "t.py:2:0: S007 use pytest.fixture(autouse=True) instead of exam.before / exam.around",
+    ]

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -21,6 +21,7 @@ S004_methods = frozenset(("assertRaises", "assertRaisesRegex"))
 S005_msg = "S005 Do not import models from sentry.models but the actual module"
 
 S006_msg = "S006 use unittest.mock instead of exam.patcher"
+S007_msg = "S007 use pytest.fixture(autouse=True) instead of exam.before / exam.around"
 
 
 class SentryVisitor(ast.NodeVisitor):
@@ -41,6 +42,8 @@ class SentryVisitor(ast.NodeVisitor):
                 self.errors.append((node.lineno, node.col_offset, S005_msg))
             elif node.module == "exam" and any(x.name == "patcher" for x in node.names):
                 self.errors.append((node.lineno, node.col_offset, S006_msg))
+            elif node.module == "exam" and any(x.name in {"before", "around"} for x in node.names):
+                self.errors.append((node.lineno, node.col_offset, S007_msg))
 
         self.generic_visit(node)
 


### PR DESCRIPTION
already done in `getsentry`