### PR TITLE
fix(jira): Fix assignee outbound sync

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -884,25 +884,21 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         Propagate a sentry issue's assignee to a jira issue's assignee
         """
         client = self.get_client()
-
         jira_user = None
-        if user and assign:
-            for ue in user.emails.filter(is_verified=True):
-                try:
-                    possible_users = client.search_users_for_issue(external_issue.key, ue.email)
-                except (ApiUnauthorized, ApiError):
-                    continue
-                for possible_user in possible_users:
-                    email = possible_user.get("emailAddress")
-                    # pull email from API if we can use it
-                    if not email and self.use_email_scope:
-                        account_id = possible_user.get("accountId")
-                        email = client.get_email(account_id)
-                    # match on lowercase email
-                    # TODO(steve): add check against display name when JIRA_USE_EMAIL_SCOPE is false
-                    if email and email.lower() == ue.email.lower():
-                        jira_user = possible_user
-                        break
+        if user and user.is_authenticated and assign:  # idk if we need to check is_authenticated
+            possible_users = client.search_users_for_issue(external_issue.key, user.email)
+            for possible_user in possible_users:
+                email = possible_user.get("emailAddress")
+                # XXX: email is coming back as an empty string here
+                # pull email from API if we can use it
+                if not email and self.use_email_scope:
+                    account_id = possible_user.get("accountId")
+                    email = client.get_email(account_id)
+                # match on lowercase email
+                # TODO(steve): add check against display name when JIRA_USE_EMAIL_SCOPE is false
+                if email and email.lower() == user.email.lower():
+                    jira_user = possible_user
+
             if jira_user is None:
                 # TODO(jess): do we want to email people about these types of failures?
                 logger.info(
@@ -914,7 +910,6 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                     },
                 )
                 return
-
         try:
             id_field = client.user_id_field()
             client.assign_issue(external_issue.key, jira_user and jira_user.get(id_field))

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -887,9 +887,9 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         client = self.get_client()
         jira_user = None
         if user and assign:
-            for ue in user.emails:
+            for ue in user.emails.all():
                 try:
-                    possible_users = client.search_users_for_issue(external_issue.key, ue)
+                    possible_users = client.search_users_for_issue(external_issue.key, ue.email)
                 except (ApiUnauthorized, ApiError):
                     continue
                 for possible_user in possible_users:
@@ -900,7 +900,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                         email = client.get_email(account_id)
                     # match on lowercase email
                     # TODO(steve): add check against display name when JIRA_USE_EMAIL_SCOPE is false
-                    if email and email.lower() == ue.lower():
+                    if email and email.lower() == ue.email.lower():
                         jira_user = possible_user
                         break
             if jira_user is None:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -26,6 +26,7 @@ from sentry.models import (
     OrganizationIntegration,
     User,
 )
+from sentry.services.hybrid_cloud.user import APIUser
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiHostError,
@@ -876,7 +877,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
     def sync_assignee_outbound(
         self,
         external_issue: ExternalIssue,
-        user: Optional[User],
+        user: Optional[APIUser],
         assign: bool = True,
         **kwargs: Any,
     ) -> None:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -887,9 +887,9 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         client = self.get_client()
         jira_user = None
         if user and assign:
-            for ue in user.emails.all():
+            for ue in user.emails:
                 try:
-                    possible_users = client.search_users_for_issue(external_issue.key, ue.email)
+                    possible_users = client.search_users_for_issue(external_issue.key, ue)
                 except (ApiUnauthorized, ApiError):
                     continue
                 for possible_user in possible_users:
@@ -900,7 +900,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                         email = client.get_email(account_id)
                     # match on lowercase email
                     # TODO(steve): add check against display name when JIRA_USE_EMAIL_SCOPE is false
-                    if email and email.lower() == ue.email.lower():
+                    if email and email.lower() == ue.lower():
                         jira_user = possible_user
                         break
             if jira_user is None:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -888,7 +888,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         if user and assign:
             for ue in user.emails:
                 try:
-                    possible_users = client.search_users_for_issue(external_issue.key, ue.email)
+                    possible_users = client.search_users_for_issue(external_issue.key, ue)
                 except (ApiUnauthorized, ApiError):
                     continue
                 for possible_user in possible_users:
@@ -899,7 +899,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                         email = client.get_email(account_id)
                     # match on lowercase email
                     # TODO(steve): add check against display name when JIRA_USE_EMAIL_SCOPE is false
-                    if email and email.lower() == ue.email.lower():
+                    if email and email.lower() == ue.lower():
                         jira_user = possible_user
                         break
             if jira_user is None:

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -971,9 +971,9 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
 
         jira_user = None
         if user and assign:
-            for ue in user.emails.all():
+            for ue in user.emails:
                 try:
-                    possible_users = client.search_users_for_issue(external_issue.key, ue.email)
+                    possible_users = client.search_users_for_issue(external_issue.key, ue)
                 except (ApiUnauthorized, ApiError):
                     continue
                 for possible_user in possible_users:
@@ -984,7 +984,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                         email = client.get_email(account_id)
                     # match on lowercase email
                     # TODO(steve): add check against display name when JIRA_USE_EMAIL_SCOPE is false
-                    if email and email.lower() == ue.email.lower():
+                    if email and email.lower() == ue.lower():
                         jira_user = possible_user
                         break
             if jira_user is None:

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -971,9 +971,9 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
 
         jira_user = None
         if user and assign:
-            for ue in user.emails:
+            for ue in user.emails.all():
                 try:
-                    possible_users = client.search_users_for_issue(external_issue.key, ue)
+                    possible_users = client.search_users_for_issue(external_issue.key, ue.email)
                 except (ApiUnauthorized, ApiError):
                     continue
                 for possible_user in possible_users:
@@ -984,7 +984,7 @@ class JiraServerIntegration(IntegrationInstallation, IssueSyncMixin):
                         email = client.get_email(account_id)
                     # match on lowercase email
                     # TODO(steve): add check against display name when JIRA_USE_EMAIL_SCOPE is false
-                    if email and email.lower() == ue.lower():
+                    if email and email.lower() == ue.email.lower():
                         jira_user = possible_user
                         break
             if jira_user is None:

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import datetime
 from abc import abstractmethod
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, List, Optional, Sequence
 
 from sentry.db.models import BaseQuerySet
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
@@ -21,6 +21,7 @@ class APIUser:
     pk: int = -1
     name: str = ""
     email: str = ""
+    emails: Sequence[str] = field(default_factory=list)
     username: str = ""
     actor_id: int = -1
     display_name: str = ""
@@ -182,6 +183,9 @@ class UserService(InterfaceWithLifecycle):
         args["is_superuser"] = user.is_superuser
         args["is_sentry_app"] = user.is_sentry_app
         args["password_usable"] = user.has_usable_password()
+        args[
+            "emails"
+        ] = user.get_unverified_emails()  # should be verified, but can't verify my email locally
 
         # And process the _base_user_query special data additions
         permissions: FrozenSet[str] = frozenset({})

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -183,9 +183,7 @@ class UserService(InterfaceWithLifecycle):
         args["is_superuser"] = user.is_superuser
         args["is_sentry_app"] = user.is_sentry_app
         args["password_usable"] = user.has_usable_password()
-        args[
-            "emails"
-        ] = user.get_unverified_emails()  # should be verified, but can't verify my email locally
+        args["emails"] = user.get_verified_emails()
 
         # And process the _base_user_query special data additions
         permissions: FrozenSet[str] = frozenset({})

--- a/src/sentry/services/hybrid_cloud/user/__init__.py
+++ b/src/sentry/services/hybrid_cloud/user/__init__.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import datetime
 from abc import abstractmethod
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, List, Optional
 
 from sentry.db.models import BaseQuerySet
 from sentry.services.hybrid_cloud import InterfaceWithLifecycle, silo_mode_delegation, stubbed
@@ -21,7 +21,7 @@ class APIUser:
     pk: int = -1
     name: str = ""
     email: str = ""
-    emails: Sequence[str] = field(default_factory=list)
+    emails: FrozenSet[str] = frozenset()
     username: str = ""
     actor_id: int = -1
     display_name: str = ""
@@ -183,7 +183,7 @@ class UserService(InterfaceWithLifecycle):
         args["is_superuser"] = user.is_superuser
         args["is_sentry_app"] = user.is_sentry_app
         args["password_usable"] = user.has_usable_password()
-        args["emails"] = user.get_verified_emails()
+        args["emails"] = frozenset([email.email for email in user.get_verified_emails()])
 
         # And process the _base_user_query special data additions
         permissions: FrozenSet[str] = frozenset({})

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -24,6 +24,7 @@ from sentry.models import (
     ScheduledDeletion,
 )
 from sentry.signals import project_created
+from sentry.silo import SiloMode
 from sentry.testutils import APITestCase, TwoFactorAPITestCase, pytest
 from sentry.testutils.silo import exempt_from_silo_limits, region_silo_test
 from sentry.utils import json
@@ -137,7 +138,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             options.delete("store.symbolicate-event-lpq-never")
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 45
+        expected_queries = 44 if SiloMode.get_current_mode() == SiloMode.MONOLITH else 45
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -137,7 +137,7 @@ class OrganizationDetailsTest(OrganizationDetailsTestBase):
             options.delete("store.symbolicate-event-lpq-never")
 
         # TODO(dcramer): We need to pare this down. Lots of duplicate queries for membership data.
-        expected_queries = 44
+        expected_queries = 45
 
         with self.assertNumQueries(expected_queries, using="default"):
             response = self.get_success_response(self.organization.slug)


### PR DESCRIPTION
Adds an `emails` attribute to the `APIUser` dataclass and serializer, and updates the Jira `sync_assignee_outbound` to use `APIUser` correctly. This fixes an issue where syncing assignment from Sentry to Jira was broken.

### Context
I found that `user.emails` ([here](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/jira/integration.py#L890)) isn't a thing anymore since this function used to be passed a `User` object and since https://github.com/getsentry/sentry/pull/41109/files or so has been passed an `APIUser` object which has `email` (singular) and no `is_verified` attribute. This is important for integrations like Jira in case the user's Sentry email is different from their Jira email and we still want to sync things like assignment, they can add a secondary email in Sentry.

Another potential issue with syncing assignment is that the response from Jira for `possible_users` may contain an empty string for `emailAddress` if the user's Jira email visibility settings do not say "Anyone".  See [this Atlassian article](https://community.atlassian.com/t5/Jira-Software-questions/user-search-API-does-not-return-emailAddress-field/qaq-p/1314708) (scroll to the bottom). We globally set `JIRA_USE_EMAIL_SCOPE` to false so we don't hit the block below that grabs the email based on their Jira account ID, therefore we may never find a match in Jira. There is a TODO to match on the display name we could add if we wanted, but that makes me a little nervous that someone could exploit it by simply changing their name. While it's not a huge risk, I'm going to punt on it for now. 

Fixes [WOR-2446](https://getsentry.atlassian.net/browse/WOR-2446)