### PR TITLE
config(anr-rate): Use option to control abnormal_mechanism extraction

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -553,6 +553,9 @@ register("sentry-metrics.cardinality-limiter.limits.performance.per-org", defaul
 register("sentry-metrics.cardinality-limiter.limits.releasehealth.per-org", default=[])
 register("sentry-metrics.cardinality-limiter.orgs-rollout-rate", default=0.0)
 
+# Flag to determine whether abnormal_mechanism tag should be extracted
+register("sentry-metrics.releasehealth.abnormal-mechanism-extraction-rate", default=0.0)
+
 # Performance issue options to change both detection (which we can monitor with metrics),
 # and the creation of performance problems, which will eventually get turned into issues.
 register("performance.issues.all.problem-detection", default=0.0)

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -250,7 +250,7 @@ def _get_project_config(
 
     if features.has("organizations:metrics-extraction", project.organization):
         config["sessionMetrics"] = {
-            "version": 1,
+            "version": 2 if _should_extract_abnormal_mechanism(project) else 1,
             "drop": features.has(
                 "organizations:release-health-drop-sessions", project.organization
             ),
@@ -490,6 +490,12 @@ def _should_extract_transaction_metrics(project: Project) -> bool:
 def _accept_transaction_names_strategy(project: Project) -> TransactionNameStrategy:
     is_selected_org = sample_modulo("relay.transaction-names-client-based", project.organization_id)
     return "clientBased" if is_selected_org else "strict"
+
+
+def _should_extract_abnormal_mechanism(project: Project) -> TransactionNameStrategy:
+    return sample_modulo(
+        "sentry-metrics.releasehealth.abnormal-mechanism-extraction-rate", project.organization_id
+    )
 
 
 def get_transaction_metrics_settings(

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -49,6 +49,9 @@ EXPOSABLE_FEATURES = [
     "organizations:session-replay",
 ]
 
+EXTRACT_METRICS_VERSION = 1
+EXTRACT_ABNORMAL_MECHANISM_VERSION = 2
+
 logger = logging.getLogger(__name__)
 
 
@@ -256,7 +259,9 @@ def _get_project_config(
 
     if features.has("organizations:metrics-extraction", project.organization):
         config["sessionMetrics"] = {
-            "version": 2 if _should_extract_abnormal_mechanism(project) else 1,
+            "version": EXTRACT_ABNORMAL_MECHANISM_VERSION
+            if _should_extract_abnormal_mechanism(project)
+            else EXTRACT_METRICS_VERSION,
             "drop": features.has(
                 "organizations:release-health-drop-sessions", project.organization
             ),

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -184,6 +184,12 @@ def add_experimental_config(
             config[key] = subconfig
 
 
+def _should_extract_abnormal_mechanism(project: Project) -> bool:
+    return sample_modulo(
+        "sentry-metrics.releasehealth.abnormal-mechanism-extraction-rate", project.organization_id
+    )
+
+
 def _get_project_config(
     project: Project, full_config: bool = True, project_keys: Optional[Sequence[ProjectKey]] = None
 ) -> "ProjectConfig":
@@ -490,12 +496,6 @@ def _should_extract_transaction_metrics(project: Project) -> bool:
 def _accept_transaction_names_strategy(project: Project) -> TransactionNameStrategy:
     is_selected_org = sample_modulo("relay.transaction-names-client-based", project.organization_id)
     return "clientBased" if is_selected_org else "strict"
-
-
-def _should_extract_abnormal_mechanism(project: Project) -> TransactionNameStrategy:
-    return sample_modulo(
-        "sentry-metrics.releasehealth.abnormal-mechanism-extraction-rate", project.organization_id
-    )
 
 
 def get_transaction_metrics_settings(


### PR DESCRIPTION
Extract abnromal_mechanism in relays if enabled.
Won't merge till 
[✅ ] https://github.com/getsentry/sentry/pull/42367 is merged and 
[✅ ] ops sets a value for the [option](https://getsentry.atlassian.net/browse/OPS-2743)