### PR TITLE
feat(dynamic-sampling): Add logging to dynamic sampling rules [TET-612]

### DIFF
--- a/src/sentry/dynamic_sampling/logging.py
+++ b/src/sentry/dynamic_sampling/logging.py
@@ -1,0 +1,98 @@
+import logging
+from datetime import datetime
+from typing import Dict, List, Union
+
+import pytz
+import sentry_sdk
+
+from sentry.dynamic_sampling.utils import BaseRule, RuleType, get_rule_hash, get_rule_type
+
+logger = logging.getLogger("dynamic_sampling.rules")
+
+# Maximum number of projects of which we track active releases. We need to bound this element in order to avoid out
+# of memory errors. In case a single instance will receive a lot of requests from Relay, it will accumulate a lot of
+# projects.
+MAX_PROJECTS_IN_MEMORY = 1000
+
+# Dictionary that contains a mapping between project_id -> active_rules where active_rules is rule_hash ->
+# sample_rate. It is used to check whether the new set of rules has been actually changed, in order to log the
+# change. This is a minor optimization to avoid flooding Google Cloud Logging with data.
+#
+# This data is stored in-memory for simplicity, however, it introduces a problem because Sentry is running in multiple
+# instances without shared memory, therefore we might have different active rules on each instance. This will lead to
+# some false positives, that is, rules are logged, but they are not changed. This can happen if a rule is marked as
+# active by instance X, and then we receive it in instance Y that didn't see it before.
+#
+# If we find that this naive implementation generates too much data, we can always use a shared-memory architecture
+# by using Redis for example.
+active_rules: Dict[int, Dict[int, float]] = {}
+
+
+def should_log_rules_change(project_id: int, rules: List[BaseRule]) -> bool:
+    active_rules_per_project = active_rules.get(project_id, None)
+    new_rules_per_project = {}
+
+    for rule in rules:
+        new_rules_per_project[get_rule_hash(rule)] = rule["sampleRate"]
+
+    should_log = new_rules_per_project != active_rules_per_project
+
+    if should_log:
+        _delete_active_rule_if_limit(active_rules_per_project is None)
+        active_rules[project_id] = new_rules_per_project
+
+    return should_log
+
+
+def _delete_active_rule_if_limit(is_new_project: bool) -> None:
+    if is_new_project and len(active_rules) >= MAX_PROJECTS_IN_MEMORY:
+        active_rules.popitem()
+
+
+def log_rules(project_id: int, rules: List[BaseRule]) -> None:
+    try:
+        if should_log_rules_change(project_id, rules):
+            logger.info(
+                "rules_generator.generate_rules",
+                extra={
+                    "rules": _format_rules(rules),
+                    # We set the current date as creation timestamp, however, this is not indicating that Relay
+                    # did apply the rules at this time as there will be a non-deterministic delay before that happens.
+                    "creation_timestamp": datetime.now(tz=pytz.utc),
+                },
+            )
+    except Exception as e:
+        # If there is any problem while generating the log message, we just silently fail and notify the error to
+        # Sentry.
+        sentry_sdk.capture_exception(e)
+
+
+def _format_rules(rules: List[BaseRule]) -> List[Dict[str, Union[List[str], str, float, None]]]:
+    formatted_rules = []
+
+    for rule in rules:
+        rule_type = get_rule_type(rule)
+        formatted_rules.append(
+            {
+                "type": rule_type.value if rule_type else "unknown_rule_type",
+                "id": rule["id"],
+                "sample_rate": rule["sampleRate"],
+                **_extract_info_from_rule(rule_type, rule),  # type:ignore
+            }
+        )
+
+    return formatted_rules  # type:ignore
+
+
+def _extract_info_from_rule(
+    rule_type: RuleType, rule: BaseRule
+) -> Dict[str, Union[List[str], str, None]]:
+    if rule_type == RuleType.BOOST_LATEST_RELEASES_RULE:
+        return {
+            "release": rule["condition"]["inner"][0]["value"],  # type:ignore
+            "environment": rule["condition"]["inner"][1]["value"],  # type:ignore
+        }
+    elif rule_type == RuleType.BOOST_KEY_TRANSACTIONS_RULE:
+        return {"transaction": rule["condition"]["inner"][0]["value"]}  # type:ignore
+    else:
+        return {}

--- a/src/sentry/dynamic_sampling/logging.py
+++ b/src/sentry/dynamic_sampling/logging.py
@@ -36,10 +36,9 @@ def should_log_rules_change(project_id: int, rules: List[BaseRule]) -> bool:
         new_rules_per_project[get_rule_hash(rule)] = rule["sampleRate"]
 
     should_log = new_rules_per_project != active_rules_per_project
-
     if should_log:
         _delete_active_rule_if_limit(active_rules_per_project is None)
-        active_rules[project_id] = new_rules_per_project
+        active_rules[project_id] = new_rules_per_project  # type:ignore
 
     return should_log
 
@@ -89,10 +88,10 @@ def _extract_info_from_rule(
 ) -> Dict[str, Union[List[str], str, None]]:
     if rule_type == RuleType.BOOST_LATEST_RELEASES_RULE:
         return {
-            "release": rule["condition"]["inner"][0]["value"],  # type:ignore
-            "environment": rule["condition"]["inner"][1]["value"],  # type:ignore
+            "release": rule["condition"]["inner"][0]["value"],
+            "environment": rule["condition"]["inner"][1]["value"],
         }
     elif rule_type == RuleType.BOOST_KEY_TRANSACTIONS_RULE:
-        return {"transaction": rule["condition"]["inner"][0]["value"]}  # type:ignore
+        return {"transaction": rule["condition"]["inner"][0]["value"]}
     else:
         return {}

--- a/src/sentry/dynamic_sampling/rules_generator.py
+++ b/src/sentry/dynamic_sampling/rules_generator.py
@@ -43,7 +43,7 @@ class DSRulesLogger:
             # Sentry.
             sentry_sdk.capture_exception(e)
 
-    def _format_rules(self) -> Dict:
+    def _format_rules(self) -> List[Dict[str, Union[List[str], str, float, None]]]:
         formatted_rules = []
 
         for rule_type, rule in self.rules:
@@ -52,22 +52,22 @@ class DSRulesLogger:
                     "type": rule_type.value,
                     "id": rule["id"],
                     "sample_rate": rule["sampleRate"],
-                    **self._extract_info_from_rule(rule_type, rule),
+                    **self._extract_info_from_rule(rule_type, rule),  # type:ignore
                 }
             )
 
-        return formatted_rules
+        return formatted_rules  # type:ignore
 
     def _extract_info_from_rule(
         self, rule_type: RuleType, rule: Union[BaseRule, ReleaseRule]
-    ) -> Dict:
+    ) -> Dict[str, Union[List[str], str, None]]:
         if rule_type == RuleType.BOOST_LATEST_RELEASES_RULE:
             return {
-                "release": rule["condition"]["inner"][0]["value"],
-                "environment": rule["condition"]["inner"][1]["value"],
+                "release": rule["condition"]["inner"][0]["value"],  # type:ignore
+                "environment": rule["condition"]["inner"][1]["value"],  # type:ignore
             }
         elif rule_type == RuleType.BOOST_KEY_TRANSACTIONS_RULE:
-            return {"transaction": rule["condition"]["inner"][0]["value"]}
+            return {"transaction": rule["condition"]["inner"][0]["value"]}  # type:ignore
         else:
             return {}
 
@@ -212,7 +212,7 @@ def generate_rules(project: Project) -> List[Union[BaseRule, ReleaseRule]]:
     """
     This function handles generate rules logic or fallback empty list of rules
     """
-    rules: List[Tuple(RuleType, Union[BaseRule, ReleaseRule])] = []
+    rules: List[Tuple[RuleType, Union[BaseRule, ReleaseRule]]] = []
 
     sample_rate = quotas.get_blended_sample_rate(project)
 

--- a/src/sentry/dynamic_sampling/utils.py
+++ b/src/sentry/dynamic_sampling/utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Optional, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict, Union
 
 from sentry.dynamic_sampling.latest_release_booster import ProjectBoostedReleases
 from sentry.utils import json
@@ -96,11 +96,19 @@ def get_rule_hash(rule: BaseRule) -> int:
     # We want to be explicit in what we use for computing the hash. In addition, we need to remove certain fields like
     # the sampleRate.
     return json.dumps(
-        {
-            "id": rule["id"],
-            "type": rule["type"],
-            "active": rule["active"],
-            "condition": rule["condition"],
-        },
-        sort_keys=True,
+        _nested_sort_dictionary(
+            {
+                "id": rule["id"],
+                "type": rule["type"],
+                "active": rule["active"],
+                "condition": rule["condition"],
+            }
+        )
     ).__hash__()
+
+
+def _nested_sort_dictionary(value: Union[Any, Dict[Any, Any]]) -> Union[Any, Dict[Any, Any]]:
+    if isinstance(value, dict):
+        return {key: _nested_sort_dictionary(value) for key, value in sorted(value.items())}
+    else:
+        return value

--- a/src/sentry/dynamic_sampling/utils.py
+++ b/src/sentry/dynamic_sampling/utils.py
@@ -96,7 +96,7 @@ def get_rule_hash(rule: BaseRule) -> int:
     # We want to be explicit in what we use for computing the hash. In addition, we need to remove certain fields like
     # the sampleRate.
     return json.dumps(
-        _nested_sort_dictionary(
+        _deep_sorted(
             {
                 "id": rule["id"],
                 "type": rule["type"],
@@ -107,8 +107,8 @@ def get_rule_hash(rule: BaseRule) -> int:
     ).__hash__()
 
 
-def _nested_sort_dictionary(value: Union[Any, Dict[Any, Any]]) -> Union[Any, Dict[Any, Any]]:
+def _deep_sorted(value: Union[Any, Dict[Any, Any]]) -> Union[Any, Dict[Any, Any]]:
     if isinstance(value, dict):
-        return {key: _nested_sort_dictionary(value) for key, value in sorted(value.items())}
+        return {key: _deep_sorted(value) for key, value in sorted(value.items())}
     else:
         return value

--- a/src/sentry/dynamic_sampling/utils.py
+++ b/src/sentry/dynamic_sampling/utils.py
@@ -1,6 +1,9 @@
 from enum import Enum
 from typing import Dict, List, Optional, TypedDict
 
+from sentry.dynamic_sampling.latest_release_booster import ProjectBoostedReleases
+from sentry.utils import json
+
 BOOSTED_RELEASES_LIMIT = 10
 BOOSTED_KEY_TRANSACTION_LIMIT = 10
 
@@ -40,6 +43,7 @@ RESERVED_IDS = {
     RuleType.BOOST_KEY_TRANSACTIONS_RULE: 1003,
     RuleType.BOOST_LATEST_RELEASES_RULE: 1500,
 }
+REVERSE_RESERVED_IDS = {value: key for key, value in RESERVED_IDS.items()}
 
 
 class Inner(TypedDict):
@@ -51,7 +55,7 @@ class Inner(TypedDict):
 
 class Condition(TypedDict):
     op: str
-    inner: List[Optional[Inner]]
+    inner: List[Inner]
 
 
 class BaseRule(TypedDict):
@@ -69,3 +73,34 @@ class TimeRange(TypedDict):
 
 class ReleaseRule(BaseRule):
     timeRange: Optional[TimeRange]
+
+
+def get_rule_type(rule: BaseRule) -> Optional[RuleType]:
+    # Edge case handled naively in which we check if the ID is within the possible bounds. This is done because the
+    # latest release rules have ids from 1500 to 1500 + (limit - 1). For example if the limit is 2, we will only have
+    # ids: 1500, 1501.
+    #
+    # This implementation MUST be changed in case we change the logic of rule ids.
+    if (
+        RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE]
+        <= rule["id"]
+        < RESERVED_IDS[RuleType.BOOST_LATEST_RELEASES_RULE]
+        + ProjectBoostedReleases.BOOSTED_RELEASES_LIMIT
+    ):
+        return RuleType.BOOST_LATEST_RELEASES_RULE
+
+    return REVERSE_RESERVED_IDS.get(rule["id"], None)
+
+
+def get_rule_hash(rule: BaseRule) -> int:
+    # We want to be explicit in what we use for computing the hash. In addition, we need to remove certain fields like
+    # the sampleRate.
+    return json.dumps(
+        {
+            "id": rule["id"],
+            "type": rule["type"],
+            "active": rule["active"],
+            "condition": rule["condition"],
+        },
+        sort_keys=True,
+    ).__hash__()

--- a/tests/sentry/dynamic_sampling/test_logging.py
+++ b/tests/sentry/dynamic_sampling/test_logging.py
@@ -40,6 +40,36 @@ def test_should_not_log_rules_if_unchanged():
         1: {
             get_rule_hash(
                 {
+                    "active": True,
+                    "condition": {"inner": [], "op": "and"},
+                    "id": 1000,
+                    "sampleRate": 0.1,
+                    "type": "trace",
+                },
+            ): 0.1
+        }
+    },
+)
+def test_should_not_log_rules_if_unchanged_and_different_order():
+    new_rules = [
+        {
+            "sampleRate": 0.1,
+            "condition": {"op": "and", "inner": []},
+            "id": 1000,
+            "type": "trace",
+            "active": True,
+        },
+    ]
+
+    assert not should_log_rules_change(1, new_rules)
+
+
+@patch(
+    "sentry.dynamic_sampling.logging.active_rules",
+    new={
+        1: {
+            get_rule_hash(
+                {
                     "sampleRate": 1,
                     "type": "trace",
                     "condition": {

--- a/tests/sentry/dynamic_sampling/test_logging.py
+++ b/tests/sentry/dynamic_sampling/test_logging.py
@@ -1,0 +1,217 @@
+from unittest.mock import patch
+
+from sentry.dynamic_sampling.logging import should_log_rules_change
+from sentry.dynamic_sampling.utils import get_rule_hash
+
+
+@patch(
+    "sentry.dynamic_sampling.logging.active_rules",
+    new={
+        1: {
+            get_rule_hash(
+                {
+                    "active": True,
+                    "condition": {"inner": [], "op": "and"},
+                    "id": 1000,
+                    "sampleRate": 0.1,
+                    "type": "trace",
+                },
+            ): 0.1
+        }
+    },
+)
+def test_should_not_log_rules_if_unchanged():
+    new_rules = [
+        {
+            "active": True,
+            "condition": {"inner": [], "op": "and"},
+            "id": 1000,
+            "sampleRate": 0.1,
+            "type": "trace",
+        },
+    ]
+
+    assert not should_log_rules_change(1, new_rules)
+
+
+@patch(
+    "sentry.dynamic_sampling.logging.active_rules",
+    new={
+        1: {
+            get_rule_hash(
+                {
+                    "sampleRate": 1,
+                    "type": "trace",
+                    "condition": {
+                        "op": "or",
+                        "inner": [
+                            {
+                                "op": "glob",
+                                "name": "trace.environment",
+                                "value": ["*dev*", "*test*"],
+                                "options": {"ignoreCase": True},
+                            }
+                        ],
+                    },
+                    "active": True,
+                    "id": 1001,
+                },
+            ): 1.0
+        }
+    },
+)
+def test_should_log_rules_if_new_rule_added():
+    new_rules = [
+        {
+            "sampleRate": 1,
+            "type": "trace",
+            "condition": {
+                "op": "or",
+                "inner": [
+                    {
+                        "op": "glob",
+                        "name": "trace.environment",
+                        "value": ["*dev*", "*test*"],
+                        "options": {"ignoreCase": True},
+                    }
+                ],
+            },
+            "active": True,
+            "id": 1001,
+        },
+        {
+            "sampleRate": 0.5,
+            "type": "trace",
+            "active": True,
+            "condition": {
+                "op": "and",
+                "inner": [
+                    {"op": "eq", "name": "trace.release", "value": ["1.0"]},
+                    {"op": "eq", "name": "trace.environment", "value": "dev"},
+                ],
+            },
+            "id": 1501,
+            "timeRange": {"start": "2022-10-21 18:50:25+00:00", "end": "2022-10-21 20:03:03+00:00"},
+        },
+    ]
+
+    assert should_log_rules_change(1, new_rules)
+
+
+@patch(
+    "sentry.dynamic_sampling.logging.active_rules",
+    new={
+        1: {
+            get_rule_hash(
+                {
+                    "sampleRate": 0.7,
+                    "type": "trace",
+                    "condition": {
+                        "op": "or",
+                        "inner": [
+                            {
+                                "op": "glob",
+                                "name": "trace.environment",
+                                "value": ["*dev*", "*test*"],
+                                "options": {"ignoreCase": True},
+                            }
+                        ],
+                    },
+                    "active": True,
+                    "id": 1001,
+                },
+            ): 0.7
+        }
+    },
+)
+def test_should_log_rules_if_same_rule_has_different_sample_rate():
+    new_rules = [
+        {
+            "sampleRate": 0.5,
+            "type": "trace",
+            "condition": {
+                "op": "or",
+                "inner": [
+                    {
+                        "op": "glob",
+                        "name": "trace.environment",
+                        "value": ["*dev*", "*test*"],
+                        "options": {"ignoreCase": True},
+                    }
+                ],
+            },
+            "active": True,
+            "id": 1001,
+        },
+    ]
+
+    assert should_log_rules_change(1, new_rules)
+
+
+@patch(
+    "sentry.dynamic_sampling.logging.active_rules",
+    new={
+        1: {
+            get_rule_hash(
+                {
+                    "sampleRate": 0.7,
+                    "type": "trace",
+                    "condition": {
+                        "op": "or",
+                        "inner": [
+                            {
+                                "op": "glob",
+                                "name": "trace.environment",
+                                "value": ["*dev*", "*test*"],
+                                "options": {"ignoreCase": True},
+                            }
+                        ],
+                    },
+                    "active": True,
+                    "id": 1001,
+                },
+            ): 0.7,
+            get_rule_hash(
+                {
+                    "sampleRate": 0.5,
+                    "type": "trace",
+                    "active": True,
+                    "condition": {
+                        "op": "and",
+                        "inner": [
+                            {"op": "eq", "name": "trace.release", "value": ["1.0"]},
+                            {"op": "eq", "name": "trace.environment", "value": "dev"},
+                        ],
+                    },
+                    "id": 1501,
+                    "timeRange": {
+                        "start": "2022-10-21 18:50:25+00:00",
+                        "end": "2022-10-21 20:03:03+00:00",
+                    },
+                },
+            ): 0.5,
+        }
+    },
+)
+def test_should_log_rules_if_rule_is_deleted():
+    new_rules = [
+        {
+            "sampleRate": 0.7,
+            "type": "trace",
+            "condition": {
+                "op": "or",
+                "inner": [
+                    {
+                        "op": "glob",
+                        "name": "trace.environment",
+                        "value": ["*dev*", "*test*"],
+                        "options": {"ignoreCase": True},
+                    }
+                ],
+            },
+            "active": True,
+            "id": 1001,
+        },
+    ]
+
+    assert should_log_rules_change(1, new_rules)


### PR DESCRIPTION
This PR aims to add logging to dynamic sampling rules generation. We will perform the logging on every call to `generate_rules` and log all the rules generated by the aforementioned function. The logging will follow a custom schema for readability and will be added to Google Cloud Logging with `name = dynamic_sampling.rules` and `event = rules_generator.generate_rules`.

_This PR contains a first iteration towards the enhanced observability effort for dynamic sampling. We will use the learnings from this simple addition to improve further how we log what happens in the system._