### PR TITLE
feat(ci): Update additional calls to `action-visual-snaphot`

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -103,7 +103,7 @@ jobs:
           css-path: src/sentry/static/sentry/dist/entrypoints/sentry.css
 
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@5811b6c34e1ec3b9fc30613d4b55ef740fec6086  # main
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -180,7 +180,7 @@ jobs:
           PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
 
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@5811b6c34e1ec3b9fc30613d4b55ef740fec6086  # main
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -243,7 +243,7 @@ jobs:
           PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
 
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@5811b6c34e1ec3b9fc30613d4b55ef740fec6086  # main
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -269,7 +269,7 @@ jobs:
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
 
       - name: Diff snapshots
-        uses: getsentry/action-visual-snapshot@5811b6c34e1ec3b9fc30613d4b55ef740fec6086  # main
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
         # Run this step only if there are acceptance related code changes
         # Forks are handled in visual-diff.yml
         if: needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -103,7 +103,7 @@ jobs:
           css-path: src/sentry/static/sentry/dist/entrypoints/sentry.css
 
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18  # main
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -180,7 +180,7 @@ jobs:
           PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
 
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18  # main
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -243,7 +243,7 @@ jobs:
           PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
 
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18  # main
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -269,7 +269,7 @@ jobs:
           echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1
 
       - name: Diff snapshots
-        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18  # main
         # Run this step only if there are acceptance related code changes
         # Forks are handled in visual-diff.yml
         if: needs.files-changed.outputs.acceptance == 'true' && github.event.pull_request.head.repo.full_name == 'getsentry/sentry'

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18  # main
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18
+        uses: getsentry/action-visual-snapshot@cbb092a1a0045c954dcecd9a56bf623754648e18  # main
         with:
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           gcs-bucket: 'sentry-visual-snapshots'


### PR DESCRIPTION
Filter by commit using API rather than code (eliminates unnecessary pagination)

(Missed these in #42262)
