### PR TITLE
ref(hybrid-cloud): add optional orgId route param to AcceptOrganizationInvite

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -153,6 +153,10 @@ function buildRoutes() {
     <Fragment>
       <IndexRoute component={make(() => import('sentry/views/app/root'))} />
       <Route
+        path="/accept/:orgId/:memberId/:token/"
+        component={make(() => import('sentry/views/acceptOrganizationInvite'))}
+      />
+      <Route
         path="/accept/:memberId/:token/"
         component={make(() => import('sentry/views/acceptOrganizationInvite'))}
       />

--- a/static/app/views/acceptOrganizationInvite.spec.jsx
+++ b/static/app/views/acceptOrganizationInvite.spec.jsx
@@ -9,7 +9,7 @@ jest.mock('sentry/actionCreators/account');
 
 const addMock = body =>
   MockApiClient.addMockResponse({
-    url: '/accept-invite/1/abc/',
+    url: '/accept-invite/test-org/1/abc/',
     method: 'GET',
     body,
   });
@@ -28,10 +28,14 @@ describe('AcceptOrganizationInvite', function () {
       existingMember: false,
     });
 
-    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
+    render(
+      <AcceptOrganizationInvite
+        params={{memberId: '1', orgId: 'test-org', token: 'abc'}}
+      />
+    );
 
     const acceptMock = MockApiClient.addMockResponse({
-      url: '/accept-invite/1/abc/',
+      url: '/accept-invite/test-org/1/abc/',
       method: 'POST',
     });
 
@@ -56,7 +60,11 @@ describe('AcceptOrganizationInvite', function () {
       existingMember: false,
     });
 
-    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
+    render(
+      <AcceptOrganizationInvite
+        params={{memberId: '1', orgId: 'test-org', token: 'abc'}}
+      />
+    );
 
     expect(getJoinButton()).not.toBeInTheDocument();
 
@@ -82,7 +90,11 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
+    render(
+      <AcceptOrganizationInvite
+        params={{memberId: '1', orgId: 'test-org', token: 'abc'}}
+      />
+    );
 
     expect(getJoinButton()).not.toBeInTheDocument();
 
@@ -109,7 +121,11 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
+    render(
+      <AcceptOrganizationInvite
+        params={{memberId: '1', orgId: 'test-org', token: 'abc'}}
+      />
+    );
 
     expect(getJoinButton()).not.toBeInTheDocument();
 
@@ -136,7 +152,11 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
+    render(
+      <AcceptOrganizationInvite
+        params={{memberId: '1', orgId: 'test-org', token: 'abc'}}
+      />
+    );
 
     expect(getJoinButton()).not.toBeInTheDocument();
 
@@ -163,7 +183,11 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
+    render(
+      <AcceptOrganizationInvite
+        params={{memberId: '1', orgId: 'test-org', token: 'abc'}}
+      />
+    );
 
     expect(screen.getByTestId('existing-member')).toBeInTheDocument();
 
@@ -184,7 +208,11 @@ describe('AcceptOrganizationInvite', function () {
       ssoProvider: 'SSO',
     });
 
-    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
+    render(
+      <AcceptOrganizationInvite
+        params={{memberId: '1', orgId: 'test-org', token: 'abc'}}
+      />
+    );
 
     expect(screen.getByTestId('action-info-sso')).toBeInTheDocument();
 
@@ -201,7 +229,11 @@ describe('AcceptOrganizationInvite', function () {
       existingMember: true,
     });
 
-    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
+    render(
+      <AcceptOrganizationInvite
+        params={{memberId: '1', orgId: 'test-org', token: 'abc'}}
+      />
+    );
 
     expect(screen.getByTestId('existing-member')).toBeInTheDocument();
     userEvent.click(screen.getByTestId('existing-member-link'));
@@ -220,7 +252,11 @@ describe('AcceptOrganizationInvite', function () {
       existingMember: false,
     });
 
-    render(<AcceptOrganizationInvite params={{memberId: '1', token: 'abc'}} />);
+    render(
+      <AcceptOrganizationInvite
+        params={{memberId: '1', orgId: 'test-org', token: 'abc'}}
+      />
+    );
 
     expect(
       screen.getByRole('button', {name: 'Configure Two-Factor Auth'})

--- a/static/app/views/acceptOrganizationInvite.tsx
+++ b/static/app/views/acceptOrganizationInvite.tsx
@@ -26,7 +26,7 @@ type InviteDetails = {
   ssoProvider?: string;
 };
 
-type Props = RouteComponentProps<{memberId: string; token: string}, {}>;
+type Props = RouteComponentProps<{memberId: string; token: string; orgId?: string}, {}>;
 
 type State = AsyncView['state'] & {
   acceptError: boolean | undefined;
@@ -38,7 +38,10 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
   disableErrorReport = false;
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {memberId, token} = this.props.params;
+    const {memberId, orgId, token} = this.props.params;
+    if (orgId) {
+      return [['inviteDetails', `/accept-invite/${orgId}/${memberId}/${token}/`]];
+    }
     return [['inviteDetails', `/accept-invite/${memberId}/${token}/`]];
   }
 
@@ -57,13 +60,19 @@ class AcceptOrganizationInvite extends AsyncView<Props, State> {
   };
 
   handleAcceptInvite = async () => {
-    const {memberId, token} = this.props.params;
+    const {memberId, orgId, token} = this.props.params;
 
     this.setState({accepting: true});
     try {
-      await this.api.requestPromise(`/accept-invite/${memberId}/${token}/`, {
-        method: 'POST',
-      });
+      if (orgId) {
+        await this.api.requestPromise(`/accept-invite/${orgId}/${memberId}/${token}/`, {
+          method: 'POST',
+        });
+      } else {
+        await this.api.requestPromise(`/accept-invite/${memberId}/${token}/`, {
+          method: 'POST',
+        });
+      }
       browserHistory.replace(`/${this.state.inviteDetails.orgSlug}/`);
     } catch {
       this.setState({acceptError: true});


### PR DESCRIPTION
Adds optional orgslug param to the frontend route for AcceptOrganizationInvite. Part 1 of changing the invite link urls to include the organization slugs.

For HC-511