### PR TITLE
fix(deps): Move non dev dependnecies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/diff": "5.0.2",
     "@types/dompurify": "^2.4.0",
     "@types/jest": "^29.2.4",
+    "@types/js-beautify": "^1.13.3",
     "@types/js-cookie": "^3.0.2",
     "@types/lodash": "^4.14.182",
     "@types/marked": "^0.7.2",
@@ -155,6 +156,7 @@
     "tslib": "^2.3.1",
     "typescript": "^4.8.3",
     "u2f-api": "1.0.10",
+    "url-loader": "^4.1.0",
     "webpack": "5.75.0",
     "webpack-cli": "5.0.1",
     "webpack-remove-empty-scripts": "^1.0.1",
@@ -181,7 +183,6 @@
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^13.5.0",
-    "@types/js-beautify": "^1.13.3",
     "@types/node": "^18.11.15",
     "@visual-snapshot/jest": "7.0.0",
     "assert": "^2.0.0",
@@ -211,7 +212,6 @@
     "tocbot": "^4.19.0",
     "tsconfig-paths": "^4.1.1",
     "typescript-styled-plugin": "^0.18.2",
-    "url-loader": "^4.1.0",
     "webpack-dev-server": "^4.9.2"
   },
   "optionalDependencies": {


### PR DESCRIPTION
These are both needed to build the app. They just happen to be installed
even though they are in devDependencies.