### PR TITLE
fix(txnames): Get transaction name from event data

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -1,11 +1,10 @@
 """ Write transactions into redis sets """
-from typing import Any, Iterator
+from typing import Any, Iterator, Mapping
 
 import sentry_sdk
 from django.conf import settings
 
 from sentry import features
-from sentry.eventstore.models import Event
 from sentry.ingest.transaction_clusterer.datasource import TRANSACTION_SOURCE_URL
 from sentry.models import Project
 from sentry.utils import redis
@@ -64,10 +63,10 @@ def get_transaction_names(project: Project) -> Iterator[str]:
     return client.sscan_iter(redis_key)  # type: ignore
 
 
-def record_transaction_name(project: Project, event: Event, **kwargs: Any) -> None:
-    transaction_info = event.data.get("transaction_info") or {}
+def record_transaction_name(project: Project, event_data: Mapping[str, Any], **kwargs: Any) -> None:
+    transaction_info = event_data.get("transaction_info") or {}
 
-    transaction_name = event.transaction
+    transaction_name = event_data.get("transaction")
     source = transaction_info.get("source")
     if transaction_name and features.has(
         "organizations:transaction-name-clusterer", project.organization

--- a/src/sentry/ingest/transaction_clusterer/datasource/redis.py
+++ b/src/sentry/ingest/transaction_clusterer/datasource/redis.py
@@ -66,6 +66,7 @@ def get_transaction_names(project: Project) -> Iterator[str]:
 
 def record_transaction_name(project: Project, event: Event, **kwargs: Any) -> None:
     transaction_info = event.data.get("transaction_info") or {}
+
     transaction_name = event.transaction
     source = transaction_info.get("source")
     if transaction_name and features.has(

--- a/src/sentry/ingest/transaction_clusterer/tasks.py
+++ b/src/sentry/ingest/transaction_clusterer/tasks.py
@@ -43,7 +43,7 @@ def spawn_clusterers(**kwargs: Any) -> None:
             project_count += len(batch)
             cluster_projects.delay(batch)
 
-        metrics.incr("txcluster.spawned_projects", amount=project_count)
+        metrics.incr("txcluster.spawned_projects", amount=project_count, sample_rate=1.0)
 
 
 @instrumented_task(

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -360,7 +360,7 @@ def post_process_group(
         # This should eventually be completely removed and transactions
         # will not go through any post processing.
         if is_transaction_event:
-            record_transaction_name_for_clustering(event.project, event)
+            record_transaction_name_for_clustering(event.project, event.data)
             with sentry_sdk.start_span(op="tasks.post_process_group.transaction_processed_signal"):
                 transaction_processed.send_robust(
                     sender=post_process_group,

--- a/tests/sentry/ingest/test_transaction_clusterer.py
+++ b/tests/sentry/ingest/test_transaction_clusterer.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 from freezegun import freeze_time
 
-from sentry.eventstore.models import Event
 from sentry.ingest.transaction_clusterer.base import ReplacementRule
 from sentry.ingest.transaction_clusterer.datasource.redis import (
     _store_transaction_name,
@@ -102,16 +101,14 @@ def test_record_transactions(
 ):
     with Feature({"organizations:transaction-name-clusterer": feature_enabled}):
         project = Project(id=111, name="project", organization_id=default_organization.id)
-        event = Event(
-            project.id,
-            "02552061b47b467cb38d1d2dd26eed21",
-            data={
+        record_transaction_name(
+            project,
+            {
                 "tags": [["transaction", txname]],
                 "transaction": txname,
                 "transaction_info": {"source": source},
             },
         )
-        record_transaction_name(project, event)
         assert len(mocked_record.mock_calls) == expected
 
 

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -99,7 +99,7 @@ class CorePostProcessGroupTestMixin(BasePostProgressGroupMixin):
             is_regression=False,
             is_new_group_environment=True,
             cache_key=cache_key,
-            group_id=1,
+            group_id=None,
         )
 
         assert mock_processor.call_count == 0


### PR DESCRIPTION
We were accessing the `Event.transaction` property to get the transaction, which uses `_snuba_data` internally. This turned out to not be populated.

To fix this, get the transaction name from the event data directly.