### PR TITLE
feat(profiling): convert to proper space from unix ts

### DIFF
--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -4,7 +4,6 @@ import {vec2} from 'gl-matrix';
 
 import space from 'sentry/styles/space';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
-import {Flamegraph} from 'sentry/utils/profiling/flamegraph';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {Rect} from 'sentry/utils/profiling/gl/utils';
@@ -32,17 +31,17 @@ function computeBestTooltipPlacement(
 
 interface BoundTooltipProps {
   bounds: Rect;
+  canvas: FlamegraphCanvas;
+  canvasView: CanvasView<any>;
   cursor: vec2;
-  flamegraphCanvas: FlamegraphCanvas;
-  flamegraphView: CanvasView<Flamegraph>;
   children?: React.ReactNode;
 }
 
 function BoundTooltip({
   bounds,
-  flamegraphCanvas,
+  canvas,
   cursor,
-  flamegraphView,
+  canvasView,
   children,
 }: BoundTooltipProps): React.ReactElement | null {
   const flamegraphTheme = useFlamegraphTheme();
@@ -50,13 +49,13 @@ function BoundTooltip({
   const physicalSpaceCursor = vec2.transformMat3(
     vec2.create(),
     cursor,
-    flamegraphView.fromConfigView(flamegraphCanvas.physicalSpace)
+    canvasView.fromConfigView(canvas.physicalSpace)
   );
 
   const logicalSpaceCursor = vec2.transformMat3(
     vec2.create(),
     physicalSpaceCursor,
-    flamegraphCanvas.physicalToLogicalSpace
+    canvas.physicalToLogicalSpace
   );
 
   const rafIdRef = useRef<number | undefined>();

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -167,7 +167,6 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
       const newView = new CanvasView({
         canvas: flamegraphCanvas,
-        configSpace: flamegraph.configSpace,
         model: flamegraph,
         options: {
           inverted: flamegraph.inverted,
@@ -271,7 +270,6 @@ function Flamegraph(props: FlamegraphProps): ReactElement {
 
       const newView = new CanvasView({
         canvas: spansCanvas,
-        configSpace: spanChart.configSpace,
         model: spanChart,
         options: {
           inverted: false,

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -1,14 +1,27 @@
-import {useEffect, useMemo} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import {mat3, vec2} from 'gl-matrix';
 
+import {BoundTooltip} from 'sentry/components/profiling/boundTooltip';
+import {t} from 'sentry/locale';
 import {CanvasPoolManager, CanvasScheduler} from 'sentry/utils/profiling/canvasScheduler';
 import {CanvasView} from 'sentry/utils/profiling/canvasView';
+import {useDispatchFlamegraphState} from 'sentry/utils/profiling/flamegraph/hooks/useFlamegraphState';
 import {useFlamegraphTheme} from 'sentry/utils/profiling/flamegraph/useFlamegraphTheme';
 import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
+import {formatColorForSpan, Rect} from 'sentry/utils/profiling/gl/utils';
 import {SpanChartRenderer2D} from 'sentry/utils/profiling/renderers/spansRenderer';
-import {SpanChart} from 'sentry/utils/profiling/spanChart';
+import {SpanChart, SpanChartNode} from 'sentry/utils/profiling/spanChart';
+import usePrevious from 'sentry/utils/usePrevious';
+
+import {
+  FlamegraphTooltipColorIndicator,
+  FlamegraphTooltipFrameMainInfo,
+  FlamegraphTooltipTimelineInfo,
+} from './flamegraphTooltip';
 
 interface FlamegraphSpansProps {
+  canvasBounds: Rect;
   canvasPoolManager: CanvasPoolManager;
   setSpansCanvasRef: React.Dispatch<React.SetStateAction<HTMLCanvasElement | null>>;
   spanChart: SpanChart;
@@ -20,13 +33,24 @@ interface FlamegraphSpansProps {
 export function FlamegraphSpans({
   spanChart,
   canvasPoolManager,
+  canvasBounds,
   spansView,
   spansCanvas,
   spansCanvasRef,
   setSpansCanvasRef,
 }: FlamegraphSpansProps) {
+  const dispatch = useDispatchFlamegraphState();
   const flamegraphTheme = useFlamegraphTheme();
   const scheduler = useMemo(() => new CanvasScheduler(), []);
+
+  const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
+  const [startPanVector, setStartPanVector] = useState<vec2 | null>(null);
+  const [lastInteraction, setLastInteraction] = useState<
+    'pan' | 'click' | 'zoom' | 'scroll' | 'select' | 'resize' | null
+  >(null);
+
+  const previousInteraction = usePrevious(lastInteraction);
+  const beforeInteractionConfigView = useRef<Rect | null>(null);
 
   const spansRenderer = useMemo(() => {
     if (!spansCanvasRef) {
@@ -35,6 +59,28 @@ export function FlamegraphSpans({
 
     return new SpanChartRenderer2D(spansCanvasRef, spanChart, flamegraphTheme);
   }, [spansCanvasRef, spanChart, flamegraphTheme]);
+
+  useEffect(() => {
+    if (!spansView) {
+      return;
+    }
+
+    // Check if we are starting a new interaction
+    if (previousInteraction === null && lastInteraction) {
+      beforeInteractionConfigView.current = spansView.configView.clone();
+      return;
+    }
+
+    if (
+      beforeInteractionConfigView.current &&
+      !beforeInteractionConfigView.current.equals(spansView.configView)
+    ) {
+      dispatch({
+        type: 'checkpoint',
+        payload: spansView.configView.clone(),
+      });
+    }
+  }, [lastInteraction, spansView, dispatch, previousInteraction]);
 
   useEffect(() => {
     canvasPoolManager.registerScheduler(scheduler);
@@ -59,7 +105,232 @@ export function FlamegraphSpans({
     };
   }, [spansCanvas, spansRenderer, scheduler, spansView]);
 
-  return <Canvas ref={ref => setSpansCanvasRef(ref)} />;
+  const hoveredNode: SpanChartNode | null = useMemo(() => {
+    if (!configSpaceCursor || !spansRenderer) {
+      return null;
+    }
+    return spansRenderer.findHoveredNode(configSpaceCursor);
+  }, [configSpaceCursor, spansRenderer]);
+
+  const onMouseDrag = useCallback(
+    (evt: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!spansCanvas || !spansView || !startPanVector) {
+        return;
+      }
+
+      const logicalMousePos = vec2.fromValues(
+        evt.nativeEvent.offsetX,
+        evt.nativeEvent.offsetY
+      );
+
+      const physicalMousePos = vec2.scale(
+        vec2.create(),
+        logicalMousePos,
+        window.devicePixelRatio
+      );
+
+      const physicalDelta = vec2.subtract(
+        vec2.create(),
+        startPanVector,
+        physicalMousePos
+      );
+
+      if (physicalDelta[0] === 0 && physicalDelta[1] === 0) {
+        return;
+      }
+
+      const physicalToConfig = mat3.invert(
+        mat3.create(),
+        spansView.fromConfigView(spansCanvas.physicalSpace)
+      );
+      const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
+
+      const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
+        m00,
+        m01,
+        m02,
+        m10,
+        m11,
+        m12,
+        0,
+        0,
+        0,
+      ]);
+
+      canvasPoolManager.dispatch('transform config view', [
+        mat3.fromTranslation(mat3.create(), configDelta),
+      ]);
+
+      setStartPanVector(physicalMousePos);
+    },
+    [spansCanvas, spansView, startPanVector, canvasPoolManager]
+  );
+
+  const onCanvasMouseMove = useCallback(
+    (evt: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!spansCanvas || !spansView) {
+        return;
+      }
+
+      const configSpaceMouse = spansView.getConfigViewCursor(
+        vec2.fromValues(evt.nativeEvent.offsetX, evt.nativeEvent.offsetY),
+        spansCanvas
+      );
+
+      setConfigSpaceCursor(configSpaceMouse);
+
+      if (startPanVector) {
+        onMouseDrag(evt);
+        setLastInteraction('pan');
+      } else {
+        setLastInteraction(null);
+      }
+    },
+    [spansCanvas, spansView, onMouseDrag, startPanVector]
+  );
+
+  const onMinimapCanvasMouseUp = useCallback(() => {
+    setConfigSpaceCursor(null);
+    setLastInteraction(null);
+  }, []);
+
+  const onMinimapZoom = useCallback(
+    (evt: WheelEvent) => {
+      if (!spansCanvas || !spansView) {
+        return;
+      }
+
+      const identity = mat3.identity(mat3.create());
+      const scale = 1 - evt.deltaY * 0.001 * -1; // -1 to invert scale
+
+      const mouseInConfigSpace = spansView.getConfigSpaceCursor(
+        vec2.fromValues(evt.offsetX, evt.offsetY),
+        spansCanvas
+      );
+
+      const configCenter = vec2.fromValues(mouseInConfigSpace[0], spansView.configView.y);
+
+      const invertedConfigCenter = vec2.multiply(
+        vec2.create(),
+        vec2.fromValues(-1, -1),
+        configCenter
+      );
+
+      const translated = mat3.translate(mat3.create(), identity, configCenter);
+      const scaled = mat3.scale(mat3.create(), translated, vec2.fromValues(scale, 1));
+      const translatedBack = mat3.translate(mat3.create(), scaled, invertedConfigCenter);
+
+      canvasPoolManager.dispatch('transform config view', [translatedBack]);
+    },
+    [spansCanvas, spansView, canvasPoolManager]
+  );
+
+  const onMinimapScroll = useCallback(
+    (evt: WheelEvent) => {
+      if (!spansCanvas || !spansView) {
+        return;
+      }
+
+      {
+        const physicalDelta = vec2.fromValues(evt.deltaX * 0.8, evt.deltaY);
+        const physicalToConfig = mat3.invert(
+          mat3.create(),
+          spansView.fromConfigView(spansCanvas.physicalSpace)
+        );
+        const [m00, m01, m02, m10, m11, m12] = physicalToConfig;
+
+        const configDelta = vec2.transformMat3(vec2.create(), physicalDelta, [
+          m00,
+          m01,
+          m02,
+          m10,
+          m11,
+          m12,
+          0,
+          0,
+          0,
+        ]);
+
+        const translate = mat3.fromTranslation(mat3.create(), configDelta);
+        canvasPoolManager.dispatch('transform config view', [translate]);
+      }
+    },
+    [spansCanvas, spansView, canvasPoolManager]
+  );
+
+  useEffect(() => {
+    if (!spansCanvasRef) {
+      return undefined;
+    }
+
+    let wheelStopTimeoutId: number | undefined;
+    function onCanvasWheel(evt: WheelEvent) {
+      window.clearTimeout(wheelStopTimeoutId);
+      wheelStopTimeoutId = window.setTimeout(() => {
+        setLastInteraction(null);
+      }, 300);
+
+      evt.preventDefault();
+
+      // When we zoom, we want to clear cursor so that any tooltips
+      // rendered on the flamegraph are removed from the view
+      setConfigSpaceCursor(null);
+
+      if (evt.metaKey || evt.ctrlKey) {
+        onMinimapZoom(evt);
+        setLastInteraction('zoom');
+      } else {
+        onMinimapScroll(evt);
+        setLastInteraction('scroll');
+      }
+    }
+
+    spansCanvasRef.addEventListener('wheel', onCanvasWheel);
+
+    return () => {
+      window.clearTimeout(wheelStopTimeoutId);
+      spansCanvasRef.removeEventListener('wheel', onCanvasWheel);
+    };
+  }, [spansCanvasRef, onMinimapZoom, onMinimapScroll]);
+
+  useEffect(() => {
+    window.addEventListener('mouseup', onMinimapCanvasMouseUp);
+
+    return () => {
+      window.removeEventListener('mouseup', onMinimapCanvasMouseUp);
+    };
+  }, [onMinimapCanvasMouseUp]);
+
+  return (
+    <Fragment>
+      <Canvas onMouseMove={onCanvasMouseMove} ref={ref => setSpansCanvasRef(ref)} />
+      {hoveredNode && spansRenderer && configSpaceCursor && spansCanvas && spansView ? (
+        <BoundTooltip
+          bounds={canvasBounds}
+          cursor={configSpaceCursor}
+          canvas={spansCanvas}
+          canvasView={spansView}
+        >
+          <FlamegraphTooltipFrameMainInfo>
+            <FlamegraphTooltipColorIndicator
+              backgroundColor={formatColorForSpan(hoveredNode, spansRenderer)}
+            />
+            {hoveredNode.node.span.description}
+          </FlamegraphTooltipFrameMainInfo>
+          <FlamegraphTooltipTimelineInfo>
+            {hoveredNode.node.span.op ? `${t('op')}:${hoveredNode.node.span.op} ` : null}
+            {hoveredNode.node.span.status
+              ? `${t('status')}:${hoveredNode.node.span.status}`
+              : null}
+          </FlamegraphTooltipTimelineInfo>
+          <FlamegraphTooltipTimelineInfo>
+            {spansRenderer.spanChart.timelineFormatter(hoveredNode.start)} {' \u2014 '}
+            {spansRenderer.spanChart.timelineFormatter(hoveredNode.end)}
+          </FlamegraphTooltipTimelineInfo>
+        </BoundTooltip>
+      ) : null}
+    </Fragment>
+  );
 }
 
 const Canvas = styled('canvas')`

--- a/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphTooltip.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
 
+import {BoundTooltip} from 'sentry/components/profiling/boundTooltip';
 import {IconLightning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import space from 'sentry/styles/space';
@@ -13,8 +14,6 @@ import {FlamegraphCanvas} from 'sentry/utils/profiling/flamegraphCanvas';
 import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {formatColorForFrame, Rect} from 'sentry/utils/profiling/gl/utils';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
-
-import {BoundTooltip} from '../boundTooltip';
 
 export function formatWeightToProfileDuration(
   frame: CallTreeNode,
@@ -51,42 +50,40 @@ export function FlamegraphTooltip(props: FlamegraphTooltipProps) {
     <BoundTooltip
       bounds={props.canvasBounds}
       cursor={props.configSpaceCursor}
-      flamegraphCanvas={props.flamegraphCanvas}
-      flamegraphView={props.flamegraphView}
+      canvas={props.flamegraphCanvas}
+      canvasView={props.flamegraphView}
     >
-      <Fragment>
-        <FlamegraphTooltipFrameMainInfo>
-          <FlamegraphTooltipColorIndicator
-            backgroundColor={formatColorForFrame(props.frame, props.flamegraphRenderer)}
-          />
-          {props.flamegraphRenderer.flamegraph.formatter(props.frame.node.totalWeight)}{' '}
-          {formatWeightToProfileDuration(
-            props.frame.node,
-            props.flamegraphRenderer.flamegraph
-          )}{' '}
-          {props.frame.frame.name}
-        </FlamegraphTooltipFrameMainInfo>
-        <FlamegraphTooltipTimelineInfo>
-          {defined(props.frame.frame.file) && (
-            <Fragment>
-              {t('source')}:{formatFileNameAndLineColumn(props.frame)}
-            </Fragment>
-          )}
-        </FlamegraphTooltipTimelineInfo>
-        <FlamegraphTooltipTimelineInfo>
-          {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.start)}{' '}
-          {' \u2014 '}
-          {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.end)}
-          {props.frame.frame.inline ? (
-            <FlamegraphInlineIndicator>
-              <IconLightning width={10} />
-              {t('inline frame')}
-            </FlamegraphInlineIndicator>
-          ) : (
-            ''
-          )}
-        </FlamegraphTooltipTimelineInfo>
-      </Fragment>
+      <FlamegraphTooltipFrameMainInfo>
+        <FlamegraphTooltipColorIndicator
+          backgroundColor={formatColorForFrame(props.frame, props.flamegraphRenderer)}
+        />
+        {props.flamegraphRenderer.flamegraph.formatter(props.frame.node.totalWeight)}{' '}
+        {formatWeightToProfileDuration(
+          props.frame.node,
+          props.flamegraphRenderer.flamegraph
+        )}{' '}
+        {props.frame.frame.name}
+      </FlamegraphTooltipFrameMainInfo>
+      <FlamegraphTooltipTimelineInfo>
+        {defined(props.frame.frame.file) && (
+          <Fragment>
+            {t('source')}:{formatFileNameAndLineColumn(props.frame)}
+          </Fragment>
+        )}
+      </FlamegraphTooltipTimelineInfo>
+      <FlamegraphTooltipTimelineInfo>
+        {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.start)}{' '}
+        {' \u2014 '}
+        {props.flamegraphRenderer.flamegraph.timelineFormatter(props.frame.end)}
+        {props.frame.frame.inline ? (
+          <FlamegraphInlineIndicator>
+            <IconLightning width={10} />
+            {t('inline frame')}
+          </FlamegraphInlineIndicator>
+        ) : (
+          ''
+        )}
+      </FlamegraphTooltipTimelineInfo>
     </BoundTooltip>
   );
 }

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -46,7 +46,6 @@ function FlamegraphZoomViewMinimap({
   const dispatch = useDispatchFlamegraphState();
 
   const [configSpaceCursor, setConfigSpaceCursor] = useState<vec2 | null>(null);
-
   const scheduler = useMemo(() => new CanvasScheduler(), []);
 
   const miniMapConfigSpaceBorderSize = useMemo(() => {

--- a/static/app/utils/profiling/canvasView.spec.tsx
+++ b/static/app/utils/profiling/canvasView.spec.tsx
@@ -21,7 +21,6 @@ const makeCanvasAndView = (
   const canvasView = new CanvasView<Flamegraph>({
     canvas: flamegraphCanvas,
     model: flamegraph,
-    configSpace: flamegraph.configSpace,
     options: {
       inverted: flamegraph.inverted,
       minWidth: flamegraph.profile.minFrameDuration,

--- a/static/app/utils/profiling/canvasView.tsx
+++ b/static/app/utils/profiling/canvasView.tsx
@@ -23,7 +23,6 @@ export class CanvasView<T extends {configSpace: Rect}> {
     model,
   }: {
     canvas: FlamegraphCanvas;
-    configSpace: Rect;
     model: T;
     options: {
       barHeight: number;

--- a/static/app/utils/profiling/flamegraph.spec.tsx
+++ b/static/app/utils/profiling/flamegraph.spec.tsx
@@ -124,10 +124,10 @@ describe('flamegraph', () => {
       }
     );
 
-    const order = ['f0', 'f1', 'f2'];
+    const order = ['f0', 'f1', 'f2'].reverse();
     for (let i = 0; i < order.length; i++) {
       expect(flamegraph.frames[i].frame.name).toBe(order[i]);
-      expect(flamegraph.frames[i].depth).toBe(i);
+      expect(flamegraph.frames[i].depth).toBe(order.length - i - 1);
     }
   });
 
@@ -254,15 +254,15 @@ describe('flamegraph', () => {
       }
     );
 
-    expect(flamegraph.frames[0].frame.name).toBe('f0');
-    expect(flamegraph.frames[0].frame.totalWeight).toBe(1);
-    expect(flamegraph.frames[0].start).toBe(2);
-    expect(flamegraph.frames[0].end).toBe(3);
+    expect(flamegraph.frames[1].frame.name).toBe('f0');
+    expect(flamegraph.frames[1].frame.totalWeight).toBe(1);
+    expect(flamegraph.frames[1].start).toBe(2);
+    expect(flamegraph.frames[1].end).toBe(3);
 
-    expect(flamegraph.frames[1].frame.name).toBe('f1');
-    expect(flamegraph.frames[1].frame.totalWeight).toBe(2);
-    expect(flamegraph.frames[1].start).toBe(0);
-    expect(flamegraph.frames[1].end).toBe(2);
+    expect(flamegraph.frames[0].frame.name).toBe('f1');
+    expect(flamegraph.frames[0].frame.totalWeight).toBe(2);
+    expect(flamegraph.frames[0].start).toBe(0);
+    expect(flamegraph.frames[0].end).toBe(2);
   });
 
   it('updates startTime and endTime of left heavy children graph', () => {
@@ -295,7 +295,7 @@ describe('flamegraph', () => {
       }
     );
 
-    expect(flamegraph.frames[0].frame.name).toBe('f0');
+    expect(flamegraph.frames[2].frame.name).toBe('f0');
   });
 
   it('From', () => {

--- a/static/app/utils/profiling/flamegraph.ts
+++ b/static/app/utils/profiling/flamegraph.ts
@@ -148,7 +148,7 @@ export class Flamegraph {
         return;
       }
 
-      frames.unshift(stackTop);
+      frames.push(stackTop);
       this.depth = Math.max(stackTop.depth, this.depth);
     };
 
@@ -162,7 +162,7 @@ export class Flamegraph {
 
     const sortTree = (node: CallTreeNode) => {
       node.children.sort((a, b) => -(a.totalWeight - b.totalWeight));
-      node.children.forEach(c => sortTree(c));
+      node.children.forEach(sortTree);
     };
 
     sortTree(profile.appendOrderTree);
@@ -218,7 +218,7 @@ export class Flamegraph {
       if (stackTop.end - stackTop.start === 0) {
         return;
       }
-      frames.unshift(stackTop);
+      frames.push(stackTop);
       this.depth = Math.max(stackTop.depth, this.depth);
     };
 

--- a/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
+++ b/static/app/utils/profiling/flamegraph/flamegraphTheme.tsx
@@ -82,6 +82,7 @@ export interface FlamegraphTheme {
     MINIMAP_HEIGHT: number;
     MINIMAP_POSITION_OVERLAY_BORDER_WIDTH: number;
     SPANS_BAR_HEIGHT: number;
+    SPANS_DEPTH_OFFSET: number;
     SPANS_HEIGHT: number;
     TIMELINE_HEIGHT: number;
     TOOLTIP_FONT_SIZE: number;
@@ -109,6 +110,7 @@ const SIZES: FlamegraphTheme['SIZES'] = {
   BAR_HEIGHT: 20,
   BAR_PADDING: 4,
   FLAMEGRAPH_DEPTH_OFFSET: 12,
+  SPANS_DEPTH_OFFSET: 3,
   FOCUSED_FRAME_BORDER_WIDTH: 2,
   FRAME_BORDER_WIDTH: 2,
   GRID_LINE_WIDTH: 2,

--- a/static/app/utils/profiling/gl/utils.ts
+++ b/static/app/utils/profiling/gl/utils.ts
@@ -5,6 +5,8 @@ import {FlamegraphFrame} from 'sentry/utils/profiling/flamegraphFrame';
 import {FlamegraphRenderer} from 'sentry/utils/profiling/renderers/flamegraphRenderer';
 
 import {clamp} from '../colors/utils';
+import {SpanChartRenderer2D} from '../renderers/spansRenderer';
+import {SpanChartNode} from '../spanChart';
 
 export function createShader(
   gl: WebGLRenderingContext,
@@ -496,6 +498,21 @@ export function findRangeBinarySearch(
       high = mid;
     }
   }
+}
+
+export function formatColorForSpan(
+  frame: SpanChartNode,
+  renderer: SpanChartRenderer2D
+): string {
+  const color = renderer.getColorForFrame(frame);
+  if (color.length === 4) {
+    return `rgba(${color
+      .slice(0, 3)
+      .map(n => n * 255)
+      .join(',')}, ${color[3]})`;
+  }
+
+  return `rgba(${color.map(n => n * 255).join(',')}, 1.0)`;
 }
 
 export function formatColorForFrame(

--- a/static/app/utils/profiling/renderers/flamegraphDomRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphDomRenderer.spec.tsx
@@ -47,7 +47,6 @@ describe('FlamegraphDomRenderer', () => {
         barHeight: theme.SIZES.BAR_HEIGHT,
         depthOffset: theme.SIZES.FLAMEGRAPH_DEPTH_OFFSET,
       },
-      configSpace: flamegraph.configSpace,
     });
 
     renderer.draw(

--- a/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
+++ b/static/app/utils/profiling/renderers/flamegraphRenderer.spec.tsx
@@ -235,7 +235,6 @@ describe('flamegraphRenderer', () => {
       const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
         model: flamegraph,
-        configSpace: flamegraph.configSpace,
         options: {
           inverted: flamegraph.inverted,
           minWidth: flamegraph.profile.minFrameDuration,
@@ -297,7 +296,6 @@ describe('flamegraphRenderer', () => {
       const flamegraphView = new CanvasView<Flamegraph>({
         canvas: flamegraphCanvas,
         model: flamegraph,
-        configSpace: flamegraph.configSpace,
         options: {
           inverted: flamegraph.inverted,
           minWidth: flamegraph.profile.minFrameDuration,

--- a/static/app/utils/profiling/spanChart.spec.tsx
+++ b/static/app/utils/profiling/spanChart.spec.tsx
@@ -134,7 +134,7 @@ describe('spanChart', () => {
     );
 
     const chart = new SpanChart(tree);
-    expect(chart.minSpanDuration).toBe(1);
+    expect(chart.minSpanDuration).toBe(1 * 1e3);
   });
 
   it('tracks chart depth', () => {
@@ -208,7 +208,7 @@ describe('spanChart', () => {
     );
 
     const chart = new SpanChart(tree);
-    expect(chart.configSpace.equals(new Rect(0, 0, 10, 3))).toBe(true);
+    expect(chart.configSpace.equals(new Rect(0, 0, 10 * 1e3, 3))).toBe(true);
   });
 
   it('remaps spans to start of benchmark', () => {
@@ -236,11 +236,11 @@ describe('spanChart', () => {
     );
 
     const chart = new SpanChart(tree);
-    expect(chart.spans[1].start).toBe(1);
-    expect(chart.spans[1].end).toBe(5);
+    expect(chart.spans[1].start).toBe(1 * 1e3);
+    expect(chart.spans[1].end).toBe(5 * 1e3);
 
-    expect(chart.spans[2].start).toBe(3);
-    expect(chart.spans[2].end).toBe(4);
+    expect(chart.spans[2].start).toBe(3 * 1e3);
+    expect(chart.spans[2].end).toBe(4 * 1e3);
   });
 
   it('converts durations to final unit', () => {
@@ -262,11 +262,11 @@ describe('spanChart', () => {
     );
 
     const chart = new SpanChart(tree, {unit: 'nanoseconds'});
-    expect(chart.spans[1].start).toBe(1 * 1e6);
-    expect(chart.spans[1].end).toBe(3 * 1e6);
-    expect(chart.spans[1].duration).toBe(2 * 1e6);
+    expect(chart.spans[1].start).toBe(1 * 1e9);
+    expect(chart.spans[1].end).toBe(3 * 1e9);
+    expect(chart.spans[1].duration).toBe(2 * 1e9);
 
     expect(chart.configSpace.height).toBe(1);
-    expect(chart.configSpace.width).toBe(10 * 1e6);
+    expect(chart.configSpace.width).toBe(10 * 1e9);
   });
 });

--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -1,27 +1,42 @@
 import {Rect} from 'sentry/utils/profiling/gl/utils';
-import {SpanTree} from 'sentry/utils/profiling/spanTree';
-import {makeFormatter, makeFormatTo} from 'sentry/utils/profiling/units/units';
+import {SpanTree, SpanTreeNode} from 'sentry/utils/profiling/spanTree';
+import {
+  makeFormatter,
+  makeFormatTo,
+  makeTimelineFormatter,
+} from 'sentry/utils/profiling/units/units';
 
 import {Profile} from './profile/profile';
 
 export interface SpanChartNode {
+  children: SpanChartNode[];
   depth: number;
   duration: number;
   end: number;
   node: SpanTree['root'];
+  parent: SpanChartNode | null;
   start: number;
 }
 
 class SpanChart {
   spans: SpanChartNode[];
+  root: SpanChartNode = {
+    parent: null,
+    node: SpanTreeNode.Root(),
+    duration: 0,
+    depth: -1,
+    start: 0,
+    end: 0,
+    children: [],
+  };
   spanTree: SpanTree;
   depth: number = 0;
   minSpanDuration: number = Number.POSITIVE_INFINITY;
-
   configSpace: Rect;
 
   toFinalUnit = makeFormatTo('milliseconds', 'milliseconds');
   formatter = makeFormatter('milliseconds');
+  timelineFormatter: (value: number) => string;
 
   constructor(
     spanTree: SpanTree,
@@ -30,6 +45,7 @@ class SpanChart {
     this.spanTree = spanTree;
     this.toFinalUnit = makeFormatTo('seconds', options.unit);
     this.spans = this.collectSpanNodes();
+    this.timelineFormatter = makeTimelineFormatter(options.unit);
 
     const duration = this.toFinalUnit(
       this.spanTree.root.span.timestamp - this.spanTree.root.span.start_timestamp
@@ -41,28 +57,42 @@ class SpanChart {
   // Bfs over the span tree while keeping track of level depth and calling the cb fn
   forEachSpan(cb: (node: SpanChartNode) => void) {
     const transactionStart = this.spanTree.root.span.start_timestamp;
-
-    const queue: SpanTree['root'][] = [this.spanTree.root];
+    const queue: [SpanChartNode | null, SpanTreeNode][] = [[null, this.spanTree.root]];
     let depth = 0;
 
     while (queue.length) {
       let children_at_depth = queue.length;
 
       while (children_at_depth-- !== 0) {
-        const node = queue.shift()!;
-        queue.push(...node.children);
+        const [parent, node] = queue.shift()!;
 
         const duration = node.span.timestamp - node.span.start_timestamp;
         const start = node.span.start_timestamp - transactionStart;
         const end = start + duration;
 
-        cb({
+        const spanChartNode: SpanChartNode = {
           duration: this.toFinalUnit(duration),
           start: this.toFinalUnit(start),
           end: this.toFinalUnit(end),
           node,
           depth,
-        });
+          parent,
+          children: [],
+        };
+
+        cb(spanChartNode);
+
+        if (parent) {
+          parent.children.push(spanChartNode);
+        } else {
+          this.root.children.push(spanChartNode);
+        }
+
+        const nodesWithParent = node.children.map(
+          // @todo use satisfies here when available
+          child => [spanChartNode, child] as [SpanChartNode, SpanTreeNode]
+        );
+        queue.push(...nodesWithParent);
       }
       depth++;
     }

--- a/static/app/utils/profiling/spanChart.tsx
+++ b/static/app/utils/profiling/spanChart.tsx
@@ -28,7 +28,7 @@ class SpanChart {
     options: {unit: Profile['unit']; configSpace?: Rect} = {unit: 'milliseconds'}
   ) {
     this.spanTree = spanTree;
-    this.toFinalUnit = makeFormatTo('milliseconds', options.unit);
+    this.toFinalUnit = makeFormatTo('seconds', options.unit);
     this.spans = this.collectSpanNodes();
 
     const duration = this.toFinalUnit(

--- a/static/app/utils/profiling/spanTree.tsx
+++ b/static/app/utils/profiling/spanTree.tsx
@@ -42,7 +42,7 @@ function sortByStartTimeAndDuration(a: RawSpanType, b: RawSpanType) {
   return 1;
 }
 
-class SpanTreeNode {
+export class SpanTreeNode {
   parent?: SpanTreeNode | null = null;
   span: RawSpanType;
   children: SpanTreeNode[] = [];

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -70,9 +70,7 @@ function ProfileFlamegraph(): React.ReactElement {
   const profiledTransaction = useProfileTransaction();
 
   const hasFlameChartSpans = useMemo(() => {
-    return (
-      organization.features.includes('organizations:profiling-flamechart-spans') || true
-    );
+    return organization.features.includes('organizations:profiling-flamechart-spans');
   }, [organization.features]);
 
   const spanTree: SpanTree = useMemo(() => {

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -70,7 +70,9 @@ function ProfileFlamegraph(): React.ReactElement {
   const profiledTransaction = useProfileTransaction();
 
   const hasFlameChartSpans = useMemo(() => {
-    return organization.features.includes('organizations:profiling-flamechart-spans');
+    return (
+      organization.features.includes('organizations:profiling-flamechart-spans') || true
+    );
   }, [organization.features]);
 
   const spanTree: SpanTree = useMemo(() => {


### PR DESCRIPTION
These are actual unix ts, the view was all jumpy and being transformed because the two axes were not normalize to the correct duration. I also dropped configSpace from the view constructor as it was not required.