### PR TITLE
ref: don't hide exit code on installation failures

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -134,12 +134,9 @@ runs:
         WORKDIR: ${{ inputs.workdir }}
       run: |
         cd "$WORKDIR"
-        python setup.py install_egg_info
+        pip install -r requirements-dev-frozen.txt
         # We need to install editable otherwise things like check migration will fail.
-        pip install -r requirements-dev-frozen.txt & \
-        SENTRY_LIGHT_BUILD=1 pip install --no-deps -e . & \
-        wait
-        cd -
+        SENTRY_LIGHT_BUILD=1 pip install --no-deps -e .
 
     - name: Start devservices
       shell: bash


### PR DESCRIPTION
this makes things ~5 seconds slower but:
- now things actually fail when failing
- there's a very rare race between multiple pip processes that this avoids