### PR TITLE
feat(issue-platform): Save generic events

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -390,7 +390,13 @@ class EventManager:
             **DEFAULT_STORE_NORMALIZER_ARGS,
         )
 
+        pre_normalize_type = self._data.get("type")
         self._data = CanonicalKeyDict(rust_normalizer.normalize_event(dict(self._data)))
+        # XXX: This is a hack to make generic events work (for now?). I'm not sure whether we should
+        # include this in the rust normalizer, since we don't want people sending us these via the
+        # sdk.
+        if pre_normalize_type == "generic":
+            self._data["type"] = pre_normalize_type
 
     def get_data(self) -> CanonicalKeyDict:
         return self._data
@@ -1184,7 +1190,7 @@ def _nodestore_save_many(jobs: Sequence[Job]) -> None:
 
         event = job["event"]
         # We only care about `unprocessed` for error events
-        if event.get_event_type() != "transaction" and job["groups"]:
+        if event.get_event_type() not in ("transaction", "generic") and job["groups"]:
             unprocessed = event_processing_store.get(
                 cache_key_for_event({"project": event.project_id, "event_id": event.event_id}),
                 unprocessed=True,

--- a/src/sentry/eventstore/snuba/backend.py
+++ b/src/sentry/eventstore/snuba/backend.py
@@ -218,8 +218,12 @@ class SnubaEventStorage(EventStorage):
                 raw_query_kwargs["conditions"] = [
                     ["timestamp", ">", datetime.fromtimestamp(random.randint(0, 1000000000))]
                 ]
+            dataset = (
+                Dataset.IssuePlatform if event.get_event_type() == "generic" else Dataset.Events
+            )
             try:
                 result = snuba.raw_query(
+                    dataset=dataset,
                     selected_columns=["group_id"],
                     start=event.datetime,
                     end=event.datetime + timedelta(seconds=1),

--- a/src/sentry/eventtypes/__init__.py
+++ b/src/sentry/eventtypes/__init__.py
@@ -1,5 +1,6 @@
 from .base import DefaultEvent
 from .error import ErrorEvent
+from .generic import GenericEvent
 from .manager import EventTypeManager
 from .security import CspEvent, ExpectCTEvent, ExpectStapleEvent, HpkpEvent
 from .transaction import TransactionEvent
@@ -12,6 +13,7 @@ default_manager.register(HpkpEvent)
 default_manager.register(ExpectCTEvent)
 default_manager.register(ExpectStapleEvent)
 default_manager.register(TransactionEvent)
+default_manager.register(GenericEvent)
 
 get = default_manager.get
 register = default_manager.register

--- a/src/sentry/eventtypes/generic.py
+++ b/src/sentry/eventtypes/generic.py
@@ -1,0 +1,5 @@
+from sentry.eventtypes.base import BaseEvent
+
+
+class GenericEvent(BaseEvent):
+    key = "generic"

--- a/src/sentry/issues/ingest.py
+++ b/src/sentry/issues/ingest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from hashlib import md5
-from typing import Any, Mapping, Optional, TypedDict, cast
+from typing import Any, Mapping, Optional, Tuple, TypedDict, cast
 
 import sentry_sdk
 from django.conf import settings
@@ -33,7 +33,9 @@ ISSUE_QUOTA = Quota(3600, 60, 5)
 logger = logging.getLogger(__name__)
 
 
-def save_issue_occurrence(occurrence_data: IssueOccurrenceData, event: Event) -> IssueOccurrence:
+def save_issue_occurrence(
+    occurrence_data: IssueOccurrenceData, event: Event
+) -> Tuple[IssueOccurrence, Optional[GroupInfo]]:
     process_occurrence_data(occurrence_data)
     # Convert occurrence data to `IssueOccurrence`
     occurrence = IssueOccurrence.from_dict(occurrence_data)
@@ -49,7 +51,7 @@ def save_issue_occurrence(occurrence_data: IssueOccurrenceData, event: Event) ->
         send_issue_occurrence_to_eventstream(event, occurrence, group_info)
         # TODO: Create group related releases here
 
-    return occurrence
+    return occurrence, group_info
 
 
 def process_occurrence_data(occurrence_data: IssueOccurrenceData) -> None:

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional, Tuple
 
 import rapidjson
 from arroyo import Topic
@@ -11,6 +11,7 @@ from arroyo.processing.strategies import ProcessingStrategy, ProcessingStrategyF
 from arroyo.types import Commit, Message, Partition
 from django.conf import settings
 
+from sentry.event_manager import GroupInfo
 from sentry.eventstore.models import Event
 from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.issue_occurrence import IssueOccurrence, IssueOccurrenceData
@@ -70,7 +71,7 @@ def save_event_from_occurrence(
 
 def process_event_and_issue_occurrence(
     occurrence_data: IssueOccurrenceData, event_data: Dict[str, Any]
-) -> Optional[IssueOccurrence]:
+) -> Optional[Tuple[IssueOccurrence, Optional[GroupInfo]]]:
     try:
         event = save_event_from_occurrence(event_data)
     except Exception:
@@ -124,7 +125,9 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
         return None
 
 
-def _process_message(message: Mapping[str, Any]) -> Optional[IssueOccurrence]:
+def _process_message(
+    message: Mapping[str, Any]
+) -> Optional[Tuple[IssueOccurrence, Optional[GroupInfo]]]:
     kwargs = _get_kwargs(message)
     if not kwargs:
         return None

--- a/src/sentry/issues/occurrence_consumer.py
+++ b/src/sentry/issues/occurrence_consumer.py
@@ -95,7 +95,6 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
             kwargs = {
                 "occurrence_data": {
                     "id": payload["id"],
-                    "event_id": payload["event_id"],
                     "fingerprint": payload["fingerprint"],
                     "issue_title": payload["issue_title"],
                     "subtitle": payload["subtitle"],
@@ -106,6 +105,8 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
                     "detection_time": payload["detection_time"],
                 }
             }
+            if "event_id" in payload:
+                kwargs["occurrence_data"]["event_id"] = payload["event_id"]
 
             if "event" in payload:
                 payload_event = payload["event"]
@@ -117,6 +118,7 @@ def _get_kwargs(payload: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
                     "timestamp": payload_event["timestamp"],
                     # TODO add other params as per the spec
                 }
+                kwargs["occurrence_data"]["event_id"] = payload_event["event_id"]
 
             return kwargs
 

--- a/src/sentry/models/event.py
+++ b/src/sentry/models/event.py
@@ -21,6 +21,13 @@ class EventDict(CanonicalKeyDict):
 
         if not skip_renormalization and not is_renormalized:
             normalizer = StoreNormalizer(is_renormalize=True, enable_trimming=False)
-            data = normalizer.normalize_event(dict(data))
+            data = dict(data)
+            pre_normalize_type = data.get("type")
+            data = normalizer.normalize_event(data)
+            # XXX: This is a hack to make generic events work (for now?). I'm not sure whether we
+            # should include this in the rust normalizer, since we don't want people sending us
+            # these via the sdk.
+            if pre_normalize_type == "generic":
+                data["type"] = pre_normalize_type
 
         CanonicalKeyDict.__init__(self, data, **kwargs)

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -26,7 +26,7 @@ class SaveIssueOccurrenceTest(OccurrenceTestMixin, TestCase):  # type: ignore
         # TODO: We should make this a platform event once we have one
         event = self.store_event(data={}, project_id=self.project.id)
         occurrence = self.build_occurrence(event_id=event.event_id)
-        saved_occurrence = save_issue_occurrence(occurrence.to_dict(), event)
+        saved_occurrence = save_issue_occurrence(occurrence.to_dict(), event)[0]
         occurrence = replace(
             occurrence,
             fingerprint=[md5(fp.encode("utf-8")).hexdigest() for fp in occurrence.fingerprint],

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -59,8 +59,9 @@ class IssueOccurrenceTestMessage(OccurrenceTestMixin, TestCase, SnubaTestCase): 
     @pytest.mark.django_db
     def test_occurrence_consumer_with_event(self) -> None:
         message = get_test_message(self.project.id)
-        occurrence = _process_message(message)
-        assert occurrence is not None
+        result = _process_message(message)
+        assert result is not None
+        occurrence = result[0]
 
         fetched_occurrence = IssueOccurrence.fetch(occurrence.id, self.project.id)
         assert fetched_occurrence is not None

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -17,12 +17,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_test_message(
-    project_id: str, include_event: bool = True, **overrides: Any
+    project_id: int, include_event: bool = True, **overrides: Any
 ) -> Dict[str, Any]:
     now = datetime.datetime.now()
     payload = {
         "id": uuid.uuid4().hex,
-        "event_id": uuid.uuid4().hex,
         "fingerprint": ["touch-id"],
         "issue_title": "segfault",
         "subtitle": "buffer overflow",
@@ -71,6 +70,8 @@ class IssueOccurrenceTestMessage(OccurrenceTestMixin, TestCase, SnubaTestCase): 
             self.project.id, fetched_occurrence.event_id
         )
         assert fetched_event is not None
+        assert fetched_event.get_event_type() == "generic"
+
         assert Group.objects.filter(grouphash__hash=occurrence.fingerprint[0]).exists()
 
     def test_invalid_event_payload(self) -> None:

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -347,9 +347,6 @@ class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
         assert group_event.event_id == "b" * 32
         assert group_event.occurrence is None
 
-    @pytest.mark.skip(
-        "Skipping this for now until a pr that fixes saving generic events is merged."
-    )
     def test_get_latest_event_occurrence(self):
         occurrence_data = self.build_occurrence_data()
         event_id = uuid.uuid4().hex
@@ -361,7 +358,7 @@ class GroupGetLatestEventTest(TestCase, OccurrenceTestMixin):
                 "project_id": self.project.id,
                 "timestamp": before_now(minutes=1).isoformat(),
             },
-        )
+        )[0]
 
         group = Group.objects.first()
         group.update(type=GroupType.PROFILE_BLOCKED_THREAD.value)


### PR DESCRIPTION
When saving events we weren't setting the type to `generic`. Even after doing this, it didn't actually work because the rust normalizer doesn't recognize the `generic` type and just sets it to `default`. Added in a hack to restore the type for now, not sure what the long term looks for this.

Also added a `GenericEvent` to eventtypes for similar reasons. This now results in the event being saved correctly.
