### PR TITLE
feat(dynamic-sampling): Add post_delete and post_save hook to invalidate project config [TET-623]

### DIFF
--- a/src/sentry/dynamic_sampling/latest_release_booster.py
+++ b/src/sentry/dynamic_sampling/latest_release_booster.py
@@ -148,7 +148,7 @@ class ProjectBoostedReleases:
         Checks whether a specific project has boosted releases.
         """
         cache_key = self._generate_cache_key_for_boosted_releases_hash()
-        return self.redis_client.exists(cache_key) == 1
+        return bool(self.redis_client.exists(cache_key) == 1)
 
     def add_boosted_release(self, release_id: int, environment: Optional[str]) -> None:
         """

--- a/src/sentry/dynamic_sampling/latest_release_booster.py
+++ b/src/sentry/dynamic_sampling/latest_release_booster.py
@@ -143,6 +143,13 @@ class ProjectBoostedReleases:
         self.project_id = project_id
         self.project_platform = _get_project_platform(self.project_id)
 
+    def has_boosted_releases(self) -> bool:
+        """
+        Checks whether a specific project has boosted releases.
+        """
+        cache_key = self._generate_cache_key_for_boosted_releases_hash()
+        return self.redis_client.exists(cache_key) == 1
+
     def add_boosted_release(self, release_id: int, environment: Optional[str]) -> None:
         """
         Adds a release to the boosted releases hash with the boosting timestamp set to the current time, signaling that

--- a/src/sentry/dynamic_sampling/latest_release_booster.py
+++ b/src/sentry/dynamic_sampling/latest_release_booster.py
@@ -143,6 +143,7 @@ class ProjectBoostedReleases:
         self.project_id = project_id
         self.project_platform = _get_project_platform(self.project_id)
 
+    @property
     def has_boosted_releases(self) -> bool:
         """
         Checks whether a specific project has boosted releases.

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -68,6 +68,8 @@ class ReleaseCommitError(Exception):
     pass
 
 
+# TODO: implement check if there is a latest release boost. (Add a method in the booster class for efficiently
+#  verifying that).
 class ReleaseProjectModelManager(BaseManager):
     def post_save(self, instance, **kwargs):
         # this hook may be called from model hooks during an

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -80,7 +80,7 @@ class ReleaseProjectModelManager(BaseManager):
         # in the project.
         if (
             ds_feature_multiplexer.is_on_dynamic_sampling
-            and project_boosted_releases.has_boosted_releases()
+            and project_boosted_releases.has_boosted_releases
         ):
             transaction.on_commit(
                 lambda: schedule_invalidate_project_config(project_id=project.id, trigger=trigger)

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -1,3 +1,4 @@
+from unittest.mock import call as mock_call
 from unittest.mock import patch
 
 import pytest
@@ -28,6 +29,7 @@ from sentry.models import (
     ReleaseHeadCommit,
     ReleaseProject,
     ReleaseProjectEnvironment,
+    ReleaseProjectModelManager,
     ReleaseStatus,
     Repository,
     add_group_to_inbox,
@@ -35,8 +37,9 @@ from sentry.models import (
 )
 from sentry.search.events.filter import parse_semver
 from sentry.signals import receivers_raise_on_send
-from sentry.testutils import SetRefsTestCase, TestCase
+from sentry.testutils import SetRefsTestCase, TestCase, TransactionTestCase
 from sentry.testutils.factories import Factories
+from sentry.testutils.helpers import Feature
 from sentry.testutils.silo import region_silo_test
 from sentry.utils.strings import truncatechars
 
@@ -1327,3 +1330,64 @@ class ClearCommitsTestCase(TestCase):
         assert Commit.objects.filter(
             id=commit2.id, organization_id=org.id, repository_id=repo.id
         ).exists()
+
+
+@region_silo_test(stable=True)
+class ReleaseProjectManagerTestCase(TransactionTestCase):
+    def test_custom_manger(self):
+        self.assertIsInstance(ReleaseProject.objects, ReleaseProjectModelManager)
+
+    @receivers_raise_on_send()
+    def test_post_save_signal_runs_if_dynamic_sampling_is_disabled(self):
+        self.project = self.create_project(name="foo")
+        self.datetime_now = timezone.now()
+
+        self.release = Release.objects.create(
+            organization_id=self.project.organization_id, version="42"
+        )
+        with patch("sentry.models.release.schedule_invalidate_project_config") as mock_task:
+            self.release.add_project(self.project)
+            assert mock_task.mock_calls == []
+
+    @receivers_raise_on_send()
+    def test_post_save_signal_runs_if_dynamic_sampling_is_enabled(self):
+        with Feature(
+            {
+                "organizations:dynamic-sampling": True,
+            }
+        ):
+            self.project = self.create_project(name="foo")
+
+            self.project.update_option(
+                "sentry:dynamic_sampling",
+                {
+                    "rules": [
+                        {
+                            "sampleRate": 0.7,
+                            "type": "trace",
+                            "active": True,
+                            "condition": {
+                                "op": "and",
+                                "inner": [
+                                    {
+                                        "op": "glob",
+                                        "name": "trace.release",
+                                        "value": ["latest"],
+                                    }
+                                ],
+                            },
+                            "id": 0,
+                        },
+                    ]
+                },
+            )
+            self.datetime_now = timezone.now()
+
+            self.release = Release.objects.create(
+                organization_id=self.project.organization_id, version="42"
+            )
+            with patch("sentry.models.release.schedule_invalidate_project_config") as mock_task:
+                self.release.add_project(self.project)
+                assert mock_task.mock_calls == [
+                    mock_call(project_id=self.project.id, trigger="releaseproject.post_save")
+                ]

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -8,10 +8,7 @@ from freezegun import freeze_time
 
 from sentry.api.exceptions import InvalidRepository
 from sentry.api.release_search import INVALID_SEMVER_MESSAGE
-from sentry.dynamic_sampling.latest_release_booster import (
-    ProjectBoostedReleases,
-    get_redis_client_for_ds,
-)
+from sentry.dynamic_sampling.latest_release_booster import ProjectBoostedReleases
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models import (
     Commit,
@@ -1338,9 +1335,6 @@ class ClearCommitsTestCase(TestCase):
 
 @region_silo_test(stable=True)
 class ReleaseProjectManagerTestCase(TransactionTestCase):
-    def setUp(self):
-        self.redis_client = get_redis_client_for_ds()
-
     def test_custom_manager(self):
         self.assertIsInstance(ReleaseProject.objects, ReleaseProjectModelManager)
 

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -1334,7 +1334,7 @@ class ClearCommitsTestCase(TestCase):
 
 @region_silo_test(stable=True)
 class ReleaseProjectManagerTestCase(TransactionTestCase):
-    def test_custom_manger(self):
+    def test_custom_manager(self):
         self.assertIsInstance(ReleaseProject.objects, ReleaseProjectModelManager)
 
     @receivers_raise_on_send()
@@ -1357,30 +1357,6 @@ class ReleaseProjectManagerTestCase(TransactionTestCase):
             }
         ):
             self.project = self.create_project(name="foo")
-
-            self.project.update_option(
-                "sentry:dynamic_sampling",
-                {
-                    "rules": [
-                        {
-                            "sampleRate": 0.7,
-                            "type": "trace",
-                            "active": True,
-                            "condition": {
-                                "op": "and",
-                                "inner": [
-                                    {
-                                        "op": "glob",
-                                        "name": "trace.release",
-                                        "value": ["latest"],
-                                    }
-                                ],
-                            },
-                            "id": 0,
-                        },
-                    ]
-                },
-            )
             self.datetime_now = timezone.now()
 
             self.release = Release.objects.create(


### PR DESCRIPTION
This PR aims at implementing the project config invalidation after a release is `saved` or `deleted`. This implementation has the goal of keeping up to date rules with the state of the system.