### PR TITLE
ref(onboarding-amplitude): Update code to cover race condition

### DIFF
--- a/src/sentry/receivers/onboarding.py
+++ b/src/sentry/receivers/onboarding.py
@@ -376,19 +376,23 @@ def record_event_with_first_minified_stack_trace_for_project(project, event, **k
         return
 
     # First, only enter this logic if we've never seen a minified stack trace before
-    # This guarantees us that this analytics event will only be ever sent once.
     if not project.flags.has_minified_stack_trace:
-        analytics.record(
-            "first_event_with_minified_stack_trace_for_project.sent",
-            user_id=user.id,
-            organization_id=project.organization_id,
-            project_id=project.id,
-            platform=event.platform,
-            url=dict(event.tags).get("url", None),
-        )
+        # Next, attempt to update the flag, but ONLY if the flag is currently not set.
+        # The number of affected rows tells us whether we succeeded or not. If we didn't, then skip sending the event.
+        # This guarantees us that this analytics event will only be ever sent once.
+        affected = Project.objects.filter(
+            id=project.id, flags=F("flags").bitand(~Project.flags.has_minified_stack_trace)
+        ).update(flags=F("flags").bitor(Project.flags.has_minified_stack_trace))
 
-        # We set the flag `has_minified_stack_trace` for the project
-        project.update(flags=F("flags").bitor(Project.flags.has_minified_stack_trace))
+        if affected:
+            analytics.record(
+                "first_event_with_minified_stack_trace_for_project.sent",
+                user_id=user.id,
+                organization_id=project.organization_id,
+                project_id=project.id,
+                platform=event.platform,
+                url=dict(event.tags).get("url", None),
+            )
 
 
 transaction_processed.connect(record_user_context_received, weak=False)


### PR DESCRIPTION
Update function with analytic's code where we track the very first received event with a minified stack trace. This PR applies the feedback https://github.com/getsentry/sentry/pull/42208#discussion_r1052594604 covering a race condition that can happen