### PR TITLE
fix(tests): Fix broken `test_existing_group_different_category` test

### DIFF
--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -108,7 +108,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignor
 
         new_event = self.store_event(data={}, project_id=self.project.id)
         new_occurrence = self.build_occurrence(
-            fingerprint=occurrence.fingerprint, type=GroupType.PERFORMANCE_N_PLUS_ONE
+            fingerprint=occurrence.fingerprint, type=GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES
         )
         with mock.patch("sentry.issues.ingest.logger") as logger:
             assert save_issue_from_occurrence(new_occurrence, new_event, None) is None

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -2,8 +2,6 @@ from dataclasses import replace
 from hashlib import md5
 from unittest import mock
 
-import pytest
-
 from sentry.constants import LOG_LEVELS_MAP
 from sentry.issues.ingest import (
     _create_issue_kwargs,
@@ -99,7 +97,6 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignor
         assert updated_group.location() == event.location
         assert updated_group.times_seen == 2
 
-    @pytest.mark.skip(reason="flaky: ISP-92")
     def test_existing_group_different_category(self) -> None:
         event = self.store_event(data={}, project_id=self.project.id)
         occurrence = self.build_occurrence()


### PR DESCRIPTION
Missed this in the pr because a separate pr merged on master that removed the enum value.

