### PR TITLE
fix(workflow): Safely render label if fallthrough is missing

### DIFF
--- a/src/sentry/mail/actions.py
+++ b/src/sentry/mail/actions.py
@@ -34,6 +34,14 @@ class NotifyEmailAction(EventAction):
             self.label = "Send a notification to {targetType} and if none can be found then send a notification to {fallthroughType}"
             self.form_fields["fallthroughType"] = {"type": "choice", "choices": FALLTHROUGH_CHOICES}
 
+    def render_label(self) -> str:
+        if self.data.get("fallthroughType", None) and features.has(
+            "organizations:issue-alert-fallback-targeting", self.project.organization, actor=None
+        ):
+            return self.label.format(**self.data)
+
+        return "Send a notification to {targetType}".format(**self.data)
+
     def after(self, event, state):
         group = event.group
         extra = {"event_id": event.event_id, "group_id": group.id}

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -309,3 +309,18 @@ class NotifyEmailTest(RuleTestCase):
         assert sent_out_to == sorted([self.user.email, gil_workflow.email, dan_workflow.email])
         for x in [out.subject for out in mail.outbox]:
             assert "uh oh" in x
+
+    @with_feature("organizations:issue-alert-fallback-targeting")
+    def test_render_label_fallback_none(self):
+        rule = self.get_rule(data={"targetType": ActionTargetType.ISSUE_OWNERS.value})
+        assert rule.render_label() == "Send a notification to IssueOwners"
+        rule = self.get_rule(
+            data={
+                "targetType": ActionTargetType.ISSUE_OWNERS.value,
+                "fallthroughType": FallthroughChoiceType.ALL_MEMBERS.value,
+            }
+        )
+        assert (
+            rule.render_label()
+            == "Send a notification to IssueOwners and if none can be found then send a notification to AllMembers"
+        )


### PR DESCRIPTION
Since we haven't written a migration yet, existing issue alerts are missing the fallthrough type when we enable the flag. This breaks when attempting to render the label that expects a fallthrough type


fixes SENTRY-XNQ