### PR TITLE
feat(profiling): remap span durations relative to transaction

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -102,13 +102,17 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
   const canvasPoolManager = useMemo(() => new CanvasPoolManager(), []);
   const scheduler = useMemo(() => new CanvasScheduler(), []);
 
+  const profile = useMemo(() => {
+    return props.profiles.profiles.find(p => p.threadId === threadId);
+  }, [props.profiles, threadId]);
+
   const spanChart = useMemo(() => {
-    if (!props.spanTree) {
+    if (!props.spanTree || !profile) {
       return null;
     }
 
-    return new SpanChart(props.spanTree);
-  }, [props.spanTree]);
+    return new SpanChart(props.spanTree, {unit: profile.unit});
+  }, [props.spanTree, profile]);
 
   const flamegraph = useMemo(() => {
     if (typeof threadId !== 'number') {
@@ -117,7 +121,6 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
     // This could happen if threadId was initialized from query string, but for some
     // reason the profile was removed from the list of profiles.
-    const profile = props.profiles.profiles.find(p => p.threadId === threadId);
     if (!profile) {
       return FALLBACK_FLAMEGRAPH;
     }
@@ -130,7 +133,7 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
           ? getTransactionConfigSpace(props.profiles, profile.startedAt, profile.unit)
           : undefined,
     });
-  }, [props.profiles, sorting, threadId, view, xAxis]);
+  }, [profile, props.profiles, sorting, threadId, view, xAxis]);
 
   const flamegraphCanvas = useMemo(() => {
     if (!flamegraphCanvasRef) {

--- a/static/app/utils/profiling/renderers/spansRenderer.tsx
+++ b/static/app/utils/profiling/renderers/spansRenderer.tsx
@@ -9,6 +9,7 @@ function colorComponentsToRgba(color: number[]): string {
     color[2] * 255
   )}, ${color[3] ?? 1})`;
 }
+const SPAN_HEIGHT_PX = 20;
 
 export class SpanChartRenderer2D {
   canvas: HTMLCanvasElement | null;
@@ -46,7 +47,6 @@ export class SpanChartRenderer2D {
     for (let i = 0; i < this.spans.length; i++) {
       const span = this.spans[i];
 
-      const SPAN_HEIGHT_PX = 20;
       const rect = new Rect(
         span.start,
         span.depth * SPAN_HEIGHT_PX,

--- a/static/app/utils/profiling/renderers/spansRenderer.tsx
+++ b/static/app/utils/profiling/renderers/spansRenderer.tsx
@@ -20,6 +20,8 @@ export class SpanChartRenderer2D {
     this.canvas = canvas;
     this.spanChart = spanChart;
 
+    this.spans = [...this.spanChart.spans];
+
     this.init();
     resizeCanvasToDisplaySize(this.canvas);
   }
@@ -44,9 +46,13 @@ export class SpanChartRenderer2D {
     for (let i = 0; i < this.spans.length; i++) {
       const span = this.spans[i];
 
-      const rect = new Rect(span.start, span.depth * 20, span.duration, 20).transformRect(
-        configViewToPhysicalSpace
-      );
+      const SPAN_HEIGHT_PX = 20;
+      const rect = new Rect(
+        span.start,
+        span.depth * SPAN_HEIGHT_PX,
+        span.duration,
+        SPAN_HEIGHT_PX
+      ).transformRect(configViewToPhysicalSpace);
 
       context.fillStyle = colorComponentsToRgba([1, 0, 0, 1]);
       context.fillRect(rect.x, rect.y, rect.width, rect.height);

--- a/static/app/utils/profiling/spanChart.spec.tsx
+++ b/static/app/utils/profiling/spanChart.spec.tsx
@@ -89,6 +89,20 @@ describe('spanChart', () => {
     expect(chart.configSpace.equals(new Rect(0, 0, 1, 2))).toBe(true);
   });
 
+  it('remaps spans to start of benchmark', () => {
+    const tree = new SpanTree(txn({startTimestamp: 5, endTimestamp: 10}), [
+      s({span_id: '1', timestamp: 10, start_timestamp: 6}),
+      s({span_id: '2', timestamp: 9, start_timestamp: 8}),
+    ]);
+
+    const chart = new SpanChart(tree);
+    expect(chart.spans[0].start).toBe(1);
+    expect(chart.spans[0].end).toBe(5);
+
+    expect(chart.spans[1].start).toBe(3);
+    expect(chart.spans[1].end).toBe(4);
+  });
+
   it('tracks chart depth', () => {
     const tree = new SpanTree(txn({startTimestamp: 0, endTimestamp: 1}), [
       s({span_id: '1', timestamp: 1, start_timestamp: 0}),

--- a/static/app/utils/profiling/spanChart.spec.tsx
+++ b/static/app/utils/profiling/spanChart.spec.tsx
@@ -64,13 +64,13 @@ describe('spanChart', () => {
 
     chart.forEachSpan(span => {
       if (span.node.span.span_id === '1') {
-        expect(span.depth).toBe(0);
+        expect(span.depth).toBe(1);
       } else if (span.node.span.span_id === '2') {
-        expect(span.depth).toBe(1);
-      } else if (span.node.span.span_id === '3') {
         expect(span.depth).toBe(2);
+      } else if (span.node.span.span_id === '3') {
+        expect(span.depth).toBe(3);
       } else if (span.node.span.span_id === '4') {
-        expect(span.depth).toBe(1);
+        expect(span.depth).toBe(2);
       }
     });
   });
@@ -86,7 +86,7 @@ describe('spanChart', () => {
     expect(tree.root.children[0].children[1].span.span_id).toBe('4');
 
     const chart = new SpanChart(tree);
-    expect(chart.configSpace.equals(new Rect(0, 0, 1, 2))).toBe(true);
+    expect(chart.configSpace.equals(new Rect(0, 0, 1, 3))).toBe(true);
   });
 
   it('remaps spans to start of benchmark', () => {
@@ -96,11 +96,22 @@ describe('spanChart', () => {
     ]);
 
     const chart = new SpanChart(tree);
-    expect(chart.spans[0].start).toBe(1);
-    expect(chart.spans[0].end).toBe(5);
+    expect(chart.spans[1].start).toBe(1);
+    expect(chart.spans[1].end).toBe(5);
 
-    expect(chart.spans[1].start).toBe(3);
-    expect(chart.spans[1].end).toBe(4);
+    expect(chart.spans[2].start).toBe(3);
+    expect(chart.spans[2].end).toBe(4);
+  });
+
+  it('converts durations to final unit', () => {
+    const tree = new SpanTree(txn({startTimestamp: 0, endTimestamp: 10}), [
+      s({span_id: '1', timestamp: 3, start_timestamp: 1}),
+    ]);
+
+    const chart = new SpanChart(tree, {unit: 'nanoseconds'});
+    expect(chart.spans[1].start).toBe(1 * 1e6);
+    expect(chart.spans[1].end).toBe(3 * 1e6);
+    expect(chart.spans[1].duration).toBe(2 * 1e6);
   });
 
   it('tracks chart depth', () => {
@@ -112,6 +123,6 @@ describe('spanChart', () => {
     ]);
 
     const chart = new SpanChart(tree);
-    expect(chart.depth).toBe(3);
+    expect(chart.depth).toBe(4);
   });
 });

--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -2,6 +2,32 @@ import {Rect} from 'sentry/utils/profiling/gl/utils';
 import {SpanTree} from 'sentry/utils/profiling/spanTree';
 import {makeFormatter} from 'sentry/utils/profiling/units/units';
 
+import {Profile} from './profile/profile';
+
+function msToUnit(unit: Profile['unit']): (value: number) => number {
+  let multiplier: number | null = null;
+
+  switch (unit) {
+    case 'milliseconds':
+      multiplier = 1;
+      break;
+    case 'microseconds':
+      multiplier = 1e3;
+      break;
+    case 'nanoseconds':
+      multiplier = 1e6;
+      break;
+    default: {
+      throw new Error(`Unknown unit : ${unit}`);
+    }
+  }
+
+  if (multiplier === null) {
+    throw new Error(`Unknown unit: ${unit} when converting span durations`);
+  }
+  return (value: number) => value * multiplier!;
+}
+
 export interface SpanChartNode {
   depth: number;
   duration: number;
@@ -14,18 +40,23 @@ class SpanChart {
   spans: SpanChartNode[];
   spanTree: SpanTree;
 
+  toFinalUnit = msToUnit('milliseconds');
   formatter = makeFormatter('milliseconds');
   configSpace: Rect = Rect.Empty();
   depth: number = 0;
 
-  constructor(spanTree: SpanTree, _options: {configSpace?: Rect} = {}) {
+  constructor(
+    spanTree: SpanTree,
+    options: {unit: Profile['unit']; configSpace?: Rect} = {unit: 'milliseconds'}
+  ) {
+    this.toFinalUnit = msToUnit(options.unit);
     this.spanTree = spanTree;
     this.spans = this.collectSpanNodes();
 
     const duration = spanTree.root.span.timestamp - spanTree.root.span.start_timestamp;
 
     if (duration > 0) {
-      this.configSpace = new Rect(0, 0, duration, this.depth);
+      this.configSpace = new Rect(0, 0, this.toFinalUnit(duration), this.depth);
     } else {
       // If the span duration is 0, set the flamegraph duration to 1 second as flamechart
       this.configSpace = new Rect(
@@ -41,22 +72,24 @@ class SpanChart {
   forEachSpan(cb: (node: SpanChartNode) => void) {
     const transactionStart = this.spanTree.root.span.start_timestamp;
 
-    const queue: SpanTree['root'][] = [...this.spanTree.root.children];
+    const queue: SpanTree['root'][] = [this.spanTree.root];
     let depth = 0;
 
     while (queue.length) {
       let children_at_depth = queue.length;
+
       while (children_at_depth-- !== 0) {
         const node = queue.shift()!;
         queue.push(...node.children);
 
         const duration = node.span.timestamp - node.span.start_timestamp;
         const start = node.span.start_timestamp - transactionStart;
+        const end = start + duration;
 
         cb({
-          duration,
-          start,
-          end: start + duration,
+          duration: this.toFinalUnit(duration),
+          start: this.toFinalUnit(start),
+          end: this.toFinalUnit(end),
           node,
           depth,
         });

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -92,6 +92,7 @@ class SpanTree {
       parent_span_id: undefined,
       op: 'transaction',
     });
+
     this.buildCollapsedSpanTree(spans);
   }
 

--- a/static/app/utils/profiling/units/units.ts
+++ b/static/app/utils/profiling/units/units.ts
@@ -15,6 +15,15 @@ const durationMappings: Record<ProfilingFormatterUnit, number> = {
   seconds: 1,
 };
 
+export function makeFormatTo(
+  from: ProfilingFormatterUnit | string,
+  to: ProfilingFormatterUnit | string
+) {
+  if (from === to) {
+    return (v: number) => v;
+  }
+  return (v: number) => formatTo(v, from, to);
+}
 export function formatTo(
   v: number,
   from: ProfilingFormatterUnit | string,


### PR DESCRIPTION
Remap span timestamps so that they are relative to transaction. I think this is temporary while we build the feature, ultimately we can achieve the same via single translation + scale matrix multiplication at render time. For the time being though, debugging these values will be easier as we experiment with generation and visualization. The refactor to use a matrix multiplication to simplify this is imo acceptable enough