### PR TITLE
fix: add TransactionProfileIdProvider

### DIFF
--- a/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -13,6 +13,7 @@ import GroupSidebar from 'sentry/components/group/sidebar';
 import * as Layout from 'sentry/components/layouts/thirds';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
 import MutedBox from 'sentry/components/mutedBox';
+import {TransactionProfileIdProvider} from 'sentry/components/profiling/transactionProfileIdProvider';
 import ReprocessedBox from 'sentry/components/reprocessedBox';
 import ResolutionBox from 'sentry/components/resolutionBox';
 import space from 'sentry/styles/space';
@@ -240,63 +241,70 @@ class GroupEventDetails extends Component<GroupEventDetailsProps, State> {
     const hasReplay = Boolean(event?.tags?.find(({key}) => key === 'replayId')?.value);
 
     return (
-      <div className={className} data-test-id="group-event-details">
-        <StyledLayoutBody>
-          {hasReprocessingV2Feature &&
-          groupReprocessingStatus === ReprocessingStatus.REPROCESSING ? (
-            <ReprocessingProgress
-              totalEvents={(mostRecentActivity as GroupActivityReprocess).data.eventCount}
-              pendingEvents={
-                (group.statusDetails as BaseGroupStatusReprocessing['statusDetails'])
-                  .pendingEvents
-              }
-            />
-          ) : (
-            <Fragment>
-              <QuickTraceQuery
-                event={eventWithMeta}
-                location={location}
-                orgSlug={organization.slug}
-              >
-                {results => {
-                  return (
-                    <StyledLayoutMain>
-                      {this.renderGroupStatusBanner()}
-                      <QuickTraceContext.Provider value={results}>
-                        {eventWithMeta && (
-                          <GroupEventToolbar
-                            group={group}
-                            event={eventWithMeta}
-                            organization={organization}
-                            location={location}
-                            project={project}
-                            hasReplay={hasReplay}
-                          />
-                        )}
-                        {this.renderReprocessedBox(
-                          groupReprocessingStatus,
-                          mostRecentActivity as GroupActivityReprocess
-                        )}
-                        {this.renderContent(eventWithMeta)}
-                      </QuickTraceContext.Provider>
-                    </StyledLayoutMain>
-                  );
-                }}
-              </QuickTraceQuery>
-
-              <StyledLayoutSide>
-                <GroupSidebar
-                  organization={organization}
-                  project={project}
-                  group={group}
+      <TransactionProfileIdProvider
+        transactionId={event?.type === 'transaction' ? event.id : undefined}
+        timestamp={event?.dateReceived}
+      >
+        <div className={className} data-test-id="group-event-details">
+          <StyledLayoutBody>
+            {hasReprocessingV2Feature &&
+            groupReprocessingStatus === ReprocessingStatus.REPROCESSING ? (
+              <ReprocessingProgress
+                totalEvents={
+                  (mostRecentActivity as GroupActivityReprocess).data.eventCount
+                }
+                pendingEvents={
+                  (group.statusDetails as BaseGroupStatusReprocessing['statusDetails'])
+                    .pendingEvents
+                }
+              />
+            ) : (
+              <Fragment>
+                <QuickTraceQuery
                   event={eventWithMeta}
-                  environments={environments}
-                />
-              </StyledLayoutSide>
-            </Fragment>
-          )}
-        </StyledLayoutBody>
-      </div>
+                  location={location}
+                  orgSlug={organization.slug}
+                >
+                  {results => {
+                    return (
+                      <StyledLayoutMain>
+                        {this.renderGroupStatusBanner()}
+                        <QuickTraceContext.Provider value={results}>
+                          {eventWithMeta && (
+                            <GroupEventToolbar
+                              group={group}
+                              event={eventWithMeta}
+                              organization={organization}
+                              location={location}
+                              project={project}
+                              hasReplay={hasReplay}
+                            />
+                          )}
+                          {this.renderReprocessedBox(
+                            groupReprocessingStatus,
+                            mostRecentActivity as GroupActivityReprocess
+                          )}
+                          {this.renderContent(eventWithMeta)}
+                        </QuickTraceContext.Provider>
+                      </StyledLayoutMain>
+                    );
+                  }}
+                </QuickTraceQuery>
+
+                <StyledLayoutSide>
+                  <GroupSidebar
+                    organization={organization}
+                    project={project}
+                    group={group}
+                    event={eventWithMeta}
+                    environments={environments}
+                  />
+                </StyledLayoutSide>
+              </Fragment>
+            )}
+          </StyledLayoutBody>
+        </div>
+      </TransactionProfileIdProvider>
     );
   }
 }


### PR DESCRIPTION
We were missing a context provider for when we showed `span evidence` on an issues page. Expanding a `span` would result in an error.


<img width="401" alt="image" src="https://user-images.githubusercontent.com/7349258/209161384-cb1bab84-039d-4e78-a1aa-bd0678c68afe.png">


<img width="1643" alt="image" src="https://user-images.githubusercontent.com/7349258/209161247-bca5cc61-b5fd-4d41-ac53-852b6680ab7f.png">


Fixes: https://sentry.io/organizations/sentry/issues/3825585272/?project=11276&query=url%3A%22https%3A%2F%2Fsentry.io%2Forganizations%2Ft38-cafe%2Fissues%2F3726412129%2F%22&referrer=issue-stream