### PR TITLE
feat(profiling): Sort flamechart thread selector

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.spec.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.spec.tsx
@@ -1,0 +1,70 @@
+import {compareProfiles} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector';
+
+describe('compareProfiles', function () {
+  it('should thread appropriately', function () {
+    const namedA = {
+      name: 'a',
+      threadId: 1,
+    };
+    const namedB = {
+      name: 'b',
+      threadId: 2,
+    };
+    const namedC = {
+      name: 'c',
+      threadId: 3,
+    };
+    const unnamed4 = {
+      name: '',
+      threadId: 4,
+    };
+    const unnamed5 = {
+      name: '',
+      threadId: 5,
+    };
+    const active = {
+      name: '',
+      threadId: 6,
+    };
+    const profiles = [unnamed5, unnamed4, namedC, namedB, namedA, active];
+    const sortedProfiles = profiles.sort(compareProfiles(active.threadId));
+    expect(sortedProfiles).toEqual([active, namedA, namedB, namedC, unnamed4, unnamed5]);
+  });
+
+  it('should work with no active thread id', function () {
+    const namedA = {
+      name: 'a',
+      threadId: 1,
+    };
+    const namedB = {
+      name: 'b',
+      threadId: 2,
+    };
+    const namedC = {
+      name: 'c',
+      threadId: 3,
+    };
+    const unnamed4 = {
+      name: '',
+      threadId: 4,
+    };
+    const unnamed5 = {
+      name: '',
+      threadId: 5,
+    };
+    const unnamed6 = {
+      name: '',
+      threadId: 6,
+    };
+    const profiles = [unnamed5, unnamed4, namedC, namedB, namedA, unnamed6];
+    const sortedProfiles = profiles.sort(compareProfiles(undefined));
+    expect(sortedProfiles).toEqual([
+      namedA,
+      namedB,
+      namedC,
+      unnamed4,
+      unnamed5,
+      unnamed6,
+    ]);
+  });
+});

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
@@ -29,7 +29,13 @@ function FlamegraphThreadSelector({
   ] = useMemo(() => {
     const profiles: SelectValue<number>[] = [];
     const emptyProfiles: SelectValue<number>[] = [];
-    const sortedProfiles = [...profileGroup.profiles].sort(compareProfiles);
+    const activeThreadId =
+      typeof profileGroup.activeProfileIndex === 'number'
+        ? profileGroup.profiles[profileGroup.activeProfileIndex]?.threadId
+        : undefined;
+    const sortedProfiles = [...profileGroup.profiles].sort(
+      compareProfiles(activeThreadId)
+    );
 
     sortedProfiles.forEach(profile => {
       const option = {
@@ -107,35 +113,38 @@ function ThreadLabelDetails(props: ThreadLabelDetailsProps) {
 }
 
 type ProfileLight = {
-  duration: Profile['duration'];
   name: Profile['name'];
   threadId: Profile['threadId'];
 };
 
-function compareProfiles(a: ProfileLight, b: ProfileLight): number {
-  if (!b.duration) {
-    return -1;
-  }
-  if (!a.duration) {
-    return 1;
-  }
+export function compareProfiles(activeThreadId?: number) {
+  return function (a: ProfileLight, b: ProfileLight): number {
+    // if one is the active thread id, it should be first
+    if (defined(activeThreadId)) {
+      if (a.threadId === activeThreadId) {
+        return -1;
+      }
+      if (b.threadId === activeThreadId) {
+        return 1;
+      }
+    }
 
-  if (a.name.startsWith('(tid') && b.name.startsWith('(tid')) {
-    return -1;
-  }
-  if (a.name.startsWith('(tid')) {
-    return -1;
-  }
-  if (b.name.startsWith('(tid')) {
-    return -1;
-  }
-  if (a.name.includes('main')) {
-    return -1;
-  }
-  if (b.name.includes('main')) {
-    return 1;
-  }
-  return a.name > b.name ? -1 : 1;
+    // if neither has a name, we use the thread id
+    if (!b.name && !a.name) {
+      return a.threadId > b.threadId ? 1 : -1;
+    }
+
+    // if one doesn't have a name, the other is first
+    if (!b.name) {
+      return -1;
+    }
+    if (!a.name) {
+      return 1;
+    }
+
+    // if both has a name, we use the name
+    return a.name > b.name ? 1 : -1;
+  };
 }
 
 const DetailsContainer = styled('div')`


### PR DESCRIPTION
The current sort on the thread selector feels seeminly random. This changes the sort order to the following
1. the active thread
2. thread with names in lexicographical order by name
3. thread without names in numerical order by thread id