### PR TITLE
feat(issue platform): Add dummy endpoint for issue occurrences

### DIFF
--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -12,6 +12,7 @@ from sentry.utils.kafka_config import get_kafka_producer_cluster_options
 
 class BasicEventSerializer(serializers.Serializer):
     event_id = serializers.CharField()
+    project_id = serializers.IntegerField()
     title = serializers.CharField()
     platform = serializers.CharField()
     tags = serializers.DictField()

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -60,7 +60,7 @@ class IssueOccurrenceEndpoint(Endpoint):
             "event": event,
         }
 
-        topic = settings.KAFKA_EVENTS  # needs to be changed, not sure what the new topic is called
+        topic = settings.KAFKA_INGEST_OCCURRENCES
         cluster_name = settings.KAFKA_TOPICS[topic]["cluster"]
         cluster_options = get_kafka_producer_cluster_options(cluster_name)
         producer = Producer(cluster_options)

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -33,7 +33,7 @@ class IssueOccurrenceSerializer(serializers.Serializer):
 @region_silo_endpoint
 class IssueOccurrenceEndpoint(Endpoint):
     permission_classes = (SuperuserPermission,)
-    private: True
+    private = True
 
     def post(self, request: Request) -> Response:
         """

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -4,7 +4,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.base import Endpoint
+from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.utils import json
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options
@@ -30,6 +30,7 @@ class IssueOccurrenceSerializer(serializers.Serializer):
     detection_time = serializers.DateTimeField()
 
 
+@region_silo_endpoint
 class IssueOccurrenceEndpoint(Endpoint):
     permission_classes = (SuperuserPermission,)
     private: True

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -1,0 +1,62 @@
+from rest_framework import serializers, status
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.base import Endpoint
+from sentry.api.permissions import SuperuserPermission
+from sentry.api.serializers import EventSerializer, serialize
+
+
+class IssueOccurrenceSerializer(serializers.Serializer):
+    # id = serializers.IntegerField()
+    event_id = serializers.UUIDField()
+    fingerprint = serializers.ListField()
+    issue_title = serializers.CharField()
+    subtitle = serializers.CharField()
+    evidence_data = serializers.DictField()
+    evidence_display = serializers.ListField()
+    type = serializers.IntegerField()
+    detection_time = serializers.DateTimeField()
+
+
+class IssueOccurrenceEndpoint(Endpoint):
+    permission_classes = (SuperuserPermission,)
+    private: True
+
+    def post(self, request: Request) -> Response:
+        """
+        Write Issue occurrence data to a Kafka topic
+        `````````````````````````````````
+        :auth: required
+        """
+        event = request.data.pop("event")
+        occurrence = request.data
+
+        # having issues here, clearly not sending the right format
+        # going to asssume for now it's valid data. or maybe passing an event_id makes more sense idk
+
+        # event_serializer = serialize(event, request.user, EventSerializer())
+        # if not event_serializer.is_valid():
+        #     return Response(event_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        # event = event_serializer.validated_data
+
+        occurrence["event_id"] = event["id"]
+
+        serializer = IssueOccurrenceSerializer(data=occurrence)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        occurrence = serializer.validated_data
+
+        print("occurrence: ", occurrence)
+
+        # write to kafka topic - see eventstream/kafka/backend.py#L171-L202
+        # example dan code below
+        # producer.produce(
+        #     topic=topic,
+        #     key=None,
+        #     value=json.dumps(<your_data>),
+        # )
+        # producer.flush()
+
+        return Response(status=201)

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -70,6 +70,7 @@ class ScopedPermission(permissions.BasePermission):  # type: ignore[misc]
 
 class SuperuserPermission(permissions.BasePermission):  # type: ignore[misc]
     def has_permission(self, request: Request, view: object) -> bool:
+        return True  # CEO hack remove this
         if is_active_superuser(request):
             return True
         if request.user.is_authenticated and request.user.is_superuser:

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -70,7 +70,6 @@ class ScopedPermission(permissions.BasePermission):  # type: ignore[misc]
 
 class SuperuserPermission(permissions.BasePermission):  # type: ignore[misc]
     def has_permission(self, request: Request, view: object) -> bool:
-        return True  # CEO hack remove this
         if is_active_superuser(request):
             return True
         if request.user.is_authenticated and request.user.is_superuser:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -210,6 +210,7 @@ from .endpoints.internal import (
     InternalStatsEndpoint,
     InternalWarningsEndpoint,
 )
+from .endpoints.issue_occurrence import IssueOccurrenceEndpoint
 from .endpoints.monitor_checkin_details import MonitorCheckInDetailsEndpoint
 from .endpoints.monitor_checkins import MonitorCheckInsEndpoint
 from .endpoints.monitor_details import MonitorDetailsEndpoint
@@ -2402,6 +2403,12 @@ urlpatterns = [
         r"^integration-features/$",
         IntegrationFeaturesEndpoint.as_view(),
         name="sentry-api-0-integration-features",
+    ),
+    # Issue Occurrences
+    url(
+        r"^issue-occurrence/$",
+        IssueOccurrenceEndpoint.as_view(),
+        name="sentry-api-0-issue-occurrence",
     ),
     # Grouping configs
     url(

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -6,20 +6,22 @@ from sentry.utils.dates import ensure_aware
 
 
 class IssueOccurrenceTest(APITestCase):
-    def test_simple(self):
+    def setUp(self):
+        super().setUp()
         user = self.create_user(is_superuser=True)
         self.login_as(user=user, superuser=True)
 
-        event = {
+        self.url = "/api/0/issue-occurrence/"
+        self.event = {
             "event_id": "44f1419e73884cd2b45c79918f4b6dc4",
+            "project_id": self.project.id,
             "title": "Meow meow",
             "platform": "python",
             "tags": {"environment": "prod"},
             "timestamp": ensure_aware(datetime.now()),
             "message_timestamp": ensure_aware(datetime.now()),
         }
-
-        data = {
+        self.data = {
             "fingerprint": ["some-fingerprint"],
             "issue_title": "something bad happened",
             "subtitle": "it was bad",
@@ -32,10 +34,21 @@ class IssueOccurrenceTest(APITestCase):
             ],
             "type": GroupType.PROFILE_BLOCKED_THREAD.value,
             "detection_time": ensure_aware(datetime.now()),
-            "event": event,
+            "event": self.event,
         }
 
-        url = "/api/0/issue-occurrence/"
-        response = self.client.post(url, data=data, format="json")
-
+    def test_simple(self):
+        response = self.client.post(self.url, data=self.data, format="json")
         assert response.status_code == 201, response.content
+
+    def test_incorrect_event_payload(self):
+        data = dict(self.data)
+        data["event"]["tags"] = ["hello", "there"]
+        response = self.client.post(self.url, data=data, format="json")
+        assert response.status_code == 400, response.content
+
+    def test_incorrect_occurrence_payload(self):
+        data = dict(self.data)
+        data["detection_time"] = "today"
+        response = self.client.post(self.url, data=data, format="json")
+        assert response.status_code == 400, response.content

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -1,0 +1,50 @@
+# import uuid
+from datetime import datetime
+
+from sentry.testutils import APITestCase
+from sentry.types.issues import GroupType
+from sentry.utils.dates import ensure_aware
+from sentry.utils.samples import load_data
+
+
+class IssueOccurrenceTest(APITestCase):
+    def test_simple(self):
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user)
+
+        event = dict(load_data("python"))
+        event["message"] = "meow meow"
+        event.pop("logentry", None)
+        event["event_id"] = "44f1419e73884cd2b45c79918f4b6dc4"
+        event["environment"] = "prod"
+        event["tags"] = [
+            ("logger", "javascript"),
+            ("environment", "prod"),
+            ("level", "error"),
+            ("device", "Other"),
+        ]
+
+        data = {
+            # "id": uuid.uuid4().hex,
+            # "event_id": data["event_id"],
+            "fingerprint": ["some-fingerprint"],
+            "issue_title": "something bad happened",
+            "subtitle": "it was bad",
+            "resource_id": "1234",
+            "evidence_data": {"Test": 123},
+            "evidence_display": [
+                ("Attention", "Very important information!!!", True),
+                ("Evidence 2", "Not important", False),
+                ("Evidence 3", "Nobody cares about this", False),
+            ],
+            "type": GroupType.PROFILE_BLOCKED_THREAD.value,
+            "detection_time": ensure_aware(datetime.now()),
+            "event": event,
+        }
+
+        url = "/api/0/issue-occurrence/"
+        response = self.client.post(url, data=data, format="json")
+
+        assert response.status_code == 201, response.content
+        # assert response.data["id"] == str(group.id)
+        # TODO do we need anything in the response?

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -1,32 +1,25 @@
-# import uuid
 from datetime import datetime
 
 from sentry.testutils import APITestCase
 from sentry.types.issues import GroupType
 from sentry.utils.dates import ensure_aware
-from sentry.utils.samples import load_data
 
 
 class IssueOccurrenceTest(APITestCase):
     def test_simple(self):
         user = self.create_user(is_superuser=True)
-        self.login_as(user=user)
+        self.login_as(user=user, superuser=True)
 
-        event = dict(load_data("python"))
-        event["message"] = "meow meow"
-        event.pop("logentry", None)
-        event["event_id"] = "44f1419e73884cd2b45c79918f4b6dc4"
-        event["environment"] = "prod"
-        event["tags"] = [
-            ("logger", "javascript"),
-            ("environment", "prod"),
-            ("level", "error"),
-            ("device", "Other"),
-        ]
+        event = {
+            "event_id": "44f1419e73884cd2b45c79918f4b6dc4",
+            "title": "Meow meow",
+            "platform": "python",
+            "tags": {"environment": "prod"},
+            "timestamp": ensure_aware(datetime.now()),
+            "message_timestamp": ensure_aware(datetime.now()),
+        }
 
         data = {
-            # "id": uuid.uuid4().hex,
-            # "event_id": data["event_id"],
             "fingerprint": ["some-fingerprint"],
             "issue_title": "something bad happened",
             "subtitle": "it was bad",
@@ -46,5 +39,3 @@ class IssueOccurrenceTest(APITestCase):
         response = self.client.post(url, data=data, format="json")
 
         assert response.status_code == 201, response.content
-        # assert response.data["id"] == str(group.id)
-        # TODO do we need anything in the response?


### PR DESCRIPTION
Create a dummy endpoint to be used internally for testing sending issue occurrence data. 

Fixes [42169](https://github.com/getsentry/sentry/issues/42169)