### PR TITLE
fix(profiling): stop layout thrashing

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -297,9 +297,12 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
     const flamegraphObserver = watchForResize(
       [flamegraphCanvasRef, flamegraphOverlayCanvasRef],
-      () => {
-        const bounds = flamegraphCanvasRef.getBoundingClientRect();
-        setCanvasBounds(new Rect(bounds.x, bounds.y, bounds.width, bounds.height));
+      entries => {
+        const contentRect =
+          entries[0].contentRect ?? flamegraphCanvasRef.getBoundingClientRect();
+        setCanvasBounds(
+          new Rect(contentRect.x, contentRect.y, contentRect.width, contentRect.height)
+        );
 
         flamegraphCanvas.initPhysicalSpace();
         flamegraphView.resizeConfigSpace(flamegraphCanvas);

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -106,11 +106,11 @@ function onResize(entries: ResizeObserverEntry[]) {
 
 export const watchForResize = (
   canvas: HTMLCanvasElement[],
-  callback?: () => void
+  callback?: (entries: ResizeObserverEntry[], observer: ResizeObserver) => void
 ): ResizeObserver => {
-  const handler: ResizeObserverCallback = entries => {
+  const handler: ResizeObserverCallback = (entries, observer) => {
     onResize(entries);
-    callback?.();
+    callback?.(entries, observer);
   };
 
   for (const c of canvas) {


### PR DESCRIPTION
Noticed this while working on span rendering - we already have the contentRect from the observer callback, we were just not exposing it.