### PR TITLE
fix(workflow): Do not re-fetch stacktrace link on window focus

### DIFF
--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -160,7 +160,7 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     refetch,
   } = useQuery<StacktraceLinkResult>(
     [`/projects/${organization.slug}/${project?.slug}/stacktrace-link/`, {query}],
-    {staleTime: Infinity, retry: 0}
+    {staleTime: Infinity, retry: false}
   );
 
   // Track stacktrace analytics after loaded

--- a/static/app/components/events/interfaces/frame/stacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/stacktraceLink.tsx
@@ -158,10 +158,10 @@ export function StacktraceLink({frame, event, line}: StacktraceLinkProps) {
     data: match,
     isLoading,
     refetch,
-  } = useQuery<StacktraceLinkResult>([
-    `/projects/${organization.slug}/${project?.slug}/stacktrace-link/`,
-    {query},
-  ]);
+  } = useQuery<StacktraceLinkResult>(
+    [`/projects/${organization.slug}/${project?.slug}/stacktrace-link/`, {query}],
+    {staleTime: Infinity, retry: 0}
+  );
 
   // Track stacktrace analytics after loaded
   useEffect(() => {


### PR DESCRIPTION
stacktrace-link hits external apis and does not need to be refetched or retried