### PR TITLE
feat(issue-details-page): Add alert to guide the user to set up source maps - [TET-599]

### DIFF
--- a/fixtures/js-stubs/exceptionWithRawStackTrace.js
+++ b/fixtures/js-stubs/exceptionWithRawStackTrace.js
@@ -1,0 +1,74 @@
+export function ExceptionWithRawStackTrace(params = {}) {
+  return {
+    platform: 'javascript',
+    entries: [
+      {
+        type: 'exception',
+        data: {
+          values: [
+            {
+              type: 'ReferenceError',
+              value: 'methodDoesNotExist is not defined',
+              stacktrace: {
+                frames: [
+                  {
+                    function: 'sentryWrapped',
+                    module: '@sentry/browser/esm/helpers',
+                    filename: './node_modules/@sentry/browser/esm/helpers.js',
+                    abs_path: 'webpack:///./node_modules/@sentry/browser/esm/helpers.js',
+                    lineno: 95,
+                    colno: 17,
+                    pre_context: [
+                      '      }); // Attempt to invoke user-land function',
+                      '      // NOTE: If you are a Sentry user, and you are seeing this stack frame, it',
+                      '      //       means the sentry.javascript SDK caught an error invoking your application code. This',
+                      '      //       is expected behavior and NOT indicative of a bug with sentry.javascript.',
+                      '',
+                    ],
+                    context_line: '      return fn.apply(this, wrappedArguments);',
+                    post_context: [
+                      '    } catch (ex) {',
+                      '      ignoreNextOnError();',
+                      '      withScope(function (scope) {',
+                      '        scope.addEventProcessor(function (event) {',
+                      '          if (options.mechanism) {',
+                    ],
+                    in_app: false,
+                    data: {
+                      sourcemap:
+                        'https://develop.sentry.dev/app-69b3880622358a8ea89e.js.map',
+                    },
+                  },
+                ],
+              },
+              rawStacktrace: {
+                frames: [
+                  {
+                    function: 'HTMLDocument.o',
+                    filename: '/app-69b3880622358a8ea89e.js',
+                    abs_path: 'https://develop.sentry.dev/app-69b3880622358a8ea89e.js',
+                    lineno: 5,
+                    colno: 133993,
+                    pre_context: [
+                      '/*! For license information please see app-69b3880622358a8ea89e.js.LICENSE.txt */',
+                      '(window.webpackJsonp=window.webpackJsonp||[]).push([[1],{"+924":function(e,t,r){"use strict";r.d(t,"a",(function(){return s})),r.d(t,"b",(fu {snip}',
+                      '  color: var(--light-text);',
+                      '  line-height: 1.65;',
+                    ],
+                    context_line:
+                      '{snip} ments);var o=n.map((function(e){return ze(e,t)}));return e.apply(this,o)}catch(i){throw Be(),$((function(e){e.addEventProcessor((function(e) {snip}',
+                    post_context: [
+                      '//# sourceMappingURL=app-69b3880622358a8ea89e.js.map',
+                    ],
+                    in_app: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    ],
+    ...params,
+  };
+}

--- a/fixtures/js-stubs/types.tsx
+++ b/fixtures/js-stubs/types.tsx
@@ -46,6 +46,7 @@ type TestStubFixtures = {
   Events: OverridableStubList;
   EventsStats: OverridableStub;
   ExceptionWithMeta: OverridableStubList;
+  ExceptionWithRawStackTrace: OverridableStub;
   GitHubIntegration: OverridableStub;
   GitHubIntegrationConfig: SimpleStub;
   GitHubIntegrationProvider: OverridableStub;

--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -114,6 +114,7 @@ describe('Exception Content', function () {
         event={event}
         values={event.entries[0].data.values}
         meta={event._meta.entries[0].data.values}
+        projectId={project.id}
       />,
       {organization, router, context: routerContext}
     );

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -4,12 +4,13 @@ import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import Tooltip from 'sentry/components/tooltip';
 import {tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {ExceptionType} from 'sentry/types';
+import {ExceptionType, Project} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {STACK_TYPE} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
 
 import {Mechanism} from './mechanism';
+import {SetupSourceMapsAlert} from './setupSourceMapsAlert';
 import StackTrace from './stackTrace';
 
 type StackTraceProps = React.ComponentProps<typeof StackTrace>;
@@ -17,6 +18,7 @@ type StackTraceProps = React.ComponentProps<typeof StackTrace>;
 type Props = {
   event: Event;
   platform: StackTraceProps['platform'];
+  projectId: Project['id'];
   type: STACK_TYPE;
   meta?: Record<any, any>;
   newestFirst?: boolean;
@@ -37,6 +39,7 @@ export function Content({
   values,
   type,
   meta,
+  projectId,
 }: Props) {
   if (!values) {
     return null;
@@ -62,6 +65,7 @@ export function Content({
         {exc.mechanism && (
           <Mechanism data={exc.mechanism} meta={meta?.[excIdx]?.mechanism} />
         )}
+        <SetupSourceMapsAlert projectId={projectId} event={event} />
         <StackTrace
           data={
             type === STACK_TYPE.ORIGINAL

--- a/static/app/components/events/interfaces/crashContent/exception/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/index.tsx
@@ -51,6 +51,7 @@ function Exception({
           hasHierarchicalGrouping={hasHierarchicalGrouping}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
+          projectId={projectId}
         />
       )}
     </ErrorBoundary>

--- a/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.spec.tsx
@@ -1,0 +1,98 @@
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SetupSourceMapsAlert} from './setupSourceMapsAlert';
+
+describe('SetupSourceMapsAlert', function () {
+  it('NOT show alert if javascript platform and source maps found', function () {
+    const {project, organization} = initializeOrg();
+    const event = TestStubs.ExceptionWithRawStackTrace();
+
+    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+      organization,
+    });
+
+    expect(
+      screen.queryByText('Get Sentry ready for your production environment')
+    ).not.toBeInTheDocument();
+  });
+
+  it('show alert if javascript platform and source maps not found', function () {
+    const {project, organization} = initializeOrg();
+    const event = TestStubs.EventStacktraceException({platform: 'javascript'});
+
+    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByText('Get Sentry ready for your production environment')
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Setup Source Maps'})).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/platforms/javascript/sourcemaps/'
+    );
+  });
+
+  it('show documentation for react according to the sdk name', function () {
+    const {project, organization} = initializeOrg();
+    const event = TestStubs.EventStacktraceException({
+      sdk: {name: 'sentry.javascript.react'},
+    });
+
+    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByText('Get Sentry ready for your production environment')
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Setup Source Maps'})).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/'
+    );
+  });
+
+  it('show documentation for react according to the event platform', function () {
+    const {project, organization} = initializeOrg();
+    const event = TestStubs.EventStacktraceException({
+      platform: 'react',
+      sdk: {name: 'sentry.javascript.browser'},
+    });
+
+    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByText('Get Sentry ready for your production environment')
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Setup Source Maps'})).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/'
+    );
+  });
+
+  it('show generic documentation if doc link not available', function () {
+    const {project, organization} = initializeOrg();
+    const event = TestStubs.EventStacktraceException({
+      platform: 'unity',
+    });
+
+    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByText('Get Sentry ready for your production environment')
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Setup Source Maps'})).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/platforms/javascript/sourcemaps/'
+    );
+  });
+});

--- a/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.spec.tsx
@@ -5,7 +5,10 @@ import {SetupSourceMapsAlert} from './setupSourceMapsAlert';
 
 describe('SetupSourceMapsAlert', function () {
   it('NOT show alert if javascript platform and source maps found', function () {
-    const {project, organization} = initializeOrg();
+    const {project, organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+    });
     const event = TestStubs.ExceptionWithRawStackTrace();
 
     render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
@@ -20,7 +23,10 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show alert if javascript platform and source maps not found', function () {
-    const {project, organization} = initializeOrg();
+    const {project, organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+    });
     const event = TestStubs.EventStacktraceException({platform: 'javascript'});
 
     render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
@@ -40,7 +46,10 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show documentation for react according to the sdk name', function () {
-    const {project, organization} = initializeOrg();
+    const {project, organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+    });
     const event = TestStubs.EventStacktraceException({
       sdk: {name: 'sentry.javascript.react'},
     });
@@ -62,7 +71,10 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show documentation for react according to the event platform', function () {
-    const {project, organization} = initializeOrg();
+    const {project, organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+    });
     const event = TestStubs.EventStacktraceException({
       platform: 'react',
       sdk: {name: 'sentry.javascript.browser'},
@@ -85,7 +97,10 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show generic documentation if doc link not available', function () {
-    const {project, organization} = initializeOrg();
+    const {project, organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+    });
     const event = TestStubs.EventStacktraceException({
       platform: 'unity',
     });
@@ -107,7 +122,10 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show localhost copy', function () {
-    const {project, organization} = initializeOrg();
+    const {project, organization} = initializeOrg({
+      ...initializeOrg(),
+      organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+    });
     const event = TestStubs.EventStacktraceException({
       platform: 'unity',
       tags: [

--- a/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.spec.tsx
@@ -13,7 +13,9 @@ describe('SetupSourceMapsAlert', function () {
     });
 
     expect(
-      screen.queryByText('Get Sentry ready for your production environment')
+      screen.queryByText(
+        'Sentry can un-minify your code to show you more readable stack traces'
+      )
     ).not.toBeInTheDocument();
   });
 
@@ -26,10 +28,12 @@ describe('SetupSourceMapsAlert', function () {
     });
 
     expect(
-      screen.getByText('Get Sentry ready for your production environment')
+      screen.getByText(
+        'Sentry can un-minify your code to show you more readable stack traces'
+      )
     ).toBeInTheDocument();
 
-    expect(screen.getByRole('button', {name: 'Setup Source Maps'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'Upload Source Maps'})).toHaveAttribute(
       'href',
       'https://docs.sentry.io/platforms/javascript/sourcemaps/'
     );
@@ -46,10 +50,12 @@ describe('SetupSourceMapsAlert', function () {
     });
 
     expect(
-      screen.getByText('Get Sentry ready for your production environment')
+      screen.getByText(
+        'Sentry can un-minify your code to show you more readable stack traces'
+      )
     ).toBeInTheDocument();
 
-    expect(screen.getByRole('button', {name: 'Setup Source Maps'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'Upload Source Maps'})).toHaveAttribute(
       'href',
       'https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/'
     );
@@ -67,10 +73,12 @@ describe('SetupSourceMapsAlert', function () {
     });
 
     expect(
-      screen.getByText('Get Sentry ready for your production environment')
+      screen.getByText(
+        'Sentry can un-minify your code to show you more readable stack traces'
+      )
     ).toBeInTheDocument();
 
-    expect(screen.getByRole('button', {name: 'Setup Source Maps'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'Upload Source Maps'})).toHaveAttribute(
       'href',
       'https://docs.sentry.io/platforms/javascript/guides/react/sourcemaps/'
     );
@@ -87,10 +95,40 @@ describe('SetupSourceMapsAlert', function () {
     });
 
     expect(
-      screen.getByText('Get Sentry ready for your production environment')
+      screen.getByText(
+        'Sentry can un-minify your code to show you more readable stack traces'
+      )
     ).toBeInTheDocument();
 
-    expect(screen.getByRole('button', {name: 'Setup Source Maps'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'Upload Source Maps'})).toHaveAttribute(
+      'href',
+      'https://docs.sentry.io/platforms/javascript/sourcemaps/'
+    );
+  });
+
+  it('show localhost copy', function () {
+    const {project, organization} = initializeOrg();
+    const event = TestStubs.EventStacktraceException({
+      platform: 'unity',
+      tags: [
+        {
+          key: 'url',
+          value: 'http://localhost:3000',
+        },
+      ],
+    });
+
+    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByText(
+        'In production, you might have minified JS code that makes stack traces hard to read. Sentry can un-minify it for you'
+      )
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Upload Source Maps'})).toHaveAttribute(
       'href',
       'https://docs.sentry.io/platforms/javascript/sourcemaps/'
     );

--- a/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.tsx
@@ -48,7 +48,7 @@ type Props = {
 export function SetupSourceMapsAlert({projectId, event}: Props) {
   const organization = useOrganization();
 
-  if (!organization.features.includes('source-maps-cta')) {
+  if (!organization.features?.includes('source-maps-cta')) {
     return null;
   }
 

--- a/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.tsx
@@ -47,6 +47,11 @@ type Props = {
 
 export function SetupSourceMapsAlert({projectId, event}: Props) {
   const organization = useOrganization();
+
+  if (!organization.features.includes('source-maps-cta')) {
+    return null;
+  }
+
   const eventPlatform = event.platform ?? 'other';
   const eventFromBrowserJavaScriptSDK = isEventFromBrowserJavaScriptSDK(
     event as EventTransaction

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -31,6 +31,10 @@ export type IssueEventParameters = {
     group?: string;
     platform?: string;
   };
+  'issue_group_details.stack_traces.setup_source_maps_alert.clicked': {
+    platform?: string;
+    project_id?: string;
+  };
   'issue_group_details.tab.clicked': {
     tab: string;
     browser?: string;
@@ -147,6 +151,8 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issues_stream.sort_changed': 'Changed Sort on Issues Stream',
   'issues_stream.paginate': 'Paginate Issues Stream',
   'issue.shared_publicly': 'Issue Shared Publicly',
+  'issue_group_details.stack_traces.setup_source_maps_alert.clicked':
+    'Issue Group Details: Setup Source Maps Alert Clicked',
   resolve_issue: 'Resolve Issue',
   'tag.clicked': 'Tag: Clicked',
   'issue.quick_trace_status': 'Issue Quick Trace Status',

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -205,7 +205,7 @@ function hasTrace(event: Event) {
 /**
  * Function to determine if an event has source maps
  */
-function eventHasSourceMaps(event: Event) {
+export function eventHasSourceMaps(event: Event) {
   return event.entries?.some(entry => {
     return (
       entry.type === EntryType.EXCEPTION &&


### PR DESCRIPTION
Add an alert to the issue details page that will only be visible for events with a platform that can have source maps configured AND only if the event doesn't contain source maps already set up.

The alert contains a link button pointing out to the documentation about source maps according to the event's SDK name or event platform.

if the documentation doesn't match either the SDK name or the event platform, it falls back to the generic javascript documentation

**Preview:**

![image](https://user-images.githubusercontent.com/29228205/208486281-c65e36a8-7a7f-457d-b14b-c2df708b0a63.png)

![image](https://user-images.githubusercontent.com/29228205/208486884-53b8601a-bba0-4606-a20b-08d795f37120.png)

