### PR TITLE
feat(issue-platform): Add feature flag for displaying issue platform issues in the ui.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1027,6 +1027,8 @@ SENTRY_FEATURES = {
     "organizations:issue-alert-preview": False,
     # Enable issue alert test notifications
     "organizations:issue-alert-test-notifications": False,
+    # Enable issue platform
+    "organizations:issue-platform": False,
     # Whether to allow issue only search on the issue list
     "organizations:issue-search-allow-postgres-only-search": False,
     # Flags for enabling CdcEventsDatasetSnubaSearchBackend in sentry.io. No effect in open-source

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -91,6 +91,7 @@ default_manager.add("organizations:issue-details-owners", OrganizationFeature, T
 default_manager.add("organizations:issue-details-tag-improvements", OrganizationFeature, True)
 default_manager.add("organizations:issue-list-removal-action", OrganizationFeature, True)
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature, True)
+default_manager.add("organizations:issue-platform", OrganizationFeature, True)
 default_manager.add("organizations:issue-search-allow-postgres-only-search", OrganizationFeature, True)
 default_manager.add("organizations:issue-search-use-cdc-primary", OrganizationFeature, True)
 default_manager.add("organizations:issue-search-use-cdc-secondary", OrganizationFeature, True)


### PR DESCRIPTION
This flag is intended for use in low volume areas to determine whether to include platform issues in search results and other related things. We'll have a separate flag for ingestion.

