### PR TITLE
fix(issue-stream): Prevent issue stream from refetching when setting default search 

### DIFF
--- a/static/app/views/issueList/issueListSetAsDefault.tsx
+++ b/static/app/views/issueList/issueListSetAsDefault.tsx
@@ -46,7 +46,7 @@ const IssueListSetAsDefault = ({
   const {mutate: pinSearch, isLoading: isPinning} = usePinSearch({
     onSuccess: response => {
       const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
-      browserHistory.push({
+      browserHistory.replace({
         ...location,
         pathname: `/organizations/${organization.slug}/issues/searches/${response.id}/`,
         query: {referrer: 'search-bar', ...currentQuery},
@@ -56,11 +56,13 @@ const IssueListSetAsDefault = ({
   const {mutate: unpinSearch, isLoading: isUnpinning} = useUnpinSearch({
     onSuccess: () => {
       const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
-      browserHistory.push({
+      browserHistory.replace({
         ...location,
         pathname: `/organizations/${organization.slug}/issues/`,
         query: {
           referrer: 'search-bar',
+          query,
+          sort,
           ...currentQuery,
         },
       });

--- a/static/app/views/issueList/overview.spec.jsx
+++ b/static/app/views/issueList/overview.spec.jsx
@@ -554,7 +554,7 @@ describe('IssueList', function () {
 
       await waitFor(() => {
         expect(createPin).toHaveBeenCalled();
-        expect(browserHistory.push).toHaveBeenLastCalledWith(
+        expect(browserHistory.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/searches/666/',
             query: {
@@ -607,7 +607,7 @@ describe('IssueList', function () {
       });
 
       await waitFor(() => {
-        expect(browserHistory.push).toHaveBeenLastCalledWith(
+        expect(browserHistory.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/',
           })
@@ -658,7 +658,7 @@ describe('IssueList', function () {
 
       await waitFor(() => {
         expect(createPin).toHaveBeenCalled();
-        expect(browserHistory.push).toHaveBeenLastCalledWith(
+        expect(browserHistory.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/searches/789/',
           })
@@ -716,7 +716,7 @@ describe('IssueList', function () {
 
       await waitFor(() => {
         expect(createPin).toHaveBeenCalled();
-        expect(browserHistory.push).toHaveBeenLastCalledWith(
+        expect(browserHistory.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/searches/666/',
             query: expect.objectContaining({
@@ -781,7 +781,7 @@ describe('IssueList', function () {
 
       await waitFor(() => {
         expect(deletePin).toHaveBeenCalled();
-        expect(browserHistory.push).toHaveBeenLastCalledWith(
+        expect(browserHistory.replace).toHaveBeenLastCalledWith(
           expect.objectContaining({
             pathname: '/organizations/org-slug/issues/',
             query: expect.objectContaining({

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -225,8 +225,20 @@ class IssueListOverview extends Component<Props, State> {
       return;
     }
 
-    const prevQuery = prevProps.location.query;
-    const newQuery = this.props.location.query;
+    const prevUrlQuery = prevProps.location.query;
+    const newUrlQuery = this.props.location.query;
+
+    const prevQuery = this.getQueryFromSavedSearchOrLocation({
+      savedSearch: prevProps.savedSearch,
+      location: prevProps.location,
+    });
+    const newQuery = this.getQuery();
+
+    const prevSort = this.getSortFromSavedSearchOrLocation({
+      savedSearch: prevProps.savedSearch,
+      location: prevProps.location,
+    });
+    const newSort = this.getSort();
 
     const selectionChanged = !isEqual(prevProps.selection, this.props.selection);
 
@@ -234,13 +246,11 @@ class IssueListOverview extends Component<Props, State> {
     // reload data.
     if (
       selectionChanged ||
-      prevQuery.cursor !== newQuery.cursor ||
-      prevQuery.sort !== newQuery.sort ||
-      prevQuery.query !== newQuery.query ||
-      prevQuery.statsPeriod !== newQuery.statsPeriod ||
-      prevQuery.groupStatsPeriod !== newQuery.groupStatsPeriod ||
-      prevProps.savedSearch?.query !== this.props.savedSearch?.query ||
-      prevProps.savedSearch?.sort !== this.props.savedSearch?.sort
+      prevUrlQuery.cursor !== newUrlQuery.cursor ||
+      prevUrlQuery.statsPeriod !== newUrlQuery.statsPeriod ||
+      prevUrlQuery.groupStatsPeriod !== newUrlQuery.groupStatsPeriod ||
+      prevQuery !== newQuery ||
+      prevSort !== newSort
     ) {
       this.fetchData(selectionChanged);
     } else if (
@@ -266,8 +276,10 @@ class IssueListOverview extends Component<Props, State> {
   private _lastStatsRequest: any;
   private _lastFetchCountsRequest: any;
 
-  getQuery(): string {
-    const {savedSearch, location} = this.props;
+  getQueryFromSavedSearchOrLocation({
+    savedSearch,
+    location,
+  }: Pick<Props, 'savedSearch' | 'location'>): string {
     if (savedSearch) {
       return savedSearch.query;
     }
@@ -281,8 +293,10 @@ class IssueListOverview extends Component<Props, State> {
     return DEFAULT_QUERY;
   }
 
-  getSort(): string {
-    const {location, savedSearch} = this.props;
+  getSortFromSavedSearchOrLocation({
+    savedSearch,
+    location,
+  }: Pick<Props, 'savedSearch' | 'location'>): string {
     if (!location.query.sort && savedSearch?.id) {
       return savedSearch.sort;
     }
@@ -292,6 +306,20 @@ class IssueListOverview extends Component<Props, State> {
     }
 
     return DEFAULT_ISSUE_STREAM_SORT;
+  }
+
+  getQuery(): string {
+    return this.getQueryFromSavedSearchOrLocation({
+      savedSearch: this.props.savedSearch,
+      location: this.props.location,
+    });
+  }
+
+  getSort(): string {
+    return this.getSortFromSavedSearchOrLocation({
+      savedSearch: this.props.savedSearch,
+      location: this.props.location,
+    });
   }
 
   getGroupStatsPeriod(): string {


### PR DESCRIPTION
Closes https://github.com/getsentry/team-coreui/issues/24

There is some logic in `overview.tsx` that was causing refetches when the saved search changed, even when the query/sort does not. I improved it a bit so that it will check what the actual query/sort are before triggering a refetch instead of just looking at the saved search ID.

While fixing this I also made sure that removing a default search did not kick you back to `is:unresolved`.

Before:

https://user-images.githubusercontent.com/10888943/207987981-e8307348-1f66-449f-ad01-75137a85f759.mp4


After:

https://user-images.githubusercontent.com/10888943/207987986-f419c012-c6c2-4b75-bff5-90210435deb8.mp4

