### PR TITLE
fix(domains) Fix url normalization in navigate()

### DIFF
--- a/static/app/utils/useNavigate.spec.tsx
+++ b/static/app/utils/useNavigate.spec.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {createMemoryHistory, Route, Router, RouterContext} from 'react-router';
 
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -6,6 +7,11 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {RouteContext} from 'sentry/views/routeContext';
 
 describe('useNavigate', () => {
+  const initialData = window.__initialData;
+  afterEach(() => {
+    window.__initialData = initialData;
+  });
+
   it('returns the navigate function', function () {
     let navigate: ReturnType<typeof useNavigate> | undefined = undefined;
 
@@ -33,5 +39,49 @@ describe('useNavigate', () => {
     );
 
     expect(typeof navigate).toBe('function');
+  });
+
+  it('applies url normalization for customer-domains', function () {
+    window.__initialData = {
+      customerDomain: {
+        subdomain: 'albertos-apples',
+        organizationUrl: 'https://albertos-apples.sentry.io',
+        sentryUrl: 'https://sentry.io',
+      },
+    } as any;
+
+    function HomePage() {
+      const navigate = useNavigate();
+      useEffect(() => {
+        navigate('/organizations/acme/issues/');
+      }, [navigate]);
+
+      return null;
+    }
+
+    const memoryHistory = createMemoryHistory();
+    memoryHistory.push('/');
+
+    render(
+      <Router
+        history={memoryHistory}
+        render={props => {
+          return (
+            <RouteContext.Provider value={props}>
+              <RouterContext {...props} />
+            </RouteContext.Provider>
+          );
+        }}
+      >
+        <Route path="/" component={HomePage} />
+        <Route
+          path="/issues"
+          component={() => {
+            return null;
+          }}
+        />
+      </Router>
+    );
+    expect(memoryHistory.getCurrentLocation().pathname).toBe('/issues/');
   });
 });

--- a/static/app/utils/useNavigate.tsx
+++ b/static/app/utils/useNavigate.tsx
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useRef} from 'react';
 
 import {useRouteContext} from 'sentry/utils/useRouteContext';
+import {normalizeUrl} from 'sentry/utils/withDomainRequired';
 
 type NavigateOptions = {
   replace?: boolean;
@@ -27,7 +28,7 @@ export function useNavigate() {
       }
 
       const nextState = {
-        pathname: to,
+        pathname: normalizeUrl(to),
         state: options.state,
       };
 


### PR DESCRIPTION
We need to normalize URLs for customer domains in useNavigate(). This fixes redirects done in function components. Having the normalization done in our custom hook means we won't have to update all the callsites now and in the future.