### PR TITLE
feat(crons): Add button to the docs

### DIFF
--- a/static/app/views/monitors/monitors.tsx
+++ b/static/app/views/monitors/monitors.tsx
@@ -163,7 +163,12 @@ class Monitors extends AsyncView<Props, State> {
                     "We'll tell you if your recurring jobs are running on schedule, failing, or succeeding."
                   )}
                 </p>
-                <NewMonitorButton>{t('Set Up First Cron Monitor')}</NewMonitorButton>
+                <ButtonList gap={1}>
+                  <Button href="https://docs.sentry.io/product/crons" external>
+                    {t('View the Docs')}
+                  </Button>
+                  <NewMonitorButton>{t('Set Up First Cron Monitor')}</NewMonitorButton>
+                </ButtonList>
               </OnboardingPanel>
             )}
           </Layout.Main>
@@ -200,6 +205,10 @@ const MonitorName = styled('div')`
 
 const StyledPanelTable = styled(PanelTable)`
   grid-template-columns: 1fr max-content max-content;
+`;
+
+const ButtonList = styled(ButtonBar)`
+  grid-template-columns: repeat(auto-fit, minmax(130px, max-content));
 `;
 
 export default withRouteAnalytics(withSentryRouter(withOrganization(Monitors)));


### PR DESCRIPTION
Adds `View the Docs` button

depends on https://github.com/getsentry/sentry-docs/pull/5985

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/9372512/208751180-e34cd550-0870-4164-a964-1aa73dda8a66.png">

