### PR TITLE
fix(issue-owner): Update cache setting db query

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -127,7 +127,7 @@ def handle_owner_assignment(job):
 
     with sentry_sdk.start_span(op="tasks.post_process_group.handle_owner_assignment"):
         try:
-            from sentry.models import ProjectOwnership
+            from sentry.models import GroupOwnerType, ProjectOwnership
 
             event = job["event"]
             project, group = event.project, event.group
@@ -136,12 +136,22 @@ def handle_owner_assignment(job):
                 with sentry_sdk.start_span(
                     op="post_process.handle_owner_assignment.cache_set_owner"
                 ):
-                    owner_key = "owner_exists:1:%s" % group.id
-                    owners_exists = cache.get(owner_key)
-                    if owners_exists is None:
-                        owners_exists = group.groupowner_set.exists()
+                    issue_owner_key = "owner_exists:1:%s" % group.id
+                    issue_owners_exists = cache.get(issue_owner_key)
+                    if issue_owners_exists is None:
+                        # We don't care if a Suspect Commit groupowjer exists
+                        issue_owners_exists = group.groupowner_set.filter(
+                            type__in=[
+                                GroupOwnerType.OWNERSHIP_RULE.value,
+                                GroupOwnerType.CODEOWNERS.value,
+                            ],
+                        ).exists()
                         # Cache for an hour if it's assigned. We don't need to move that fast.
-                        cache.set(owner_key, owners_exists, 3600 if owners_exists else 60)
+                        cache.set(
+                            issue_owner_key,
+                            issue_owners_exists,
+                            3600 if issue_owners_exists else 60,
+                        )
 
                 with sentry_sdk.start_span(
                     op="post_process.handle_owner_assignment.cache_set_assignee"
@@ -154,7 +164,7 @@ def handle_owner_assignment(job):
                         # Cache for an hour if it's assigned. We don't need to move that fast.
                         cache.set(assignee_key, assignees_exists, 3600 if assignees_exists else 60)
 
-                if owners_exists and assignees_exists:
+                if issue_owners_exists and assignees_exists:
                     return
 
                 with sentry_sdk.start_span(
@@ -200,7 +210,7 @@ def handle_owner_assignment(job):
                 with sentry_sdk.start_span(
                     op="post_process.handle_owner_assignment.handle_group_owners"
                 ):
-                    if issue_owners and not owners_exists:
+                    if issue_owners and not issue_owners_exists:
                         try:
                             handle_group_owners(project, group, issue_owners)
                         except Exception:
@@ -294,6 +304,7 @@ def handle_group_owners(project, group, issue_owners):
                         )
             if new_group_owners:
                 GroupOwner.objects.bulk_create(new_group_owners)
+
     except UnableToAcquireLock:
         pass
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -139,7 +139,7 @@ def handle_owner_assignment(job):
                     issue_owner_key = "owner_exists:1:%s" % group.id
                     issue_owners_exists = cache.get(issue_owner_key)
                     if issue_owners_exists is None:
-                        # We don't care if a Suspect Commit groupowjer exists
+                        # We don't care if a Suspect Commit groupowner exists
                         issue_owners_exists = group.groupowner_set.filter(
                             type__in=[
                                 GroupOwnerType.OWNERSHIP_RULE.value,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -136,7 +136,7 @@ def handle_owner_assignment(job):
                 with sentry_sdk.start_span(
                     op="post_process.handle_owner_assignment.cache_set_owner"
                 ):
-                    issue_owner_key = "owner_exists:1:%s" % group.id
+                    issue_owner_key = f"owner_exists:1:{group.id}"
                     issue_owners_exists = cache.get(issue_owner_key)
                     if issue_owners_exists is None:
                         # We don't care if a Suspect Commit groupowner exists

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -795,6 +795,34 @@ class AssignmentTestMixin(BasePostProgressGroupMixin):
         assignee = event.group.assignee_set.first()
         assert assignee is None
 
+    def test_suspect_committer_affect_cache_debouncing_issue_owners_calculations(self):
+        self.make_ownership()
+        committer = GroupOwner(
+            group=self.created_event.group,
+            project=self.created_event.project,
+            organization=self.created_event.project.organization,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+        )
+        committer.save()
+        event = self.create_event(
+            data={
+                "message": "oh no",
+                "platform": "python",
+                "stacktrace": {"frames": [{"filename": "src/app/example.py"}]},
+            },
+            project_id=self.project.id,
+        )
+        event.group.assignee_set.create(team=self.team, project=self.project)
+        self.call_post_process_group(
+            is_new=False,
+            is_regression=False,
+            is_new_group_environment=False,
+            event=event,
+        )
+        assignee = event.group.assignee_set.first()
+        assert assignee.user_id is None
+        assert assignee.team == self.team
+
     def test_owner_assignment_when_owners_have_been_unassigned(self):
         """
         Test that ensures that if certain assignees get unassigned, and project rules are changed


### PR DESCRIPTION
## Objective:
We are skipping Issue Owner assignments because the cache setting db query is finding a Suspect Commit GroupOwner record. This PR updates the query to only look for Ownership Rule/ Code Owner GroupOwners.