### PR TITLE
feat(txnames): Sort rules in project options

### DIFF
--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -10,7 +10,11 @@ from sentry.ingest.transaction_clusterer.datasource.redis import (
     get_transaction_names,
     record_transaction_name,
 )
-from sentry.ingest.transaction_clusterer.rules import _get_rules, _sort_rules, update_rules
+from sentry.ingest.transaction_clusterer.rules import (
+    ProjectOptionRuleStore,
+    _get_rules,
+    update_rules,
+)
 from sentry.ingest.transaction_clusterer.tasks import cluster_projects, spawn_clusterers
 from sentry.ingest.transaction_clusterer.tree import TreeClusterer
 from sentry.models.project import Project
@@ -113,7 +117,7 @@ def test_record_transactions(
 
 def test_sort_rules():
     rules = {"/a/*/**": 1, "/a/**": 2, "/a/*/c/**": 3}
-    assert _sort_rules(rules) == [
+    assert ProjectOptionRuleStore()._sort(rules) == [
         ("/a/*/c/**", 3),
         ("/a/*/**", 1),
         ("/a/**", 2),

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -4,13 +4,13 @@ import pytest
 from freezegun import freeze_time
 
 from sentry.eventstore.models import Event
-from sentry.ingest.transaction_clusterer import rules
 from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.datasource.redis import (
     _store_transaction_name,
     get_transaction_names,
     record_transaction_name,
 )
+from sentry.ingest.transaction_clusterer.rules import _get_rules, _sort_rules, update_rules
 from sentry.ingest.transaction_clusterer.tasks import cluster_projects, spawn_clusterers
 from sentry.ingest.transaction_clusterer.tree import TreeClusterer
 from sentry.models.project import Project
@@ -111,21 +111,30 @@ def test_record_transactions(
         assert len(mocked_record.mock_calls) == expected
 
 
+def test_sort_rules():
+    rules = {"/a/*/**": 1, "/a/**": 2, "/a/*/c/**": 3}
+    assert _sort_rules(rules) == [
+        ("/a/*/c/**", 3),
+        ("/a/*/**", 1),
+        ("/a/**", 2),
+    ]
+
+
 @pytest.mark.django_db
 def test_save_rules(default_project):
     project = default_project
 
-    project_rules = rules.get_rules(project)
+    project_rules = _get_rules(project)
     assert project_rules == {}
 
     with freeze_time("2012-01-14 12:00:01"):
-        rules.update_rules(project, [ReplacementRule("foo"), ReplacementRule("bar")])
-    project_rules = rules.get_rules(project)
+        update_rules(project, [ReplacementRule("foo"), ReplacementRule("bar")])
+    project_rules = _get_rules(project)
     assert project_rules == {"foo": 1326542401, "bar": 1326542401}
 
     with freeze_time("2012-01-14 12:00:02"):
-        rules.update_rules(project, [ReplacementRule("bar"), ReplacementRule("zap")])
-    project_rules = rules.get_rules(project)
+        update_rules(project, [ReplacementRule("bar"), ReplacementRule("zap")])
+    project_rules = _get_rules(project)
     assert {"bar": 1326542402, "foo": 1326542401, "zap": 1326542402}
 
 
@@ -151,8 +160,8 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
         assert cluster_projects_delay.call_count == 1
         cluster_projects_delay.reset_mock()
 
-        pr1_rules = rules.get_rules(project1)
-        pr2_rules = rules.get_rules(project2)
+        pr1_rules = _get_rules(project1)
+        pr2_rules = _get_rules(project2)
 
         assert set(pr1_rules.keys()) == {"/org/*/**", "/user/*/**"}
         assert set(pr2_rules.keys()) == {"/org/*/**", "/user/*/**"}
@@ -168,7 +177,7 @@ def test_run_clusterer_task(cluster_projects_delay, default_organization):
         # One project per batch now:
         assert cluster_projects_delay.call_count == 2
 
-        pr_rules = rules.get_rules(project1)
+        pr_rules = _get_rules(project1)
         assert pr_rules.keys() == {
             "/org/*/**",
             "/user/*/**",


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/42290 added logic to store rules from the transaction clusterer in project options.

Relay will want to execute these rules in order of specifity (that is, depth of the URL directory == number of slashes in the URL), so we need to sort them before writing to project options.