### PR TITLE
fix(weekly-report): wrap filter call in list()

### DIFF
--- a/src/sentry/tasks/weekly_reports.py
+++ b/src/sentry/tasks/weekly_reports.py
@@ -382,16 +382,18 @@ def fetch_key_error_groups(ctx):
     for project_ctx in ctx.projects.values():
         # note Snuba might have groups that have since been deleted
         # we should just ignore those
-        project_ctx.key_errors = filter(
-            lambda x: x[0] is not None,
-            [
-                (
-                    group_id_to_group.get(group_id),
-                    group_id_to_group_history.get(group_id, None),
-                    count,
-                )
-                for group_id, count in project_ctx.key_errors
-            ],
+        project_ctx.key_errors = list(
+            filter(
+                lambda x: x[0] is not None,
+                [
+                    (
+                        group_id_to_group.get(group_id),
+                        group_id_to_group_history.get(group_id, None),
+                        count,
+                    )
+                    for group_id, count in project_ctx.key_errors
+                ],
+            )
         )
 
 


### PR DESCRIPTION
- previously, the weekly report was using `filter` as part of the `key_errors` calculation. filter returns an iterable, which will be empty after it is iterated through. 
- we fix this by adding a wrapping `list` call
- update one test to send an email to two organization members, and check the length of key_errors. this test fails on master.