### PR TITLE
ref(hybrid-cloud): use organization_slug in MonitorCheckIns

### DIFF
--- a/src/sentry/api/bases/monitor.py
+++ b/src/sentry/api/bases/monitor.py
@@ -1,3 +1,4 @@
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,6 +16,10 @@ class InvalidAuthProject(Exception):
 
 class MonitorEndpoint(Endpoint):
     permission_classes = (ProjectPermission,)
+
+    @staticmethod
+    def respond_invalid() -> Response:
+        return Response(status=status.HTTP_400_BAD_REQUEST, data={"details": "Invalid monitor"})
 
     def convert_args(self, request: Request, monitor_id, *args, **kwargs):
         try:

--- a/src/sentry/api/endpoints/monitor_details.py
+++ b/src/sentry/api/endpoints/monitor_details.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from django.db import transaction
-from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,10 +14,6 @@ from sentry.models import Monitor, MonitorStatus, ScheduledDeletion
 
 @region_silo_endpoint
 class MonitorDetailsEndpoint(MonitorEndpoint):
-    @staticmethod
-    def respond_invalid() -> Response:
-        return Response(status=status.HTTP_400_BAD_REQUEST, data={"details": "Invalid monitor"})
-
     def get(
         self, request: Request, project, monitor, organization_slug: str | None = None
     ) -> Response:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -680,6 +680,11 @@ urlpatterns = [
                     name="sentry-api-0-monitor-check-in-index",
                 ),
                 url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<monitor_id>[^\/]+)/checkins/$",
+                    MonitorCheckInsEndpoint.as_view(),
+                    name="sentry-api-0-monitor-check-in-index-with-org",
+                ),
+                url(
                     r"^(?P<monitor_id>[^\/]+)/$",
                     MonitorDetailsEndpoint.as_view(),
                     name="sentry-api-0-monitor-details",

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2208,12 +2208,14 @@ class MonitorTestCase(APITestCase):
     def _get_path_functions(self):
         return (
             lambda monitor: reverse(self.endpoint, args=[monitor.guid]),
-            lambda monitor: reverse(self.endpoint_with_org, args=[self.org.slug, monitor.guid]),
+            lambda monitor: reverse(
+                self.endpoint_with_org, args=[self.organization.slug, monitor.guid]
+            ),
         )
 
     def _create_monitor(self):
         return Monitor.objects.create(
-            organization_id=self.org.id,
+            organization_id=self.organization.id,
             project_id=self.project.id,
             next_checkin=timezone.now() - timedelta(minutes=1),
             type=MonitorType.CRON_JOB,

--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -3,85 +3,90 @@ from uuid import UUID
 
 from django.utils import timezone
 from freezegun import freeze_time
-from rest_framework import status
 
 from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, MonitorType
-from sentry.testutils import APITestCase
+from sentry.testutils import MonitorTestCase
+from sentry.testutils.silo import region_silo_test
 
 
+@region_silo_test(stable=True)
 @freeze_time()
-class CreateMonitorCheckInTest(APITestCase):
+class CreateMonitorCheckInTest(MonitorTestCase):
     endpoint = "sentry-api-0-monitor-check-in-index"
-    method = "post"
+    endpoint_with_org = "sentry-api-0-monitor-check-in-index-with-org"
+
+    def setUp(self):
+        super().setUp()
 
     def test_passing(self):
         self.login_as(self.user)
 
-        monitor = Monitor.objects.create(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            next_checkin=timezone.now() - timedelta(minutes=1),
-            type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *"},
-        )
-
         with self.feature("organizations:monitors"):
-            response = self.get_success_response(monitor.guid, status="ok")
+            for path_func in self._get_path_functions():
+                monitor = self._create_monitor()
+                path = path_func(monitor)
 
-        checkin = MonitorCheckIn.objects.get(guid=response.data["id"])
-        assert checkin.status == CheckInStatus.OK
+                resp = self.client.post(path, {"status": "ok"})
+                assert resp.status_code == 201, resp.content
 
-        monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == MonitorStatus.OK
-        assert monitor.last_checkin == checkin.date_added
-        assert monitor.next_checkin == monitor.get_next_scheduled_checkin(checkin.date_added)
+                checkin = MonitorCheckIn.objects.get(guid=resp.data["id"])
+                assert checkin.status == CheckInStatus.OK
+
+                monitor = Monitor.objects.get(id=monitor.id)
+                assert monitor.status == MonitorStatus.OK
+                assert monitor.last_checkin == checkin.date_added
+                assert monitor.next_checkin == monitor.get_next_scheduled_checkin(
+                    checkin.date_added
+                )
 
     def test_failing(self):
         self.login_as(self.user)
 
-        monitor = Monitor.objects.create(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            next_checkin=timezone.now() - timedelta(minutes=1),
-            type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *"},
-        )
-
         with self.feature("organizations:monitors"):
-            response = self.get_success_response(monitor.guid, status="error")
+            for path_func in self._get_path_functions():
+                monitor = self._create_monitor()
+                path = path_func(monitor)
 
-        checkin = MonitorCheckIn.objects.get(guid=response.data["id"])
-        assert checkin.status == CheckInStatus.ERROR
+                resp = self.client.post(path, {"status": "error"})
+                assert resp.status_code == 201, resp.content
 
-        monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == MonitorStatus.ERROR
-        assert monitor.last_checkin == checkin.date_added
-        assert monitor.next_checkin == monitor.get_next_scheduled_checkin(checkin.date_added)
+                checkin = MonitorCheckIn.objects.get(guid=resp.data["id"])
+                assert checkin.status == CheckInStatus.ERROR
+
+                monitor = Monitor.objects.get(id=monitor.id)
+                assert monitor.status == MonitorStatus.ERROR
+                assert monitor.last_checkin == checkin.date_added
+                assert monitor.next_checkin == monitor.get_next_scheduled_checkin(
+                    checkin.date_added
+                )
 
     def test_disabled(self):
         self.login_as(self.user)
 
-        monitor = Monitor.objects.create(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            next_checkin=timezone.now() - timedelta(minutes=1),
-            type=MonitorType.CRON_JOB,
-            status=MonitorStatus.DISABLED,
-            config={"schedule": "* * * * *"},
-        )
-
         with self.feature("organizations:monitors"):
-            response = self.get_success_response(monitor.guid, status="error")
+            for path_func in self._get_path_functions():
+                monitor = Monitor.objects.create(
+                    organization_id=self.organization.id,
+                    project_id=self.project.id,
+                    next_checkin=timezone.now() - timedelta(minutes=1),
+                    type=MonitorType.CRON_JOB,
+                    status=MonitorStatus.DISABLED,
+                    config={"schedule": "* * * * *"},
+                )
+                path = path_func(monitor)
 
-        assert response.status_code == 201, response.content
+                resp = self.client.post(path, {"status": "error"})
+                assert resp.status_code == 201, resp.content
 
-        checkin = MonitorCheckIn.objects.get(guid=response.data["id"])
-        assert checkin.status == CheckInStatus.ERROR
+                checkin = MonitorCheckIn.objects.get(guid=resp.data["id"])
+                assert checkin.status == CheckInStatus.ERROR
 
-        monitor = Monitor.objects.get(id=monitor.id)
-        assert monitor.status == MonitorStatus.DISABLED
-        assert monitor.last_checkin == checkin.date_added
-        assert monitor.next_checkin == monitor.get_next_scheduled_checkin(checkin.date_added)
+                monitor = Monitor.objects.get(id=monitor.id)
+                assert monitor.status == MonitorStatus.DISABLED
+                assert monitor.last_checkin == checkin.date_added
+                assert monitor.next_checkin == monitor.get_next_scheduled_checkin(
+                    checkin.date_added
+                )
 
     def test_pending_deletion(self):
         self.login_as(self.user)
@@ -96,11 +101,11 @@ class CreateMonitorCheckInTest(APITestCase):
         )
 
         with self.feature("organizations:monitors"):
-            self.get_error_response(
-                monitor.guid,
-                status="error",
-                status_code=status.HTTP_404_NOT_FOUND,
-            )
+            for path_func in self._get_path_functions():
+                path = path_func(monitor)
+
+                resp = self.client.post(path, {"status": "error"})
+                assert resp.status_code == 404
 
     def test_deletion_in_progress(self):
         self.login_as(self.user)
@@ -115,33 +120,28 @@ class CreateMonitorCheckInTest(APITestCase):
         )
 
         with self.feature("organizations:monitors"):
-            self.get_error_response(
-                monitor.guid,
-                status="error",
-                status_code=status.HTTP_404_NOT_FOUND,
-            )
+            for path_func in self._get_path_functions():
+                path = path_func(monitor)
+
+                resp = self.client.post(path, {"status": "error"})
+                assert resp.status_code == 404
 
     def test_with_dsn_auth(self):
         project_key = self.create_project_key(project=self.project)
 
-        monitor = Monitor.objects.create(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            next_checkin=timezone.now() - timedelta(minutes=1),
-            type=MonitorType.CRON_JOB,
-            config={"schedule": "* * * * *"},
-        )
-
         with self.feature("organizations:monitors"):
-            response = self.get_success_response(
-                monitor.guid,
-                status="ok",
-                extra_headers={"HTTP_AUTHORIZATION": f"DSN {project_key.dsn_public}"},
-            )
+            for path_func in self._get_path_functions():
+                monitor = self._create_monitor()
+                path = path_func(monitor)
 
-        # DSN auth should only return id
-        assert list(response.data.keys()) == ["id"]
-        assert UUID(response.data["id"])
+                resp = self.client.post(
+                    path, {"status": "ok"}, HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}"
+                )
+                assert resp.status_code == 201, resp.content
+
+                # DSN auth should only return id
+                assert list(resp.data.keys()) == ["id"]
+                assert UUID(resp.data["id"])
 
     def test_with_dsn_auth_invalid_project(self):
         project2 = self.create_project()
@@ -156,9 +156,13 @@ class CreateMonitorCheckInTest(APITestCase):
         )
 
         with self.feature("organizations:monitors"):
-            self.get_error_response(
-                monitor.guid,
-                status="ok",
-                extra_headers={"HTTP_AUTHORIZATION": f"DSN {project_key.dsn_public}"},
-                status_code=status.HTTP_400_BAD_REQUEST,
-            )
+            for path_func in self._get_path_functions():
+                path = path_func(monitor)
+
+                resp = self.client.post(
+                    path,
+                    {"status": "ok"},
+                    HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}",
+                )
+
+                assert resp.status_code == 400, resp.content

--- a/tests/sentry/api/endpoints/test_monitor_details.py
+++ b/tests/sentry/api/endpoints/test_monitor_details.py
@@ -9,10 +9,7 @@ class MonitorDetailsTest(MonitorTestCase):
     endpoint_with_org = "sentry-api-0-monitor-details-with-org"
 
     def setUp(self):
-        self.user = self.create_user()
-        self.org = self.create_organization(owner=self.user)
-        self.team = self.create_team(organization=self.org, members=[self.user])
-        self.project = self.create_project(teams=[self.team])
+        super().setUp()
 
     def test_simple(self):
         self.login_as(user=self.user)
@@ -43,10 +40,7 @@ class UpdateMonitorTest(MonitorTestCase):
     endpoint_with_org = "sentry-api-0-monitor-details-with-org"
 
     def setUp(self):
-        self.user = self.create_user()
-        self.org = self.create_organization(owner=self.user)
-        self.team = self.create_team(organization=self.org, members=[self.user])
-        self.project = self.create_project(teams=[self.team])
+        super().setUp()
 
         self.login_as(user=self.user)
 
@@ -267,10 +261,7 @@ class DeleteMonitorTest(MonitorTestCase):
     endpoint_with_org = "sentry-api-0-monitor-details-with-org"
 
     def setUp(self):
-        self.user = self.create_user()
-        self.org = self.create_organization(owner=self.user)
-        self.team = self.create_team(organization=self.org, members=[self.user])
-        self.project = self.create_project(teams=[self.team])
+        super().setUp()
 
     def test_simple(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Adds `organization_slug` to the url for the MonitorCheckIns endpoint. Keeps the original orgless URL for now.

Also refactors MonitorEndpoint and MonitorTestCase for better reusability.

For HC-513