### PR TITLE
feat(issue-platform): Include the `IssueOccurrence` with the `GroupEvent` when fetching latest event

### DIFF
--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -140,7 +140,7 @@ class EventStorage(Service):
             Columns.PROJECT_ID,
             Columns.TIMESTAMP,
         ],
-        Dataset.IssuePlatformGeneric: [
+        Dataset.IssuePlatform: [
             Columns.EVENT_ID,
             Columns.GROUP_ID,
             Columns.PROJECT_ID,

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -140,6 +140,13 @@ class EventStorage(Service):
             Columns.PROJECT_ID,
             Columns.TIMESTAMP,
         ],
+        Dataset.IssuePlatformGeneric: [
+            Columns.EVENT_ID,
+            Columns.GROUP_ID,
+            Columns.PROJECT_ID,
+            Columns.TIMESTAMP,
+            Columns.OCCURRENCE_ID,
+        ],
     }
 
     def get_events(

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -678,7 +678,7 @@ class Event(BaseEvent):
         for group in self.groups:
             yield GroupEvent.from_event(self, group)
 
-    def for_group(self, group: Group):
+    def for_group(self, group: Group) -> GroupEvent:
         return GroupEvent.from_event(self, group)
 
 
@@ -722,7 +722,7 @@ class GroupEvent(BaseEvent):
         self._data = value
 
     @classmethod
-    def from_event(cls, event: Event, group: Group):
+    def from_event(cls, event: Event, group: Group) -> GroupEvent:
         group_event = cls(
             project_id=event.project_id,
             event_id=event.event_id,
@@ -741,6 +741,16 @@ class GroupEvent(BaseEvent):
     @occurrence.setter
     def occurrence(self, value: IssueOccurrence) -> None:
         self._occurrence = value
+
+    @property
+    def occurrence_id(self) -> Optional[str]:
+        if self.occurrence:
+            return self.occurrence.id
+
+        column = self._get_column_name(Columns.OCCURRENCE_ID)
+        if column in self._snuba_data:
+            return cast(str, self._snuba_data[column])
+        return None
 
 
 class EventSubjectTemplate(string.Template):

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -205,7 +205,7 @@ def get_oldest_or_latest_event_for_environments(
         if group.issue_category == GroupCategory.ERROR:
             dataset = Dataset.Events
         else:
-            dataset = Dataset.IssuePlatformGeneric
+            dataset = Dataset.IssuePlatform
 
         _filter = eventstore.Filter(
             conditions=conditions, project_ids=[group.project_id], group_ids=[group.id]

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -192,9 +192,15 @@ def get_oldest_or_latest_event_for_environments(
         conditions.append(["environment", "IN", environments])
 
     if (
-        features.has("organizations:performance-issues", group.organization)
+        not features.has("organizations:performance-issues", group.organization)
         and group.issue_category == GroupCategory.PERFORMANCE
     ):
+        # Generally we shouldn't arrive here, since if the feature flag is disabled we shouldn't
+        # be loading performance issues. Regardless, if the flag is disabled we should always return
+        # None here.
+        return None
+
+    if group.issue_category == GroupCategory.PERFORMANCE:
         apply_performance_conditions(conditions, group)
         _filter = eventstore.Filter(
             conditions=conditions,

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -31,6 +31,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.eventstore.models import GroupEvent
+from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.query import apply_performance_conditions
 from sentry.models.grouphistory import record_group_history_from_activity_type
 from sentry.snuba.dataset import Dataset
@@ -201,10 +202,14 @@ def get_oldest_or_latest_event_for_environments(
         )
         dataset = Dataset.Transactions
     else:
+        if group.issue_category == GroupCategory.ERROR:
+            dataset = Dataset.Events
+        else:
+            dataset = Dataset.IssuePlatformGeneric
+
         _filter = eventstore.Filter(
             conditions=conditions, project_ids=[group.project_id], group_ids=[group.id]
         )
-        dataset = Dataset.Events
 
     events = eventstore.get_events(
         filter=_filter,
@@ -215,7 +220,16 @@ def get_oldest_or_latest_event_for_environments(
     )
 
     if events:
-        return events[0].for_group(group)
+        group_event = events[0].for_group(group)
+        occurrence_id = group_event.occurrence_id
+        if occurrence_id:
+            group_event.occurrence = IssueOccurrence.fetch(occurrence_id, group.project_id)
+            if group_event.occurrence is None:
+                logger.error(
+                    "Failed to fetch occurrence for event",
+                    extra={"group_id", group.id, "occurrence_id", occurrence_id},
+                )
+        return group_event
 
     return None
 

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -1,7 +1,16 @@
-from collections import namedtuple
+from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
 
-Column = namedtuple("Column", "group_name event_name transaction_name discover_name alias")
+
+@dataclass
+class Column:
+    group_name: Optional[str]
+    event_name: Optional[str]
+    transaction_name: Optional[str]
+    discover_name: Optional[str]
+    alias: Optional[str]
+    issue_platform_name: Optional[str] = None
 
 
 class Columns(Enum):
@@ -17,6 +26,7 @@ class Columns(Enum):
         event_name="event_id",
         transaction_name="event_id",
         discover_name="event_id",
+        issue_platform_name="event_id",
         alias="id",
     )
     GROUP_ID = Column(
@@ -24,6 +34,7 @@ class Columns(Enum):
         event_name="group_id",
         transaction_name=None,
         discover_name="group_id",
+        issue_platform_name="group_id",
         alias="issue.id",
     )
     # This is needed to query transactions by group id
@@ -36,11 +47,20 @@ class Columns(Enum):
         discover_name="group_ids",
         alias="performance.issue_ids",
     )
+    OCCURRENCE_ID = Column(
+        group_name=None,
+        event_name="occurrence_id",
+        transaction_name=None,
+        discover_name=None,
+        issue_platform_name="occurrence_id",
+        alias="occurrence_id",
+    )
     PROJECT_ID = Column(
         group_name="events.project_id",
         event_name="project_id",
         transaction_name="project_id",
         discover_name="project_id",
+        issue_platform_name="project_id",
         alias="project.id",
     )
     TIMESTAMP = Column(
@@ -48,6 +68,7 @@ class Columns(Enum):
         event_name="timestamp",
         transaction_name="finish_ts",
         discover_name="timestamp",
+        issue_platform_name="timestamp",
         alias="timestamp",
     )
     TIME = Column(

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -83,6 +83,12 @@ TRANSACTIONS_SNUBA_MAP = {
     if col.value.transaction_name is not None
 }
 
+ISSUE_PLATFORM_MAP = {
+    col.value.alias: col.value.issue_platform_name
+    for col in Columns
+    if col.value.issue_platform_name is not None
+}
+
 SESSIONS_FIELD_LIST = [
     "release",
     "sessions",
@@ -130,6 +136,7 @@ DATASETS = {
     Dataset.Sessions: SESSIONS_SNUBA_MAP,
     Dataset.Metrics: METRICS_COLUMN_MAP,
     Dataset.PerformanceMetrics: METRICS_COLUMN_MAP,
+    Dataset.IssuePlatformGeneric: ISSUE_PLATFORM_MAP,
 }
 
 # Store the internal field names to save work later on.
@@ -140,6 +147,7 @@ DATASET_FIELDS = {
     Dataset.Transactions: list(TRANSACTIONS_SNUBA_MAP.values()),
     Dataset.Discover: list(DISCOVER_COLUMN_MAP.values()),
     Dataset.Sessions: SESSIONS_FIELD_LIST,
+    Dataset.IssuePlatformGeneric: list(ISSUE_PLATFORM_MAP.values()),
 }
 
 SNUBA_OR = "or"

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -136,7 +136,7 @@ DATASETS = {
     Dataset.Sessions: SESSIONS_SNUBA_MAP,
     Dataset.Metrics: METRICS_COLUMN_MAP,
     Dataset.PerformanceMetrics: METRICS_COLUMN_MAP,
-    Dataset.IssuePlatformGeneric: ISSUE_PLATFORM_MAP,
+    Dataset.IssuePlatform: ISSUE_PLATFORM_MAP,
 }
 
 # Store the internal field names to save work later on.
@@ -147,7 +147,7 @@ DATASET_FIELDS = {
     Dataset.Transactions: list(TRANSACTIONS_SNUBA_MAP.values()),
     Dataset.Discover: list(DISCOVER_COLUMN_MAP.values()),
     Dataset.Sessions: SESSIONS_FIELD_LIST,
-    Dataset.IssuePlatformGeneric: list(ISSUE_PLATFORM_MAP.values()),
+    Dataset.IssuePlatform: list(ISSUE_PLATFORM_MAP.values()),
 }
 
 SNUBA_OR = "or"

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.db.models import ProtectedError
 from django.utils import timezone
 
+from sentry.issues.ingest import save_issue_occurrence
 from sentry.models import (
     Group,
     GroupRedirect,
@@ -18,6 +19,8 @@ from sentry.models.release import _get_cache_key
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
+from sentry.types.issues import GroupType
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 @region_silo_test(stable=True)
@@ -25,8 +28,6 @@ class GroupTest(TestCase, SnubaTestCase):
     def setUp(self):
         super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
-        self.two_min_ago = iso_format(before_now(minutes=2))
-        self.just_over_one_min_ago = iso_format(before_now(seconds=61))
 
     def test_is_resolved(self):
         group = self.create_group(status=GroupStatus.RESOLVED)
@@ -47,42 +48,6 @@ class GroupTest(TestCase, SnubaTestCase):
         group.project.update_option("sentry:resolve_age", 1)
 
         assert group.is_resolved()
-
-    def test_get_latest_event_no_events(self):
-        project = self.create_project()
-        group = self.create_group(project=project)
-        assert group.get_latest_event() is None
-
-    def test_get_latest_event(self):
-        self.store_event(
-            data={"event_id": "a" * 32, "fingerprint": ["group-1"], "timestamp": self.two_min_ago},
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={"event_id": "b" * 32, "fingerprint": ["group-1"], "timestamp": self.min_ago},
-            project_id=self.project.id,
-        )
-
-        group = Group.objects.first()
-
-        assert group.get_latest_event().event_id == "b" * 32
-
-    def test_get_latest_almost_identical_timestamps(self):
-        self.store_event(
-            data={
-                "event_id": "a" * 32,
-                "fingerprint": ["group-1"],
-                "timestamp": self.just_over_one_min_ago,
-            },
-            project_id=self.project.id,
-        )
-        self.store_event(
-            data={"event_id": "b" * 32, "fingerprint": ["group-1"], "timestamp": self.min_ago},
-            project_id=self.project.id,
-        )
-        group = Group.objects.first()
-
-        assert group.get_latest_event().event_id == "b" * 32
 
     def test_is_ignored_with_expired_snooze(self):
         group = self.create_group(status=GroupStatus.IGNORED)
@@ -330,3 +295,70 @@ class GroupIsOverResolveAgeTest(TestCase):
         assert group.is_over_resolve_age() is True
         group.last_seen = timezone.now()
         assert group.is_over_resolve_age() is False
+
+
+class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
+    def setUp(self):
+        super().setUp()
+        self.min_ago = iso_format(before_now(minutes=1))
+        self.two_min_ago = iso_format(before_now(minutes=2))
+        self.just_over_one_min_ago = iso_format(before_now(seconds=61))
+
+    def test_get_latest_event_no_events(self):
+        project = self.create_project()
+        group = self.create_group(project=project)
+        assert group.get_latest_event() is None
+
+    def test_get_latest_event(self):
+        self.store_event(
+            data={"event_id": "a" * 32, "fingerprint": ["group-1"], "timestamp": self.two_min_ago},
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={"event_id": "b" * 32, "fingerprint": ["group-1"], "timestamp": self.min_ago},
+            project_id=self.project.id,
+        )
+
+        group = Group.objects.first()
+
+        group_event = group.get_latest_event()
+
+        assert group_event.event_id == "b" * 32
+        assert group_event.occurrence is None
+
+    def test_get_latest_almost_identical_timestamps(self):
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "fingerprint": ["group-1"],
+                "timestamp": self.just_over_one_min_ago,
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={"event_id": "b" * 32, "fingerprint": ["group-1"], "timestamp": self.min_ago},
+            project_id=self.project.id,
+        )
+        group = Group.objects.first()
+
+        group_event = group.get_latest_event()
+
+        assert group_event.event_id == "b" * 32
+        assert group_event.occurrence is None
+
+    def test_get_latest_event_occurrence(self):
+        event = self.store_event(
+            data={"event_id": "a" * 32, "fingerprint": ["group-1"], "timestamp": self.two_min_ago},
+            project_id=self.project.id,
+        )
+        occurrence_data = self.build_occurrence_data(event_id=event.event_id)
+        occurrence = save_issue_occurrence(occurrence_data, event)
+
+        group = Group.objects.first()
+        group.update(type=GroupType.PROFILE_BLOCKED_THREAD.value)
+
+        # TODO: Validate that this works once the clickhouse dataset is merged.
+        group_event = group.get_latest_event()
+
+        assert group_event.event_id == "b" * 32
+        self.assert_occurrences_identical(group_event.occurrence, occurrence)

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -347,6 +347,7 @@ class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
         assert group_event.event_id == "b" * 32
         assert group_event.occurrence is None
 
+    @pytest.skip("Skipping this for now until a pr that fixes saving generic events is merged.")
     def test_get_latest_event_occurrence(self):
         occurrence_data = self.build_occurrence_data()
         event_id = uuid.uuid4().hex

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -358,7 +358,7 @@ class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
                 "project_id": self.project.id,
                 "timestamp": before_now(minutes=1).isoformat(),
             },
-        )[0]
+        )
 
         group = Group.objects.first()
         group.update(type=GroupType.PROFILE_BLOCKED_THREAD.value)

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -347,7 +347,9 @@ class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
         assert group_event.event_id == "b" * 32
         assert group_event.occurrence is None
 
-    @pytest.skip("Skipping this for now until a pr that fixes saving generic events is merged.")
+    @pytest.mark.skip(
+        "Skipping this for now until a pr that fixes saving generic events is merged."
+    )
     def test_get_latest_event_occurrence(self):
         occurrence_data = self.build_occurrence_data()
         event_id = uuid.uuid4().hex


### PR DESCRIPTION
This ensures that when we fetch the latest event for a `Group` that if an `IssueOccurrence` exists and is associated with the event that we fetch it and include it in the `GroupEvent`.

This also adds various other necessary work to be able to query this dataset in snuba. I haven't included all the columns, that can happen as needed.
