### PR TITLE
ref(hybrid-cloud): use organization_slug in org invite link url

### DIFF
--- a/fixtures/emails/invitation.txt
+++ b/fixtures/emails/invitation.txt
@@ -4,6 +4,6 @@ Your teammates at Example are using Sentry to track and debug software errors.
 
 Join your team by visiting the following url:
 
-    http://testserver/accept/1/None/
+    http://testserver/accept/example/1/None/
 
 Check out the Sentry website (https://sentry.io) if you'd like to learn more before diving in.

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -83,7 +83,7 @@ class AcceptOrganizationInvite(Endpoint):
             # When SSO is required do *not* set a next_url to return to accept
             # invite. The invite will be accepted after SSO is completed.
             url = (
-                reverse("sentry-accept-invite-with-org", args=[organization_slug, member_id, token])
+                reverse("sentry-accept-invite", args=[organization_slug, member_id, token])
                 if not auth_provider
                 else "/"
             )

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -83,7 +83,7 @@ class AcceptOrganizationInvite(Endpoint):
             # When SSO is required do *not* set a next_url to return to accept
             # invite. The invite will be accepted after SSO is completed.
             url = (
-                reverse("sentry-accept-invite", args=[organization_slug, member_id, token])
+                reverse("sentry-accept-invite-with-org", args=[organization_slug, member_id, token])
                 if not auth_provider
                 else "/"
             )

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -83,7 +83,7 @@ class AcceptOrganizationInvite(Endpoint):
             # When SSO is required do *not* set a next_url to return to accept
             # invite. The invite will be accepted after SSO is completed.
             url = (
-                reverse("sentry-accept-invite", args=[member_id, token])
+                reverse("sentry-accept-invite-with-org", args=[organization_slug, member_id, token])
                 if not auth_provider
                 else "/"
             )

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -244,7 +244,7 @@ class OrganizationMember(Model):
             return None
         return absolute_uri(
             reverse(
-                "sentry-accept-invite-with-org",
+                "sentry-accept-invite",
                 kwargs={
                     "organization_slug": self.organization.slug,
                     "member_id": self.id,

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -244,7 +244,7 @@ class OrganizationMember(Model):
             return None
         return absolute_uri(
             reverse(
-                "sentry-accept-invite",
+                "sentry-accept-invite-with-org",
                 kwargs={
                     "organization_slug": self.organization.slug,
                     "member_id": self.id,

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -244,8 +244,9 @@ class OrganizationMember(Model):
             return None
         return absolute_uri(
             reverse(
-                "sentry-accept-invite",
+                "sentry-accept-invite-with-org",
                 kwargs={
+                    "organization_slug": self.organization.slug,
                     "member_id": self.id,
                     "token": self.token or self.legacy_token,
                 },

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -598,7 +598,7 @@ def invitation(request):
             "organization": org,
             "url": absolute_uri(
                 reverse(
-                    "sentry-accept-invite",
+                    "sentry-accept-invite-with-org",
                     kwargs={"organization_slug": org.slug, "member_id": om.id, "token": om.token},
                 )
             ),

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -598,8 +598,8 @@ def invitation(request):
             "organization": org,
             "url": absolute_uri(
                 reverse(
-                    "sentry-accept-invite",
-                    kwargs={"member_id": om.id, "token": om.token},
+                    "sentry-accept-invite-with-org",
+                    kwargs={"organization_slug": org.slug, "member_id": om.id, "token": om.token},
                 )
             ),
         },

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -598,7 +598,7 @@ def invitation(request):
             "organization": org,
             "url": absolute_uri(
                 reverse(
-                    "sentry-accept-invite-with-org",
+                    "sentry-accept-invite",
                     kwargs={"organization_slug": org.slug, "member_id": om.id, "token": om.token},
                 )
             ),

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -352,14 +352,9 @@ urlpatterns += [
     url(r"^out/$", OutView.as_view()),
     url(r"^accept-transfer/$", react_page_view, name="sentry-accept-project-transfer"),
     url(
-        r"^accept/(?P<member_id>\d+)/(?P<token>\w+)/$",
-        GenericReactPageView.as_view(auth_required=False),
-        name="sentry-accept-invite",
-    ),
-    url(
         r"^accept/(?P<organization_slug>[^/]+)/(?P<member_id>\d+)/(?P<token>\w+)/$",
         GenericReactPageView.as_view(auth_required=False),
-        name="sentry-accept-invite-with-org",
+        name="sentry-accept-invite",
     ),
     # User settings use generic_react_page_view, while any view acting on
     # behalf of an organization should use react_page_view

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -352,9 +352,14 @@ urlpatterns += [
     url(r"^out/$", OutView.as_view()),
     url(r"^accept-transfer/$", react_page_view, name="sentry-accept-project-transfer"),
     url(
-        r"^accept/(?P<organization_slug>[^/]+)/(?P<member_id>\d+)/(?P<token>\w+)/$",
+        r"^accept/(?P<member_id>\d+)/(?P<token>\w+)/$",
         GenericReactPageView.as_view(auth_required=False),
         name="sentry-accept-invite",
+    ),
+    url(
+        r"^accept/(?P<organization_slug>[^/]+)/(?P<member_id>\d+)/(?P<token>\w+)/$",
+        GenericReactPageView.as_view(auth_required=False),
+        name="sentry-accept-invite-with-org",
     ),
     # User settings use generic_react_page_view, while any view acting on
     # behalf of an organization should use react_page_view


### PR DESCRIPTION
Changes the organization invite links to use the endpoint with the org slug.

Keeps both orgless and with org slug endpoints for the AcceptOrganizationInvite APIs until the last of the email invites without the org slug expire 30 days after this PR is deployed.

For HC-511