### PR TITLE
feat(crons): Calculate duration when marking check-in as ok/error

### DIFF
--- a/src/sentry/api/endpoints/monitor_checkin_details.py
+++ b/src/sentry/api/endpoints/monitor_checkin_details.py
@@ -113,6 +113,10 @@ class MonitorCheckInDetailsEndpoint(Endpoint):
         params = {"date_updated": current_datetime}
         if "duration" in result:
             params["duration"] = result["duration"]
+        else:
+            duration = int((current_datetime - checkin.date_added).total_seconds() * 1000)
+            params["duration"] = duration
+
         if "status" in result:
             params["status"] = getattr(CheckInStatus, result["status"].upper())
 


### PR DESCRIPTION
Previously we required users to state the duration of your scheduled job when finishing a check-in. This is fine, but if the user chooses not to do this extra step, we should calculate it for them since we have all the data necessary to do so.