### PR TITLE
feat(profiling): initialize root to transaction

### DIFF
--- a/static/app/utils/profiling/spanChart.spec.tsx
+++ b/static/app/utils/profiling/spanChart.spec.tsx
@@ -1,4 +1,4 @@
-import {EntrySpans} from 'sentry/types/event';
+import {EntrySpans, EventOrGroupType, EventTransaction} from 'sentry/types/event';
 import {SpanChart} from 'sentry/utils/profiling/spanChart';
 import {SpanTree} from 'sentry/utils/profiling/spanTree';
 
@@ -20,9 +20,38 @@ function s(partial: Partial<EntrySpans['data'][0]>): EntrySpans['data'][0] {
   };
 }
 
+function txn(partial: Partial<EventTransaction>): EventTransaction {
+  return {
+    id: '',
+    projectID: '',
+    user: {},
+    contexts: {},
+    entries: [],
+    errors: [],
+    dateCreated: '',
+    startTimestamp: Date.now(),
+    endTimestamp: Date.now() + 1000,
+    title: '',
+    type: EventOrGroupType.TRANSACTION,
+    culprit: '',
+    dist: null,
+    eventID: '',
+    fingerprints: [],
+    dateReceived: new Date().toISOString(),
+    message: '',
+    metadata: {},
+    size: 0,
+    tags: [],
+    occurrence: null,
+    location: '',
+    crashFile: null,
+    ...partial,
+  };
+}
+
 describe('spanChart', () => {
   it('iterates over all spans with depth', () => {
-    const tree = new SpanTree([
+    const tree = new SpanTree(txn({startTimestamp: 0, endTimestamp: 1}), [
       s({span_id: '1', timestamp: 1, start_timestamp: 0}),
       s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
       s({span_id: '3', timestamp: 0.2, start_timestamp: 0}),
@@ -47,7 +76,7 @@ describe('spanChart', () => {
   });
 
   it('sets configView to duration of the spans', () => {
-    const tree = new SpanTree([
+    const tree = new SpanTree(txn({startTimestamp: 0, endTimestamp: 1}), [
       s({span_id: '1', timestamp: 1, start_timestamp: 0}),
       s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
       s({span_id: '3', timestamp: 0.2, start_timestamp: 0}),
@@ -61,7 +90,7 @@ describe('spanChart', () => {
   });
 
   it('tracks chart depth', () => {
-    const tree = new SpanTree([
+    const tree = new SpanTree(txn({startTimestamp: 0, endTimestamp: 1}), [
       s({span_id: '1', timestamp: 1, start_timestamp: 0}),
       s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
       s({span_id: '3', timestamp: 0.2, start_timestamp: 0}),

--- a/static/app/utils/profiling/spanTree.spec.tsx
+++ b/static/app/utils/profiling/spanTree.spec.tsx
@@ -57,7 +57,6 @@ describe('SpanTree', () => {
     const tree = new SpanTree(transaction, []);
     expect(tree.root.span.start_timestamp).toBe(transaction.startTimestamp);
     expect(tree.root.span.timestamp).toBe(transaction.endTimestamp);
-    expect(tree.root.span.exclusive_time).toBe(1000);
   });
   it('appends to parent that contains span', () => {
     const tree = new SpanTree(

--- a/static/app/utils/profiling/spanTree.spec.tsx
+++ b/static/app/utils/profiling/spanTree.spec.tsx
@@ -1,4 +1,4 @@
-import {EntrySpans} from 'sentry/types/event';
+import {EntrySpans, EventOrGroupType, EventTransaction} from 'sentry/types/event';
 
 import {SpanTree} from './spanTree';
 
@@ -18,32 +18,93 @@ function s(partial: Partial<EntrySpans['data'][0]>): EntrySpans['data'][0] {
   };
 }
 
+function txn(partial: Partial<EventTransaction>): EventTransaction {
+  return {
+    id: '',
+    projectID: '',
+    user: {},
+    contexts: {},
+    entries: [],
+    errors: [],
+    dateCreated: '',
+    startTimestamp: Date.now(),
+    endTimestamp: Date.now() + 1000,
+    title: '',
+    type: EventOrGroupType.TRANSACTION,
+    culprit: '',
+    dist: null,
+    eventID: '',
+    fingerprints: [],
+    dateReceived: new Date().toISOString(),
+    message: '',
+    metadata: {},
+    size: 0,
+    tags: [],
+    occurrence: null,
+    location: '',
+    crashFile: null,
+    ...partial,
+  };
+}
+
 describe('SpanTree', () => {
+  it('initializes the root to txn', () => {
+    const transaction = txn({
+      title: 'transaction root',
+      startTimestamp: Date.now(),
+      endTimestamp: Date.now() + 1000,
+    });
+    const tree = new SpanTree(transaction, []);
+    expect(tree.root.span.start_timestamp).toBe(transaction.startTimestamp);
+    expect(tree.root.span.timestamp).toBe(transaction.endTimestamp);
+    expect(tree.root.span.exclusive_time).toBe(1000);
+  });
   it('appends to parent that contains span', () => {
-    const tree = new SpanTree([
-      s({span_id: '1', timestamp: 1, start_timestamp: 0}),
-      s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
-    ]);
+    const tree = new SpanTree(
+      txn({
+        title: 'transaction root',
+        startTimestamp: Date.now(),
+        endTimestamp: Date.now() + 1000,
+      }),
+      [
+        s({span_id: '1', timestamp: 1, start_timestamp: 0}),
+        s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
+      ]
+    );
     expect(tree.orphanedSpans.length).toBe(0);
     expect(tree.root.children[0].span.span_id).toBe('1');
     expect(tree.root.children[0].children[0].span.span_id).toBe('2');
   });
   it('pushes consecutive span', () => {
-    const tree = new SpanTree([
-      s({span_id: '1', timestamp: 1, start_timestamp: 0}),
-      s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
-      s({span_id: '3', timestamp: 0.8, start_timestamp: 0.5}),
-    ]);
+    const tree = new SpanTree(
+      txn({
+        title: 'transaction root',
+        startTimestamp: Date.now(),
+        endTimestamp: Date.now() + 1000,
+      }),
+      [
+        s({span_id: '1', timestamp: 1, start_timestamp: 0}),
+        s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
+        s({span_id: '3', timestamp: 0.8, start_timestamp: 0.5}),
+      ]
+    );
 
     expect(tree.orphanedSpans.length).toBe(0);
     expect(tree.root.children[0].children[0].span.span_id).toBe('2');
     expect(tree.root.children[0].children[1].span.span_id).toBe('3');
   });
   it('marks span as orphaned if end overlaps', () => {
-    const tree = new SpanTree([
-      s({span_id: '1', timestamp: 1, start_timestamp: 0}),
-      s({span_id: '2', timestamp: 1.1, start_timestamp: 0.1}),
-    ]);
+    const tree = new SpanTree(
+      txn({
+        title: 'transaction root',
+        startTimestamp: Date.now(),
+        endTimestamp: Date.now() + 1000,
+      }),
+      [
+        s({span_id: '1', timestamp: 1, start_timestamp: 0}),
+        s({span_id: '2', timestamp: 1.1, start_timestamp: 0.1}),
+      ]
+    );
     expect(tree.orphanedSpans[0].span_id).toBe('2');
   });
 });

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -87,7 +87,7 @@ class SpanTree {
       description: transaction.title,
       start_timestamp: transaction.startTimestamp,
       timestamp: transaction.endTimestamp,
-      exclusive_time: transaction.endTimestamp - transaction.startTimestamp,
+      exclusive_time: transaction.contexts?.trace?.exclusive_time ?? undefined,
       parent_span_id: undefined,
       op: 'transaction',
     });

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -80,11 +80,9 @@ class SpanTreeNode {
 
 class SpanTree {
   root: SpanTreeNode;
-  transaction: EventTransaction;
   orphanedSpans: RawSpanType[] = [];
 
   constructor(transaction: EventTransaction, spans: RawSpanType[]) {
-    this.transaction = transaction;
     this.root = SpanTreeNode.Root({
       description: transaction.title,
       start_timestamp: transaction.startTimestamp,

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -1,4 +1,32 @@
 import {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
+import {EventOrGroupType, EventTransaction} from 'sentry/types';
+
+// Empty transaction to use as a default value with duration of 1 second
+const EmptyEventTransaction: EventTransaction = {
+  id: '',
+  projectID: '',
+  user: {},
+  contexts: {},
+  entries: [],
+  errors: [],
+  dateCreated: '',
+  startTimestamp: Date.now(),
+  endTimestamp: Date.now() + 1000,
+  title: '',
+  type: EventOrGroupType.TRANSACTION,
+  culprit: '',
+  dist: null,
+  eventID: '',
+  fingerprints: [],
+  dateReceived: new Date().toISOString(),
+  message: '',
+  metadata: {},
+  size: 0,
+  tags: [],
+  occurrence: null,
+  location: '',
+  crashFile: null,
+};
 
 function sortByStartTimeAndDuration(a: RawSpanType, b: RawSpanType) {
   if (a.start_timestamp < b.start_timestamp) {
@@ -23,7 +51,7 @@ class SpanTreeNode {
     this.parent = parent;
   }
 
-  static Root() {
+  static Root(partial: Partial<RawSpanType> = {}): SpanTreeNode {
     return new SpanTreeNode(
       {
         description: 'root',
@@ -36,6 +64,7 @@ class SpanTreeNode {
         span_id: '<root>',
         trace_id: '',
         hash: '',
+        ...partial,
       },
       null
     );
@@ -50,15 +79,25 @@ class SpanTreeNode {
 }
 
 class SpanTree {
-  root: SpanTreeNode = SpanTreeNode.Root();
+  root: SpanTreeNode;
+  transaction: EventTransaction;
   orphanedSpans: RawSpanType[] = [];
 
-  constructor(spans: RawSpanType[]) {
+  constructor(transaction: EventTransaction, spans: RawSpanType[]) {
+    this.transaction = transaction;
+    this.root = SpanTreeNode.Root({
+      description: transaction.title,
+      start_timestamp: transaction.startTimestamp,
+      timestamp: transaction.endTimestamp,
+      exclusive_time: transaction.endTimestamp - transaction.startTimestamp,
+      parent_span_id: undefined,
+      op: 'transaction',
+    });
     this.buildCollapsedSpanTree(spans);
   }
 
   static Empty(): SpanTree {
-    return new SpanTree([]);
+    return new SpanTree(EmptyEventTransaction, []);
   }
 
   buildCollapsedSpanTree(spans: RawSpanType[]) {

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -70,15 +70,15 @@ function ProfileFlamegraph(): React.ReactElement {
   const profiledTransaction = useProfileTransaction();
 
   const hasFlameChartSpans = useMemo(() => {
-    return (
-      // @TODO REMOVE TRUE
-      organization.features.includes('organizations:profiling-flamechart-spans') || true
-    );
+    return organization.features.includes('organizations:profiling-flamechart-spans');
   }, [organization.features]);
 
   const spanTree: SpanTree = useMemo(() => {
     if (profiledTransaction.type === 'resolved' && profiledTransaction.data) {
-      return new SpanTree(collectAllSpanEntriesFromTransaction(profiledTransaction.data));
+      return new SpanTree(
+        profiledTransaction.data,
+        collectAllSpanEntriesFromTransaction(profiledTransaction.data)
+      );
     }
 
     return LoadingSpanTree;


### PR DESCRIPTION
A SpanTree belongs to a transaction which should be reflected in our tree representation. Before this change, root was just an arbitrary node with 0-max int duration.