### PR TITLE
chore(releases): Track chart type change

### DIFF
--- a/static/app/utils/analytics/releasesAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/releasesAnalyticsEvents.tsx
@@ -1,4 +1,7 @@
+import {ReleaseComparisonChartType} from 'sentry/types';
+
 export type ReleasesEventParameters = {
+  'releases.change_chart_type': {chartType: ReleaseComparisonChartType};
   'releases.quickstart_copied': {project_id: string};
   'releases.quickstart_create_integration.success': {
     integration_uuid: string;
@@ -17,4 +20,5 @@ export const releasesEventMap: Record<ReleasesEventKey, string | null> = {
     'Releases: Quickstart Created Integration',
   'releases.quickstart_create_integration_modal.close':
     'Releases: Quickstart Create Integration Modal Exit',
+  'releases.change_chart_type': 'Releases: Change Chart Type',
 };

--- a/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -28,6 +28,7 @@ import {
   SessionStatus,
 } from 'sentry/types';
 import {defined} from 'sentry/utils';
+import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {formatPercentage} from 'sentry/utils/formatters';
 import getDynamicText from 'sentry/utils/getDynamicText';
 import {decodeList, decodeScalar} from 'sentry/utils/queryString';
@@ -842,6 +843,10 @@ function ReleaseComparisonChart({
   }
 
   function handleChartChange(chartType: ReleaseComparisonChartType) {
+    trackAdvancedAnalyticsEvent('releases.change_chart_type', {
+      organization,
+      chartType,
+    });
     browserHistory.push({
       ...location,
       query: {


### PR DESCRIPTION
Adding analytics tracking to the release details chart.
We want to see how often people change the default chart view and what options they usually prefer.
<img width="909" alt="image" src="https://user-images.githubusercontent.com/9060071/207361192-c41143d7-8923-4152-ba2b-33c21a56be9e.png">
