### PR TITLE
fix(issues): Remove regex for code mapping sorting

### DIFF
--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -362,12 +362,13 @@ class ProjectStacktraceLinkTestMultipleMatches(BaseProjectStacktraceLink):
         configs = self.code_mappings
         # Expected configs: stack_root, automatically_generated
         expected_config_order = [
+            self.code_mapping1,  # "", False
             self.code_mapping3,  # "usr/src/getsentry/", False
             self.code_mapping4,  # "usr/src/", False
-            self.code_mapping1,  # "", False
-            self.code_mapping5,  # "usr/src/getsentry/src/sentry/", True
             self.code_mapping2,  # "usr/src/getsentry/src/", True
+            self.code_mapping5,  # "usr/src/getsentry/src/sentry/", True
         ]
+        # This will just check that the user generated code mappings are inserted first for now
         sorted_configs = project_stacktrace_link_endpoint.sort_code_mapping_configs(configs)
         assert sorted_configs == expected_config_order
 
@@ -380,9 +381,8 @@ class ProjectStacktraceLinkTestMultipleMatches(BaseProjectStacktraceLink):
             response = self.get_success_response(
                 self.organization.slug, self.project.slug, qs_params={"file": self.filepath}
             )
-            # Assert that the code mapping that is user generated and has the most defined stack
-            # trace of the user generated code mappings is chosen
-            assert response.data["config"] == self.expected_configurations(self.code_mapping3)
+            # Assert that the code mapping that is user generated is chosen
+            assert response.data["config"] == self.expected_configurations(self.code_mapping1)
             assert (
                 response.data["sourceUrl"]
                 == "https://github.com/usr/src/getsentry/src/sentry/src/sentry/utils/safe.py"


### PR DESCRIPTION
Fixes SENTRY-XMV

Remove the regex to put code mappings with more defined stack root first since it was causing an error. Now, only user generated code mappings are prioritized
This precedence will be added again in a different PR.