### PR TITLE
chore: disable flaky visual snapshot test

### DIFF
--- a/tests/acceptance/test_replay_detail.py
+++ b/tests/acceptance/test_replay_detail.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 from uuid import uuid4
 
+import pytest
+
 from sentry.replays.testutils import (
     mock_replay,
     mock_rrweb_div_helloworld,
@@ -75,6 +77,7 @@ class ReplayDetailTest(ReplaysAcceptanceTestCase):
             self.browser.wait_until_not('[data-test-id="loading-indicator"]')
             self.browser.snapshot("replay detail not found")
 
+    @pytest.mark.skip(reason="flaky: https://github.com/getsentry/sentry/issues/42263")
     def test_simple(self):
         with self.feature(FEATURE_NAME):
             self.browser.get(self.path)


### PR DESCRIPTION
see https://github.com/getsentry/sentry/issues/42263 for details

example flaky snapshots:
https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/8439f3febf64f52c2561584a85e06c1de9255171/index.html
https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/f79db1d62bcdf8b183f809fdf3cfb3b8a671084e/index.html