### PR TITLE
feat(github): Support generic issue types

### DIFF
--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from operator import attrgetter
 from typing import Any, Mapping, Sequence
 
 from django.urls import reverse
@@ -42,9 +41,10 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
         body = "|  |  |\n"
         body += "| ------------- | --------------- |\n"
         for evidence in sorted(
-            event.occurrence.evidence_display, key=attrgetter("important"), reverse=True
+            enumerate(event.occurrence.evidence_display),
+            key=lambda evidence: (not evidence[1].important, evidence[0]),
         ):
-            body += f"| **{evidence.name}** | {truncatechars(evidence.value, MAX_CHAR)} |\n"
+            body += f"| **{evidence[1].name}** | {truncatechars(evidence[1].value, MAX_CHAR)} |\n"
 
         return body[:-2]
 

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from operator import attrgetter
 from typing import Any, Mapping, Sequence
 
 from django.urls import reverse
@@ -40,14 +41,10 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
     def get_generic_issue_body(self, event: GroupEvent) -> str:
         body = "|  |  |\n"
         body += "| ------------- | --------------- |\n"
-
-        important = event.occurrence.important_evidence_display
-        if important:
-            body += f"| **{important.name}** | {truncatechars(important.value, MAX_CHAR)} |\n"
-
-        for evidence in event.occurrence.evidence_display:
-            if evidence.important is False:
-                body += f"| **{evidence.name}** | {truncatechars(evidence.value, MAX_CHAR)} |\n"
+        for evidence in sorted(
+            event.occurrence.evidence_display, key=attrgetter("important"), reverse=True
+        ):
+            body += f"| **{evidence.name}** | {truncatechars(evidence.value, MAX_CHAR)} |\n"
 
         return body[:-2]
 

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from operator import attrgetter
 from typing import Any, Mapping, Sequence
 
 from django.urls import reverse
@@ -41,10 +42,9 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
         body = "|  |  |\n"
         body += "| ------------- | --------------- |\n"
         for evidence in sorted(
-            enumerate(event.occurrence.evidence_display),
-            key=lambda evidence: (not evidence[1].important, evidence[0]),
+            event.occurrence.evidence_display, key=attrgetter("important"), reverse=True
         ):
-            body += f"| **{evidence[1].name}** | {truncatechars(evidence[1].value, MAX_CHAR)} |\n"
+            body += f"| **{evidence.name}** | {truncatechars(evidence.value, MAX_CHAR)} |\n"
 
         return body[:-2]
 

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -37,7 +37,7 @@ class GitHubIssueBasic(IssueBasicMixin):  # type: ignore
         body += f"| **Repeating Spans ({num_repeating_spans})** | {truncatechars(repeating_spans, MAX_CHAR)} |"
         return body
 
-    def get_generic_issue_body(self, event: GroupEvent):
+    def get_generic_issue_body(self, event: GroupEvent) -> str:
         body = "|  |  |\n"
         body += "| ------------- | --------------- |\n"
 

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -1,24 +1,26 @@
+import uuid
+from datetime import datetime
 from functools import cached_property
 from unittest.mock import patch
 
 import responses
 from django.test import RequestFactory
 
-from sentry.event_manager import EventManager
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.github.issues import GitHubIssueBasic
+from sentry.issues.issue_occurrence import IssueEvidence, IssueOccurrence
 from sentry.models import ExternalIssue, Integration
 from sentry.testutils import TestCase
-from sentry.testutils.helpers import override_options
+from sentry.testutils.cases import PerformanceIssueTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.silo import region_silo_test
 from sentry.types.issues import GroupType
 from sentry.utils import json
-from sentry.utils.samples import load_data
+from sentry.utils.dates import ensure_aware
 
 
 @region_silo_test
-class GitHubIssueBasicTest(TestCase):
+class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase):
     @cached_property
     def request(self):
         return RequestFactory()
@@ -101,30 +103,9 @@ class GitHubIssueBasicTest(TestCase):
         payload = json.loads(request.body)
         assert payload == {"body": "This is the description", "assignee": None, "title": "hello"}
 
-    def test_performance_issues_description(self):
-        """Test that a GitHub issue created from a performance issue has span evidence data in its description"""
-        event_data = load_data(
-            "transaction-n-plus-one",
-            timestamp=before_now(minutes=10),
-            fingerprint=[f"{GroupType.PERFORMANCE_N_PLUS_ONE_DB_QUERIES.value}-group1"],
-        )
-        perf_event_manager = EventManager(event_data)
-        perf_event_manager.normalize()
-        with override_options(
-            {
-                "performance.issues.all.problem-creation": 1.0,
-                "performance.issues.all.problem-detection": 1.0,
-                "performance.issues.n_plus_one_db.problem-creation": 1.0,
-            }
-        ), self.feature(
-            [
-                "organizations:performance-issues-ingest",
-                "projects:performance-suspect-spans-ingestion",
-            ]
-        ):
-            event = perf_event_manager.save(self.project.id)
-        event = event.for_group(event.groups[0])
-
+    def test_performance_issues_content(self):
+        """Test that a GitHub issue created from a performance issue has the expected title and description"""
+        event = self.create_performance_issue()
         description = GitHubIssueBasic().get_group_description(event.group, event)
         assert "db - SELECT `books_author`.`id`, `books_author" in description
         title = GitHubIssueBasic().get_group_title(event.group, event)
@@ -133,8 +114,44 @@ class GitHubIssueBasicTest(TestCase):
             == 'N+1 Query: SELECT "books_author"."id", "books_author"."name" FROM "books_author" WHERE "books_author"."id" = %s LIMIT 21'
         )
 
-    def test_error_issues_description(self):
-        """Test that a GitHub issue created from an error issue has message  data in its description"""
+    def test_generic_issues_content(self):
+        """Test that a GitHub issue created from a generic issue has the expected title and description"""
+
+        # TODO replace w/ TEST_ISSUE_OCCURRENCE
+        occurrence = IssueOccurrence(
+            uuid.uuid4().hex,
+            uuid.uuid4().hex,
+            ["some-fingerprint"],
+            "something bad happened",
+            "it was bad",
+            "1234",
+            {"Test": 123},
+            [
+                IssueEvidence("Attention", "Very important information!!!", True),
+                IssueEvidence("Evidence 2", "Not important", False),
+                IssueEvidence("Evidence 3", "Nobody cares about this", False),
+            ],
+            GroupType.PROFILE_BLOCKED_THREAD,
+            ensure_aware(datetime.now()),
+        )
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "oh no",
+                "timestamp": iso_format(before_now(minutes=1)),
+            },
+            project_id=self.project.id,
+        )
+        event = event.for_group(event.groups[0])
+        event.occurrence = occurrence
+
+        description = GitHubIssueBasic().get_group_description(event.group, event)
+        assert event.occurrence.evidence_display[0].value in description
+        title = GitHubIssueBasic().get_group_title(event.group, event)
+        assert title == event.occurrence.issue_title
+
+    def test_error_issues_content(self):
+        """Test that a GitHub issue created from an error issue has the expected title and descriptionn"""
         event = self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -146,6 +163,8 @@ class GitHubIssueBasicTest(TestCase):
 
         description = GitHubIssueBasic().get_group_description(event.group, event)
         assert "oh no" in description
+        title = GitHubIssueBasic().get_group_title(event.group, event)
+        assert title == event.title
 
     @responses.activate
     @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")


### PR DESCRIPTION
Add support to GitHub issues for generic issue types. This uses the issue title from the evidence, and renders the evidence display in a table view similar to how it's done for [performance issues](https://github.com/getsentry/sentry/pull/41041).

Closes #42049

Relies on https://github.com/getsentry/sentry/pull/42470 being merged first for the assertion about the title to pass.

<img width="1011" alt="Screen Shot 2022-12-19 at 3 34 12 PM" src="https://user-images.githubusercontent.com/29959063/208548490-159e9c0d-9b56-482b-b974-e8500141c6d1.png">
