### PR TITLE
chore(pr): Add self as org member codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -285,7 +285,7 @@ yarn.lock           @getsentry/owners-js-deps
 /src/sentry/models/groupresolution.py         @getsentry/data
 /src/sentry/models/integration.py             @getsentry/data @getsentry/ecosystem
 /src/sentry/models/organization.py            @getsentry/data
-/src/sentry/models/organizationmember.py      @getsentry/data
+/src/sentry/models/organizationmember.py      @getsentry/data @AniketDas-Tekky
 /src/sentry/models/organizationoption.py      @getsentry/data
 /src/sentry/models/project.py                 @getsentry/data
 /src/sentry/models/projectoption.py           @getsentry/data


### PR DESCRIPTION
Tracking any changes to the org member model. Looking for a way to also get ownership for any usage of the model.
