### PR TITLE
fix(workflow): Change fallthrough copy to active members

### DIFF
--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -222,7 +222,7 @@ def get_owner_reason(
     if fallthrough_choice == FallthroughChoiceType.ALL_MEMBERS:
         return f"We notified all members in the {project.get_full_name()} project of this issue"
     if fallthrough_choice == FallthroughChoiceType.ACTIVE_MEMBERS:
-        return f"We notified team admins and recently active members in the {project.get_full_name()} project of this issue"
+        return f"We notified recently active members in the {project.get_full_name()} project of this issue"
 
     return None
 

--- a/tests/sentry/notifications/utils/test_participants.py
+++ b/tests/sentry/notifications/utils/test_participants.py
@@ -529,7 +529,7 @@ class GetOwnersCase(TestCase):
             )
             assert (
                 owner_reason
-                == f"We notified team admins and recently active members in the {self.project.get_full_name()} project of this issue"
+                == f"We notified recently active members in the {self.project.get_full_name()} project of this issue"
             )
 
     def test_get_owner_reason_member(self):


### PR DESCRIPTION
No longer targeting team admins
