### PR TITLE
feat(issues): Add code mapping precedence based on stack root

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -147,7 +147,12 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
             inserted = False
             for index, sorted_config in enumerate(sorted_configs):
                 # This check will ensure that all user defined code mappings will come before Sentry generated ones
-                if sorted_config.automatically_generated and not config.automatically_generated:
+                if (
+                    sorted_config.automatically_generated and not config.automatically_generated
+                ) or (  # Insert more defined stack roots before less defined ones
+                    (sorted_config.automatically_generated == config.automatically_generated)
+                    and config.stack_root.startswith(sorted_config.stack_root)
+                ):
                     sorted_configs.insert(index, config)
                     inserted = True
                     break

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -137,7 +137,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):  # type: ignore
         Sorts the code mapping config list based on precedence.
         User generated code mappings are evaluated before Sentry generated code mappings.
         Code mappings with more defined stack trace roots are evaluated before less defined stack trace
-        roots (To Do)
+        roots.
 
         `configs`: The list of code mapping configs
 

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -362,13 +362,13 @@ class ProjectStacktraceLinkTestMultipleMatches(BaseProjectStacktraceLink):
         configs = self.code_mappings
         # Expected configs: stack_root, automatically_generated
         expected_config_order = [
-            self.code_mapping1,  # "", False
             self.code_mapping3,  # "usr/src/getsentry/", False
             self.code_mapping4,  # "usr/src/", False
-            self.code_mapping2,  # "usr/src/getsentry/src/", True
+            self.code_mapping1,  # "", False
             self.code_mapping5,  # "usr/src/getsentry/src/sentry/", True
+            self.code_mapping2,  # "usr/src/getsentry/src/", True
         ]
-        # This will just check that the user generated code mappings are inserted first for now
+
         sorted_configs = project_stacktrace_link_endpoint.sort_code_mapping_configs(configs)
         assert sorted_configs == expected_config_order
 
@@ -381,8 +381,9 @@ class ProjectStacktraceLinkTestMultipleMatches(BaseProjectStacktraceLink):
             response = self.get_success_response(
                 self.organization.slug, self.project.slug, qs_params={"file": self.filepath}
             )
-            # Assert that the code mapping that is user generated is chosen
-            assert response.data["config"] == self.expected_configurations(self.code_mapping1)
+            # Assert that the code mapping that is user generated and has the most defined stack
+            # trace of the user generated code mappings is chosen
+            assert response.data["config"] == self.expected_configurations(self.code_mapping3)
             assert (
                 response.data["sourceUrl"]
                 == "https://github.com/usr/src/getsentry/src/sentry/src/sentry/utils/safe.py"


### PR DESCRIPTION
Add statement to prioritize code mappings with more defined stack roots

Fixes WOR-2395

Previously, a regex was used to compare how defined stack roots were. This was causing an error and thus precedence based on stack roots was removed [here](https://github.com/getsentry/sentry/commit/aada27c5ac52fffd8d08078cd8b263173a2a41ec). Using a regex was overcomplicating the comparison; the stack roots can be compared with `startswith`, which does not cause any errors as far as I am aware of.
