### PR TITLE
feat(profiling): preserve layout resizes

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -383,6 +383,10 @@ const StyledButton = styled(Button)<{active: boolean}>`
     margin-right: ${space(1)};
   }
 
+  span:first-child {
+    opacity: 0 !important;
+  }
+
   &:hover {
     border: none;
     background-color: transparent;

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/profileDetails.tsx
@@ -75,8 +75,8 @@ export function ProfileDetails(props: ProfileDetailsProps) {
       flamegraphPreferences.layout === 'table bottom' ? [260, 200] : [0, 200];
 
     const onResize = (
-      newDimensions: [number, number],
-      maybeOldDimensions?: [number, number]
+      newDimensions: [number, number] | undefined,
+      maybeOldDimensions?: [number, number] | undefined
     ) => {
       if (!detailsBarRef.current) {
         return;
@@ -88,7 +88,7 @@ export function ProfileDetails(props: ProfileDetailsProps) {
       ) {
         detailsBarRef.current.style.width = `100%`;
         detailsBarRef.current.style.height =
-          (maybeOldDimensions?.[1] ?? newDimensions[1]) + 'px';
+          (maybeOldDimensions?.[1] ?? newDimensions?.[1]) + 'px';
       } else {
         detailsBarRef.current.style.height = ``;
         detailsBarRef.current.style.width = ``;

--- a/static/app/utils/profiling/hooks/useStoredDimensions.tsx
+++ b/static/app/utils/profiling/hooks/useStoredDimensions.tsx
@@ -1,0 +1,69 @@
+import {useMemo} from 'react';
+import debounce from 'lodash/debounce';
+
+import {clamp} from 'sentry/utils/profiling/colors/utils';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
+
+const factor = Math.pow(10, 4);
+function toPrecision(n: number): number {
+  return clamp(Math.round(n * factor) / factor, 0, 1);
+}
+function isStoredDimensions<K extends string>(
+  value: unknown
+): value is StoredDrawerDimensions<K> {
+  if (!value) {
+    return false;
+  }
+
+  if (typeof value !== 'object') {
+    return false;
+  }
+
+  return Object.keys(value).every(
+    (k: string) =>
+      Array.isArray(value[k]) &&
+      value[k].length === 2 &&
+      value[k].every(v => {
+        return typeof v === 'number' && !isNaN(v) && v > 0 && v < 1;
+      })
+  );
+}
+
+type StoredDrawerDimensions<K extends string> = Partial<Record<K, [number, number]>>;
+
+/**
+ * Serializes the dimensions of a resizable drawer into local storage. Basically a K/V store
+ * with value specific validation and updating mechanism.
+ */
+export function useStoredDimensions<K extends string>(
+  key: string,
+  defaultValue: StoredDrawerDimensions<K>,
+  options: {debounce?: number} = {}
+): [StoredDrawerDimensions<K> | null, (layout: K, state: [number, number]) => void] {
+  const [initialDrawerSize, setDrawerSize] =
+    useLocalStorageState<StoredDrawerDimensions<K> | null>(key, rawValue => {
+      if (rawValue === null || rawValue === undefined) {
+        return defaultValue ?? {};
+      }
+
+      if (isStoredDimensions<K>(rawValue)) {
+        return rawValue;
+      }
+
+      // If all else fails, return empty obj. Since StoredDrawerDimensions is a partial obj,
+      // this makes it easier to work with than if we returned null
+      return {};
+    });
+
+  const debouncedSetDrawerSize = useMemo(() => {
+    function callback(currentLayout: K, dimensions: [number, number]) {
+      setDrawerSize({
+        ...initialDrawerSize,
+        [currentLayout]: [toPrecision(dimensions[0]), toPrecision(dimensions[1])],
+      });
+    }
+    return debounce(callback, options.debounce ?? 1000);
+  }, [setDrawerSize, options.debounce, initialDrawerSize]);
+
+  return [initialDrawerSize, debouncedSetDrawerSize];
+}


### PR DESCRIPTION
It is annoying that switching views does not preserve the previous layout and we force users to re-tailor their experience each time they open a chart page. This PR improves that by storing the data in localstorage in % relative values and initializes it from there.

https://user-images.githubusercontent.com/9317857/207391257-2a84d898-c0ea-4e2e-bebe-765ca849b4e0.mp4