### PR TITLE
feat(onboarding): adds redirect to signup for wizard

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2920,3 +2920,6 @@ SLICED_KAFKA_TOPICS: Mapping[Tuple[str, int], Mapping[str, Any]] = {}
 # Used by silo tests -- when requests pass through decorated endpoints, switch the server silo mode to match that
 # decorator.
 SINGLE_SERVER_SILO_MODE = False
+
+# Set the URL for signup page that we redirect to for the setup wizard if signup=1 is in the query params
+SENTRY_SIGNUP_URL = None

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -32,16 +32,16 @@ class SetupWizardView(BaseView):
     def handle_auth_required(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         if request.GET.get("signup") == "1" and settings.SENTRY_SIGNUP_URL:
 
-            fragments = list(urlparse(absolute_uri(request.get_full_path())))
+            uri_components = list(urlparse(absolute_uri(request.get_full_path())))
 
             # get the params from the url and apply it to the signup url
-            params_for_signup = dict(parse_qsl(fragments[4]))
+            params_for_signup = dict(parse_qsl(uri_components[4]))
             # remove the signup query param
             params_for_signup.pop("signup", None)
             # remove query params from next url
-            fragments[4] = ""
+            uri_components[4] = ""
             # add the params to the signup url
-            params = {"next": urlunparse(fragments), **params_for_signup}
+            params = {"next": urlunparse(uri_components), **params_for_signup}
             return self.redirect(add_params_to_url(settings.SENTRY_SIGNUP_URL, params))
         return super().handle_auth_required(request, *args, **kwargs)
 

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -1,4 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from django.conf import settings
 from django.db.models import F
+from django.http import HttpResponse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,11 +22,27 @@ from sentry.models import (
     ProjectKeyStatus,
     ProjectStatus,
 )
+from sentry.utils.http import absolute_uri
+from sentry.utils.urls import add_params_to_url
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
 
 
 class SetupWizardView(BaseView):
+    def handle_auth_required(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
+        if request.GET.get("signup") == "1" and settings.SENTRY_SIGNUP_URL:
+
+            fragments = list(urlparse(absolute_uri(request.get_full_path())))
+            params_for_next_url = dict(parse_qsl(fragments[4]))
+            # remove signup if it's there
+            params_for_next_url.pop("signup", None)
+            fragments[4] = urlencode(list(params_for_next_url))
+
+            params = {"next": urlunparse(fragments)}
+
+            return self.redirect(add_params_to_url(settings.SENTRY_SIGNUP_URL, params))
+        return super().handle_auth_required(request, *args, **kwargs)
+
     def get(self, request: Request, wizard_hash) -> Response:
         """
         This opens a page where with an active session fill stuff into the cache

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from urllib.parse import parse_qsl, urlparse, urlunparse
 
 from django.conf import settings
 from django.db.models import F
@@ -33,13 +33,15 @@ class SetupWizardView(BaseView):
         if request.GET.get("signup") == "1" and settings.SENTRY_SIGNUP_URL:
 
             fragments = list(urlparse(absolute_uri(request.get_full_path())))
-            params_for_next_url = dict(parse_qsl(fragments[4]))
-            # remove signup if it's there
-            params_for_next_url.pop("signup", None)
-            fragments[4] = urlencode(list(params_for_next_url))
 
-            params = {"next": urlunparse(fragments)}
-
+            # get the params from the url and apply it to the signup url
+            params_for_signup = dict(parse_qsl(fragments[4]))
+            # remove the signup query param
+            params_for_signup.pop("signup", None)
+            # remove query params from next url
+            fragments[4] = ""
+            # add the params to the signup url
+            params = {"next": urlunparse(fragments), **params_for_signup}
             return self.redirect(add_params_to_url(settings.SENTRY_SIGNUP_URL, params))
         return super().handle_auth_required(request, *args, **kwargs)
 

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -64,13 +64,16 @@ class SetupWizard(PermissionTestCase):
     @override_settings(SENTRY_SIGNUP_URL="https://sentry.io/signup/")
     def test_redirect_to_signup(self):
         self.create_organization(owner=self.user)
-        url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "xyz"}) + "?signup=1"
+        url = (
+            reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "xyz"})
+            + "?signup=1&test=other"
+        )
         resp = self.client.get(url)
 
         assert resp.status_code == 302
         assert (
             resp.url
-            == "https://sentry.io/signup/?next=http%3A%2F%2Ftestserver%2Faccount%2Fsettings%2Fwizard%2Fxyz%2F"
+            == "https://sentry.io/signup/?next=http%3A%2F%2Ftestserver%2Faccount%2Fsettings%2Fwizard%2Fxyz%2F&test=other"
         )
 
     @override_settings(SENTRY_SIGNUP_URL="https://sentry.io/signup/")

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -1,3 +1,4 @@
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY
@@ -59,3 +60,24 @@ class SetupWizard(PermissionTestCase):
         assert cached.get("projects")[0].get("status") == "active"
         assert cached.get("projects")[0].get("keys")[0].get("isActive")
         assert cached.get("projects")[0].get("organization").get("status").get("id") == "active"
+
+    @override_settings(SENTRY_SIGNUP_URL="https://sentry.io/signup/")
+    def test_redirect_to_signup(self):
+        self.create_organization(owner=self.user)
+        url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "xyz"}) + "?signup=1"
+        resp = self.client.get(url)
+
+        assert resp.status_code == 302
+        assert (
+            resp.url
+            == "https://sentry.io/signup/?next=http%3A%2F%2Ftestserver%2Faccount%2Fsettings%2Fwizard%2Fxyz%2F"
+        )
+
+    @override_settings(SENTRY_SIGNUP_URL="https://sentry.io/signup/")
+    def test_redirect_to_login_if_no_query_param(self):
+        self.create_organization(owner=self.user)
+        url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "xyz"})
+        resp = self.client.get(url)
+
+        assert resp.status_code == 302
+        assert resp.url == "/auth/login/"


### PR DESCRIPTION
This PR adds a redirect to the signup page from the Sentry Wizard if `signup=1` and the user is logged out. This change will allow us to optimize the wizard for new users who don't have accounts (we are going to add a `-s` option that adds the query param).