### PR TITLE
fix(discover-quick-context) Removed cache invalidation.

### DIFF
--- a/static/app/views/eventsV2/table/quickContext/eventContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext/eventContext.tsx
@@ -31,7 +31,7 @@ import {
   NoContextWrapper,
   Wrapper,
 } from './styles';
-import {BaseContextProps, ContextType, fiveMinutesInMs} from './utils';
+import {BaseContextProps, ContextType, tenSecondInMs} from './utils';
 
 interface EventContextProps extends BaseContextProps {
   eventView?: EventView;
@@ -46,7 +46,7 @@ function EventContext(props: EventContextProps) {
       `/organizations/${organization.slug}/events/${dataRow['project.name']}:${dataRow.id}/`,
     ],
     {
-      staleTime: fiveMinutesInMs,
+      staleTime: tenSecondInMs,
     }
   );
 

--- a/static/app/views/eventsV2/table/quickContext/issueContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext/issueContext.tsx
@@ -27,7 +27,7 @@ import {
   ContextTitle,
   Wrapper,
 } from './styles';
-import {BaseContextProps, ContextType, fiveMinutesInMs} from './utils';
+import {BaseContextProps, ContextType, tenSecondInMs} from './utils';
 
 function IssueContext(props: BaseContextProps) {
   const {dataRow, organization} = props;
@@ -54,7 +54,7 @@ function IssueContext(props: BaseContextProps) {
       },
     ],
     {
-      staleTime: fiveMinutesInMs,
+      staleTime: tenSecondInMs,
     }
   );
 
@@ -65,7 +65,7 @@ function IssueContext(props: BaseContextProps) {
     isError: eventError,
     data: event,
   } = useQuery<Event>([`/issues/${dataRow['issue.id']}/events/oldest/`], {
-    staleTime: fiveMinutesInMs,
+    staleTime: tenSecondInMs,
   });
 
   const title = issue?.title;

--- a/static/app/views/eventsV2/table/quickContext/quickContextWrapper.tsx
+++ b/static/app/views/eventsV2/table/quickContext/quickContextWrapper.tsx
@@ -1,4 +1,3 @@
-import {useEffect} from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
@@ -13,7 +12,6 @@ import {Organization, Project} from 'sentry/types';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import EventView, {EventData} from 'sentry/utils/discover/eventView';
 import {getShortEventId} from 'sentry/utils/events';
-import {useQueryClient} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 
 import EventContext from './eventContext';
@@ -163,14 +161,7 @@ type ContextProps = {
 
 export function QuickContextHoverWrapper(props: ContextProps) {
   const location = useLocation();
-  const queryClient = useQueryClient();
   const {dataRow, contextType, organization, projects, eventView} = props;
-
-  useEffect(() => {
-    return () => {
-      queryClient.clear();
-    };
-  }, [queryClient]);
 
   return (
     <HoverWrapper>

--- a/static/app/views/eventsV2/table/quickContext/releaseContext.tsx
+++ b/static/app/views/eventsV2/table/quickContext/releaseContext.tsx
@@ -23,15 +23,14 @@ import {
   ContextTitle,
   Wrapper,
 } from './styles';
-import {BaseContextProps, ContextType, fiveMinutesInMs} from './utils';
+import {BaseContextProps, ContextType, tenSecondInMs} from './utils';
 
 function ReleaseContext(props: BaseContextProps) {
   const {dataRow, organization} = props;
   const {isLoading, isError, data} = useQuery<ReleaseWithHealth>(
     [`/organizations/${organization.slug}/releases/${dataRow.release}/`],
     {
-      staleTime: fiveMinutesInMs,
-      retry: false,
+      staleTime: tenSecondInMs,
     }
   );
 

--- a/static/app/views/eventsV2/table/quickContext/utils.tsx
+++ b/static/app/views/eventsV2/table/quickContext/utils.tsx
@@ -1,7 +1,7 @@
 import {Organization} from 'sentry/types';
 import {EventData} from 'sentry/utils/discover/eventView';
 
-export const fiveMinutesInMs = 5 * 60 * 1000;
+export const tenSecondInMs = 10 * 1000;
 
 export enum ContextType {
   ISSUE = 'issue',


### PR DESCRIPTION
Motive: Avoid clearing the entire react-query cache for the whole app. Reduced stale time to 10s, to account for repeated hovering. Discussed this as a solution with core-ui.

1. Shortened staletime from 5mins to 10s.
2. Removed cache clear.
3. Shouldn't see loading state after staletime expires, but there will be a refetch to check if data is updated. 
