### PR TITLE
fix(sampling): Make dynamicSamplingRules only for superusers

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -19,6 +19,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.project import DetailedProjectSerializer
 from sentry.api.serializers.rest_framework.list import EmptyListField, ListField
 from sentry.api.serializers.rest_framework.origin import OriginField
+from sentry.auth.superuser import is_active_superuser
 from sentry.constants import RESERVED_PROJECT_SLUGS
 from sentry.datascrubbing import validate_pii_config_update
 from sentry.dynamic_sampling.feature_multiplexer import DynamicSamplingFeatureMultiplexer
@@ -385,7 +386,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             data["dynamicSamplingBiases"] = ds_bias_serializer.data
 
             include_rules = request.GET.get("includeDynamicSamplingRules") == "1"
-            if include_rules and request.user.is_staff:
+            if include_rules and is_active_superuser(request):
                 data["dynamicSamplingRules"] = generate_rules(project)
         else:
             data["dynamicSamplingBiases"] = None

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1201,12 +1201,12 @@ class TestProjectDetailsDynamicSamplingRules(TestProjectDetailsDynamicSamplingBa
                 "project_slug": self.project.slug,
             },
         )
-        self.login_as(user=self.user)
+        self.login_as(user=self.user, superuser=True)
         token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
         self.authorization = f"Bearer {token.token}"
 
     @mock.patch("sentry.dynamic_sampling.rules_generator.quotas.get_blended_sample_rate")
-    def test_get_dynamic_sampling_rules_for_stuff_user(self, get_blended_sample_rate):
+    def test_get_dynamic_sampling_rules_for_superuser_user(self, get_blended_sample_rate):
         get_blended_sample_rate.return_value = 0.1
         new_biases = [
             {"id": "boostEnvironments", "active": True},
@@ -1247,7 +1247,7 @@ class TestProjectDetailsDynamicSamplingRules(TestProjectDetailsDynamicSamplingBa
             )
             assert response.data["dynamicSamplingRules"] is None
 
-    def test_non_stuff_user_trying_to_access_dynamic_sampling_rules(self):
+    def test_non_superuser_user_trying_to_access_dynamic_sampling_rules(self):
         user = self.create_user(is_staff=False, is_superuser=False)
         self.org = self.create_organization()
         self.org.save()


### PR DESCRIPTION
This PR switch from `is_staff` to  `is_active_superuser`, since we are not using `is_staff`.

