### PR TITLE
ref(hybrid-cloud): move SentryAppAvatar to control silo

### DIFF
--- a/src/sentry/models/avatars/sentry_app_avatar.py
+++ b/src/sentry/models/avatars/sentry_app_avatar.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, List
 
 from django.db import models
 
-from sentry.db.models import FlexibleForeignKey, region_silo_only_model
+from sentry.db.models import FlexibleForeignKey, control_silo_only_model
 from sentry.db.models.manager import BaseManager
 
 from . import AvatarBase
@@ -36,7 +36,7 @@ class SentryAppAvatarManager(BaseManager):
         return avatar_to_app_map
 
 
-@region_silo_only_model
+@control_silo_only_model
 class SentryAppAvatar(AvatarBase):
     """
     A SentryAppAvatar associates a SentryApp with a logo photo File

--- a/tests/sentry/models/test_sentryapp.py
+++ b/tests/sentry/models/test_sentryapp.py
@@ -1,8 +1,10 @@
 from sentry.constants import SentryAppStatus
 from sentry.models import ApiApplication, SentryApp
 from sentry.testutils import TestCase
+from sentry.testutils.silo import control_silo_test
 
 
+@control_silo_test(stable=True)
 class SentryAppTest(TestCase):
     def setUp(self):
         self.user = self.create_user()


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/HC-547
Moving SentryAppAvatar to control silo because SentryApp is in the control silo and SentryAppAvatar has db references only to SentryApp

This also tags SentryAppTest as stable.
