### PR TITLE
feat(replays): Drop borders between Replay console rows

### DIFF
--- a/static/app/views/replays/detail/console/consoleLogRow.tsx
+++ b/static/app/views/replays/detail/console/consoleLogRow.tsx
@@ -11,6 +11,7 @@ import TimestampButton from 'sentry/views/replays/detail/timestampButton';
 
 type Props = {
   breadcrumb: Extract<Crumb, BreadcrumbTypeDefault>;
+  hasOccurred: boolean;
   isCurrent: boolean;
   isHovered: boolean;
   onClickTimestamp: any;
@@ -22,6 +23,7 @@ type Props = {
 
 function ConsoleMessage({
   breadcrumb,
+  hasOccurred,
   isCurrent,
   isHovered,
   onClickTimestamp,
@@ -32,6 +34,7 @@ function ConsoleMessage({
 }: Props) {
   return (
     <ConsoleLog
+      hasOccurred={hasOccurred}
       isCurrent={isCurrent}
       isHovered={isHovered}
       level={breadcrumb.level}
@@ -64,6 +67,7 @@ const IssueLinkWrapper = styled('div')`
 `;
 
 const ConsoleLog = styled('div')<{
+  hasOccurred: boolean;
   isCurrent: boolean;
   isHovered: boolean;
   level: string;
@@ -80,15 +84,13 @@ const ConsoleLog = styled('div')<{
 
   border-bottom: 1px solid
     ${p =>
-      p.isCurrent
-        ? p.theme.purple300
-        : p.isHovered
-        ? p.theme.purple200
-        : p.theme.innerBorder};
+      p.isCurrent ? p.theme.purple300 : p.isHovered ? p.theme.purple200 : 'transparent'};
 
   color: ${p =>
     ['warning', 'error'].includes(p.level)
       ? p.theme.alert[p.level].iconColor
+      : p.hasOccurred
+      ? p.theme.gray300
       : 'inherit'};
 
   & ${IssueLinkWrapper} {

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -9,6 +9,7 @@ import styled from '@emotion/styled';
 
 import Placeholder from 'sentry/components/placeholder';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
+import {relativeTimeInMs} from 'sentry/components/replays/utils';
 import {t} from 'sentry/locale';
 import type {BreadcrumbTypeDefault, Crumb} from 'sentry/types/breadcrumbs';
 import {getPrevReplayEvent} from 'sentry/utils/replays/getReplayEvent';
@@ -73,6 +74,9 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
         rowIndex={index}
       >
         <ConsoleLogRow
+          hasOccurred={
+            currentTime < relativeTimeInMs(item.timestamp || 0, startTimestampMs)
+          }
           isCurrent={item.id === current?.id}
           isHovered={item.id === hovered?.id}
           breadcrumb={item}
@@ -94,11 +98,8 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
           <AutoSizer>
             {({width, height}) => (
               <ReactVirtualizedList
-                ref={listRef}
                 deferredMeasurementCache={cache}
                 height={height}
-                overscanRowCount={5}
-                rowCount={items.length}
                 noRowsRenderer={() => (
                   <NoRowRenderer
                     unfilteredItems={breadcrumbs}
@@ -107,6 +108,9 @@ function Console({breadcrumbs, startTimestampMs}: Props) {
                     {t('No console logs recorded')}
                   </NoRowRenderer>
                 )}
+                overscanRowCount={5}
+                ref={listRef}
+                rowCount={items.length}
                 rowHeight={cache.rowHeight}
                 rowRenderer={renderRow}
                 width={width}


### PR DESCRIPTION
No more borders generally,, but we do still have the borders for currentTime and currentHoverTime

Also brought back `hasOccurred`, we fade out rows that are in the future part of the video, not yet played. But we don't fade if they're red or yellow.

<img width="647" alt="SCR-20221209-ior" src="https://user-images.githubusercontent.com/187460/206799189-97f6fcdf-cee0-4d02-9012-4ce381085048.png">
