### PR TITLE
test(dashboards): Skip flaky area chart to big number layout test

### DIFF
--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -651,6 +651,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
                 "dashboards - change from big number to other chart enforces min height of 2"
             )
 
+    @pytest.mark.skip(reason="flaky: DD-1211")
     def test_changing_area_widget_larger_than_min_height_for_number_chart_keeps_height(
         self,
     ):


### PR DESCRIPTION
Skipping because it's flaky

ex: https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/bd60f32c4880fea7fb74090c7b3fc88c6c4909dd/index.html