### PR TITLE
fix(metrics): Fix flaky test (test_metrics_enhanced_performance.py:1878 test_team_key_transaction_as_condition)

### DIFF
--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -1773,7 +1773,7 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
     def test_team_key_transaction_as_condition(self):
         now = timezone.now()
 
-        for idx, (transaction, value) in enumerate(
+        for minutes, (transaction, value) in enumerate(
             (("foo_transaction", 1), ("bar_transaction", 1), ("baz_transaction", 0.5))
         ):
             self.store_performance_metric(
@@ -1781,7 +1781,7 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
                 name=TransactionMRI.DURATION.value,
                 tags={"transaction": transaction},
                 value=value,
-                minutes_before_now=idx,
+                minutes_before_now=minutes,
             )
 
         metrics_query = MetricsQuery(

--- a/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
+++ b/tests/sentry/snuba/metrics/test_metrics_layer/test_metrics_enhanced_performance.py
@@ -1424,7 +1424,7 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
         )
 
     def test_team_key_transactions_my_teams(self):
-        for idx, (transaction, value) in enumerate(
+        for minutes, (transaction, value) in enumerate(
             (("foo_transaction", 1), ("bar_transaction", 1), ("baz_transaction", 0.5))
         ):
             self.store_performance_metric(
@@ -1432,7 +1432,7 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
                 name=TransactionMRI.DURATION.value,
                 tags={"transaction": transaction},
                 value=value,
-                minutes_before_now=idx,
+                minutes_before_now=minutes,
             )
 
         metrics_query = self.build_metrics_query(
@@ -1770,22 +1770,18 @@ class PerformanceMetricsLayerTestCase(BaseMetricsLayerTestCase, TestCase):
                 use_case_id=UseCaseKey.PERFORMANCE,
             )
 
-    @freeze_time("2022-09-22 11:07:00")
     def test_team_key_transaction_as_condition(self):
         now = timezone.now()
 
         for idx, (transaction, value) in enumerate(
             (("foo_transaction", 1), ("bar_transaction", 1), ("baz_transaction", 0.5))
         ):
-            self.store_metric(
-                org_id=self.organization.id,
-                project_id=self.project.id,
+            self.store_performance_metric(
                 type="distribution",
                 name=TransactionMRI.DURATION.value,
                 tags={"transaction": transaction},
-                timestamp=(now - timedelta(minutes=idx)).timestamp(),
                 value=value,
-                use_case_id=UseCaseKey.PERFORMANCE,
+                minutes_before_now=idx,
             )
 
         metrics_query = MetricsQuery(


### PR DESCRIPTION
This PR aims at fixing a small flaky test that wasn't updated to the new mechanism.
```
<Click to see difference>

test_metrics_enhanced_performance.py:1878: in test_team_key_transaction_as_condition
    assert data["groups"] == [
E   AssertionError: assert [] == [{'by': {'team_key_transactions': 1, 'transaction': 'foo_transaction'}, 'totals': {'team_key_transactions': 1, 'p95': 1.0}}]
E     Right contains one more item: {'by': {'team_key_transactions': 1, 'transaction': 'foo_transaction'}, 'totals': {'p95': 1.0, 'team_key_transactions': 1}}
E     Full diff:
E       [
E     +  ,
E     -  {'by': {'team_key_transactions': 1,
E     -          'transaction': 'foo_transaction'},
E     -   'totals': {'p95': 1.0,
E     -              'team_key_transactions': 1}},
E       ]
PASSED [ 77%]PASSED [ 80%]PASSED [ 83%]PASSED [ 87%]PASSED [ 90%]PASSED [ 93%]PASSED [ 96%]PASSED [100%]Destroying test database for alias 'default' ('test_sentry')...
```