### PR TITLE
fix(profiling): remove wasteful rect 

### DIFF
--- a/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.tsx
@@ -386,17 +386,18 @@ class FlamegraphRenderer {
         return;
       }
 
-      const frameRect = new Rect(frame.start, frame.depth, frame.end - frame.start, 1);
-
       // We treat entire flamegraph as a segment tree, this allows us to query in O(log n) time by
       // only looking at the nodes that are relevant to the current cursor position. We discard any values
       // on x axis that do not overlap the cursor, and descend until we find a node that overlaps at cursor y position
-      if (!frameRect.containsX(configSpaceCursor)) {
+      if (configSpaceCursor[0] < frame.start || configSpaceCursor[0] > frame.end) {
         return;
       }
 
       // If our frame depth overlaps cursor y position, we have found our node
-      if (frameRect.containsY(configSpaceCursor)) {
+      if (
+        configSpaceCursor[1] >= frame.depth &&
+        configSpaceCursor[1] <= frame.depth + 1
+      ) {
         hoveredNode = frame;
         return;
       }


### PR DESCRIPTION
When hovering around large flamecharts I noticed that every now and then the tooltip could slightly stutter, I assume we could be creating and discarding a lot of rect classes here which ends up triggering gc and maybe dropping frames. This PR removes the usage of the rect class to check for overlap which is a reasonable tradeoff as the bounds check is a simple x1 < cursor x < x2 and y1 <  cursor y < y2 