### PR TITLE
feat(issue-platform): Make sure that merging/deleting/discarding can only be performed on error issues

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -324,8 +324,8 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         """
         from sentry.utils import snuba
 
-        if group.issue_category == GroupCategory.PERFORMANCE:
-            raise ValidationError(detail="Cannot delete performance issues.", code=400)
+        if group.issue_category != GroupCategory.ERROR:
+            raise ValidationError(detail="Only error issues can be deleted.", code=400)
 
         try:
             delete_group_list(request, group.project, [group], "delete")

--- a/src/sentry/api/helpers/group_index/delete.py
+++ b/src/sentry/api/helpers/group_index/delete.py
@@ -122,9 +122,9 @@ def delete_groups(
     if not group_list:
         return Response(status=204)
 
-    if any(group.issue_category == GroupCategory.PERFORMANCE for group in group_list):
+    if any(group.issue_category != GroupCategory.ERROR for group in group_list):
         raise rest_framework.exceptions.ValidationError(
-            detail="Cannot delete performance issues.", code=400
+            detail="Only error issues can be deleted.", code=400
         )
 
     groups_by_project_id = defaultdict(list)

--- a/src/sentry/api/helpers/group_index/update.py
+++ b/src/sentry/api/helpers/group_index/update.py
@@ -77,9 +77,9 @@ def handle_discard(
         if not features.has("projects:discard-groups", project, actor=user):
             return Response({"detail": ["You do not have that feature enabled"]}, status=400)
 
-    if any(group.issue_category == GroupCategory.PERFORMANCE for group in group_list):
+    if any(group.issue_category != GroupCategory.ERROR for group in group_list):
         raise rest_framework.exceptions.ValidationError(
-            detail="Cannot discard performance issues.", code=400
+            detail="Only error issues can be discarded.", code=400
         )
     # grouped by project_id
     groups_to_delete = defaultdict(list)
@@ -805,9 +805,9 @@ def update_groups(
         if len(projects) > 1:
             return Response({"detail": "Merging across multiple projects is not supported"})
 
-        if any([group.issue_category == GroupCategory.PERFORMANCE for group in group_list]):
+        if any([group.issue_category != GroupCategory.ERROR for group in group_list]):
             raise rest_framework.exceptions.ValidationError(
-                detail="Cannot merge performance issues.", code=400
+                detail="Only error issues can be merged.", code=400
             )
 
         group_list_by_times_seen = sorted(


### PR DESCRIPTION
If we add a new issue category the current logic will allow this functionality to run on it. Future proofing this logic. We will probably enable this functionality for issues generated by the issue platform at some point as well.
