### PR TITLE
fix(replays): pass project_id to replay count endpoint

### DIFF
--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -95,6 +95,7 @@ describe('useReplaysCount', () => {
         query: {
           query: `issue.id:[${mockGroupIds.join(',')}]`,
           statsPeriod: '14d',
+          project: [2],
         },
       })
     );

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -85,6 +85,7 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
             query: {
               query: query.conditions,
               statsPeriod: '14d',
+              project: [Number(project?.id)],
             },
           }
         );
@@ -107,7 +108,7 @@ function useReplaysCount({groupIds, transactionNames, organization, project}: Op
     } catch (err) {
       Sentry.captureException(err);
     }
-  }, [api, organization.slug, query, zeroCounts, eventView]);
+  }, [api, organization.slug, query, zeroCounts, eventView, project]);
 
   useEffect(() => {
     const hasSessionReplay =


### PR DESCRIPTION
- pass the project_id in to our issue count query to resolve a perms error we were seeing with the endpoint.