### PR TITLE
ref(perf): Add interaction transactions for clicks

### DIFF
--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -51,6 +51,9 @@ function getSentryIntegrations(sentryConfig: Config['sentryConfig'], routes?: Fu
       _metricOptions: {
         _reportAllChanges: false,
       },
+      _experiments: {
+        enableInteractions: true,
+      },
       ...partialTracingOptions,
     }),
   ];
@@ -84,6 +87,12 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
     allowUrls: SPA_DSN ? SPA_MODE_ALLOW_URLS : sentryConfig?.whitelistUrls,
     integrations: getSentryIntegrations(sentryConfig, routes),
     tracesSampleRate,
+    tracesSampler: context => {
+      if (context.transactionContext.op?.startsWith('ui.action')) {
+        return tracesSampleRate / 100;
+      }
+      return tracesSampleRate;
+    },
     /**
      * There is a bug in Safari, that causes `AbortError` when fetch is
      * aborted, and you are in the middle of reading the response. In Chrome


### PR DESCRIPTION
### Summary
This adds the 'interactions' to our frontend automatically on click. This will help capture a lot of performance behaviour in SPA's that currently isn't covered, but can be a core part of user journeys (eg. settings modals, paywalls etc. are all on-page examples of what might get captured by click interactions).

Caveats:
- For now our idleTimeout of 5000ms will also apply so for the first interactions we may capture more spans than we should to cover an interaction, as well as the fact that other user behaviour (eg. scroll) isn't currently captured, but can create spans and reset the idleTimeout.
- We probably want to add click-targets for click interactions to the interaction themselves to help identify the source of the click.

Other:
- Sets the rate at 1/100th our sample rate (1% right now) for interactions to keep it low, we can always bump or trend down the number later.
