### PR TITLE
ref(crons): Hide rest of cron details when no details visible

### DIFF
--- a/static/app/views/monitors/details.tsx
+++ b/static/app/views/monitors/details.tsx
@@ -60,21 +60,25 @@ class MonitorDetails extends AsyncView<Props, State> {
         <MonitorHeader monitor={monitor} orgId={this.orgSlug} onUpdate={this.onUpdate} />
         <Layout.Body>
           <Layout.Main fullWidth>
-            {!monitor.lastCheckIn && <MonitorOnboarding monitor={monitor} />}
+            {!monitor.lastCheckIn ? (
+              <MonitorOnboarding monitor={monitor} />
+            ) : (
+              <Fragment>
+                <StyledPageFilterBar condensed>
+                  <DatePageFilter alignDropdown="left" />
+                </StyledPageFilterBar>
 
-            <StyledPageFilterBar condensed>
-              <DatePageFilter alignDropdown="left" />
-            </StyledPageFilterBar>
+                <MonitorStats monitor={monitor} />
 
-            <MonitorStats monitor={monitor} />
+                <MonitorIssues monitor={monitor} orgId={this.orgSlug} />
 
-            <MonitorIssues monitor={monitor} orgId={this.orgSlug} />
+                <Panel>
+                  <PanelHeader>{t('Recent Check-ins')}</PanelHeader>
 
-            <Panel>
-              <PanelHeader>{t('Recent Check-ins')}</PanelHeader>
-
-              <MonitorCheckIns monitor={monitor} />
-            </Panel>
+                  <MonitorCheckIns monitor={monitor} />
+                </Panel>
+              </Fragment>
+            )}
           </Layout.Main>
         </Layout.Body>
       </Fragment>


### PR DESCRIPTION
not necessary to show these empty states when we know the user hasn't instrumented their cron monitor yet.

before:
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/9372512/208675651-975d56f2-7b43-43cc-ad05-9524bf9b43ef.png">


after:
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/9372512/208675527-4d6386a2-eb9e-4a8a-86bc-2d5abf058e6e.png">
