### PR TITLE
feat(profiling): Force active thread to have priority for suspect fun…

### DIFF
--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
@@ -20,7 +20,7 @@ import {
 type FlamegraphCandidate = {
   frame: FlamegraphFrame;
   threadId: number;
-  isActiveThread?: boolean;
+  isActiveThread?: boolean; // this is the thread referred to by the active profile index
 };
 
 function findLongestMatchingFrame(

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
@@ -20,6 +20,7 @@ import {
 type FlamegraphCandidate = {
   frame: FlamegraphFrame;
   threadId: number;
+  isActiveThread?: boolean;
 };
 
 function findLongestMatchingFrame(
@@ -118,6 +119,11 @@ export function FlamegraphStateProvider(
     if (defined(state.profiles.threadId)) {
       return;
     }
+    const threadId =
+      profileGroup.type === 'resolved' &&
+      typeof profileGroup.data.activeProfileIndex === 'number'
+        ? profileGroup.data.profiles[profileGroup.data.activeProfileIndex].threadId
+        : null;
 
     // if the state has a highlight frame specified, then we want to jump to the
     // thread containing it, highlight the frames on the thread, and change the
@@ -125,6 +131,11 @@ export function FlamegraphStateProvider(
     if (state.profiles.highlightFrames && profileGroup.type === 'resolved') {
       const candidate = profileGroup.data.profiles.reduce<FlamegraphCandidate | null>(
         (prevCandidate, profile) => {
+          // if the previous candidate is the active thread, it always takes priority
+          if (prevCandidate?.isActiveThread) {
+            return prevCandidate;
+          }
+
           const flamegraph = new Flamegraph(profile, profile.threadId, {
             inverted: false,
             leftHeavy: false,
@@ -142,6 +153,15 @@ export function FlamegraphStateProvider(
 
           const newScore = frame.node.totalWeight || 0;
           const oldScore = prevCandidate?.frame?.node?.totalWeight || 0;
+
+          // if we find the frame on the active thread, it always takes priority
+          if (newScore > 0 && profile.threadId === threadId) {
+            return {
+              frame,
+              threadId: profile.threadId,
+              isActiveThread: true,
+            };
+          }
 
           return newScore <= oldScore
             ? prevCandidate
@@ -167,19 +187,11 @@ export function FlamegraphStateProvider(
 
     // fall back case, when we finally load the active profile index from the profile,
     // make sure we update the thread id so that it is show first
-    if (
-      profileGroup.type === 'resolved' &&
-      typeof profileGroup.data.activeProfileIndex === 'number'
-    ) {
-      const threadId =
-        profileGroup.data.profiles[profileGroup.data.activeProfileIndex].threadId;
-
-      if (defined(threadId)) {
-        dispatch({
-          type: 'set thread id',
-          payload: threadId,
-        });
-      }
+    if (defined(threadId)) {
+      dispatch({
+        type: 'set thread id',
+        payload: threadId,
+      });
     }
   }, [
     props.initialState?.profiles?.threadId,


### PR DESCRIPTION
…ctions

Suspect functions is changing to focus on the active thread, so we want to bias the flamechart link to show the active thread whenever we find the frame on the active thread.