### PR TITLE
feat(hybrid-cloud): Allow cross-silo clients to proxy

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Mapping, Sequence, Type, Union
 
 import sentry_sdk
 from django.core.cache import cache
+from requests import PreparedRequest
 from requests.exceptions import ConnectionError, HTTPError, Timeout
 
 from sentry.http import build_session
@@ -80,6 +81,7 @@ class BaseApiClient(TrackResponseMixin):
         allow_redirects: bool | None = None,
         timeout: int | None = None,
         ignore_webhook_errors: bool = False,
+        prepared_request: PreparedRequest | None = None,
     ) -> BaseApiResponseX:
         if allow_text is None:
             allow_text = self.allow_text
@@ -118,16 +120,20 @@ class BaseApiClient(TrackResponseMixin):
         ) as span:
             try:
                 with build_session() as session:
-                    resp = getattr(session, method.lower())(
-                        url=full_url,
-                        headers=headers,
-                        json=data if json else None,
-                        data=data if not json else None,
-                        params=params,
-                        auth=auth,
-                        verify=self.verify_ssl,
-                        allow_redirects=allow_redirects,
-                        timeout=timeout,
+                    resp = (
+                        session.send(prepared_request)
+                        if prepared_request is not None
+                        else getattr(session, method.lower())(
+                            url=full_url,
+                            headers=headers,
+                            json=data if json else None,
+                            data=data if not json else None,
+                            params=params,
+                            auth=auth,
+                            verify=self.verify_ssl,
+                            allow_redirects=allow_redirects,
+                            timeout=timeout,
+                        )
                     )
                     resp.raise_for_status()
             except ConnectionError as e:

--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -44,9 +44,9 @@ class BaseApiResponse:
 
     def to_http_response(self) -> HttpResponse:
         """
-        These response types to not inherit from HttpResponse, meaning Django might throw
-        internal library errors when interacting with these responses in middleware. This method
-        returns an HttpResponse equivalent of the request.
+        These response types do not inherit from HttpResponse, meaning Django might throw
+        internal library errors when interacting with these objects in middleware. This method
+        returns an HttpResponse/JsonResponse equivalent of the request.
         """
         response = (
             JsonResponse(self.body)

--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 import requests
+from django.http import HttpResponse, JsonResponse
 from django.utils.functional import cached_property
 from requests import Response
 
@@ -31,11 +32,29 @@ class BaseApiResponse:
     def json(self) -> Any:
         raise NotImplementedError
 
+    @property
+    def body(self) -> Any:
+        return self.json
+
     @cached_property  # type: ignore
     def rel(self) -> Mapping[str, str]:
         link_header = (self.headers or {}).get("Link", "")
         parsed_links = requests.utils.parse_header_links(link_header)
         return {item["rel"]: item["url"] for item in parsed_links}
+
+    def to_http_response(self) -> HttpResponse:
+        """
+        These response types to not inherit from HttpResponse, meaning Django might throw
+        internal library errors when interacting with these responses in middleware. This method
+        returns an HttpResponse equivalent of the request.
+        """
+        response = (
+            JsonResponse(self.body)
+            if self.headers.get("Content-Type") == "application/json"
+            else HttpResponse(self.body)
+        )
+        response.headers = self.headers
+        return response
 
     @classmethod
     def from_response(

--- a/src/sentry/shared_integrations/response/base.py
+++ b/src/sentry/shared_integrations/response/base.py
@@ -50,7 +50,7 @@ class BaseApiResponse:
         """
         response = (
             JsonResponse(self.body)
-            if self.headers.get("Content-Type") == "application/json"
+            if (self.headers or {}).get("Content-Type") == "application/json"
             else HttpResponse(self.body)
         )
         response.headers = self.headers

--- a/src/sentry/shared_integrations/response/text.py
+++ b/src/sentry/shared_integrations/response/text.py
@@ -7,3 +7,7 @@ class TextApiResponse(BaseApiResponse):
     def __init__(self, text: str, *args: Any, **kwargs: Any) -> None:
         self.text = text
         super().__init__(*args, **kwargs)
+
+    @property
+    def body(self) -> Any:
+        return self.text

--- a/src/sentry/shared_integrations/response/xml.py
+++ b/src/sentry/shared_integrations/response/xml.py
@@ -9,3 +9,7 @@ class XmlApiResponse(BaseApiResponse):
     def __init__(self, text: str, *args: Any, **kwargs: Any) -> None:
         self.xml = BeautifulSoup(text, "xml")
         super().__init__(*args, **kwargs)
+
+    @property
+    def body(self) -> Any:
+        return self.xml

--- a/src/sentry/silo/README.md
+++ b/src/sentry/silo/README.md
@@ -76,13 +76,25 @@ To make a **synchronous request** to another Sentry Silo, simply import the clie
 ```python
 from sentry.silo.client import RegionSiloClient
 
-client = RegionSiloClient("region") # For RegionSiloClient, provide the region name
+
+region = get_region_for_organization(organization)
+client = RegionSiloClient(region) # For RegionSiloClient, provide the region
 response = client.get(
     "/organizations/slug/some-endpoint/",
-    headers={"some": "header"}
+    headers={"some header": "some value"}
     data={"some": "payload"}
 )
 print(response.json) # {'some': 'response'}
 ```
 
 > Note: Protected endpoints may not work as expected while we figure out how API credentials work across silos.
+
+To directly **proxy a request synchronously** you can provide the request as follows:
+
+```python
+response = client.proxy_request(self.request)
+print(response.json) # {'some': 'response'}
+
+# If you need to return the response, it must be converted to a HttpResponse to avoid Django errors
+return response.to_http_response()
+```

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -44,7 +44,7 @@ class BaseSiloClient(BaseApiClient):
             modified_headers.pop(invalid_header, None)
         return modified_headers
 
-    def proxy_request(self, incoming_request: HttpRequest):
+    def proxy_request(self, incoming_request: HttpRequest) -> BaseApiResponseX:
         """
         Directly proxy the provided request to the appropriate silo with minimal header changes
         """

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -37,9 +37,11 @@ class BaseSiloClient(BaseApiClient):
             )
 
     def clean_headers(self, headers: Mapping[str, Any] | None) -> Mapping[str, Any]:
+        if not headers:
+            headers = {}
         modified_headers = {**headers}
         for invalid_header in INVALID_PROXY_HEADERS:
-            modified_headers.pop(invalid_header)
+            modified_headers.pop(invalid_header, None)
         return modified_headers
 
     def proxy_request(self, incoming_request: HttpRequest):
@@ -58,7 +60,7 @@ class BaseSiloClient(BaseApiClient):
             allow_text=True,
             prepared_request=prepared_request,
         )
-        return client_response.to_http_response()
+        return client_response
 
     def request(
         self,

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 from typing import Any, Iterable, Mapping
 
 from django.conf import settings
+from django.http.request import HttpRequest
+from requests import Request
 
 from sentry.shared_integrations.client.base import BaseApiClient, BaseApiResponseX
 from sentry.silo.base import SiloMode
-from sentry.types.region import get_region_by_name
+from sentry.types.region import Region, get_region_by_id
+
+INVALID_PROXY_HEADERS = ["Host"]
 
 
 class SiloClientError(Exception):
@@ -23,13 +27,8 @@ class BaseSiloClient(BaseApiClient):
         """
         raise NotImplementedError
 
-    def create_base_url(self, address: str) -> str:
-        # We're intentionally not exposing API Versioning as an interface just yet
-        # This may be revisited once deployment drift prevention in Hybrid Cloud is pinned down.
-        api_prefix = "/api/0"
-        return f"{address}{api_prefix}"
-
     def __init__(self) -> None:
+        super().__init__()
         if SiloMode.get_current_mode() not in self.access_modes:
             access_mode_str = ", ".join(str(m) for m in self.access_modes)
             raise SiloClientError(
@@ -37,13 +36,56 @@ class BaseSiloClient(BaseApiClient):
                 f"Only available in: {access_mode_str}"
             )
 
-    def request(self, *args: Iterable[Any], **kwargs: Mapping[str, Any]) -> BaseApiResponseX:
+    def clean_headers(self, headers: Mapping[str, Any] | None) -> Mapping[str, Any]:
+        modified_headers = {**headers}
+        for invalid_header in INVALID_PROXY_HEADERS:
+            modified_headers.pop(invalid_header)
+        return modified_headers
+
+    def proxy_request(self, incoming_request: HttpRequest):
+        """
+        Directly proxy the provided request to the appropriate silo with minimal header changes
+        """
+        prepared_request = Request(
+            method=incoming_request.method,
+            url=self.build_url(incoming_request.path),
+            headers=self.clean_headers(incoming_request.headers),
+            data=incoming_request.body,
+        ).prepare()
+        client_response = super()._request(
+            incoming_request.method,
+            incoming_request.path,
+            allow_text=True,
+            prepared_request=prepared_request,
+        )
+        return client_response.to_http_response()
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        headers: Mapping[str, Any] | None = None,
+        data: Mapping[str, Any] | None = None,
+        params: Mapping[str, Any] | None = None,
+    ) -> BaseApiResponseX:
+        """
+        Use the BaseApiClient interface to send a cross-region request.
+        If the API is protected, auth may have to be provided manually.
+        """
         # TODO: Establish a scheme to authorize requests across silos
         # (e.g. signing secrets, JWTs)
-        response = super()._request(*args, kwargs)  # type: ignore
+        client_response = super()._request(
+            method,
+            path,
+            headers=self.clean_headers(headers),
+            data=data,
+            params=params,
+            json=True,
+            allow_text=True,
+        )
         # TODO: Establish a scheme to check/log the Sentry Version of the requestor and server
         # optionally raising an error to alert developers of version drift
-        return response
+        return client_response
 
 
 class RegionSiloClient(BaseSiloClient):
@@ -53,10 +95,14 @@ class RegionSiloClient(BaseSiloClient):
     log_path = "sentry.silo.client.region"
     silo_client_name = "region"
 
-    def __init__(self, region_name: str) -> None:
+    def __init__(self, region: Region) -> None:
         super().__init__()
-        self.region = get_region_by_name(region_name)
-        self.base_url = self.create_base_url(self.region.address)
+        if not isinstance(region, Region):
+            raise SiloClientError(f"Invalid region provided. Received {type(region)} type instead.")
+
+        # Ensure the region is registered
+        self.region = get_region_by_id(region.id)
+        self.base_url = self.region.address
 
 
 class ControlSiloClient(BaseSiloClient):
@@ -68,4 +114,4 @@ class ControlSiloClient(BaseSiloClient):
 
     def __init__(self) -> None:
         super().__init__()
-        self.base_url = self.create_base_url(settings.SENTRY_CONTROL_ADDRESS)
+        self.base_url = settings.SENTRY_CONTROL_ADDRESS

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -18,7 +18,7 @@ class SiloClientTest(TestCase):
             ControlSiloClient()
 
         with raises(SiloClientError):
-            RegionSiloClient(self.region.name)
+            RegionSiloClient(self.region)
 
     @override_settings(SILO_MODE=SiloMode.CONTROL)
     @override_settings(SENTRY_REGION_CONFIG=region_config)
@@ -26,17 +26,21 @@ class SiloClientTest(TestCase):
         with raises(SiloClientError):
             ControlSiloClient()
 
-        with raises(RegionResolutionError):
+        with raises(SiloClientError):
             RegionSiloClient("atlantis")
 
-        client = RegionSiloClient(self.region.name)
+        with raises(RegionResolutionError):
+            region = Region("atlantis", 2, self.dummy_address, RegionCategory.MULTI_TENANT)
+            RegionSiloClient(region)
+
+        client = RegionSiloClient(self.region)
         assert self.region.address in client.base_url
 
     @override_settings(SILO_MODE=SiloMode.REGION)
     @override_settings(SENTRY_CONTROL_ADDRESS=dummy_address)
     def test_init_clients_from_region(self):
         with raises(SiloClientError):
-            RegionSiloClient(self.region.name)
+            RegionSiloClient(self.region)
 
         client = ControlSiloClient()
         assert self.dummy_address in client.base_url


### PR DESCRIPTION
See [HC-467](https://getsentry.atlassian.net/browse/HC-467)

This PR allows the cross silo clients to directly proxy requests along with verifying that the region clients are registered before sending data to that sentry instance.