### PR TITLE
bug(replays): Fix <button> in <button> nesting

### DIFF
--- a/static/app/views/replays/detail/timestampButton.tsx
+++ b/static/app/views/replays/detail/timestampButton.tsx
@@ -23,7 +23,11 @@ function TimestampButton({
 }: Props) {
   return (
     <Tooltip title={<DateTime date={timestampMs} />}>
-      <StyledButton onClick={onClick} className={className}>
+      <StyledButton
+        as={onClick ? 'button' : 'span'}
+        onClick={onClick}
+        className={className}
+      >
         <IconPlay size="xs" />
         {showPlayerTime(timestampMs, startTimestampMs, format === 'mm:ss.SSS')}
       </StyledButton>


### PR DESCRIPTION
Chrome console was showing a warning:
> validateDOMNesting(...): <button> cannot appear as a descendant of <button>.
![SCR-20221214-klf](https://user-images.githubusercontent.com/187460/207742719-0b10a21a-cf84-4836-9ec0-9f7ad9acb279.png)

Now it's a span (still without it's own onClick handler, no need for that so it wasn't there):
<img width="938" alt="SCR-20221214-qpc" src="https://user-images.githubusercontent.com/187460/207742819-e1f51fcc-d7ed-4f7e-9782-874ab55d6ecd.png">
