### PR TITLE
ref(feature-feedback): Add full url path to the capture event object

### DIFF
--- a/static/app/components/featureFeedback/feedbackModal.tsx
+++ b/static/app/components/featureFeedback/feedbackModal.tsx
@@ -88,6 +88,7 @@ export function FeedbackModal<T extends Data>({
   const {organization} = useLegacyStore(OrganizationStore);
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const location = useLocation();
+
   const theme = useTheme();
   const user = ConfigStore.get('user');
   const isSelfHosted = ConfigStore.get('isSelfHosted');
@@ -112,7 +113,7 @@ export function FeedbackModal<T extends Data>({
       const commonEventProps: Event = {
         message,
         request: {
-          url: location.pathname,
+          url: window.location.href, // gives the full url (origin + pathname)
         },
         extra: {
           orgFeatures: organization?.features ?? [],
@@ -150,7 +151,6 @@ export function FeedbackModal<T extends Data>({
       closeModal();
     },
     [
-      location.pathname,
       closeModal,
       organization?.features,
       organization?.access,


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/29228205/209106827-741e76cb-e476-4c0d-b22a-4440249fa7ca.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/209107051-ea5ef9b3-0332-497e-83a9-780d6bad1dd3.png)
