### PR TITLE
ref(onboarding): Remove duplicate has source map func and analytics code

### DIFF
--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -214,18 +214,6 @@ function eventHasSourceMaps(event: Event) {
   });
 }
 
-/**
- * Function to determine if an event has minified stack trace
- */
-function eventHasMinifiedStackTrace(event: Event) {
-  return event.entries?.some(entry => {
-    return (
-      entry.type === EntryType.EXCEPTION &&
-      entry.data.values?.some(value => !!value.rawStacktrace)
-    );
-  });
-}
-
 function getExceptionEntries(event: Event) {
   return event.entries?.filter(entry => entry.type === 'exception') as EntryException[];
 }
@@ -286,7 +274,6 @@ export function getAnalyicsDataForEvent(event?: Event) {
     event_type: event?.type,
     has_release: !!event?.release,
     has_source_maps: event ? eventHasSourceMaps(event) : false,
-    has_minified_stack_trace: event ? eventHasMinifiedStackTrace(event) : false,
     has_trace: event ? hasTrace(event) : false,
     has_commit: !!event?.release?.lastCommit,
     event_errors: event ? getEventErrorString(event) : '',


### PR DESCRIPTION
It was introduced in the [PR](https://github.com/getsentry/sentry/pull/42060)  the function `eventHasMinifiedStackTrace` and the new analytic event property `has_minified_stack_trace` so we could track via Amplitude when an event contains a minified stack trace. 

This PR removes this change as we recently noticed that the `has_source_maps ` property already tracks this information