### PR TITLE
feat(perf): Close the transaction searchbar when clicked outside of

### DIFF
--- a/static/app/components/performance/searchBar.spec.tsx
+++ b/static/app/components/performance/searchBar.spec.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {
   act,
   render,
@@ -170,5 +172,30 @@ describe('SearchBar', () => {
     expect(screen.queryByTestId('smart-search-dropdown')).not.toBeInTheDocument();
     expect(onSearch).toHaveBeenCalledTimes(1);
     expect(onSearch).toHaveBeenCalledWith('transaction:client*');
+  });
+
+  it('closes the search dropdown when clicked outside of', () => {
+    const onSearch = jest.fn();
+    eventsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        data: [
+          {project_id: 1, transaction: 'clients.call'},
+          {project_id: 1, transaction: 'clients.fetch'},
+        ],
+      },
+    });
+    render(
+      <Fragment>
+        <div data-test-id="some-div" />
+        <SearchBar {...testProps} onSearch={onSearch} />
+      </Fragment>
+    );
+
+    userEvent.type(screen.getByRole('textbox'), 'proje');
+    expect(screen.getByTestId('smart-search-dropdown')).toBeInTheDocument();
+
+    userEvent.click(screen.getByTestId('some-div'));
+    expect(screen.queryByTestId('smart-search-dropdown')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -37,7 +37,7 @@ function SearchBar(props: SearchBarProps) {
   const [loading, setLoading] = useState(false);
   const [searchString, setSearchString] = useState(searchQuery);
   const containerRef = useRef<HTMLDivElement>(null);
-  useOnClickOutside(containerRef, closeDropdown);
+  useOnClickOutside(containerRef, useCallback(closeDropdown, []));
 
   const api = useApi();
   const eventView = _eventView.clone();

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -55,9 +55,7 @@ function SearchBar(props: SearchBarProps) {
 
     document.addEventListener('pointerup', handleBackgroundPointerUp);
 
-    return () => {
-      document.removeEventListener('pointerup', handleBackgroundPointerUp);
-    };
+    return () => document.removeEventListener('pointerup', handleBackgroundPointerUp);
   }, [containerRef]);
 
   const handleSearchChange = query => {

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
@@ -12,6 +12,7 @@ import EventView from 'sentry/utils/discover/eventView';
 import {doDiscoverQuery} from 'sentry/utils/discover/genericDiscoverQuery';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import useApi from 'sentry/utils/useApi';
+import useOnClickOutside from 'sentry/utils/useOnClickOutside';
 import {transactionSummaryRouteWithQuery} from 'sentry/views/performance/transactionSummary/utils';
 
 import SearchDropdown from '../smartSearchBar/searchDropdown';
@@ -36,6 +37,7 @@ function SearchBar(props: SearchBarProps) {
   const [loading, setLoading] = useState(false);
   const [searchString, setSearchString] = useState(searchQuery);
   const containerRef = useRef<HTMLDivElement>(null);
+  useOnClickOutside(containerRef, closeDropdown);
 
   const api = useApi();
   const eventView = _eventView.clone();
@@ -43,20 +45,6 @@ function SearchBar(props: SearchBarProps) {
   const url = `/organizations/${organization.slug}/events/`;
 
   const projectIdStrings = (eventView.project as Readonly<number>[])?.map(String);
-
-  useEffect(() => {
-    const handleBackgroundPointerUp = (e: PointerEvent) => {
-      if (containerRef.current?.contains(e.target as Node)) {
-        return;
-      }
-
-      closeDropdown();
-    };
-
-    document.addEventListener('pointerup', handleBackgroundPointerUp);
-
-    return () => document.removeEventListener('pointerup', handleBackgroundPointerUp);
-  }, [containerRef]);
 
   const handleSearchChange = query => {
     setSearchString(query);

--- a/static/app/components/performance/searchBar.tsx
+++ b/static/app/components/performance/searchBar.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
@@ -35,6 +35,7 @@ function SearchBar(props: SearchBarProps) {
   const closeDropdown = () => setIsDropdownOpen(false);
   const [loading, setLoading] = useState(false);
   const [searchString, setSearchString] = useState(searchQuery);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const api = useApi();
   const eventView = _eventView.clone();
@@ -42,6 +43,22 @@ function SearchBar(props: SearchBarProps) {
   const url = `/organizations/${organization.slug}/events/`;
 
   const projectIdStrings = (eventView.project as Readonly<number>[])?.map(String);
+
+  useEffect(() => {
+    const handleBackgroundPointerUp = (e: PointerEvent) => {
+      if (containerRef.current?.contains(e.target as Node)) {
+        return;
+      }
+
+      closeDropdown();
+    };
+
+    document.addEventListener('pointerup', handleBackgroundPointerUp);
+
+    return () => {
+      document.removeEventListener('pointerup', handleBackgroundPointerUp);
+    };
+  }, [containerRef]);
 
   const handleSearchChange = query => {
     setSearchString(query);
@@ -210,7 +227,7 @@ function SearchBar(props: SearchBarProps) {
   };
 
   return (
-    <Container data-test-id="transaction-search-bar">
+    <Container data-test-id="transaction-search-bar" ref={containerRef}>
       <BaseSearchBar
         placeholder={t('Search Transactions')}
         onChange={handleSearchChange}


### PR DESCRIPTION
Previously, clicking outside of the transaction searchbar would not close the dropdown. This adds an event listener to the document that will close the dropdown when the user clicks anywhere outside of it