### PR TITLE
fix(workflow): Disable useCommiters request retry

### DIFF
--- a/static/app/utils/useCommitters.tsx
+++ b/static/app/utils/useCommitters.tsx
@@ -27,6 +27,7 @@ function useCommitters(
     makeCommittersQueryKey(org.slug, projectSlug, eventId),
     {
       staleTime: Infinity,
+      retry: false,
       ...options,
     }
   );


### PR DESCRIPTION
Committers api can 404, which useQuery treats as a retry. We don't need to retry this request.
