### PR TITLE
ref(replays): Refactor useReplaysCount to fetch replay count only for newly seen issues

### DIFF
--- a/static/app/components/replays/issuesReplayCountProvider.tsx
+++ b/static/app/components/replays/issuesReplayCountProvider.tsx
@@ -61,7 +61,7 @@ function Provider({
   const counts = useReplaysCount({
     groupIds,
     organization,
-    project,
+    projectIds: project ? [Number(project.id)] : [],
   });
 
   return (

--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -1,32 +1,10 @@
 import {reactHooks} from 'sentry-test/reactTestingLibrary';
 
-import type {Project} from 'sentry/types';
 import {useLocation} from 'sentry/utils/useLocation';
 
 import useReplaysCount from './useReplaysCount';
 
 jest.mock('sentry/utils/useLocation');
-
-function getExpectedReqestParams({
-  field,
-  project,
-  query,
-}: {
-  field: string[];
-  project: Project;
-  query: string;
-}) {
-  return expect.objectContaining({
-    query: {
-      environment: [],
-      field,
-      per_page: 50,
-      project: [String(project.id)],
-      query,
-      statsPeriod: '14d',
-    },
-  });
-}
 
 describe('useReplaysCount', () => {
   const MockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>;
@@ -255,12 +233,17 @@ describe('useReplaysCount', () => {
     expect(result.current).toEqual({});
     expect(countRequest).toHaveBeenCalledWith(
       '/organizations/org-slug/events/',
-      getExpectedReqestParams({
-        field: ['count_unique(replayId)', 'transaction'],
-        project,
-        query: `!replayId:"" event.type:transaction transaction:[${mockTransactionNames.join(
-          ','
-        )}]`,
+      expect.objectContaining({
+        query: {
+          environment: [],
+          field: ['count_unique(replayId)', 'transaction'],
+          per_page: 50,
+          project: [String(project.id)],
+          query: `!replayId:"" event.type:transaction transaction:[${mockTransactionNames.join(
+            ','
+          )}]`,
+          statsPeriod: '14d',
+        },
       })
     );
 

--- a/static/app/components/replays/useReplaysCount.spec.tsx
+++ b/static/app/components/replays/useReplaysCount.spec.tsx
@@ -50,12 +50,13 @@ describe('useReplaysCount', () => {
   const project = TestStubs.Project({
     platform: 'javascript',
   });
+  const projectIds = [Number(project.id)];
 
   it('should throw if neither groupIds nor transactionNames is provided', () => {
     const {result} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
-        project,
+        projectIds,
       },
     });
     expect(result.error).toBeTruthy();
@@ -65,7 +66,7 @@ describe('useReplaysCount', () => {
     const {result} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
-        project,
+        projectIds,
         groupIds: [],
         transactionNames: [],
       },
@@ -83,7 +84,7 @@ describe('useReplaysCount', () => {
     const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
-        project,
+        projectIds,
         groupIds: mockGroupIds,
       },
     });
@@ -115,7 +116,7 @@ describe('useReplaysCount', () => {
     const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
-        project,
+        projectIds,
         groupIds: mockGroupIds,
       },
     });
@@ -141,7 +142,7 @@ describe('useReplaysCount', () => {
     const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
-        project,
+        projectIds,
         transactionNames: mockTransactionNames,
       },
     });
@@ -178,7 +179,7 @@ describe('useReplaysCount', () => {
     const {result, waitForNextUpdate} = reactHooks.renderHook(useReplaysCount, {
       initialProps: {
         organization,
-        project,
+        projectIds,
         transactionNames: mockTransactionNames,
       },
     });

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -76,7 +76,7 @@ function useReplaysCount({
         version: 2,
         fields: ['count_unique(replayId)', String(query?.field)],
         query: `!replayId:"" ${query?.conditions}`,
-        projects: projectIds, // [Number(project?.id)],
+        projects: projectIds,
       }),
     [projectIds, query]
   );
@@ -94,7 +94,7 @@ function useReplaysCount({
             query: {
               query: query.conditions,
               statsPeriod: '14d',
-              project: projectIds, // [Number(project?.id)],
+              project: projectIds,
             },
           }
         );

--- a/static/app/components/replays/useReplaysCount.tsx
+++ b/static/app/components/replays/useReplaysCount.tsx
@@ -47,9 +47,14 @@ function useReplaysCount({
       );
     }
     if (groupIds && groupIds.length) {
+      const groupsToFetch = toArray(groupIds).filter(gid => !(gid in replayCounts));
+      if (!groupsToFetch.length) {
+        return null;
+      }
+
       return {
         field: 'issue.id' as const,
-        conditions: `issue.id:[${toArray(groupIds).join(',')}]`,
+        conditions: `issue.id:[${groupsToFetch.join(',')}]`,
       };
     }
     if (transactionNames && transactionNames.length) {
@@ -61,7 +66,7 @@ function useReplaysCount({
       };
     }
     return null;
-  }, [groupIds, transactionNames]);
+  }, [replayCounts, groupIds, transactionNames]);
 
   const eventView = useMemo(
     () =>

--- a/static/app/views/organizationGroupDetails/header.tsx
+++ b/static/app/views/organizationGroupDetails/header.tsx
@@ -57,7 +57,7 @@ function GroupHeader({
   const replaysCount = useReplaysCount({
     groupIds: group.id,
     organization,
-    project,
+    projectIds: [Number(project.id)],
   })[group.id];
 
   const disabledTabs = useMemo(() => {

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -110,7 +110,7 @@ function TransactionHeader({
   const replaysCount = useReplaysCount({
     transactionNames: transactionName,
     organization,
-    project,
+    projectIds: project ? [Number(project.id)] : [],
   })[transactionName];
 
   return (

--- a/static/app/views/replays/detail/issueList.tsx
+++ b/static/app/views/replays/detail/issueList.tsx
@@ -82,7 +82,7 @@ function IssueList({projectId, replayId}: Props) {
   const counts = useReplaysCount({
     groupIds: state.issues.map(issue => issue.id),
     organization,
-    project,
+    projectIds: project ? [Number(project.id)] : [],
   });
 
   return (


### PR DESCRIPTION
This will only fetch the count of replay's for an issue when the list of groupIds changes, and only for those issues that have not been seen before. So if polling is enabled then we don't fetch after every poll unless there is a new issue appearing.

We only fetch on pageload, or whenever polling returns a new id. So counts will be stale. It's possible to pass along `this._poller.active` from:
- https://github.com/getsentry/sentry/blob/master/static/app/views/issueList/overview.tsx#L1256
- to https://github.com/getsentry/sentry/blob/master/static/app/views/issueList/groupListBody.tsx#L78
- to https://github.com/getsentry/sentry/blob/master/static/app/components/replays/issuesReplayCountProvider.tsx
- to useReplaysCount
and then have our own polling, but i didn't do that here, we're trying to be conservative to start. There will be stale counts on the list.

Also, added a pre-filter so we only ask for counts when we know the project is supported by replay. When the issue list is focused on a single project this won't do anything, but if the user is on a business plan and can see multiple projects at once then we could save some parallel requests.

Fixes #42239
