### PR TITLE
feat(issue-platform): Send issue occurrences to eventstream when saving them.

### DIFF
--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -206,7 +206,6 @@ def send_issue_occurrence_to_eventstream(
         is_regression=group_info.is_regression,
         is_new_group_environment=group_info.is_new_group_environment,
         primary_hash=group_event.get_primary_hash(),
-        # Not totally sure this is right. Should it be detection time instead?
         received_timestamp=group_event.data.get("received") or group_event.datetime,
         skip_consume=False,
         group_states=[

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -205,7 +205,7 @@ def send_issue_occurrence_to_eventstream(
         is_new=group_info.is_new,
         is_regression=group_info.is_regression,
         is_new_group_environment=group_info.is_new_group_environment,
-        primary_hash=group_event.get_primary_hash(),
+        primary_hash=occurrence.fingerprint[0],
         received_timestamp=group_event.data.get("received") or group_event.datetime,
         skip_consume=False,
         group_states=[

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -197,17 +197,17 @@ def save_issue_from_occurrence(
 def send_issue_occurrence_to_eventstream(
     event: Event, occurrence: IssueOccurrence, group_info: GroupInfo
 ) -> None:
-    event_group = event.for_group(group_info.group)
-    event_group.occurrence = occurrence
+    group_event = event.for_group(group_info.group)
+    group_event.occurrence = occurrence
 
     eventstream.insert(
-        event=event_group,
+        event=group_event,
         is_new=group_info.is_new,
         is_regression=group_info.is_regression,
         is_new_group_environment=group_info.is_new_group_environment,
-        primary_hash=event_group.get_primary_hash(),
+        primary_hash=group_event.get_primary_hash(),
         # Not totally sure this is right. Should it be detection time instead?
-        received_timestamp=event_group.datetime,
+        received_timestamp=group_event.data.get("received") or group_event.datetime,
         skip_consume=False,
         group_states=[
             {

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -197,8 +197,9 @@ class SaveIssueOccurrenceToEventstreamTest(OccurrenceTestMixin, TestCase):  # ty
                 is_new=group_info.is_new,
                 is_regression=group_info.is_regression,
                 is_new_group_environment=group_info.is_new_group_environment,
-                primary_hash=event.get_primary_hash(),
-                received_timestamp=event.datetime,
+                primary_hash=occurrence.fingerprint[0],
+                received_timestamp=group_event.data.get("received")
+                or group_event.datetime.timestamp(),
                 skip_consume=False,
                 group_states=[
                     {

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -185,15 +185,15 @@ class SaveIssueOccurrenceToEventstreamTest(OccurrenceTestMixin, TestCase):  # ty
     def test(self) -> None:
         # TODO: We should make this a platform event once we have one
         event = self.store_event(data={}, project_id=self.project.id)
-        event_group = event.for_group(self.group)
+        group_event = event.for_group(self.group)
         occurrence = self.build_occurrence(event_id=event.event_id)
         group_info = GroupInfo(event.group, True, False, None, False)
         with mock.patch("sentry.issues.ingest.eventstream") as eventstream, mock.patch.object(
-            event, "for_group", return_value=event_group
+            event, "for_group", return_value=group_event
         ):
             send_issue_occurrence_to_eventstream(event, occurrence, group_info)
             eventstream.insert.assert_called_once_with(
-                event=event_group,
+                event=group_event,
                 is_new=group_info.is_new,
                 is_regression=group_info.is_regression,
                 is_new_group_environment=group_info.is_new_group_environment,


### PR DESCRIPTION
This hooks up the work done in https://github.com/getsentry/sentry/pull/42195 to the occurrence saving process. Tests will fail until we have a dataset available in snuba.
