### PR TITLE
feat(txnames): Write rules to project option

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -1,36 +1,99 @@
 from datetime import datetime, timezone
-from typing import MutableMapping, Sequence
+from typing import List, Mapping, NewType, Protocol, Sequence
 
 from sentry.ingest.transaction_clusterer.datasource.redis import get_redis_client
 from sentry.models import Project
 
 from .base import ReplacementRule
 
-#: Retention of a rule derived by the clusterer
-RULE_TTL = 90 * 24 * 60 * 60
-
-REDIS_KEY_PREFIX_RULES = "txrules:"
+#: Map from rule string to last_seen timestamp
+RuleSet = NewType("RuleSet", Mapping[ReplacementRule, int])
 
 
-def _get_rules_key(project: Project) -> str:
-    return f"{REDIS_KEY_PREFIX_RULES}o:{project.organization_id}:p:{project.id}"
+class RuleStore(Protocol):
+    def read(self, project: Project) -> RuleSet:
+        ...
+
+    def write(self, project: Project, rules: RuleSet) -> None:
+        ...
+
+
+class RedisRuleStore:
+    @staticmethod
+    def _get_rules_key(project: Project) -> str:
+        return f"txrules:o:{project.organization_id}:p:{project.id}"
+
+    def read(self, project: Project) -> RuleSet:
+        client = get_redis_client()
+        key = self._get_rules_key(project)
+        return client.hgetall(key)  # type: ignore
+
+    def write(self, project: Project, rules: RuleSet) -> None:
+        client = get_redis_client()
+        key = self._get_rules_key(project)
+
+        # TODO: Replace contents
+        client.hmset(key, rules)
+
+
+class ProjectOptionRuleStore:
+
+    _option_name = "TODO"
+
+    def read(self, project: Project) -> RuleSet:
+        return project.get_option(self._option_name)
+
+    def write(self, project: Project, rules: RuleSet) -> None:
+        project.update_option(self._option_name, rules)
+
+
+class CompositeRuleStore:
+    def __init__(self, stores: List[RuleStore]):
+        self._stores = stores
+
+    def read(self, project: Project) -> RuleSet:
+        merged_rules = {}
+        for store in self._stores:
+            rules = store.read(project)
+            for rule, last_seen in rules.items():
+                if rule not in merged_rules or merged_rules[rule] < last_seen:
+                    merged_rules[rule] = last_seen
+
+        return RuleSet(merged_rules)
+
+    def write(self, project: Project, rules: RuleSet) -> None:
+        for store in self._stores:
+            store.write(project, rules)
+
+    def merge(self, project: Project) -> None:
+        merged_rules = self.read(project)
+        self.write(project, merged_rules)
+
+
+class LocalRuleStore:
+    def __init__(self, rules: RuleSet):
+        self._rules = rules
+
+    def read(self, project: Project) -> RuleSet:
+        return self._rules
+
+    def write(self, project: Project, rules: RuleSet) -> None:
+        self._rules = rules
 
 
 def _now() -> int:
     return int(datetime.now(timezone.utc).timestamp())
 
 
-def get_rules(project: Project) -> MutableMapping[str, int]:
-    client = get_redis_client()
-    key = _get_rules_key(project)
-    return client.hgetall(key)  # type: ignore
-
-
 def update_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> None:
-    new_expiry = _now() + RULE_TTL
+    last_seen = _now()
+    new_rule_set = RuleSet({rule: last_seen for rule in new_rules})
 
-    client = get_redis_client()
-    key = _get_rules_key(project)
-
-    # Update rules, overwrite existing entries to update their expiry dates
-    client.hmset(key, {rule: new_expiry for rule in new_rules})
+    rule_store = CompositeRuleStore(
+        [
+            RedisRuleStore(),
+            ProjectOptionRuleStore(),
+            LocalRuleStore(new_rule_set),
+        ]
+    )
+    rule_store.merge(project)

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -100,9 +100,9 @@ def _now() -> int:
 
 
 def get_rules(project: Project) -> Mapping[ReplacementRule, int]:
-    """ Public interface for fetching rules for a project.
+    """Public interface for fetching rules for a project.
     Project options are the persistent, long-term store for rules, while redis is just a short-term buffer,
-    so project options is what we fetch from. """
+    so project options is what we fetch from."""
     return ProjectOptionRuleStore().read(project)
 
 

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -41,8 +41,10 @@ class RedisRuleStore:
         client = get_redis_client()
         key = self._get_rules_key(project)
 
-        # TODO: Replace contents
-        client.hmset(key, rules)
+        with client.pipeline() as p:
+            # to be consistent with other stores, clear previous hash entries:
+            p.delete(key)
+            p.hmset(key, rules)
 
 
 class ProjectOptionRuleStore:

--- a/src/sentry/ingest/transaction_clusterer/rules.py
+++ b/src/sentry/ingest/transaction_clusterer/rules.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import List, Mapping, NewType, Protocol, Sequence
+from typing import Dict, List, Mapping, Protocol, Sequence
 
 from sentry.ingest.transaction_clusterer.datasource.redis import get_redis_client
 from sentry.models import Project
@@ -7,7 +7,7 @@ from sentry.models import Project
 from .base import ReplacementRule
 
 #: Map from rule string to last_seen timestamp
-RuleSet = NewType("RuleSet", Mapping[ReplacementRule, int])
+RuleSet = Mapping[ReplacementRule, int]
 
 
 class RuleStore(Protocol):
@@ -19,6 +19,14 @@ class RuleStore(Protocol):
 
 
 class RedisRuleStore:
+    """We store rules in both project options and redis.
+    The reason for the additional redis store is that in the future, we want
+    to extend rule lifetimes when we see a sanitized transaction.
+    Writing to postgres every time we see a sanitzed transaction will presumably
+    create too much load, so we write to both redis and postgres and merge
+    their contents every time we discover new rules.
+    """
+
     @staticmethod
     def _get_rules_key(project: Project) -> str:
         return f"txrules:o:{project.organization_id}:p:{project.id}"
@@ -26,7 +34,8 @@ class RedisRuleStore:
     def read(self, project: Project) -> RuleSet:
         client = get_redis_client()
         key = self._get_rules_key(project)
-        return client.hgetall(key)  # type: ignore
+        data = client.hgetall(key)
+        return {rule: int(timestamp) for rule, timestamp in data.items()}
 
     def write(self, project: Project, rules: RuleSet) -> None:
         client = get_redis_client()
@@ -37,11 +46,10 @@ class RedisRuleStore:
 
 
 class ProjectOptionRuleStore:
-
-    _option_name = "TODO"
+    _option_name = "sentry:transaction_name_cluster_rules"
 
     def read(self, project: Project) -> RuleSet:
-        return project.get_option(self._option_name)
+        return project.get_option(self._option_name, default={})  # type: ignore
 
     def write(self, project: Project, rules: RuleSet) -> None:
         project.update_option(self._option_name, rules)
@@ -52,20 +60,21 @@ class CompositeRuleStore:
         self._stores = stores
 
     def read(self, project: Project) -> RuleSet:
-        merged_rules = {}
+        merged_rules: Dict[ReplacementRule, int] = {}
         for store in self._stores:
             rules = store.read(project)
             for rule, last_seen in rules.items():
                 if rule not in merged_rules or merged_rules[rule] < last_seen:
                     merged_rules[rule] = last_seen
 
-        return RuleSet(merged_rules)
+        return merged_rules
 
     def write(self, project: Project, rules: RuleSet) -> None:
         for store in self._stores:
             store.write(project, rules)
 
     def merge(self, project: Project) -> None:
+        """Read rules from all stores and write back so they all contain the same set"""
         merged_rules = self.read(project)
         self.write(project, merged_rules)
 
@@ -85,10 +94,13 @@ def _now() -> int:
     return int(datetime.now(timezone.utc).timestamp())
 
 
+def get_rules(project: Project) -> Mapping[ReplacementRule, int]:
+    return ProjectOptionRuleStore().read(project)
+
+
 def update_rules(project: Project, new_rules: Sequence[ReplacementRule]) -> None:
     last_seen = _now()
-    new_rule_set = RuleSet({rule: last_seen for rule in new_rules})
-
+    new_rule_set = {rule: last_seen for rule in new_rules}
     rule_store = CompositeRuleStore(
         [
             RedisRuleStore(),

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -52,6 +52,7 @@ OPTION_KEYS = frozenset(
         "sentry:breakdowns",
         "sentry:span_attributes",
         "sentry:performance_issue_creation_rate",
+        "sentry:transaction_name_cluster_rules",
         "quotas:spike-protection-disabled",
         "feedback:branding",
         "digests:mail:minimum_delay",

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -107,3 +107,8 @@ register(
 
 # Using simple bools instead of rates for disabling individual detectors
 register(key="sentry:performance_issue_creation_enabled_n_plus_one_db", default=True)
+
+# Replacement rules for transaction names discovered by the transaction clusterer.
+# Contains a mapping from rule to last seen timestamp,
+# for example `{"/organizations/*/**": 1334318402}`
+register(key="sentry:transaction_name_cluster_rules", default={})

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -111,8 +111,9 @@ def test_record_transactions(
         assert len(mocked_record.mock_calls) == expected
 
 
-def test_save_rules():
-    project = Project(id=111, name="project", organization_id=1)
+@pytest.mark.django_db
+def test_save_rules(default_project):
+    project = default_project
 
     project_rules = rules.get_rules(project)
     assert project_rules == {}
@@ -120,12 +121,12 @@ def test_save_rules():
     with freeze_time("2012-01-14 12:00:01"):
         rules.update_rules(project, [ReplacementRule("foo"), ReplacementRule("bar")])
     project_rules = rules.get_rules(project)
-    assert project_rules == {"foo": "1334318401", "bar": "1334318401"}
+    assert project_rules == {"foo": 1326542401, "bar": 1326542401}
 
     with freeze_time("2012-01-14 12:00:02"):
         rules.update_rules(project, [ReplacementRule("bar"), ReplacementRule("zap")])
     project_rules = rules.get_rules(project)
-    assert {"bar": "1334318402", "foo": "1334318401", "zap": "1334318402"}
+    assert {"bar": 1326542402, "foo": 1326542401, "zap": 1326542402}
 
 
 @mock.patch("django.conf.settings.SENTRY_TRANSACTION_CLUSTERER_RUN", True)


### PR DESCRIPTION
To have a persistent store of rules discovered by the transaction clusterer, now also write rules to project options.

We still keep the redis store around, and merge newly discovered rules into both, such that we can later use this synchronized redis store to update rule lifetimes efficiently: The load of writes on every sanitized transaction name is very high, but the load of writes on the generation of new rules is low. Both postgres and redis can handle the latter, but only redis can handle the former.

See https://github.com/getsentry/team-ingest/issues/23