### PR TITLE
fix(profiling): add check for project.hasProfiles

### DIFF
--- a/static/app/components/profiling/ProfilingOnboarding/util.ts
+++ b/static/app/components/profiling/ProfilingOnboarding/util.ts
@@ -38,7 +38,8 @@ const platformToDocsPlatform: Record<
 export function isProfilingSupportedOrProjectHasProfiles(project: Project): boolean {
   return !!(
     (project.platform && platformToDocsPlatform[project.platform]) ||
-    // if they somehow managed to send profiles already, then profiling is supported
+    // If this project somehow managed to send profiles, then profiling is supported for this project.
+    // Sometimes and for whatever reason, platform can also not be set on a project so the above check alone would fail
     project.hasProfiles
   );
 }

--- a/static/app/components/profiling/ProfilingOnboarding/util.ts
+++ b/static/app/components/profiling/ProfilingOnboarding/util.ts
@@ -35,8 +35,12 @@ const platformToDocsPlatform: Record<
   'python-tornado': 'python',
 };
 
-export function isProfilingSupportedForProject(project: Project): boolean {
-  return !!(project.platform && platformToDocsPlatform[project.platform]);
+export function isProfilingSupportedOrProjectHasProfiles(project: Project): boolean {
+  return !!(
+    (project.platform && platformToDocsPlatform[project.platform]) ||
+    // if they somehow managed to send profiles already, then profiling is supported
+    project.hasProfiles
+  );
 }
 
 export const profilingOnboardingDocKeys = [

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -9,6 +9,7 @@ import {CreateAlertFromViewButton} from 'sentry/components/createAlertButton';
 import FeatureBadge from 'sentry/components/featureBadge';
 import IdBadge from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {isProfilingSupportedOrProjectHasProfiles} from 'sentry/components/profiling/ProfilingOnboarding/util';
 import ReplayCountBadge from 'sentry/components/replays/replayCountBadge';
 import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import useReplaysCount from 'sentry/components/replays/useReplaysCount';
@@ -23,7 +24,6 @@ import HasMeasurementsQuery from 'sentry/utils/performance/vitals/hasMeasurement
 import projectSupportsReplay from 'sentry/utils/replays/projectSupportsReplay';
 import Breadcrumb from 'sentry/views/performance/breadcrumb';
 
-import {isProfilingSupportedForProject} from '../../../components/profiling/ProfilingOnboarding/util';
 import {getCurrentLandingDisplay, LandingDisplayField} from '../landing/utils';
 
 import Tab from './tabs';
@@ -76,7 +76,7 @@ function TransactionHeader({
   const hasProfiling =
     project &&
     organization.features.includes('profiling') &&
-    isProfilingSupportedForProject(project);
+    isProfilingSupportedOrProjectHasProfiles(project);
 
   const getWebVitals = useCallback(
     (hasMeasurements: boolean) => {


### PR DESCRIPTION
We noticed a customer project had no platform set, so the check was failing and we were not showing them the profiling tab. This slightly extends the check to check for presence of any profiles that may have already been sent - in that case consider profiling to be supported.