### PR TITLE
ref(js): Remove enforceActOnUseLegacyStoreHook hack

### DIFF
--- a/static/app/stores/useLegacyStore.tsx
+++ b/static/app/stores/useLegacyStore.tsx
@@ -6,17 +6,6 @@ import {CommonStoreDefinition} from './types';
 interface LegacyStoreShape extends Store, CommonStoreDefinition<any> {}
 
 /**
- * This wrapper exists because we have many old-style enzyme tests that trigger
- * updates to stores without being wrapped in act.
- *
- * Wrting tests with React Testing Library typically circumvents the need for
- * this. See [0].
- *
- * [0]: https://javascript.plainenglish.io/you-probably-dont-need-act-in-your-react-tests-2a0bcd2ad65c
- */
-window._legacyStoreHookUpdate = update => update();
-
-/**
  * Returns the state of a reflux store. Automatically unsubscribes when destroyed
  *
  * ```
@@ -29,7 +18,7 @@ export function useLegacyStore<T extends LegacyStoreShape>(
   const [state, setState] = useState(store.getState());
 
   // Not all stores emit the new state, call get on change
-  const callback = () => window._legacyStoreHookUpdate(() => setState(store.getState()));
+  const callback = () => setState(store.getState());
 
   // If we setup the listener in useEffect, there is a small race condition
   // where the store may emit an event before we're listening (since useEffect

--- a/static/app/types/system.tsx
+++ b/static/app/types/system.tsx
@@ -73,13 +73,6 @@ declare global {
      * Assets public location
      */
     __sentryGlobalStaticPrefix: string;
-    /**
-     * This is used for testing purposes as an interem while we translate tests
-     * to React Testing Library.
-     *
-     * See the useLegacyStore hook for more unformation about this.
-     */
-    _legacyStoreHookUpdate: (update: () => void) => void;
     // typing currently used for demo add on
     // TODO: improve typing
     SentryApp?: {

--- a/static/app/views/performance/trends/index.spec.tsx
+++ b/static/app/views/performance/trends/index.spec.tsx
@@ -182,7 +182,6 @@ function initializeTrendsData(
 
 describe('Performance > Trends', function () {
   let trendsStatsMock;
-  // const originalHook = window._legacyStoreHookUpdate;
   beforeEach(function () {
     browserHistory.push = jest.fn();
     MockApiClient.addMockResponse({

--- a/tests/js/sentry-test/enzyme.js
+++ b/tests/js/sentry-test/enzyme.js
@@ -2,8 +2,6 @@ import {cache} from '@emotion/css'; // eslint-disable-line @emotion/no-vanilla
 import {CacheProvider, ThemeProvider} from '@emotion/react';
 import {mount, shallow as enzymeShallow} from 'enzyme'; // eslint-disable-line no-restricted-imports
 
-import {act} from 'sentry-test/reactTestingLibrary';
-
 import {lightTheme} from 'sentry/utils/theme';
 
 /**
@@ -33,25 +31,3 @@ export function mountWithTheme(tree, opts = {}) {
  * please avoid using `sentry-test/enzyme/shallow` and use `sentry-test/reactTestingLibrary/render` instead.
  */
 export const shallow = enzymeShallow;
-
-/**
- * @deprecated
- * Force the useLegacyStore setState updates to be wrapped in act.
- *
- * This is useful for old-style enzyme tests where enzyme does not correctly
- * wrap things in `act()` for you.
- *
- * Do NOT use this in RTL tests, as setState's triggered by store updates
- * should be captured with RTL style tests.
- */
-export function enforceActOnUseLegacyStoreHook() {
-  const originalHook = window._legacyStoreHookUpdate;
-
-  beforeEach(() => {
-    window._legacyStoreHookUpdate = update => act(update);
-  });
-
-  afterEach(() => {
-    window._legacyStoreHookUpdate = originalHook;
-  });
-}


### PR DESCRIPTION
This was only needed because enzyme wasn't wrapping actions in `act`.