### PR TITLE
feat(crons): Correct frontend permissions for crons

### DIFF
--- a/static/app/views/monitors/monitorForm.tsx
+++ b/static/app/views/monitors/monitorForm.tsx
@@ -1,7 +1,6 @@
 import {Component, Fragment} from 'react';
 import {Observer} from 'mobx-react';
 
-import Access from 'sentry/components/acl/access';
 import Field from 'sentry/components/forms/field';
 import NumberField from 'sentry/components/forms/fields/numberField';
 import SelectField from 'sentry/components/forms/fields/selectField';
@@ -108,156 +107,143 @@ class MonitorForm extends Component<Props> {
       ? this.props.projects.find(p => p.id === selectedProjectId + '')
       : null;
     return (
-      <Access access={['project:write']}>
-        {({hasAccess}) => (
-          <Form
-            allowUndo
-            requireChanges
-            apiEndpoint={this.props.apiEndpoint}
-            apiMethod={this.props.apiMethod}
-            model={this.form}
-            initialData={
-              monitor
-                ? {
-                    name: monitor.name,
-                    type: monitor.type ?? DEFAULT_MONITOR_TYPE,
-                    project: monitor.project.slug,
-                    ...this.formDataFromConfig(monitor.type, monitor.config),
-                  }
-                : {
-                    project: selectedProject ? selectedProject.slug : null,
-                    type: DEFAULT_MONITOR_TYPE,
-                  }
-            }
-            onSubmitSuccess={this.props.onSubmitSuccess}
-            submitLabel={submitLabel}
-          >
-            <Panel>
-              <PanelHeader>{t('Details')}</PanelHeader>
+      <Form
+        allowUndo
+        requireChanges
+        apiEndpoint={this.props.apiEndpoint}
+        apiMethod={this.props.apiMethod}
+        model={this.form}
+        initialData={
+          monitor
+            ? {
+                name: monitor.name,
+                type: monitor.type ?? DEFAULT_MONITOR_TYPE,
+                project: monitor.project.slug,
+                ...this.formDataFromConfig(monitor.type, monitor.config),
+              }
+            : {
+                project: selectedProject ? selectedProject.slug : null,
+                type: DEFAULT_MONITOR_TYPE,
+              }
+        }
+        onSubmitSuccess={this.props.onSubmitSuccess}
+        submitLabel={submitLabel}
+      >
+        <Panel>
+          <PanelHeader>{t('Details')}</PanelHeader>
 
-              <PanelBody>
-                {monitor && (
-                  <Field label={t('ID')}>
-                    <div className="controls">
-                      <TextCopyInput>{monitor.id}</TextCopyInput>
-                    </div>
-                  </Field>
-                )}
-                <SelectField
-                  name="project"
-                  label={t('Project')}
-                  disabled={!hasAccess}
-                  options={this.props.projects
-                    .filter(p => p.isMember)
-                    .map(p => ({value: p.slug, label: p.slug}))}
-                  help={t(
-                    "Select the project which contains the recurring job you'd like to monitor."
-                  )}
-                  required
-                />
-                <TextField
-                  name="name"
-                  placeholder={t('My Cron Job')}
-                  label={t('Name your cron monitor')}
-                  disabled={!hasAccess}
-                  required
-                />
-              </PanelBody>
-            </Panel>
-            <Panel>
-              <PanelHeader>{t('Config')}</PanelHeader>
+          <PanelBody>
+            {monitor && (
+              <Field label={t('ID')}>
+                <div className="controls">
+                  <TextCopyInput>{monitor.id}</TextCopyInput>
+                </div>
+              </Field>
+            )}
+            <SelectField
+              name="project"
+              label={t('Project')}
+              options={this.props.projects
+                .filter(p => p.isMember)
+                .map(p => ({value: p.slug, label: p.slug}))}
+              help={t(
+                "Select the project which contains the recurring job you'd like to monitor."
+              )}
+              required
+            />
+            <TextField
+              name="name"
+              placeholder={t('My Cron Job')}
+              label={t('Name your cron monitor')}
+              required
+            />
+          </PanelBody>
+        </Panel>
+        <Panel>
+          <PanelHeader>{t('Config')}</PanelHeader>
 
-              <PanelBody>
-                <NumberField
-                  name="config.max_runtime"
-                  label={t('Max Runtime')}
-                  disabled={!hasAccess}
-                  help={t(
-                    "Set the number of minutes a recurring job is allowed to run before it's considered failed"
-                  )}
-                  placeholder="e.g. 30"
-                />
-                <SelectField
-                  name="config.schedule_type"
-                  label={t('Schedule Type')}
-                  disabled={!hasAccess}
-                  options={SCHEDULE_TYPES}
-                  required
-                />
-                <Observer>
-                  {() => {
-                    switch (this.form.getValue('config.schedule_type')) {
-                      case 'crontab':
-                        return (
-                          <Fragment>
-                            <TextField
-                              name="config.schedule"
-                              label={t('Schedule')}
-                              disabled={!hasAccess}
-                              placeholder="*/5 * * * *"
-                              required
-                              help={tct(
-                                'Any schedule changes will be applied to the next check-in. See [link:Wikipedia] for crontab syntax.',
-                                {
-                                  link: <a href="https://en.wikipedia.org/wiki/Cron" />,
-                                }
-                              )}
-                            />
-                            <NumberField
-                              name="config.checkin_margin"
-                              label={t('Check-in Margin')}
-                              disabled={!hasAccess}
-                              help={t(
-                                "The max error margin (in minutes) before a check-in is considered missed. If you don't expect your job to start immediately at the scheduled time, expand this margin to account for delays."
-                              )}
-                              placeholder="e.g. 30"
-                            />
-                          </Fragment>
-                        );
-                      case 'interval':
-                        return (
-                          <Fragment>
-                            <NumberField
-                              name="config.schedule.frequency"
-                              label={t('Frequency')}
-                              disabled={!hasAccess}
-                              placeholder="e.g. 1"
-                              help={t(
-                                'The amount of intervals that pass between executions of the cron job.'
-                              )}
-                              required
-                            />
-                            <SelectField
-                              name="config.schedule.interval"
-                              label={t('Interval')}
-                              disabled={!hasAccess}
-                              options={INTERVALS}
-                              help={t(
-                                'The interval on which the frequency will be applied. 1 time every X amount of (minutes, hours, days)'
-                              )}
-                              required
-                            />
-                            <NumberField
-                              name="config.checkin_margin"
-                              label={t('Check-in Margin')}
-                              disabled={!hasAccess}
-                              help={t(
-                                "The max error margin (in minutes) before a check-in is considered missed. If you don't expect your job to start immediately at the scheduled time, expand this margin to account for delays."
-                              )}
-                              placeholder="e.g. 30"
-                            />
-                          </Fragment>
-                        );
-                      default:
-                        return null;
-                    }
-                  }}
-                </Observer>
-              </PanelBody>
-            </Panel>
-          </Form>
-        )}
-      </Access>
+          <PanelBody>
+            <NumberField
+              name="config.max_runtime"
+              label={t('Max Runtime')}
+              help={t(
+                "Set the number of minutes a recurring job is allowed to run before it's considered failed"
+              )}
+              placeholder="e.g. 30"
+            />
+            <SelectField
+              name="config.schedule_type"
+              label={t('Schedule Type')}
+              options={SCHEDULE_TYPES}
+              required
+            />
+            <Observer>
+              {() => {
+                switch (this.form.getValue('config.schedule_type')) {
+                  case 'crontab':
+                    return (
+                      <Fragment>
+                        <TextField
+                          name="config.schedule"
+                          label={t('Schedule')}
+                          placeholder="*/5 * * * *"
+                          required
+                          help={tct(
+                            'Any schedule changes will be applied to the next check-in. See [link:Wikipedia] for crontab syntax.',
+                            {
+                              link: <a href="https://en.wikipedia.org/wiki/Cron" />,
+                            }
+                          )}
+                        />
+                        <NumberField
+                          name="config.checkin_margin"
+                          label={t('Check-in Margin')}
+                          help={t(
+                            "The max error margin (in minutes) before a check-in is considered missed. If you don't expect your job to start immediately at the scheduled time, expand this margin to account for delays."
+                          )}
+                          placeholder="e.g. 30"
+                        />
+                      </Fragment>
+                    );
+                  case 'interval':
+                    return (
+                      <Fragment>
+                        <NumberField
+                          name="config.schedule.frequency"
+                          label={t('Frequency')}
+                          placeholder="e.g. 1"
+                          help={t(
+                            'The amount of intervals that pass between executions of the cron job.'
+                          )}
+                          required
+                        />
+                        <SelectField
+                          name="config.schedule.interval"
+                          label={t('Interval')}
+                          options={INTERVALS}
+                          help={t(
+                            'The interval on which the frequency will be applied. 1 time every X amount of (minutes, hours, days)'
+                          )}
+                          required
+                        />
+                        <NumberField
+                          name="config.checkin_margin"
+                          label={t('Check-in Margin')}
+                          help={t(
+                            "The max error margin (in minutes) before a check-in is considered missed. If you don't expect your job to start immediately at the scheduled time, expand this margin to account for delays."
+                          )}
+                          placeholder="e.g. 30"
+                        />
+                      </Fragment>
+                    );
+                  default:
+                    return null;
+                }
+              }}
+            </Observer>
+          </PanelBody>
+        </Panel>
+      </Form>
     );
   }
 }

--- a/static/app/views/monitors/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/monitorHeaderActions.tsx
@@ -6,7 +6,6 @@ import {
   addLoadingMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
-import Access from 'sentry/components/acl/access';
 import Button from 'sentry/components/button';
 import ButtonBar from 'sentry/components/buttonBar';
 import Confirm from 'sentry/components/confirm';
@@ -23,10 +22,6 @@ type Props = {
   onUpdate: (data: Monitor) => void;
   orgId: string;
 };
-
-const DISABLED_TOOLTIP_TEXT = t(
-  'These settings can only be edited by users with the organization owner, manager, or admin role.'
-);
 
 const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
   const api = useApi();
@@ -70,46 +65,28 @@ const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
     });
 
   return (
-    <Access access={['project:write']}>
-      {({hasAccess}) => (
-        <ButtonContainer>
-          <ButtonBar gap={1}>
-            <Button
-              size="sm"
-              icon={<IconEdit size="xs" />}
-              to={`/organizations/${orgId}/monitors/${monitor.id}/edit/`}
-            >
-              {hasAccess ? t('Edit') : t('View Config')}
-            </Button>
-            <Button
-              size="sm"
-              onClick={toggleStatus}
-              disabled={!hasAccess}
-              title={DISABLED_TOOLTIP_TEXT}
-              tooltipProps={{disabled: hasAccess}}
-            >
-              {monitor.status !== 'disabled' ? t('Pause') : t('Enable')}
-            </Button>
-            <Confirm
-              onConfirm={handleDelete}
-              message={t(
-                'Are you sure you want to permanently delete this cron monitor?'
-              )}
-              disabled={!hasAccess}
-            >
-              <Button
-                size="sm"
-                icon={<IconDelete size="xs" />}
-                title={DISABLED_TOOLTIP_TEXT}
-                tooltipProps={{disabled: hasAccess}}
-              >
-                {t('Delete')}
-              </Button>
-            </Confirm>
-          </ButtonBar>
-        </ButtonContainer>
-      )}
-    </Access>
+    <ButtonContainer>
+      <ButtonBar gap={1}>
+        <Button
+          size="sm"
+          icon={<IconEdit size="xs" />}
+          to={`/organizations/${orgId}/monitors/${monitor.id}/edit/`}
+        >
+          {t('Edit')}
+        </Button>
+        <Button size="sm" onClick={toggleStatus}>
+          {monitor.status !== 'disabled' ? t('Pause') : t('Enable')}
+        </Button>
+        <Confirm
+          onConfirm={handleDelete}
+          message={t('Are you sure you want to permanently delete this cron monitor?')}
+        >
+          <Button size="sm" icon={<IconDelete size="xs" />}>
+            {t('Delete')}
+          </Button>
+        </Confirm>
+      </ButtonBar>
+    </ButtonContainer>
   );
 };
 

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -5,7 +5,6 @@ import * as qs from 'query-string';
 
 import onboardingImg from 'sentry-images/spot/onboarding-preview.svg';
 
-import Access from 'sentry/components/acl/access';
 import Button, {ButtonProps} from 'sentry/components/button';
 import FeatureBadge from 'sentry/components/featureBadge';
 import IdBadge from 'sentry/components/idBadge';
@@ -47,24 +46,13 @@ type State = AsyncView['state'] & {
 function NewMonitorButton(props: ButtonProps) {
   const organization = useOrganization();
   return (
-    <Access organization={organization} access={['project:write']}>
-      {({hasAccess}) => (
-        <Button
-          to={`/organizations/${organization.slug}/monitors/create/`}
-          priority="primary"
-          disabled={!hasAccess}
-          tooltipProps={{
-            disabled: hasAccess,
-          }}
-          title={t(
-            'You must be an organization owner, manager, or admin to set up a monitor'
-          )}
-          {...props}
-        >
-          {props.children}
-        </Button>
-      )}
-    </Access>
+    <Button
+      to={`/organizations/${organization.slug}/monitors/create/`}
+      priority="primary"
+      {...props}
+    >
+      {props.children}
+    </Button>
   );
 }
 


### PR DESCRIPTION
Following the widening of permission here https://github.com/getsentry/sentry/pull/42400, we can adjust the frontend to no longer prevent the user from accessing certain actions (creating, editing, deleting cron monitors).

*Recommend viewing diff with "hide whitespace" on