### PR TITLE
bug(replays): Make it easier to inspect inside the replay player iframe

### DIFF
--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -172,6 +172,10 @@ const PlayerRoot = styled(BasePlayerRoot)`
   .replayer-wrapper {
     user-select: none;
   }
+
+  .replayer-wrapper > .replayer-mouse {
+    pointer-events: none;
+  }
   .replayer-wrapper > .replayer-mouse-tail {
     position: absolute;
     pointer-events: none;
@@ -181,6 +185,7 @@ const PlayerRoot = styled(BasePlayerRoot)`
   .replayer-wrapper > iframe {
     border: none;
     background: white;
+    pointer-events: initial !important;
   }
 `;
 

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -185,6 +185,8 @@ const PlayerRoot = styled(BasePlayerRoot)`
   .replayer-wrapper > iframe {
     border: none;
     background: white;
+
+    /* Set pointer-events to make it easier to right-click & inspect */
     pointer-events: initial !important;
   }
 `;


### PR DESCRIPTION
Before whenever you wanted to inspect the replay player iframe, right-click inspect would drop you outside the iframe and you'd have to dif in yourself. 

Now you can just jump inside and inspect elements inside the iframe directly. The virtual mouse, mouse-tail, and even the "you can inspect things" notif are all set to pointer-events: none, so they won't get in the way for folks either.

<img width="800" alt="SCR-20221214-qb6" src="https://user-images.githubusercontent.com/187460/207741406-680f244a-74c0-4f05-88ef-61dd8b6b3638.png">
