### PR TITLE
bug(replays): Call the replay play/pause helper when visibility changes

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -334,23 +334,6 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
     [events, theme.purple200, setReplayFinished, hasNewEvents]
   );
 
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== 'visible') {
-        replayerRef.current?.pause();
-      }
-    };
-
-    if (replayerRef.current && events) {
-      initRoot(replayerRef.current.wrapper.parentElement as RootElem);
-      document.addEventListener('visibilitychange', handleVisibilityChange);
-    }
-
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [initRoot, events]);
-
   const getCurrentTime = useCallback(
     () => (replayerRef.current ? Math.max(replayerRef.current.getCurrentTime(), 0) : 0),
     []
@@ -444,6 +427,23 @@ export function Provider({children, replay, initialTimeOffset = 0, value = {}}: 
     },
     [getCurrentTime, config.user.email, organization]
   );
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') {
+        togglePlayPause(false);
+      }
+    };
+
+    if (replayerRef.current && events) {
+      initRoot(replayerRef.current.wrapper.parentElement as RootElem);
+      document.addEventListener('visibilitychange', handleVisibilityChange);
+    }
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [initRoot, events, togglePlayPause]);
 
   const restart = useCallback(() => {
     if (replayerRef.current) {


### PR DESCRIPTION
We need to use the play/pause wrapper instead of talking to rrweb directly so all the state stays in sync.

Fixes #42443
