### PR TITLE
frontend(invite): update invite link helper text

### DIFF
--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -292,7 +292,9 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
                       <DetailLabel>{t('Invite Link')}</DetailLabel>
                       <TextCopyInput>{inviteLink}</TextCopyInput>
                       <p className="help-block">
-                        {t('This unique invite link may only be used by this member.')}
+                        {t(
+                          'This invite link can be used by anyone who knows it. Keep it secure!'
+                        )}
                       </p>
                     </div>
                     <InviteActions>


### PR DESCRIPTION
We allow anyone with the invite link to use it, this includes users already with an account or even a different email address. This is by design since we allow a single user to be a part of multiple organizations. 

The help text here was misleading and would lead one to assume the only person who could use the invite link was the person with the email it was sent to.