### PR TITLE
bug(replays): Remember list page filter so Replay header can link back to it

### DIFF
--- a/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
+++ b/static/app/components/replays/header/detailsPageBreadcrumbs.tsx
@@ -5,6 +5,8 @@ import Breadcrumbs from 'sentry/components/breadcrumbs';
 import Placeholder from 'sentry/components/placeholder';
 import ReplaysFeatureBadge from 'sentry/components/replays/replaysFeatureBadge';
 import {t} from 'sentry/locale';
+import EventView from 'sentry/utils/discover/eventView';
+import {useLocation} from 'sentry/utils/useLocation';
 import type {ReplayRecord} from 'sentry/views/replays/types';
 
 type Props = {
@@ -13,13 +15,18 @@ type Props = {
 };
 
 function DetailsPageBreadcrumbs({orgSlug, replayRecord}: Props) {
+  const location = useLocation();
+  const eventView = EventView.fromLocation(location);
   const labelTitle = replayRecord?.user.displayName;
 
   return (
     <Breadcrumbs
       crumbs={[
         {
-          to: `/organizations/${orgSlug}/replays/`,
+          to: {
+            pathname: `/organizations/${orgSlug}/replays/`,
+            query: eventView.generateQueryStringObject(),
+          },
           label: t('Replays'),
         },
         {

--- a/static/app/views/organizationGroupDetails/groupReplays/groupReplays.spec.tsx
+++ b/static/app/views/organizationGroupDetails/groupReplays/groupReplays.spec.tsx
@@ -362,16 +362,19 @@ describe('GroupReplays', () => {
       // Expect the table to have 2 rows
       expect(screen.getAllByText('testDisplayName')).toHaveLength(2);
 
+      const expectedQuery =
+        'query=&referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F&statsPeriod=14d&yAxis=count%28%29';
+
       // Expect the first row to have the correct href
       expect(screen.getAllByRole('link', {name: 'testDisplayName'})[0]).toHaveAttribute(
         'href',
-        '/organizations/org-slug/replays/project-slug:346789a703f6454384f1de473b8b9fcc/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F'
+        `/organizations/org-slug/replays/project-slug:346789a703f6454384f1de473b8b9fcc/?${expectedQuery}`
       );
 
       // Expect the second row to have the correct href
       expect(screen.getAllByRole('link', {name: 'testDisplayName'})[1]).toHaveAttribute(
         'href',
-        '/organizations/org-slug/replays/project-slug:b05dae9b6be54d21a4d5ad9f8f02b780/?referrer=%2Forganizations%2F%3AorgId%2Fissues%2F%3AgroupId%2Freplays%2F'
+        `/organizations/org-slug/replays/project-slug:b05dae9b6be54d21a4d5ad9f8f02b780/?${expectedQuery}`
       );
 
       // Expect the first row to have the correct duration

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -244,16 +244,18 @@ describe('TransactionReplays', () => {
     // Expect the table to have 2 rows
     expect(screen.getAllByText('testDisplayName')).toHaveLength(2);
 
+    const expectedQuery =
+      'project=1&query=&referrer=%2Forganizations%2F%3AorgId%2Fperformance%2Fsummary%2Freplays%2F&statsPeriod=14d&yAxis=count%28%29';
     // Expect the first row to have the correct href
     expect(screen.getAllByRole('link', {name: 'testDisplayName'})[0]).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/project-slug:346789a703f6454384f1de473b8b9fcc/?referrer=%2Forganizations%2F%3AorgId%2Fperformance%2Fsummary%2Freplays%2F'
+      `/organizations/org-slug/replays/project-slug:346789a703f6454384f1de473b8b9fcc/?${expectedQuery}`
     );
 
     // Expect the second row to have the correct href
     expect(screen.getAllByRole('link', {name: 'testDisplayName'})[1]).toHaveAttribute(
       'href',
-      '/organizations/org-slug/replays/project-slug:b05dae9b6be54d21a4d5ad9f8f02b780/?referrer=%2Forganizations%2F%3AorgId%2Fperformance%2Fsummary%2Freplays%2F'
+      `/organizations/org-slug/replays/project-slug:b05dae9b6be54d21a4d5ad9f8f02b780/?${expectedQuery}`
     );
 
     // Expect the first row to have the correct duration

--- a/static/app/views/replays/replayTable.tsx
+++ b/static/app/views/replays/replayTable.tsx
@@ -17,6 +17,7 @@ import {IconArrow, IconCalendar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import type {Organization} from 'sentry/types';
+import EventView from 'sentry/utils/discover/eventView';
 import {spanOperationRelativeBreakdownRenderer} from 'sentry/utils/discover/fieldRenderers';
 import type {Sort} from 'sentry/utils/discover/fields';
 import getRouteStringFromRoutes from 'sentry/utils/getRouteStringFromRoutes';
@@ -43,6 +44,7 @@ type TableProps = {
 };
 
 type RowProps = {
+  eventView: EventView;
   minWidthIsSmall: boolean;
   organization: Organization;
   referrer: string;
@@ -108,6 +110,7 @@ function ReplayTable({
   showSlowestTxColumn = false,
 }: Props) {
   const routes = useRoutes();
+  const location = useLocation();
   const referrer = getRouteStringFromRoutes(routes);
 
   const organization = useOrganization();
@@ -186,6 +189,8 @@ function ReplayTable({
     );
   }
 
+  const eventView = EventView.fromLocation(location);
+
   return (
     <StyledPanelTable
       isLoading={isFetching}
@@ -196,6 +201,7 @@ function ReplayTable({
     >
       {replays?.map(replay => (
         <ReplayTableRow
+          eventView={eventView}
           key={replay.id}
           minWidthIsSmall={minWidthIsSmall}
           organization={organization}
@@ -210,6 +216,7 @@ function ReplayTable({
 }
 
 function ReplayTableRow({
+  eventView,
   minWidthIsSmall,
   organization,
   referrer,
@@ -234,6 +241,7 @@ function ReplayTableRow({
               pathname: `/organizations/${organization.slug}/replays/${project?.slug}:${replay.id}/`,
               query: {
                 referrer,
+                ...eventView.generateQueryStringObject(),
               },
             }}
           >


### PR DESCRIPTION
Preserve list-page query params when opening the replay details page, so that we can use those params in the Replay Header to link you back to where you came from.

Fixed workflow:
1. Do a search on the Replay List page (project/env/date/search-terms)
2. Click through to view a replay
3. Click here in the header to get back to your search: 
  <img width="573" alt="SCR-20221220-j7q" src="https://user-images.githubusercontent.com/187460/208743740-3623c1a8-8f00-4232-a66a-b3ff80263fb7.png">


Fixes #42499 
