### PR TITLE
chore(replays): add cache to replays query in issue_replay_count endpoint

### DIFF
--- a/src/sentry/replays/query.py
+++ b/src/sentry/replays/query.py
@@ -175,7 +175,9 @@ def query_replays_count(
             granularity=Granularity(3600),
         ),
     )
-    return raw_snql_query(snuba_request, "replays.query.query_replays_count")
+    return raw_snql_query(
+        snuba_request, referrer="replays.query.query_replays_count", use_cache=True
+    )
 
 
 # Select.


### PR DESCRIPTION
- since we're cacheing the first query we make in this endpoint to get the list of replay_ids from issue_ids, it's also likely fine to cache the second request which is made to the replays dataset here.