### PR TITLE
feat(hybrid-cloud): Add org mapping repair task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -583,6 +583,7 @@ CELERY_IMPORTS = (
     "sentry.tasks.low_priority_symbolication",
     "sentry.tasks.merge",
     "sentry.tasks.options",
+    "sentry.tasks.organization_mapping",
     "sentry.tasks.ping",
     "sentry.tasks.post_process",
     "sentry.tasks.process_buffer",
@@ -688,6 +689,7 @@ CELERY_QUEUES = [
     Queue(
         "transactions.name_clusterer", routing_key="transactions.name_clusterer"
     ),  # TODO: add workers
+    Queue("hybrid_cloud.control_repair", routing_key="hybrid_cloud.control_repair"),
 ]
 
 for queue in CELERY_QUEUES:
@@ -818,6 +820,11 @@ CELERYBEAT_SCHEDULE = {
     },
     "transaction-name-clusterer": {
         "task": "sentry.ingest.transaction_clusterer.tasks.spawn_clusterers",
+        "schedule": timedelta(hours=1),
+        "options": {"expires": 3600},
+    },
+    "hybrid-cloud-repair-mappings": {
+        "task": "sentry.tasks.organization_mapping.repair_mappings",
         "schedule": timedelta(hours=1),
         "options": {"expires": 3600},
     },

--- a/src/sentry/services/hybrid_cloud/organization/__init__.py
+++ b/src/sentry/services/hybrid_cloud/organization/__init__.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class OrganizationService(InterfaceWithLifecycle):
     @abstractmethod
     def get_organization_by_id(
-        self, *, id: int, user_id: Optional[int]
+        self, *, id: int, user_id: Optional[int] = None, slug: Optional[str] = None
     ) -> Optional[ApiUserOrganizationContext]:
         """
         Fetches the organization, team, and project data given by an organization id, regardless of its visibility

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -149,7 +149,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         return self._serialize_member(member)
 
     def get_organization_by_id(
-        self, *, id: int, user_id: Optional[int] = None, slug: Optional[int] = None
+        self, *, id: int, user_id: Optional[int] = None, slug: Optional[str] = None
     ) -> Optional[ApiUserOrganizationContext]:
         membership: Optional[ApiOrganizationMember] = None
         if user_id is not None:

--- a/src/sentry/services/hybrid_cloud/organization/impl.py
+++ b/src/sentry/services/hybrid_cloud/organization/impl.py
@@ -149,7 +149,7 @@ class DatabaseBackedOrganizationService(OrganizationService):
         return self._serialize_member(member)
 
     def get_organization_by_id(
-        self, *, id: int, user_id: Optional[int]
+        self, *, id: int, user_id: Optional[int] = None, slug: Optional[int] = None
     ) -> Optional[ApiUserOrganizationContext]:
         membership: Optional[ApiOrganizationMember] = None
         if user_id is not None:
@@ -160,7 +160,10 @@ class DatabaseBackedOrganizationService(OrganizationService):
                 pass
 
         try:
-            org = Organization.objects.get(id=id)
+            query = Organization.objects.filter(id=id)
+            if slug is not None:
+                query = query.filter(slug=slug)
+            org = query.get()
         except Organization.DoesNotExist:
             return None
 

--- a/src/sentry/tasks/organization_mapping.py
+++ b/src/sentry/tasks/organization_mapping.py
@@ -64,9 +64,8 @@ def _remove_duplicate_mappings(expiration_threshold_time: datetime) -> None:
             return
 
         # Delete all expired mappings that don't match this org slug
-        for mapping in OrganizationMapping.objects.filter(organization_id=organization_id):
-            if (
-                mapping.slug != found_org.organization.slug
-                and mapping.date_created <= expiration_threshold_time
-            ):
+        for mapping in OrganizationMapping.objects.filter(organization_id=organization_id).exclude(
+            slug=found_org.organization.slug
+        ):
+            if mapping.date_created <= expiration_threshold_time:
                 mapping.delete()

--- a/src/sentry/tasks/organization_mapping.py
+++ b/src/sentry/tasks/organization_mapping.py
@@ -54,6 +54,9 @@ def _remove_duplicate_mappings(expiration_threshold_time: datetime) -> None:
 
     # Enumerate orgs with multiple mappings, remove ones that don't exist in region silo
     for dupe in duplicates_query:
+        metrics.incr(
+            "sentry.hybrid_cloud.tasks.organizationmapping.remove_duplicate", sample_rate=1.0
+        )
         organization_id = dupe["organization_id"]
 
         # Organization exists in the region silo

--- a/src/sentry/tasks/organization_mapping.py
+++ b/src/sentry/tasks/organization_mapping.py
@@ -64,8 +64,6 @@ def _remove_duplicate_mappings(expiration_threshold_time: datetime) -> None:
             return
 
         # Delete all expired mappings that don't match this org slug
-        for mapping in OrganizationMapping.objects.filter(organization_id=organization_id).exclude(
-            slug=found_org.organization.slug
-        ):
-            if mapping.date_created <= expiration_threshold_time:
-                mapping.delete()
+        OrganizationMapping.objects.filter(
+            organization_id=organization_id, date_created__lte=expiration_threshold_time
+        ).exclude(slug=found_org.organization.slug).delete()

--- a/src/sentry/tasks/organization_mapping.py
+++ b/src/sentry/tasks/organization_mapping.py
@@ -1,0 +1,72 @@
+import logging
+from datetime import datetime, timedelta
+
+from django.contrib.postgres.aggregates import ArrayAgg
+from django.db.models import Count
+from django.utils import timezone
+
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.services.hybrid_cloud.organization import organization_service
+from sentry.tasks.base import instrumented_task
+from sentry.utils import metrics
+from sentry.utils.query import RangeQuerySetWrapper
+
+ORGANIZATION_MAPPING_EXPIRY = timedelta(hours=2)
+
+logger = logging.getLogger(__name__)
+
+
+@instrumented_task(
+    name="sentry.tasks.organization_mapping.repair_mappings",
+    queue="hybrid_cloud.control_repair",
+    default_retry_delay=5,
+    max_retries=5,
+)  # type: ignore
+def repair_mappings() -> None:
+    metrics.incr("sentry.hybrid_cloud.tasks.organizationmapping.start", sample_rate=1.0)
+    with metrics.timer("sentry.hybrid_cloud.tasks.organizationmapping.repair", sample_rate=1.0):
+        expiration_threshold_time = timezone.now() - ORGANIZATION_MAPPING_EXPIRY
+        _verify_mappings(expiration_threshold_time)
+        _remove_duplicate_mappings(expiration_threshold_time)
+
+
+def _verify_mappings(expiration_threshold_time: datetime) -> None:
+    # For each unverified mapping in the control silo
+    for mapping in RangeQuerySetWrapper(OrganizationMapping.objects.filter(verified=False)):
+        # Lookup organization record in the region silo
+        org = organization_service.get_organization_by_id(
+            id=mapping.organization_id, slug=mapping.slug
+        )
+        if org is None and mapping.date_created <= expiration_threshold_time:
+            mapping.delete()
+        elif org is not None:
+            mapping.verified = True
+            mapping.idempotency_key = ""
+            mapping.save()
+
+
+def _remove_duplicate_mappings(expiration_threshold_time: datetime) -> None:
+    duplicates_query = (
+        OrganizationMapping.objects.values("organization_id")
+        .annotate(total=Count("*"), slugs=ArrayAgg("slug"))
+        .filter(total__gt=1)
+    )
+
+    # Enumerate orgs with multiple mappings, remove ones that don't exist in region silo
+    for dupe in duplicates_query:
+        organization_id = dupe["organization_id"]
+
+        # Organization exists in the region silo
+        found_org = organization_service.get_organization_by_id(id=organization_id)
+        if found_org is None:
+            # Delete all mappings.
+            OrganizationMapping.objects.filter(organization_id=organization_id).delete()
+            return
+
+        # Delete all expired mappings that don't match this org slug
+        for mapping in OrganizationMapping.objects.filter(organization_id=organization_id):
+            if (
+                mapping.slug != found_org.organization.slug
+                and mapping.date_created <= expiration_threshold_time
+            ):
+                mapping.delete()

--- a/tests/sentry/tasks/test_organization_mapping.py
+++ b/tests/sentry/tasks/test_organization_mapping.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+import pytest
+
+from sentry.models.organization import Organization
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.tasks.organization_mapping import ORGANIZATION_MAPPING_EXPIRY, repair_mappings
+from sentry.testutils import TestCase
+
+
+class OrganizationMappingRepairTest(TestCase):
+    def test_removes_expired_unverified(self):
+        expired_time = datetime.now() - ORGANIZATION_MAPPING_EXPIRY
+        mapping = self.create_organization_mapping(
+            self.organization, verified=False, date_created=expired_time
+        )
+        phantom_mapping = self.create_organization_mapping(
+            Organization(id=123, slug="fake-slug"), date_created=expired_time, verified=False
+        )
+
+        repair_mappings()
+
+        with pytest.raises(OrganizationMapping.DoesNotExist):
+            phantom_mapping.refresh_from_db()
+        mapping.refresh_from_db()
+        assert mapping.verified
+
+    def test_removes_expired_duplicates(self):
+        expired_time = datetime.now() - ORGANIZATION_MAPPING_EXPIRY
+        mapping = self.create_organization_mapping(
+            self.organization, verified=False, date_created=expired_time
+        )
+        old_mapping = self.create_organization_mapping(
+            self.organization,
+            verified=True,
+            slug="old_slug_name",
+            date_created=expired_time,
+        )
+
+        repair_mappings()
+
+        with pytest.raises(OrganizationMapping.DoesNotExist):
+            old_mapping.refresh_from_db()
+
+        mapping.refresh_from_db()
+        assert mapping.verified
+
+    def test_set_verified(self):
+        expired_time = datetime.now() - ORGANIZATION_MAPPING_EXPIRY
+        mapping = self.create_organization_mapping(
+            self.organization, verified=False, date_created=expired_time, idempotency_key="1234"
+        )
+
+        repair_mappings()
+
+        mapping.refresh_from_db()
+        assert mapping.verified is True
+        assert mapping.idempotency_key == ""


### PR DESCRIPTION
Adds a repair task to run every hour to verify organization mappings and delete duplicates.

Split out from https://github.com/getsentry/sentry/pull/41113