### PR TITLE
fix(profiling): zoom into frame

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -281,7 +281,7 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
       const newConfigView = computeConfigViewWithStrategy(
         strategy,
         flamegraphView.configView,
-        new Rect(frame.start, frame.depth, frame.end, 1)
+        new Rect(frame.start, frame.depth, frame.end - frame.start, 1)
       );
 
       flamegraphView.setConfigView(newConfigView);


### PR DESCRIPTION
We had a subtle bug that went by unnoticed where we were passing the wrong frame duration to the zoomIntoView which meant that zooming with exact strategy wasnt working (we would not zoom into all the way into the frame).