### PR TITLE
ref(profiling): rm profiling-onboarding-checklist feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1001,8 +1001,6 @@ SENTRY_FEATURES = {
     "organizations:performance-view": True,
     # Enable profiling
     "organizations:profiling": False,
-    # Enable profiling on-boarding checklist
-    "organizations:profiling-onboarding-checklist": False,
     # Enable multi project selection
     "organizations:global-views": False,
     # Enable experimental new version of Merged Issues where sub-hashes are shown

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -129,7 +129,6 @@ default_manager.add("organizations:performance-mep-bannerless-ui", OrganizationF
 default_manager.add("organizations:performance-mep-reintroduce-histograms", OrganizationFeature, True)
 default_manager.add("organizations:performance-new-widget-designs", OrganizationFeature, True)
 default_manager.add("organizations:profiling", OrganizationFeature)
-default_manager.add("organizations:profiling-onboarding-checklist", OrganizationFeature, True)
 default_manager.add("organizations:project-event-date-limit", OrganizationFeature, True)
 default_manager.add("organizations:project-stats", OrganizationFeature, True)
 default_manager.add("organizations:related-events", OrganizationFeature)


### PR DESCRIPTION
## Summary
Removes the `organizations:profiling-onboarding-checklist` flag which is no longer in use.