### PR TITLE
fix(audit-log): Filter null entry

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -167,7 +167,7 @@ export type AuditLog = {
   note: string;
   targetObject: number;
   targetUser: Actor | null;
-} | null;
+};
 
 export type AccessRequest = {
   id: string;

--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -167,7 +167,7 @@ export type AuditLog = {
   note: string;
   targetObject: number;
   targetUser: Actor | null;
-};
+} | null;
 
 export type AccessRequest = {
   id: string;

--- a/static/app/views/settings/organizationAuditLog/auditLogList.tsx
+++ b/static/app/views/settings/organizationAuditLog/auditLogList.tsx
@@ -55,7 +55,13 @@ const addUsernameDisplay = (logEntryUser: User | undefined) => {
   return null;
 };
 
-function AuditNote({entry, orgSlug}: {entry: AuditLog; orgSlug: Organization['slug']}) {
+function AuditNote({
+  entry,
+  orgSlug,
+}: {
+  entry: NonNullable<AuditLog>;
+  orgSlug: Organization['slug'];
+}) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === String(entry.data.id));
 
@@ -208,7 +214,10 @@ const AuditLogList = ({
         emptyMessage={t('No audit entries available')}
         isLoading={isLoading}
       >
-        {entries?.map(entry => {
+        {(entries ?? []).map(entry => {
+          if (!entry) {
+            return null;
+          }
           return (
             <Fragment key={entry.id}>
               <UserInfo>


### PR DESCRIPTION
the audit log endpoint is also returning `null` as row's entry and this breaks the page on the frontend

![image](https://user-images.githubusercontent.com/29228205/209142736-b963077e-03c4-42c3-b70a-5ae34f82290c.png)

This filters these entries

fixes JAVASCRIPT-2BKY