### PR TITLE
bug(replays): Trust the Replay api response `duration` field and dont re-compute it on the frontend

### DIFF
--- a/static/app/utils/replays/replayDataUtils.tsx
+++ b/static/app/utils/replays/replayDataUtils.tsx
@@ -244,36 +244,3 @@ export function spansFactory(spans: ReplaySpan[]) {
       timestamp: span.startTimestamp * 1000,
     }));
 }
-
-/**
- * We need to figure out the real start and end timestamps based on when
- * first and last bits of data were collected. In milliseconds.
- *
- * @deprecated Once the backend returns the corrected timestamps, this is not needed.
- */
-export function replayTimestamps(
-  replayRecord: ReplayRecord,
-  rrwebEvents: RecordingEvent[],
-  rawCrumbs: ReplayCrumb[],
-  rawSpanData: ReplaySpan[]
-) {
-  const rrwebTimestamps = rrwebEvents.map(event => event.timestamp).filter(Boolean);
-  const breadcrumbTimestamps = (
-    rawCrumbs.map(rawCrumb => rawCrumb.timestamp).filter(Boolean) as number[]
-  )
-    .map(timestamp => +new Date(timestamp * 1000))
-    .filter(Boolean);
-  const spanStartTimestamps = rawSpanData.map(span => span.startTimestamp * 1000);
-  const spanEndTimestamps = rawSpanData.map(span => span.endTimestamp * 1000);
-
-  return {
-    startTimestampMs: Math.min(
-      replayRecord.startedAt.getTime(),
-      ...[...rrwebTimestamps, ...breadcrumbTimestamps, ...spanStartTimestamps]
-    ),
-    endTimestampMs: Math.max(
-      replayRecord.finishedAt.getTime(),
-      ...[...rrwebTimestamps, ...breadcrumbTimestamps, ...spanEndTimestamps]
-    ),
-  };
-}

--- a/static/app/utils/replays/replayReader.tsx
+++ b/static/app/utils/replays/replayReader.tsx
@@ -1,5 +1,3 @@
-import {duration} from 'moment';
-
 import type {Crumb} from 'sentry/types/breadcrumbs';
 import {
   breadcrumbFactory,
@@ -7,7 +5,6 @@ import {
   isMemorySpan,
   isNetworkSpan,
   mapRRWebAttachments,
-  replayTimestamps,
   rrwebEventListFactory,
   spansFactory,
 } from 'sentry/utils/replays/replayDataUtils';
@@ -54,20 +51,6 @@ export default class ReplayReader {
     errors,
   }: RequiredNotNull<ReplayReaderParams>) {
     const {breadcrumbs, rrwebEvents, spans} = mapRRWebAttachments(attachments);
-
-    // TODO(replays): We should get correct timestamps from the backend instead
-    // of having to fix them up here.
-    const {startTimestampMs, endTimestampMs} = replayTimestamps(
-      replayRecord,
-      rrwebEvents,
-      breadcrumbs,
-      spans
-    );
-    replayRecord.startedAt = new Date(startTimestampMs);
-    replayRecord.finishedAt = new Date(endTimestampMs);
-    replayRecord.duration = duration(
-      replayRecord.finishedAt.getTime() - replayRecord.startedAt.getTime()
-    );
 
     const sortedSpans = spansFactory(spans);
     this.networkSpans = sortedSpans.filter(isNetworkSpan);


### PR DESCRIPTION
Early on in the replay api development we didn't have a reliable `duration` field. It needed to account for the earliest event that was captured, whether that be a breadcrumb, span, or error.

That's been fixed for a little while now, so we can remove this front-end shim finally.

Fixes #42292