### PR TITLE
feat(jira): Support generic issue types

### DIFF
--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -23,6 +23,7 @@ from django.utils.safestring import mark_safe
 
 from sentry import integrations
 from sentry.api.serializers.models.event import get_entries, get_problems
+from sentry.eventstore.models import Event, GroupEvent
 from sentry.incidents.models import AlertRuleTriggerAction
 from sentry.integrations import IntegrationFeatures, IntegrationProvider
 from sentry.models import (
@@ -55,7 +56,6 @@ from sentry.utils.performance_issues.performance_detection import (
 from sentry.web.helpers import render_to_string
 
 if TYPE_CHECKING:
-    from sentry.eventstore.models import Event, GroupEvent
     from sentry.notifications.notifications.activity.base import ActivityNotification
     from sentry.notifications.notifications.user_report import UserReportNotification
 
@@ -436,13 +436,15 @@ def get_performance_issue_alert_subtitle(event: Event) -> str:
 
 
 def get_notification_group_title(
-    group: Group, event: Event, max_length: int = 255, **kwargs: str
+    group: Group, event: GroupEvent, max_length: int = 255, **kwargs: str
 ) -> str:
     if group.issue_category == GroupCategory.PERFORMANCE:
         issue_type = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
         transaction = get_performance_issue_alert_subtitle(event)
         title = f"{issue_type}: {transaction}"
         return (title[: max_length - 2] + "..") if len(title) > max_length else title
+    elif isinstance(event, GroupEvent) and event.occurrence is not None:
+        return event.occurrence.issue_title
     else:
         event_title: str = event.title
         return event_title

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -443,7 +443,7 @@ def get_notification_group_title(
         transaction = get_performance_issue_alert_subtitle(event)
         title = f"{issue_type}: {transaction}"
         return (title[: max_length - 2] + "..") if len(title) > max_length else title
-    elif isinstance(event, GroupEvent) and event.occurrence is not None:
+    elif event.occurrence is not None:
         return event.occurrence.issue_title
     else:
         event_title: str = event.title

--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -436,15 +436,16 @@ def get_performance_issue_alert_subtitle(event: Event) -> str:
 
 
 def get_notification_group_title(
-    group: Group, event: GroupEvent, max_length: int = 255, **kwargs: str
+    group: Group, event: Event | GroupEvent, max_length: int = 255, **kwargs: str
 ) -> str:
     if group.issue_category == GroupCategory.PERFORMANCE:
         issue_type = GROUP_TYPE_TO_TEXT.get(group.issue_type, "Issue")
         transaction = get_performance_issue_alert_subtitle(event)
         title = f"{issue_type}: {transaction}"
         return (title[: max_length - 2] + "..") if len(title) > max_length else title
-    elif event.occurrence is not None:
-        return event.occurrence.issue_title
+    elif isinstance(event, GroupEvent) and event.occurrence is not None:
+        issue_title: str = event.occurrence.issue_title
+        return issue_title
     else:
         event_title: str = event.title
         return event_title

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -1,17 +1,12 @@
-import uuid
-from datetime import datetime
-
 import responses
 
 from fixtures.integrations.mock_service import StubService
 from sentry.integrations.jira import JiraCreateTicketAction
-from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.models import ExternalIssue, GroupLink, Integration, Rule
 from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
-from sentry.types.issues import GroupType
+from sentry.testutils.helpers.notifications import TEST_ISSUE_OCCURRENCE
 from sentry.types.rules import RuleFuture
 from sentry.utils import json
-from sentry.utils.dates import ensure_aware
 
 
 class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
@@ -126,23 +121,7 @@ class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
     def test_creates_generic_issue(self):
         """Test that a generic issue properly creates a Jira ticket"""
 
-        # TODO replace w/ TEST_ISSUE_OCCURRENCE
-        occurrence = IssueOccurrence(
-            uuid.uuid4().hex,
-            uuid.uuid4().hex,
-            ["some-fingerprint"],
-            "something bad happened",
-            "it was bad",
-            "1234",
-            {"Test": 123},
-            [
-                IssueEvidence("Attention", "Very important information!!!", True),
-                IssueEvidence("Evidence 2", "Not important", False),
-                IssueEvidence("Evidence 3", "Nobody cares about this", False),
-            ],
-            GroupType.PROFILE_BLOCKED_THREAD,
-            ensure_aware(datetime.now()),
-        )
+        occurrence = TEST_ISSUE_OCCURRENCE
         event = self.get_event()
         event = event.for_group(event.groups[0])
         event.occurrence = occurrence

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -1,19 +1,20 @@
+import uuid
+from datetime import datetime
+
 import responses
 
 from fixtures.integrations.mock_service import StubService
-from sentry.event_manager import EventManager
 from sentry.integrations.jira import JiraCreateTicketAction
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.models import ExternalIssue, GroupLink, Integration, Rule
-from sentry.testutils.cases import RuleTestCase
-from sentry.testutils.helpers import override_options
-from sentry.testutils.helpers.datetime import before_now
+from sentry.testutils.cases import PerformanceIssueTestCase, RuleTestCase
 from sentry.types.issues import GroupType
 from sentry.types.rules import RuleFuture
 from sentry.utils import json
-from sentry.utils.samples import load_data
+from sentry.utils.dates import ensure_aware
 
 
-class JiraCreateTicketActionTest(RuleTestCase):
+class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
     rule_cls = JiraCreateTicketAction
 
     def setUp(self):
@@ -30,9 +31,27 @@ class JiraCreateTicketActionTest(RuleTestCase):
         self.integration.add_organization(self.organization, self.user)
         self.installation = self.integration.get_installation(self.organization.id)
 
-    @responses.activate
-    def test_creates_issue(self):
-        event = self.get_event()
+        self.jira_rule = self.get_rule(
+            data={
+                "issuetype": "1",
+                "labels": "bunnies",
+                "customfield_10200": "sad",
+                "customfield_10300": ["Feature 1", "Feature 2"],
+                "project": "10000",
+                "integration": self.integration.id,
+                "jira_project": "10000",
+                "issue_type": "Bug",
+                "fixVersions": "[10000]",
+            }
+        )
+        self.jira_rule.rule = Rule.objects.create(
+            project=self.project,
+            label="test rule",
+        )
+
+        self.jira_rule.data["key"] = "APP-123"
+
+    def create_issue_base(self, event):
         responses.add(
             responses.GET,
             "https://example.atlassian.net/rest/api/2/project",
@@ -46,31 +65,12 @@ class JiraCreateTicketActionTest(RuleTestCase):
             body=StubService.get_stub_json("jira", "createmeta_response.json"),
             content_type="json",
         )
-        jira_rule = self.get_rule(
-            data={
-                "issuetype": "1",
-                "labels": "bunnies",
-                "customfield_10200": "sad",
-                "customfield_10300": ["Feature 1", "Feature 2"],
-                "project": "10000",
-                "integration": self.integration.id,
-                "jira_project": "10000",
-                "issue_type": "Bug",
-                "fixVersions": "[10000]",
-            }
-        )
-        jira_rule.rule = Rule.objects.create(
-            project=self.project,
-            label="test rule",
-        )
-
-        jira_rule.data["key"] = "APP-123"
 
         # Add two mocks: one for POSTing the issue and a GET to confirm it's there.
         responses.add(
             method=responses.POST,
             url="https://example.atlassian.net/rest/api/2/issue",
-            json=jira_rule.data,
+            json=self.jira_rule.data,
             status=202,
             content_type="application/json",
         )
@@ -81,15 +81,20 @@ class JiraCreateTicketActionTest(RuleTestCase):
             content_type="application/json",
         )
 
-        results = list(jira_rule.after(event=event, state=self.get_state()))
+        results = list(self.jira_rule.after(event=event, state=self.get_state()))
         assert len(results) == 1
 
         # Trigger rule callback
-        rule_future = RuleFuture(rule=jira_rule, kwargs=results[0].kwargs)
+        rule_future = RuleFuture(rule=self.jira_rule, kwargs=results[0].kwargs)
         results[0].callback(event, futures=[rule_future])
+        return json.loads(responses.calls[1].request.body)
+
+    @responses.activate
+    def test_creates_issue(self):
+        event = self.get_event()
+        data = self.create_issue_base(event)
 
         # Make assertions about what would be POSTed to api/2/issue.
-        data = json.loads(responses.calls[1].request.body)
         assert data["fields"]["summary"] == event.title
         assert event.message in data["fields"]["description"]
         assert data["fields"]["issuetype"]["id"] == "1"
@@ -100,85 +105,10 @@ class JiraCreateTicketActionTest(RuleTestCase):
     @responses.activate
     def test_creates_performance_issue(self):
         """Test that a performance issue properly creates a Jira ticket"""
-        event_data = load_data(
-            "transaction-n-plus-one",
-            timestamp=before_now(minutes=10),
-            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
-        )
-        perf_event_manager = EventManager(event_data)
-        perf_event_manager.normalize()
-        with override_options(
-            {
-                "performance.issues.all.problem-creation": 1.0,
-                "performance.issues.all.problem-detection": 1.0,
-                "performance.issues.n_plus_one_db.problem-creation": 1.0,
-            }
-        ), self.feature(
-            [
-                "organizations:performance-issues-ingest",
-                "projects:performance-suspect-spans-ingestion",
-            ]
-        ):
-            event = perf_event_manager.save(self.project.id)
-        event = event.for_group(event.groups[0])
-
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/project",
-            body=StubService.get_stub_json("jira", "project_list_response.json"),
-            content_type="application/json",
-        )
-
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/issue/createmeta",
-            body=StubService.get_stub_json("jira", "createmeta_response.json"),
-            content_type="json",
-        )
-        jira_rule = self.get_rule(
-            data={
-                "issuetype": "1",
-                "labels": "bunnies",
-                "customfield_10200": "sad",
-                "customfield_10300": ["Feature 1", "Feature 2"],
-                "project": "10000",
-                "integration": self.integration.id,
-                "jira_project": "10000",
-                "issue_type": "Bug",
-                "fixVersions": "[10000]",
-            }
-        )
-        jira_rule.rule = Rule.objects.create(
-            project=self.project,
-            label="test rule",
-        )
-
-        jira_rule.data["key"] = "APP-123"
-
-        # Add two mocks: one for POSTing the issue and a GET to confirm it's there.
-        responses.add(
-            method=responses.POST,
-            url="https://example.atlassian.net/rest/api/2/issue",
-            json=jira_rule.data,
-            status=202,
-            content_type="application/json",
-        )
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/issue/APP-123",
-            body=StubService.get_stub_json("jira", "get_issue_response.json"),
-            content_type="application/json",
-        )
-
-        results = list(jira_rule.after(event=event, state=self.get_state()))
-        assert len(results) == 1
-
-        # Trigger rule callback
-        rule_future = RuleFuture(rule=jira_rule, kwargs=results[0].kwargs)
-        results[0].callback(event, futures=[rule_future])
+        event = self.create_performance_issue()
+        data = self.create_issue_base(event)
 
         # Make assertions about what would be POSTed to api/2/issue.
-        data = json.loads(responses.calls[1].request.body)
         assert (
             data["fields"]["summary"]
             == 'N+1 Query: SELECT "books_author"."id", "books_author"."name" FROM "books_author" WHERE "books_author"."id" = %s LIMIT 21'
@@ -187,6 +117,39 @@ class JiraCreateTicketActionTest(RuleTestCase):
             "*Transaction Name* | db - SELECT `books_author`.`id`, `books_author`"
             in data["fields"]["description"]
         )
+        assert data["fields"]["issuetype"]["id"] == "1"
+
+        external_issue = ExternalIssue.objects.get(key="APP-123")
+        assert external_issue
+
+    @responses.activate
+    def test_creates_generic_issue(self):
+        """Test that a generic issue properly creates a Jira ticket"""
+
+        # TODO replace w/ TEST_ISSUE_OCCURRENCE
+        occurrence = IssueOccurrence(
+            uuid.uuid4().hex,
+            uuid.uuid4().hex,
+            ["some-fingerprint"],
+            "something bad happened",
+            "it was bad",
+            "1234",
+            {"Test": 123},
+            [
+                IssueEvidence("Attention", "Very important information!!!", True),
+                IssueEvidence("Evidence 2", "Not important", False),
+                IssueEvidence("Evidence 3", "Nobody cares about this", False),
+            ],
+            GroupType.PROFILE_BLOCKED_THREAD,
+            ensure_aware(datetime.now()),
+        )
+        event = self.get_event()
+        event.occurrence = occurrence
+        data = self.create_issue_base(event)
+
+        # Make assertions about what would be POSTed to api/2/issue.
+        assert data["fields"]["summary"] == event.occurrence.issue_title
+        assert event.occurrence.evidence_display[0].value in data["fields"]["description"]
         assert data["fields"]["issuetype"]["id"] == "1"
 
         external_issue = ExternalIssue.objects.get(key="APP-123")
@@ -212,27 +175,8 @@ class JiraCreateTicketActionTest(RuleTestCase):
             relationship=GroupLink.Relationship.references,
             data={"provider": self.integration.provider},
         )
-        jira_rule = self.get_rule(
-            data={
-                "title": "example summary",
-                "description": "example bug report",
-                "issuetype": "1",
-                "project": "10000",
-                "customfield_10200": "sad",
-                "customfield_10300": ["Feature 1", "Feature 2"],
-                "labels": "bunnies",
-                "integration": self.integration.id,
-                "jira_project": "10000",
-                "issue_type": "Bug",
-                "fixVersions": "[10000]",
-            }
-        )
-        jira_rule.rule = Rule.objects.create(
-            project=self.project,
-            label="test rule",
-        )
 
-        results = list(jira_rule.after(event=event, state=self.get_state()))
+        results = list(self.jira_rule.after(event=event, state=self.get_state()))
         assert len(results) == 1
         results[0].callback(event, futures=[])
 

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -144,6 +144,7 @@ class JiraCreateTicketActionTest(RuleTestCase, PerformanceIssueTestCase):
             ensure_aware(datetime.now()),
         )
         event = self.get_event()
+        event = event.for_group(event.groups[0])
         event.occurrence = occurrence
         data = self.create_issue_base(event)
 


### PR DESCRIPTION
Add support to Jira for generic issue types. This uses the issue title from the evidence, and renders the evidence display in a table view similar to how it's done for performance issues.

Fixes #42048

<img width="753" alt="Screen Shot 2022-12-19 at 2 56 48 PM" src="https://user-images.githubusercontent.com/29959063/208543029-7623e5ab-9a52-4e1a-9737-065ecd66209c.png">
