### PR TITLE
feat(ui): Add custom styling to Checkbox component

### DIFF
--- a/docs-ui/stories/components/checkbox.stories.js
+++ b/docs-ui/stories/components/checkbox.stories.js
@@ -1,0 +1,51 @@
+import styled from '@emotion/styled';
+
+import Checkbox from 'sentry/components/checkbox';
+
+export default {
+  title: 'Components/Forms/Controls/Checkbox',
+  component: Checkbox,
+  args: {
+    size: 'md',
+    disabled: false,
+    checked: true,
+  },
+  argTypes: {
+    size: {
+      options: ['xs', 'sm', 'md'],
+      control: {type: 'radio'},
+    },
+    disabled: {
+      control: {type: 'boolean'},
+    },
+    checked: {
+      control: {type: 'boolean'},
+    },
+  },
+};
+
+export const Default = props => (
+  <div>
+    <Checkbox {...props} />
+  </div>
+);
+
+export const WithLabel = props => (
+  <div>
+    <Label>
+      Label to left
+      <Checkbox {...props} />
+    </Label>
+    <Label>
+      <Checkbox {...props} />
+      Label to right
+    </Label>
+  </div>
+);
+
+const Label = styled('label')`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+`;

--- a/docs-ui/stories/components/checkbox.stories.js
+++ b/docs-ui/stories/components/checkbox.stories.js
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Forms/Controls/Checkbox',
   component: Checkbox,
   args: {
-    size: 'md',
+    size: 'sm',
     disabled: false,
     checked: true,
   },

--- a/docs-ui/stories/components/checkbox.stories.js
+++ b/docs-ui/stories/components/checkbox.stories.js
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import Checkbox from 'sentry/components/checkbox';
@@ -18,30 +19,48 @@ export default {
     disabled: {
       control: {type: 'boolean'},
     },
-    checked: {
-      control: {type: 'boolean'},
-    },
   },
 };
 
-export const Default = props => (
-  <div>
-    <Checkbox {...props} />
-  </div>
-);
+export const Default = props => {
+  const [checked, setChecked] = useState(true);
 
-export const WithLabel = props => (
-  <div>
-    <Label>
-      Label to left
-      <Checkbox {...props} />
-    </Label>
-    <Label>
-      <Checkbox {...props} />
-      Label to right
-    </Label>
-  </div>
-);
+  return (
+    <div>
+      <Checkbox
+        {...props}
+        checked={checked}
+        onChange={e => setChecked(e.target.checked)}
+      />
+    </div>
+  );
+};
+
+export const WithLabel = props => {
+  const [check1, setCheck1] = useState(true);
+  const [check2, setCheck2] = useState(false);
+
+  return (
+    <div>
+      <Label>
+        Label to left
+        <Checkbox
+          {...props}
+          checked={check1}
+          onChange={e => setCheck1(e.target.checked)}
+        />
+      </Label>
+      <Label>
+        <Checkbox
+          {...props}
+          checked={check2}
+          onChange={e => setCheck2(e.target.checked)}
+        />
+        Label to right
+      </Label>
+    </div>
+  );
+};
 
 const Label = styled('label')`
   display: flex;

--- a/static/app/components/checkbox.spec.tsx
+++ b/static/app/components/checkbox.spec.tsx
@@ -1,12 +1,61 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {useState} from 'react';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import Checkbox from 'sentry/components/checkbox';
 
 describe('Checkbox', function () {
-  it('renders', async function () {
-    const {container} = render(<Checkbox onChange={() => {}} />);
+  const defaultProps = {
+    checked: false,
+    onChange: jest.fn(),
+  };
 
-    expect(await screen.findByRole('checkbox')).toBeInTheDocument();
-    expect(container).toSnapshot();
+  describe('snapshots', function () {
+    it('unchecked state', async function () {
+      const {container} = render(<Checkbox {...defaultProps} />);
+
+      expect(await screen.findByRole('checkbox')).toBeInTheDocument();
+      expect(container).toSnapshot();
+    });
+
+    it('checked state', async function () {
+      const {container} = render(<Checkbox {...defaultProps} checked />);
+
+      expect(await screen.findByRole('checkbox')).toBeInTheDocument();
+      expect(container).toSnapshot();
+    });
+
+    it('indeterminate state', async function () {
+      const {container} = render(<Checkbox {...defaultProps} checked />);
+
+      expect(await screen.findByRole('checkbox')).toBeInTheDocument();
+      expect(container).toSnapshot();
+    });
+  });
+
+  describe('behavior', function () {
+    function CheckboxWithLabel() {
+      const [checked, setChecked] = useState(false);
+
+      return (
+        <label>
+          <Checkbox
+            checked={checked}
+            onChange={e => {
+              setChecked(e.target.checked);
+            }}
+          />
+          Label text
+        </label>
+      );
+    }
+
+    it('toggles on click', function () {
+      render(<CheckboxWithLabel />);
+
+      expect(screen.getByRole('checkbox')).not.toBeChecked();
+      userEvent.click(screen.getByLabelText('Label text'));
+      expect(screen.getByRole('checkbox')).toBeChecked();
+    });
   });
 });

--- a/static/app/components/checkbox.spec.tsx
+++ b/static/app/components/checkbox.spec.tsx
@@ -26,7 +26,7 @@ describe('Checkbox', function () {
     });
 
     it('indeterminate state', async function () {
-      const {container} = render(<Checkbox {...defaultProps} checked />);
+      const {container} = render(<Checkbox {...defaultProps} checked="indeterminate" />);
 
       expect(await screen.findByRole('checkbox')).toBeInTheDocument();
       expect(container).toSnapshot();

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -1,16 +1,35 @@
 import {useEffect, useRef} from 'react';
+import styled from '@emotion/styled';
+import {useHover, usePress} from '@react-aria/interactions';
+import {mergeProps} from '@react-aria/utils';
+
+import InteractionStateLayer from 'sentry/components/interactionStateLayer';
+import {IconCheckmark, IconSubtract} from 'sentry/icons';
+import commonTheme, {FormSize} from 'sentry/utils/theme';
 
 type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
 
-interface Props extends Omit<CheckboxProps, 'checked'> {
+interface Props extends Omit<CheckboxProps, 'checked' | 'size'> {
   /**
    * Is the checkbox active? Supports 'indeterminate'
    */
   checked?: CheckboxProps['checked'] | 'indeterminate';
+  /**
+   *
+   */
+  size?: FormSize;
 }
 
-const Checkbox = ({checked = false, ...props}: Props) => {
+const checkboxSizeMap = {
+  xs: {box: '12px', icon: '10px', borderRadius: '4px'},
+  sm: {box: '16px', icon: '12px', borderRadius: '4px'},
+  md: {box: '22px', icon: '16px', borderRadius: commonTheme.borderRadius},
+};
+
+const Checkbox = ({checked = false, size = 'sm', ...props}: Props) => {
   const checkboxRef = useRef<HTMLInputElement>(null);
+  const {isPressed, pressProps} = usePress({isDisabled: props.disabled});
+  const {isHovered, hoverProps} = useHover({isDisabled: props.disabled});
 
   // Support setting the indeterminate value, which is only possible through
   // setting this attribute
@@ -21,13 +40,65 @@ const Checkbox = ({checked = false, ...props}: Props) => {
   }, [checked]);
 
   return (
-    <input
-      ref={checkboxRef}
-      checked={checked !== 'indeterminate' && checked}
-      type="checkbox"
-      {...props}
-    />
+    <Wrapper>
+      <HiddenInput
+        checked={checked !== 'indeterminate' && checked}
+        type="checkbox"
+        {...mergeProps({ref: checkboxRef}, pressProps, hoverProps, props)}
+      />
+      <StyledCheckbox aria-hidden checked={checked} size={size} {...pressProps}>
+        {checked === true && <IconCheckmark size={checkboxSizeMap[size].icon} />}
+        {checked === 'indeterminate' && (
+          <IconSubtract size={checkboxSizeMap[size].icon} />
+        )}
+        <InteractionStateLayer {...{isPressed, isHovered}} />
+      </StyledCheckbox>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled('div')`
+  position: relative;
+  cursor: pointer;
+  display: inline-flex;
+  justify-content: flex-start;
+`;
+
+const HiddenInput = styled('input')`
+  position: absolute;
+  opacity: 0;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  cursor: pointer;
+
+  &.focus-visible + * {
+    box-shadow: ${p => p.theme.focusBorder} 0 0 0 2px;
+  }
+
+  &:disabled + * {
+    background: ${p => (p.checked ? p.theme.disabled : p.theme.backgroundSecondary)};
+    border-color: ${p => (p.checked ? p.theme.disabled : p.theme.disabledBorder)};
+  }
+`;
+
+const StyledCheckbox = styled('div')<{
+  checked: Props['checked'];
+  size: FormSize;
+}>`
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${p => (p.checked ? p.theme.white : p.theme.textColor)};
+  box-shadow: ${p => p.theme.dropShadowLight} inset;
+  width: ${p => checkboxSizeMap[p.size].box};
+  height: ${p => checkboxSizeMap[p.size].box};
+  border-radius: ${p => checkboxSizeMap[p.size].borderRadius};
+  background: ${p => (p.checked ? p.theme.active : 'transparent')};
+  border: 1px solid ${p => (p.checked ? p.theme.active : p.theme.gray200)};
+  pointer-events: none;
+`;
 
 export default Checkbox;

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -99,7 +99,7 @@ const StyledCheckbox = styled('div')<{
   width: ${p => checkboxSizeMap[p.size].box};
   height: ${p => checkboxSizeMap[p.size].box};
   border-radius: ${p => checkboxSizeMap[p.size].borderRadius};
-  background: ${p => (p.checked ? p.theme.active : 'transparent')};
+  background: ${p => (p.checked ? p.theme.active : p.theme.background)};
   border: 1px solid ${p => (p.checked ? p.theme.active : p.theme.gray200)};
   pointer-events: none;
 `;

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -20,7 +20,9 @@ interface Props extends Omit<CheckboxProps, 'checked' | 'size'> {
   size?: FormSize;
 }
 
-const checkboxSizeMap = {
+type CheckboxConfig = {borderRadius: string; box: string; icon: string};
+
+const checkboxSizeMap: Record<FormSize, CheckboxConfig> = {
   xs: {box: '12px', icon: '10px', borderRadius: '4px'},
   sm: {box: '16px', icon: '12px', borderRadius: '4px'},
   md: {box: '22px', icon: '16px', borderRadius: commonTheme.borderRadius},
@@ -71,6 +73,7 @@ const HiddenInput = styled('input')`
   width: 100%;
   top: 0;
   left: 0;
+  margin: 0;
   cursor: pointer;
 
   &.focus-visible + * {

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -94,6 +94,7 @@ const StyledCheckbox = styled('div')<{
   display: flex;
   align-items: center;
   justify-content: center;
+  color: inherit;
   box-shadow: ${p => p.theme.dropShadowLight} inset;
   width: ${p => checkboxSizeMap[p.size].box};
   height: ${p => checkboxSizeMap[p.size].box};

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -1,7 +1,5 @@
 import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
-import {useHover, usePress} from '@react-aria/interactions';
-import {mergeProps} from '@react-aria/utils';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {IconCheckmark, IconSubtract} from 'sentry/icons';
@@ -30,8 +28,6 @@ const checkboxSizeMap: Record<FormSize, CheckboxConfig> = {
 
 const Checkbox = ({checked = false, size = 'sm', ...props}: Props) => {
   const checkboxRef = useRef<HTMLInputElement>(null);
-  const {isPressed, pressProps} = usePress({isDisabled: props.disabled});
-  const {isHovered, hoverProps} = useHover({isDisabled: props.disabled});
 
   // Support setting the indeterminate value, which is only possible through
   // setting this attribute
@@ -42,28 +38,32 @@ const Checkbox = ({checked = false, size = 'sm', ...props}: Props) => {
   }, [checked]);
 
   return (
-    <Wrapper>
+    <Wrapper {...{checked, size}}>
       <HiddenInput
         checked={checked !== 'indeterminate' && checked}
         type="checkbox"
-        {...mergeProps({ref: checkboxRef}, pressProps, hoverProps, props)}
+        {...props}
       />
-      <StyledCheckbox aria-hidden checked={checked} size={size} {...pressProps}>
+      <StyledCheckbox aria-hidden checked={checked} size={size}>
         {checked === true && <IconCheckmark size={checkboxSizeMap[size].icon} />}
         {checked === 'indeterminate' && (
           <IconSubtract size={checkboxSizeMap[size].icon} />
         )}
-        <InteractionStateLayer {...{isPressed, isHovered}} />
       </StyledCheckbox>
+      <InteractionStateLayer
+        higherOpacity={checked === true || checked === 'indeterminate'}
+      />
     </Wrapper>
   );
 };
 
-const Wrapper = styled('div')`
+const Wrapper = styled('div')<{checked: Props['checked']; size: FormSize}>`
   position: relative;
   cursor: pointer;
   display: inline-flex;
   justify-content: flex-start;
+  color: ${p => (p.checked ? p.theme.white : p.theme.textColor)};
+  border-radius: ${p => checkboxSizeMap[p.size].borderRadius};
 `;
 
 const HiddenInput = styled('input')`
@@ -94,7 +94,6 @@ const StyledCheckbox = styled('div')<{
   display: flex;
   align-items: center;
   justify-content: center;
-  color: ${p => (p.checked ? p.theme.white : p.theme.textColor)};
   box-shadow: ${p => p.theme.dropShadowLight} inset;
   width: ${p => checkboxSizeMap[p.size].box};
   height: ${p => checkboxSizeMap[p.size].box};

--- a/static/app/components/checkbox.tsx
+++ b/static/app/components/checkbox.tsx
@@ -5,7 +5,7 @@ import {mergeProps} from '@react-aria/utils';
 
 import InteractionStateLayer from 'sentry/components/interactionStateLayer';
 import {IconCheckmark, IconSubtract} from 'sentry/icons';
-import commonTheme, {FormSize} from 'sentry/utils/theme';
+import {FormSize} from 'sentry/utils/theme';
 
 type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
 
@@ -23,9 +23,9 @@ interface Props extends Omit<CheckboxProps, 'checked' | 'size'> {
 type CheckboxConfig = {borderRadius: string; box: string; icon: string};
 
 const checkboxSizeMap: Record<FormSize, CheckboxConfig> = {
-  xs: {box: '12px', icon: '10px', borderRadius: '4px'},
+  xs: {box: '12px', icon: '10px', borderRadius: '2px'},
   sm: {box: '16px', icon: '12px', borderRadius: '4px'},
-  md: {box: '22px', icon: '16px', borderRadius: commonTheme.borderRadius},
+  md: {box: '22px', icon: '16px', borderRadius: '6px'},
 };
 
 const Checkbox = ({checked = false, size = 'sm', ...props}: Props) => {

--- a/static/app/components/forms/controls/multipleCheckbox.tsx
+++ b/static/app/components/forms/controls/multipleCheckbox.tsx
@@ -2,6 +2,7 @@ import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import Checkbox from 'sentry/components/checkbox';
+import space from 'sentry/styles/space';
 import {Choices} from 'sentry/types';
 import {defined} from 'sentry/utils';
 
@@ -21,7 +22,7 @@ const Label = styled('label')`
 `;
 
 const CheckboxLabel = styled('span')`
-  margin-left: 3px;
+  margin-left: ${space(1)};
 `;
 
 type SelectedValue = (string | number)[];

--- a/static/app/components/forms/controls/multipleCheckbox.tsx
+++ b/static/app/components/forms/controls/multipleCheckbox.tsx
@@ -1,6 +1,7 @@
 import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
+import Checkbox from 'sentry/components/checkbox';
 import {Choices} from 'sentry/types';
 import {defined} from 'sentry/utils';
 
@@ -10,6 +11,8 @@ const MultipleCheckboxWrapper = styled('div')`
 `;
 
 const Label = styled('label')`
+  display: inline-flex;
+  align-items: center;
   font-weight: normal;
   white-space: nowrap;
   margin-right: 10px;
@@ -55,7 +58,7 @@ function MultipleCheckbox({choices, value, disabled, onChange}: Props) {
       {choices.map(([choiceValue, choiceLabel]) => (
         <LabelContainer key={choiceValue}>
           <Label>
-            <input
+            <Checkbox
               type="checkbox"
               value={choiceValue}
               onChange={e => handleChange(choiceValue, e)}

--- a/static/app/components/forms/fields/checkboxField.tsx
+++ b/static/app/components/forms/fields/checkboxField.tsx
@@ -88,10 +88,6 @@ const ControlWrapper = styled('span')`
   align-self: flex-start;
   display: flex;
   margin-right: ${space(1)};
-
-  & input {
-    margin: 0;
-  }
 `;
 
 const FieldLayout = styled('div')`

--- a/static/app/components/interactionStateLayer.tsx
+++ b/static/app/components/interactionStateLayer.tsx
@@ -1,4 +1,5 @@
 import isPropValid from '@emotion/is-prop-valid';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {defined} from 'sentry/utils';
@@ -8,6 +9,18 @@ interface StateLayerProps extends React.HTMLAttributes<HTMLSpanElement> {
   higherOpacity?: boolean;
   isHovered?: boolean;
   isPressed?: boolean;
+}
+
+function getControlledOpacityValue(p: StateLayerProps) {
+  if (p.isPressed) {
+    return p.higherOpacity ? 0.12 : 0.09;
+  }
+
+  if (p.isHovered) {
+    return p.higherOpacity ? 0.085 : 0.06;
+  }
+
+  return null;
 }
 
 const InteractionStateLayer = styled(
@@ -32,32 +45,31 @@ const InteractionStateLayer = styled(
   opacity: 0;
 
   ${p =>
-    defined(p.isHovered)
-      ? `
-        *:not(.focus-visible) > & {
-          opacity: ${p.isHovered ? (p.higherOpacity ? 0.085 : 0.06) : 0};
-        }
-      `
-      : `
-        *:hover:not(.focus-visible) > & {
-          opacity: ${p.higherOpacity ? 0.085 : 0.06};
-        }
-      `}
+    !defined(p.isHovered)
+      ? css`
+          *:hover:not(.focus-visible) > & {
+            opacity: ${p.higherOpacity ? 0.085 : 0.06};
+          }
+        `
+      : ''}
 
   ${p =>
-    defined(p.isPressed)
-      ? `
-        && {
-          opacity: ${p.isPressed ? (p.higherOpacity ? 0.12 : 0.09) : 0};
-        }
-      `
-      : `
-        *:active > &&,
-        *[aria-expanded='true'] > &&,
-        *[aria-selected='true'] > && {
-          opacity: ${p.higherOpacity ? 0.12 : 0.09};
-        }
-      `}
+    !defined(p.isPressed)
+      ? css`
+          *:active > &&,
+          *[aria-expanded='true'] > &&,
+          *[aria-selected='true'] > && {
+            opacity: ${p.higherOpacity ? 0.12 : 0.09};
+          }
+        `
+      : ''}
+
+  ${p =>
+    getControlledOpacityValue(p)
+      ? css`
+          opacity: ${getControlledOpacityValue(p)};
+        `
+      : ''}
 
   *:disabled > && {
     opacity: 0;

--- a/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
+++ b/static/app/components/organizations/timeRangeSelector/dateRange/index.tsx
@@ -205,13 +205,7 @@ class BaseDateRange extends Component<Props, State> {
             />
             <UtcPicker>
               {t('Use UTC')}
-              <Checkbox
-                onChange={onChangeUtc}
-                checked={utc || false}
-                style={{
-                  margin: '0 0 0 0.5em',
-                }}
-              />
+              <Checkbox onChange={onChangeUtc} checked={utc || false} />
             </UtcPicker>
           </TimeAndUtcPicker>
         )}
@@ -240,6 +234,7 @@ const UtcPicker = styled('div')`
   align-items: center;
   justify-content: flex-end;
   flex: 1;
+  gap: ${space(1)};
 `;
 
 export default DateRange;

--- a/static/app/components/smartSearchBar/searchBarDatePicker.tsx
+++ b/static/app/components/smartSearchBar/searchBarDatePicker.tsx
@@ -209,11 +209,7 @@ const UtcPickerLabel = styled('label')`
   font-weight: normal;
   user-select: none;
   cursor: pointer;
-
-  input {
-    margin: 0 0 0 0.5em;
-    cursor: pointer;
-  }
+  gap: ${space(1)};
 `;
 
 export default SearchBarDatePicker;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -543,11 +543,6 @@ const GroupCheckBoxWrapper = styled('div')`
   height: 15px;
   display: flex;
   align-items: center;
-
-  & input[type='checkbox'] {
-    margin: 0;
-    display: block;
-  }
 `;
 
 const primaryStatStyle = (theme: Theme) => css`

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -347,10 +347,6 @@ const StyledFlex = styled('div')`
 const ActionsCheckbox = styled('div')<{isReprocessingQuery: boolean}>`
   padding-left: ${space(2)};
   margin-bottom: 1px;
-  & input[type='checkbox'] {
-    margin: 0;
-    display: block;
-  }
   ${p => p.isReprocessingQuery && 'flex: 1'};
 `;
 

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -345,6 +345,8 @@ const StyledFlex = styled('div')`
 `;
 
 const ActionsCheckbox = styled('div')<{isReprocessingQuery: boolean}>`
+  display: flex;
+  align-items: center;
   padding-left: ${space(2)};
   margin-bottom: 1px;
   ${p => p.isReprocessingQuery && 'flex: 1'};

--- a/static/app/views/organizationGroupDetails/groupMerged/mergedItem.tsx
+++ b/static/app/views/organizationGroupDetails/groupMerged/mergedItem.tsx
@@ -162,11 +162,6 @@ const ActionWrapper = styled('div')`
   grid-auto-flow: column;
   align-items: center;
   gap: ${space(1)};
-
-  /* Can't use styled components for this because of broad selector */
-  input[type='checkbox'] {
-    margin: 0;
-  }
 `;
 
 const Controls = styled('div')<{expanded: boolean}>`

--- a/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/static/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -171,10 +171,6 @@ const Details = styled('div')`
   gap: ${space(1)};
   grid-template-columns: max-content auto max-content;
   margin-left: ${space(2)};
-
-  input[type='checkbox'] {
-    margin: 0;
-  }
 `;
 
 const StyledPanelItem = styled(PanelItem)`

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -325,11 +325,8 @@ const RequestLogFilters = styled('div')`
 `;
 
 const ErrorsOnlyCheckbox = styled('div')`
-  input {
-    margin: 0 ${space(1)} 0 0;
-  }
-
   display: flex;
+  gap: ${space(1)};
   align-items: center;
 `;
 

--- a/static/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/static/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -178,10 +178,6 @@ const FilterList = styled('div')`
     font-weight: normal;
     white-space: nowrap;
     height: ${space(2)};
-  }
-
-  input,
-  label {
     margin: 0;
   }
 `;

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -279,10 +279,7 @@ const Label = styled('label')`
   display: flex;
   margin-bottom: 0;
   white-space: nowrap;
-  input {
-    margin-top: 0;
-    margin-right: ${space(1)};
-  }
+  gap: ${space(1)};
 `;
 
 export default ProjectDebugSymbols;

--- a/static/less/shared/forms.less
+++ b/static/less/shared/forms.less
@@ -136,9 +136,8 @@ input[type='search'] {
   appearance: none;
 }
 
-// Position radios and checkboxes better
-input[type='radio'],
-input[type='checkbox'] {
+// Position radios better
+input[type='radio'] {
   margin: 4px 0 0;
   margin-top: 1px \9; // IE8-9
   line-height: normal;


### PR DESCRIPTION
Ref https://github.com/getsentry/team-coreui/issues/29

Right now our checkboxes use default browser styling, so this attempts to make `Checkbox` look more like `CheckboxFancy`.

Done in this PR:

- Add custom styling to `Checkbox` by using an invisible `input` and visual aria-hidden checkbox (built similarly to the [material UI checkbox component](https://mui.com/material-ui/react-checkbox/))
- Fixes downstream styling issues stemming from the `input` being wrapped. In doing so, I removed a global CSS style where a `margin` was being added to `input[type="checkbox"]`, which obviated the need for a lot of `& input { margin: 0 }` styles

Before:

![CleanShot 2022-12-21 at 14 43 15](https://user-images.githubusercontent.com/10888943/209016836-dfb99bab-a9b8-4a58-88db-cfa9d63cbccb.png)

After:

![CleanShot 2022-12-21 at 14 43 21](https://user-images.githubusercontent.com/10888943/209016845-077f5339-0d9f-48d2-b2e3-c76c0068aa8e.png)

Future work:

- Convert existing uses of `CheckboxFancy` to use `Checkbox`
- Remove `CheckboxFancy`
- Add a label component? Seeing a lot of uses where components need to add `display: flex; align-items: center; gap: ${space(1)}` but we could provide that as an additional export.