### PR TITLE
fix(js): Use more named icon sizes

### DIFF
--- a/static/app/components/assigneeSelector.tsx
+++ b/static/app/components/assigneeSelector.tsx
@@ -102,7 +102,7 @@ function AssigneeSelector({noDropdown, ...props}: AssigneeSelectorProps) {
           </TooltipWrapper>
         }
       >
-        <StyledIconUser data-test-id="unassigned" size="20px" color="gray400" />
+        <StyledIconUser data-test-id="unassigned" size="md" color="gray400" />
       </Tooltip>
     );
   }

--- a/static/app/components/questionTooltip.tsx
+++ b/static/app/components/questionTooltip.tsx
@@ -5,14 +5,14 @@ import {IconQuestion} from 'sentry/icons';
 import type {Color, IconSize} from 'sentry/utils/theme';
 
 type ContainerProps = {
-  size: IconSize | string;
+  size: IconSize;
   className?: string;
 };
 
 const QuestionIconContainer = styled('span')<ContainerProps>`
   display: inline-block;
-  height: ${p => p.theme.iconSizes[p.size] ?? p.size};
-  line-height: ${p => p.theme.iconSizes[p.size] ?? p.size};
+  height: ${p => p.theme.iconSizes[p.size]};
+  line-height: ${p => p.theme.iconSizes[p.size]};
 
   & svg {
     transition: 120ms opacity;
@@ -26,7 +26,7 @@ const QuestionIconContainer = styled('span')<ContainerProps>`
 `;
 
 type QuestionProps = {
-  size: string;
+  size: IconSize;
   title: React.ReactNode;
   className?: string;
   color?: Color;

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -77,7 +77,7 @@ const SidebarDropdown = ({
       />
     ) : (
       <SentryLink to="/">
-        <IconSentry size="32px" />
+        <IconSentry size="xl" />
       </SentryLink>
     );
 

--- a/static/app/components/teamSelector.tsx
+++ b/static/app/components/teamSelector.tsx
@@ -38,7 +38,7 @@ const unassignedOption = {
   value: null,
   label: (
     <UnassignedWrapper>
-      <StyledIconUser size="20px" />
+      <StyledIconUser size="md" />
       {t('Unassigned')}
     </UnassignedWrapper>
   ),

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -581,7 +581,7 @@ const SPECIAL_FIELDS: SpecialFields = {
             <NumberContainer>
               <Count value={count} />
             </NumberContainer>
-            <UserIcon size="20" />
+            <UserIcon size="md" />
           </FlexContainer>
         );
       }

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -34,6 +34,8 @@ import {
 } from 'sentry/utils/analytics/integrations';
 import makeAnalyticsFunction from 'sentry/utils/analytics/makeAnalyticsFunction';
 
+import {IconSize} from './theme';
+
 const mapIntegrationParams = analyticsParams => {
   // Reload expects integration_status even though it's not relevant for non-sentry apps
   // Passing in a dummy value of published in those cases
@@ -196,8 +198,10 @@ export const safeGetQsParam = (param: string) => {
   }
 };
 
-export const getIntegrationIcon = (integrationType?: string, size?: string) => {
-  const iconSize = size || 'md';
+export const getIntegrationIcon = (
+  integrationType?: string,
+  iconSize: IconSize = 'md'
+) => {
   switch (integrationType) {
     case 'asana':
       return <IconAsana size={iconSize} />;

--- a/static/app/views/alerts/list/rules/row.tsx
+++ b/static/app/views/alerts/list/rules/row.tsx
@@ -238,7 +238,7 @@ function RuleListRow({
     value: '',
     label: () => (
       <MenuItemWrapper>
-        <StyledIconUser size="20px" />
+        <StyledIconUser size="md" />
         {t('Unassigned')}
       </MenuItemWrapper>
     ),
@@ -293,7 +293,7 @@ function RuleListRow({
     />
   ) : (
     <Tooltip isHoverable skipWrapper title={t('Unassigned')}>
-      <StyledIconUser size="20px" color="gray400" />
+      <StyledIconUser size="md" color="gray400" />
     </Tooltip>
   );
 

--- a/static/app/views/auth/layout.tsx
+++ b/static/app/views/auth/layout.tsx
@@ -61,7 +61,7 @@ const AuthSidebar = styled('div')`
 const SentryButton = styled(
   (p: Omit<React.ComponentPropsWithoutRef<typeof Link>, 'to'>) => (
     <Link to="/" {...p}>
-      <IconSentry size="24px" />
+      <IconSentry size="lg" />
     </Link>
   )
 )`

--- a/static/app/views/organizationStats/teamInsights/teamIssuesAge.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesAge.tsx
@@ -143,7 +143,7 @@ class TeamIssuesAge extends AsyncComponent<Props, State> {
             <RightAligned key="events">{t('Events')}</RightAligned>,
             <RightAligned key="users">{t('Users')}</RightAligned>,
             <RightAligned key="age">
-              {t('Age')} <IconArrow direction="down" size="12px" color="gray300" />
+              {t('Age')} <IconArrow direction="down" size="xs" color="gray300" />
             </RightAligned>,
           ]}
           isLoading={loading}

--- a/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamIssuesBreakdown.tsx
@@ -180,8 +180,7 @@ class TeamIssuesBreakdown extends AsyncComponent<Props, State> {
                     <AlignRight key={action}>{action}</AlignRight>
                   )),
                   <AlignRight key="total">
-                    {t('total')}{' '}
-                    <IconArrow direction="down" size="12px" color="gray300" />
+                    {t('total')} <IconArrow direction="down" size="xs" color="gray300" />
                   </AlignRight>,
                 ]}
                 isLoading={loading}

--- a/static/app/views/organizationStats/usageChart/index.tsx
+++ b/static/app/views/organizationStats/usageChart/index.tsx
@@ -417,7 +417,7 @@ export class UsageChart extends Component<Props, State> {
     if (isError) {
       return (
         <Placeholder height="200px">
-          <IconWarning size={theme.fontSizeExtraLarge} />
+          <IconWarning size="sm" />
           <ErrorMessages data-test-id="error-messages">
             {errors &&
               Object.keys(errors).map(k => <span key={k}>{errors[k]?.message}</span>)}

--- a/static/app/views/organizationStats/usageTable/index.tsx
+++ b/static/app/views/organizationStats/usageTable/index.tsx
@@ -12,7 +12,6 @@ import {IconSettings, IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import space from 'sentry/styles/space';
 import {DataCategory, Project} from 'sentry/types';
-import theme from 'sentry/utils/theme';
 
 import {formatUsageWithUnits} from '../utils';
 
@@ -83,7 +82,7 @@ class UsageTable extends Component<Props> {
           />
         </Link>
         <SettingsIconLink to={stat.projectSettingsLink}>
-          <IconSettings size={theme.iconSizes.sm} />
+          <IconSettings size="sm" />
         </SettingsIconLink>
       </CellProject>,
       <CellStat key={1}>

--- a/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -96,7 +96,7 @@ const TimestampLink = ({date, link}: {date: moment.MomentInput; link?: string}) 
   link ? (
     <ExternalLink href={link}>
       <DateTime date={date} />
-      <StyledIconOpen size="12px" />
+      <StyledIconOpen size="xs" />
     </ExternalLink>
   ) : (
     <DateTime date={date} format={is24Hours ? 'MMM D, YYYY HH:mm:ss z' : 'll LTS z'} />


### PR DESCRIPTION
Attempting to get rid of the `string` type here