### PR TITLE
feat(perf): Remove landing page tooltips

### DIFF
--- a/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.tsx
@@ -164,17 +164,37 @@ const _WidgetContainer = (props: Props) => {
     'withStaticFilters',
   ]);
 
+  const titleTooltip = showNewWidgetDesign ? '' : widgetProps.titleTooltip;
+
   switch (widgetProps.dataType) {
     case GenericPerformanceWidgetDataType.trends:
-      return <TrendsWidget {...passedProps} {...widgetProps} />;
+      return (
+        <TrendsWidget {...passedProps} {...widgetProps} titleTooltip={titleTooltip} />
+      );
     case GenericPerformanceWidgetDataType.area:
-      return <SingleFieldAreaWidget {...passedProps} {...widgetProps} />;
+      return (
+        <SingleFieldAreaWidget
+          {...passedProps}
+          {...widgetProps}
+          titleTooltip={titleTooltip}
+        />
+      );
     case GenericPerformanceWidgetDataType.vitals:
-      return <VitalWidget {...passedProps} {...widgetProps} />;
+      return (
+        <VitalWidget {...passedProps} {...widgetProps} titleTooltip={titleTooltip} />
+      );
     case GenericPerformanceWidgetDataType.line_list:
-      return <LineChartListWidget {...passedProps} {...widgetProps} />;
+      return (
+        <LineChartListWidget
+          {...passedProps}
+          {...widgetProps}
+          titleTooltip={titleTooltip}
+        />
+      );
     case GenericPerformanceWidgetDataType.histogram:
-      return <HistogramWidget {...passedProps} {...widgetProps} />;
+      return (
+        <HistogramWidget {...passedProps} {...widgetProps} titleTooltip={titleTooltip} />
+      );
     default:
       throw new Error(`Widget type "${widgetProps.dataType}" has no implementation.`);
   }

--- a/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetHeader.tsx
@@ -26,7 +26,9 @@ export function WidgetHeader<T extends WidgetDataConstraint>(
             <TextOverflow>{title}</TextOverflow>
           )}
           <MEPTag />
-          <QuestionTooltip position="top" size="sm" title={titleTooltip} />
+          {titleTooltip && (
+            <QuestionTooltip position="top" size="sm" title={titleTooltip} />
+          )}
         </StyledHeaderTitleLegend>
         {Subtitle ? <Subtitle {...props} /> : null}
       </TitleContainer>


### PR DESCRIPTION
When new landing page designs feature flag is on, hide tooltips. The widget header is getting cluttered, so the goal of removing tooltips is to draw more attention to the header menu (caret).