### PR TITLE
feat(onboarding): Add feature flag for the new footer - [TET-610]

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1190,6 +1190,8 @@ SENTRY_FEATURES = {
     "organizations:dynamic-sampling": False,
     # Enable View Hierarchies in issue details page
     "organizations:mobile-view-hierarchies": False,
+    # Enable the onboarding heartbeat footer on the sdk setup page
+    "organizations:onboarding-heartbeat-footer": False,
     # Enable ANR rates in project details page
     "organizations:anr-rate": False,
     # Enable deobfuscating exception values in Java issues

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -198,6 +198,7 @@ default_manager.add("organizations:integrations-issue-basic", OrganizationFeatur
 default_manager.add("organizations:integrations-issue-sync", OrganizationFeature)
 default_manager.add("organizations:integrations-stacktrace-link", OrganizationFeature)
 default_manager.add("organizations:integrations-ticket-rules", OrganizationFeature)
+default_manager.add("organizations:onboarding-heartbeat-footer", OrganizationFeature, True)
 default_manager.add("organizations:performance-view", OrganizationFeature)
 default_manager.add("organizations:relay", OrganizationFeature)
 default_manager.add("organizations:sso-basic", OrganizationFeature)


### PR DESCRIPTION
Add the new feature flag `organizations:onboarding-heartbeat-footer` that will be controlled by flagr. When enabled, if the new project chosen during onboarding is of type javascript, the new heartbeat footer will be displayed