### PR TITLE
ref(profiling): generalize view component

### DIFF
--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 
 import space from 'sentry/styles/space';
+import {FlamegraphView} from 'sentry/utils/profiling/canvasView';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 import theme from 'sentry/utils/theme';
 

--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -3,7 +3,8 @@ import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 
 import space from 'sentry/styles/space';
-import {FlamegraphView} from 'sentry/utils/profiling/canvasView';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
@@ -33,7 +34,7 @@ interface BoundTooltipProps {
   bounds: Rect;
   cursor: vec2;
   flamegraphCanvas: FlamegraphCanvas;
-  flamegraphView: FlamegraphView;
+  flamegraphView: CanvasView<Flamegraph>;
   children?: React.ReactNode;
 }
 

--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -4,7 +4,6 @@ import {vec2} from 'gl-matrix';
 
 import space from 'sentry/styles/space';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
-import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
@@ -32,17 +31,17 @@ function computeBestTooltipPlacement(
 
 interface BoundTooltipProps {
   bounds: Rect;
+  canvas: FlamegraphCanvas;
+  canvasView: CanvasView<any>;
   cursor: vec2;
-  flamegraphCanvas: FlamegraphCanvas;
-  flamegraphView: CanvasView<Flamegraph>;
   children?: React.ReactNode;
 }
 
 function BoundTooltip({
   bounds,
-  flamegraphCanvas,
+  canvas,
   cursor,
-  flamegraphView,
+  canvasView,
   children,
 }: BoundTooltipProps): React.ReactElement | null {
   const flamegraphTheme = useFlamegraphTheme();
@@ -50,13 +49,13 @@ function BoundTooltip({
   const physicalSpaceCursor = vec2.transformMat3(
     vec2.create(),
     cursor,
-    flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
+    canvasView.fromConfigView(canvas.physicalSpace)
   );
 
   const logicalSpaceCursor = vec2.transformMat3(
     vec2.create(),
     physicalSpaceCursor,
-    flamegraphCanvas.physicalToLogicalSpace
+    canvas.physicalToLogicalSpace
   );
 
   const rafIdRef = useRef<number | undefined>();

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -78,6 +78,7 @@ interface FlamegraphProps {
 
 function Flamegraph(props: FlamegraphProps): ReactElement {
   const [canvasBounds, setCanvasBounds] = useState<Rect>(Rect.Empty());
+  const [spansCanvasBounds, setSpansCanvasBounds] = useState<Rect>(Rect.Empty());
   const devicePixelRatio = useDevicePixelRatio();
   const dispatch = useDispatchFlamegraphState();
 
@@ -167,7 +168,6 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
       const newView = new CanvasView({
         canvas: flamegraphCanvas,
-        configSpace: flamegraph.configSpace,
         model: flamegraph,
         options: {
           inverted: flamegraph.inverted,
@@ -263,6 +263,28 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
     [flamegraph, flamegraphCanvas, flamegraphTheme, zoomIntoFrame]
   );
 
+  const spansView = useMemoWithPrevious<CanvasView<SpanChart> | null>(
+    _previousView => {
+      if (!spansCanvas || !spanChart) {
+        return null;
+      }
+
+      const newView = new CanvasView({
+        canvas: spansCanvas,
+        model: spanChart,
+        options: {
+          inverted: false,
+          minWidth: spanChart.minSpanDuration,
+          barHeight: flamegraphTheme.SIZES.SPANS_BAR_HEIGHT,
+          depthOffset: flamegraphTheme.SIZES.SPANS_DEPTH_OFFSET,
+        },
+      });
+
+      return newView;
+    },
+    [spanChart, spansCanvas, flamegraphTheme.SIZES]
+  );
+
   useEffect(() => {
     if (!flamegraphCanvas || !flamegraphView) {
       return undefined;
@@ -270,16 +292,25 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
     const onConfigViewChange = (rect: Rect) => {
       flamegraphView.setConfigView(rect);
+      if (spansView) {
+        spansView.setConfigView(rect);
+      }
       canvasPoolManager.draw();
     };
 
     const onTransformConfigView = (mat: mat3) => {
       flamegraphView.transformConfigView(mat);
+      if (spansView) {
+        spansView.transformConfigView(mat);
+      }
       canvasPoolManager.draw();
     };
 
     const onResetZoom = () => {
       flamegraphView.resetConfigView(flamegraphCanvas);
+      if (spansView && spansCanvas) {
+        spansView.resetConfigView(spansCanvas);
+      }
       canvasPoolManager.draw();
     };
 
@@ -291,6 +322,9 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
       );
 
       flamegraphView.setConfigView(newConfigView);
+      if (spansView) {
+        spansView.setConfigView(newConfigView);
+      }
       canvasPoolManager.draw();
     };
 
@@ -305,7 +339,14 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
       scheduler.off('reset zoom', onResetZoom);
       scheduler.off('zoom at frame', onZoomIntoFrame);
     };
-  }, [canvasPoolManager, flamegraphCanvas, flamegraphView, scheduler]);
+  }, [
+    canvasPoolManager,
+    flamegraphCanvas,
+    flamegraphView,
+    scheduler,
+    spansCanvas,
+    spansView,
+  ]);
 
   useEffect(() => {
     canvasPoolManager.registerScheduler(scheduler);
@@ -343,7 +384,12 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
     const flamegraphMiniMapObserver = watchForResize(
       [flamegraphMiniMapCanvasRef, flamegraphMiniMapOverlayCanvasRef],
-      () => {
+      entries => {
+        const contentRect =
+          entries[0].contentRect ?? flamegraphCanvasRef.getBoundingClientRect();
+        setCanvasBounds(
+          new Rect(contentRect.x, contentRect.y, contentRect.width, contentRect.height)
+        );
         flamegraphMiniMapCanvas.initPhysicalSpace();
 
         canvasPoolManager.drawSync();
@@ -352,7 +398,18 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
     const spansCanvasObserver =
       spansCanvasRef && spansCanvas
-        ? watchForResize([spansCanvasRef], () => {
+        ? watchForResize([spansCanvasRef], entries => {
+            const contentRect =
+              entries[0].contentRect ?? spansCanvasRef.getBoundingClientRect();
+
+            setSpansCanvasBounds(
+              new Rect(
+                contentRect.x,
+                contentRect.y,
+                contentRect.width,
+                contentRect.height
+              )
+            );
             spansCanvas.initPhysicalSpace();
             canvasPoolManager.drawSync();
           })
@@ -445,12 +502,13 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
         spans={
           spanChart ? (
             <FlamegraphSpans
+              canvasBounds={spansCanvasBounds}
               spanChart={spanChart}
               spansCanvas={spansCanvas}
               spansCanvasRef={spansCanvasRef}
               setSpansCanvasRef={setSpansCanvasRef}
               canvasPoolManager={canvasPoolManager}
-              flamegraphView={flamegraphView}
+              spansView={spansView}
             />
           ) : null
         }

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -167,12 +167,13 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
       const newView = new CanvasView({
         canvas: flamegraphCanvas,
-        theme: flamegraphTheme,
         configSpace: flamegraph.configSpace,
         model: flamegraph,
         options: {
           inverted: flamegraph.inverted,
           minWidth: flamegraph.profile.minFrameDuration,
+          barHeight: flamegraphTheme.SIZES.BAR_HEIGHT,
+          depthOffset: flamegraphTheme.SIZES.FLAMEGRAPH_DEPTH_OFFSET,
         },
       });
 

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -3,14 +3,14 @@ import styled from '@emotion/styled';
 
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {SpanChartRenderer2D} from 'sentry/utils/profiling/renderers/spansRenderer';
 import {SpanChart} from 'sentry/utils/profiling/spanChart';
-import {SpanTree} from 'sentry/utils/profiling/spanTree';
 
 interface FlamegraphSpansProps {
   canvasPoolManager: CanvasPoolManager;
-  flamegraphView: CanvasView<SpanTree> | null;
+  flamegraphView: CanvasView<Flamegraph> | null;
   setSpansCanvasRef: React.Dispatch<React.SetStateAction<HTMLCanvasElement | null>>;
   spanChart: SpanChart;
   spansCanvas: FlamegraphCanvas | null;

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -2,14 +2,15 @@ import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {SpanChartRenderer2D} from 'sentry/utils/profiling/renderers/spansRenderer';
 import {SpanChart} from 'sentry/utils/profiling/spanChart';
+import {SpanTree} from 'sentry/utils/profiling/spanTree';
 
 interface FlamegraphSpansProps {
   canvasPoolManager: CanvasPoolManager;
-  flamegraphView: FlamegraphView | null;
+  flamegraphView: CanvasView<SpanTree> | null;
   setSpansCanvasRef: React.Dispatch<React.SetStateAction<HTMLCanvasElement | null>>;
   spanChart: SpanChart;
   spansCanvas: FlamegraphCanvas | null;

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -1,39 +1,86 @@
-import {useEffect, useMemo} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import {mat3, vec2} from 'gl-matrix';
 
+import {BoundTooltip} from 'sentry/components/profiling/boundTooltip';
+import {t} from 'sentry/locale';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
-import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
+import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
+import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {formatColorForSpan, Rect} from 'sentry/utils/profiling/gl/utils';
 import {SpanChartRenderer2D} from 'sentry/utils/profiling/renderers/spansRenderer';
-import {SpanChart} from 'sentry/utils/profiling/spanChart';
+import {SpanChart, SpanChartNode} from 'sentry/utils/profiling/spanChart';
+import usePrevious from 'sentry/utils/usePrevious';
+
+import {
+  FlamegraphTooltipColorIndicator,
+  FlamegraphTooltipFrameMainInfo,
+  FlamegraphTooltipTimelineInfo,
+} from './flamegraphTooltip';
 
 interface FlamegraphSpansProps {
+  canvasBounds: Rect;
   canvasPoolManager: CanvasPoolManager;
-  flamegraphView: CanvasView<Flamegraph> | null;
   setSpansCanvasRef: React.Dispatch<React.SetStateAction<HTMLCanvasElement | null>>;
   spanChart: SpanChart;
   spansCanvas: FlamegraphCanvas | null;
   spansCanvasRef: HTMLCanvasElement | null;
+  spansView: CanvasView<SpanChart> | null;
 }
 
 export function FlamegraphSpans({
   spanChart,
   canvasPoolManager,
-  flamegraphView,
+  canvasBounds,
+  spansView,
   spansCanvas,
   spansCanvasRef,
   setSpansCanvasRef,
 }: FlamegraphSpansProps) {
+  const dispatch = useDispatchFlamegraphState();
+  const flamegraphTheme = useFlamegraphTheme();
   const scheduler = useMemo(() => new CanvasScheduler(), []);
+
+  const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
+  const [startPanVector, setStartPanVector] = useState<vec2 | null>(null);
+  const [lastInteraction, setLastInteraction] = useState<
+    'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null
+  >(null);
+
+  const previousInteraction = usePrevious(lastInteraction);
+  const beforeInteractionConfigView = useRef<Rect | null>(null);
 
   const spansRenderer = useMemo(() => {
     if (!spansCanvasRef) {
       return null;
     }
 
-    return new SpanChartRenderer2D(spansCanvasRef, spanChart);
-  }, [spansCanvasRef, spanChart]);
+    return new SpanChartRenderer2D(spansCanvasRef, spanChart, flamegraphTheme);
+  }, [spansCanvasRef, spanChart, flamegraphTheme]);
+
+  useEffect(() => {
+    if (!spansView) {
+      return;
+    }
+
+    // Check if we are starting a new interaction
+    if (previousInteraction === null && lastInteraction) {
+      beforeInteractionConfigView.current = spansView.configView.clone();
+      return;
+    }
+
+    if (
+      beforeInteractionConfigView.current &&
+      !beforeInteractionConfigView.current.equals(spansView.configView)
+    ) {
+      dispatch({
+        type: 'checkpoint',
+        payload: spansView.configView.clone(),
+      });
+    }
+  }, [lastInteraction, spansView, dispatch, previousInteraction]);
 
   useEffect(() => {
     canvasPoolManager.registerScheduler(scheduler);
@@ -41,12 +88,12 @@ export function FlamegraphSpans({
   }, [canvasPoolManager, scheduler]);
 
   useEffect(() => {
-    if (!spansCanvas || !flamegraphView || !spansRenderer) {
+    if (!spansCanvas || !spansView || !spansRenderer) {
       return undefined;
     }
 
     const drawSpans = () => {
-      spansRenderer.draw(flamegraphView.fromConfigView(spansCanvas.physicalSpace));
+      spansRenderer.draw(spansView.fromConfigView(spansCanvas.physicalSpace));
     };
 
     drawSpans();
@@ -56,9 +103,234 @@ export function FlamegraphSpans({
     return () => {
       scheduler.unregisterBeforeFrameCallback(drawSpans);
     };
-  }, [spansCanvas, spansRenderer, scheduler, flamegraphView]);
+  }, [spansCanvas, spansRenderer, scheduler, spansView]);
 
-  return <Canvas ref={ref => setSpansCanvasRef(ref)} />;
+  const hoveredNode: SpanChartNode | null = useMemo(() => {
+    if (!configSpaceCursor || !spansRenderer) {
+      return null;
+    }
+    return spansRenderer.findHoveredNode(configSpaceCursor);
+  }, [configSpaceCursor, spansRenderer]);
+
+  const onMouseDrag = useCallback(
+    (evt: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!spansCanvas || !spansView || !startPanVector) {
+        return;
+      }
+
+      const logicalMousePos = vec2.fromValues(
+        evt.nativeEvent.offsetX,
+        evt.nativeEvent.offsetY
+      );
+
+      const physicalMousePos = vec2.scale(
+        vec2.create(),
+        logicalMousePos,
+        window.devicePixelRatio
+      );
+
+      const physicalDelta = vec2.subtract(
+        vec2.create(),
+        startPanVector,
+        physicalMousePos
+      );
+
+      if (physicalDelta[0] === 0 && physicalDelta[1] === 0) {
+        return;
+      }
+
+      const physicalToConfig = mat3.invert(
+        mat3.create(),
+        spansView.fromConfigView(spansCanvas.physicalSpace)
+      );
+      const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
+
+      const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
+        m00,
+        m01,
+        m02,
+        m10,
+        m11,
+        m12,
+        0,
+        0,
+        0,
+      ]);
+
+      canvasPoolManager.dispatch('transform config view', [
+        mat3.fromTranslation(mat3.create(), configDelta),
+      ]);
+
+      setStartPanVector(physicalMousePos);
+    },
+    [spansCanvas, spansView, startPanVector, canvasPoolManager]
+  );
+
+  const onCanvasMouseMove = useCallback(
+    (evt: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!spansCanvas || !spansView) {
+        return;
+      }
+
+      const configSpaceMouse = spansView.getConfigViewCursor(
+        vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY),
+        spansCanvas
+      );
+
+      setConfigSpaceCursor(configSpaceMouse);
+
+      if (startPanVector) {
+        onMouseDrag(evt);
+        setLastInteraction('pan');
+      } else {
+        setLastInteraction(null);
+      }
+    },
+    [spansCanvas, spansView, onMouseDrag, startPanVector]
+  );
+
+  const onMinimapCanvasMouseUp = useCallback(() => {
+    setConfigSpaceCursor(null);
+    setLastInteraction(null);
+  }, []);
+
+  const onMinimapZoom = useCallback(
+    (evt: WheelEvent) => {
+      if (!spansCanvas || !spansView) {
+        return;
+      }
+
+      const identity = mat3.identity(mat3.create());
+      const scale = 1 - evt.deltaY * 0.001 * -1; // -1 to invert scale
+
+      const mouseInConfigSpace = spansView.getConfigSpaceCursor(
+        vec2.fromValues(evt.offsetX, evt.offsetY),
+        spansCanvas
+      );
+
+      const configCenter = vec2.fromValues(mouseInConfigSpace[0], spansView.configView.y);
+
+      const invertedConfigCenter = vec2.multiply(
+        vec2.create(),
+        vec2.fromValues(-1, -1),
+        configCenter
+      );
+
+      const translated = mat3.translate(mat3.create(), identity, configCenter);
+      const scaled = mat3.scale(mat3.create(), translated, vec2.fromValues(scale, 1));
+      const translatedBack = mat3.translate(mat3.create(), scaled, invertedConfigCenter);
+
+      canvasPoolManager.dispatch('transform config view', [translatedBack]);
+    },
+    [spansCanvas, spansView, canvasPoolManager]
+  );
+
+  const onMinimapScroll = useCallback(
+    (evt: WheelEvent) => {
+      if (!spansCanvas || !spansView) {
+        return;
+      }
+
+      {
+        const physicalDelta = vec2.fromValues(evt.deltaX * 0.8, evt.deltaY);
+        const physicalToConfig = mat3.invert(
+          mat3.create(),
+          spansView.fromConfigView(spansCanvas.physicalSpace)
+        );
+        const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
+
+        const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
+          m00,
+          m01,
+          m02,
+          m10,
+          m11,
+          m12,
+          0,
+          0,
+          0,
+        ]);
+
+        const translate = mat3.fromTranslation(mat3.create(), configDelta);
+        canvasPoolManager.dispatch('transform config view', [translate]);
+      }
+    },
+    [spansCanvas, spansView, canvasPoolManager]
+  );
+
+  useEffect(() => {
+    if (!spansCanvasRef) {
+      return undefined;
+    }
+
+    let wheelStopTimeoutId: number | undefined;
+    function onCanvasWheel(evt: WheelEvent) {
+      window.clearTimeout(wheelStopTimeoutId);
+      wheelStopTimeoutId = window.setTimeout(() => {
+        setLastInteraction(null);
+      }, 300);
+
+      evt.preventDefault();
+
+      // When we zoom, we want to clear cursor so that any tooltips
+      // rendered on the flamegraph are removed from the view
+      setConfigSpaceCursor(null);
+
+      if (evt.metaKey || evt.ctrlKey) {
+        onMinimapZoom(evt);
+        setLastInteraction('zoom');
+      } else {
+        onMinimapScroll(evt);
+        setLastInteraction('scroll');
+      }
+    }
+
+    spansCanvasRef.addEventListener('wheel', onCanvasWheel);
+
+    return () => {
+      window.clearTimeout(wheelStopTimeoutId);
+      spansCanvasRef.removeEventListener('wheel', onCanvasWheel);
+    };
+  }, [spansCanvasRef, onMinimapZoom, onMinimapScroll]);
+
+  useEffect(() => {
+    window.addEventListener('mouseup', onMinimapCanvasMouseUp);
+
+    return () => {
+      window.removeEventListener('mouseup', onMinimapCanvasMouseUp);
+    };
+  }, [onMinimapCanvasMouseUp]);
+
+  return (
+    <Fragment>
+      <Canvas onMouseMove={onCanvasMouseMove} ref={ref => setSpansCanvasRef(ref)} />
+      {hoveredNode && spansRenderer && configSpaceCursor && spansCanvas && spansView ? (
+        <BoundTooltip
+          bounds={canvasBounds}
+          cursor={configSpaceCursor}
+          canvas={spansCanvas}
+          canvasView={spansView}
+        >
+          <FlamegraphTooltipFrameMainInfo>
+            <FlamegraphTooltipColorIndicator
+              backgroundColor={formatColorForSpan(hoveredNode, spansRenderer)}
+            />
+            {hoveredNode.node.span.description}
+          </FlamegraphTooltipFrameMainInfo>
+          <FlamegraphTooltipTimelineInfo>
+            {hoveredNode.node.span.op ? `${t('op')}:${hoveredNode.node.span.op} ` : null}
+            {hoveredNode.node.span.status
+              ? `${t('status')}:${hoveredNode.node.span.status}`
+              : null}
+          </FlamegraphTooltipTimelineInfo>
+          <FlamegraphTooltipTimelineInfo>
+            {spansRenderer.spanChart.timelineFormatter(hoveredNode.start)} {' \u2014 '}
+            {spansRenderer.spanChart.timelineFormatter(hoveredNode.end)}
+          </FlamegraphTooltipTimelineInfo>
+        </BoundTooltip>
+      ) : null}
+    </Fragment>
+  );
 }
 
 const Canvas = styled('canvas')`

--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 
+import {BoundTooltip} from 'sentry/components/profiling/boundTooltip';
 import {IconLightning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -13,8 +14,6 @@ import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {formatColorForFrame, Rect} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
-
-import {BoundTooltip} from '../boundTooltip';
 
 export function formatWeightToProfileDuration(
   frame: CallTreeNode,
@@ -51,42 +50,40 @@ export function FlamegraphTooltip(props: FlamegraphTooltipProps) {
     <BoundTooltip
       bounds={props.canvasBounds}
       cursor={props.configSpaceCursor}
-      flamegraphCanvas={props.flamegraphCanvas}
-      flamegraphView={props.flamegraphView}
+      canvas={props.flamegraphCanvas}
+      canvasView={props.flamegraphView}
     >
-      <Fragment>
-        <FlamegraphTooltipFrameMainInfo>
-          <FlamegraphTooltipColorIndicator
-            backgroundColor={formatColorForFrame(props.frame, props.flamegraphRenderer)}
-          />
-          {props.flamegraphRenderer.flamegraph.formatter(props.frame.node.totalWeight)}{' '}
-          {formatWeightToProfileDuration(
-            props.frame.node,
-            props.flamegraphRenderer.flamegraph
-          )}{' '}
-          {props.frame.frame.name}
-        </FlamegraphTooltipFrameMainInfo>
-        <FlamegraphTooltipTimelineInfo>
-          {defined(props.frame.frame.file) && (
-            <Fragment>
-              {t('source')}:{formatFileNameAndLineColumn(props.frame)}
-            </Fragment>
-          )}
-        </FlamegraphTooltipTimelineInfo>
-        <FlamegraphTooltipTimelineInfo>
-          {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.start)}{' '}
-          {' \u2014 '}
-          {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.end)}
-          {props.frame.frame.inline ? (
-            <FlamegraphInlineIndicator>
-              <IconLightning width={10} />
-              {t('inline frame')}
-            </FlamegraphInlineIndicator>
-          ) : (
-            ''
-          )}
-        </FlamegraphTooltipTimelineInfo>
-      </Fragment>
+      <FlamegraphTooltipFrameMainInfo>
+        <FlamegraphTooltipColorIndicator
+          backgroundColor={formatColorForFrame(props.frame, props.flamegraphRenderer)}
+        />
+        {props.flamegraphRenderer.flamegraph.formatter(props.frame.node.totalWeight)}{' '}
+        {formatWeightToProfileDuration(
+          props.frame.node,
+          props.flamegraphRenderer.flamegraph
+        )}{' '}
+        {props.frame.frame.name}
+      </FlamegraphTooltipFrameMainInfo>
+      <FlamegraphTooltipTimelineInfo>
+        {defined(props.frame.frame.file) && (
+          <Fragment>
+            {t('source')}:{formatFileNameAndLineColumn(props.frame)}
+          </Fragment>
+        )}
+      </FlamegraphTooltipTimelineInfo>
+      <FlamegraphTooltipTimelineInfo>
+        {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.start)}{' '}
+        {' \u2014 '}
+        {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.end)}
+        {props.frame.frame.inline ? (
+          <FlamegraphInlineIndicator>
+            <IconLightning width={10} />
+            {t('inline frame')}
+          </FlamegraphInlineIndicator>
+        ) : (
+          ''
+        )}
+      </FlamegraphTooltipTimelineInfo>
     </BoundTooltip>
   );
 }

--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -7,10 +7,10 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
+import {FlamegraphView} from 'sentry/utils/profiling/canvasView';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
-import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {formatColorForFrame, Rect} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 

--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -7,7 +7,7 @@ import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {defined} from 'sentry/utils';
 import {CallTreeNode} from 'sentry/utils/profiling/callTreeNode';
-import {FlamegraphView} from 'sentry/utils/profiling/canvasView';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
@@ -41,7 +41,7 @@ export interface FlamegraphTooltipProps {
   configSpaceCursor: vec2;
   flamegraphCanvas: FlamegraphCanvas;
   flamegraphRenderer: FlamegraphRenderer;
-  flamegraphView: FlamegraphView;
+  flamegraphView: CanvasView<Flamegraph>;
   frame: FlamegraphFrame;
   platform: 'javascript' | 'python' | 'ios' | 'android' | string | undefined;
 }

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -7,6 +7,7 @@ import {FlamegraphContextMenu} from 'sentry/components/profiling/flamegraph/flam
 import {FlamegraphTooltip} from 'sentry/components/profiling/flamegraph/flamegraphTooltip';
 import {t} from 'sentry/locale';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {DifferentialFlamegraph} from 'sentry/utils/profiling/differentialFlamegraph';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphSearch} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphSearch';
@@ -21,7 +22,6 @@ import {
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
-import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 import {useContextMenu} from 'sentry/utils/profiling/hooks/useContextMenu';
 import {useInternalFlamegraphDebugMode} from 'sentry/utils/profiling/hooks/useInternalFlamegraphDebugMode';
@@ -53,7 +53,7 @@ interface FlamegraphZoomViewProps {
   flamegraphCanvasRef: HTMLCanvasElement | null;
   flamegraphOverlayCanvasRef: HTMLCanvasElement | null;
   flamegraphRenderer: FlamegraphRenderer | null;
-  flamegraphView: FlamegraphView | null;
+  flamegraphView: CanvasView<Flamegraph> | null;
   setFlamegraphCanvasRef: React.Dispatch<React.SetStateAction<HTMLCanvasElement | null>>;
   setFlamegraphOverlayCanvasRef: React.Dispatch<
     React.SetStateAction<HTMLCanvasElement | null>

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -46,7 +46,6 @@ function FlamegraphZoomViewMinimap({
   const dispatch = useDispatchFlamegraphState();
 
   const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
-
   const scheduler = useMemo(() => new CanvasScheduler(), []);
 
   const miniMapConfigSpaceBorderSize = useMemo(() => {
@@ -64,17 +63,11 @@ function FlamegraphZoomViewMinimap({
       return null;
     }
 
-    const BAR_HEIGHT =
-      flamegraphTheme.SIZES.MINIMAP_HEIGHT /
-      (flamegraph.depth + flamegraphTheme.SIZES.FLAMEGRAPH_DEPTH_OFFSET);
-
-    return new FlamegraphRenderer(flamegraphMiniMapCanvasRef, flamegraph, {
-      ...flamegraphTheme,
-      SIZES: {
-        ...flamegraphTheme.SIZES,
-        BAR_HEIGHT,
-      },
-    });
+    return new FlamegraphRenderer(
+      flamegraphMiniMapCanvasRef,
+      flamegraph,
+      flamegraphTheme
+    );
   }, [flamegraph, flamegraphMiniMapCanvasRef, flamegraphTheme]);
 
   const positionIndicatorRenderer: PositionIndicatorRenderer | null = useMemo(() => {

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -3,11 +3,11 @@ import styled from '@emotion/styled';
 import {mat3, vec2} from 'gl-matrix';
 
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 import {PositionIndicatorRenderer} from 'sentry/utils/profiling/renderers/positionIndicatorRenderer';
@@ -19,7 +19,7 @@ interface FlamegraphZoomViewMinimapProps {
   flamegraphMiniMapCanvas: FlamegraphCanvas | null;
   flamegraphMiniMapCanvasRef: HTMLCanvasElement | null;
   flamegraphMiniMapOverlayCanvasRef: HTMLCanvasElement | null;
-  flamegraphMiniMapView: FlamegraphView | null;
+  flamegraphMiniMapView: CanvasView<Flamegraph> | null;
   setFlamegraphMiniMapCanvasRef: React.Dispatch<
     React.SetStateAction<HTMLCanvasElement | null>
   >;

--- a/static/app/utils/profiling/canvasView.spec.tsx
+++ b/static/app/utils/profiling/canvasView.spec.tsx
@@ -6,10 +6,10 @@ import {
   makeFlamegraph,
 } from 'sentry-test/profiling/utils';
 
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {LightFlamegraphTheme as theme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 
 const makeCanvasAndView = (
@@ -18,16 +18,21 @@ const makeCanvasAndView = (
   origin: vec2 = vec2.fromValues(0, 0)
 ) => {
   const flamegraphCanvas = new FlamegraphCanvas(canvas, origin);
-  const flamegraphView = new FlamegraphView({
+  const canvasView = new CanvasView<Flamegraph>({
     canvas: flamegraphCanvas,
-    flamegraph,
+    model: flamegraph,
     theme,
+    configSpace: flamegraph.configSpace,
+    options: {
+      inverted: flamegraph.inverted,
+      minWidth: flamegraph.profile.minFrameDuration,
+    },
   });
 
-  return {flamegraphCanvas, flamegraphView};
+  return {flamegraphCanvas, view: canvasView};
 };
 
-describe('flamegraphView', () => {
+describe('CanvasView', () => {
   beforeEach(() => {
     // We simulate regular screens unless differently specified
     window.devicePixelRatio = 1;
@@ -37,50 +42,50 @@ describe('flamegraphView', () => {
     it('initializes config space', () => {
       const canvas = makeCanvasMock();
       const flamegraph = makeFlamegraph();
-      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
-      expect(flamegraphView.configSpace).toEqual(new Rect(0, 0, 10, 50));
+      const {view} = makeCanvasAndView(canvas, flamegraph);
+      expect(view.configSpace).toEqual(new Rect(0, 0, 10, 50));
     });
 
     it('initializes config view', () => {
       const canvas = makeCanvasMock();
       const flamegraph = makeFlamegraph();
-      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
-      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 50));
+      const {view} = makeCanvasAndView(canvas, flamegraph);
+      expect(view.configView).toEqual(new Rect(0, 0, 10, 50));
     });
 
     it('initializes config view with insufficient height', () => {
       const canvas = makeCanvasMock({height: 100});
       const flamegraph = makeFlamegraph();
-      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
+      const {view} = makeCanvasAndView(canvas, flamegraph);
       // 20 pixels tall each, and canvas is 100 pixels tall
-      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 5));
+      expect(view.configView).toEqual(new Rect(0, 0, 10, 5));
     });
 
     it('resizes config space and config view', () => {
       const canvas = makeCanvasMock({width: 200, height: 200});
       const flamegraph = makeFlamegraph();
-      const {flamegraphCanvas, flamegraphView} = makeCanvasAndView(canvas, flamegraph);
+      const {flamegraphCanvas, view} = makeCanvasAndView(canvas, flamegraph);
 
-      expect(flamegraphView.configSpace).toEqual(new Rect(0, 0, 10, 13));
-      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 10));
+      expect(view.configSpace).toEqual(new Rect(0, 0, 10, 12));
+      expect(view.configView).toEqual(new Rect(0, 0, 10, 10));
 
       // make it smaller
       canvas.width = 100;
       canvas.height = 100;
       flamegraphCanvas.initPhysicalSpace();
-      flamegraphView.resizeConfigSpace(flamegraphCanvas);
+      view.resizeConfigSpace(flamegraphCanvas);
 
-      expect(flamegraphView.configSpace).toEqual(new Rect(0, 0, 10, 13));
-      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 5));
+      expect(view.configSpace).toEqual(new Rect(0, 0, 10, 12));
+      expect(view.configView).toEqual(new Rect(0, 0, 10, 5));
 
       // make it bigger
       canvas.width = 1000;
       canvas.height = 1000;
       flamegraphCanvas.initPhysicalSpace();
-      flamegraphView.resizeConfigSpace(flamegraphCanvas);
+      view.resizeConfigSpace(flamegraphCanvas);
 
-      expect(flamegraphView.configSpace).toEqual(new Rect(0, 0, 10, 50));
-      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 10, 50));
+      expect(view.configSpace).toEqual(new Rect(0, 0, 10, 50));
+      expect(view.configView).toEqual(new Rect(0, 0, 10, 50));
     });
   });
 
@@ -95,11 +100,11 @@ describe('flamegraphView', () => {
 
       const flamegraph = makeFlamegraph({startValue: 0, endValue: 100});
 
-      const {flamegraphCanvas, flamegraphView} = makeCanvasAndView(canvas, flamegraph);
+      const {flamegraphCanvas, view} = makeCanvasAndView(canvas, flamegraph);
 
       // x=250 is 1/4 of the width of the viewport, so it should map to flamegraph duration / 4
       // y=250 is at 1/8th the height of the viewport, so it should map to view height / 8
-      const cursor = flamegraphView.getConfigSpaceCursor(
+      const cursor = view.getConfigSpaceCursor(
         vec2.fromValues(250, 250),
         flamegraphCanvas
       );
@@ -122,58 +127,58 @@ describe('flamegraphView', () => {
     );
 
     it('does not allow zooming in more than the min width of a frame', () => {
-      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
-      flamegraphView.setConfigView(new Rect(0, 0, 10, 50));
-      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 500, 50));
+      const {view} = makeCanvasAndView(canvas, flamegraph);
+      view.setConfigView(new Rect(0, 0, 10, 50));
+      expect(view.configView).toEqual(new Rect(0, 0, 500, 50));
     });
 
     it('does not allow zooming out more than the duration of a profile', () => {
-      const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
-      flamegraphView.setConfigView(new Rect(0, 0, 2000, 50));
-      expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+      const {view} = makeCanvasAndView(canvas, flamegraph);
+      view.setConfigView(new Rect(0, 0, 2000, 50));
+      expect(view.configView).toEqual(new Rect(0, 0, 1000, 50));
     });
 
     describe('edge detection on X axis', () => {
       it('is not zoomed in', () => {
-        const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
+        const {view} = makeCanvasAndView(canvas, flamegraph);
 
         // Check that we cant go negative X from start of profile
-        flamegraphView.setConfigView(new Rect(-100, 0, 1000, 50));
-        expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+        view.setConfigView(new Rect(-100, 0, 1000, 50));
+        expect(view.configView).toEqual(new Rect(0, 0, 1000, 50));
 
         // Check that we cant go over X from end of profile
-        flamegraphView.setConfigView(new Rect(2000, 0, 1000, 50));
-        expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+        view.setConfigView(new Rect(2000, 0, 1000, 50));
+        expect(view.configView).toEqual(new Rect(0, 0, 1000, 50));
       });
 
       it('is zoomed in', () => {
-        const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
+        const {view} = makeCanvasAndView(canvas, flamegraph);
 
         // Duration is is 1000, so we can't go over the end of the profile
-        flamegraphView.setConfigView(new Rect(600, 0, 500, 50));
-        expect(flamegraphView.configView).toEqual(new Rect(500, 0, 500, 50));
+        view.setConfigView(new Rect(600, 0, 500, 50));
+        expect(view.configView).toEqual(new Rect(500, 0, 500, 50));
       });
     });
 
     describe('edge detection on Y axis', () => {
       it('is not zoomed in', () => {
-        const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
+        const {view} = makeCanvasAndView(canvas, flamegraph);
 
         // Check that we cant go under stack height
-        flamegraphView.setConfigView(new Rect(0, -50, 1000, 50));
-        expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+        view.setConfigView(new Rect(0, -50, 1000, 50));
+        expect(view.configView).toEqual(new Rect(0, 0, 1000, 50));
 
         // Check that we cant go over stack height
-        flamegraphView.setConfigView(new Rect(0, 50, 1000, 50));
-        expect(flamegraphView.configView).toEqual(new Rect(0, 0, 1000, 50));
+        view.setConfigView(new Rect(0, 50, 1000, 50));
+        expect(view.configView).toEqual(new Rect(0, 0, 1000, 50));
       });
 
       it('is zoomed in', () => {
-        const {flamegraphView} = makeCanvasAndView(canvas, flamegraph);
+        const {view} = makeCanvasAndView(canvas, flamegraph);
 
         // Check that we cant go over stack height
-        flamegraphView.setConfigView(new Rect(0, 50, 1000, 25));
-        expect(flamegraphView.configView).toEqual(new Rect(0, 25, 1000, 25));
+        view.setConfigView(new Rect(0, 50, 1000, 25));
+        expect(view.configView).toEqual(new Rect(0, 25, 1000, 25));
       });
     });
   });

--- a/static/app/utils/profiling/canvasView.spec.tsx
+++ b/static/app/utils/profiling/canvasView.spec.tsx
@@ -21,7 +21,6 @@ const makeCanvasAndView = (
   const canvasView = new CanvasView<Flamegraph>({
     canvas: flamegraphCanvas,
     model: flamegraph,
-    configSpace: flamegraph.configSpace,
     options: {
       inverted: flamegraph.inverted,
       minWidth: flamegraph.profile.minFrameDuration,

--- a/static/app/utils/profiling/canvasView.spec.tsx
+++ b/static/app/utils/profiling/canvasView.spec.tsx
@@ -21,11 +21,12 @@ const makeCanvasAndView = (
   const canvasView = new CanvasView<Flamegraph>({
     canvas: flamegraphCanvas,
     model: flamegraph,
-    theme,
     configSpace: flamegraph.configSpace,
     options: {
       inverted: flamegraph.inverted,
       minWidth: flamegraph.profile.minFrameDuration,
+      barHeight: theme.SIZES.BAR_HEIGHT,
+      depthOffset: theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET,
     },
   });
 

--- a/static/app/utils/profiling/canvasView.tsx
+++ b/static/app/utils/profiling/canvasView.tsx
@@ -23,7 +23,6 @@ export class CanvasView<T extends {configSpace: Rect}> {
     model,
   }: {
     canvas: FlamegraphCanvas;
-    configSpace: Rect;
     model: T;
     options: {
       barHeight: number;

--- a/static/app/utils/profiling/canvasView.tsx
+++ b/static/app/utils/profiling/canvasView.tsx
@@ -1,6 +1,5 @@
 import {mat3, vec2} from 'gl-matrix';
 
-import {FlamegraphTheme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {
   computeClampedConfigView,
@@ -9,53 +8,53 @@ import {
 } from 'sentry/utils/profiling/gl/utils';
 
 export class CanvasView<T extends {configSpace: Rect}> {
-  theme: FlamegraphTheme;
-
   configView: Rect = Rect.Empty();
   configSpace: Readonly<Rect> = Rect.Empty();
 
   inverted: boolean;
   minWidth: number;
+  depthOffset: number;
+  barHeight: number;
   model: T;
 
   constructor({
     canvas,
-    theme,
     options,
     model,
   }: {
     canvas: FlamegraphCanvas;
     configSpace: Rect;
     model: T;
-    options: {inverted?: boolean; minWidth?: number};
-    theme: FlamegraphTheme;
+    options: {
+      barHeight: number;
+      depthOffset?: number;
+      inverted?: boolean;
+      minWidth?: number;
+    };
   }) {
-    this.theme = theme;
     this.inverted = !!options.inverted;
     this.minWidth = options.minWidth ?? 0;
     this.model = model;
+    this.depthOffset = options.depthOffset ?? 0;
+    this.barHeight = options.barHeight ? options.barHeight * window.devicePixelRatio : 0;
     this.initConfigSpace(canvas);
   }
 
   private _initConfigSpace(canvas: FlamegraphCanvas): void {
-    const BAR_HEIGHT = this.theme.SIZES.BAR_HEIGHT * window.devicePixelRatio;
-
     this.configSpace = new Rect(
       0,
       0,
       this.model.configSpace.width,
       Math.max(
-        this.model.configSpace.height + this.theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET,
-        canvas.physicalSpace.height / BAR_HEIGHT
+        this.model.configSpace.height + this.depthOffset,
+        canvas.physicalSpace.height / this.barHeight
       )
     );
   }
 
   private _initConfigView(canvas: FlamegraphCanvas, space: Rect): void {
-    const BAR_HEIGHT = this.theme.SIZES.BAR_HEIGHT * window.devicePixelRatio;
-
     this.configView = Rect.From(space).withHeight(
-      canvas.physicalSpace.height / BAR_HEIGHT
+      canvas.physicalSpace.height / this.barHeight
     );
   }
 

--- a/static/app/utils/profiling/colors/utils.tsx
+++ b/static/app/utils/profiling/colors/utils.tsx
@@ -1,24 +1,27 @@
+import {SpanChart, SpanChartNode} from 'sentry/utils/profiling/spanChart';
+
 import {ColorChannels, FlamegraphTheme, LCH} from '../flamegraph/flamegraphTheme';
 import {FlamegraphFrame} from '../flamegraphFrame';
 
-const uniqueBy = <T,>(arr: ReadonlyArray<T>, predicate: (t: T) => unknown): Array<T> => {
+function uniqueBy<T>(arr: ReadonlyArray<T>, predicate: (t: T) => unknown): Array<T> {
   const cb = typeof predicate === 'function' ? predicate : (o: T) => o[predicate];
 
-  return [
-    ...arr
-      .reduce((map, item) => {
-        const key = item === null || item === undefined ? item : cb(item);
+  const seen = new Set();
+  const set: Array<T> = [];
 
-        if (key === undefined || key === null) {
-          return map;
-        }
-        map.has(key) || map.set(key, item);
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i];
+    const key = item === null || item === undefined ? item : cb(item);
 
-        return map;
-      }, new Map())
-      .values(),
-  ];
-};
+    if (key === undefined || key === null || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    set.push(item);
+  }
+
+  return set;
+}
 
 // These were taken from speedscope, originally described in
 // https://en.wikipedia.org/wiki/HSL_and_HSV#From_luma/chroma/hue
@@ -50,10 +53,10 @@ export const makeStackToColor = (
 ): FlamegraphTheme['COLORS']['STACK_TO_COLOR'] => {
   return (
     frames: ReadonlyArray<FlamegraphFrame>,
-    colorMap: FlamegraphTheme['COLORS']['COLOR_MAP'],
+    generateColorMap: FlamegraphTheme['COLORS']['COLOR_MAP'],
     colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
   ) => {
-    const colors = colorMap(frames, colorBucket);
+    const colorMap = generateColorMap(frames, colorBucket);
     const length = frames.length;
 
     // Length * number of frames * color components
@@ -66,7 +69,7 @@ export const makeStackToColor = (
         continue;
       }
 
-      const c = colors.get(frame.key);
+      const c = colorMap.get(frame.key);
       const colorWithAlpha: [number, number, number, number] =
         c && c.length === 3
           ? (c.concat(1) as [number, number, number, number])
@@ -85,14 +88,14 @@ export const makeStackToColor = (
 
     return {
       colorBuffer,
-      colorMap: colors,
+      colorMap,
     };
   };
 };
 
-export const isNumber = (input: unknown): input is number => {
+export function isNumber(input: unknown): input is number {
   return typeof input === 'number' && !isNaN(input);
-};
+}
 
 export function clamp(number: number, min?: number, max?: number): number {
   if (!isNumber(min) && !isNumber(max)) {
@@ -130,7 +133,7 @@ function defaultFrameSort(a: FlamegraphFrame, b: FlamegraphFrame): number {
   return defaultFrameSortKey(a) > defaultFrameSortKey(b) ? 1 : -1;
 }
 
-export const makeColorBucketTheme = (lch: LCH) => {
+export function makeColorBucketTheme(lch: LCH) {
   return (t: number): ColorChannels => {
     const x = triangle(30.0 * t);
     const H = 360.0 * (0.9 * t);
@@ -138,13 +141,13 @@ export const makeColorBucketTheme = (lch: LCH) => {
     const L = lch.L_0 - lch.L_d * x;
     return fromLumaChromaHue(L, C, H);
   };
-};
+}
 
-export const makeColorMap = (
+export function makeColorMap(
   frames: ReadonlyArray<FlamegraphFrame>,
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET'],
   sortBy: (a: FlamegraphFrame, b: FlamegraphFrame) => number = defaultFrameSort
-): Map<FlamegraphFrame['frame']['key'], ColorChannels> => {
+): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   const colors = new Map<FlamegraphFrame['frame']['key'], ColorChannels>();
 
   const sortedFrames = [...frames].sort(sortBy);
@@ -157,10 +160,7 @@ export const makeColorMap = (
     const nameKey = frame.frame.name + frame.frame.image ?? '';
 
     if (!colorsByName.has(nameKey)) {
-      const color = colorBucket(
-        Math.floor((255 * i) / uniqueFrames.length) / 256,
-        frame.frame
-      );
+      const color = colorBucket(Math.floor((255 * i) / uniqueFrames.length) / 256);
       colorsByName.set(nameKey, color);
     }
 
@@ -168,12 +168,12 @@ export const makeColorMap = (
   }
 
   return colors;
-};
+}
 
-export const makeColorMapByRecursion = (
+export function makeColorMapByRecursion(
   frames: ReadonlyArray<FlamegraphFrame>,
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
-): Map<FlamegraphFrame['frame']['key'], ColorChannels> => {
+): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   const colors = new Map<FlamegraphFrame['frame']['key'], ColorChannels>();
 
   const sortedFrames = [...frames]
@@ -187,10 +187,7 @@ export const makeColorMapByRecursion = (
     const nameKey = frame.frame.name + frame.frame.image ?? '';
 
     if (!colorsByName.has(nameKey)) {
-      const color = colorBucket(
-        Math.floor((255 * i) / sortedFrames.length) / 256,
-        frame.frame
-      );
+      const color = colorBucket(Math.floor((255 * i) / sortedFrames.length) / 256);
 
       colorsByName.set(nameKey, color);
     }
@@ -199,12 +196,12 @@ export const makeColorMapByRecursion = (
   }
 
   return colors;
-};
+}
 
-export const makeColorMapByImage = (
+export function makeColorMapByImage(
   frames: ReadonlyArray<FlamegraphFrame>,
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
-): Map<FlamegraphFrame['frame']['key'], ColorChannels> => {
+): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   const colors = new Map<FlamegraphFrame['frame']['key'], ColorChannels>();
 
   const reverseFrameToImageIndex: Record<string, FlamegraphFrame[]> = {};
@@ -235,38 +232,38 @@ export const makeColorMapByImage = (
       const frame = imageFrames[j]!;
       colors.set(
         frame.key,
-        colorBucket(Math.floor((255 * i) / sortedFrames.length) / 256, frame.frame)
+        colorBucket(Math.floor((255 * i) / sortedFrames.length) / 256)
       );
     }
   }
 
   return colors;
-};
+}
 
-export const makeColorMapBySystemVsApplication = (
+export function makeColorMapBySystemVsApplication(
   frames: ReadonlyArray<FlamegraphFrame>,
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
-): Map<FlamegraphFrame['frame']['key'], ColorChannels> => {
+): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   const colors = new Map<FlamegraphFrame['key'], ColorChannels>();
 
   for (let i = 0; i < frames.length; i++) {
     const frame = frames[i]!; // iterating over non empty array
 
     if (frame.frame.is_application) {
-      colors.set(frame.key, colorBucket(0.7, frame.frame));
+      colors.set(frame.key, colorBucket(0.7));
       continue;
     }
 
-    colors.set(frame.key, colorBucket(0.09, frame.frame));
+    colors.set(frame.key, colorBucket(0.09));
   }
 
   return colors;
-};
+}
 
-export const makeColorMapByFrequency = (
+export function makeColorMapByFrequency(
   frames: ReadonlyArray<FlamegraphFrame>,
   colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
-): Map<FlamegraphFrame['frame']['key'], ColorChannels> => {
+): Map<FlamegraphFrame['frame']['key'], ColorChannels> {
   let max = 0;
 
   const countMap = new Map<FlamegraphFrame['frame']['key'], number>();
@@ -290,11 +287,29 @@ export const makeColorMapByFrequency = (
     const frame = frames[i]!; // iterating over non empty array
     const key = frame.frame.name + frame.frame.image;
     const count = countMap.get(key)!;
-    const [r, g, b] = colorBucket(0.7, frame.frame);
+    const [r, g, b] = colorBucket(0.7);
     const color: ColorChannels = [r, g, b, Math.max(count / max, 0.1)];
 
     colors.set(frame.key, color);
   }
 
   return colors;
-};
+}
+
+export function makeSpansColorMapByOpAndDescription(
+  spans: ReadonlyArray<SpanChart['spans'][0]>,
+  colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET']
+): Map<SpanChartNode['node']['span']['span_id'], ColorChannels> {
+  const colors = new Map<SpanChartNode['node']['span']['span_id'], ColorChannels>();
+
+  const uniqueSpans = uniqueBy(
+    spans,
+    s => s.node.span.op ?? '' + s.node.span.description ?? ''
+  );
+
+  for (let i = 0; i < spans.length; i++) {
+    colors.set(spans[i].node.span.span_id, colorBucket(i / uniqueSpans.length));
+  }
+
+  return colors;
+}

--- a/static/app/utils/profiling/flamegraph.spec.tsx
+++ b/static/app/utils/profiling/flamegraph.spec.tsx
@@ -124,10 +124,10 @@ describe('flamegraph', () => {
       }
     );
 
-    const order = ['f0', 'f1', 'f2'];
+    const order = ['f0', 'f1', 'f2'].reverse();
     for (let i = 0; i < order.length; i++) {
       expect(flamegraph.frames[i].frame.name).toBe(order[i]);
-      expect(flamegraph.frames[i].depth).toBe(i);
+      expect(flamegraph.frames[i].depth).toBe(order.length - i - 1);
     }
   });
 
@@ -254,15 +254,15 @@ describe('flamegraph', () => {
       }
     );
 
-    expect(flamegraph.frames[0].frame.name).toBe('f0');
-    expect(flamegraph.frames[0].frame.totalWeight).toBe(1);
-    expect(flamegraph.frames[0].start).toBe(2);
-    expect(flamegraph.frames[0].end).toBe(3);
+    expect(flamegraph.frames[1].frame.name).toBe('f0');
+    expect(flamegraph.frames[1].frame.totalWeight).toBe(1);
+    expect(flamegraph.frames[1].start).toBe(2);
+    expect(flamegraph.frames[1].end).toBe(3);
 
-    expect(flamegraph.frames[1].frame.name).toBe('f1');
-    expect(flamegraph.frames[1].frame.totalWeight).toBe(2);
-    expect(flamegraph.frames[1].start).toBe(0);
-    expect(flamegraph.frames[1].end).toBe(2);
+    expect(flamegraph.frames[0].frame.name).toBe('f1');
+    expect(flamegraph.frames[0].frame.totalWeight).toBe(2);
+    expect(flamegraph.frames[0].start).toBe(0);
+    expect(flamegraph.frames[0].end).toBe(2);
   });
 
   it('updates startTime and endTime of left heavy children graph', () => {
@@ -295,7 +295,7 @@ describe('flamegraph', () => {
       }
     );
 
-    expect(flamegraph.frames[0].frame.name).toBe('f0');
+    expect(flamegraph.frames[2].frame.name).toBe('f0');
   });
 
   it('From', () => {

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -148,7 +148,7 @@ export class Flamegraph {
         return;
       }
 
-      frames.unshift(stackTop);
+      frames.push(stackTop);
       this.depth = Math.max(stackTop.depth, this.depth);
     };
 
@@ -162,7 +162,7 @@ export class Flamegraph {
 
     const sortTree = (node: CallTreeNode) => {
       node.children.sort((a, b) => -(a.totalWeight - b.totalWeight));
-      node.children.forEach(c => sortTree(c));
+      node.children.forEach(sortTree);
     };
 
     sortTree(profile.appendOrderTree);
@@ -218,7 +218,7 @@ export class Flamegraph {
       if (stackTop.end - stackTop.start === 0) {
         return;
       }
-      frames.unshift(stackTop);
+      frames.push(stackTop);
       this.depth = Math.max(stackTop.depth, this.depth);
     };
 

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -29,7 +29,7 @@ export interface FlamegraphTheme {
   // They should instead be defined as arrays of numbers so we can use them with glsl and avoid unnecessary parsing
   COLORS: {
     BAR_LABEL_FONT_COLOR: string;
-    COLOR_BUCKET: (t: number, frame?: Frame) => ColorChannels;
+    COLOR_BUCKET: (t: number) => ColorChannels;
     COLOR_MAP: (
       frames: ReadonlyArray<FlamegraphFrame>,
       colorBucket: FlamegraphTheme['COLORS']['COLOR_BUCKET'],
@@ -51,6 +51,7 @@ export interface FlamegraphTheme {
     SAMPLE_TICK_COLOR: ColorChannels;
     SEARCH_RESULT_FRAME_COLOR: string;
     SELECTED_FRAME_BORDER_COLOR: string;
+    SPAN_FALLBACK_COLOR: [number, number, number, number];
     SPAN_FRAME_BACKGROUND: string;
     SPAN_FRAME_BORDER: string;
     STACK_TO_COLOR: (
@@ -61,9 +62,6 @@ export interface FlamegraphTheme {
       colorBuffer: Array<number>;
       colorMap: Map<Frame['key'], ColorChannels>;
     };
-  };
-  CONFIG: {
-    HIGHLIGHT_RECURSION: boolean;
   };
   FONTS: {
     FONT: string;
@@ -83,6 +81,8 @@ export interface FlamegraphTheme {
     LABEL_FONT_SIZE: number;
     MINIMAP_HEIGHT: number;
     MINIMAP_POSITION_OVERLAY_BORDER_WIDTH: number;
+    SPANS_BAR_HEIGHT: number;
+    SPANS_DEPTH_OFFSET: number;
     SPANS_HEIGHT: number;
     TIMELINE_HEIGHT: number;
     TOOLTIP_FONT_SIZE: number;
@@ -105,28 +105,34 @@ export const LCH_DARK = {
   L_d: 0.1,
 };
 
+const SIZES: FlamegraphTheme['SIZES'] = {
+  BAR_FONT_SIZE: 11,
+  BAR_HEIGHT: 20,
+  BAR_PADDING: 4,
+  FLAMEGRAPH_DEPTH_OFFSET: 12,
+  SPANS_DEPTH_OFFSET: 3,
+  FOCUSED_FRAME_BORDER_WIDTH: 2,
+  FRAME_BORDER_WIDTH: 2,
+  GRID_LINE_WIDTH: 2,
+  HOVERED_FRAME_BORDER_WIDTH: 1,
+  INTERNAL_SAMPLE_TICK_LINE_WIDTH: 1,
+  LABEL_FONT_PADDING: 6,
+  LABEL_FONT_SIZE: 10,
+  MINIMAP_HEIGHT: 100,
+  MINIMAP_POSITION_OVERLAY_BORDER_WIDTH: 2,
+  SPANS_HEIGHT: 100,
+  SPANS_BAR_HEIGHT: 12,
+  TIMELINE_HEIGHT: 20,
+  TOOLTIP_FONT_SIZE: 12,
+};
+
+const FONTS: FlamegraphTheme['FONTS'] = {
+  FONT: MONOSPACE_FONT,
+  FRAME_FONT,
+};
+
 export const LightFlamegraphTheme: FlamegraphTheme = {
-  CONFIG: {
-    HIGHLIGHT_RECURSION: false,
-  },
-  SIZES: {
-    BAR_FONT_SIZE: 11,
-    BAR_HEIGHT: 20,
-    BAR_PADDING: 4,
-    FLAMEGRAPH_DEPTH_OFFSET: 12,
-    FOCUSED_FRAME_BORDER_WIDTH: 2,
-    FRAME_BORDER_WIDTH: 2,
-    GRID_LINE_WIDTH: 2,
-    HOVERED_FRAME_BORDER_WIDTH: 1,
-    INTERNAL_SAMPLE_TICK_LINE_WIDTH: 1,
-    LABEL_FONT_PADDING: 6,
-    LABEL_FONT_SIZE: 10,
-    MINIMAP_HEIGHT: 100,
-    MINIMAP_POSITION_OVERLAY_BORDER_WIDTH: 2,
-    SPANS_HEIGHT: 100,
-    TIMELINE_HEIGHT: 20,
-    TOOLTIP_FONT_SIZE: 12,
-  },
+  SIZES,
   COLORS: {
     BAR_LABEL_FONT_COLOR: '#000',
     COLOR_BUCKET: makeColorBucketTheme(LCH_LIGHT),
@@ -136,6 +142,7 @@ export const LightFlamegraphTheme: FlamegraphTheme = {
     DIFFERENTIAL_INCREASE: [0.98, 0.2058, 0.4381],
     FOCUSED_FRAME_BORDER_COLOR: lightTheme.focus,
     FRAME_FALLBACK_COLOR: [0, 0, 0, 0.035],
+    SPAN_FALLBACK_COLOR: [0, 0, 0, 0.035],
     GRID_FRAME_BACKGROUND_COLOR: 'rgba(255, 255, 255, 0.8)',
     GRID_LINE_COLOR: '#e5e7eb',
     HIGHLIGHTED_LABEL_COLOR: [255, 255, 0],
@@ -150,34 +157,11 @@ export const LightFlamegraphTheme: FlamegraphTheme = {
     SPAN_FRAME_BORDER: 'rgba(200, 200, 200, 1)',
     STACK_TO_COLOR: makeStackToColor([0, 0, 0, 0.035]),
   },
-  FONTS: {
-    FONT: MONOSPACE_FONT,
-    FRAME_FONT,
-  },
+  FONTS,
 };
 
 export const DarkFlamegraphTheme: FlamegraphTheme = {
-  CONFIG: {
-    HIGHLIGHT_RECURSION: false,
-  },
-  SIZES: {
-    BAR_FONT_SIZE: 11,
-    BAR_HEIGHT: 20,
-    BAR_PADDING: 4,
-    FLAMEGRAPH_DEPTH_OFFSET: 12,
-    FOCUSED_FRAME_BORDER_WIDTH: 1,
-    FRAME_BORDER_WIDTH: 2,
-    GRID_LINE_WIDTH: 2,
-    HOVERED_FRAME_BORDER_WIDTH: 1,
-    INTERNAL_SAMPLE_TICK_LINE_WIDTH: 1,
-    LABEL_FONT_PADDING: 6,
-    LABEL_FONT_SIZE: 10,
-    MINIMAP_HEIGHT: 100,
-    MINIMAP_POSITION_OVERLAY_BORDER_WIDTH: 2,
-    SPANS_HEIGHT: 100,
-    TIMELINE_HEIGHT: 20,
-    TOOLTIP_FONT_SIZE: 12,
-  },
+  SIZES,
   COLORS: {
     BAR_LABEL_FONT_COLOR: 'rgb(255 255 255 / 80%)',
     COLOR_BUCKET: makeColorBucketTheme(LCH_DARK),
@@ -187,6 +171,7 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
     DIFFERENTIAL_INCREASE: [0.98, 0.2058, 0.4381],
     FOCUSED_FRAME_BORDER_COLOR: darkTheme.focus,
     FRAME_FALLBACK_COLOR: [1, 1, 1, 0.1],
+    SPAN_FALLBACK_COLOR: [1, 1, 1, 0.1],
     GRID_FRAME_BACKGROUND_COLOR: 'rgba(0, 0, 0, 0.4)',
     GRID_LINE_COLOR: '#222227',
     HIGHLIGHTED_LABEL_COLOR: [255, 255, 0],
@@ -201,8 +186,5 @@ export const DarkFlamegraphTheme: FlamegraphTheme = {
     SPAN_FRAME_BORDER: '#57575b',
     STACK_TO_COLOR: makeStackToColor([1, 1, 1, 0.1]),
   },
-  FONTS: {
-    FONT: MONOSPACE_FONT,
-    FRAME_FONT,
-  },
+  FONTS,
 };

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -5,6 +5,8 @@ import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 
 import {clamp} from '../colors/utils';
+import {SpanChartRenderer2D} from '../renderers/spansRenderer';
+import {SpanChartNode} from '../spanChart';
 
 export function createShader(
   gl: WebGLRenderingContext,
@@ -496,6 +498,21 @@ export function findRangeBinarySearch(
       high = mid;
     }
   }
+}
+
+export function formatColorForSpan(
+  frame: SpanChartNode,
+  renderer: SpanChartRenderer2D
+): string {
+  const color = renderer.getColorForFrame(frame);
+  if (color.length === 4) {
+    return `rgba(${color
+      .slice(0, 3)
+      .map(n => n * 255)
+      .join(',')}, ${color[3]})`;
+  }
+
+  return `rgba(${color.map(n => n * 255).join(',')}, 1.0)`;
 }
 
 export function formatColorForFrame(

--- a/static/app/utils/profiling/renderers/flamegraphDomRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphDomRenderer.spec.tsx
@@ -9,8 +9,9 @@ import {
 } from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {FlamegraphDomRenderer} from 'sentry/utils/profiling/renderers/flamegraphDomRenderer';
 
+import {CanvasView} from '../canvasView';
+import {Flamegraph} from '../flamegraph';
 import {FlamegraphCanvas} from '../flamegraphCanvas';
-import {FlamegraphView} from '../flamegraphView';
 
 const originalDpr = window.devicePixelRatio;
 
@@ -40,10 +41,15 @@ describe('FlamegraphDomRenderer', () => {
     const renderer = new FlamegraphDomRenderer(canvas, flamegraph, theme);
     const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
 
-    const flamegraphView = new FlamegraphView({
+    const flamegraphView = new CanvasView<Flamegraph>({
       canvas: flamegraphCanvas,
-      flamegraph,
+      model: flamegraph,
       theme: LightFlamegraphTheme,
+      options: {
+        inverted: flamegraph.inverted,
+        minWidth: flamegraph.profile.minFrameDuration,
+      },
+      configSpace: flamegraph.configSpace,
     });
 
     renderer.draw(

--- a/static/app/utils/profiling/renderers/flamegraphDomRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphDomRenderer.spec.tsx
@@ -3,10 +3,7 @@ import {vec2} from 'gl-matrix';
 import {makeCanvasMock, makeFlamegraph} from 'sentry-test/profiling/utils';
 import {screen} from 'sentry-test/reactTestingLibrary';
 
-import {
-  LightFlamegraphTheme,
-  LightFlamegraphTheme as theme,
-} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
+import {LightFlamegraphTheme as theme} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {FlamegraphDomRenderer} from 'sentry/utils/profiling/renderers/flamegraphDomRenderer';
 
 import {CanvasView} from '../canvasView';
@@ -44,10 +41,11 @@ describe('FlamegraphDomRenderer', () => {
     const flamegraphView = new CanvasView<Flamegraph>({
       canvas: flamegraphCanvas,
       model: flamegraph,
-      theme: LightFlamegraphTheme,
       options: {
         inverted: flamegraph.inverted,
         minWidth: flamegraph.profile.minFrameDuration,
+        barHeight: theme.SIZES.BAR_HEIGHT,
+        depthOffset: theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET,
       },
       configSpace: flamegraph.configSpace,
     });

--- a/static/app/utils/profiling/renderers/flamegraphDomRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphDomRenderer.spec.tsx
@@ -47,7 +47,6 @@ describe('FlamegraphDomRenderer', () => {
         barHeight: theme.SIZES.BAR_HEIGHT,
         depthOffset: theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET,
       },
-      configSpace: flamegraph.configSpace,
     });
 
     renderer.draw(

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
@@ -235,7 +235,6 @@ describe('flamegraphRenderer', () => {
       const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
         model: flamegraph,
-        configSpace: flamegraph.configSpace,
         options: {
           inverted: flamegraph.inverted,
           minWidth: flamegraph.profile.minFrameDuration,
@@ -297,7 +296,6 @@ describe('flamegraphRenderer', () => {
       const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
         model: flamegraph,
-        configSpace: flamegraph.configSpace,
         options: {
           inverted: flamegraph.inverted,
           minWidth: flamegraph.profile.minFrameDuration,

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
@@ -6,16 +6,17 @@ import {
   makeFlamegraph,
 } from 'sentry-test/profiling/utils';
 
+import {CanvasView} from 'sentry/utils/profiling/canvasView';
 import {FlamegraphSearch} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphSearch';
 import {
   LightFlamegraphTheme,
   LightFlamegraphTheme as theme,
 } from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
-import {FlamegraphView} from 'sentry/utils/profiling/flamegraphView';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 
+import {Flamegraph} from '../flamegraph';
 import {getFlamegraphFrameSearchId} from '../flamegraphFrame';
 
 const originalDpr = window.devicePixelRatio;
@@ -231,10 +232,15 @@ describe('flamegraphRenderer', () => {
       const results: FlamegraphSearch['results'] = new Map();
 
       const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-      const flamegraphView = new FlamegraphView({
+      const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
-        flamegraph,
         theme,
+        model: flamegraph,
+        configSpace: flamegraph.configSpace,
+        options: {
+          inverted: flamegraph.inverted,
+          minWidth: flamegraph.profile.minFrameDuration,
+        },
       });
       const renderer = new FlamegraphRenderer(canvas, flamegraph, theme);
 
@@ -287,10 +293,15 @@ describe('flamegraphRenderer', () => {
       );
 
       const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
-      const flamegraphView = new FlamegraphView({
+      const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
-        flamegraph,
         theme,
+        model: flamegraph,
+        configSpace: flamegraph.configSpace,
+        options: {
+          inverted: flamegraph.inverted,
+          minWidth: flamegraph.profile.minFrameDuration,
+        },
       });
       const renderer = new FlamegraphRenderer(canvas, flamegraph, theme);
 

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
@@ -234,12 +234,13 @@ describe('flamegraphRenderer', () => {
       const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
       const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
-        theme,
         model: flamegraph,
         configSpace: flamegraph.configSpace,
         options: {
           inverted: flamegraph.inverted,
           minWidth: flamegraph.profile.minFrameDuration,
+          barHeight: theme.SIZES.BAR_HEIGHT,
+          depthOffset: theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET,
         },
       });
       const renderer = new FlamegraphRenderer(canvas, flamegraph, theme);
@@ -295,12 +296,13 @@ describe('flamegraphRenderer', () => {
       const flamegraphCanvas = new FlamegraphCanvas(canvas, vec2.fromValues(0, 0));
       const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
-        theme,
         model: flamegraph,
         configSpace: flamegraph.configSpace,
         options: {
           inverted: flamegraph.inverted,
           minWidth: flamegraph.profile.minFrameDuration,
+          barHeight: theme.SIZES.BAR_HEIGHT,
+          depthOffset: theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET,
         },
       });
       const renderer = new FlamegraphRenderer(canvas, flamegraph, theme);

--- a/static/app/utils/profiling/renderers/spansRenderer.tsx
+++ b/static/app/utils/profiling/renderers/spansRenderer.tsx
@@ -1,11 +1,17 @@
-import {mat3} from 'gl-matrix';
+import {mat3, vec2} from 'gl-matrix';
 
+import {
+  FlamegraphTheme,
+  LCH_LIGHT,
+} from 'sentry/utils/profiling/flamegraph/flamegraphTheme';
 import {
   getContext,
   Rect,
   resizeCanvasToDisplaySize,
 } from 'sentry/utils/profiling/gl/utils';
 import {SpanChart, SpanChartNode} from 'sentry/utils/profiling/spanChart';
+
+import {makeColorBucketTheme, makeSpansColorMapByOpAndDescription} from '../colors/utils';
 
 // Convert color component from 0-1 to 0-255 range
 function colorComponentsToRgba(color: number[]): string {
@@ -17,23 +23,64 @@ function colorComponentsToRgba(color: number[]): string {
 export class SpanChartRenderer2D {
   canvas: HTMLCanvasElement | null;
   spanChart: SpanChart;
+  theme: FlamegraphTheme;
 
   context: CanvasRenderingContext2D;
   spans: ReadonlyArray<SpanChartNode> = [];
+  colors: ReturnType<typeof makeSpansColorMapByOpAndDescription>;
 
-  constructor(canvas: HTMLCanvasElement, spanChart: SpanChart) {
+  constructor(canvas: HTMLCanvasElement, spanChart: SpanChart, theme: FlamegraphTheme) {
     this.canvas = canvas;
     this.spanChart = spanChart;
+    this.theme = theme;
 
     this.spans = [...this.spanChart.spans];
     this.context = getContext(this.canvas, '2d');
+    this.colors = makeSpansColorMapByOpAndDescription(
+      this.spans,
+      makeColorBucketTheme(LCH_LIGHT)
+    );
 
     this.init();
     resizeCanvasToDisplaySize(this.canvas);
   }
 
+  getColorForFrame(span: SpanChartNode): number[] {
+    return (
+      this.colors.get(span.node.span.span_id) ?? this.theme.COLORS.FRAME_FALLBACK_COLOR
+    );
+  }
+
   init() {
     this.spans = [...this.spanChart.spans];
+  }
+
+  findHoveredNode(configSpaceCursor: vec2): SpanChartNode | null {
+    let hoveredNode: SpanChartNode | null = null;
+    const queue = [...this.spanChart.root.children];
+
+    while (queue.length && !hoveredNode) {
+      const span = queue.pop()!;
+
+      // We treat entire span chart as a segment tree, this allows us to query in O(log n) time by
+      // only looking at the nodes that are relevant to the current cursor position. We discard any values
+      // on x axis that do not overlap the cursor, and descend until we find a node that overlaps at cursor y position
+      if (configSpaceCursor[0] < span.start || configSpaceCursor[0] > span.end) {
+        continue;
+      }
+
+      // If our frame depth overlaps cursor y position, we have found our node
+      if (configSpaceCursor[1] >= span.depth && configSpaceCursor[1] <= span.depth + 1) {
+        hoveredNode = span;
+        break;
+      }
+
+      // Descend into the rest of the children
+      for (let i = 0; i < span.children.length; i++) {
+        queue.push(span.children[i]);
+      }
+    }
+    return hoveredNode;
   }
 
   draw(configViewToPhysicalSpace: mat3) {
@@ -42,16 +89,27 @@ export class SpanChartRenderer2D {
     }
 
     this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
-    this.context.fillStyle = colorComponentsToRgba([1, 0, 0, 1]);
+    const BORDER_WIDTH = 2 * window.devicePixelRatio;
 
     for (let i = 0; i < this.spans.length; i++) {
       const span = this.spans[i];
+      const color = this.colors.get(span.node.span.span_id);
 
+      if (!color) {
+        throw new Error('Missing color for span');
+      }
+
+      this.context.fillStyle = colorComponentsToRgba(color);
       const rect = new Rect(span.start, span.depth, span.duration, 1).transformRect(
         configViewToPhysicalSpace
       );
 
-      this.context.fillRect(rect.x, rect.y, rect.width, rect.height);
+      this.context.fillRect(
+        rect.x + BORDER_WIDTH / 2,
+        rect.y + BORDER_WIDTH / 2,
+        rect.width - BORDER_WIDTH / 2,
+        rect.height - BORDER_WIDTH / 2
+      );
     }
   }
 }

--- a/static/app/utils/profiling/spanChart.spec.tsx
+++ b/static/app/utils/profiling/spanChart.spec.tsx
@@ -2,6 +2,8 @@ import {EntrySpans, EventOrGroupType, EventTransaction} from 'sentry/types/event
 import {SpanChart} from 'sentry/utils/profiling/spanChart';
 import {SpanTree} from 'sentry/utils/profiling/spanTree';
 
+import {Rect} from './gl/utils';
+
 function s(partial: Partial<EntrySpans['data'][0]>): EntrySpans['data'][0] {
   return {
     timestamp: 0,
@@ -49,12 +51,40 @@ function txn(partial: Partial<EventTransaction>): EventTransaction {
 
 describe('spanChart', () => {
   it('iterates over all spans with depth', () => {
-    const tree = new SpanTree(txn({startTimestamp: 0, endTimestamp: 1}), [
-      s({span_id: '1', timestamp: 1, start_timestamp: 0}),
-      s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
-      s({span_id: '3', timestamp: 0.2, start_timestamp: 0}),
-      s({span_id: '4', timestamp: 1, start_timestamp: 0.5}),
-    ]);
+    const start = Date.now();
+    const tree = new SpanTree(
+      txn({
+        contexts: {trace: {span_id: 'root'}},
+        startTimestamp: start + 0,
+        endTimestamp: start + 1,
+      }),
+      [
+        s({
+          span_id: '1',
+          parent_span_id: 'root',
+          timestamp: start + 1,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '2',
+          parent_span_id: '1',
+          timestamp: start + 0.5,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '3',
+          parent_span_id: '2',
+          timestamp: start + 0.2,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '4',
+          parent_span_id: '1',
+          timestamp: start + 1,
+          start_timestamp: start + 0.5,
+        }),
+      ]
+    );
 
     expect(tree.root.children[0].children[1].span.span_id).toBe('4');
 
@@ -73,40 +103,170 @@ describe('spanChart', () => {
     });
   });
 
-  it('remaps spans to start of benchmark', () => {
-    const tree = new SpanTree(txn({startTimestamp: 5, endTimestamp: 10}), [
-      s({span_id: '1', timestamp: 10, start_timestamp: 6}),
-      s({span_id: '2', timestamp: 9, start_timestamp: 8}),
-    ]);
+  it('keeps track of shortest duration span', () => {
+    const start = Date.now();
+    const tree = new SpanTree(
+      txn({
+        contexts: {trace: {span_id: 'root'}},
+        startTimestamp: start + 0,
+        endTimestamp: start + 10,
+      }),
+      [
+        s({
+          span_id: '1',
+          parent_span_id: 'root',
+          timestamp: start + 10,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '2',
+          parent_span_id: '1',
+          timestamp: start + 5,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '3',
+          parent_span_id: '2',
+          timestamp: start + 1,
+          start_timestamp: start,
+        }),
+      ]
+    );
 
     const chart = new SpanChart(tree);
-    expect(chart.spans[1].start).toBe(1);
-    expect(chart.spans[1].end).toBe(5);
-
-    expect(chart.spans[2].start).toBe(3);
-    expect(chart.spans[2].end).toBe(4);
-  });
-
-  it('converts durations to final unit', () => {
-    const tree = new SpanTree(txn({startTimestamp: 0, endTimestamp: 10}), [
-      s({span_id: '1', timestamp: 3, start_timestamp: 1}),
-    ]);
-
-    const chart = new SpanChart(tree, {unit: 'nanoseconds'});
-    expect(chart.spans[1].start).toBe(1 * 1e6);
-    expect(chart.spans[1].end).toBe(3 * 1e6);
-    expect(chart.spans[1].duration).toBe(2 * 1e6);
+    expect(chart.minSpanDuration).toBe(1 * 1e3);
   });
 
   it('tracks chart depth', () => {
-    const tree = new SpanTree(txn({startTimestamp: 0, endTimestamp: 1}), [
-      s({span_id: '1', timestamp: 1, start_timestamp: 0}),
-      s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
-      s({span_id: '3', timestamp: 0.2, start_timestamp: 0}),
-      s({span_id: '4', timestamp: 0.1, start_timestamp: 0}),
-    ]);
+    const start = Date.now();
+    const tree = new SpanTree(
+      txn({
+        contexts: {trace: {span_id: 'root'}},
+        startTimestamp: start + 0,
+        endTimestamp: start + 1,
+      }),
+      [
+        s({
+          span_id: '1',
+          parent_span_id: 'root',
+          timestamp: start + 1,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '2',
+          parent_span_id: '1',
+          timestamp: start + 0.5,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '3',
+          parent_span_id: '2',
+          timestamp: start + 0.2,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '4',
+          parent_span_id: '3',
+          timestamp: start + 0.1,
+          start_timestamp: start,
+        }),
+      ]
+    );
 
     const chart = new SpanChart(tree);
     expect(chart.depth).toBe(4);
+  });
+
+  it('initializes configSpace', () => {
+    const start = Date.now();
+    const tree = new SpanTree(
+      txn({
+        contexts: {trace: {span_id: 'root'}},
+        startTimestamp: start + 0,
+        endTimestamp: start + 10,
+      }),
+      [
+        s({
+          span_id: '1',
+          parent_span_id: 'root',
+          timestamp: start + 10,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '2',
+          parent_span_id: '1',
+          timestamp: start + 5,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '3',
+          parent_span_id: '2',
+          timestamp: start + 1,
+          start_timestamp: start,
+        }),
+      ]
+    );
+
+    const chart = new SpanChart(tree);
+    expect(chart.configSpace.equals(new Rect(0, 0, 10 * 1e3, 3))).toBe(true);
+  });
+
+  it('remaps spans to start of benchmark', () => {
+    const start = Date.now();
+    const tree = new SpanTree(
+      txn({
+        contexts: {trace: {span_id: 'root'}},
+        startTimestamp: start + 5,
+        endTimestamp: start + 10,
+      }),
+      [
+        s({
+          span_id: '1',
+          parent_span_id: 'root',
+          timestamp: start + 10,
+          start_timestamp: start + 6,
+        }),
+        s({
+          span_id: '2',
+          parent_span_id: '1',
+          timestamp: start + 9,
+          start_timestamp: start + 8,
+        }),
+      ]
+    );
+
+    const chart = new SpanChart(tree);
+    expect(chart.spans[1].start).toBe(1 * 1e3);
+    expect(chart.spans[1].end).toBe(5 * 1e3);
+
+    expect(chart.spans[2].start).toBe(3 * 1e3);
+    expect(chart.spans[2].end).toBe(4 * 1e3);
+  });
+
+  it('converts durations to final unit', () => {
+    const start = Date.now();
+    const tree = new SpanTree(
+      txn({
+        contexts: {trace: {span_id: 'root'}},
+        startTimestamp: start + 1,
+        endTimestamp: start + 11,
+      }),
+      [
+        s({
+          span_id: '1',
+          parent_span_id: 'root',
+          timestamp: start + 4,
+          start_timestamp: start + 2,
+        }),
+      ]
+    );
+
+    const chart = new SpanChart(tree, {unit: 'nanoseconds'});
+    expect(chart.spans[1].start).toBe(1 * 1e9);
+    expect(chart.spans[1].end).toBe(3 * 1e9);
+    expect(chart.spans[1].duration).toBe(2 * 1e9);
+
+    expect(chart.configSpace.height).toBe(1);
+    expect(chart.configSpace.width).toBe(10 * 1e9);
   });
 });

--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -1,59 +1,98 @@
 import {Rect} from 'sentry/utils/profiling/gl/utils';
-import {SpanTree} from 'sentry/utils/profiling/spanTree';
-import {makeFormatter, makeFormatTo} from 'sentry/utils/profiling/units/units';
+import {SpanTree, SpanTreeNode} from 'sentry/utils/profiling/spanTree';
+import {
+  makeFormatter,
+  makeFormatTo,
+  makeTimelineFormatter,
+} from 'sentry/utils/profiling/units/units';
 
 import {Profile} from './profile/profile';
 
 export interface SpanChartNode {
+  children: SpanChartNode[];
   depth: number;
   duration: number;
   end: number;
   node: SpanTree['root'];
+  parent: SpanChartNode | null;
   start: number;
 }
 
 class SpanChart {
   spans: SpanChartNode[];
+  root: SpanChartNode = {
+    parent: null,
+    node: SpanTreeNode.Root(),
+    duration: 0,
+    depth: -1,
+    start: 0,
+    end: 0,
+    children: [],
+  };
   spanTree: SpanTree;
   depth: number = 0;
+  minSpanDuration: number = Number.POSITIVE_INFINITY;
+  configSpace: Rect;
 
   toFinalUnit = makeFormatTo('milliseconds', 'milliseconds');
   formatter = makeFormatter('milliseconds');
+  timelineFormatter: (value: number) => string;
 
   constructor(
     spanTree: SpanTree,
     options: {unit: Profile['unit']; configSpace?: Rect} = {unit: 'milliseconds'}
   ) {
     this.spanTree = spanTree;
-    this.toFinalUnit = makeFormatTo('milliseconds', options.unit);
+    this.toFinalUnit = makeFormatTo('seconds', options.unit);
     this.spans = this.collectSpanNodes();
+    this.timelineFormatter = makeTimelineFormatter(options.unit);
+
+    const duration = this.toFinalUnit(
+      this.spanTree.root.span.timestamp - this.spanTree.root.span.start_timestamp
+    );
+
+    this.configSpace = new Rect(0, 0, duration, this.depth);
   }
 
   // Bfs over the span tree while keeping track of level depth and calling the cb fn
   forEachSpan(cb: (node: SpanChartNode) => void) {
     const transactionStart = this.spanTree.root.span.start_timestamp;
-
-    const queue: SpanTree['root'][] = [this.spanTree.root];
+    const queue: [SpanChartNode | null, SpanTreeNode][] = [[null, this.spanTree.root]];
     let depth = 0;
 
     while (queue.length) {
       let children_at_depth = queue.length;
 
       while (children_at_depth-- !== 0) {
-        const node = queue.shift()!;
-        queue.push(...node.children);
+        const [parent, node] = queue.shift()!;
 
         const duration = node.span.timestamp - node.span.start_timestamp;
         const start = node.span.start_timestamp - transactionStart;
         const end = start + duration;
 
-        cb({
+        const spanChartNode: SpanChartNode = {
           duration: this.toFinalUnit(duration),
           start: this.toFinalUnit(start),
           end: this.toFinalUnit(end),
           node,
           depth,
-        });
+          parent,
+          children: [],
+        };
+
+        cb(spanChartNode);
+
+        if (parent) {
+          parent.children.push(spanChartNode);
+        } else {
+          this.root.children.push(spanChartNode);
+        }
+
+        const nodesWithParent = node.children.map(
+          // @todo use satisfies here when available
+          child => [spanChartNode, child] as [SpanChartNode, SpanTreeNode]
+        );
+        queue.push(...nodesWithParent);
       }
       depth++;
     }
@@ -64,6 +103,7 @@ class SpanChart {
 
     const visit = (node: SpanChartNode): void => {
       this.depth = Math.max(this.depth, node.depth);
+      this.minSpanDuration = Math.min(this.minSpanDuration, node.duration);
       nodes.push(node);
     };
 

--- a/static/app/utils/profiling/spanTree.spec.tsx
+++ b/static/app/utils/profiling/spanTree.spec.tsx
@@ -59,15 +59,27 @@ describe('SpanTree', () => {
     expect(tree.root.span.timestamp).toBe(transaction.endTimestamp);
   });
   it('appends to parent that contains span', () => {
+    const start = Date.now();
     const tree = new SpanTree(
       txn({
         title: 'transaction root',
-        startTimestamp: Date.now(),
-        endTimestamp: Date.now() + 1000,
+        startTimestamp: start,
+        endTimestamp: start + 10,
+        contexts: {trace: {span_id: 'root'}},
       }),
       [
-        s({span_id: '1', timestamp: 1, start_timestamp: 0}),
-        s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
+        s({
+          span_id: '1',
+          parent_span_id: 'root',
+          timestamp: start + 10,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '2',
+          parent_span_id: '1',
+          timestamp: start + 5,
+          start_timestamp: start,
+        }),
       ]
     );
     expect(tree.orphanedSpans.length).toBe(0);
@@ -75,16 +87,33 @@ describe('SpanTree', () => {
     expect(tree.root.children[0].children[0].span.span_id).toBe('2');
   });
   it('pushes consecutive span', () => {
+    const start = Date.now();
     const tree = new SpanTree(
       txn({
         title: 'transaction root',
-        startTimestamp: Date.now(),
-        endTimestamp: Date.now() + 1000,
+        startTimestamp: start,
+        endTimestamp: start + 1000,
+        contexts: {trace: {span_id: 'root'}},
       }),
       [
-        s({span_id: '1', timestamp: 1, start_timestamp: 0}),
-        s({span_id: '2', timestamp: 0.5, start_timestamp: 0}),
-        s({span_id: '3', timestamp: 0.8, start_timestamp: 0.5}),
+        s({
+          span_id: '1',
+          parent_span_id: 'root',
+          timestamp: start + 1,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '2',
+          parent_span_id: '1',
+          timestamp: start + 0.5,
+          start_timestamp: start,
+        }),
+        s({
+          span_id: '3',
+          parent_span_id: '1',
+          timestamp: start + 0.8,
+          start_timestamp: start + 0.5,
+        }),
       ]
     );
 
@@ -92,16 +121,22 @@ describe('SpanTree', () => {
     expect(tree.root.children[0].children[0].span.span_id).toBe('2');
     expect(tree.root.children[0].children[1].span.span_id).toBe('3');
   });
-  it('marks span as orphaned if end overlaps', () => {
+  it('marks span as orphaned if parent_id does not match', () => {
     const tree = new SpanTree(
       txn({
         title: 'transaction root',
         startTimestamp: Date.now(),
         endTimestamp: Date.now() + 1000,
+        contexts: {trace: {span_id: 'root'}},
       }),
       [
-        s({span_id: '1', timestamp: 1, start_timestamp: 0}),
-        s({span_id: '2', timestamp: 1.1, start_timestamp: 0.1}),
+        s({span_id: '1', parent_span_id: 'root', timestamp: 1, start_timestamp: 0}),
+        s({
+          span_id: '2',
+          parent_span_id: 'orphaned',
+          timestamp: 1.1,
+          start_timestamp: 0.1,
+        }),
       ]
     );
     expect(tree.orphanedSpans[0].span_id).toBe('2');

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -42,7 +42,7 @@ function sortByStartTimeAndDuration(a: RawSpanType, b: RawSpanType) {
   return 1;
 }
 
-class SpanTreeNode {
+export class SpanTreeNode {
   parent?: SpanTreeNode | null = null;
   span: RawSpanType;
   children: SpanTreeNode[] = [];
@@ -73,8 +73,8 @@ class SpanTreeNode {
 
   contains(span: RawSpanType) {
     return (
-      span.start_timestamp >= this.span.start_timestamp &&
-      span.timestamp <= this.span.timestamp
+      this.span.start_timestamp <= span.start_timestamp &&
+      this.span.timestamp >= span.timestamp
     );
   }
 }
@@ -89,6 +89,7 @@ class SpanTree {
       start_timestamp: transaction.startTimestamp,
       timestamp: transaction.endTimestamp,
       exclusive_time: transaction.contexts?.trace?.exclusive_time ?? undefined,
+      span_id: transaction.contexts?.trace?.span_id ?? undefined,
       parent_span_id: undefined,
       op: 'transaction',
     });
@@ -103,30 +104,31 @@ class SpanTree {
   buildCollapsedSpanTree(spans: RawSpanType[]) {
     const spansSortedByStartTime = [...spans].sort(sortByStartTimeAndDuration);
 
-    for (const span of spansSortedByStartTime) {
-      const queue = [...this.root.children];
-      let parent: SpanTreeNode | null = null;
+    for (let i = 0; i < spansSortedByStartTime.length; i++) {
+      const span = spansSortedByStartTime[i];
+      let parent = this.root;
 
-      // If this is the first span, just push it to the root
-      if (!this.root.children.length) {
-        this.root.children.push(new SpanTreeNode(span, this.root));
-        continue;
-      }
-
-      while (queue.length > 0) {
-        const current = queue.pop()!;
-        if (current.contains(span)) {
-          parent = current;
-          queue.push(...current.children);
+      while (parent.contains(span)) {
+        let nextParent: SpanTreeNode | null = null;
+        for (let j = 0; j < parent.children.length; j++) {
+          const child = parent.children[j];
+          if (child.contains(span)) {
+            nextParent = child;
+            break;
+          }
         }
+        if (nextParent === null) {
+          break;
+        }
+        parent = nextParent;
       }
 
-      // if we didn't find a parent, we have an orphaned span
-      if (parent === null) {
-        this.orphanedSpans.push(span);
+      if (parent.span.span_id === span.parent_span_id) {
+        parent.children.push(new SpanTreeNode(span, parent));
         continue;
       }
-      parent.children.push(new SpanTreeNode(span, parent));
+
+      this.orphanedSpans.push(span);
     }
   }
 }


### PR DESCRIPTION
Decouple the view component from flamegraph so that it can be used in combination with different models (like spans). 

This enables us to split the zoom/pan functionality per timeline (model) that we are rendering and allows us to set proper bounds. For example if span tree is much shallower than chart, we dont want to allow users to pan/zoom far deep into the tree on Y axis as the spans would run out of view.