### PR TITLE
ref(issue platform): Allow dummy param to be passed to issue occurrence endpoint

### DIFF
--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -47,7 +47,7 @@ class IssueOccurrenceEndpoint(Endpoint):
         :pparam: string dummy: pass 'True' to load a dummy event instead of providing one in the request
         """
         event = {}
-        if request.query_params.get("dummy") == "True" or "true":
+        if request.query_params.get("dummy") == "True":
             event = {
                 "event_id": "44f1419e73884cd2b45c79918f4b6dc4",
                 "project_id": 1,
@@ -58,7 +58,13 @@ class IssueOccurrenceEndpoint(Endpoint):
                 "message_timestamp": ensure_aware(datetime.now()),
             }
         else:
-            event = request.data.pop("event")
+            event = request.data.pop("event", None)
+
+        if not event:
+            return Response(
+                "Must pass an event or query param of dummy=True",
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         occurrence = request.data
 

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint, region_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.models import User
+from sentry.types.issues import GroupType
 from sentry.utils import json
 from sentry.utils.dates import ensure_aware
 from sentry.utils.kafka_config import get_kafka_producer_cluster_options
@@ -45,10 +46,11 @@ class IssueOccurrenceEndpoint(Endpoint):
         Write issue occurrence and event data to a Kafka topic
         ``````````````````````````````````````````````````````
         :auth: superuser required
-        :pparam: string dummy: pass 'True' to load a dummy event instead of providing one in the request
+        :pparam: string dummyEvent: pass 'True' to load a dummy event instead of providing one in the request
+        :pparam: string dummyOccurrence: pass 'True' to load a dummy occurrence instead of providing one in the request
         """
         event = {}
-        if request.query_params.get("dummy") == "True":
+        if request.query_params.get("dummyEvent") == "True":
             user = User.objects.get(id=request.user.id)
             projects = user.get_projects()
             if not projects:
@@ -70,11 +72,35 @@ class IssueOccurrenceEndpoint(Endpoint):
 
         if not event:
             return Response(
-                "Must pass an event or query param of dummy=True",
+                "Must pass an event or query param of dummyEvent=True",
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        occurrence = request.data
+        occurrence = {}
+        if request.query_params.get("dummyOccurrence") == "True":
+            occurrence = {
+                "fingerprint": ["some-fingerprint"],
+                "issue_title": "something bad happened",
+                "subtitle": "it was bad",
+                "resource_id": "1234",
+                "evidence_data": {"Test": 123},
+                "evidence_display": [
+                    ("Attention", "Very important information!!!", True),
+                    ("Evidence 2", "Not important", False),
+                    ("Evidence 3", "Nobody cares about this", False),
+                ],
+                "type": GroupType.PROFILE_BLOCKED_THREAD.value,
+                "detection_time": ensure_aware(datetime.now()),
+                "event": event,
+            }
+        else:
+            occurrence = request.data
+
+        if not occurrence:
+            return Response(
+                "Must pass occurrence data or query param of dummyOccurrence=True",
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         event_serializer = BasicEventSerializer(data=event)
         if not event_serializer.is_valid():

--- a/src/sentry/api/endpoints/issue_occurrence.py
+++ b/src/sentry/api/endpoints/issue_occurrence.py
@@ -85,9 +85,21 @@ class IssueOccurrenceEndpoint(Endpoint):
                 "resource_id": "1234",
                 "evidence_data": {"Test": 123},
                 "evidence_display": [
-                    ("Attention", "Very important information!!!", True),
-                    ("Evidence 2", "Not important", False),
-                    ("Evidence 3", "Nobody cares about this", False),
+                    {
+                        "name": "Attention",
+                        "value": "Very important information!!!",
+                        "important": True,
+                    },
+                    {
+                        "name": "Evidence 2",
+                        "value": "Not important",
+                        "important": False,
+                    },
+                    {
+                        "name": "Evidence 3",
+                        "value": "Nobody cares about this",
+                        "important": False,
+                    },
                 ],
                 "type": GroupType.PROFILE_BLOCKED_THREAD.value,
                 "detection_time": ensure_aware(datetime.now()),

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -52,3 +52,10 @@ class IssueOccurrenceTest(APITestCase):
         data["detection_time"] = "today"
         response = self.client.post(self.url, data=data, format="json")
         assert response.status_code == 400, response.content
+
+    def test_load_fake_event(self):
+        url = self.url + "?dummy=True"
+        data = dict(self.data)
+        data.pop("event", None)
+        response = self.client.post(url, data=data, format="json")
+        assert response.status_code == 201, response.content

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -32,9 +32,21 @@ class IssueOccurrenceTest(APITestCase):
             "resource_id": "1234",
             "evidence_data": {"Test": 123},
             "evidence_display": [
-                ("Attention", "Very important information!!!", True),
-                ("Evidence 2", "Not important", False),
-                ("Evidence 3", "Nobody cares about this", False),
+                {
+                    "name": "Attention",
+                    "value": "Very important information!!!",
+                    "important": True,
+                },
+                {
+                    "name": "Evidence 2",
+                    "value": "Not important",
+                    "important": False,
+                },
+                {
+                    "name": "Evidence 3",
+                    "value": "Nobody cares about this",
+                    "important": False,
+                },
             ],
             "type": GroupType.PROFILE_BLOCKED_THREAD.value,
             "detection_time": ensure_aware(datetime.now()),

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sentry.models import OrganizationMember, OrganizationMemberTeam
+from sentry.models import OrganizationMemberTeam
 from sentry.testutils import APITestCase
 from sentry.types.issues import GroupType
 from sentry.utils.dates import ensure_aware
@@ -72,8 +72,7 @@ class IssueOccurrenceTest(APITestCase):
 
     def test_no_projects(self):
         """Test that we raise a 400 if the user belongs to no project teams and passes the dummy query param"""
-        member = OrganizationMember(id=self.user.id, organization=self.org, email=self.user.email)
-        OrganizationMemberTeam.objects.get(team=self.team, organizationmember=member).delete()
+        OrganizationMemberTeam.objects.all().delete()
         url = self.url + "?dummy=True"
         data = dict(self.data)
         data.pop("event", None)

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -58,10 +58,21 @@ class IssueOccurrenceTest(APITestCase):
         assert response.status_code == 400, response.content
 
     def test_load_fake_event(self):
-        url = self.url + "?dummy=True"
+        url = self.url + "?dummyEvent=True"
         data = dict(self.data)
         data.pop("event", None)
         response = self.client.post(url, data=data, format="json")
+        assert response.status_code == 201, response.content
+
+    def test_load_fake_occurrence(self):
+        url = self.url + "?dummyOccurrence=True"
+        data = {"event": self.event}
+        response = self.client.post(url, data=data, format="json")
+        assert response.status_code == 201, response.content
+
+    def test_load_fake_event_and_occurrence(self):
+        url = self.url + "?dummyEvent=True&dummyOccurrence=True"
+        response = self.client.post(url, data={}, format="json")
         assert response.status_code == 201, response.content
 
     def test_no_event_passed(self):
@@ -70,10 +81,16 @@ class IssueOccurrenceTest(APITestCase):
         response = self.client.post(self.url, data=data, format="json")
         assert response.status_code == 400, response.content
 
+    def test_no_occurrence_passed(self):
+        data = dict(self.data)
+        data = data["event"]
+        response = self.client.post(self.url, data=data, format="json")
+        assert response.status_code == 400, response.content
+
     def test_no_projects(self):
-        """Test that we raise a 400 if the user belongs to no project teams and passes the dummy query param"""
+        """Test that we raise a 400 if the user belongs to no project teams and passes the dummyEvent query param"""
         OrganizationMemberTeam.objects.all().delete()
-        url = self.url + "?dummy=True"
+        url = self.url + "?dummyEvent=True"
         data = dict(self.data)
         data.pop("event", None)
         response = self.client.post(url, data=data, format="json")

--- a/tests/sentry/api/endpoints/test_issue_occurrence.py
+++ b/tests/sentry/api/endpoints/test_issue_occurrence.py
@@ -59,3 +59,9 @@ class IssueOccurrenceTest(APITestCase):
         data.pop("event", None)
         response = self.client.post(url, data=data, format="json")
         assert response.status_code == 201, response.content
+
+    def test_no_event_passed(self):
+        data = dict(self.data)
+        data.pop("event", None)
+        response = self.client.post(self.url, data=data, format="json")
+        assert response.status_code == 400, response.content


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry/pull/42306 that adds the ability to pass a query param `dummy` to the issue occurrence endpoint to load a fake event instead of passing one in the request. This endpoint is intended for internal testing purposes only.