### PR TITLE
ref(profiling): optimize rerendering

### DIFF
--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -15,9 +15,15 @@ import {
 } from 'sentry/components/profiling/flamegraph/flamegraphOverlays/profileDragDropImport';
 import {FlamegraphOptionsMenu} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphOptionsMenu';
 import {FlamegraphSearch} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch';
-import {FlamegraphThreadSelector} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector';
+import {
+  FlamegraphThreadSelector,
+  FlamegraphThreadSelectorProps,
+} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector';
 import {FlamegraphToolbar} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphToolbar';
-import {FlamegraphViewSelectMenu} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphViewSelectMenu';
+import {
+  FlamegraphViewSelectMenu,
+  FlamegraphViewSelectMenuProps,
+} from 'sentry/components/profiling/flamegraph/flamegraphToolbar/flamegraphViewSelectMenu';
 import {FlamegraphZoomView} from 'sentry/components/profiling/flamegraph/flamegraphZoomView';
 import {FlamegraphZoomViewMinimap} from 'sentry/components/profiling/flamegraph/flamegraphZoomViewMinimap';
 import {defined} from 'sentry/utils';
@@ -410,28 +416,47 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
     return selectedRoot ? [selectedRoot] : flamegraph.root.children;
   }, [selectedRoot, flamegraph.root]);
 
+  const onSortingChange: FlamegraphViewSelectMenuProps['onSortingChange'] = useCallback(
+    newSorting => {
+      dispatch({type: 'set sorting', payload: newSorting});
+    },
+    [dispatch]
+  );
+
+  const onViewChange: FlamegraphViewSelectMenuProps['onViewChange'] = useCallback(
+    newView => {
+      dispatch({type: 'set view', payload: newView});
+    },
+    [dispatch]
+  );
+
+  const onThreadIdChange: FlamegraphThreadSelectorProps['onThreadIdChange'] = useCallback(
+    newThreadId => {
+      dispatch({type: 'set thread id', payload: newThreadId});
+    },
+    [dispatch]
+  );
+
+  // A bit unfortunate for now, but the search component accepts a list
+  // of model to search through. This will become useful as we  build
+  // differential flamecharts or start comparing different profiles/charts
+  const flamegraphs = useMemo(() => [flamegraph], [flamegraph]);
   return (
     <Fragment>
       <FlamegraphToolbar>
         <FlamegraphThreadSelector
           profileGroup={props.profiles}
           threadId={threadId}
-          onThreadIdChange={newThreadId =>
-            dispatch({type: 'set thread id', payload: newThreadId})
-          }
+          onThreadIdChange={onThreadIdChange}
         />
         <FlamegraphViewSelectMenu
           view={view}
           sorting={sorting}
-          onSortingChange={s => {
-            dispatch({type: 'set sorting', payload: s});
-          }}
-          onViewChange={v => {
-            dispatch({type: 'set view', payload: v});
-          }}
+          onSortingChange={onSortingChange}
+          onViewChange={onViewChange}
         />
         <FlamegraphSearch
-          flamegraphs={[flamegraph]}
+          flamegraphs={flamegraphs}
           canvasPoolManager={canvasPoolManager}
         />
         <FlamegraphOptionsMenu canvasPoolManager={canvasPoolManager} />

--- a/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphLayout.tsx
@@ -85,9 +85,9 @@ export function FlamegraphLayout(props: FlamegraphLayoutProps) {
           </SpansContainer>
         ) : null}
         <ZoomViewContainer>{props.flamegraph}</ZoomViewContainer>
-        <FLAMEGRAPH_DRAWERContainer ref={flamegraphDrawerRef} layout={layout}>
+        <FlamegraphDrawerContainer ref={flamegraphDrawerRef} layout={layout}>
           {cloneElement(props.flamegraphDrawer, {onResize: onMouseDown})}
-        </FLAMEGRAPH_DRAWERContainer>
+        </FlamegraphDrawerContainer>
       </FlamegraphGrid>
     </FlamegraphLayoutContainer>
   );
@@ -165,7 +165,7 @@ const SpansContainer = styled('div')<{
   grid-area: spans;
 `;
 
-const FLAMEGRAPH_DRAWERContainer = styled('div')<{
+const FlamegraphDrawerContainer = styled('div')<{
   layout: FlamegraphPreferences['layout'];
 }>`
   grid-area: frame-stack;

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphThreadSelector.tsx
@@ -12,7 +12,7 @@ import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
 import {makeFormatter} from 'sentry/utils/profiling/units/units';
 
-interface FlamegraphThreadSelectorProps {
+export interface FlamegraphThreadSelectorProps {
   onThreadIdChange: (threadId: Profile['threadId']) => void;
   profileGroup: ProfileGroup;
   threadId: FlamegraphState['profiles']['threadId'];

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphViewSelectMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphViewSelectMenu.tsx
@@ -5,7 +5,7 @@ import ButtonBar from 'sentry/components/buttonBar';
 import {t} from 'sentry/locale';
 import {FlamegraphPreferences} from 'sentry/utils/profiling/flamegraph/flamegraphStateProvider/reducers/flamegraphPreferences';
 
-interface FlamegraphViewSelectMenuProps {
+export interface FlamegraphViewSelectMenuProps {
   onSortingChange: (sorting: FlamegraphViewSelectMenuProps['sorting']) => void;
   onViewChange: (view: FlamegraphViewSelectMenuProps['view']) => void;
   sorting: FlamegraphPreferences['sorting'];

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -75,7 +75,7 @@ function FlamegraphZoomView({
   setFlamegraphOverlayCanvasRef,
 }: FlamegraphZoomViewProps): React.ReactElement {
   const flamegraphTheme = useFlamegraphTheme();
-  const [profileGroup] = useProfileGroup();
+  const profileGroup = useProfileGroup();
   const flamegraphSearch = useFlamegraphSearch();
   const isInternalFlamegraphDebugModeEnabled = useInternalFlamegraphDebugMode();
 

--- a/static/app/components/profiling/profileHeader.tsx
+++ b/static/app/components/profiling/profileHeader.tsx
@@ -12,22 +12,22 @@ import {
 } from 'sentry/utils/profiling/routes';
 import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
-import {useParams} from 'sentry/utils/useParams';
 import {useProfileGroup} from 'sentry/views/profiling/profileGroupProvider';
 
 interface ProfileHeaderProps {
+  eventId: string;
+  projectId: string;
   transaction: Event | null;
 }
 
-function ProfileHeader({transaction}: ProfileHeaderProps) {
-  const params = useParams();
+function ProfileHeader({transaction, projectId, eventId}: ProfileHeaderProps) {
   const location = useLocation();
   const organization = useOrganization();
-  const [profileGroup] = useProfileGroup();
+  const profileGroup = useProfileGroup();
 
   const transactionName = profileGroup.type === 'resolved' ? profileGroup.data.name : '';
-  const profileId = params.eventId ?? '';
-  const projectSlug = params.projectId ?? '';
+  const profileId = eventId ?? '';
+  const projectSlug = projectId ?? '';
 
   const transactionTarget = transaction?.id
     ? getTransactionDetailsUrl(organization.slug, `${projectSlug}:${transaction.id}`)

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
@@ -69,7 +69,7 @@ interface FlamegraphStateProviderProps {
 export function FlamegraphStateProvider(
   props: FlamegraphStateProviderProps
 ): React.ReactElement {
-  const [profileGroup] = useProfileGroup();
+  const profileGroup = useProfileGroup();
   const [state, dispatch, {nextState, previousState}] = useUndoableReducer(
     flamegraphStateReducer,
     {

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphContextProvider.tsx
@@ -1,4 +1,4 @@
-import {useEffect} from 'react';
+import {useEffect, useMemo} from 'react';
 
 import {DeepPartial} from 'sentry/types/utils';
 import {defined} from 'sentry/utils';
@@ -14,6 +14,7 @@ import {
   FlamegraphState,
   FlamegraphStateDispatchContext,
   flamegraphStateReducer,
+  FlamegraphStateValue,
   FlamegraphStateValueContext,
 } from './flamegraphContext';
 
@@ -201,8 +202,12 @@ export function FlamegraphStateProvider(
     state.profiles.highlightFrames,
   ]);
 
+  const flamegraphContextValue: FlamegraphStateValue = useMemo(() => {
+    return [state, {nextState, previousState}];
+  }, [state, nextState, previousState]);
+
   return (
-    <FlamegraphStateValueContext.Provider value={[state, {nextState, previousState}]}>
+    <FlamegraphStateValueContext.Provider value={flamegraphContextValue}>
       <FlamegraphStateDispatchContext.Provider value={dispatch}>
         {props.children}
       </FlamegraphStateDispatchContext.Provider>

--- a/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphQueryParamSync.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphStateProvider/flamegraphQueryParamSync.tsx
@@ -1,6 +1,7 @@
 import {useEffect} from 'react';
 import {browserHistory} from 'react-router';
 import {Query} from 'history';
+import * as qs from 'query-string';
 
 import {DeepPartial} from 'sentry/types/utils';
 import {useFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
@@ -64,7 +65,7 @@ function isXAxis(
 }
 
 export function decodeFlamegraphStateFromQueryParams(
-  query: Query
+  query: qs.ParsedQuery
 ): DeepPartial<FlamegraphState> {
   return {
     profiles: {

--- a/static/app/utils/useUndoableReducer.tsx
+++ b/static/app/utils/useUndoableReducer.tsx
@@ -1,4 +1,4 @@
-import {ReducerAction, ReducerState, useReducer} from 'react';
+import {ReducerAction, ReducerState, useMemo, useReducer} from 'react';
 
 export type UndoableNode<S> = {
   current: S;
@@ -67,28 +67,31 @@ export function makeUndoableReducer<R extends React.Reducer<any, any>>(
   };
 }
 
-export function useUndoableReducer<
-  R extends React.Reducer<ReducerState<R>, ReducerAction<R>>
->(
-  reducer: R,
-  initialState: ReducerState<R>
-): [
+type UndoableReducerState<R extends React.Reducer<ReducerState<R>, ReducerAction<R>>> = [
   ReducerState<R>,
   React.Dispatch<UndoableReducerAction<ReducerAction<R>>>,
   {
     nextState: ReducerState<R> | undefined;
     previousState: ReducerState<R> | undefined;
   }
-] {
+];
+
+export function useUndoableReducer<
+  R extends React.Reducer<ReducerState<R>, ReducerAction<R>>
+>(reducer: R, initialState: ReducerState<R>): UndoableReducerState<R> {
   const [state, dispatch] = useReducer(makeUndoableReducer(reducer), {
     current: initialState,
     previous: undefined,
     next: undefined,
   });
 
-  return [
-    state.current,
-    dispatch,
-    {previousState: state.previous?.current, nextState: state.next?.current},
-  ];
+  const value: UndoableReducerState<R> = useMemo(() => {
+    return [
+      state.current,
+      dispatch,
+      {previousState: state.previous?.current, nextState: state.next?.current},
+    ];
+  }, [state, dispatch]);
+
+  return value;
 }

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.spec.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.spec.tsx
@@ -23,7 +23,7 @@ const mockUseProfileData: RequestState<ProfileGroup> = {
   type: 'resolved',
   data: importProfile(makeSentrySampledProfile(), ''),
 };
-useProfileGroupSpy.mockImplementation(() => [mockUseProfileData, () => {}]);
+useProfileGroupSpy.mockImplementation(() => mockUseProfileData);
 
 function assertTableHeaders(headerText: string[]) {
   const gridHeadRow = screen.getByTestId('grid-head-row');

--- a/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
+++ b/static/app/views/profiling/profileDetails/components/profileDetailsTable.tsx
@@ -32,7 +32,7 @@ const RESULTS_PER_PAGE = 50;
 
 export function ProfileDetailsTable() {
   const location = useLocation();
-  const [state] = useProfileGroup();
+  const profileGroup = useProfileGroup();
   const [groupByViewKey, setGroupByView] = useQuerystringState({
     key: 'detailView',
     initialState: 'occurrence',
@@ -54,10 +54,12 @@ export function ProfileDetailsTable() {
 
   const allData = useMemo(() => {
     const data =
-      state.type === 'resolved' ? state.data.profiles.flatMap(collectProfileFrames) : [];
+      profileGroup.type === 'resolved'
+        ? profileGroup.data.profiles.flatMap(collectProfileFrames)
+        : [];
 
     return groupByView.transform(data);
-  }, [state, groupByView]);
+  }, [profileGroup, groupByView]);
 
   const {search} = useFuseSearch(allData, {
     keys: groupByView.search.key,
@@ -189,8 +191,8 @@ export function ProfileDetailsTable() {
       </ActionBar>
 
       <GridEditable
-        isLoading={state.type === 'loading'}
-        error={state.type === 'errored'}
+        isLoading={profileGroup.type === 'loading'}
+        error={profileGroup.type === 'errored'}
         data={data}
         columnOrder={groupByView.columns.map(key => COLUMNS[key])}
         columnSortBy={[currentSort]}

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -1,5 +1,6 @@
-import {Fragment, useEffect, useMemo} from 'react';
+import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
+import * as qs from 'query-string';
 
 import Alert from 'sentry/components/alert';
 import LoadingIndicator from 'sentry/components/loadingIndicator';
@@ -27,7 +28,6 @@ import {ProfileGroup} from 'sentry/utils/profiling/profile/importProfile';
 import {Profile} from 'sentry/utils/profiling/profile/profile';
 import {SpanTree} from 'sentry/utils/profiling/spanTree';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
-import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 
 import {useProfileGroup, useProfileTransaction} from './profileGroupProvider';
@@ -64,7 +64,6 @@ const LoadingGroup: ProfileGroup = {
 const LoadingSpanTree = SpanTree.Empty();
 
 function ProfileFlamegraph(): React.ReactElement {
-  const location = useLocation();
   const organization = useOrganization();
   const [profileGroup, setProfileGroup] = useProfileGroup();
   const profiledTransaction = useProfileTransaction();
@@ -97,12 +96,17 @@ function ProfileFlamegraph(): React.ReactElement {
     });
   }, [organization]);
 
-  const onImport: ProfileDragDropImportProps['onImport'] = profiles => {
-    setProfileGroup({type: 'resolved', data: profiles});
-  };
+  const onImport: ProfileDragDropImportProps['onImport'] = useCallback(
+    profiles => {
+      setProfileGroup({type: 'resolved', data: profiles});
+    },
+    [setProfileGroup]
+  );
 
   const initialFlamegraphPreferencesState = useMemo((): DeepPartial<FlamegraphState> => {
-    const queryStringState = decodeFlamegraphStateFromQueryParams(location.query);
+    const queryStringState = decodeFlamegraphStateFromQueryParams(
+      qs.parse(window.location.search)
+    );
 
     return {
       ...queryStringState,

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -30,7 +30,11 @@ import {SpanTree} from 'sentry/utils/profiling/spanTree';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import useOrganization from 'sentry/utils/useOrganization';
 
-import {useProfileGroup, useProfileTransaction} from './profileGroupProvider';
+import {
+  useProfileGroup,
+  useProfileTransaction,
+  useSetProfileGroup,
+} from './profileGroupProvider';
 
 function collectAllSpanEntriesFromTransaction(
   transaction: EventTransaction
@@ -65,7 +69,8 @@ const LoadingSpanTree = SpanTree.Empty();
 
 function ProfileFlamegraph(): React.ReactElement {
   const organization = useOrganization();
-  const [profileGroup, setProfileGroup] = useProfileGroup();
+  const profileGroup = useProfileGroup();
+  const setProfileGroup = useSetProfileGroup();
   const profiledTransaction = useProfileTransaction();
 
   const hasFlameChartSpans = useMemo(() => {

--- a/static/app/views/profiling/profileGroupProvider.tsx
+++ b/static/app/views/profiling/profileGroupProvider.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useEffect, useState} from 'react';
+import {createContext, useContext, useEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Client} from 'sentry/api';
@@ -33,13 +33,11 @@ interface FlamegraphViewProps {
   children: React.ReactNode;
 }
 
-const ProfileGroupContext = createContext<
-  | [
-      RequestState<ProfileGroup>,
-      React.Dispatch<React.SetStateAction<RequestState<ProfileGroup>>>
-    ]
-  | null
->(null);
+type ProfileGroupContextValue = [
+  RequestState<ProfileGroup>,
+  React.Dispatch<React.SetStateAction<RequestState<ProfileGroup>>>
+];
+const ProfileGroupContext = createContext<ProfileGroupContextValue | null>(null);
 
 export function useProfileGroup() {
   const context = useContext(ProfileGroupContext);
@@ -99,8 +97,13 @@ function ProfileGroupProvider(props: FlamegraphViewProps): React.ReactElement {
     };
   }, [params.eventId, params.projectId, api, organization]);
 
+  const contextValue: ProfileGroupContextValue = useMemo(
+    () => [profileGroupState, setProfileGroupState],
+    [profileGroupState, setProfileGroupState]
+  );
+
   return (
-    <ProfileGroupContext.Provider value={[profileGroupState, setProfileGroupState]}>
+    <ProfileGroupContext.Provider value={contextValue}>
       <ProfileTransactionContext.Provider value={profileTransaction}>
         <ProfileHeader
           transaction={

--- a/static/app/views/profiling/utils.tsx
+++ b/static/app/views/profiling/utils.tsx
@@ -36,6 +36,25 @@ export function getColorEncodingFromLocation(location: Location): ColorEncoding 
   return 'transaction_name';
 }
 
+export function requestAnimationFrameTimeout(cb: () => void, timeout: number) {
+  const rafId = {current: 0};
+  const start = performance.now();
+
+  function timer() {
+    if (rafId.current) {
+      window.cancelAnimationFrame(rafId.current);
+    }
+    if (performance.now() - start > timeout) {
+      cb();
+      return;
+    }
+    rafId.current = window.requestAnimationFrame(timer);
+  }
+
+  rafId.current = window.requestAnimationFrame(timer);
+  return rafId;
+}
+
 export function renderTableHeader<K>(rightAlignedColumns: Set<K>) {
   return (column: GridColumnOrder<K>, _columnIndex: number) => {
     return (


### PR DESCRIPTION
When we update QS on user pan/zoom around the chart, react router triggers a full page rerender which in turn causes frame drops. This is especially noticeable when users keep navigating and the qs update may trigger (only 300ms debounce) which causes jank on the pan/zoom behavior