### PR TITLE
ref(source-maps-alert): Get the correct projectId for analytics

### DIFF
--- a/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.spec.tsx
@@ -114,7 +114,6 @@ describe('Exception Content', function () {
         event={event}
         values={event.entries[0].data.values}
         meta={event._meta.entries[0].data.values}
-        projectId={project.id}
       />,
       {organization, router, context: routerContext}
     );

--- a/static/app/components/events/interfaces/crashContent/exception/content.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/content.tsx
@@ -4,7 +4,7 @@ import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import Tooltip from 'sentry/components/tooltip';
 import {tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
-import {ExceptionType, Project} from 'sentry/types';
+import {ExceptionType} from 'sentry/types';
 import {Event} from 'sentry/types/event';
 import {STACK_TYPE} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
@@ -18,7 +18,6 @@ type StackTraceProps = React.ComponentProps<typeof StackTrace>;
 type Props = {
   event: Event;
   platform: StackTraceProps['platform'];
-  projectId: Project['id'];
   type: STACK_TYPE;
   meta?: Record<any, any>;
   newestFirst?: boolean;
@@ -39,7 +38,6 @@ export function Content({
   values,
   type,
   meta,
-  projectId,
 }: Props) {
   if (!values) {
     return null;
@@ -65,7 +63,7 @@ export function Content({
         {exc.mechanism && (
           <Mechanism data={exc.mechanism} meta={meta?.[excIdx]?.mechanism} />
         )}
-        <SetupSourceMapsAlert projectId={projectId} event={event} />
+        <SetupSourceMapsAlert event={event} />
         <StackTrace
           data={
             type === STACK_TYPE.ORIGINAL

--- a/static/app/components/events/interfaces/crashContent/exception/index.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/index.tsx
@@ -51,7 +51,6 @@ function Exception({
           hasHierarchicalGrouping={hasHierarchicalGrouping}
           groupingCurrentLevel={groupingCurrentLevel}
           meta={meta}
-          projectId={projectId}
         />
       )}
     </ErrorBoundary>

--- a/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.spec.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.spec.tsx
@@ -5,14 +5,23 @@ import {SetupSourceMapsAlert} from './setupSourceMapsAlert';
 
 describe('SetupSourceMapsAlert', function () {
   it('NOT show alert if javascript platform and source maps found', function () {
-    const {project, organization} = initializeOrg({
+    const {organization, router} = initializeOrg({
       ...initializeOrg(),
       organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+      router: {
+        ...initializeOrg().router,
+        location: {
+          ...initializeOrg().router.location,
+          query: {project: '1'},
+        },
+      },
     });
+
     const event = TestStubs.ExceptionWithRawStackTrace();
 
-    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+    render(<SetupSourceMapsAlert event={event} />, {
       organization,
+      router,
     });
 
     expect(
@@ -23,14 +32,23 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show alert if javascript platform and source maps not found', function () {
-    const {project, organization} = initializeOrg({
+    const {organization, router} = initializeOrg({
       ...initializeOrg(),
       organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+      router: {
+        ...initializeOrg().router,
+        location: {
+          ...initializeOrg().router.location,
+          query: {project: '1'},
+        },
+      },
     });
+
     const event = TestStubs.EventStacktraceException({platform: 'javascript'});
 
-    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+    render(<SetupSourceMapsAlert event={event} />, {
       organization,
+      router,
     });
 
     expect(
@@ -46,16 +64,25 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show documentation for react according to the sdk name', function () {
-    const {project, organization} = initializeOrg({
+    const {organization, router} = initializeOrg({
       ...initializeOrg(),
       organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+      router: {
+        ...initializeOrg().router,
+        location: {
+          ...initializeOrg().router.location,
+          query: {project: '1'},
+        },
+      },
     });
+
     const event = TestStubs.EventStacktraceException({
       sdk: {name: 'sentry.javascript.react'},
     });
 
-    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+    render(<SetupSourceMapsAlert event={event} />, {
       organization,
+      router,
     });
 
     expect(
@@ -71,17 +98,26 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show documentation for react according to the event platform', function () {
-    const {project, organization} = initializeOrg({
+    const {organization, router} = initializeOrg({
       ...initializeOrg(),
       organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+      router: {
+        ...initializeOrg().router,
+        location: {
+          ...initializeOrg().router.location,
+          query: {project: '1'},
+        },
+      },
     });
+
     const event = TestStubs.EventStacktraceException({
       platform: 'react',
       sdk: {name: 'sentry.javascript.browser'},
     });
 
-    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+    render(<SetupSourceMapsAlert event={event} />, {
       organization,
+      router,
     });
 
     expect(
@@ -97,16 +133,25 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show generic documentation if doc link not available', function () {
-    const {project, organization} = initializeOrg({
+    const {organization, router} = initializeOrg({
       ...initializeOrg(),
       organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+      router: {
+        ...initializeOrg().router,
+        location: {
+          ...initializeOrg().router.location,
+          query: {project: '1'},
+        },
+      },
     });
+
     const event = TestStubs.EventStacktraceException({
       platform: 'unity',
     });
 
-    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+    render(<SetupSourceMapsAlert event={event} />, {
       organization,
+      router,
     });
 
     expect(
@@ -122,9 +167,16 @@ describe('SetupSourceMapsAlert', function () {
   });
 
   it('show localhost copy', function () {
-    const {project, organization} = initializeOrg({
+    const {organization, router} = initializeOrg({
       ...initializeOrg(),
       organization: {...initializeOrg().organization, features: ['source-maps-cta']},
+      router: {
+        ...initializeOrg().router,
+        location: {
+          ...initializeOrg().router.location,
+          query: {project: '1'},
+        },
+      },
     });
     const event = TestStubs.EventStacktraceException({
       platform: 'unity',
@@ -136,8 +188,9 @@ describe('SetupSourceMapsAlert', function () {
       ],
     });
 
-    render(<SetupSourceMapsAlert projectId={project.id} event={event} />, {
+    render(<SetupSourceMapsAlert event={event} />, {
       organization,
+      router,
     });
 
     expect(

--- a/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/setupSourceMapsAlert.tsx
@@ -3,10 +3,12 @@ import Button from 'sentry/components/button';
 import {isEventFromBrowserJavaScriptSDK} from 'sentry/components/events/interfaces/spans/utils';
 import {PlatformKey, sourceMaps} from 'sentry/data/platformCategories';
 import {t} from 'sentry/locale';
-import {EntryType, Event, EventTransaction, Project} from 'sentry/types';
+import {EntryType, Event, EventTransaction} from 'sentry/types';
+import {defined} from 'sentry/utils';
 import trackAdvancedAnalyticsEvent from 'sentry/utils/analytics/trackAdvancedAnalyticsEvent';
 import {eventHasSourceMaps} from 'sentry/utils/events';
 import useOrganization from 'sentry/utils/useOrganization';
+import useRouter from 'sentry/utils/useRouter';
 
 // This list must always be updated with the documentation.
 // Ideally it would be nice if we could send a request validating that this URL exists,
@@ -42,13 +44,19 @@ function isLocalhost(url?: string) {
 
 type Props = {
   event: Event;
-  projectId: Project['id'];
 };
 
-export function SetupSourceMapsAlert({projectId, event}: Props) {
+export function SetupSourceMapsAlert({event}: Props) {
   const organization = useOrganization();
+  const router = useRouter();
 
   if (!organization.features?.includes('source-maps-cta')) {
+    return null;
+  }
+
+  const projectId = router.location.query.project;
+
+  if (!defined(projectId)) {
     return null;
   }
 


### PR DESCRIPTION
The `projectId` passed to the analytics code was actually a project's slug 

https://github.com/getsentry/sentry/blob/dc9ab5ed6b4bcf8add67de2416f74a48360de440/static/app/components/events/eventEntry.tsx#L125

This PR gets this info from the url parameter

