### PR TITLE
feat(hybrid-cloud): Add organization mapping service

### DIFF
--- a/src/sentry/api/serializers/models/__init__.py
+++ b/src/sentry/api/serializers/models/__init__.py
@@ -6,6 +6,7 @@ from .alert_rule_trigger_action import *  # noqa: F401,F403
 from .apiapplication import *  # noqa: F401,F403
 from .apiauthorization import *  # noqa: F401,F403
 from .apikey import *  # noqa: F401,F403
+from .apiorganizationmapping import *  # noqa: F401,F403
 from .apitoken import *  # noqa: F401,F403
 from .app_platform_event import *  # noqa: F401,F403
 from .auditlogentry import *  # noqa: F401,F403

--- a/src/sentry/api/serializers/models/apiorganizationmapping.py
+++ b/src/sentry/api/serializers/models/apiorganizationmapping.py
@@ -1,0 +1,19 @@
+from typing import Any, Mapping
+
+from sentry.api.serializers import Serializer, register
+from sentry.models.user import User
+from sentry.services.hybrid_cloud.organization_mapping import APIOrganizationMapping
+
+
+@register(APIOrganizationMapping)
+class APIOrganizationMappingSerializer(Serializer):  # type: ignore
+    def serialize(self, obj: APIOrganizationMapping, attrs: Mapping[str, Any], user: User):
+        return {
+            "id": obj.id,
+            "organizationId": str(obj.organization_id),
+            "slug": obj.slug,
+            "regionName": obj.region_name,
+            "dateCreated": obj.date_created,
+            "verified": obj.verified,
+            "customerId": obj.customer_id,
+        }

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -35,7 +35,10 @@ class OrganizationMappingService(InterfaceWithLifecycle):
     ) -> APIOrganizationMapping:
         """
         This method returns a new or recreated OrganizationMapping object.
+        If a record already exists with the same slug, the organization_id can only be
+        updated IF the idempotency key is identical.
         Will raise IntegrityError if the slug already exists.
+
         :param organization_id:
         The org id to create the slug for
         :param slug:

--- a/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/__init__.py
@@ -1,0 +1,71 @@
+from abc import abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+from django.utils import timezone
+
+from sentry.models.user import User
+from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
+from sentry.silo import SiloMode
+
+
+@dataclass(frozen=True, eq=True)
+class APIOrganizationMapping:
+    id: int = -1
+    organization_id: int = -1
+    slug: str = ""
+    region_name: str = ""
+    date_created: datetime = timezone.now()
+    verified: bool = False
+    customer_id: Optional[str] = None
+
+
+class OrganizationMappingService(InterfaceWithLifecycle):
+    @abstractmethod
+    def create(
+        self,
+        *,
+        user: User,
+        organization_id: int,
+        slug: str,
+        region_name: str,
+        idempotency_key: Optional[str] = "",
+        customer_id: Optional[str],
+    ) -> APIOrganizationMapping:
+        """
+        This method returns a new or recreated OrganizationMapping object.
+        Will raise IntegrityError if the slug already exists.
+        :param organization_id:
+        The org id to create the slug for
+        :param slug:
+        A slug to reserve for this organization
+        :param customer_id:
+        A unique per customer billing identifier
+        :return:
+        """
+        pass
+
+    def close(self) -> None:
+        pass
+
+    @abstractmethod
+    def update_customer_id(self, organization_id: int, customer_id: str) -> Any:
+        pass
+
+
+def impl_with_db() -> OrganizationMappingService:
+    from sentry.services.hybrid_cloud.organization_mapping.impl import (
+        DatabaseBackedOrganizationMappingService,
+    )
+
+    return DatabaseBackedOrganizationMappingService()
+
+
+organization_mapping_service: OrganizationMappingService = silo_mode_delegation(
+    {
+        SiloMode.MONOLITH: impl_with_db,
+        SiloMode.REGION: stubbed(impl_with_db, SiloMode.CONTROL),
+        SiloMode.CONTROL: impl_with_db,
+    }
+)

--- a/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization_mapping/impl.py
@@ -1,0 +1,75 @@
+from dataclasses import fields
+from typing import Any, Optional
+
+from django.db import IntegrityError, transaction
+
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.models.user import User
+from sentry.services.hybrid_cloud.organization_mapping import (
+    APIOrganizationMapping,
+    OrganizationMappingService,
+)
+
+
+class DatabaseBackedOrganizationMappingService(OrganizationMappingService):
+    def create(
+        self,
+        *,
+        user: User,
+        organization_id: int,
+        slug: str,
+        region_name: str,
+        idempotency_key: Optional[str] = "",
+        # There's only a customer_id when updating an org slug
+        customer_id: Optional[str] = None,
+    ) -> APIOrganizationMapping:
+        try:
+            with transaction.atomic():
+                # Creating an identical mapping should succeed, even if a record already exists
+                # with this slug. We allow this IFF the idempotency key is identical.
+                org_mapping = OrganizationMapping.objects.create(
+                    organization_id=organization_id,
+                    slug=slug,
+                    customer_id=customer_id,
+                    idempotency_key=idempotency_key,
+                    region_name=region_name,
+                )
+            return self.serialize_organization_mapping(org_mapping)
+        except IntegrityError:
+            pass
+
+        # If we got here, the slug already exists
+        if idempotency_key != "":
+            try:
+                with transaction.atomic():
+                    existing_mapping = OrganizationMapping.objects.select_for_update().get(
+                        slug=slug, idempotency_key=idempotency_key
+                    )
+                    existing_mapping.update(
+                        organization_id=organization_id,
+                        customer_id=customer_id,
+                        region_name=region_name,
+                    )
+                return self.serialize_organization_mapping(existing_mapping)
+            except OrganizationMapping.DoesNotExist:
+                pass
+
+        raise IntegrityError("An organization with this slug already exists.")
+
+    def serialize_organization_mapping(
+        cls, org_mapping: OrganizationMapping
+    ) -> APIOrganizationMapping:
+        args = {
+            field.name: getattr(org_mapping, field.name)
+            for field in fields(APIOrganizationMapping)
+            if hasattr(org_mapping, field.name)
+        }
+        return APIOrganizationMapping(**args)
+
+    def update_customer_id(self, organization_id: int, customer_id: str) -> Any:
+        with transaction.atomic():
+            return (
+                OrganizationMapping.objects.filter(organization_id=organization_id)
+                .select_for_update()
+                .update(customer_id=customer_id)
+            )

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -91,6 +91,7 @@ from sentry.models import (
     UserReport,
 )
 from sentry.models.integrations.integration_feature import Feature, IntegrationTypes
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.releasefile import update_artifact_index
 from sentry.signals import project_created
 from sentry.snuba.dataset import Dataset
@@ -254,6 +255,13 @@ class Factories:
         if owner:
             Factories.create_member(organization=org, user=owner, role="owner")
         return org
+
+    @staticmethod
+    @exempt_from_silo_limits()
+    def create_organization_mapping(org, **kwargs):
+        kwargs.setdefault("slug", org.slug)
+        mapping = OrganizationMapping.objects.create(organization_id=org.id, **kwargs)
+        return mapping
 
     @staticmethod
     @exempt_from_silo_limits()

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -431,6 +431,9 @@ class Fixtures:
     def create_saved_search(self, *args, **kwargs):
         return Factories.create_saved_search(*args, **kwargs)
 
+    def create_organization_mapping(self, *args, **kwargs):
+        return Factories.create_organization_mapping(*args, **kwargs)
+
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot):
         self.insta_snapshot = insta_snapshot

--- a/tests/sentry/hybrid_cloud/test_organizationmapping.py
+++ b/tests/sentry/hybrid_cloud/test_organizationmapping.py
@@ -1,0 +1,92 @@
+import pytest
+from django.db import IntegrityError
+
+from sentry.api.serializers import serialize
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.services.hybrid_cloud.organization_mapping import organization_mapping_service
+from sentry.testutils import TransactionTestCase
+from sentry.testutils.silo import control_silo_test
+
+
+@control_silo_test(stable=True)
+class OrganizationMappingTest(TransactionTestCase):
+    def test_create(self):
+        fields = {
+            "user": self.user,
+            "organization_id": self.organization.id,
+            "slug": self.organization.slug,
+            "region_name": "us",
+        }
+        api_org_mapping = organization_mapping_service.create(**fields)
+        org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+
+        data = serialize(api_org_mapping, self.user)
+        assert data["id"]
+        assert data["organizationId"] == str(self.organization.id)
+        assert data["verified"] is False
+        assert data["slug"] == fields["slug"]
+        assert data["regionName"] == fields["region_name"]
+        assert data["dateCreated"] == org_mapping.date_created
+
+    def test_idempotency_key(self):
+        data = {
+            "slug": self.organization.slug,
+            "region_name": "us",
+            "idempotency_key": "test",
+        }
+        self.create_organization_mapping(self.organization, **data)
+        next_organization_id = 7654321
+        api_org_mapping = organization_mapping_service.create(
+            **{
+                **data,
+                "user": self.user,
+                "organization_id": next_organization_id,
+                "region_name": "de",
+            }
+        )
+
+        assert not OrganizationMapping.objects.filter(organization_id=self.organization.id).exists()
+        assert OrganizationMapping.objects.filter(organization_id=next_organization_id)
+
+        data = serialize(api_org_mapping, self.user)
+        assert data["id"]
+        assert data["organizationId"] == str(next_organization_id)
+        assert data["regionName"] == "de"
+
+    def test_duplicate_slug(self):
+        data = {
+            "slug": self.organization.slug,
+            "region_name": "us",
+            "idempotency_key": "test",
+        }
+        self.create_organization_mapping(self.organization, **data)
+
+        with pytest.raises(IntegrityError):
+            organization_mapping_service.create(
+                **{
+                    **data,
+                    "user": self.user,
+                    "organization_id": 7654321,
+                    "region_name": "de",
+                    "idempotency_key": "test2",
+                }
+            )
+
+    def test_update_customer_id(self):
+        fields = {
+            "user": self.user,
+            "organization_id": self.organization.id,
+            "slug": self.organization.slug,
+            "region_name": "us",
+        }
+        api_org_mapping = organization_mapping_service.create(**fields)
+        assert api_org_mapping.customer_id is None
+
+        assert (
+            organization_mapping_service.update_customer_id(
+                organization_id=self.organization.id, customer_id="test"
+            )
+            == 1
+        )
+        org_mapping = OrganizationMapping.objects.get(organization_id=self.organization.id)
+        assert org_mapping.customer_id == "test"


### PR DESCRIPTION
Adds an organization mapping service to handle cross-silo communication when creating an organization to region mapping. [Internal documentation](https://www.notion.so/sentry/Draft-Reduce-usage-of-replication-from-Control-to-Region-Silos-7265991ff2104f1490acfded02b6a1b3#763a77050ceb4bf699995fb04f5b01aa)

Split out from #41113 