### PR TITLE
fix(dynamic-sampling): Fix edge case of latest release boosting [TET-618]

### DIFF
--- a/src/sentry/dynamic_sampling/latest_release_booster.py
+++ b/src/sentry/dynamic_sampling/latest_release_booster.py
@@ -98,8 +98,16 @@ class BoostedReleases:
         extended_boosted_releases = []
         expired_boosted_releases = []
         for boosted_release in self.boosted_releases:
+            release_model = models.get(boosted_release.id, None)
+            # In case we are unable to find the release in the database, it means that it has been deleted but
+            # it still present in Redis. For this reason, we will mark this as expired, in order to have it deleted
+            # during cleanup.
+            if release_model is None:
+                expired_boosted_releases.append(boosted_release.cache_key)
+                continue
+
             extended_boosted_release = boosted_release.extend(
-                release=models[boosted_release.id], project_id=project_id
+                release=release_model, project_id=project_id
             )
 
             if extended_boosted_release.is_active(current_timestamp):

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -478,6 +478,59 @@ def test_generate_rules_return_uniform_rules_and_latest_release_rule(
 
 
 @pytest.mark.django_db
+@freeze_time("2022-10-21 18:50:25+00:00")
+@patch("sentry.dynamic_sampling.rules_generator.quotas.get_blended_sample_rate")
+def test_generate_rules_does_not_return_rule_with_deleted_release(
+    get_blended_sample_rate, default_project, latest_release_only
+):
+    get_blended_sample_rate.return_value = 0.1
+
+    redis_client = get_redis_client_for_ds()
+
+    default_project.update(platform="python")
+    first_release = Factories.create_release(project=default_project, version="1.0")
+
+    redis_client.hset(
+        f"ds::p:{default_project.id}:boosted_releases",
+        f"ds::r:{first_release.id}",
+        time.time(),
+    )
+    redis_client.hset(
+        f"ds::p:{default_project.id}:boosted_releases",
+        "ds::r:1234",
+        time.time(),
+    )
+
+    expected = [
+        {
+            "sampleRate": 0.5,
+            "type": "trace",
+            "active": True,
+            "condition": {
+                "op": "and",
+                "inner": [
+                    {"op": "eq", "name": "trace.release", "value": ["1.0"]},
+                    {"op": "eq", "name": "trace.environment", "value": None},
+                ],
+            },
+            "id": 1500,
+            "timeRange": {"start": "2022-10-21 18:50:25+00:00", "end": "2022-10-21 20:03:03+00:00"},
+        },
+        {
+            "active": True,
+            "condition": {"inner": [], "op": "and"},
+            "id": 1000,
+            "sampleRate": 0.1,
+            "type": "trace",
+        },
+    ]
+
+    assert generate_rules(default_project) == expected
+    config_str = json.dumps({"rules": generate_rules(default_project)})
+    validate_sampling_configuration(config_str)
+
+
+@pytest.mark.django_db
 @patch("sentry.dynamic_sampling.rules_generator.quotas.get_blended_sample_rate")
 def test_generate_rules_return_uniform_rule_with_100_rate_and_without_latest_release_rule(
     get_blended_sample_rate, default_project, latest_release_only

--- a/tests/sentry/dynamic_sampling/test_generate_rules.py
+++ b/tests/sentry/dynamic_sampling/test_generate_rules.py
@@ -489,6 +489,7 @@ def test_generate_rules_does_not_return_rule_with_deleted_release(
 
     default_project.update(platform="python")
     first_release = Factories.create_release(project=default_project, version="1.0")
+    second_release = Factories.create_release(project=default_project, version="2.0")
 
     redis_client.hset(
         f"ds::p:{default_project.id}:boosted_releases",
@@ -497,9 +498,11 @@ def test_generate_rules_does_not_return_rule_with_deleted_release(
     )
     redis_client.hset(
         f"ds::p:{default_project.id}:boosted_releases",
-        "ds::r:1234",
+        f"ds::r:{second_release.id}",
         time.time(),
     )
+
+    second_release.delete()
 
     expected = [
         {


### PR DESCRIPTION
This PR aims at fixing an edge case in which a release is deleted after being boosted. In the previous implementation an error would be thrown. In the new implementation the boosted release will be marked as expired and evicted from Redis when a read is performed through `ProjectBoostedReleases`.