### PR TITLE
feat(sampling): Add dynamic sampling rule types - [TET-560]

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -5,7 +5,7 @@ import type {SDKUpdatesSuggestion} from './event';
 import type {Plugin} from './integrations';
 import type {Organization, Team} from './organization';
 import type {Deploy, Release} from './release';
-import type {DynamicSamplingBias} from './sampling';
+import type {DynamicSamplingBias, DynamicSamplingRule} from './sampling';
 
 // Minimal project representation for use with avatars.
 export type AvatarProject = {
@@ -45,6 +45,7 @@ export type Project = {
   subjectTemplate: string;
   teams: Team[];
   builtinSymbolSources?: string[];
+  dynamicSamplingRules?: DynamicSamplingRule[];
   hasUserReports?: boolean;
   latestDeploys?: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;
   latestRelease?: Release;

--- a/static/app/types/sampling.tsx
+++ b/static/app/types/sampling.tsx
@@ -9,3 +9,59 @@ export type DynamicSamplingBias = {
   active: boolean;
   id: DynamicSamplingBiasType;
 };
+
+enum SamplingConditionOperator {
+  /**
+   * Combine multiple sub-conditions with the operator 'and'
+   */
+  AND = 'and',
+  OR = 'or',
+}
+
+type DynamicSamplingConditionLogicalInner = {
+  name: string;
+  op: string;
+  options: {
+    ignoreCase: boolean;
+  };
+  value: string[];
+};
+
+type DynamicSamplingRuleCondition = {
+  inner: DynamicSamplingConditionLogicalInner[];
+  op: SamplingConditionOperator;
+};
+
+enum DynamicSamplingRuleType {
+  /**
+   * The rule applies to traces (transaction events considered in the context of a trace)
+   */
+  TRACE = 'trace',
+  /**
+   * The rule applies to transactions
+   */
+  TRANSACTION = 'transaction',
+}
+
+export type DynamicSamplingRule = {
+  /**
+   * Indicates if the rule is enabled or not
+   */
+  active: boolean;
+  /**
+   * It is a possibly empty list of conditions to which the rule applies
+   */
+  condition: DynamicSamplingRuleCondition;
+  /**
+   * This is a unique number within a project
+   */
+  id: number;
+  /**
+   * It is the sampling rate that is applied
+   */
+  sampleRate: number;
+  /**
+   * Describes the type of rule
+   */
+  type: DynamicSamplingRuleType;
+};


### PR DESCRIPTION
Add Dynamic Sampling Rule types and the optional property `dynamicSamplingRules` to the project types.

This will be used in the PR https://github.com/getsentry/getsentry/pull/9156