### PR TITLE
ref(hybrid-cloud): use organization_slug in MonitorDetails

### DIFF
--- a/src/sentry/api/endpoints/monitor_details.py
+++ b/src/sentry/api/endpoints/monitor_details.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from __future__ import annotations
 
 from django.db import transaction
 from rest_framework import status
@@ -20,7 +20,7 @@ class MonitorDetailsEndpoint(MonitorEndpoint):
         return Response(status=status.HTTP_400_BAD_REQUEST, data={"details": "Invalid monitor"})
 
     def get(
-        self, request: Request, project, monitor, organization_slug: Optional[str] = None
+        self, request: Request, project, monitor, organization_slug: str | None = None
     ) -> Response:
         """
         Retrieve a monitor
@@ -36,7 +36,7 @@ class MonitorDetailsEndpoint(MonitorEndpoint):
         return self.respond(serialize(monitor, request.user))
 
     def put(
-        self, request: Request, project, monitor, organization_slug: Optional[str] = None
+        self, request: Request, project, monitor, organization_slug: str | None = None
     ) -> Response:
         """
         Update a monitor
@@ -93,7 +93,7 @@ class MonitorDetailsEndpoint(MonitorEndpoint):
         return self.respond(serialize(monitor, request.user))
 
     def delete(
-        self, request: Request, project, monitor, organization_slug: Optional[str] = None
+        self, request: Request, project, monitor, organization_slug: str | None = None
     ) -> Response:
         """
         Delete a monitor

--- a/src/sentry/api/endpoints/monitor_details.py
+++ b/src/sentry/api/endpoints/monitor_details.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.db import transaction
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -22,7 +24,9 @@ class MonitorDetailsEndpoint(MonitorEndpoint):
         """
         return self.respond(serialize(monitor, request.user))
 
-    def put(self, request: Request, project, monitor) -> Response:
+    def put(
+        self, request: Request, project, monitor, organization_slug: Optional[str] = None
+    ) -> Response:
         """
         Update a monitor
         ````````````````
@@ -73,7 +77,9 @@ class MonitorDetailsEndpoint(MonitorEndpoint):
 
         return self.respond(serialize(monitor, request.user))
 
-    def delete(self, request: Request, project, monitor) -> Response:
+    def delete(
+        self, request: Request, project, monitor, organization_slug: Optional[str] = None
+    ) -> Response:
         """
         Delete a monitor
         ````````````````

--- a/src/sentry/api/endpoints/monitor_details.py
+++ b/src/sentry/api/endpoints/monitor_details.py
@@ -5,14 +5,14 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import audit_log
-from sentry.api.base import pending_silo_endpoint
+from sentry.api.base import region_silo_endpoint
 from sentry.api.bases.monitor import MonitorEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.validators import MonitorValidator
 from sentry.models import Monitor, MonitorStatus, ScheduledDeletion
 
 
-@pending_silo_endpoint
+@region_silo_endpoint
 class MonitorDetailsEndpoint(MonitorEndpoint):
     def get(
         self, request: Request, project, monitor, organization_slug: Optional[str] = None

--- a/src/sentry/api/endpoints/monitor_details.py
+++ b/src/sentry/api/endpoints/monitor_details.py
@@ -14,7 +14,9 @@ from sentry.models import Monitor, MonitorStatus, ScheduledDeletion
 
 @pending_silo_endpoint
 class MonitorDetailsEndpoint(MonitorEndpoint):
-    def get(self, request: Request, project, monitor) -> Response:
+    def get(
+        self, request: Request, project, monitor, organization_slug: Optional[str] = None
+    ) -> Response:
         """
         Retrieve a monitor
         ``````````````````

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -680,6 +680,11 @@ urlpatterns = [
                     name="sentry-api-0-monitor-details",
                 ),
                 url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<monitor_id>[^\/]+)/$",
+                    MonitorDetailsEndpoint.as_view(),
+                    name="sentry-api-0-monitor-details-with-org",
+                ),
+                url(
                     r"^(?P<monitor_id>[^\/]+)/checkins/$",
                     MonitorCheckInsEndpoint.as_view(),
                     name="sentry-api-0-monitor-check-in-index",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -675,6 +675,11 @@ urlpatterns = [
         include(
             [
                 url(
+                    r"^(?P<monitor_id>[^\/]+)/checkins/$",
+                    MonitorCheckInsEndpoint.as_view(),
+                    name="sentry-api-0-monitor-check-in-index",
+                ),
+                url(
                     r"^(?P<monitor_id>[^\/]+)/$",
                     MonitorDetailsEndpoint.as_view(),
                     name="sentry-api-0-monitor-details",
@@ -683,11 +688,6 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<monitor_id>[^\/]+)/$",
                     MonitorDetailsEndpoint.as_view(),
                     name="sentry-api-0-monitor-details-with-org",
-                ),
-                url(
-                    r"^(?P<monitor_id>[^\/]+)/checkins/$",
-                    MonitorCheckInsEndpoint.as_view(),
-                    name="sentry-api-0-monitor-check-in-index",
                 ),
                 url(
                     r"^(?P<monitor_id>[^\/]+)/checkins/(?P<checkin_id>[^\/]+)/$",

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -29,6 +29,7 @@ __all__ = (
     "OrganizationMetricMetaIntegrationTestCase",
     "ReplaysAcceptanceTestCase",
     "ReplaysSnubaTestCase",
+    "MonitorTestCase",
 )
 
 import hashlib
@@ -99,12 +100,15 @@ from sentry.models import (
     Identity,
     IdentityProvider,
     IdentityStatus,
+    Monitor,
+    MonitorType,
     NotificationSetting,
     Organization,
     ProjectOption,
     Release,
     ReleaseCommit,
     Repository,
+    ScheduleType,
     UserEmail,
     UserOption,
 )
@@ -2192,4 +2196,25 @@ class OrganizationMetricMetaIntegrationTestCase(MetricsAPIBaseTestCase):
                 },
             ],
             entity="metrics_sets",
+        )
+
+
+class MonitorTestCase(APITestCase):
+    @property
+    def endpoint_with_org(self):
+        raise NotImplementedError(f"implement for {type(self).__module__}.{type(self).__name__}")
+
+    def _get_path_functions(self):
+        return (
+            lambda monitor: reverse(self.endpoint, args=[monitor.guid]),
+            lambda monitor: reverse(self.endpoint_with_org, args=[self.org.slug, monitor.guid]),
+        )
+
+    def _create_monitor(self):
+        return Monitor.objects.create(
+            organization_id=self.org.id,
+            project_id=self.project.id,
+            next_checkin=timezone.now() - timedelta(minutes=1),
+            type=MonitorType.CRON_JOB,
+            config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
         )

--- a/tests/sentry/api/endpoints/test_monitor_details.py
+++ b/tests/sentry/api/endpoints/test_monitor_details.py
@@ -5,8 +5,10 @@ from django.utils import timezone
 
 from sentry.models import Monitor, MonitorStatus, MonitorType, ScheduledDeletion, ScheduleType
 from sentry.testutils import APITestCase
+from sentry.testutils.silo import region_silo_test
 
 
+@region_silo_test(stable=True)
 class MonitorDetailsTest(APITestCase):
     def test_simple(self):
         user = self.create_user()
@@ -33,6 +35,7 @@ class MonitorDetailsTest(APITestCase):
                 assert resp.data["id"] == str(monitor.guid)
 
 
+@region_silo_test(stable=True)
 class UpdateMonitorTest(APITestCase):
     def setUp(self):
         self.user = self.create_user()
@@ -258,6 +261,7 @@ class UpdateMonitorTest(APITestCase):
                 assert resp.status_code == 400, resp.content
 
 
+@region_silo_test()
 class DeleteMonitorTest(APITestCase):
     def _create_monitor(self, org, project):
         return Monitor.objects.create(
@@ -296,6 +300,7 @@ class DeleteMonitorTest(APITestCase):
 
                 monitor = Monitor.objects.get(id=monitor.id)
                 assert monitor.status == MonitorStatus.PENDING_DELETION
+                # ScheduledDeletion only available in control silo
                 assert ScheduledDeletion.objects.filter(
                     object_id=monitor.id, model_name="Monitor"
                 ).exists()


### PR DESCRIPTION
Add `organization_slug` to the url for the MonitorDetails endpoint. Keeps the original orgless URL for now.

For HC-512