### PR TITLE
fix(span-tree): White span bug in virtualized span tree

### DIFF
--- a/static/app/components/events/interfaces/spans/spanTreeModel.tsx
+++ b/static/app/components/events/interfaces/spans/spanTreeModel.tsx
@@ -470,8 +470,20 @@ class SpanTreeModel {
                   spanModel.isEmbeddedTransactionTimeAdjusted,
               };
 
+              const bounds = generateBounds({
+                startTimestamp: spanModel.span.start_timestamp,
+                endTimestamp: spanModel.span.timestamp,
+              });
+
               acc.previousSiblingEndTimestamp = spanModel.span.timestamp;
-              acc.descendants.push(enhancedSibling);
+
+              // It's possible that a section in the minimap is selected so some spans in this group may be out of view
+              bounds.isSpanVisibleInView
+                ? acc.descendants.push(enhancedSibling)
+                : acc.descendants.push({
+                    type: 'filtered_out',
+                    span: spanModel.span,
+                  });
             }
           });
 


### PR DESCRIPTION
Fixes a strange bug found by @DominikB2014, where if you select a boundary on the minimap of an embedded span tree (on issue details), and then expand a group of autogrouped siblings, a bunch of the spans will appear as blank white spaces.

This was because of a very specific branch of logic that targets whether a span within an expanded autogroup should be visible, we were not checking in this branch whether the span is within the boundary or not.

### Before
https://user-images.githubusercontent.com/16740047/208027391-6a5bc844-2d47-42f6-ae40-3e5c58ee8337.mp4

### After

[ REDACTED due to privacy concerns ]



