### PR TITLE
Add `Sync: Jira` label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -193,6 +193,9 @@
 - name: 'Team: Design'
   color: '8D5494'
   description: ''
+- name: 'Team: Dev Infrastructure'
+  color: '8D5494'
+  description: dev-infra
 - name: 'Team: Ecosystem'
   color: '8D5494'
   description: ''

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -15,6 +15,11 @@
   color: '3E5E06'
   description: 'add to a merged PR to revert it (skips CI)'
 
+# Unito - notion.so/52d10dbfad474328850319e48b057a5b
+- name: "Sync: Jira"
+  color: 'A0CABD'
+  description: 'apply to auto-create a Jira shadow ticket'
+
 # Dependabot
 - name: dependencies
   color: 'ffffff'


### PR DESCRIPTION
This PR adds a `Sync: Jira` label to support an automation to create Jira shadow tickets for certain GitHub Issues (https://github.com/getsentry/team-ospo/issues/63).