### PR TITLE
chore(hybrid-cloud): add test stable annotations

### DIFF
--- a/tests/sentry/models/test_integrationfeature.py
+++ b/tests/sentry/models/test_integrationfeature.py
@@ -4,7 +4,7 @@ from sentry.testutils import TestCase
 from sentry.testutils.silo import control_silo_test
 
 
-@control_silo_test
+@control_silo_test(stable=True)
 class IntegrationFeatureTest(TestCase):
     def setUp(self):
         self.sentry_app = self.create_sentry_app()

--- a/tests/sentry/models/test_sentryappinstallation.py
+++ b/tests/sentry/models/test_sentryappinstallation.py
@@ -1,7 +1,9 @@
 from sentry.models import ApiApplication, SentryApp, SentryAppInstallation
 from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test
 
 
+@control_silo_test(stable=True)
 class SentryAppInstallationTest(TestCase):
     def setUp(self):
         self.user = self.create_user()

--- a/tests/sentry/models/test_sentryappinstallationtoken.py
+++ b/tests/sentry/models/test_sentryappinstallationtoken.py
@@ -6,8 +6,10 @@ from sentry.models import (
     SentryAppInstallationToken,
 )
 from sentry.testutils import TestCase
+from sentry.testutils.silo import region_silo_test
 
 
+@region_silo_test(stable=True)
 class SentryAppInstallationTokenTest(TestCase):
     def setUp(self):
         self.application = ApiApplication.objects.create(owner=self.user)


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/HC-547

Adds `@control_silo_test(stable=True)` annotation to `IntegrationFeatureTest` and `SentryAppInstallationTest`

Adds `@region_silo_test(stable=True)` annotation to `SentryAppInstallationTokenTest`
