### PR TITLE
feat(anr-rate): Expose ANR rates through session API

### DIFF
--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -46,6 +46,7 @@ SessionsQueryFunction = Literal[
     "crash_rate(user)",
     "crash_free_rate(session)",
     "crash_free_rate(user)",
+    "anr_rate()",
 ]
 
 GroupByFieldName = Literal[

--- a/src/sentry/release_health/base.py
+++ b/src/sentry/release_health/base.py
@@ -47,6 +47,7 @@ SessionsQueryFunction = Literal[
     "crash_free_rate(session)",
     "crash_free_rate(user)",
     "anr_rate()",
+    "foreground_anr_rate()",
 ]
 
 GroupByFieldName = Literal[

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -364,6 +364,7 @@ class SimpleForwardingField(Field):
         "crash_rate(user)": SessionMRI.CRASH_USER_RATE,
         "crash_free_rate(session)": SessionMRI.CRASH_FREE_RATE,
         "crash_free_rate(user)": SessionMRI.CRASH_FREE_USER_RATE,
+        "anr_rate()": SessionMRI.ANR_RATE,
     }
 
     def __init__(self, name: str, raw_groupby: Sequence[str], status_filter: StatusFilter):
@@ -400,6 +401,7 @@ FIELD_MAP: Mapping[SessionsQueryFunction, Type[Field]] = {
     "crash_rate(user)": SimpleForwardingField,
     "crash_free_rate(session)": SimpleForwardingField,
     "crash_free_rate(user)": SimpleForwardingField,
+    "anr_rate()": SimpleForwardingField,
 }
 PREFLIGHT_QUERY_COLUMNS = {"release.timestamp"}
 VirtualOrderByName = Literal["release.timestamp"]

--- a/src/sentry/release_health/metrics_sessions_v2.py
+++ b/src/sentry/release_health/metrics_sessions_v2.py
@@ -365,6 +365,7 @@ class SimpleForwardingField(Field):
         "crash_free_rate(session)": SessionMRI.CRASH_FREE_RATE,
         "crash_free_rate(user)": SessionMRI.CRASH_FREE_USER_RATE,
         "anr_rate()": SessionMRI.ANR_RATE,
+        "foreground_anr_rate()": SessionMRI.FOREGROUND_ANR_RATE,
     }
 
     def __init__(self, name: str, raw_groupby: Sequence[str], status_filter: StatusFilter):
@@ -402,6 +403,7 @@ FIELD_MAP: Mapping[SessionsQueryFunction, Type[Field]] = {
     "crash_free_rate(session)": SimpleForwardingField,
     "crash_free_rate(user)": SimpleForwardingField,
     "anr_rate()": SimpleForwardingField,
+    "foreground_anr_rate()": SimpleForwardingField,
 }
 PREFLIGHT_QUERY_COLUMNS = {"release.timestamp"}
 VirtualOrderByName = Literal["release.timestamp"]

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -53,6 +53,7 @@ from sentry.snuba.metrics.fields.snql import (
     errored_all_users,
     errored_preaggr_sessions,
     failure_count_transaction,
+    foreground_anr_users,
     histogram_snql_factory,
     miserable_users,
     rate_snql_factory,
@@ -1311,6 +1312,14 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             ),
         ),
         SingularEntityDerivedMetric(
+            metric_mri=SessionMRI.FOREGROUND_ANR_USER.value,
+            metrics=[SessionMRI.USER.value],
+            unit="users",
+            snql=lambda project_ids, org_id, metric_ids, alias=None: foreground_anr_users(
+                org_id, metric_ids, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
             metric_mri=SessionMRI.CRASH_RATE.value,
             metrics=[SessionMRI.CRASHED.value, SessionMRI.ALL.value],
             unit="percentage",
@@ -1338,6 +1347,17 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             unit="percentage",
             snql=lambda anr_user_count, all_user_count, project_ids, org_id, metric_ids, alias=None: division_float(
                 anr_user_count, all_user_count, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
+            metric_mri=SessionMRI.FOREGROUND_ANR_RATE.value,
+            metrics=[
+                SessionMRI.FOREGROUND_ANR_USER.value,
+                SessionMRI.ALL_USER.value,
+            ],
+            unit="percentage",
+            snql=lambda foreground_anr_user_count, all_user_count, project_ids, org_id, metric_ids, alias=None: division_float(
+                foreground_anr_user_count, all_user_count, alias=alias
             ),
         ),
         SingularEntityDerivedMetric(

--- a/src/sentry/snuba/metrics/fields/base.py
+++ b/src/sentry/snuba/metrics/fields/base.py
@@ -42,6 +42,7 @@ from sentry.snuba.metrics.fields.snql import (
     all_sessions,
     all_transactions,
     all_users,
+    anr_users,
     apdex,
     complement,
     count_transaction_name_snql_factory,
@@ -1302,6 +1303,14 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             ),
         ),
         SingularEntityDerivedMetric(
+            metric_mri=SessionMRI.ANR_USER.value,
+            metrics=[SessionMRI.USER.value],
+            unit="users",
+            snql=lambda project_ids, org_id, metric_ids, alias=None: anr_users(
+                org_id, metric_ids, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
             metric_mri=SessionMRI.CRASH_RATE.value,
             metrics=[SessionMRI.CRASHED.value, SessionMRI.ALL.value],
             unit="percentage",
@@ -1318,6 +1327,17 @@ DERIVED_METRICS: Mapping[str, DerivedMetricExpression] = {
             unit="percentage",
             snql=lambda crashed_user_count, all_user_count, project_ids, org_id, metric_ids, alias=None: division_float(
                 crashed_user_count, all_user_count, alias=alias
+            ),
+        ),
+        SingularEntityDerivedMetric(
+            metric_mri=SessionMRI.ANR_RATE.value,
+            metrics=[
+                SessionMRI.ANR_USER.value,
+                SessionMRI.ALL_USER.value,
+            ],
+            unit="percentage",
+            snql=lambda anr_user_count, all_user_count, project_ids, org_id, metric_ids, alias=None: division_float(
+                anr_user_count, all_user_count, alias=alias
             ),
         ),
         SingularEntityDerivedMetric(

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -257,6 +257,15 @@ def anr_users(org_id: int, metric_ids, alias=None):
     )
 
 
+def foreground_anr_users(org_id: int, metric_ids, alias=None):
+    return _aggregation_on_abnormal_mechanism_func_factory(
+        org_id,
+        abnormal_mechanism="anr_foreground",
+        metric_ids=metric_ids,
+        alias=alias,
+    )
+
+
 def errored_preaggr_sessions(org_id: int, metric_ids, alias=None):
     return _counter_sum_aggregation_on_session_status_factory(
         org_id, session_status="errored_preaggr", metric_ids=metric_ids, alias=alias

--- a/src/sentry/snuba/metrics/fields/snql.py
+++ b/src/sentry/snuba/metrics/fields/snql.py
@@ -54,6 +54,57 @@ def _aggregation_on_session_status_func_factory(aggregate):
     return _snql_on_session_status_factory
 
 
+def _aggregation_on_abnormal_mechanism_func_factory(
+    org_id, abnormal_mechanism, metric_ids, alias=None
+):
+    if isinstance(abnormal_mechanism, list):
+        abnormal_mechanism_condition = Function(
+            "in",
+            [
+                Column(
+                    resolve_tag_key(
+                        UseCaseKey.RELEASE_HEALTH,
+                        org_id,
+                        "abnormal_mechanism",
+                    )
+                ),
+                [
+                    resolve_tag_value(UseCaseKey.RELEASE_HEALTH, org_id, mechanism)
+                    for mechanism in abnormal_mechanism
+                ],
+            ],
+        )
+    else:
+        abnormal_mechanism_condition = Function(
+            "equals",
+            [
+                Column(
+                    resolve_tag_key(
+                        UseCaseKey.RELEASE_HEALTH,
+                        org_id,
+                        "abnormal_mechanism",
+                    )
+                ),
+                resolve_tag_value(UseCaseKey.RELEASE_HEALTH, org_id, abnormal_mechanism),
+            ],
+        )
+
+    return Function(
+        "uniqIf",
+        [
+            Column("value"),
+            Function(
+                "and",
+                [
+                    abnormal_mechanism_condition,
+                    Function("in", [Column("metric_id"), list(metric_ids)]),
+                ],
+            ),
+        ],
+        alias,
+    )
+
+
 def _counter_sum_aggregation_on_session_status_factory(
     org_id: int, session_status, metric_ids, alias=None
 ):
@@ -194,6 +245,15 @@ def crashed_sessions(org_id: int, metric_ids, alias=None):
 def crashed_users(org_id: int, metric_ids, alias=None):
     return _set_uniq_aggregation_on_session_status_factory(
         org_id, session_status="crashed", metric_ids=metric_ids, alias=alias
+    )
+
+
+def anr_users(org_id: int, metric_ids, alias=None):
+    return _aggregation_on_abnormal_mechanism_func_factory(
+        org_id,
+        abnormal_mechanism=["anr_foreground", "anr_background"],
+        metric_ids=metric_ids,
+        alias=alias,
     )
 
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -72,6 +72,8 @@ class SessionMRI(Enum):
     CRASH_FREE_USER_RATE = "e:sessions/user.crash_free_rate@ratio"
     ANR_USER = "e:sessions/user.anr@none"
     ANR_RATE = "e:sessions/user.anr_rate@ratio"
+    FOREGROUND_ANR_USER = "e:sessions/user.foreground_anr@none"
+    FOREGROUND_ANR_RATE = "e:sessions/user.foreground_anr_rate@ratio"
     DURATION = "d:sessions/duration.exited@second"
 
 

--- a/src/sentry/snuba/metrics/naming_layer/mri.py
+++ b/src/sentry/snuba/metrics/naming_layer/mri.py
@@ -70,6 +70,8 @@ class SessionMRI(Enum):
     ABNORMAL_USER = "e:sessions/user.abnormal@none"
     CRASH_USER_RATE = "e:sessions/user.crash_rate@ratio"
     CRASH_FREE_USER_RATE = "e:sessions/user.crash_free_rate@ratio"
+    ANR_USER = "e:sessions/user.anr@none"
+    ANR_RATE = "e:sessions/user.anr_rate@ratio"
     DURATION = "d:sessions/duration.exited@second"
 
 

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -50,6 +50,7 @@ class SessionMetricKey(Enum):
     CRASH_USER_RATE = "session.crash_user_rate"
     CRASH_FREE_USER_RATE = "session.crash_free_user_rate"
     ANR_RATE = "session.anr_rate"
+    FOREGROUND_ANR_RATE = "session.foreground_anr_rate"
 
 
 class TransactionMetricKey(Enum):

--- a/src/sentry/snuba/metrics/naming_layer/public.py
+++ b/src/sentry/snuba/metrics/naming_layer/public.py
@@ -49,6 +49,7 @@ class SessionMetricKey(Enum):
     HEALTHY_USER = "session.healthy_user"
     CRASH_USER_RATE = "session.crash_user_rate"
     CRASH_FREE_USER_RATE = "session.crash_free_user_rate"
+    ANR_RATE = "session.anr_rate"
 
 
 class TransactionMetricKey(Enum):

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1148,6 +1148,8 @@ class BaseMetricsTestCase(SnubaTestCase):
             base_tags["release"] = session["release"]
         if session.get("environment") is not None:
             base_tags["environment"] = session["environment"]
+        if session.get("abnormal_mechanism") is not None:
+            base_tags["abnormal_mechanism"] = session["abnormal_mechanism"]
 
         # This check is not yet reflected in relay, see https://getsentry.atlassian.net/browse/INGEST-464
         user_is_nil = user is None or user == "00000000-0000-0000-0000-000000000000"

--- a/tests/sentry/api/endpoints/test_organization_metrics.py
+++ b/tests/sentry/api/endpoints/test_organization_metrics.py
@@ -111,6 +111,7 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
             {"name": "session.abnormal_user", "operations": [], "type": "numeric", "unit": "users"},
             {"name": "session.all", "type": "numeric", "operations": [], "unit": "sessions"},
             {"name": "session.all_user", "type": "numeric", "operations": [], "unit": "users"},
+            {"name": "session.anr_rate", "operations": [], "type": "numeric", "unit": "percentage"},
             {
                 "name": "session.crash_free_rate",
                 "type": "numeric",
@@ -142,6 +143,12 @@ class OrganizationMetricsIndexIntegrationTest(OrganizationMetricMetaIntegrationT
                 "type": "numeric",
                 "operations": [],
                 "unit": "users",
+            },
+            {
+                "name": "session.foreground_anr_rate",
+                "operations": [],
+                "type": "numeric",
+                "unit": "percentage",
             },
             {
                 "name": "session.healthy_user",


### PR DESCRIPTION
We've added a new tag to the release health metrics dataset
`abnormal_mechanism` in https://github.com/getsentry/relay/pull/1665. In this PR, we are using those tags
to calculate ANR rate and foreground ANR rate.

ANR rate is defined as the ratio of unique users that have
experienced a background or foreground ANR / total unique users

Foreground ANR rate is defined as the ratio of unique users that have
experienced a foreground ANR / total unique users

Add new derived metrics `anr_rate()` and `foreground_anr_rate()`
queryable through the sessions API. Note these fields are only supported
on the metrics backend and not on the sessions backend.

resolves https://github.com/getsentry/sentry/issues/42468