### PR TITLE
test(emails): Disable flaky performance test

### DIFF
--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -19,7 +19,7 @@ EMAILS = (
     ("/debug/mail/unable-to-fetch-commits/", "unable to fetch commits"),
     ("/debug/mail/unable-to-delete-repo/", "unable to delete repo"),
     ("/debug/mail/error-alert/", "alert"),
-    ("/debug/mail/performance-alert/", "performance"),
+    # ("/debug/mail/performance-alert/", "performance"), TODO: Flaky: GRW-778
     ("/debug/mail/digest/", "digest"),
     ("/debug/mail/invalid-identity/", "invalid identity"),
     ("/debug/mail/invitation/", "invitation"),


### PR DESCRIPTION
Disabling this because it showed up again recently (https://github.com/getsentry/sentry/pull/42349/checks?check_run_id=10121104710)