### PR TITLE
feat(issue-platform): Allow generic issue platform events to be searched via issue search

### DIFF
--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -73,7 +73,6 @@ def group_categories_from(
     # if its unspecified, we have to query all datasources
     for search_filter in search_filters or ():
         if search_filter.key.name in ("issue.category", "issue.type"):
-            print("search filter", search_filter.key.name, search_filter.value.value)
             if search_filter.is_negation:
                 group_categories.update(
                     GROUP_TYPE_TO_CATEGORY[GroupType(value)]
@@ -222,6 +221,7 @@ def _query_params_for_generic(
     return None
 
 
+# TODO: We need to add a way to make this dynamic for additional generic types
 SEARCH_STRATEGIES: Mapping[GroupCategory, GroupSearchStrategy] = {
     GroupCategory.ERROR: _query_params_for_error,
     GroupCategory.PERFORMANCE: _query_params_for_perf,
@@ -230,14 +230,12 @@ SEARCH_STRATEGIES: Mapping[GroupCategory, GroupSearchStrategy] = {
 
 
 SEARCH_FILTER_UPDATERS: Mapping[GroupCategory, GroupSearchFilterUpdater] = {
-    GroupCategory.ERROR: lambda search_filters: search_filters,
     GroupCategory.PERFORMANCE: lambda search_filters: [
         # need to remove this search filter, so we don't constrain the returned transactions
         sf
         for sf in search_filters
         if sf.key.name != "message"
     ],
-    GroupCategory.PROFILE: lambda search_filters: search_filters,
 }
 
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -616,7 +616,7 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
                 end=end,
                 project_ids=[p.id for p in projects],
                 environment_ids=environments and [environment.id for environment in environments],
-                organization_id=projects[0].organization,
+                organization=projects[0].organization,
                 sort_field=sort_field,
                 cursor=cursor,
                 group_ids=group_ids,

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2307,7 +2307,6 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         super().setUp()
         self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
 
-        now = datetime.now()
         occurrence, group_info = process_event_and_issue_occurrence(
             self.build_occurrence_data(),
             {

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2369,6 +2369,10 @@ class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
         )
         self.error_group_2 = error_event_2.group
 
+    def test_no_feature(self):
+        results = self.make_query(search_filter_query="issue.category:profile my_tag:1")
+        assert list(results) == []
+
     def test_generic_query(self):
         with self.feature("organizations:issue-platform"):
             results = self.make_query(search_filter_query="issue.category:profile my_tag:1")

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from sentry import options
 from sentry.api.issue_search import convert_query_values, issue_search_config, parse_search_query
 from sentry.exceptions import InvalidSearchQuery
+from sentry.issues.occurrence_consumer import process_event_and_issue_occurrence
 from sentry.models import (
     Environment,
     Group,
@@ -32,6 +33,7 @@ from sentry.testutils import SnubaTestCase, TestCase, xfail_if_not_postgres
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.types.issues import GroupType
 from sentry.utils.snuba import SENTRY_SNUBA_MAP, SnubaError
+from tests.sentry.issues.test_utils import OccurrenceTestMixin
 
 
 def date_to_query_format(date):
@@ -2294,6 +2296,158 @@ class EventsTransactionsSnubaSearchTest(SharedSnubaTest):
         error_and_perf_issues = self.make_query(search_filter_query="!message:else")
 
         assert set(error_and_perf_issues) > set(error_issues_only)
+
+
+class EventsGenericSnubaSearchTest(SharedSnubaTest, OccurrenceTestMixin):
+    @property
+    def backend(self):
+        return EventsDatasetSnubaSearchBackend()
+
+    def setUp(self):
+        super().setUp()
+        self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
+
+        now = datetime.now()
+        occurrence, group_info = process_event_and_issue_occurrence(
+            self.build_occurrence_data(),
+            {
+                "event_id": uuid.uuid4().hex,
+                "project_id": self.project.id,
+                "title": "some problem",
+                "platform": "python",
+                "tags": {"my_tag": "1"},
+                "timestamp": before_now(minutes=1).isoformat(),
+                "message_timestamp": before_now(minutes=1).isoformat(),
+            },
+        )
+        self.profile_group_1 = group_info.group
+
+        occurrence, group_info = process_event_and_issue_occurrence(
+            self.build_occurrence_data(fingerprint=["put-me-in-group-2"]),
+            {
+                "event_id": uuid.uuid4().hex,
+                "project_id": self.project.id,
+                "title": "some other problem",
+                "platform": "python",
+                "tags": {"my_tag": "1"},
+                "timestamp": before_now(minutes=2).isoformat(),
+                "message_timestamp": before_now(minutes=2).isoformat(),
+            },
+        )
+        self.profile_group_2 = group_info.group
+
+        error_event_data = {
+            "timestamp": iso_format(self.base_datetime - timedelta(days=20)),
+            "message": "bar",
+            "environment": "staging",
+            "tags": {
+                "server": "example.com",
+                "url": "http://example.com",
+                "sentry:user": "event2@example.com",
+                "my_tag": 1,
+            },
+        }
+
+        error_event = self.store_event(
+            data={
+                **error_event_data,
+                "fingerprint": ["put-me-in-error_group_1"],
+                "event_id": "c" * 32,
+                "stacktrace": {"frames": [{"module": "error_group_1"}]},
+            },
+            project_id=self.project.id,
+        )
+        self.error_group_1 = error_event.group
+
+        error_event_2 = self.store_event(
+            data={
+                **error_event_data,
+                "fingerprint": ["put-me-in-error_group_2"],
+                "event_id": "d" * 32,
+                "stacktrace": {"frames": [{"module": "error_group_2"}]},
+            },
+            project_id=self.project.id,
+        )
+        self.error_group_2 = error_event_2.group
+
+    def test_generic_query(self):
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(search_filter_query="issue.category:profile my_tag:1")
+        assert list(results) == [self.profile_group_1, self.profile_group_2]
+
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                search_filter_query="issue.type:profile_blocked_thread my_tag:1"
+            )
+        assert list(results) == [self.profile_group_1, self.profile_group_2]
+
+    def test_error_generic_query(self):
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(search_filter_query="my_tag:1")
+        assert list(results) == [
+            self.profile_group_1,
+            self.profile_group_2,
+            self.error_group_2,
+            self.error_group_1,
+        ]
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                search_filter_query="issue.category:[profile, error] my_tag:1"
+            )
+        assert list(results) == [
+            self.profile_group_1,
+            self.profile_group_2,
+            self.error_group_2,
+            self.error_group_1,
+        ]
+
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                search_filter_query="issue.type:[profile_blocked_thread, error] my_tag:1"
+            )
+        assert list(results) == [
+            self.profile_group_1,
+            self.profile_group_2,
+            self.error_group_2,
+            self.error_group_1,
+        ]
+
+    def test_cursor_performance_issues(self):
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:profile my_tag:1",
+                sort_by="date",
+                limit=1,
+                count_hits=True,
+            )
+
+        assert list(results) == [self.profile_group_1]
+        assert results.hits == 2
+
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:profile my_tag:1",
+                sort_by="date",
+                limit=1,
+                cursor=results.next,
+                count_hits=True,
+            )
+        assert list(results) == [self.profile_group_2]
+        assert results.hits == 2
+
+        with self.feature("organizations:issue-platform"):
+            results = self.make_query(
+                projects=[self.project],
+                search_filter_query="issue.category:profile my_tag:1",
+                sort_by="date",
+                limit=1,
+                cursor=results.next,
+                count_hits=True,
+            )
+        assert list(results) == []
+        assert results.hits == 2
 
 
 class CdcEventsSnubaSearchTest(SharedSnubaTest):


### PR DESCRIPTION
This allows issue platform events to be searched via issues search. This is gated by the `organizations:issue-platform` flag, so that we can make sure that only sentry sees these for now.


