### PR TITLE
fix(profiling): dont call getAllExpandedNodes on each render

### DIFF
--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -88,7 +88,7 @@ export function useVirtualizedTree<T extends TreeLike>(
   );
 
   const flattenedHistory = useRef<ReadonlyArray<VirtualizedTreeNode<T>>>(tree.flattened);
-  const expandedHistory = useRef<Set<T>>(tree.getAllExpandedNodes(new Set()));
+  const expandedHistory = useRef<Set<T>>(new Set());
 
   // Keep a ref to latest state to avoid re-rendering
   const latestStateRef = useRef<typeof state>(state);


### PR DESCRIPTION
If a tree is large and we are resizing the drawer, the hook gets rerendered and getAllExpandedNodes will run on all nodes of the tree causing frame drops. The call is actually unnecessary as we already update the ref whenever the tree changes.