### PR TITLE
fix(hybrid-cloud): Customer domain middleware should not redirect for non-GET HTTP methods

### DIFF
--- a/src/sentry/middleware/customer_domain.py
+++ b/src/sentry/middleware/customer_domain.py
@@ -74,9 +74,11 @@ class CustomerDomainMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: Request) -> Response:
-        if not getattr(settings, "SENTRY_USE_CUSTOMER_DOMAINS", False):
-            return self.get_response(request)
-        if not hasattr(request, "subdomain"):
+        if (
+            request.method != "GET"
+            or not getattr(settings, "SENTRY_USE_CUSTOMER_DOMAINS", False)
+            or not hasattr(request, "subdomain")
+        ):
             return self.get_response(request)
         subdomain = request.subdomain
         if subdomain is None or resolve_region(request) is not None:

--- a/tests/sentry/middleware/test_customer_domain.py
+++ b/tests/sentry/middleware/test_customer_domain.py
@@ -301,6 +301,16 @@ class End2EndTest(APITestCase):
             assert "activeorg" in self.client.session
             assert self.client.session["activeorg"] == "albertos-apples"
 
+            # No redirect for http methods that is not GET
+            response = self.client.post(
+                reverse("org-events-endpoint", kwargs={"organization_slug": "some-org"}),
+                data={"querystring": "value"},
+                HTTP_HOST="albertos-apples.testserver",
+                follow=True,
+            )
+            assert response.status_code == 200
+            assert response.redirect_chain == []
+
     def test_with_middleware_and_non_staff(self):
         self.create_organization(name="albertos-apples")
         non_staff_user = self.create_user(is_staff=False)


### PR DESCRIPTION
Fixes SENTRY-XN5