### PR TITLE
ref(crons): Change public facing urls to /crons

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -235,8 +235,8 @@ function Sidebar({location, organization}: Props) {
         {...sidebarItemProps}
         icon={<IconTimer size="md" />}
         label={t('Crons')}
-        to={`/organizations/${organization.slug}/monitors/`}
-        id="monitors"
+        to={`/organizations/${organization.slug}/crons/`}
+        id="crons"
         isBeta
       />
     </Feature>

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1281,15 +1281,13 @@ function buildRoutes() {
     </Fragment>
   );
 
-  const monitorsChildRoutes = ({forCustomerDomain}: {forCustomerDomain: boolean}) => {
+  const cronsChildRoutes = ({forCustomerDomain}: {forCustomerDomain: boolean}) => {
     return (
       <Fragment>
         <IndexRoute component={make(() => import('sentry/views/monitors/monitors'))} />
         <Route
           path={
-            forCustomerDomain
-              ? '/monitors/create/'
-              : '/organizations/:orgId/monitors/create/'
+            forCustomerDomain ? '/crons/create/' : '/organizations/:orgId/crons/create/'
           }
           component={make(() => import('sentry/views/monitors/create'))}
           key={forCustomerDomain ? 'orgless-monitors-create' : 'org-monitors-create'}
@@ -1297,8 +1295,8 @@ function buildRoutes() {
         <Route
           path={
             forCustomerDomain
-              ? '/monitors/:monitorId/'
-              : '/organizations/:orgId/monitors/:monitorId/'
+              ? '/crons/:monitorId/'
+              : '/organizations/:orgId/crons/:monitorId/'
           }
           component={make(() => import('sentry/views/monitors/details'))}
           key={
@@ -1308,8 +1306,8 @@ function buildRoutes() {
         <Route
           path={
             forCustomerDomain
-              ? '/monitors/:monitorId/edit/'
-              : '/organizations/:orgId/monitors/:monitorId/edit/'
+              ? '/crons/:monitorId/edit/'
+              : '/organizations/:orgId/crons/:monitorId/edit/'
           }
           component={make(() => import('sentry/views/monitors/edit'))}
           key={forCustomerDomain ? 'orgless-monitors-edit' : 'org-monitors-edit'}
@@ -1318,23 +1316,23 @@ function buildRoutes() {
     );
   };
 
-  const monitorsRoutes = (
+  const cronsRoutes = (
     <Fragment>
       {usingCustomerDomain ? (
         <Route
-          path="/monitors/"
+          path="/crons/"
           component={withDomainRequired(make(() => import('sentry/views/monitors')))}
           key="orgless-monitors-route"
         >
-          {monitorsChildRoutes({forCustomerDomain: true})}
+          {cronsChildRoutes({forCustomerDomain: true})}
         </Route>
       ) : null}
       <Route
-        path="/organizations/:orgId/monitors/"
+        path="/organizations/:orgId/crons/"
         component={withDomainRedirect(make(() => import('sentry/views/monitors')))}
         key="org-monitors"
       >
-        {monitorsChildRoutes({forCustomerDomain: false})}
+        {cronsChildRoutes({forCustomerDomain: false})}
       </Route>
     </Fragment>
   );
@@ -2110,7 +2108,7 @@ function buildRoutes() {
       {issueListRoutes}
       {issueDetailsRoutes}
       {alertRoutes}
-      {monitorsRoutes}
+      {cronsRoutes}
       {replayRoutes}
       {releasesRoutes}
       {activityRoutes}

--- a/static/app/views/monitors/create.tsx
+++ b/static/app/views/monitors/create.tsx
@@ -28,7 +28,7 @@ class CreateMonitor extends AsyncView<Props, AsyncView['state']> {
   }
 
   onSubmitSuccess = (data: Monitor) => {
-    const url = normalizeUrl(`/organizations/${this.orgSlug}/monitors/${data.id}/`);
+    const url = normalizeUrl(`/organizations/${this.orgSlug}/crons/${data.id}/`);
     browserHistory.push(url);
   };
 

--- a/static/app/views/monitors/edit.tsx
+++ b/static/app/views/monitors/edit.tsx
@@ -32,7 +32,7 @@ class EditMonitor extends AsyncView<Props, State> {
     this.setState(state => ({monitor: {...state.monitor, ...data}}));
 
   onSubmitSuccess = (data: Monitor) =>
-    browserHistory.push(`/organizations/${this.orgSlug}/monitors/${data.id}/`);
+    browserHistory.push(`/organizations/${this.orgSlug}/crons/${data.id}/`);
 
   getTitle() {
     if (this.state.monitor) {

--- a/static/app/views/monitors/monitorHeader.tsx
+++ b/static/app/views/monitors/monitorHeader.tsx
@@ -26,7 +26,7 @@ const MonitorHeader = ({monitor, orgId, onUpdate}: Props) => {
   const crumbs = [
     {
       label: t('Crons'),
-      to: `/organizations/${orgId}/monitors`,
+      to: `/organizations/${orgId}/crons`,
     },
     {
       label: t('Cron Monitor Details'),

--- a/static/app/views/monitors/monitorHeaderActions.tsx
+++ b/static/app/views/monitors/monitorHeaderActions.tsx
@@ -28,7 +28,7 @@ const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
   const api = useApi();
 
   const handleDelete = () => {
-    const redirectPath = `/organizations/${orgId}/monitors/`;
+    const redirectPath = `/organizations/${orgId}/crons/`;
     addLoadingMessage(t('Deleting Monitor...'));
 
     api
@@ -71,7 +71,7 @@ const MonitorHeaderActions = ({monitor, orgId, onUpdate}: Props) => {
         <Button
           size="sm"
           icon={<IconEdit size="xs" />}
-          to={`/organizations/${orgId}/monitors/${monitor.id}/edit/`}
+          to={`/organizations/${orgId}/crons/${monitor.id}/edit/`}
         >
           {t('Edit')}
         </Button>

--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -49,7 +49,7 @@ function NewMonitorButton(props: ButtonProps) {
   const organization = useOrganization();
   return (
     <Button
-      to={`/organizations/${organization.slug}/monitors/create/`}
+      to={`/organizations/${organization.slug}/crons/create/`}
       priority="primary"
       {...props}
     >
@@ -133,7 +133,7 @@ class Monitors extends AsyncView<Props, State> {
                       <MonitorName>
                         <MonitorIcon status={monitor.status} size={16} />
                         <StyledLink
-                          to={`/organizations/${organization.slug}/monitors/${monitor.id}/`}
+                          to={`/organizations/${organization.slug}/crons/${monitor.id}/`}
                         >
                           {monitor.name}
                         </StyledLink>


### PR DESCRIPTION
Changing the name from `monitors` -> `crons` in the URL as well. 

Chose not to add any redirects from the old route name since crons is only out to internal orgs (and a small handful of test orgs)