### PR TITLE
(perf-issues) add fingerprinting to consecutive db detector

### DIFF
--- a/src/sentry/utils/performance_issues/performance_detection.py
+++ b/src/sentry/utils/performance_issues/performance_detection.py
@@ -468,6 +468,15 @@ def fingerprint_span(span: Span):
     return fingerprint
 
 
+def fingerprint_spans(spans: List[Span]):
+    span_hashes = []
+    for span in spans:
+        hash = span.get("hash", "") or ""
+        span_hashes.append(str(hash))
+    joined_hashes = "-".join(span_hashes)
+    return hashlib.sha1(joined_hashes.encode("utf8")).hexdigest()
+
+
 # Simple fingerprint for broader checks, using the span op.
 def fingerprint_span_op(span: Span):
     op = span.get("op", None)
@@ -1003,11 +1012,9 @@ class ConsecutiveDBSpanDetector(PerformanceDetector):
         return is_db_op and is_query
 
     def _fingerprint(self) -> str:
-        """
-        TODO - improve fingerprinting
-        """
+        hashed_spans = fingerprint_spans(self.consecutive_db_spans)
         problem_class = GroupType.PERFORMANCE_CONSECUTIVE_DB_OP
-        return f"1-{problem_class}"
+        return f"1-{problem_class}-{hashed_spans}"
 
     def on_complete(self) -> None:
         self._validate_and_store_performance_problem()

--- a/tests/sentry/utils/performance_issues/test_performance_detection.py
+++ b/tests/sentry/utils/performance_issues/test_performance_detection.py
@@ -679,7 +679,10 @@ class PerformanceDetectionTest(unittest.TestCase):
                 call("_pi_all_issue_count", 1),
                 call("_pi_sdk_name", ""),
                 call("_pi_transaction", "ba9cf0e72b8c42439a6490be90d9733e"),
-                call("_pi_consecutive_db_fp", "1-GroupType.PERFORMANCE_CONSECUTIVE_DB_OP"),
+                call(
+                    "_pi_consecutive_db_fp",
+                    "1-GroupType.PERFORMANCE_CONSECUTIVE_DB_OP-0700523cc3ca755e447329779e50aeb19549e74f",
+                ),
                 call("_pi_consecutive_db", "abca1c35669c11f2"),
             ]
         )
@@ -851,7 +854,10 @@ class PerformanceDetectionTest(unittest.TestCase):
                 call("_pi_all_issue_count", 4),
                 call("_pi_sdk_name", "sentry.python"),
                 call("_pi_transaction", "aaaaaaaaaaaaaaaa"),
-                call("_pi_consecutive_db_fp", "1-GroupType.PERFORMANCE_CONSECUTIVE_DB_OP"),
+                call(
+                    "_pi_consecutive_db_fp",
+                    "1-GroupType.PERFORMANCE_CONSECUTIVE_DB_OP-e6a9fc04320a924f46c7c737432bb0389d9dd095",
+                ),
                 call("_pi_consecutive_db", "bbbbbbbbbbbbbbbb"),
             ]
         )


### PR DESCRIPTION
Initial version of fingerprinting, from the examples i've seen from auditing, it seems like it is enough to just fingerprint on the set of consecutive db spans.