### PR TITLE
feat(workflow): Hide alert rule fallback options for teams

### DIFF
--- a/static/app/views/alerts/rules/issue/memberTeamFields.tsx
+++ b/static/app/views/alerts/rules/issue/memberTeamFields.tsx
@@ -79,48 +79,57 @@ class MemberTeamFields extends Component<Props> {
 
     return (
       <PanelItemGrid>
-        <SelectControl
-          isClearable={false}
-          isDisabled={disabled || loading}
-          value={ruleData.targetType}
-          styles={selectControlStyles}
-          options={options}
-          onChange={this.handleChangeActorType}
-        />
-        {teamSelected ? (
-          <TeamSelector
-            disabled={disabled}
-            key={teamValue}
-            project={project}
-            // The value from the endpoint is of type `number`, `SelectMembers` require value to be of type `string`
-            value={`${ruleData.targetIdentifier}`}
+        <SelectWrapper>
+          <SelectControl
+            isClearable={false}
+            isDisabled={disabled || loading}
+            value={ruleData.targetType}
             styles={selectControlStyles}
-            onChange={this.handleChangeActorId}
-            useId
+            options={options}
+            onChange={this.handleChangeActorType}
           />
-        ) : memberSelected ? (
-          <SelectMembers
-            disabled={disabled}
-            key={teamSelected ? teamValue : memberValue}
-            project={project}
-            organization={organization}
-            // The value from the endpoint is of type `number`, `SelectMembers` require value to be of type `string`
-            value={`${ruleData.targetIdentifier}`}
-            styles={selectControlStyles}
-            onChange={this.handleChangeActorId}
-          />
-        ) : null}
+        </SelectWrapper>
+        {(teamSelected || memberSelected) && (
+          <SelectWrapper>
+            {teamSelected ? (
+              <TeamSelector
+                disabled={disabled}
+                key={teamValue}
+                project={project}
+                // The value from the endpoint is of type `number`, `SelectMembers` require value to be of type `string`
+                value={`${ruleData.targetIdentifier}`}
+                styles={selectControlStyles}
+                onChange={this.handleChangeActorId}
+                useId
+              />
+            ) : memberSelected ? (
+              <SelectMembers
+                disabled={disabled}
+                key={teamSelected ? teamValue : memberValue}
+                project={project}
+                organization={organization}
+                // The value from the endpoint is of type `number`, `SelectMembers` require value to be of type `string`
+                value={`${ruleData.targetIdentifier}`}
+                styles={selectControlStyles}
+                onChange={this.handleChangeActorId}
+              />
+            ) : null}
+          </SelectWrapper>
+        )}
       </PanelItemGrid>
     );
   }
 }
 
 const PanelItemGrid = styled(PanelItem)`
-  display: grid;
-  grid-template-columns: 200px 200px;
-  padding: 0;
+  display: flex;
   align-items: center;
+  padding: 0;
   gap: ${space(2)};
+`;
+
+const SelectWrapper = styled('div')`
+  width: 200px;
 `;
 
 export default MemberTeamFields;

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -304,8 +304,7 @@ function RuleNode({
     if (
       data.id === NOTIFY_EMAIL_ACTION &&
       data.targetType !== MailActionTargetType.IssueOwners &&
-      organization.features.includes('issue-alert-fallback-targeting') &&
-      label.startsWith('Send a notification to {targetType}')
+      organization.features.includes('issue-alert-fallback-targeting')
     ) {
       // Hide the fallback options when targeting team or member
       label = 'Send a notification to {targetType}';

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -299,15 +299,17 @@ function RuleNode({
       );
     }
 
+    let {label} = node;
+
     if (
       data.id === NOTIFY_EMAIL_ACTION &&
       data.targetType !== MailActionTargetType.IssueOwners &&
-      organization.features.includes('issue-alert-fallback-targeting')
+      organization.features.includes('issue-alert-fallback-targeting') &&
+      label.startsWith('Send a notification to {targetType}')
     ) {
-      node = {...node, label: 'Send a notification to {targetType}'};
+      // Hide the fallback options when targeting team or member
+      label = 'Send a notification to {targetType}';
     }
-
-    const {label, formFields} = node;
 
     const parts = label.split(/({\w+})/).map((part, i) => {
       if (!/^{\w+}$/.test(part)) {
@@ -323,8 +325,8 @@ function RuleNode({
       }
       return (
         <Separator key={key}>
-          {formFields && formFields.hasOwnProperty(key)
-            ? getField(key, formFields[key])
+          {node.formFields && node.formFields.hasOwnProperty(key)
+            ? getField(key, node.formFields[key])
             : part}
         </Separator>
       );

--- a/static/app/views/alerts/rules/issue/ruleNode.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNode.tsx
@@ -28,6 +28,8 @@ import TicketRuleModal from 'sentry/views/alerts/rules/issue/ticketRuleModal';
 import {SchemaFormConfig} from 'sentry/views/organizationIntegrations/sentryAppExternalForm';
 import {EVENT_FREQUENCY_PERCENT_CONDITION} from 'sentry/views/projectInstall/issueAlertOptions';
 
+const NOTIFY_EMAIL_ACTION = 'sentry.mail.actions.NotifyEmailAction';
+
 interface FieldProps {
   data: Props['data'];
   disabled: boolean;
@@ -297,6 +299,14 @@ function RuleNode({
       );
     }
 
+    if (
+      data.id === NOTIFY_EMAIL_ACTION &&
+      data.targetType !== MailActionTargetType.IssueOwners &&
+      organization.features.includes('issue-alert-fallback-targeting')
+    ) {
+      node = {...node, label: 'Send a notification to {targetType}'};
+    }
+
     const {label, formFields} = node;
 
     const parts = label.split(/({\w+})/).map((part, i) => {
@@ -382,8 +392,9 @@ function RuleNode({
     }
 
     if (
-      data.id === 'sentry.mail.actions.NotifyEmailAction' &&
-      data.targetType === MailActionTargetType.IssueOwners
+      data.id === NOTIFY_EMAIL_ACTION &&
+      data.targetType === MailActionTargetType.IssueOwners &&
+      !organization.features.includes('issue-alert-fallback-targeting')
     ) {
       return (
         <MarginlessAlert type="warning">


### PR DESCRIPTION
Hides the fallback options when selecting a team or member

WOR-2500

gets the frontend ready for https://github.com/getsentry/sentry/pull/42191