### PR TITLE
feat(queryclient): Make `staleTime` a required option

### DIFF
--- a/static/app/utils/queryClient.spec.tsx
+++ b/static/app/utils/queryClient.spec.tsx
@@ -21,7 +21,7 @@ describe('queryClient', function () {
       });
 
       const TestComponent = () => {
-        const {data} = useQuery<ResponseData>(['/some/test/path/']);
+        const {data} = useQuery<ResponseData>(['/some/test/path/'], {staleTime: 0});
 
         if (!data) {
           return null;
@@ -44,10 +44,10 @@ describe('queryClient', function () {
       });
 
       const TestComponent = () => {
-        const {data} = useQuery<ResponseData>([
-          '/some/test/path/',
-          {query: {filter: 'red'}},
-        ]);
+        const {data} = useQuery<ResponseData>(
+          ['/some/test/path/', {query: {filter: 'red'}}],
+          {staleTime: 0}
+        );
 
         if (!data) {
           return null;
@@ -93,7 +93,9 @@ describe('queryClient', function () {
       jest.spyOn(api, 'requestPromise').mockRejectedValue(requestError);
 
       const TestComponent = () => {
-        const {isError, error} = useQuery<ResponseData>(['/some/test/path']);
+        const {isError, error} = useQuery<ResponseData>(['/some/test/path'], {
+          staleTime: 0,
+        });
 
         if (!isError) {
           return null;

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -12,10 +12,28 @@ export type QueryKey =
   | readonly [url: string]
   | readonly [url: string, options: QueryKeyEndpointOptions];
 
-type UseQueryOptions<TQueryFnData, TError = RequestError, TData = TQueryFnData> = Omit<
-  reactQuery.UseQueryOptions<TQueryFnData, TError, TData, QueryKey>,
-  'queryKey' | 'queryFn'
->;
+interface UseQueryOptions<TQueryFnData, TError = RequestError, TData = TQueryFnData>
+  extends Omit<
+    reactQuery.UseQueryOptions<TQueryFnData, TError, TData, QueryKey>,
+    'queryKey' | 'queryFn'
+  > {
+  /**
+   * staleTime is the amount of time (in ms) before cached data gets marked as stale.
+   * Once data is marked stale, it will be refreshed on the next refetch event, which by default is when:
+   * - The hook is mounted (configure with `refetchOnMount` option)
+   * - The window is refocused (configure with `refetchOnWindowFocus` option)
+   *
+   * Use `staleTime: 0` if you need your data to always be up to date and don't mind excess refetches.
+   * Be careful with this, especially if your hook is used at the root level or in multiple components.
+   *
+   * Use `staleTime: Infinity` if the data should never change, or changes very irregularly.
+   * Note that the cached entries are garbage collected after 5 minutes of being unused (configure with `cacheTime`).
+   *
+   * Otherwise, provide a reasonable number (in ms) for your use case. Remember that the cache
+   * can be updated or invalidated manually with QueryClient if you neeed to do so.
+   */
+  staleTime: number;
+}
 
 // We are not overriding any defaults options for stale time, retries, etc.
 // See https://tanstack.com/query/v4/docs/guides/important-defaults
@@ -39,25 +57,32 @@ function isQueryFn<TQueryFnData, TError, TData>(
  *
  * Example usage:
  *
- * const { data, isLoading, isError } = useQuery<EventsResponse>(['/events', { query: { limit: 50 }}])
+ * const {data, isLoading, isError} = useQuery<EventsResponse>(
+ *   ['/events', {query: {limit: 50}}],
+ *   {staleTime: 0}
+ * );
  */
 function useQuery<TQueryFnData, TError = RequestError, TData = TQueryFnData>(
   queryKey: QueryKey,
-  queryOptions?: UseQueryOptions<TQueryFnData, TError, TData>
+  queryOptions: UseQueryOptions<TQueryFnData, TError, TData>
 ): reactQuery.UseQueryResult<TData, TError>;
 /**
  * Example usage with custom query function:
  *
- * const { data, isLoading, isError } = useQuery<EventsResponse>(['events'], () => api.requestPromise(...))
+ * const { data, isLoading, isError } = useQuery<EventsResponse>(
+ *   ['events', {limit: 50}],
+ *   () => api.requestPromise({limit: 50}),
+ *   {staleTime: 0}
+ * )
  */
 function useQuery<TQueryFnData, TError = RequestError, TData = TQueryFnData>(
   queryKey: QueryKey,
-  queryFn?: reactQuery.QueryFunction<TQueryFnData, QueryKey>,
+  queryFn: reactQuery.QueryFunction<TQueryFnData, QueryKey>,
   queryOptions?: UseQueryOptions<TQueryFnData, TError, TData>
 ): reactQuery.UseQueryResult<TData, TError>;
 function useQuery<TQueryFnData, TError = RequestError, TData = TQueryFnData>(
   queryKey: QueryKey,
-  queryFnOrQueryOptions?:
+  queryFnOrQueryOptions:
     | reactQuery.QueryFunction<TQueryFnData, QueryKey>
     | UseQueryOptions<TQueryFnData, TError, TData>,
   queryOptions?: UseQueryOptions<TQueryFnData, TError, TData>

--- a/static/app/utils/useCommitters.tsx
+++ b/static/app/utils/useCommitters.tsx
@@ -20,7 +20,7 @@ const makeCommittersQueryKey = (
 
 function useCommitters(
   {eventId, projectSlug}: UseCommittersProps,
-  options: UseQueryOptions<CommittersResponse> = {}
+  options: Partial<UseQueryOptions<CommittersResponse>> = {}
 ) {
   const org = useOrganization();
   return useQuery<CommittersResponse>(

--- a/static/app/views/issueList/queries/useFetchSavedSearchesForOrg.tsx
+++ b/static/app/views/issueList/queries/useFetchSavedSearchesForOrg.tsx
@@ -14,7 +14,7 @@ export const makeFetchSavedSearchesForOrgQueryKey = ({
 
 export const useFetchSavedSearchesForOrg = (
   {orgSlug}: FetchSavedSearchesForOrgParameters,
-  options: UseQueryOptions<FetchSavedSearchesForOrgResponse> = {}
+  options: Partial<UseQueryOptions<FetchSavedSearchesForOrgResponse>> = {}
 ) => {
   return useQuery<FetchSavedSearchesForOrgResponse>(
     makeFetchSavedSearchesForOrgQueryKey({orgSlug}),


### PR DESCRIPTION
As discussed in the frontend TSC, `staleTime` has been a confusing option and is easy to get wrong.

- Makes `staleTime` required, forcing consumers to think about the correct value (instead of making it `0` by default)
- And adds a lengthy comment in the type definition to give consumers a better idea of what value to use (and why) 