### PR TITLE
fix(alerts): Link to alert details page instead of edit

### DIFF
--- a/src/sentry/templates/sentry/emails/issue_alert_base.html
+++ b/src/sentry/templates/sentry/emails/issue_alert_base.html
@@ -215,7 +215,7 @@
     <p class="info-box">
         You are receiving this email due to matching rules:
         {% for rule in rules %}
-            <a href="{% absolute_uri rule.url %}">{{ rule.label }}</a>{% if not forloop.last %}, {% endif %}
+            <a href="{% absolute_uri rule.status_url %}">{{ rule.label }}</a>{% if not forloop.last %}, {% endif %}
         {% endfor %}
     </p>
 


### PR DESCRIPTION
Changes the link to go to the details page instead of the edit page. We already had this in the "rules" object

this one 
![image](https://user-images.githubusercontent.com/1400464/208535882-59d2e454-55bc-4a34-b5df-59f707981fe4.png)
